### PR TITLE
feat: add ease-order flex order utilities

### DIFF
--- a/submissions/examples/ease-order-utilities/README.md
+++ b/submissions/examples/ease-order-utilities/README.md
@@ -1,0 +1,21 @@
+# ease-order utilities
+
+Flex order utilities to control the visual order of flex children.
+
+## Usage
+```html
+<div class="ease-order-first">Appears first</div>
+<div class="ease-order-last">Appears last</div>
+<div class="ease-order-2">Appears second</div>
+```
+
+## Classes
+| Class | CSS |
+|---|---|
+| `ease-order-first` | `order: -9999` |
+| `ease-order-last` | `order: 9999` |
+| `ease-order-none` | `order: 0` |
+| `ease-order-1` through `ease-order-5` | `order: 1` through `order: 5` |
+
+## Use Case
+Reordering flex children for responsive layouts without changing HTML structure.

--- a/submissions/examples/ease-order-utilities/demo.html
+++ b/submissions/examples/ease-order-utilities/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ease-order Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { margin: 0; font-family: sans-serif; padding: 2rem; }
+    .container { display: flex; gap: 1rem; }
+    .box { background: #6366f1; color: white; padding: 1rem 2rem; border-radius: 8px; }
+  </style>
+</head>
+<body>
+  <h2>ease-order utilities</h2>
+  <div class="container">
+    <div class="box ease-order-3">Box 1 (order-3)</div>
+    <div class="box ease-order-1">Box 2 (order-1)</div>
+    <div class="box ease-order-2">Box 3 (order-2)</div>
+  </div>
+  <br>
+  <div class="container">
+    <div class="box ease-order-last">First in HTML (order-last)</div>
+    <div class="box ease-order-first">Last in HTML (order-first)</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-order-utilities/style.css
+++ b/submissions/examples/ease-order-utilities/style.css
@@ -1,0 +1,8 @@
+.ease-order-first { order: -9999; }
+.ease-order-last  { order: 9999; }
+.ease-order-none  { order: 0; }
+.ease-order-1     { order: 1; }
+.ease-order-2     { order: 2; }
+.ease-order-3     { order: 3; }
+.ease-order-4     { order: 4; }
+.ease-order-5     { order: 5; }


### PR DESCRIPTION
## Pull Request Description
Adds flex order utility classes. Closes #388

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-order-utilities/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
Flex order utilities to control visual order of flex children without changing HTML.

**How does a developer use it?**
```html
<div class="ease-order-first">Appears first</div>
<div class="ease-order-last">Appears last</div>
<div class="ease-order-2">Appears second</div>
```

**Why does it fit EaseMotion CSS?**
Class names describe exactly what they do in plain English — fits the human-readable philosophy perfectly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Implemented `ease-order-first` (order: -9999), `ease-order-last` (order: 9999), 
`ease-order-none` (order: 0), and numeric `ease-order-1` through `ease-order-5`.