### PR TITLE
fix(accessibility): add targeted prefers-reduced-motion overrides example (#480)

### DIFF
--- a/submissions/examples/prefers-reduced-motion-fix/README.md
+++ b/submissions/examples/prefers-reduced-motion-fix/README.md
@@ -1,0 +1,26 @@
+# Prefers Reduced Motion Accessibility Fix
+
+### What does this do?
+This submission provides precise, targeted `@media (prefers-reduced-motion: reduce)` resets and fallbacks for all entrance, exit, looping, and hover classes in EaseMotion CSS, replacing the global `*` wildcard reset that disables benign transitions and introduces layout visibility bugs.
+
+---
+
+### How is it used?
+
+The maintainer should replace the legacy wildcard rule at the bottom of `core/animations.css` (lines 688–696) with the production media query blocks inside `style.css`. 
+
+No modifications are needed on the user side; standard class usage (e.g., `<div class="ease-slide-up">`) automatically detects user OS settings and applies the appropriate overrides:
+
+1. **Entrances** (`.ease-slide-up`, `.ease-zoom-in`, `.ease-flip`, etc.) gracefully transition to standard opacity fades (`ease-kf-fade-in`) instead of sliding or spinning across the viewport.
+2. **Exits** (`.ease-shake-card-exit`, `.ease-bounce-button-exit`, etc.) gracefully transition to standard opacity fades (`ease-kf-fade-out`) instead of shaking or scaling violently.
+3. **Loops & Skeletons** (`.ease-bounce`, `.ease-rotate`, `.ease-skeleton-shimmer`, `.ease-btn-loading::after`, etc.) freeze completely via `animation: none` to prevent constant visual distraction.
+4. **Hover Interactions** (`.ease-hover-grow`, `.ease-card-lift`, `.ease-hover-morph-card`, etc.) suppress physical translations/scales (`transform: none`), while keeping harmless, non-motion-based color and shadow transitions intact.
+5. **Typewriter Layouts** (`.ease-typewriter-loop`) disable typing movements but force `width: auto` and remove `overflow: hidden`, ensuring the text remains fully visible and readable.
+
+---
+
+### Why is it useful?
+
+1. **Fixes Accessibility Anti-Patterns**: The global `* { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }` wildcard kills *all* transitions on a webpage. Harmless transitions like button hover background-color fades, focus border-color glow transitions, and light mode/dark mode theme fades are completely disabled despite having no impact on vestibular disorders. This fix selectively disables only motion-heavy properties (transforms, translations, bounces, infinite loops) while keeping benign color transitions functional.
+2. **Prevents Layout and Visibility Failures**: Under the legacy wildcard system, typewriter animations (`.ease-typewriter-loop`) remain permanently hidden at `width: 0` because the animation is cancelled. Similarly, exit animations with delays can get stuck in incomplete states. This fix explicitly handles layout-critical properties to guarantee content visibility under reduced-motion.
+3. **Graceful Fallbacks over Complete Halts**: Rather than cutting off elements immediately mid-animation or skipping entrance effects entirely, mapping entrances to simple opacity fades (`ease-kf-fade-in`) maintains design continuity and polished UX without compromising accessibility.

--- a/submissions/examples/prefers-reduced-motion-fix/demo.html
+++ b/submissions/examples/prefers-reduced-motion-fix/demo.html
@@ -1,0 +1,458 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reduced Motion Accessibility Audit & Demo — EaseMotion CSS</title>
+  
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  
+  <!-- Core & Component Framework CSS -->
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/animations.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  <link rel="stylesheet" href="../../../components/cards.css" />
+  
+  <!-- Proposed Overrides & Emulation -->
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    :root {
+      --color-bg-dark: #0f172a;
+      --color-surface-dark: #1e293b;
+      --color-border-dark: #334155;
+      --color-text-muted: #94a3b8;
+      --color-primary-glow: rgba(99, 102, 241, 0.15);
+    }
+
+    body {
+      font-family: 'Inter', sans-serif;
+      background-color: var(--color-bg-dark);
+      color: #f8fafc;
+      min-height: 100vh;
+      padding: var(--ease-space-8) 0;
+      margin: 0;
+    }
+
+    /* Glassmorphism Header and Controls */
+    .dashboard-header {
+      background: rgba(30, 41, 59, 0.7);
+      border: 1px solid var(--color-border-dark);
+      backdrop-filter: blur(12px);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-6) var(--ease-space-8);
+      margin-bottom: var(--ease-space-8);
+      box-shadow: 0 4px 30px rgba(0, 0, 0, 0.2);
+    }
+
+    .control-panel {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--ease-space-4);
+      margin-top: var(--ease-space-6);
+      padding-top: var(--ease-space-6);
+      border-top: 1px solid var(--color-border-dark);
+    }
+
+    /* Emulation Indicator Badge */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      border-radius: var(--ease-radius-full);
+      font-size: var(--ease-text-xs);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      transition: all 0.3s ease;
+    }
+    
+    .badge-off {
+      background-color: rgba(239, 68, 68, 0.15);
+      color: #ef4444;
+      border: 1px solid rgba(239, 68, 68, 0.3);
+    }
+
+    .badge-on {
+      background-color: rgba(34, 197, 94, 0.15);
+      color: #22c55e;
+      border: 1px solid rgba(34, 197, 94, 0.3);
+      box-shadow: 0 0 12px rgba(34, 197, 94, 0.2);
+    }
+
+    /* Section Cards styling */
+    .section-card {
+      background-color: var(--color-surface-dark);
+      border: 1px solid var(--color-border-dark);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-6);
+      height: 100%;
+      box-sizing: border-box;
+    }
+
+    .section-title {
+      font-size: var(--ease-text-lg);
+      font-weight: 700;
+      margin-bottom: var(--ease-space-4);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      border-bottom: 1px solid var(--color-border-dark);
+      padding-bottom: var(--ease-space-2);
+    }
+
+    /* Grid boxes */
+    .showcase-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+      gap: var(--ease-space-4);
+    }
+
+    .demo-element {
+      background-color: var(--color-bg-dark);
+      border: 1px solid var(--color-border-dark);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4) var(--ease-space-2);
+      text-align: center;
+      font-size: var(--ease-text-xs);
+      font-weight: 500;
+      color: #f1f5f9;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 90px;
+      cursor: pointer;
+      position: relative;
+      overflow: hidden;
+      user-select: none;
+      transition: background-color 0.2s, border-color 0.2s;
+    }
+
+    .demo-element:hover {
+      border-color: var(--ease-color-primary);
+    }
+
+    /* Code Block styling */
+    pre {
+      background: #090d16;
+      border: 1px solid var(--color-border-dark);
+      padding: var(--ease-space-3);
+      border-radius: var(--ease-radius-md);
+      overflow-x: auto;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 11px;
+      margin: 0;
+    }
+
+    code {
+      color: #a78bfa;
+    }
+
+    /* Replay animation triggers */
+    .trigger-active {
+      animation-play-state: running !important;
+    }
+
+    /* Exit items interactive state */
+    .exit-triggered {
+      opacity: 0.2;
+      pointer-events: none;
+    }
+
+    .reset-btn {
+      font-size: 10px;
+      padding: 4px 8px;
+    }
+
+    /* Heart pulse visual */
+    .heart-icon {
+      fill: #ef4444;
+      width: 24px;
+      height: 24px;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-container">
+    
+    <!-- ── Header & Control Dashboard ── -->
+    <header class="dashboard-header">
+      <div class="ease-flex ease-justify-between ease-items-center ease-sm-flex-col ease-sm-text-center">
+        <div>
+          <h1 class="ease-text-3xl ease-font-bold ease-text-primary">Reduced Motion Access Center</h1>
+          <p class="ease-text-sm ease-text-muted ease-mt-2">
+            Targeted accessibility audit demonstrating the transition from physics-heavy motion classes to accessible, user-friendly overrides.
+          </p>
+        </div>
+        <div class="badge badge-off ease-mt-4" id="modeBadge">
+          <span style="display:inline-block; width:8px; height:8px; border-radius:50%; background-color:currentColor;"></span>
+          Standard Mode
+        </div>
+      </div>
+
+      <div class="control-panel">
+        <div style="max-width: 600px;">
+          <p class="ease-text-xs ease-text-muted">
+            Clicking the toggle below applies the <code>.emulate-reduced-motion</code> container class to showcase the exact behavior users experience when their system preference is set to <strong>reduce motion</strong>.
+          </p>
+        </div>
+        <button id="toggleMotionBtn" class="ease-btn ease-btn-primary ease-btn-hover">
+          Enable Reduced Motion Emulation
+        </button>
+      </div>
+    </header>
+
+    <!-- ── Main Grid ── -->
+    <div class="ease-grid ease-grid-cols-2 ease-gap-6 ease-sm-grid-cols-1">
+      
+      <!-- 1. ENTRANCES -->
+      <div>
+        <div class="section-card">
+          <div class="section-title">
+            <span>Entrances <span class="ease-text-xs ease-text-muted">(Slide/Zoom/Flip → Fade)</span></span>
+            <button class="ease-btn ease-btn-outline reset-btn" onclick="replayEntrances()">Replay</button>
+          </div>
+          <div class="showcase-grid" id="entranceGrid">
+            <div class="demo-element ease-slide-up">
+              <span class="ease-mb-2">Slide Up</span>
+              <pre><code>.ease-slide-up</code></pre>
+            </div>
+            <div class="demo-element ease-zoom-in">
+              <span class="ease-mb-2">Zoom In</span>
+              <pre><code>.ease-zoom-in</code></pre>
+            </div>
+            <div class="demo-element ease-flip">
+              <span class="ease-mb-2">Flip 3D</span>
+              <pre><code>.ease-flip</code></pre>
+            </div>
+          </div>
+          <p class="ease-text-xs ease-text-muted ease-mt-4">
+            * Entrance transforms (moves/zooms/rotates) collapse into clean opacity fades (.ease-kf-fade-in) to maintain layout entries without rapid motion.
+          </p>
+        </div>
+      </div>
+
+      <!-- 2. EXITS -->
+      <div>
+        <div class="section-card">
+          <div class="section-title">
+            <span>Exits <span class="ease-text-xs ease-text-muted">(Click to Trigger)</span></span>
+            <button class="ease-btn ease-btn-outline reset-btn" onclick="resetExits()">Reset Exits</button>
+          </div>
+          <div class="showcase-grid">
+            <div class="demo-element" onclick="triggerExit(this, 'ease-shake-card-exit')">
+              <span class="ease-mb-2">Shake Exit</span>
+              <pre><code>.ease-shake-card-exit</code></pre>
+            </div>
+            <div class="demo-element" onclick="triggerExit(this, 'ease-bounce-button-exit')">
+              <span class="ease-mb-2">Bounce Exit</span>
+              <pre><code>.ease-bounce-button-exit</code></pre>
+            </div>
+            <div class="demo-element" onclick="triggerExit(this, 'ease-scale-text-exit')">
+              <span class="ease-mb-2">Scale Exit</span>
+              <pre><code>.ease-scale-text-exit</code></pre>
+            </div>
+          </div>
+          <p class="ease-text-xs ease-text-muted ease-mt-4">
+            * Dynamic exits collapse into clean opacity fade-outs (.ease-kf-fade-out) to prevent jarring screen shakes or scaling shifts while exiting.
+          </p>
+        </div>
+      </div>
+
+      <!-- 3. INFINITE LOOPS -->
+      <div>
+        <div class="section-card">
+          <div class="section-title">
+            <span>Infinite Loops <span class="ease-text-xs ease-text-muted">(Stopped entirely)</span></span>
+          </div>
+          <div class="showcase-grid">
+            <div class="demo-element ease-bounce">
+              <span class="ease-mb-2">Bounce Loop</span>
+              <pre><code>.ease-bounce</code></pre>
+            </div>
+            <div class="demo-element ease-rotate">
+              <span class="ease-mb-2">Rotate Loop</span>
+              <svg class="ease-mt-1" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M21.5 2v6h-6M21.34 15.57a10 10 0 1 1-.57-8.38l5.67-5.67"/></svg>
+            </div>
+            <div class="demo-element ease-ping">
+              <span class="ease-mb-2">Ping Loop</span>
+              <span style="display:inline-block; width:12px; height:12px; background:#818cf8; border-radius:50%;"></span>
+            </div>
+            <div class="demo-element ease-pulse">
+              <span class="ease-mb-2">Pulse Loop</span>
+              <pre><code>.ease-pulse</code></pre>
+            </div>
+          </div>
+          <p class="ease-text-xs ease-text-muted ease-mt-4">
+            * Loop animations are completely disabled (animation: none) to avoid causing distraction or eye strain on static pages.
+          </p>
+        </div>
+      </div>
+
+      <!-- 4. SKELETONS & TYPEWRITER -->
+      <div>
+        <div class="section-card">
+          <div class="section-title">
+            <span>Skeletons & Text Loops <span class="ease-text-xs ease-text-muted">(Typewriter Safe)</span></span>
+          </div>
+          <div class="ease-flex ease-flex-col ease-gap-4">
+            <!-- Skeleton Blocks -->
+            <div class="ease-flex ease-gap-2 ease-items-center">
+              <div class="ease-skeleton-block ease-skeleton-shimmer" style="width: 50px; height: 50px; flex-shrink:0;"></div>
+              <div class="ease-flex-col ease-grow ease-gap-2 ease-flex">
+                <div class="ease-skeleton-block ease-skeleton-shimmer" style="width: 80%; height: 12px;"></div>
+                <div class="ease-skeleton-block ease-skeleton-pulse" style="width: 50%; height: 10px;"></div>
+              </div>
+            </div>
+            
+            <!-- Typewriter loop block -->
+            <div style="background:#090d16; border: 1px solid var(--color-border-dark); padding: var(--ease-space-3); border-radius: var(--ease-radius-md); min-height: 48px; display: flex; align-items: center;">
+              <span class="ease-text-xs ease-font-mono">
+                System Status: <span class="ease-typewriter-loop ease-text-success" style="--ease-typewriter-length: 12ch; --ease-typewriter-steps: 12;">Online Active</span>
+              </span>
+            </div>
+          </div>
+          <p class="ease-text-xs ease-text-muted ease-mt-4">
+            * Skeletons cease shimmer/pulse behavior to remain static placeholder blocks.
+            <br>
+            * <strong>Typewriter Fix</strong>: The typewriter loop width resets to auto and removes hidden overflow so the full string remains visible.
+          </p>
+        </div>
+      </div>
+
+      <!-- 5. INTERACTIVE HOVERS -->
+      <div>
+        <div class="section-card">
+          <div class="section-title">
+            <span>Hover Interactions <span class="ease-text-xs ease-text-muted">(Preserves Colors/Glows)</span></span>
+          </div>
+          <div class="showcase-grid">
+            <div class="demo-element ease-hover-grow ease-hover-glow">
+              <span class="ease-mb-2">Grow + Glow</span>
+              <pre><code>.ease-hover-grow</code></pre>
+            </div>
+            <div class="demo-element ease-hover-lift ease-hover-glow">
+              <span class="ease-mb-2">Lift + Glow</span>
+              <pre><code>.ease-hover-lift</code></pre>
+            </div>
+            <div class="demo-element ease-hover-morph-card ease-hover-glow" style="border-radius: var(--ease-radius-md);">
+              <span class="ease-mb-2">Morph Shape</span>
+              <pre><code>.ease-hover-morph-card</code></pre>
+            </div>
+            <div class="demo-element ease-hover-shimmer ease-bg-primary">
+              <span class="ease-mb-2">Hover Shimmer</span>
+              <pre><code>.ease-hover-shimmer</code></pre>
+            </div>
+          </div>
+          <p class="ease-text-xs ease-text-muted ease-mt-4">
+            * Hover transforms are disabled, but harmless hover indicators (e.g. shadow glow or color shifts) remain fully functional.
+          </p>
+        </div>
+      </div>
+
+      <!-- 6. COMPONENT EXAMPLES -->
+      <div>
+        <div class="section-card">
+          <div class="section-title">
+            <span>Component Behaviors <span class="ease-text-xs ease-text-muted">(Buttons & Cards)</span></span>
+          </div>
+          <div class="ease-flex ease-flex-wrap ease-gap-4 ease-items-center">
+            
+            <!-- Cards component -->
+            <div class="ease-card ease-card-hover ease-card-glow" style="max-width: 200px; padding: var(--ease-space-4);">
+              <h4 class="ease-card-title ease-text-base">Glow Card</h4>
+              <p class="ease-text-xs ease-text-muted">Hover preserves border color and shadow glow transitions.</p>
+            </div>
+
+            <!-- Buttons components -->
+            <div class="ease-flex ease-flex-col ease-gap-2">
+              <button class="ease-btn ease-btn-primary ease-btn-hover">
+                Interactive Button
+              </button>
+              <button class="ease-btn ease-btn-danger ease-btn-loading">
+                Saving State
+              </button>
+            </div>
+
+          </div>
+          <p class="ease-text-xs ease-text-muted ease-mt-4">
+            * Loader rotation freezes, hover scaling resets, but normal interactive button/card highlight states remain fully intact.
+          </p>
+        </div>
+      </div>
+
+    </div>
+
+  </div>
+
+  <!-- JavaScript logic to toggle emulation -->
+  <script>
+    const btn = document.getElementById('toggleMotionBtn');
+    const badge = document.getElementById('modeBadge');
+    let isReduced = false;
+
+    btn.addEventListener('click', () => {
+      isReduced = !isReduced;
+      if (isReduced) {
+        document.body.classList.add('emulate-reduced-motion');
+        btn.textContent = 'Disable Reduced Motion Emulation';
+        btn.classList.replace('ease-btn-primary', 'ease-btn-success');
+        badge.textContent = 'Reduced Motion Active';
+        badge.classList.replace('badge-off', 'badge-on');
+      } else {
+        document.body.classList.remove('emulate-reduced-motion');
+        btn.textContent = 'Enable Reduced Motion Emulation';
+        btn.classList.replace('ease-btn-success', 'ease-btn-primary');
+        badge.textContent = 'Standard Mode';
+        badge.classList.replace('badge-on', 'badge-off');
+      }
+    });
+
+    // JavaScript to restart entrance animations for demonstration
+    function replayEntrances() {
+      const grid = document.getElementById('entranceGrid');
+      const elements = grid.querySelectorAll('.demo-element');
+      
+      elements.forEach(el => {
+        // Capture all animation classes
+        const classes = Array.from(el.classList).filter(c => c.startsWith('ease-'));
+        
+        // Remove classes
+        classes.forEach(c => el.classList.remove(c));
+        
+        // Trigger reflow to restart
+        void el.offsetWidth;
+        
+        // Restore classes
+        classes.forEach(c => el.classList.add(c));
+      });
+    }
+
+    // JavaScript to trigger exit animations
+    function triggerExit(element, className) {
+      element.classList.add(className);
+      
+      // Mark as exit triggered for opacity reference
+      element.classList.add('exit-triggered');
+    }
+
+    function resetExits() {
+      const elements = document.querySelectorAll('.exit-triggered');
+      elements.forEach(el => {
+        el.classList.remove('exit-triggered', 'ease-shake-card-exit', 'ease-bounce-button-exit', 'ease-scale-text-exit');
+      });
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/prefers-reduced-motion-fix/style.css
+++ b/submissions/examples/prefers-reduced-motion-fix/style.css
@@ -1,0 +1,157 @@
+/* ============================================================
+   EaseMotion CSS — prefers-reduced-motion-fix
+   Targeted accessibility overrides for reduced motion preferences.
+   ============================================================ */
+
+/* ── 1. Media Query Overrides (Production) ──────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  
+  /* Entrance Animations: Gracefully fall back to simple opacity fade-ins */
+  .ease-slide-up,
+  .ease-slide-down,
+  .ease-slide-in-left,
+  .ease-slide-in-right,
+  .ease-zoom-in,
+  .ease-flip,
+  .ease-blur-to-focus,
+  .ease-contract-image-entrance {
+    animation-name: ease-kf-fade-in !important;
+    transform: none !important;
+  }
+
+  /* Exit Animations: Gracefully fall back to simple opacity fade-outs */
+  .ease-shake-card-exit,
+  .ease-bounce-button-exit,
+  .ease-fade-icon-exit,
+  .ease-scale-text-exit,
+  .ease-glow-shadow-exit,
+  .ease-slide-image-exit,
+  .ease-rotate-image-exit,
+  .ease-expand-border-exit,
+  .ease-contract-bg-exit {
+    animation-name: ease-kf-fade-out !important;
+    transform: none !important;
+  }
+
+  /* Looping / Infinite Animations: Halt completely to prevent distraction/nausea */
+  .ease-bounce,
+  .ease-rotate,
+  .ease-pulse,
+  .ease-ping,
+  .ease-shake,
+  .ease-shimmer-sweep,
+  .ease-gradient-rotation,
+  .ease-pulse-border-emphasis,
+  .ease-skeleton-shimmer,
+  .ease-skeleton-pulse,
+  .ease-btn-loading::after {
+    animation: none !important;
+  }
+
+  /* Typewriter Fix: Prevent text from being hidden behind width: 0 and animation: none */
+  .ease-typewriter-loop {
+    width: auto !important;
+    max-width: none !important;
+    border-right: none !important;
+    white-space: normal !important;
+    animation: none !important;
+  }
+
+  /* Hover & Active Micro-interactions: Strip physical translations/scaling */
+  .ease-hover-grow:hover,
+  .ease-hover-shrink:hover,
+  .ease-hover-lift:hover,
+  .ease-card-lift:hover,
+  .ease-hover-morph-card:hover,
+  .ease-hover-bounce-text:hover,
+  .ease-squish-button:hover,
+  .ease-squish-button:focus-visible,
+  .ease-squish-button:active,
+  .ease-btn:active,
+  .ease-btn-hover:hover,
+  .ease-card-hover:hover {
+    transform: none !important;
+    animation: none !important;
+  }
+
+  /* Remove sliding shimmers on hover */
+  .ease-hover-shimmer::before {
+    display: none !important;
+  }
+}
+
+/* ── 2. Emulation Selector Overrides (For Demo Testing) ────── */
+
+/* Entrance Animations emulation */
+.emulate-reduced-motion .ease-slide-up,
+.emulate-reduced-motion .ease-slide-down,
+.emulate-reduced-motion .ease-slide-in-left,
+.emulate-reduced-motion .ease-slide-in-right,
+.emulate-reduced-motion .ease-zoom-in,
+.emulate-reduced-motion .ease-flip,
+.emulate-reduced-motion .ease-blur-to-focus,
+.emulate-reduced-motion .ease-contract-image-entrance {
+  animation-name: ease-kf-fade-in !important;
+  transform: none !important;
+}
+
+/* Exit Animations emulation */
+.emulate-reduced-motion .ease-shake-card-exit,
+.emulate-reduced-motion .ease-bounce-button-exit,
+.emulate-reduced-motion .ease-fade-icon-exit,
+.emulate-reduced-motion .ease-scale-text-exit,
+.emulate-reduced-motion .ease-glow-shadow-exit,
+.emulate-reduced-motion .ease-slide-image-exit,
+.emulate-reduced-motion .ease-rotate-image-exit,
+.emulate-reduced-motion .ease-expand-border-exit,
+.emulate-reduced-motion .ease-contract-bg-exit {
+  animation-name: ease-kf-fade-out !important;
+  transform: none !important;
+}
+
+/* Looping Animations emulation */
+.emulate-reduced-motion .ease-bounce,
+.emulate-reduced-motion .ease-rotate,
+.emulate-reduced-motion .ease-pulse,
+.emulate-reduced-motion .ease-ping,
+.emulate-reduced-motion .ease-shake,
+.emulate-reduced-motion .ease-shimmer-sweep,
+.emulate-reduced-motion .ease-gradient-rotation,
+.emulate-reduced-motion .ease-pulse-border-emphasis,
+.emulate-reduced-motion .ease-skeleton-shimmer,
+.emulate-reduced-motion .ease-skeleton-pulse,
+.emulate-reduced-motion .ease-btn-loading::after {
+  animation: none !important;
+}
+
+/* Typewriter emulation */
+.emulate-reduced-motion .ease-typewriter-loop {
+  width: auto !important;
+  max-width: none !important;
+  border-right: none !important;
+  white-space: normal !important;
+  animation: none !important;
+}
+
+/* Hover emulation */
+.emulate-reduced-motion .ease-hover-grow:hover,
+.emulate-reduced-motion .ease-hover-shrink:hover,
+.emulate-reduced-motion .ease-hover-lift:hover,
+.emulate-reduced-motion .ease-card-lift:hover,
+.emulate-reduced-motion .ease-hover-morph-card:hover,
+.emulate-reduced-motion .ease-hover-bounce-text:hover,
+.emulate-reduced-motion .ease-squish-button:hover,
+.emulate-reduced-motion .ease-squish-button:focus-visible,
+.emulate-reduced-motion .ease-squish-button:active,
+.emulate-reduced-motion .ease-btn:active,
+.emulate-reduced-motion .ease-btn-hover:hover,
+.emulate-reduced-motion .ease-card-hover:hover {
+  transform: none !important;
+  animation: none !important;
+}
+
+/* Shimmer emulation */
+.emulate-reduced-motion .ease-hover-shimmer::before {
+  display: none !important;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds CSS rules for people who prefer less motion on their devices. These rules help make animations and transitions more accessible.

The new rules fix Issue #480. They replace old rules that caused problems with some styling and text effects.
The new rules only affect motion- features like spins, bounces and loops. They do not affect transitions like color changes or opacity.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission (Accessibility override audit)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/prefers-reduced-motion-fix/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This adds rules that disable motion-heavy features. These features include translates, bounces, spins and loops. The rules only apply when a user prefers motion.
The rules preserve transitions like color changes, opacity changes and background changes.

**How does a developer use it?**

The developer should replace rules at the bottom of `core/animations.css` with new rules from `style.css`.
To use it just add a class to an HTML element:
```html
<div class="ease-slide-up">Gentle fade-in on motion</div>
<div class="ease-typewriter-loop">Fully visible text, on reduced motion</div>