### PR TITLE
feat: add shake shadow entrance submission

### DIFF
--- a/submissions/examples/shake-shadow-entrance/README.md
+++ b/submissions/examples/shake-shadow-entrance/README.md
@@ -1,0 +1,15 @@
+# Shake Shadow Entrance
+
+**What does this do?**
+Adds an entrance animation where the element settles in while its shadow briefly shakes from side to side.
+
+**How is it used?**
+```html
+<article class="shadow-shake-card" style="--shake-distance: 12px; --shadow-strength: 34px;">
+  <h2>New lesson unlocked</h2>
+  <p>The card arrives with a tactile shadow shake.</p>
+</article>
+```
+
+**Why is it useful?**
+Shadow movement gives new cards, alerts, and calls to action a noticeable entrance without shaking the text itself, which keeps the content readable and fits EaseMotion CSS's lightweight animation philosophy.

--- a/submissions/examples/shake-shadow-entrance/demo.html
+++ b/submissions/examples/shake-shadow-entrance/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Shake Shadow Entrance</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro">
+      <p class="eyebrow">Entrance utility</p>
+      <h1>Shake Shadow Entrance</h1>
+      <p>
+        A crisp entrance effect where the element settles in place while its
+        shadow briefly shakes, giving cards and actions a tactile arrival.
+      </p>
+    </section>
+
+    <section class="showcase" aria-label="Shake shadow entrance examples">
+      <article
+        class="shadow-shake-card"
+        style="--shake-distance: 12px; --shadow-strength: 34px; --entrance-speed: 880ms;"
+      >
+        <span class="badge">Card</span>
+        <h2>New lesson unlocked</h2>
+        <p>
+          The card stays readable while the shadow does the motion work,
+          keeping the entrance noticeable without feeling jumpy.
+        </p>
+      </article>
+
+      <article
+        class="shadow-shake-card calm"
+        style="--shake-distance: 7px; --shadow-strength: 24px; --entrance-speed: 720ms;"
+      >
+        <span class="badge">Subtle</span>
+        <h2>Status updated</h2>
+        <p>
+          Smaller variables create a calmer version for compact surfaces,
+          success messages, and secondary notifications.
+        </p>
+      </article>
+
+      <button
+        class="shadow-shake-action"
+        type="button"
+        style="--shake-distance: 9px; --shadow-strength: 28px; --entrance-speed: 760ms;"
+      >
+        Review Changes
+      </button>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/shake-shadow-entrance/style.css
+++ b/submissions/examples/shake-shadow-entrance/style.css
@@ -1,0 +1,207 @@
+:root {
+  color-scheme: light dark;
+  --page-bg: #f5f7fb;
+  --panel-bg: #ffffff;
+  --panel-bg-dark: #151924;
+  --ink: #111827;
+  --ink-dark: #f8fafc;
+  --muted: #5b6472;
+  --muted-dark: #aeb8c8;
+  --accent: #2563eb;
+  --accent-strong: #7c3aed;
+  --shadow-rgb: 37, 99, 235;
+  --shake-distance: 10px;
+  --shadow-strength: 30px;
+  --entrance-speed: 820ms;
+  --entrance-ease: cubic-bezier(0.2, 0.85, 0.22, 1.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.1), transparent 34%),
+    linear-gradient(315deg, rgba(124, 58, 237, 0.12), transparent 36%),
+    var(--page-bg);
+  color: var(--ink);
+}
+
+.demo-shell {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.intro {
+  max-width: 720px;
+  margin-bottom: 40px;
+}
+
+.eyebrow,
+.badge {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(2.4rem, 8vw, 5.1rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.intro p,
+.shadow-shake-card p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.intro p {
+  max-width: 58ch;
+  margin-bottom: 0;
+  font-size: 1.06rem;
+}
+
+.showcase {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+  align-items: stretch;
+}
+
+.shadow-shake-card,
+.shadow-shake-action {
+  animation: shadow-shake-entrance var(--entrance-speed) var(--entrance-ease) both;
+}
+
+.shadow-shake-card {
+  min-height: 260px;
+  padding: 30px;
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 20px;
+  background: var(--panel-bg);
+  box-shadow: 0 16px var(--shadow-strength) rgba(var(--shadow-rgb), 0.16);
+}
+
+.shadow-shake-card:nth-child(2) {
+  animation-delay: 140ms;
+}
+
+.shadow-shake-card.calm {
+  --shadow-rgb: 124, 58, 237;
+}
+
+.shadow-shake-card h2 {
+  margin-bottom: 12px;
+  font-size: clamp(1.45rem, 4vw, 2.25rem);
+  line-height: 1.05;
+}
+
+.shadow-shake-card p {
+  margin-bottom: 0;
+}
+
+.shadow-shake-action {
+  grid-column: 1 / -1;
+  justify-self: start;
+  min-height: 52px;
+  padding: 0 24px;
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  box-shadow: 0 14px var(--shadow-strength) rgba(var(--shadow-rgb), 0.22);
+  animation-delay: 280ms;
+}
+
+.shadow-shake-action:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 4px;
+}
+
+@keyframes shadow-shake-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+    box-shadow: calc(var(--shake-distance) * -1) 24px var(--shadow-strength) rgba(var(--shadow-rgb), 0);
+  }
+
+  34% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    box-shadow: var(--shake-distance) 18px var(--shadow-strength) rgba(var(--shadow-rgb), 0.28);
+  }
+
+  52% {
+    box-shadow: calc(var(--shake-distance) * -0.65) 16px var(--shadow-strength) rgba(var(--shadow-rgb), 0.24);
+  }
+
+  70% {
+    box-shadow: calc(var(--shake-distance) * 0.38) 15px var(--shadow-strength) rgba(var(--shadow-rgb), 0.2);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    box-shadow: 0 16px var(--shadow-strength) rgba(var(--shadow-rgb), 0.16);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background:
+      linear-gradient(135deg, rgba(37, 99, 235, 0.16), transparent 34%),
+      linear-gradient(315deg, rgba(124, 58, 237, 0.16), transparent 36%),
+      #0d111b;
+    color: var(--ink-dark);
+  }
+
+  .intro p,
+  .shadow-shake-card p {
+    color: var(--muted-dark);
+  }
+
+  .shadow-shake-card {
+    border-color: rgba(148, 163, 184, 0.16);
+    background: var(--panel-bg-dark);
+  }
+}
+
+@media (max-width: 720px) {
+  .demo-shell {
+    padding: 42px 0;
+  }
+
+  .showcase {
+    grid-template-columns: 1fr;
+  }
+
+  .shadow-shake-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shadow-shake-card,
+  .shadow-shake-action {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What changed\n- Added a pure CSS Shake Shadow Entrance submission under `submissions/examples/shake-shadow-entrance/`.\n- Included a self-contained demo with card and button examples.\n- Added configurable CSS variables for shake distance, shadow strength, and entrance speed.\n- Included a reduced-motion fallback.\n\n## Why\nCloses #116. This gives EaseMotion CSS a tactile entrance idea where the shadow carries the shake motion while the content remains readable.\n\n## How to test\n- Open `submissions/examples/shake-shadow-entrance/demo.html` directly in a browser.\n- Confirm the cards and action button enter with a short shadow shake.\n- Confirm no JavaScript or external assets are required.\n\n## Validation\n- Confirmed the submission folder contains exactly `README.md`, `demo.html`, and `style.css`.\n- Parsed `demo.html` with Python `HTMLParser`.\n- Checked CSS brace balance.\n- Verified no external HTTP links, scripts, CDNs, or imports.\n- `git diff --cached --check` passed before commit.