### PR TITLE
feat: add css-only accordion submission

### DIFF
--- a/submissions/examples/ease-accordion/README.md
+++ b/submissions/examples/ease-accordion/README.md
@@ -1,0 +1,22 @@
+# Ease Accordion
+
+**What does this do?**  
+Creates a CSS-only accordion that expands to its natural content height without a `max-height` timing hack.
+
+**How is it used?**  
+```html
+<input class="accordion-toggle" id="faq-1" type="checkbox" />
+<label class="accordion-trigger" for="faq-1">How does it animate?</label>
+<div class="accordion-panel">
+  <div class="accordion-content">Any unknown-height content can live here.</div>
+</div>
+```
+
+**Why is it useful?**  
+Accordions often use oversized `max-height` values that make timing feel uneven. This submission uses modern `interpolate-size: allow-keywords` for real `height: auto` transitions, then falls back to the grid-row technique in older browsers so the motion remains smooth and dependency-free.
+
+---
+
+Submitted by: @saurabhhhcodes  
+Issue: #132  
+Status: **Pending review**

--- a/submissions/examples/ease-accordion/demo.html
+++ b/submissions/examples/ease-accordion/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Ease Accordion</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro">
+      <p class="eyebrow">CSS-only motion</p>
+      <h1>Ease Accordion</h1>
+      <p>
+        Expand panels to their natural height with modern CSS, while keeping a
+        graceful grid fallback for browsers that do not animate to auto yet.
+      </p>
+    </section>
+
+    <section class="accordion-stack" aria-label="Accordion demo">
+      <article class="accordion-item">
+        <input class="accordion-toggle" id="panel-modern" type="checkbox" checked />
+        <label class="accordion-trigger" for="panel-modern">
+          <span>Natural-height animation</span>
+          <span class="accordion-icon" aria-hidden="true"></span>
+        </label>
+        <div class="accordion-panel">
+          <div class="accordion-content">
+            <p>
+              The preferred path uses <code>interpolate-size: allow-keywords</code>
+              and transitions from <code>height: 0</code> to <code>height: auto</code>.
+              This avoids the uneven easing caused by arbitrary max-height values.
+            </p>
+          </div>
+        </div>
+      </article>
+
+      <article class="accordion-item">
+        <input class="accordion-toggle" id="panel-dynamic" type="checkbox" />
+        <label class="accordion-trigger" for="panel-dynamic">
+          <span>Unknown content height</span>
+          <span class="accordion-icon" aria-hidden="true"></span>
+        </label>
+        <div class="accordion-panel">
+          <div class="accordion-content">
+            <p>
+              Panels can contain short copy, longer paragraphs, lists, or inline
+              controls. The transition is based on the rendered content instead
+              of a fixed numeric ceiling.
+            </p>
+            <ul>
+              <li>Works with variable copy length.</li>
+              <li>Uses no JavaScript.</li>
+              <li>Keeps overflow clipped during the animation.</li>
+            </ul>
+          </div>
+        </div>
+      </article>
+
+      <article class="accordion-item">
+        <input class="accordion-toggle" id="panel-fallback" type="checkbox" />
+        <label class="accordion-trigger" for="panel-fallback">
+          <span>Progressive fallback</span>
+          <span class="accordion-icon" aria-hidden="true"></span>
+        </label>
+        <div class="accordion-panel">
+          <div class="accordion-content">
+            <p>
+              Browsers without auto-size interpolation use the grid row fallback:
+              the wrapper animates from <code>0fr</code> to <code>1fr</code>, and
+              the inner content stays clipped until the panel finishes opening.
+            </p>
+          </div>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-accordion/style.css
+++ b/submissions/examples/ease-accordion/style.css
@@ -1,0 +1,214 @@
+/* ============================================================
+   SUBMISSION - ease-accordion
+   CSS-only accordion with modern auto-height animation and
+   grid-template fallback. No framework or JavaScript required.
+   ============================================================ */
+
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #101112;
+  color: #f6f3ea;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 40px 20px;
+  background:
+    radial-gradient(circle at top left, rgba(78, 205, 196, 0.18), transparent 32rem),
+    linear-gradient(135deg, #101112 0%, #1c1e23 48%, #161719 100%);
+}
+
+.demo-shell {
+  width: min(760px, 100%);
+}
+
+.intro {
+  margin-bottom: 24px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #4ecdc4;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: clamp(2.2rem, 8vw, 4.4rem);
+  line-height: 0.98;
+}
+
+.intro p:not(.eyebrow) {
+  max-width: 620px;
+  margin: 0;
+  color: rgba(246, 243, 234, 0.68);
+  line-height: 1.7;
+}
+
+.accordion-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.accordion-item {
+  border: 1px solid rgba(246, 243, 234, 0.12);
+  border-radius: 12px;
+  background: rgba(246, 243, 234, 0.065);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.24);
+  overflow: hidden;
+}
+
+.accordion-toggle {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.accordion-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 64px;
+  padding: 18px 20px;
+  cursor: pointer;
+  font-weight: 800;
+  color: #fffaf0;
+}
+
+.accordion-trigger:hover,
+.accordion-toggle:focus-visible + .accordion-trigger {
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.accordion-toggle:focus-visible + .accordion-trigger {
+  outline: 2px solid #4ecdc4;
+  outline-offset: -4px;
+}
+
+.accordion-icon {
+  position: relative;
+  flex: 0 0 auto;
+  inline-size: 22px;
+  block-size: 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(78, 205, 196, 0.54);
+}
+
+.accordion-icon::before,
+.accordion-icon::after {
+  content: "";
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-start: 50%;
+  inline-size: 10px;
+  block-size: 2px;
+  border-radius: 999px;
+  background: #4ecdc4;
+  transform: translate(-50%, -50%);
+  transition: transform 220ms ease;
+}
+
+.accordion-icon::after {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+
+.accordion-toggle:checked + .accordion-trigger .accordion-icon::after {
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+
+/* Fallback path: grid rows can animate dynamic/unknown content height. */
+.accordion-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 360ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.accordion-toggle:checked ~ .accordion-panel {
+  grid-template-rows: 1fr;
+}
+
+.accordion-content {
+  min-block-size: 0;
+  overflow: hidden;
+  padding-inline: 20px;
+  color: rgba(246, 243, 234, 0.72);
+  line-height: 1.65;
+}
+
+.accordion-content > * {
+  margin-block: 0 16px;
+}
+
+.accordion-content > :first-child {
+  padding-block-start: 2px;
+}
+
+.accordion-content > :last-child {
+  margin-block-end: 20px;
+}
+
+code {
+  border-radius: 6px;
+  padding: 2px 6px;
+  background: rgba(78, 205, 196, 0.14);
+  color: #8cf7ee;
+  font-size: 0.92em;
+}
+
+ul {
+  padding-inline-start: 20px;
+}
+
+@supports (interpolate-size: allow-keywords) {
+  :root {
+    interpolate-size: allow-keywords;
+  }
+
+  .accordion-panel {
+    display: block;
+    height: 0;
+    overflow: hidden;
+    transition: height 360ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .accordion-toggle:checked ~ .accordion-panel {
+    height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .accordion-panel,
+  .accordion-icon::before,
+  .accordion-icon::after {
+    transition-duration: 1ms;
+  }
+}
+
+@media (max-width: 520px) {
+  body {
+    padding: 28px 14px;
+  }
+
+  .accordion-trigger {
+    min-height: 58px;
+    padding: 16px;
+  }
+
+  .accordion-content {
+    padding-inline: 16px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a curated raw CSS submission for issue #132: a CSS-only accordion that animates dynamic content height without a max-height implementation hack.

---

## Type of Change

- [x] New feature submission (inside `submissions/examples/`)
- [ ] Bug fix in an existing submission
- [ ] Documentation improvement
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes a `demo.html` — a self-contained working HTML demo
- [x] Includes a `style.css` — raw CSS for the proposed feature
- [x] Includes a `README.md` — answers: what it does, how to use it, why it's useful
- [x] **No changes made to `core/`**
- [x] **No changes made to `components/`**
- [x] One feature per PR (not multiple unrelated changes)
- [x] Demo works by opening `demo.html` directly in a browser (no server required)

---

## Feature Description

**What does this submission add?**

A CSS-only accordion with modern `interpolate-size: allow-keywords` auto-height animation and a grid-template fallback for browsers that do not support auto-size interpolation yet.

**How does a developer use it?**

```html
<input class="accordion-toggle" id="faq-1" type="checkbox" />
<label class="accordion-trigger" for="faq-1">How does it animate?</label>
<div class="accordion-panel">
  <div class="accordion-content">Any unknown-height content can live here.</div>
</div>
```

**Why does it fit Flow CSS?**

It is animation-first, dependency-free, and avoids the common oversized max-height workaround that makes accordion easing feel uneven.

---

## Notes for Maintainer

Validation performed:
- `git diff --check`
- confirmed the submission folder contains exactly `demo.html`, `style.css`, and `README.md`
- parsed `demo.html` with Python's built-in HTML parser
- checked that there are no external links, CDNs, scripts, or Tailwind dependencies in the demo folder

Closes #132
