### PR TITLE
feat: add smooth marquee submission

### DIFF
--- a/submissions/examples/smooth-marquee/README.md
+++ b/submissions/examples/smooth-marquee/README.md
@@ -1,0 +1,23 @@
+# Smooth Marquee
+
+**What does this do?**
+A seamless horizontal ticker loops duplicated content with a constant-speed CSS transform.
+
+**How is it used?**
+```html
+<div class="marquee-frame" style="--ease-marquee-speed: 22s;">
+  <div class="marquee-track">
+    <div class="marquee-group">
+      <span class="ticker-pill">Motion tokens</span>
+      <span class="ticker-pill">Hover pause</span>
+    </div>
+    <div class="marquee-group" aria-hidden="true">
+      <span class="ticker-pill">Motion tokens</span>
+      <span class="ticker-pill">Hover pause</span>
+    </div>
+  </div>
+</div>
+```
+
+**Why is it useful?**
+Marquees are useful for release notes, logo rows, and compact announcement bands, but they often jump at the loop boundary. This submission keeps the pattern small and CSS-only so EaseMotion CSS can expose a polished ticker primitive with configurable speed and pause-on-hover behavior.

--- a/submissions/examples/smooth-marquee/demo.html
+++ b/submissions/examples/smooth-marquee/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Smooth Marquee</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro-panel">
+      <p class="eyebrow">Continuous motion</p>
+      <h1>Smooth Infinite Marquee</h1>
+      <p>
+        A zero-JavaScript ticker that loops text, chips, or logo-like content
+        without a visible jump.
+      </p>
+    </section>
+
+    <section class="marquee-demo" aria-label="Product update ticker">
+      <div class="marquee-frame" style="--ease-marquee-speed: 22s;">
+        <div class="marquee-track">
+          <div class="marquee-group" aria-label="Latest release highlights">
+            <span class="ticker-pill">Motion tokens</span>
+            <span class="ticker-pill">Hover pause</span>
+            <span class="ticker-pill">No JavaScript</span>
+            <span class="ticker-pill">GPU friendly</span>
+            <span class="ticker-pill">Any content</span>
+          </div>
+          <div class="marquee-group" aria-hidden="true">
+            <span class="ticker-pill">Motion tokens</span>
+            <span class="ticker-pill">Hover pause</span>
+            <span class="ticker-pill">No JavaScript</span>
+            <span class="ticker-pill">GPU friendly</span>
+            <span class="ticker-pill">Any content</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="marquee-frame marquee-frame-dark" style="--ease-marquee-speed: 34s;">
+        <div class="marquee-track">
+          <div class="marquee-group" aria-label="Trusted by teams">
+            <span class="logo-tile">Northstar</span>
+            <span class="logo-tile">CanvasLab</span>
+            <span class="logo-tile">Orbit UI</span>
+            <span class="logo-tile">SignalDesk</span>
+          </div>
+          <div class="marquee-group" aria-hidden="true">
+            <span class="logo-tile">Northstar</span>
+            <span class="logo-tile">CanvasLab</span>
+            <span class="logo-tile">Orbit UI</span>
+            <span class="logo-tile">SignalDesk</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/smooth-marquee/style.css
+++ b/submissions/examples/smooth-marquee/style.css
@@ -1,0 +1,168 @@
+:root {
+  color-scheme: light;
+  --page-bg: #f5f7fb;
+  --ink: #182033;
+  --muted: #657086;
+  --panel: #ffffff;
+  --line: #dce3ee;
+  --green: #20a878;
+  --violet: #7657d6;
+  --navy: #151b2d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(130deg, rgba(32, 168, 120, 0.14), transparent 34rem),
+    linear-gradient(250deg, rgba(118, 87, 214, 0.12), transparent 28rem),
+    var(--page-bg);
+  color: var(--ink);
+}
+
+.demo-shell {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.intro-panel {
+  max-width: 700px;
+  margin-bottom: 44px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--green);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(2.4rem, 8vw, 5.25rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.intro-panel p:last-child {
+  max-width: 58ch;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.marquee-demo {
+  display: grid;
+  gap: 22px;
+}
+
+.marquee-frame {
+  --marquee-speed: var(--ease-marquee-speed, 28s);
+  --marquee-gap: 16px;
+
+  overflow: hidden;
+  padding: 18px 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 18px 50px rgba(24, 32, 51, 0.08);
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 9%, #000 91%, transparent);
+  mask-image: linear-gradient(90deg, transparent, #000 9%, #000 91%, transparent);
+}
+
+.marquee-frame:hover .marquee-track {
+  animation-play-state: paused;
+}
+
+.marquee-frame-dark {
+  --marquee-gap: 18px;
+
+  border-color: rgba(255, 255, 255, 0.12);
+  background: var(--navy);
+  box-shadow: 0 22px 70px rgba(21, 27, 45, 0.22);
+}
+
+.marquee-track {
+  width: max-content;
+  display: flex;
+  gap: 0;
+  will-change: transform;
+  animation: marquee-scroll var(--marquee-speed) linear infinite;
+}
+
+.marquee-group {
+  min-width: max-content;
+  display: flex;
+  gap: var(--marquee-gap);
+  padding-inline: calc(var(--marquee-gap) / 2);
+}
+
+.ticker-pill,
+.logo-tile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  border-radius: 999px;
+  white-space: nowrap;
+  font-weight: 800;
+}
+
+.ticker-pill {
+  min-width: 150px;
+  padding: 0 22px;
+  border: 1px solid color-mix(in srgb, var(--green), white 56%);
+  background: color-mix(in srgb, var(--green), white 88%);
+  color: #12684c;
+}
+
+.logo-tile {
+  min-width: 190px;
+  padding: 0 26px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+}
+
+@keyframes marquee-scroll {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@media (max-width: 680px) {
+  .demo-shell {
+    width: min(100% - 24px, 560px);
+    padding: 44px 0;
+  }
+
+  .marquee-frame {
+    --marquee-gap: 12px;
+  }
+
+  .ticker-pill {
+    min-width: 126px;
+    min-height: 44px;
+    padding: 0 16px;
+  }
+
+  .logo-tile {
+    min-width: 156px;
+    min-height: 44px;
+    padding: 0 18px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new `smooth-marquee` submission for #129: a pure CSS infinite horizontal ticker that uses duplicated content, constant-speed transform motion, hover pause, and a configurable speed custom property.

Closes #129

---

## Type of Change

- [x] New feature submission (inside `submissions/examples/`)
- [ ] Bug fix in an existing submission
- [ ] Documentation improvement
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/smooth-marquee/`
- [x] Includes a `demo.html` — a self-contained working HTML demo
- [x] Includes a `style.css` — raw CSS for the proposed feature
- [x] Includes a `README.md` — answers: what it does, how to use it, why it is useful
- [x] No changes made to `core/`
- [x] No changes made to `components/`
- [x] One feature per PR (not multiple unrelated changes)
- [x] Demo works by opening `demo.html` directly in a browser (no server required)

---

## Feature Description

**What does this submission add?**

A seamless marquee/ticker pattern for text chips or logo-style content.

**How does a developer use it?**

```html
<div class="marquee-frame" style="--ease-marquee-speed: 22s;">
  <div class="marquee-track">
    <div class="marquee-group">
      <span class="ticker-pill">Motion tokens</span>
      <span class="ticker-pill">Hover pause</span>
    </div>
    <div class="marquee-group" aria-hidden="true">
      <span class="ticker-pill">Motion tokens</span>
      <span class="ticker-pill">Hover pause</span>
    </div>
  </div>
</div>
```

**Why does it fit Flow CSS?**

It gives the framework a compact, reusable continuous-motion primitive for announcement rows, release notes, and logo strips while keeping the implementation CSS-only and easy to standardize.

---

## Notes for Maintainer

The track uses two identical groups and translates by `-50%` for a clean loop. Speed can be controlled through `--ease-marquee-speed`, and hovering pauses the animation.
