### PR TITLE
feat: add blur card exit submission

### DIFF
--- a/submissions/examples/blur-card-exit/README.md
+++ b/submissions/examples/blur-card-exit/README.md
@@ -1,0 +1,16 @@
+# Blur Card Exit
+
+**What does this do?**
+A card dismisses with opacity, blur, scale, and downward motion to create a soft exit state.
+
+**How is it used?**
+```html
+<article class="blur-card">
+  <span class="status-pill">Review ready</span>
+  <h2>Motion token audit</h2>
+  <p>This card can exit with the blur-card-exit keyframe.</p>
+</article>
+```
+
+**Why is it useful?**
+Exit animations help users understand that an item was dismissed or removed instead of simply disappearing. This version stays pure CSS and focused on a single card pattern, making it straightforward for EaseMotion CSS to standardize as a reusable exit utility.

--- a/submissions/examples/blur-card-exit/demo.html
+++ b/submissions/examples/blur-card-exit/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Blur Card Exit</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro-panel">
+      <p class="eyebrow">Exit motion</p>
+      <h1>Blur Card Exit</h1>
+      <p>
+        A card exits by softening, blurring, and shrinking away from focus,
+        useful for dismissed notifications or removed dashboard items.
+      </p>
+    </section>
+
+    <section class="demo-panel" aria-label="Blur card exit demo">
+      <input class="exit-toggle" type="checkbox" id="exit-demo" />
+      <div class="toolbar">
+        <label class="toggle-button" for="exit-demo">
+          <span class="show-text">Dismiss card</span>
+          <span class="reset-text">Reset card</span>
+        </label>
+      </div>
+
+      <div class="card-stage">
+        <article class="blur-card">
+          <span class="status-pill">Review ready</span>
+          <h2>Motion token audit</h2>
+          <p>
+            This item demonstrates a pure CSS exit state with blur, opacity,
+            scale, and vertical drift.
+          </p>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/blur-card-exit/style.css
+++ b/submissions/examples/blur-card-exit/style.css
@@ -1,0 +1,235 @@
+:root {
+  color-scheme: light;
+  --page-bg: #f5f7fb;
+  --panel-bg: #ffffff;
+  --ink: #182033;
+  --muted: #657086;
+  --line: #dce3ea;
+  --green: #1fa875;
+  --blue: #366ff2;
+  --rose: #d94f70;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(140deg, rgba(31, 168, 117, 0.14), transparent 31rem),
+    linear-gradient(240deg, rgba(217, 79, 112, 0.12), transparent 28rem),
+    var(--page-bg);
+  color: var(--ink);
+}
+
+.demo-shell {
+  width: min(1040px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.intro-panel {
+  max-width: 720px;
+  margin-bottom: 40px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--green);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(2.4rem, 8vw, 5.25rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.intro-panel p {
+  max-width: 58ch;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.demo-panel {
+  min-height: 420px;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  box-shadow: 0 18px 54px rgba(24, 32, 51, 0.08);
+}
+
+.exit-toggle {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 28px;
+}
+
+.toggle-button {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 18px;
+  border: 1px solid color-mix(in srgb, var(--rose), white 45%);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--rose), white 88%);
+  color: #8f2540;
+  font-weight: 800;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease;
+}
+
+.toggle-button:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--rose), white 82%);
+  border-color: color-mix(in srgb, var(--rose), white 30%);
+}
+
+.reset-text {
+  display: none;
+}
+
+.exit-toggle:checked + .toolbar .show-text {
+  display: none;
+}
+
+.exit-toggle:checked + .toolbar .reset-text {
+  display: inline;
+}
+
+.card-stage {
+  min-height: 260px;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  background: #fbfcfe;
+}
+
+.blur-card {
+  width: min(100%, 480px);
+  padding: 28px;
+  border: 1px solid color-mix(in srgb, var(--blue), white 66%);
+  border-radius: 8px;
+  background: linear-gradient(180deg, #ffffff, color-mix(in srgb, var(--blue), white 94%));
+  box-shadow: 0 20px 55px rgba(24, 32, 51, 0.12);
+  transform-origin: center top;
+  will-change: transform, opacity, filter;
+}
+
+.status-pill {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--green), white 86%);
+  color: #116948;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.blur-card h2 {
+  margin: 18px 0 10px;
+  font-size: 1.8rem;
+}
+
+.blur-card p {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.exit-toggle:checked ~ .card-stage .blur-card {
+  animation: blur-card-exit 720ms cubic-bezier(0.22, 0.72, 0.22, 1) forwards;
+  pointer-events: none;
+}
+
+.exit-toggle:not(:checked) ~ .card-stage .blur-card {
+  animation: blur-card-enter 460ms cubic-bezier(0.22, 0.72, 0.22, 1) both;
+}
+
+@keyframes blur-card-exit {
+  0% {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0) scale(1);
+  }
+
+  55% {
+    opacity: 0.62;
+    filter: blur(4px);
+    transform: translateY(10px) scale(0.97);
+  }
+
+  100% {
+    opacity: 0;
+    filter: blur(14px);
+    transform: translateY(28px) scale(0.9);
+  }
+}
+
+@keyframes blur-card-enter {
+  from {
+    opacity: 0;
+    filter: blur(10px);
+    transform: translateY(18px) scale(0.94);
+  }
+
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 680px) {
+  .demo-shell {
+    width: min(100% - 24px, 560px);
+    padding: 44px 0;
+  }
+
+  .demo-panel {
+    padding: 18px;
+  }
+
+  .toolbar {
+    justify-content: stretch;
+  }
+
+  .toggle-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new `blur-card-exit` submission for #117: a pure CSS card dismissal animation that combines blur, opacity, scale, and downward motion. The demo uses a checkbox state so the exit interaction works directly in the browser without JavaScript.

Closes #117

---

## Type of Change

- [x] New feature submission (inside `submissions/examples/`)
- [ ] Bug fix in an existing submission
- [ ] Documentation improvement
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/blur-card-exit/`
- [x] Includes a `demo.html` — a self-contained working HTML demo
- [x] Includes a `style.css` — raw CSS for the proposed feature
- [x] Includes a `README.md` — answers: what it does, how to use it, why it is useful
- [x] No changes made to `core/`
- [x] No changes made to `components/`
- [x] One feature per PR (not multiple unrelated changes)
- [x] Demo works by opening `demo.html` directly in a browser (no server required)

---

## Feature Description

**What does this submission add?**

A soft card exit animation for dismissed cards and notification-style UI.

**How does a developer use it?**

```html
<article class="blur-card">
  <span class="status-pill">Review ready</span>
  <h2>Motion token audit</h2>
  <p>This card can exit with the blur-card-exit keyframe.</p>
</article>
```

**Why does it fit Flow CSS?**

It covers a common exit interaction with a lightweight CSS-only effect that can be standardized into the framework without adding runtime dependencies.

---

## Notes for Maintainer

The demo uses a hidden checkbox only to toggle the exit state in static HTML. The animation itself is pure CSS and does not need JavaScript.
