### PR TITLE
feat: add staggered reveal submission

### DIFF
--- a/submissions/examples/staggered-reveal/README.md
+++ b/submissions/examples/staggered-reveal/README.md
@@ -1,0 +1,16 @@
+# Staggered Reveal
+
+**What does this do?**
+Applies increasing animation delays to repeated child elements so they fade or slide into view one after another.
+
+**How is it used?**
+```html
+<ul class="stagger-list slide-up" style="--ease-stagger-step: 90ms;">
+  <li>Review contribution guide</li>
+  <li>Build the raw demo</li>
+  <li>Submit for review</li>
+</ul>
+```
+
+**Why is it useful?**
+Staggered entrances make dense lists and card grids easier to scan without requiring JavaScript or per-item inline delays. The pattern fits EaseMotion CSS because the maintainer can pair the parent delay utility with existing entrance classes while preserving a small CSS API.

--- a/submissions/examples/staggered-reveal/demo.html
+++ b/submissions/examples/staggered-reveal/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Staggered Reveal</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro-panel">
+      <p class="eyebrow">Sequential entrance</p>
+      <h1>Staggered List Reveal</h1>
+      <p>
+        A parent utility assigns increasing delays to repeated children, so
+        lists and card groups can enter with a calm sequence.
+      </p>
+    </section>
+
+    <section class="demo-grid">
+      <article class="demo-panel">
+        <h2>Task Checklist</h2>
+        <ul class="stagger-list slide-up" style="--ease-stagger-step: 90ms;">
+          <li>Review contribution guide</li>
+          <li>Keep one focused feature</li>
+          <li>Build the raw demo</li>
+          <li>Validate browser behavior</li>
+          <li>Submit for maintainer review</li>
+        </ul>
+      </article>
+
+      <article class="demo-panel">
+        <h2>Launch Cards</h2>
+        <div class="stagger-list fade-in card-stack" style="--ease-stagger-step: 130ms;">
+          <div class="mini-card">Design tokens</div>
+          <div class="mini-card">Motion classes</div>
+          <div class="mini-card">Accessible states</div>
+          <div class="mini-card">Tiny CSS surface</div>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/staggered-reveal/style.css
+++ b/submissions/examples/staggered-reveal/style.css
@@ -1,0 +1,230 @@
+:root {
+  color-scheme: light;
+  --page-bg: #f4f7f9;
+  --panel-bg: #ffffff;
+  --ink: #182033;
+  --muted: #657086;
+  --line: #dce3ea;
+  --green: #1aa875;
+  --blue: #3478f6;
+  --rose: #d94f70;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(135deg, rgba(26, 168, 117, 0.14), transparent 32rem),
+    linear-gradient(245deg, rgba(52, 120, 246, 0.12), transparent 28rem),
+    var(--page-bg);
+  color: var(--ink);
+}
+
+.demo-shell {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.intro-panel {
+  max-width: 720px;
+  margin-bottom: 42px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--green);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(2.4rem, 8vw, 5.25rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.intro-panel p {
+  max-width: 58ch;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.demo-panel {
+  min-height: 420px;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  box-shadow: 0 18px 54px rgba(24, 32, 51, 0.08);
+}
+
+.demo-panel h2 {
+  margin-bottom: 22px;
+  font-size: 1.35rem;
+}
+
+.stagger-list {
+  --ease-stagger-step: 100ms;
+
+  display: grid;
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stagger-list > * {
+  --stagger-index: 0;
+
+  opacity: 0;
+  animation-delay: calc(var(--stagger-index) * var(--ease-stagger-step));
+  animation-duration: 680ms;
+  animation-timing-function: cubic-bezier(0.21, 0.78, 0.24, 1);
+  animation-fill-mode: both;
+}
+
+.stagger-list > :nth-child(1) {
+  --stagger-index: 0;
+}
+
+.stagger-list > :nth-child(2) {
+  --stagger-index: 1;
+}
+
+.stagger-list > :nth-child(3) {
+  --stagger-index: 2;
+}
+
+.stagger-list > :nth-child(4) {
+  --stagger-index: 3;
+}
+
+.stagger-list > :nth-child(5) {
+  --stagger-index: 4;
+}
+
+.stagger-list > :nth-child(6) {
+  --stagger-index: 5;
+}
+
+.stagger-list > :nth-child(7) {
+  --stagger-index: 6;
+}
+
+.stagger-list > :nth-child(8) {
+  --stagger-index: 7;
+}
+
+.stagger-list > :nth-child(9) {
+  --stagger-index: 8;
+}
+
+.stagger-list > :nth-child(10) {
+  --stagger-index: 9;
+}
+
+.slide-up > * {
+  animation-name: stagger-slide-up;
+}
+
+.fade-in > * {
+  animation-name: stagger-fade-in;
+}
+
+.stagger-list li,
+.mini-card {
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcfe;
+  color: var(--ink);
+  font-weight: 760;
+}
+
+.stagger-list li {
+  padding: 0 18px;
+  border-left: 4px solid var(--green);
+}
+
+.card-stack {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.mini-card {
+  min-height: 132px;
+  justify-content: center;
+  padding: 18px;
+  text-align: center;
+  border-color: color-mix(in srgb, var(--blue), white 66%);
+  background: linear-gradient(180deg, #ffffff, color-mix(in srgb, var(--blue), white 93%));
+}
+
+.mini-card:nth-child(even) {
+  border-color: color-mix(in srgb, var(--rose), white 66%);
+  background: linear-gradient(180deg, #ffffff, color-mix(in srgb, var(--rose), white 93%));
+}
+
+@keyframes stagger-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes stagger-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 760px) {
+  .demo-shell {
+    width: min(100% - 24px, 560px);
+    padding: 44px 0;
+  }
+
+  .demo-grid,
+  .card-stack {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-panel {
+    min-height: auto;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new `staggered-reveal` submission for #127: a CSS-only parent utility that assigns increasing delays to direct children using custom properties and `:nth-child()` selectors.

Closes #127

---

## Type of Change

- [x] New feature submission (inside `submissions/examples/`)
- [ ] Bug fix in an existing submission
- [ ] Documentation improvement
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/staggered-reveal/`
- [x] Includes a `demo.html` — a self-contained working HTML demo
- [x] Includes a `style.css` — raw CSS for the proposed feature
- [x] Includes a `README.md` — answers: what it does, how to use it, why it is useful
- [x] No changes made to `core/`
- [x] No changes made to `components/`
- [x] One feature per PR (not multiple unrelated changes)
- [x] Demo works by opening `demo.html` directly in a browser (no server required)

---

## Feature Description

**What does this submission add?**

A staggered entrance pattern for repeated children in lists and card groups.

**How does a developer use it?**

```html
<ul class="stagger-list slide-up" style="--ease-stagger-step: 90ms;">
  <li>Review contribution guide</li>
  <li>Build the raw demo</li>
  <li>Submit for review</li>
</ul>
```

**Why does it fit Flow CSS?**

It gives repeated content a readable sequence while staying CSS-only, configurable, and easy for the maintainer to standardize with existing entrance classes.

---

## Notes for Maintainer

The CSS supports up to 10 direct children with automatic delays, uses `--ease-stagger-step` for delay spacing, and includes both `ul > li` and `div > div` examples.
