### PR TITLE
feat: Add npm package.json enhancement for CDN publishing

### DIFF
--- a/submissions/examples/npm-package-cdn-publishing/README.md
+++ b/submissions/examples/npm-package-cdn-publishing/README.md
@@ -1,0 +1,56 @@
+# Add npm package.json for CDN Publishing
+
+## What does this do?
+
+Enhances the existing `package.json` with CDN-specific fields (`unpkg`, `jsdelivr`, `exports`) so EaseMotion CSS works optimally via jsDelivr and unpkg CDNs, and supports modern bundler resolution.
+
+## Proposed Changes to `package.json`
+
+The following fields should be added to the existing `package.json`:
+
+```json
+{
+  "unpkg": "easemotion.css",
+  "jsdelivr": "easemotion.css",
+  "exports": {
+    ".": "./easemotion.css",
+    "./core/variables.css": "./core/variables.css",
+    "./core/base.css": "./core/base.css",
+    "./core/animations.css": "./core/animations.css",
+    "./core/utilities.css": "./core/utilities.css",
+    "./components/buttons.css": "./components/buttons.css",
+    "./components/cards.css": "./components/cards.css"
+  }
+}
+```
+
+## How is it used?
+
+After publishing to npm, developers can use EaseMotion CSS via:
+
+**jsDelivr CDN:**
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />
+```
+
+**unpkg CDN:**
+```html
+<link rel="stylesheet" href="https://unpkg.com/easemotion-css/easemotion.css" />
+```
+
+**npm install + bundler import:**
+```js
+// In Vite, webpack, or any bundler
+import 'easemotion-css';
+// or granular:
+import 'easemotion-css/core/variables.css';
+import 'easemotion-css/core/animations.css';
+```
+
+## Why is it useful?
+
+- The `jsdelivr` field tells jsDelivr which file to serve as the default entry point
+- The `unpkg` field does the same for unpkg CDN
+- The `exports` field enables modern bundlers (Vite, webpack 5+) to resolve individual CSS modules
+- This makes EaseMotion CSS a first-class npm package that works seamlessly with CDNs and bundlers
+- Aligns with the project's goal of "link one file and start building"

--- a/submissions/examples/npm-package-cdn-publishing/demo.html
+++ b/submissions/examples/npm-package-cdn-publishing/demo.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>npm package.json for CDN Publishing — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 3rem 2rem;
+      min-height: 100vh;
+    }
+    h1 {
+      text-align: center;
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+      background: linear-gradient(135deg, #6c63ff, #a78bfa);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .subtitle {
+      text-align: center;
+      color: #94a3b8;
+      margin-bottom: 2.5rem;
+      font-size: 0.85rem;
+    }
+    h2 {
+      font-size: 1rem;
+      color: #a78bfa;
+      margin-bottom: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    section {
+      margin-bottom: 2.5rem;
+    }
+    .json-block {
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 0.5rem;
+      padding: 1.25rem;
+      margin-bottom: 1.5rem;
+      overflow-x: auto;
+    }
+    .json-block pre {
+      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-size: 0.8rem;
+      line-height: 1.6;
+      color: #e2e8f0;
+    }
+    .json-block .key { color: #a78bfa; }
+    .json-block .string { color: #86efac; }
+  </style>
+</head>
+<body>
+  <h1>npm package.json for CDN Publishing</h1>
+  <p class="subtitle">Enhanced package.json fields for jsDelivr, unpkg, and modern bundlers</p>
+
+  <div class="cdn-demo-container">
+    <section>
+      <h2>Proposed package.json additions</h2>
+      <div class="json-block">
+        <pre>{
+  <span class="key">"unpkg"</span>: <span class="string">"easemotion.css"</span>,
+  <span class="key">"jsdelivr"</span>: <span class="string">"easemotion.css"</span>,
+  <span class="key">"exports"</span>: {
+    <span class="key">"."</span>: <span class="string">"./easemotion.css"</span>,
+    <span class="key">"./core/variables.css"</span>: <span class="string">"./core/variables.css"</span>,
+    <span class="key">"./core/base.css"</span>: <span class="string">"./core/base.css"</span>,
+    <span class="key">"./core/animations.css"</span>: <span class="string">"./core/animations.css"</span>,
+    <span class="key">"./core/utilities.css"</span>: <span class="string">"./core/utilities.css"</span>,
+    <span class="key">"./components/buttons.css"</span>: <span class="string">"./components/buttons.css"</span>,
+    <span class="key">"./components/cards.css"</span>: <span class="string">"./components/cards.css"</span>
+  }
+}</pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>CDN URLs (after publishing)</h2>
+      <div class="cdn-link-card">
+        <div class="label">jsDelivr — Full Bundle</div>
+        <code>https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css</code>
+      </div>
+      <div class="cdn-link-card">
+        <div class="label">unpkg — Full Bundle</div>
+        <code>https://unpkg.com/easemotion-css/easemotion.css</code>
+      </div>
+      <div class="cdn-link-card">
+        <div class="label">jsDelivr — Individual Module</div>
+        <code>https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css</code>
+      </div>
+      <div class="cdn-link-card">
+        <div class="label">unpkg — Individual Module</div>
+        <code>https://unpkg.com/easemotion-css/core/animations.css</code>
+      </div>
+    </section>
+
+    <section>
+      <h2>Bundler Import (Vite / webpack)</h2>
+      <div class="json-block">
+        <pre><span class="key">// Full import</span>
+import <span class="string">'easemotion-css'</span>;
+
+<span class="key">// Granular imports</span>
+import <span class="string">'easemotion-css/core/variables.css'</span>;
+import <span class="string">'easemotion-css/core/base.css'</span>;
+import <span class="string">'easemotion-css/core/animations.css'</span>;
+import <span class="string">'easemotion-css/core/utilities.css'</span>;</pre>
+      </div>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/examples/npm-package-cdn-publishing/style.css
+++ b/submissions/examples/npm-package-cdn-publishing/style.css
@@ -1,0 +1,67 @@
+/* ============================================================
+   npm package.json Enhancement for CDN Publishing
+   
+   This is a documentation-only submission. The actual change
+   is to the root package.json (maintainer action).
+   
+   This file demonstrates how the CDN links resolve after
+   the package.json is updated with jsdelivr/unpkg fields.
+   ============================================================ */
+
+/* 
+   After adding these fields to package.json:
+   
+   "unpkg": "easemotion.css",
+   "jsdelivr": "easemotion.css",
+   "exports": {
+     ".": "./easemotion.css",
+     "./core/variables.css": "./core/variables.css",
+     "./core/base.css": "./core/base.css",
+     "./core/animations.css": "./core/animations.css",
+     "./core/utilities.css": "./core/utilities.css",
+     "./components/buttons.css": "./components/buttons.css",
+     "./components/cards.css": "./components/cards.css"
+   }
+   
+   The following CDN URLs will work:
+   
+   Full bundle:
+   https://cdn.jsdelivr.net/npm/easemotion-css
+   https://unpkg.com/easemotion-css
+   
+   Individual modules:
+   https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css
+   https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css
+   https://unpkg.com/easemotion-css/core/animations.css
+*/
+
+/* Demo styles for the test page */
+.cdn-demo-container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: system-ui, sans-serif;
+}
+
+.cdn-link-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.cdn-link-card code {
+  font-size: 0.8rem;
+  color: #a78bfa;
+  word-break: break-all;
+}
+
+.cdn-link-card .label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Pull Request Description

Proposes enhancements to `package.json` for optimal CDN publishing via jsDelivr and unpkg, plus modern bundler support with an `exports` map.

Closes #352

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: npm package configuration enhancement

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/npm-package-cdn-publishing/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Proposes adding `unpkg`, `jsdelivr`, and `exports` fields to `package.json` for optimal CDN resolution and modern bundler support.

**How does a developer use it?**

```html
<- Browser: N/A (server-side jsDelivr -->
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />

<- Browser: N/A (server-side unpkg -->
<link rel="stylesheet" href="https://unpkg.com/easemotion-css/easemotion.css" />
```

```js
// Vite / webpack
import 'easemotion-css';
import 'easemotion-css/core/animations.css';
```

**Why does it fit EaseMotion CSS?**

EaseMotion CSS's philosophy is "link one file and start building." Proper CDN fields ensure the default URL resolves to the right file without needing to specify a path, making adoption frictionless.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The existing `package.json` already has `main` and `style` fields. This submission proposes adding:
- `"unpkg": "easemotion.css"` — for unpkg CDN default resolution
- `"jsdelivr": "easemotion.css"` — for jsDelivr CDN optimization
- `"exports"` map — for modern bundler (Vite, webpack 5+) granular imports

These are additive changes that don't break anything existing.

---

> **Reminder:** Only the repository maintainer may merge pull requests.