### PR TITLE
feat: add slide-in from off-canvas utility classes

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -63,6 +63,45 @@
     transform: translateX(0);
   }
 }
+@keyframes ease-kf-slide-in-from-top {
+  from { opacity: 0; transform: translateY(-100%); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-kf-slide-in-from-bottom {
+  from { opacity: 0; transform: translateY(100%); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-kf-slide-in-from-left {
+  from { opacity: 0; transform: translateX(-100%); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-kf-slide-in-from-right {
+  from { opacity: 0; transform: translateX(100%); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-kf-slide-in-from-top-left {
+  from { opacity: 0; transform: translate(-100%, -100%); }
+  to   { opacity: 1; transform: translate(0, 0); }
+}
+
+@keyframes ease-kf-slide-in-from-top-right {
+  from { opacity: 0; transform: translate(100%, -100%); }
+  to   { opacity: 1; transform: translate(0, 0); }
+}
+
+@keyframes ease-kf-slide-in-from-bottom-left {
+  from { opacity: 0; transform: translate(-100%, 100%); }
+  to   { opacity: 1; transform: translate(0, 0); }
+}
+
+@keyframes ease-kf-slide-in-from-bottom-right {
+  from { opacity: 0; transform: translate(100%, 100%); }
+  to   { opacity: 1; transform: translate(0, 0); }
+}
 
 @keyframes ease-kf-bounce {
   0%, 100% {
@@ -481,6 +520,31 @@
 
 .ease-slide-in-right {
   animation: ease-kf-slide-in-right var(--ease-speed-medium) var(--ease-ease) both;
+}
+
+.ease-slide-in-from-top {
+  animation: ease-kf-slide-in-from-top var(--ease-speed-medium) var(--ease-ease) both;
+}
+.ease-slide-in-from-bottom {
+  animation: ease-kf-slide-in-from-bottom var(--ease-speed-medium) var(--ease-ease) both;
+}
+.ease-slide-in-from-left {
+  animation: ease-kf-slide-in-from-left var(--ease-speed-medium) var(--ease-ease) both;
+}
+.ease-slide-in-from-right {
+  animation: ease-kf-slide-in-from-right var(--ease-speed-medium) var(--ease-ease) both;
+}
+.ease-slide-in-from-top-left {
+  animation: ease-kf-slide-in-from-top-left var(--ease-speed-medium) var(--ease-ease) both;
+}
+.ease-slide-in-from-top-right {
+  animation: ease-kf-slide-in-from-top-right var(--ease-speed-medium) var(--ease-ease) both;
+}
+.ease-slide-in-from-bottom-left {
+  animation: ease-kf-slide-in-from-bottom-left var(--ease-speed-medium) var(--ease-ease) both;
+}
+.ease-slide-in-from-bottom-right {
+  animation: ease-kf-slide-in-from-bottom-right var(--ease-speed-medium) var(--ease-ease) both;
 }
 
 .ease-zoom-in {

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -501,7 +501,42 @@
             <span class="tag">ease-hover-bounce-text</span>
            </div>
         </div>
-
+      <!-- Slide-in from Off-Canvas -->
+<div class="demo-chip">// Slide-in from off-canvas (sides & corners)</div>
+<div class="ease-flex ease-flex-wrap ease-gap-6" style="margin-bottom: var(--ease-space-10); overflow: hidden;">
+  <div class="anim-cell">
+    <div class="anim-box ease-slide-in-from-top" onclick="replay(this,'ease-slide-in-from-top')">↓</div>
+    <span class="tag">ease-slide-in-from-top</span>
+  </div>
+  <div class="anim-cell">
+    <div class="anim-box ease-slide-in-from-bottom" onclick="replay(this,'ease-slide-in-from-bottom')">↑</div>
+    <span class="tag">ease-slide-in-from-bottom</span>
+  </div>
+  <div class="anim-cell">
+    <div class="anim-box ease-slide-in-from-left" onclick="replay(this,'ease-slide-in-from-left')">→</div>
+    <span class="tag">ease-slide-in-from-left</span>
+  </div>
+  <div class="anim-cell">
+    <div class="anim-box ease-slide-in-from-right" onclick="replay(this,'ease-slide-in-from-right')">←</div>
+    <span class="tag">ease-slide-in-from-right</span>
+  </div>
+  <div class="anim-cell">
+    <div class="anim-box ease-slide-in-from-top-left" onclick="replay(this,'ease-slide-in-from-top-left')">↘</div>
+    <span class="tag">ease-slide-in-from-top-left</span>
+  </div>
+  <div class="anim-cell">
+    <div class="anim-box ease-slide-in-from-top-right" onclick="replay(this,'ease-slide-in-from-top-right')">↙</div>
+    <span class="tag">ease-slide-in-from-top-right</span>
+  </div>
+  <div class="anim-cell">
+    <div class="anim-box ease-slide-in-from-bottom-left" onclick="replay(this,'ease-slide-in-from-bottom-left')">↗</div>
+    <span class="tag">ease-slide-in-from-bottom-left</span>
+  </div>
+  <div class="anim-cell">
+    <div class="anim-box ease-slide-in-from-bottom-right" onclick="replay(this,'ease-slide-in-from-bottom-right')">↖</div>
+    <span class="tag">ease-slide-in-from-bottom-right</span>
+  </div>
+</div>
       <!-- Exit anims -->
       <div class="demo-chip">// Exit animations</div>
       <div class="ease-flex ease-flex-wrap ease-gap-6" >

--- a/submissions/examples/slide-in-from-corners/README.md
+++ b/submissions/examples/slide-in-from-corners/README.md
@@ -1,0 +1,28 @@
+# Slide-in from Off-Canvas
+
+Slides elements into view from any screen edge or corner using pure CSS `@keyframes`.
+
+## Classes
+
+| Class | Direction |
+|---|---|
+| `ease-slide-in-from-top` | Top edge |
+| `ease-slide-in-from-bottom` | Bottom edge |
+| `ease-slide-in-from-left` | Left edge |
+| `ease-slide-in-from-right` | Right edge |
+| `ease-slide-in-from-top-left` | Top-left corner |
+| `ease-slide-in-from-top-right` | Top-right corner |
+| `ease-slide-in-from-bottom-left` | Bottom-left corner |
+| `ease-slide-in-from-bottom-right` | Bottom-right corner |
+
+## Usage
+
+```html
+<div class="ease-slide-in-from-top">Hello</div>
+```
+
+> Note: wrap the parent in `overflow: hidden` for a true off-canvas effect.
+
+## Why it fits EaseMotion CSS
+
+Pure CSS, no JS, human-readable class names, and respects `prefers-reduced-motion`.

--- a/submissions/examples/slide-in-from-corners/demo.html
+++ b/submissions/examples/slide-in-from-corners/demo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Slide-in from Corners — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      background: #0f0e17;
+      color: #fff;
+      font-family: sans-serif;
+      padding: 2rem;
+    }
+    h1 { margin-bottom: 0.5rem; }
+    p  { color: rgba(255,255,255,0.6); margin-bottom: 2rem; }
+    .grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 2rem;
+      overflow: hidden;
+    }
+    .cell {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .box {
+      width: 64px;
+      height: 64px;
+      border-radius: 12px;
+      background: linear-gradient(135deg, #6c63ff, #a78bfa);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.5rem;
+      cursor: pointer;
+      color: #fff;
+    }
+    code {
+      font-size: 11px;
+      background: rgba(108,99,255,0.15);
+      color: #a78bfa;
+      border: 1px solid rgba(108,99,255,0.3);
+      padding: 0.15em 0.6em;
+      border-radius: 999px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Slide-in from Off-Canvas</h1>
+  <p>Click any box to replay its animation.</p>
+
+  <div class="grid">
+    <div class="cell">
+      <div class="box ease-slide-in-from-top" onclick="replay(this,'ease-slide-in-from-top')">↓</div>
+      <code>ease-slide-in-from-top</code>
+    </div>
+    <div class="cell">
+      <div class="box ease-slide-in-from-bottom" onclick="replay(this,'ease-slide-in-from-bottom')">↑</div>
+      <code>ease-slide-in-from-bottom</code>
+    </div>
+    <div class="cell">
+      <div class="box ease-slide-in-from-left" onclick="replay(this,'ease-slide-in-from-left')">→</div>
+      <code>ease-slide-in-from-left</code>
+    </div>
+    <div class="cell">
+      <div class="box ease-slide-in-from-right" onclick="replay(this,'ease-slide-in-from-right')">←</div>
+      <code>ease-slide-in-from-right</code>
+    </div>
+    <div class="cell">
+      <div class="box ease-slide-in-from-top-left" onclick="replay(this,'ease-slide-in-from-top-left')">↘</div>
+      <code>ease-slide-in-from-top-left</code>
+    </div>
+    <div class="cell">
+      <div class="box ease-slide-in-from-top-right" onclick="replay(this,'ease-slide-in-from-top-right')">↙</div>
+      <code>ease-slide-in-from-top-right</code>
+    </div>
+    <div class="cell">
+      <div class="box ease-slide-in-from-bottom-left" onclick="replay(this,'ease-slide-in-from-bottom-left')">↗</div>
+      <code>ease-slide-in-from-bottom-left</code>
+    </div>
+    <div class="cell">
+      <div class="box ease-slide-in-from-bottom-right" onclick="replay(this,'ease-slide-in-from-bottom-right')">↖</div>
+      <code>ease-slide-in-from-bottom-right</code>
+    </div>
+  </div>
+
+  <script>
+    function replay(el, cls) {
+      el.classList.remove(cls);
+      void el.offsetWidth;
+      el.classList.add(cls);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/slide-in-from-corners/style.css
+++ b/submissions/examples/slide-in-from-corners/style.css
@@ -1,0 +1,76 @@
+/* Slide-in from Off-Canvas — Sides */
+@keyframes ease-kf-slide-in-from-top {
+  from { opacity: 0; transform: translateY(-100%); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-kf-slide-in-from-bottom {
+  from { opacity: 0; transform: translateY(100%); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-kf-slide-in-from-left {
+  from { opacity: 0; transform: translateX(-100%); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-kf-slide-in-from-right {
+  from { opacity: 0; transform: translateX(100%); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* Slide-in from Off-Canvas — Corners */
+@keyframes ease-kf-slide-in-from-top-left {
+  from { opacity: 0; transform: translate(-100%, -100%); }
+  to   { opacity: 1; transform: translate(0, 0); }
+}
+
+@keyframes ease-kf-slide-in-from-top-right {
+  from { opacity: 0; transform: translate(100%, -100%); }
+  to   { opacity: 1; transform: translate(0, 0); }
+}
+
+@keyframes ease-kf-slide-in-from-bottom-left {
+  from { opacity: 0; transform: translate(-100%, 100%); }
+  to   { opacity: 1; transform: translate(0, 0); }
+}
+
+@keyframes ease-kf-slide-in-from-bottom-right {
+  from { opacity: 0; transform: translate(100%, 100%); }
+  to   { opacity: 1; transform: translate(0, 0); }
+}
+
+/* Utility Classes */
+.ease-slide-in-from-top {
+  animation: ease-kf-slide-in-from-top 0.4s ease-out both;
+}
+.ease-slide-in-from-bottom {
+  animation: ease-kf-slide-in-from-bottom 0.4s ease-out both;
+}
+.ease-slide-in-from-left {
+  animation: ease-kf-slide-in-from-left 0.4s ease-out both;
+}
+.ease-slide-in-from-right {
+  animation: ease-kf-slide-in-from-right 0.4s ease-out both;
+}
+.ease-slide-in-from-top-left {
+  animation: ease-kf-slide-in-from-top-left 0.4s ease-out both;
+}
+.ease-slide-in-from-top-right {
+  animation: ease-kf-slide-in-from-top-right 0.4s ease-out both;
+}
+.ease-slide-in-from-bottom-left {
+  animation: ease-kf-slide-in-from-bottom-left 0.4s ease-out both;
+}
+.ease-slide-in-from-bottom-right {
+  animation: ease-kf-slide-in-from-bottom-right 0.4s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Fixes #32 
Adds 8 new CSS animation utility classes that slide elements into view from off-canvas which are 4 sides (top, bottom, left, right) and 4 corners (top-left, top-right, bottom-left, bottom-right).


---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

Adds 8 slide-in from off-canvas utility classes which are 4 sides and 4 corners


```html
<div class="ease-slide-in-from-top">Hello</div>
```

**Why does it fit EaseMotion CSS?**

Pure CSS, human-readable class names which fits EaseMotion's animation-first philosophy.
---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Parent element needs overflow: hidden for true off-canvas effect.
Closes #32

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
