### PR TITLE
feat(animation): add scale icon emphasis interaction example

### DIFF
--- a/submissions/examples/scale-icon-emphasis/README.md
+++ b/submissions/examples/scale-icon-emphasis/README.md
@@ -1,0 +1,28 @@
+# Scale Icon Emphasis
+
+A physics-based spring scale animation designed to provide micro-interaction emphasis for icon components during user actions.
+
+---
+
+## 1. What does this do?
+It creates an elastic, springy scale-up bounce effect on icons during hover, focus, or click interactions, drawing attention to active components.
+
+---
+
+## 2. How is it used?
+Apply the `.scale-icon-emphasis` class to your icon wrapper or direct icon element (e.g., SVG or emoji container):
+
+```html
+<!-- Using on an SVG Icon -->
+<svg class="scale-icon-emphasis" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M12 21.35l-1.45-1.32C5.4..."/>
+</svg>
+
+<!-- Using on an Emoji Icon -->
+<span class="scale-icon-emphasis" role="img" aria-label="notification">🔔</span>
+```
+
+---
+
+## 3. Why is it useful?
+It fits EaseMotion CSS's philosophy by adding lightweight, high-performance, and delightful micro-interactions without relying on heavy JavaScript libraries. By incorporating keyframe-based anticipation (compression before pop) and rebounds, it mimics physical material behavior, resulting in an interface that feels responsive and organic.

--- a/submissions/examples/scale-icon-emphasis/demo.html
+++ b/submissions/examples/scale-icon-emphasis/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scale Icon Emphasis - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <h1>Scale Icon Emphasis</h1>
+      <p>A custom physical-spring scale animation for icon components. Hover over the cards below to see the elastic feedback effect on the icons.</p>
+    </header>
+
+    <div class="grid">
+      
+      <!-- Card 1: Heart/Like (Rose Accent) -->
+      <div class="card card-rose">
+        <div class="icon-wrapper">
+          <!-- SVG Heart Icon -->
+          <svg class="icon scale-icon-emphasis" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+          </svg>
+        </div>
+        <h3>Like Interaction</h3>
+        <p>Springy pop emphasis on hover. Perfect for favorite or liking actions.</p>
+      </div>
+
+      <!-- Card 2: Star/Favorite (Amber Accent) -->
+      <div class="card card-amber">
+        <div class="icon-wrapper">
+          <!-- SVG Star Icon -->
+          <svg class="icon scale-icon-emphasis" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
+          </svg>
+        </div>
+        <h3>Favorite Action</h3>
+        <p>Delightful snap attention grabber for bookmarks and rating systems.</p>
+      </div>
+
+      <!-- Card 3: Bell/Notifications (Indigo Accent) -->
+      <div class="card card-indigo">
+        <div class="icon-wrapper">
+          <!-- SVG Bell Icon -->
+          <svg class="icon scale-icon-emphasis" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/>
+          </svg>
+        </div>
+        <h3>Alert Emphasis</h3>
+        <p>Highly visible focus animation to highlight notification triggers.</p>
+      </div>
+
+    </div>
+
+    <!-- Usage Code Block -->
+    <div class="code-box">
+      <h4>How to use</h4>
+      <code>&lt;!-- Simply add the class to any icon element --&gt;
+&lt;svg class="scale-icon-emphasis" ...&gt;
+  &lt;path d="..."/&gt;
+&lt;/svg&gt;</code>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/scale-icon-emphasis/style.css
+++ b/submissions/examples/scale-icon-emphasis/style.css
@@ -1,0 +1,240 @@
+/* ============================================================
+   EaseMotion CSS — Scale Icon Emphasis Example
+   ============================================================ */
+
+/* ── Keyframe Definition ──────────────────────────────────── */
+
+@keyframes scale-icon-emphasis {
+  0% {
+    transform: scale(1);
+  }
+  15% {
+    transform: scale(0.82); /* Subtle compression/anticipation */
+  }
+  45% {
+    transform: scale(1.28); /* Springy overshoot pop */
+  }
+  70% {
+    transform: scale(0.92); /* Gentle recoil */
+  }
+  85% {
+    transform: scale(1.04); /* Tiny secondary settle */
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* ── Utility Class ────────────────────────────────────────── */
+
+.scale-icon-emphasis {
+  display: inline-block;
+  will-change: transform;
+}
+
+/* Triggers on hover or keyboard focus */
+.scale-icon-emphasis:hover,
+.scale-icon-emphasis:focus-visible {
+  animation: scale-icon-emphasis 0.65s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+}
+
+/* Double click/tap spring speed up */
+.scale-icon-emphasis:active {
+  animation: scale-icon-emphasis 0.45s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+}
+
+
+/* ── Demo Page Styling ────────────────────────────────────── */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --bg-color: #0b0f17;
+  --surface-color: rgba(19, 26, 42, 0.65);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --text-primary: #f3f4f6;
+  --text-secondary: #9ca3af;
+  
+  /* Color Accents */
+  --accent-rose: #f43f5e;
+  --accent-amber: #f59e0b;
+  --accent-indigo: #6366f1;
+  --accent-emerald: #10b981;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: var(--bg-color);
+  background-image: 
+    radial-gradient(at 0% 0%, rgba(99, 102, 241, 0.12) 0px, transparent 50%),
+    radial-gradient(at 100% 100%, rgba(244, 63, 94, 0.08) 0px, transparent 50%);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  overflow-x: hidden;
+}
+
+.container {
+  width: 100%;
+  max-width: 900px;
+  text-align: center;
+}
+
+header {
+  margin-bottom: 3.5rem;
+}
+
+header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  margin-bottom: 0.75rem;
+  background: linear-gradient(to right, #f3f4f6, #6366f1);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+header p {
+  color: var(--text-secondary);
+  font-size: 1.125rem;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* ── Interactive Grid ─────────────────────────────────────── */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.75rem;
+  margin-bottom: 4rem;
+}
+
+.card {
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  padding: 2.25rem 1.75rem;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.4);
+  transition: border-color 0.3s ease, transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: transparent;
+  transition: background 0.3s ease;
+}
+
+.card:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-4px);
+}
+
+/* Accent overrides on hover */
+.card-rose:hover::before { background: var(--accent-rose); }
+.card-amber:hover::before { background: var(--accent-amber); }
+.card-indigo:hover::before { background: var(--accent-indigo); }
+
+.icon-wrapper {
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.icon {
+  width: 32px;
+  height: 32px;
+  fill: currentColor;
+  transition: color 0.3s ease;
+}
+
+.card-rose .icon { color: rgba(244, 63, 94, 0.7); }
+.card-amber .icon { color: rgba(245, 158, 11, 0.7); }
+.card-indigo .icon { color: rgba(99, 102, 241, 0.7); }
+
+.card-rose:hover .icon { color: var(--accent-rose); }
+.card-amber:hover .icon { color: var(--accent-amber); }
+.card-indigo:hover .icon { color: var(--accent-indigo); }
+
+.card h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
+}
+
+.card p {
+  color: var(--text-secondary);
+  font-size: 0.925rem;
+  line-height: 1.5;
+}
+
+/* ── Code Display ─────────────────────────────────────────── */
+
+.code-box {
+  background: rgba(13, 17, 23, 0.8);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  text-align: left;
+  max-width: 600px;
+  margin: 0 auto;
+  box-shadow: inset 0 2px 8px rgba(0,0,0,0.8);
+}
+
+.code-box h4 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent-indigo);
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+}
+
+code {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.9rem;
+  color: #38bdf8;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* ── Accessibility ────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .scale-icon-emphasis:hover,
+  .scale-icon-emphasis:focus-visible,
+  .scale-icon-emphasis:active {
+    animation: none !important;
+    transform: scale(1.05) !important; /* Gentle static scale replacement */
+    transition: transform 0.2s ease !important;
+  }
+}


### PR DESCRIPTION
### Summary
This PR adds the `Scale Icon Emphasis` animation utility example inside the `submissions/examples/scale-icon-emphasis/` directory. It resolves issue #113.

### Proposed Changes
- **submissions/examples/scale-icon-emphasis/style.css**:
  - Implements `@keyframes scale-icon-emphasis` mimicking physical spring behaviors (incorporating anticipation compression, peak overshoot, and dual recoils).
  - Added `.scale-icon-emphasis` class triggering on hover, focus-visible, and active click states.
  - Configured `@media (prefers-reduced-motion: reduce)` accessibility overrides to gracefully fallback to static scaling.
- **submissions/examples/scale-icon-emphasis/demo.html**:
  - A standalone HTML showcase demonstrating the pop interaction on various interactive cards featuring crisp SVG icons (Heart/Like, Star/Favorite, Bell/Notification).
- **submissions/examples/scale-icon-emphasis/README.md**:
  - Documents what the animation does, how it is used, and how it aligns with EaseMotion CSS's lightweight, CSS-only design philosophy.

