### PR TITLE
feat: add pure css ripple submission

### DIFF
--- a/submissions/examples/ease-ripple/README.md
+++ b/submissions/examples/ease-ripple/README.md
@@ -1,0 +1,21 @@
+# Ease Ripple
+
+**What does this do?**  
+Adds a pure CSS click ripple that expands and fades inside a button without JavaScript.
+
+**How is it used?**  
+```html
+<button class="ripple-button">Save changes</button>
+<button class="ripple-button ripple-pill" style="--ease-ripple-color: rgba(255,255,255,0.5)">
+  Continue
+</button>
+```
+
+**Why is it useful?**  
+Ripple feedback makes buttons feel tactile on mouse and touch devices. This submission keeps the effect self-contained with `::after`, supports rounded and pill-shaped buttons through `overflow: hidden`, and lets developers tune the ripple color through `--ease-ripple-color`.
+
+---
+
+Submitted by: @saurabhhhcodes  
+Issue: #128  
+Status: **Pending review**

--- a/submissions/examples/ease-ripple/demo.html
+++ b/submissions/examples/ease-ripple/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Ease Ripple</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro">
+      <p class="eyebrow">Pure CSS interaction</p>
+      <h1>Ease Ripple</h1>
+      <p>
+        Press any button to see a radial ripple expand and fade inside its
+        bounds. The effect uses only a pseudo-element and the active state.
+      </p>
+    </section>
+
+    <section class="button-grid" aria-label="Ripple button examples">
+      <button class="ripple-button ripple-primary">Primary Action</button>
+      <button class="ripple-button ripple-success">Confirm</button>
+      <button class="ripple-button ripple-alert">Delete</button>
+      <button class="ripple-button ripple-pill">Pill Button</button>
+      <button class="ripple-button ripple-outline">Outline Button</button>
+      <button class="ripple-button ripple-soft">Soft Surface</button>
+    </section>
+
+    <section class="usage-card" aria-label="Configuration example">
+      <h2>Configurable color</h2>
+      <p>
+        Set <code>--ease-ripple-color</code> on the button to match any brand
+        surface. Border radius is inherited automatically because the ripple is
+        clipped by the button.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-ripple/style.css
+++ b/submissions/examples/ease-ripple/style.css
@@ -1,0 +1,198 @@
+/* ============================================================
+   SUBMISSION - ease-ripple
+   Pure CSS button ripple using :active and ::after.
+   No JavaScript, no external assets, no framework dependencies.
+   ============================================================ */
+
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #101014;
+  color: #f8f7f2;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 42px 20px;
+  background:
+    radial-gradient(circle at 15% 15%, rgba(255, 209, 102, 0.18), transparent 28rem),
+    radial-gradient(circle at 85% 10%, rgba(17, 138, 178, 0.2), transparent 32rem),
+    linear-gradient(145deg, #101014 0%, #191b22 54%, #111317 100%);
+}
+
+.demo-shell {
+  width: min(820px, 100%);
+}
+
+.intro {
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #ffd166;
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: clamp(2.4rem, 8vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.intro p:not(.eyebrow),
+.usage-card p {
+  max-width: 620px;
+  margin: 0;
+  color: rgba(248, 247, 242, 0.68);
+  line-height: 1.7;
+}
+
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.ripple-button {
+  --ease-ripple-color: rgba(255, 255, 255, 0.42);
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  min-height: 52px;
+  padding: 0 22px;
+  border: 0;
+  border-radius: 12px;
+  background: #2d7ff9;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.96rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.24);
+  transition:
+    transform 180ms ease,
+    box-shadow 220ms ease,
+    filter 220ms ease;
+}
+
+.ripple-button:hover {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.28);
+}
+
+.ripple-button:active {
+  transform: translateY(0) scale(0.985);
+}
+
+.ripple-button:focus-visible {
+  outline: 3px solid rgba(255, 209, 102, 0.74);
+  outline-offset: 3px;
+}
+
+.ripple-button::after {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  inset-block-start: 50%;
+  inset-inline-start: 50%;
+  inline-size: 38%;
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background: var(--ease-ripple-color);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50%) scale(4);
+  transition:
+    transform 520ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 700ms ease-out;
+}
+
+.ripple-button:active::after {
+  opacity: 0.55;
+  transform: translate(-50%, -50%) scale(0);
+  transition: none;
+}
+
+.ripple-primary {
+  background: linear-gradient(135deg, #2d7ff9, #4f46e5);
+}
+
+.ripple-success {
+  --ease-ripple-color: rgba(236, 255, 240, 0.52);
+  background: linear-gradient(135deg, #118a5a, #19b86d);
+}
+
+.ripple-alert {
+  --ease-ripple-color: rgba(255, 241, 230, 0.5);
+  background: linear-gradient(135deg, #d33f49, #f15a24);
+}
+
+.ripple-pill {
+  --ease-ripple-color: rgba(255, 255, 255, 0.48);
+  border-radius: 999px;
+  background: linear-gradient(135deg, #6d5dfc, #c471ed);
+}
+
+.ripple-outline {
+  --ease-ripple-color: rgba(45, 127, 249, 0.22);
+  border: 1px solid rgba(45, 127, 249, 0.72);
+  background: rgba(45, 127, 249, 0.08);
+  color: #9fc7ff;
+}
+
+.ripple-soft {
+  --ease-ripple-color: rgba(255, 209, 102, 0.24);
+  background: rgba(255, 209, 102, 0.12);
+  color: #ffe2a3;
+}
+
+.usage-card {
+  border: 1px solid rgba(248, 247, 242, 0.12);
+  border-radius: 14px;
+  padding: 22px;
+  background: rgba(248, 247, 242, 0.065);
+}
+
+.usage-card h2 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+}
+
+code {
+  border-radius: 6px;
+  padding: 2px 6px;
+  background: rgba(255, 209, 102, 0.13);
+  color: #ffe2a3;
+  font-size: 0.92em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ripple-button,
+  .ripple-button::after {
+    transition-duration: 1ms;
+  }
+}
+
+@media (max-width: 680px) {
+  .button-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ripple-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a curated raw CSS submission for issue #128: a pure CSS button ripple that expands and fades inside the button bounds without JavaScript.

---

## Type of Change

- [x] New feature submission (inside `submissions/examples/`)
- [ ] Bug fix in an existing submission
- [ ] Documentation improvement
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes a `demo.html` — a self-contained working HTML demo
- [x] Includes a `style.css` — raw CSS for the proposed feature
- [x] Includes a `README.md` — answers: what it does, how to use it, why it's useful
- [x] **No changes made to `core/`**
- [x] **No changes made to `components/`**
- [x] One feature per PR (not multiple unrelated changes)
- [x] Demo works by opening `demo.html` directly in a browser (no server required)

---

## Feature Description

**What does this submission add?**

A CSS-only ripple click effect using `:active`, `::after`, `transform`, and opacity transitions, with the ripple clipped inside the button.

**How does a developer use it?**

```html
<button class="ripple-button">Save changes</button>
<button class="ripple-button ripple-pill" style="--ease-ripple-color: rgba(255,255,255,0.5)">
  Continue
</button>
```

**Why does it fit Flow CSS?**

It adds tactile animation feedback with zero dependencies, respects rounded and pill-shaped buttons, and lets the ripple color be configured through a CSS custom property.

---

## Notes for Maintainer

Validation performed:
- `git diff --check`
- confirmed the submission folder contains exactly `demo.html`, `style.css`, and `README.md`
- parsed `demo.html` with Python's built-in HTML parser
- checked that there are no external links, CDNs, scripts, Tailwind references, JavaScript, or max-height usage in the demo folder

Closes #128
