### PR TITLE
feat: Add Expand Image Hover Animation Utility

### DIFF
--- a/submissions/examples/expand-image-hover/README.md
+++ b/submissions/examples/expand-image-hover/README.md
@@ -1,0 +1,34 @@
+# Expand Image Hover
+
+A smooth CSS animation utility that gently expands 
+an image on hover for a polished interactive effect.
+
+## Usage
+
+```html
+<div class="ease-expand-image">
+  <img src="your-image.jpg" alt="description"/>
+</div>
+` ``
+
+## Features
+- Pure CSS, no JavaScript
+- Works across Chrome, Firefox, Safari, Edge
+- Follows EaseMotion CSS naming conventions
+- Smooth scale transition on hover
+- Demo included
+```
+
+---
+
+**Step 4 — Commit aur push karo:**
+
+```bash
+git add .
+git commit -m "feat: add expand-image-hover animation utility (#120)"
+git push origin animation/expand-image-hover-120
+```
+
+---
+
+**Step 5 — PR banao:**

--- a/submissions/examples/expand-image-hover/demo.html
+++ b/submissions/examples/expand-image-hover/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Expand Image Hover - EaseMotion</title>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body style="display:flex; justify-content:center;
+             align-items:center; height:100vh;
+             background:#f8f8f8; font-family:sans-serif;">
+
+  <div class="ease-expand-image" style="width:300px;">
+    <img src="https://picsum.photos/300/200" alt="Hover me!"/>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/expand-image-hover/style.css
+++ b/submissions/examples/expand-image-hover/style.css
@@ -1,0 +1,23 @@
+@keyframes expandImage {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.08); }
+  100% { transform: scale(1.05); }
+}
+
+.ease-expand-image {
+  overflow: hidden;
+  border-radius: 8px;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.ease-expand-image img {
+  transition: transform 0.4s ease;
+  display: block;
+  width: 100%;
+}
+
+.ease-expand-image:hover img {
+  animation: expandImage 0.4s ease-in-out forwards;
+  transform: scale(1.05);
+}


### PR DESCRIPTION

Closes #120

Added a new CSS animation utility — Expand Image Hover — 
to the EaseMotion library.

## Files Added
- submissions/examples/expand-image-hover/style.css
- submissions/examples/expand-image-hover/demo.html
- submissions/examples/expand-image-hover/README.md

## What it does
Adds a smooth expand/scale effect to images on hover 
using pure CSS transitions and @keyframes animation.

## Checklist
- [x] Pure CSS, no JavaScript
- [x] Works across Chrome, Firefox, Safari, Edge
- [x] Follows EaseMotion CSS naming conventions
- [x] Demo included
- [x] README included