### PR TITLE
feat: add shake text emphasis submission

### DIFF
--- a/submissions/examples/ease-shake-text/README.md
+++ b/submissions/examples/ease-shake-text/README.md
@@ -1,0 +1,14 @@
+# Shake Text Emphasis
+
+**What does this do?**
+Adds a CSS-only shake animation for short text elements that need a brief attention cue during hover or focus interactions.
+
+**How is it used?**
+```html
+<button class="shake-text" style="--shake-distance: 5px; --shake-duration: 360ms;">
+  Username already taken
+</button>
+```
+
+**Why is it useful?**
+Shake motion is a familiar pattern for validation messages, warning labels, counters, and inline reminders. This fits EaseMotion CSS because it is small, readable, dependency-free, transform-based, and easy for the maintainer to standardize into a configurable text-emphasis utility.

--- a/submissions/examples/ease-shake-text/demo.html
+++ b/submissions/examples/ease-shake-text/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Shake Text Emphasis</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro">
+      <p class="eyebrow">Micro text emphasis</p>
+      <h1>Shake Text Emphasis</h1>
+      <p>
+        A lightweight CSS-only emphasis effect for labels, warnings, counters,
+        and short inline messages that need a quick attention cue.
+      </p>
+    </section>
+
+    <section class="demo-list" aria-label="Shake text emphasis examples">
+      <article class="demo-row">
+        <p class="row-label">Gentle validation cue</p>
+        <button class="shake-text" type="button">
+          Username already taken
+        </button>
+      </article>
+
+      <article class="demo-row">
+        <p class="row-label">Stronger alert message</p>
+        <button
+          class="shake-text shake-text-alert"
+          type="button"
+          style="--shake-distance: 7px; --shake-duration: 420ms; --shake-accent: #f97316;"
+        >
+          Payment method expired
+        </button>
+      </article>
+
+      <article class="demo-row">
+        <p class="row-label">Tiny inline nudge</p>
+        <button
+          class="shake-text shake-text-soft"
+          type="button"
+          style="--shake-distance: 3px; --shake-duration: 520ms; --shake-accent: #38bdf8;"
+        >
+          Review required fields
+        </button>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-shake-text/style.css
+++ b/submissions/examples/ease-shake-text/style.css
@@ -1,0 +1,183 @@
+:root {
+  color-scheme: light dark;
+  --page-bg: #10131a;
+  --surface: #171c27;
+  --surface-strong: #202737;
+  --ink: #f8fafc;
+  --muted: #a8b0c2;
+  --shake-accent: #ef4444;
+  --shake-distance: 5px;
+  --shake-duration: 360ms;
+  --shake-count: 1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(140deg, rgba(239, 68, 68, 0.15), transparent 34rem),
+    linear-gradient(320deg, rgba(56, 189, 248, 0.12), transparent 34rem),
+    var(--page-bg);
+  color: var(--ink);
+}
+
+.demo-shell {
+  width: min(980px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.intro {
+  max-width: 680px;
+  margin-bottom: 38px;
+}
+
+.eyebrow,
+.row-label {
+  margin: 0 0 10px;
+  color: var(--shake-accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 10ch;
+  margin-bottom: 18px;
+  font-size: clamp(2.35rem, 8vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.intro p:not(.eyebrow) {
+  max-width: 58ch;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo-list {
+  display: grid;
+  gap: 18px;
+}
+
+.demo-row {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.38fr) minmax(0, 1fr);
+  gap: 20px;
+  align-items: center;
+  min-height: 112px;
+  padding: 22px;
+  border: 1px solid rgba(248, 250, 252, 0.09);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface), transparent 6%);
+  box-shadow: 0 24px 60px rgba(3, 7, 18, 0.28);
+}
+
+.row-label {
+  margin-bottom: 0;
+}
+
+.shake-text {
+  justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  min-height: 48px;
+  max-width: 100%;
+  padding: 0 18px;
+  border: 1px solid color-mix(in srgb, var(--shake-accent), white 24%);
+  border-radius: 999px;
+  background: var(--surface-strong);
+  color: var(--ink);
+  font: inherit;
+  font-size: clamp(1rem, 2vw, 1.18rem);
+  font-weight: 800;
+  letter-spacing: 0;
+  text-align: left;
+  transform: translateX(0);
+  transform-origin: center;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.shake-text:hover,
+.shake-text:focus-visible {
+  color: color-mix(in srgb, var(--shake-accent), white 72%);
+  animation: shake-text-emphasis var(--shake-duration) cubic-bezier(0.36, 0, 0.66, -0.56) var(--shake-count);
+}
+
+.shake-text:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--shake-accent), white 20%);
+  outline-offset: 4px;
+}
+
+.shake-text-alert {
+  --shake-count: 2;
+  background: color-mix(in srgb, var(--shake-accent), #111827 82%);
+}
+
+.shake-text-soft {
+  background: #111827;
+}
+
+@keyframes shake-text-emphasis {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  18% {
+    transform: translateX(calc(var(--shake-distance) * -1));
+  }
+
+  36% {
+    transform: translateX(var(--shake-distance));
+  }
+
+  54% {
+    transform: translateX(calc(var(--shake-distance) * -0.62));
+  }
+
+  72% {
+    transform: translateX(calc(var(--shake-distance) * 0.62));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shake-text:hover,
+  .shake-text:focus-visible {
+    animation: none;
+    color: color-mix(in srgb, var(--shake-accent), white 72%);
+  }
+}
+
+@media (max-width: 680px) {
+  .demo-shell {
+    width: min(100% - 24px, 520px);
+    padding: 44px 0;
+  }
+
+  .demo-row {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    min-height: 0;
+  }
+
+  .shake-text {
+    justify-self: stretch;
+    justify-content: center;
+    white-space: normal;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS-only shake text emphasis submission for #103. The demo shows validation, alert, and inline nudge variants using transform-based motion, focus-visible support, configurable distance/duration/count variables, and a reduced-motion fallback.

Fixes #103

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-shake-text/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A reusable text shake emphasis effect for validation messages, warning labels, counters, and short inline reminders.

**How does a developer use it?**

```html
<button class="shake-text" style="--shake-distance: 5px; --shake-duration: 360ms;">
  Username already taken
</button>
```

**Why does it fit EaseMotion CSS?**

It is a compact, human-readable motion utility that uses transform-only CSS, no JavaScript, and clear custom properties the maintainer can standardize into the framework.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

I kept the PR scoped to one raw submission folder only. Validated with HTML parsing, exact folder file check, no external scripts/CDNs/imports, and `git diff --check`.
