### PR TITLE
Add bordered card variant submission

### DIFF
--- a/submissions/examples/bordered-card-variant/README.md
+++ b/submissions/examples/bordered-card-variant/README.md
@@ -1,0 +1,15 @@
+# Bordered Card Variant
+
+1. **What does this do?**  
+   Adds a bordered card variant idea with subtle outlines, corner accents, and clear hover focus.
+
+2. **How is it used?**  
+   ```html
+   <article class="bordered-card">
+     <h3>Card title</h3>
+     <p>Supporting content.</p>
+   </article>
+   ```
+
+3. **Why is it useful?**  
+   It fits EaseMotion CSS by offering a readable card style for interfaces that need structure without heavy shadows.

--- a/submissions/examples/bordered-card-variant/demo.html
+++ b/submissions/examples/bordered-card-variant/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bordered Card Variant Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <header class="demo-header">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Bordered cards with quiet emphasis</h1>
+      <p>Use bordered cards when content needs separation without relying on heavy elevation.</p>
+    </header>
+
+    <section class="card-grid" aria-label="Bordered card examples">
+      <article class="bordered-card">
+        <span class="corner-mark"></span>
+        <p class="card-label">Plan</p>
+        <h2>Starter</h2>
+        <p>Simple outline card for lightweight summaries and onboarding steps.</p>
+      </article>
+
+      <article class="bordered-card accent-card">
+        <span class="corner-mark"></span>
+        <p class="card-label">Build</p>
+        <h2>Team</h2>
+        <p>Accent border state for selected, recommended, or active content.</p>
+      </article>
+
+      <article class="bordered-card dashed-card">
+        <span class="corner-mark"></span>
+        <p class="card-label">Extend</p>
+        <h2>Custom</h2>
+        <p>Dashed border style for placeholders, upload zones, or empty states.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/bordered-card-variant/style.css
+++ b/submissions/examples/bordered-card-variant/style.css
@@ -1,0 +1,121 @@
+:root {
+  --ink: #1f2937;
+  --muted: #667085;
+  --surface: #ffffff;
+  --line: #cfd8e6;
+  --accent: #dc2626;
+  --accent-soft: #fee2e2;
+  --blue: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background: #f7f9fc;
+}
+
+.demo-shell {
+  width: min(1000px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 56px 0;
+}
+
+.demo-header {
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.eyebrow,
+.card-label {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  margin-bottom: 8px;
+  color: var(--accent);
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2rem, 5vw, 3.8rem);
+  line-height: 1.04;
+}
+
+.demo-header p:last-child {
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.bordered-card {
+  position: relative;
+  min-height: 245px;
+  padding: 24px;
+  border: 2px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  transition: border-color 220ms ease, transform 220ms ease, box-shadow 220ms ease;
+}
+
+.bordered-card:hover {
+  border-color: var(--blue);
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.12);
+  transform: translateY(-4px);
+}
+
+.accent-card {
+  border-color: var(--accent);
+  background: linear-gradient(180deg, var(--accent-soft), #ffffff 42%);
+}
+
+.dashed-card {
+  border-style: dashed;
+}
+
+.corner-mark {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  width: 28px;
+  height: 28px;
+  border-top: 3px solid currentColor;
+  border-right: 3px solid currentColor;
+  color: var(--accent);
+}
+
+.card-label {
+  margin-bottom: 58px;
+  color: var(--blue);
+}
+
+.bordered-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.45rem;
+}
+
+.bordered-card p:last-child {
+  color: var(--muted);
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a bordered card variant submission with subtle outlines, accent states, dashed placeholder styling, and hover focus.

Closes #367

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/bordered-card-variant/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A bordered card variant for quiet content separation without heavy shadows.

**How does a developer use it?**

```html
<article class="bordered-card">
  <h3>Card title</h3>
  <p>Supporting content.</p>
</article>
```

**Why does it fit EaseMotion CSS?**

It gives developers a readable visual structure utility for cards that need emphasis but still feel lightweight.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Validation: `npm test` passes and `git diff --check -- submissions/examples/bordered-card-variant` passes.
