### PR TITLE
feat(a11y): audit prefers-reduced-motion overrides (#354)

### DIFF
--- a/submissions/examples/reduced-motion-audit/README.md
+++ b/submissions/examples/reduced-motion-audit/README.md
@@ -1,0 +1,11 @@
+# Prefers Reduced Motion Audit
+
+### What does this do?
+This submission provides explicit, targeted `@media (prefers-reduced-motion: reduce)` overrides for all motion-heavy animation and hover classes in `core/animations.css`, replacing the global `*` wildcard override.
+
+### How is it used?
+The maintainer should replace the wildcard rule (lines 634-643 in `core/animations.css`) with the contents of `style.css`.
+The provided `demo.html` includes a Javascript toggle to easily emulate the media query so the maintainer can test the fallbacks instantly in the browser.
+
+### Why is it useful?
+Using `*` to force `animation-duration: 0.01ms` is an accessibility anti-pattern because it kills *all* transitions on a webpage, including harmless color/opacity transitions. This submission ensures that `EaseMotion CSS` respects the user's OS settings by stripping nausea-inducing motion (`transform`, `translate`, `scale`) while elegantly falling back to opacity fades (`ease-kf-fade-in` / `ease-kf-fade-out`) where applicable. This provides a vastly superior user experience for those with motion sensitivity.

--- a/submissions/examples/reduced-motion-audit/demo.html
+++ b/submissions/examples/reduced-motion-audit/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Prefers Reduced Motion Audit Demo</title>
+  
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/animations.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  <link rel="stylesheet" href="../../../components/cards.css" />
+  
+  <!-- The proposed overrides -->
+  <link rel="stylesheet" href="style.css" id="audit-styles" />
+
+  <style>
+    body { padding: var(--ease-space-8); background: var(--ease-color-surface); color: var(--ease-color-neutral-900); }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: var(--ease-space-6); margin-top: var(--ease-space-8); }
+    .demo-box { height: 100px; background: var(--ease-color-primary); border-radius: var(--ease-radius-md); display: flex; align-items: center; justify-content: center; color: white; font-weight: bold; }
+    
+    /* Emulate prefers-reduced-motion via a parent class for testing purposes */
+    .emulate-reduced-motion .ease-slide-up,
+    .emulate-reduced-motion .ease-slide-in-left { animation-name: ease-kf-fade-in !important; }
+    .emulate-reduced-motion .ease-bounce { animation: none !important; }
+    .emulate-reduced-motion .ease-hover-grow { transform: none !important; }
+  </style>
+</head>
+<body>
+
+  <h1>Reduced Motion Accessibility Audit</h1>
+  <p class="ease-text-muted ease-mb-6">
+    Click the button below to toggle specific overrides on and off. When "Reduced Motion" is enabled, entrance animations (slide-up) gracefully fall back to opacity fades instead of being entirely cancelled, and looping animations (bounce) freeze in place.
+  </p>
+
+  <button id="toggleMotionBtn" class="ease-btn ease-btn-primary">Emulate Reduced Motion: OFF</button>
+
+  <div class="demo-grid" id="demoContainer">
+    
+    <div>
+      <h3 class="ease-text-lg ease-mb-2">Entrance (ease-slide-up)</h3>
+      <div class="demo-box ease-slide-up" id="box1" style="animation-iteration-count: infinite;">Slide Up (repeating)</div>
+    </div>
+
+    <div>
+      <h3 class="ease-text-lg ease-mb-2">Loop (ease-bounce)</h3>
+      <div class="demo-box ease-bounce">Bounce</div>
+    </div>
+
+    <div>
+      <h3 class="ease-text-lg ease-mb-2">Hover (ease-hover-grow)</h3>
+      <div class="demo-box ease-hover-grow">Hover Me</div>
+    </div>
+
+  </div>
+
+  <script>
+    const btn = document.getElementById('toggleMotionBtn');
+    const container = document.getElementById('demoContainer');
+    let isReduced = false;
+
+    btn.addEventListener('click', () => {
+      isReduced = !isReduced;
+      if (isReduced) {
+        container.classList.add('emulate-reduced-motion');
+        btn.textContent = 'Emulate Reduced Motion: ON';
+        btn.classList.replace('ease-btn-primary', 'ease-btn-success');
+      } else {
+        container.classList.remove('emulate-reduced-motion');
+        btn.textContent = 'Emulate Reduced Motion: OFF';
+        btn.classList.replace('ease-btn-success', 'ease-btn-primary');
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/reduced-motion-audit/style.css
+++ b/submissions/examples/reduced-motion-audit/style.css
@@ -1,0 +1,55 @@
+/* 
+  Targeted reduced motion overrides to replace the global wildcard in core/animations.css.
+  This allows safe transitions (like color/opacity) to persist while disabling nausea-inducing motion (transforms).
+*/
+
+@media (prefers-reduced-motion: reduce) {
+  
+  /* ── 1. IMPORTANT: Delete the Global Wildcard ── 
+     The maintainer MUST delete the `*, *::before, *::after` rule 
+     (lines 634-643 in core/animations.css) when integrating this code. 
+     You cannot override an !important wildcard without breaking specificity. 
+  */
+
+  /* ── 2. Convert Motion Exits to Fade Outs ── */
+  .ease-shake-card-exit,
+  .ease-bounce-button-exit,
+  .ease-fade-icon-exit,
+  .ease-scale-text-exit,
+  .ease-slide-image-exit,
+  .ease-rotate-image-exit,
+  .ease-expand-border-exit,
+  .ease-contract-bg-exit {
+    animation-name: ease-kf-fade-out !important;
+  }
+
+  /* ── 3. Convert Motion Entrances to Fade Ins ── */
+  .ease-slide-up,
+  .ease-slide-down,
+  .ease-slide-in-left,
+  .ease-slide-in-right,
+  .ease-zoom-in,
+  .ease-flip,
+  .ease-contract-image-entrance {
+    animation-name: ease-kf-fade-in !important;
+  }
+
+  /* ── 4. Halt Infinite Motion Loops ── */
+  .ease-bounce,
+  .ease-rotate,
+  .ease-ping,
+  .ease-shake,
+  .ease-shimmer-sweep,
+  .ease-gradient-rotation {
+    animation: none !important;
+  }
+
+  /* ── 5. Strip Transforms from Hover Transitions ── */
+  .ease-hover-grow,
+  .ease-hover-shrink,
+  .ease-hover-lift,
+  .ease-card-lift,
+  .ease-squish-button {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves Issue #354. 

This submission audits all animation and hover classes in `core/animations.css` and provides targeted `@media (prefers-reduced-motion: reduce)` overrides to replace the global `*` brute-force wildcard.

This allows safe transitions (like color/opacity) to persist while gracefully degrading nausea-inducing motion (`transform`, `translate`, `scale`). For example, `ease-slide-up` gracefully falls back to `ease-kf-fade-in` rather than snapping abruptly.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Targeted accessibility overrides for motion-heavy classes, replacing the global `*` wildcard.

**How does a developer use it?**

The maintainer should replace lines 634-643 in `core/animations.css` with the contents of `style.css`.

**Why does it fit EaseMotion CSS?**

Using a global `*` wildcard to kill all transitions (`0.01ms`) is an accessibility anti-pattern because it kills harmless color and opacity transitions. This submission ensures the framework elegantly respects OS settings while maintaining a premium feel.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

I included a Javascript toggle in `demo.html` that artificially adds a parent class to emulate `prefers-reduced-motion` directly in the browser. This allows you to easily test the fallbacks locally without having to dive into your OS settings!