### PR TITLE
feat: add css count up submission

### DIFF
--- a/submissions/examples/css-count-up/README.md
+++ b/submissions/examples/css-count-up/README.md
@@ -1,0 +1,15 @@
+# CSS Count Up
+
+**What does this do?**
+Animates a stat number from zero to its configured target value when the card scrolls into view.
+
+**How is it used?**
+```html
+<article class="count-card" data-target="95" data-suffix="%" data-ease="ease-out">
+  <span class="count-label">Retention lift</span>
+  <strong class="count-number"></strong>
+</article>
+```
+
+**Why is it useful?**
+Metric counters are common in dashboards, landing pages, and proof sections, and this version keeps the motion mostly in CSS with configurable targets, suffixes, and easing. That makes it a good fit for EaseMotion CSS because the maintainer can standardize the class names while preserving a small, reusable animation pattern.

--- a/submissions/examples/css-count-up/demo.html
+++ b/submissions/examples/css-count-up/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - CSS Count Up</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro-panel">
+      <p class="eyebrow">Scroll-triggered stats</p>
+      <h1>CSS Count Up</h1>
+      <p>
+        Each stat animates from zero to its target when the card enters the
+        viewport, while keeping suffixes and easing configurable per element.
+      </p>
+    </section>
+
+    <div class="scroll-spacer" aria-hidden="true">
+      <span>Scroll down</span>
+    </div>
+
+    <section class="stats-grid" aria-label="Animated product statistics">
+      <article class="count-card" data-target="95" data-suffix="%" data-ease="ease-out">
+        <span class="count-label">Retention lift</span>
+        <strong class="count-number"></strong>
+        <span class="count-note">Ease-out finish for dashboard highlights</span>
+      </article>
+
+      <article class="count-card count-card-blue" data-target="1200" data-suffix="+" data-ease="linear">
+        <span class="count-label">Components styled</span>
+        <strong class="count-number"></strong>
+        <span class="count-note">Linear pacing for neutral progress counters</span>
+      </article>
+
+      <article class="count-card count-card-amber" data-target="48" data-suffix="ms" data-ease="ease-in-out">
+        <span class="count-label">Interaction delay</span>
+        <strong class="count-number"></strong>
+        <span class="count-note">Ease-in-out motion for compact metric cards</span>
+      </article>
+    </section>
+  </main>
+
+  <script>
+    const cards = document.querySelectorAll(".count-card");
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+
+          const card = entry.target;
+          const number = card.querySelector(".count-number");
+          card.style.setProperty("--count-target", card.dataset.target || "0");
+          card.style.setProperty("--counter-ease", card.dataset.ease || "ease-out");
+          if (number) {
+            number.dataset.suffix = card.dataset.suffix || "";
+          }
+          card.classList.add("is-visible");
+          observer.unobserve(card);
+        });
+      },
+      { threshold: 0.45 }
+    );
+
+    cards.forEach((card) => observer.observe(card));
+  </script>
+</body>
+</html>

--- a/submissions/examples/css-count-up/style.css
+++ b/submissions/examples/css-count-up/style.css
@@ -1,0 +1,196 @@
+@property --count-value {
+  syntax: "<integer>";
+  initial-value: 0;
+  inherits: false;
+}
+
+:root {
+  color-scheme: light;
+  --page-bg: #f6f7fb;
+  --panel-bg: #ffffff;
+  --ink: #182033;
+  --muted: #657086;
+  --line: #dce2ea;
+  --green: #18a874;
+  --blue: #2f6fed;
+  --amber: #d78b16;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 150vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(120deg, rgba(24, 168, 116, 0.12), transparent 32rem),
+    linear-gradient(240deg, rgba(47, 111, 237, 0.12), transparent 28rem),
+    var(--page-bg);
+  color: var(--ink);
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 56px 0 80px;
+}
+
+.intro-panel {
+  max-width: 680px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--green);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 7vw, 4.75rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.intro-panel p:last-child {
+  max-width: 58ch;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.scroll-spacer {
+  min-height: 44vh;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.scroll-spacer span {
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.count-card {
+  --count-target: 0;
+  --count-value: 0;
+  --counter-ease: ease-out;
+  --accent: var(--green);
+
+  min-height: 230px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border: 1px solid color-mix(in srgb, var(--accent), white 68%);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  box-shadow: 0 18px 50px rgba(24, 32, 51, 0.08);
+  opacity: 0;
+  transform: translateY(22px);
+  transition:
+    opacity 420ms ease,
+    transform 420ms ease,
+    border-color 420ms ease,
+    box-shadow 420ms ease;
+}
+
+.count-card-blue {
+  --accent: var(--blue);
+}
+
+.count-card-amber {
+  --accent: var(--amber);
+}
+
+.count-card.is-visible {
+  --count-value: var(--count-target);
+  opacity: 1;
+  transform: translateY(0);
+  border-color: color-mix(in srgb, var(--accent), white 34%);
+  box-shadow:
+    0 24px 70px rgba(24, 32, 51, 0.12),
+    inset 0 4px 0 var(--accent);
+  animation: count-up 1500ms var(--counter-ease) both;
+}
+
+.count-label {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.count-number {
+  margin: 28px 0 18px;
+  color: var(--accent);
+  font-size: clamp(3rem, 10vw, 5.5rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+  counter-reset: count var(--count-value);
+}
+
+.count-number::before {
+  content: counter(count);
+}
+
+.count-number::after {
+  content: attr(data-suffix);
+  font-size: 0.44em;
+  margin-left: 0.08em;
+  vertical-align: 0.42em;
+}
+
+.count-number[data-suffix="%"]::after,
+.count-number[data-suffix="+"]::after {
+  font-size: 0.72em;
+  margin-left: 0.04em;
+  vertical-align: 0.16em;
+}
+
+.count-note {
+  color: var(--muted);
+  font-size: 0.96rem;
+  line-height: 1.55;
+}
+
+@keyframes count-up {
+  from {
+    --count-value: 0;
+  }
+
+  to {
+    --count-value: var(--count-target);
+  }
+}
+
+@media (max-width: 760px) {
+  .demo-shell {
+    width: min(100% - 24px, 560px);
+    padding-top: 40px;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .scroll-spacer {
+    min-height: 34vh;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new `css-count-up` submission for #130: scroll-triggered stat cards that animate integer counters from 0 to a target value using CSS `@property`, `counter()`, and a tiny IntersectionObserver trigger.

Closes #130

---

## Type of Change

- [x] New feature submission (inside `submissions/examples/`)
- [ ] Bug fix in an existing submission
- [ ] Documentation improvement
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-count-up/`
- [x] Includes a `demo.html` — a self-contained working HTML demo
- [x] Includes a `style.css` — raw CSS for the proposed feature
- [x] Includes a `README.md` — answers: what it does, how to use it, why it is useful
- [x] No changes made to `core/`
- [x] No changes made to `components/`
- [x] One feature per PR (not multiple unrelated changes)
- [x] Demo works by opening `demo.html` directly in a browser (no server required)

---

## Feature Description

**What does this submission add?**

A count-up statistic card animation with configurable target values, suffixes, and easing.

**How does a developer use it?**

```html
<article class="count-card" data-target="95" data-suffix="%" data-ease="ease-out">
  <span class="count-label">Retention lift</span>
  <strong class="count-number"></strong>
</article>
```

**Why does it fit Flow CSS?**

It turns a common UI metric pattern into a reusable motion primitive while keeping the visual effect lightweight, readable, and easy for the maintainer to standardize into EaseMotion naming.

---

## Notes for Maintainer

The demo uses a tiny inline IntersectionObserver only to start the animation when the stat enters the viewport and to pass `data-target`/`data-suffix` into CSS-driven rendering. No external scripts, CDNs, or framework dependencies are used.
