### PR TITLE
docs: Vite and webpack Import Guide

### DIFF
--- a/submissions/examples/vite-webpack-import-guide/README.md
+++ b/submissions/examples/vite-webpack-import-guide/README.md
@@ -1,0 +1,98 @@
+# Docs: Vite and webpack Import Guide
+
+## What does this do?
+
+Shows how to import EaseMotion CSS in Vite and webpack projects, with a CDN alternative for non-bundler setups. Designed to be added to the docs site.
+
+## How is it used?
+
+### Vite
+
+```bash
+npm install easemotion-css
+```
+
+```js
+// main.js or main.ts
+import 'easemotion-css';
+```
+
+Or for granular imports (smaller bundle):
+
+```js
+// Import only what you need
+import 'easemotion-css/core/variables.css';
+import 'easemotion-css/core/base.css';
+import 'easemotion-css/core/animations.css';
+import 'easemotion-css/core/utilities.css';
+
+// Components (optional)
+import 'easemotion-css/components/buttons.css';
+import 'easemotion-css/components/cards.css';
+```
+
+### webpack
+
+```bash
+npm install easemotion-css
+```
+
+```js
+// index.js or app.js
+import 'easemotion-css';
+```
+
+Requires `css-loader` and `style-loader` (or `MiniCssExtractPlugin`):
+
+```js
+// webpack.config.js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+};
+```
+
+### CDN Alternative (no bundler)
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />
+```
+
+### Framework-specific examples
+
+**React (Vite):**
+```jsx
+// src/main.jsx
+import 'easemotion-css';
+import App from './App';
+```
+
+**Vue (Vite):**
+```js
+// src/main.js
+import 'easemotion-css';
+import { createApp } from 'vue';
+import App from './App.vue';
+createApp(App).mount('#app');
+```
+
+**Svelte (Vite):**
+```js
+// src/main.js
+import 'easemotion-css';
+import App from './App.svelte';
+new App({ target: document.getElementById('app') });
+```
+
+## Why is it useful?
+
+- Most modern projects use a bundler (Vite or webpack)
+- Developers need clear, copy-paste instructions for their setup
+- Reduces friction for adoption in real-world projects
+- Covers the three most common scenarios: Vite, webpack, and CDN

--- a/submissions/examples/vite-webpack-import-guide/demo.html
+++ b/submissions/examples/vite-webpack-import-guide/demo.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vite & webpack Import Guide — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: #0f172a; min-height: 100vh; }
+  </style>
+</head>
+<body>
+  <div class="import-guide">
+    <h1>Import Guide</h1>
+    <p class="subtitle">How to use EaseMotion CSS in Vite, webpack, and CDN projects</p>
+
+    <!-- Tab Navigation -->
+    <nav class="tab-nav">
+      <button class="tab-btn active" data-tab="vite">Vite</button>
+      <button class="tab-btn" data-tab="webpack">webpack</button>
+      <button class="tab-btn" data-tab="cdn">CDN</button>
+    </nav>
+
+    <!-- Vite Tab -->
+    <div class="tab-content active" id="tab-vite">
+      <p class="section-label">Step 1 — Install</p>
+      <div class="code-block">
+        <span class="lang-badge">bash</span>
+        <pre>npm install easemotion-css</pre>
+      </div>
+
+      <p class="section-label">Step 2 — Import in your entry file</p>
+      <p class="step-description">Add one line to your main.js (or main.ts). Vite handles CSS imports natively — no extra config needed.</p>
+      <div class="code-block">
+        <span class="lang-badge">js</span>
+        <pre><span class="comment">// main.js or main.ts</span>
+<span class="keyword">import</span> <span class="string">'easemotion-css'</span>;</pre>
+      </div>
+
+      <p class="section-label">Granular imports (optional)</p>
+      <p class="step-description">Import only the modules you need for a smaller bundle:</p>
+      <div class="code-block">
+        <span class="lang-badge">js</span>
+        <pre><span class="comment">// Core (required, in this order)</span>
+<span class="keyword">import</span> <span class="string">'easemotion-css/core/variables.css'</span>;
+<span class="keyword">import</span> <span class="string">'easemotion-css/core/base.css'</span>;
+<span class="keyword">import</span> <span class="string">'easemotion-css/core/animations.css'</span>;
+<span class="keyword">import</span> <span class="string">'easemotion-css/core/utilities.css'</span>;
+
+<span class="comment">// Components (add as needed)</span>
+<span class="keyword">import</span> <span class="string">'easemotion-css/components/buttons.css'</span>;
+<span class="keyword">import</span> <span class="string">'easemotion-css/components/cards.css'</span>;</pre>
+      </div>
+
+      <div class="info-callout">
+        <span class="icon">💡</span>
+        <div>Vite supports CSS imports out of the box. No loaders or plugins required.</div>
+      </div>
+
+      <hr class="guide-divider" />
+
+      <p class="section-label">Framework examples</p>
+
+      <p class="step-description"><strong>React + Vite:</strong></p>
+      <div class="code-block">
+        <span class="lang-badge">jsx</span>
+        <pre><span class="comment">// src/main.jsx</span>
+<span class="keyword">import</span> <span class="string">'easemotion-css'</span>;
+<span class="keyword">import</span> React <span class="keyword">from</span> <span class="string">'react'</span>;
+<span class="keyword">import</span> ReactDOM <span class="keyword">from</span> <span class="string">'react-dom/client'</span>;
+<span class="keyword">import</span> App <span class="keyword">from</span> <span class="string">'./App'</span>;
+
+ReactDOM.<span class="func">createRoot</span>(document.<span class="func">getElementById</span>(<span class="string">'root'</span>)).<span class="func">render</span>(&lt;App /&gt;);</pre>
+      </div>
+
+      <p class="step-description"><strong>Vue + Vite:</strong></p>
+      <div class="code-block">
+        <span class="lang-badge">js</span>
+        <pre><span class="comment">// src/main.js</span>
+<span class="keyword">import</span> <span class="string">'easemotion-css'</span>;
+<span class="keyword">import</span> { createApp } <span class="keyword">from</span> <span class="string">'vue'</span>;
+<span class="keyword">import</span> App <span class="keyword">from</span> <span class="string">'./App.vue'</span>;
+
+<span class="func">createApp</span>(App).<span class="func">mount</span>(<span class="string">'#app'</span>);</pre>
+      </div>
+
+      <p class="step-description"><strong>Svelte + Vite:</strong></p>
+      <div class="code-block">
+        <span class="lang-badge">js</span>
+        <pre><span class="comment">// src/main.js</span>
+<span class="keyword">import</span> <span class="string">'easemotion-css'</span>;
+<span class="keyword">import</span> App <span class="keyword">from</span> <span class="string">'./App.svelte'</span>;
+
+<span class="keyword">new</span> <span class="func">App</span>({ target: document.<span class="func">getElementById</span>(<span class="string">'app'</span>) });</pre>
+      </div>
+    </div>
+
+    <!-- webpack Tab -->
+    <div class="tab-content" id="tab-webpack">
+      <p class="section-label">Step 1 — Install</p>
+      <div class="code-block">
+        <span class="lang-badge">bash</span>
+        <pre>npm install easemotion-css</pre>
+      </div>
+
+      <p class="section-label">Step 2 — Configure CSS loaders</p>
+      <p class="step-description">webpack needs css-loader to handle CSS imports. Add this to your config:</p>
+      <div class="code-block">
+        <span class="lang-badge">js</span>
+        <pre><span class="comment">// webpack.config.js</span>
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: <span class="string">/\.css$/</span>,
+        use: [<span class="string">'style-loader'</span>, <span class="string">'css-loader'</span>],
+      },
+    ],
+  },
+};</pre>
+      </div>
+
+      <div class="info-callout">
+        <span class="icon">⚠️</span>
+        <div>If you don't have css-loader installed: <code>npm install -D css-loader style-loader</code></div>
+      </div>
+
+      <p class="section-label">Step 3 — Import</p>
+      <div class="code-block">
+        <span class="lang-badge">js</span>
+        <pre><span class="comment">// index.js or app.js</span>
+<span class="keyword">import</span> <span class="string">'easemotion-css'</span>;</pre>
+      </div>
+
+      <p class="section-label">Granular imports</p>
+      <div class="code-block">
+        <span class="lang-badge">js</span>
+        <pre><span class="keyword">import</span> <span class="string">'easemotion-css/core/variables.css'</span>;
+<span class="keyword">import</span> <span class="string">'easemotion-css/core/base.css'</span>;
+<span class="keyword">import</span> <span class="string">'easemotion-css/core/animations.css'</span>;
+<span class="keyword">import</span> <span class="string">'easemotion-css/core/utilities.css'</span>;</pre>
+      </div>
+
+      <div class="info-callout">
+        <span class="icon">💡</span>
+        <div>For production, consider using <code>MiniCssExtractPlugin</code> instead of <code>style-loader</code> to extract CSS into separate files.</div>
+      </div>
+    </div>
+
+    <!-- CDN Tab -->
+    <div class="tab-content" id="tab-cdn">
+      <p class="section-label">Full bundle (recommended)</p>
+      <p class="step-description">One line in your HTML head. No npm, no build step, no config.</p>
+      <div class="code-block">
+        <span class="lang-badge">html</span>
+        <pre>&lt;<span class="keyword">link</span> <span class="func">rel</span>=<span class="string">"stylesheet"</span>
+      <span class="func">href</span>=<span class="string">"https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css"</span> /&gt;</pre>
+      </div>
+
+      <p class="section-label">Individual modules</p>
+      <p class="step-description">Load only what you need:</p>
+      <div class="code-block">
+        <span class="lang-badge">html</span>
+        <pre><span class="comment">&lt;!-- Core (required, in this order) --&gt;</span>
+&lt;<span class="keyword">link</span> <span class="func">rel</span>=<span class="string">"stylesheet"</span> <span class="func">href</span>=<span class="string">"https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css"</span> /&gt;
+&lt;<span class="keyword">link</span> <span class="func">rel</span>=<span class="string">"stylesheet"</span> <span class="func">href</span>=<span class="string">"https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css"</span> /&gt;
+&lt;<span class="keyword">link</span> <span class="func">rel</span>=<span class="string">"stylesheet"</span> <span class="func">href</span>=<span class="string">"https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css"</span> /&gt;
+&lt;<span class="keyword">link</span> <span class="func">rel</span>=<span class="string">"stylesheet"</span> <span class="func">href</span>=<span class="string">"https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css"</span> /&gt;
+
+<span class="comment">&lt;!-- Components (add as needed) --&gt;</span>
+&lt;<span class="keyword">link</span> <span class="func">rel</span>=<span class="string">"stylesheet"</span> <span class="func">href</span>=<span class="string">"https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css"</span> /&gt;
+&lt;<span class="keyword">link</span> <span class="func">rel</span>=<span class="string">"stylesheet"</span> <span class="func">href</span>=<span class="string">"https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css"</span> /&gt;</pre>
+      </div>
+
+      <p class="section-label">unpkg alternative</p>
+      <div class="code-block">
+        <span class="lang-badge">html</span>
+        <pre>&lt;<span class="keyword">link</span> <span class="func">rel</span>=<span class="string">"stylesheet"</span>
+      <span class="func">href</span>=<span class="string">"https://unpkg.com/easemotion-css/easemotion.css"</span> /&gt;</pre>
+      </div>
+
+      <div class="info-callout">
+        <span class="icon">⚠️</span>
+        <div>Always load <code>variables.css</code> first — all other modules depend on the CSS custom properties it defines.</div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Simple tab switching
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        // Remove active from all tabs and content
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        
+        // Activate clicked tab and its content
+        btn.classList.add('active');
+        document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/vite-webpack-import-guide/style.css
+++ b/submissions/examples/vite-webpack-import-guide/style.css
@@ -1,0 +1,153 @@
+/* ============================================================
+   Vite and webpack Import Guide — Reference Styles
+   
+   This is a documentation submission. The CSS below styles
+   the demo page that shows import instructions for different
+   bundler setups.
+   ============================================================ */
+
+/* Demo page layout */
+.import-guide {
+  max-width: 740px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #e2e8f0;
+}
+
+.import-guide h1 {
+  text-align: center;
+  font-size: 1.75rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.import-guide .subtitle {
+  text-align: center;
+  color: #94a3b8;
+  margin-bottom: 2.5rem;
+  font-size: 0.85rem;
+}
+
+/* Tab navigation */
+.tab-nav {
+  display: flex;
+  gap: 0;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.tab-btn {
+  padding: 0.75rem 1.5rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+  font-family: inherit;
+}
+
+.tab-btn:hover {
+  color: #e2e8f0;
+}
+
+.tab-btn.active {
+  color: #a78bfa;
+  border-bottom-color: #6c63ff;
+}
+
+/* Tab content */
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+/* Code blocks */
+.code-block {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 0.5rem;
+  padding: 1.25rem;
+  margin-bottom: 1.5rem;
+  overflow-x: auto;
+  position: relative;
+}
+
+.code-block pre {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.8rem;
+  line-height: 1.7;
+  color: #e2e8f0;
+  margin: 0;
+}
+
+.code-block .lang-badge {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.25);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* Syntax highlighting */
+.code-block .keyword { color: #c084fc; }
+.code-block .string { color: #86efac; }
+.code-block .comment { color: #64748b; }
+.code-block .func { color: #67e8f9; }
+
+/* Section headers */
+.section-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #a78bfa;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.step-description {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+  line-height: 1.6;
+}
+
+/* Info callout */
+.info-callout {
+  background: rgba(108, 99, 255, 0.08);
+  border: 1px solid rgba(108, 99, 255, 0.25);
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.info-callout .icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+/* Divider */
+.guide-divider {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  margin: 2rem 0;
+}


### PR DESCRIPTION
## Pull Request Description

Shows how to import EaseMotion CSS in Vite and webpack projects, with CDN alternative and framework-specific examples.

Closes #491

---

## Type of Change

- [ ] New animation / hover effect
- [ ] New component
- [x] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside submissions/examples/vite-webpack-import-guide/
- [x] Includes demo.html — self-contained, opens in browser with no server
- [x] Includes style.css — raw CSS for the proposed feature
- [x] Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to core/
- [x] No changes to components/
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A complete import guide covering Vite (zero config), webpack (with css-loader), and CDN alternatives. Includes framework-specific examples for React, Vue, and Svelte.

**How does a developer use it?**

```js
// Vite or webpack — one line
import 'easemotion-css';

// Granular imports
import 'easemotion-css/core/variables.css';
import 'easemotion-css/core/animations.css';
```

**Why does it fit EaseMotion CSS?**

Most modern projects use a bundler. Clear import instructions reduce friction and make EaseMotion CSS accessible to the majority of web developers who use Vite or webpack daily.

---

## Demo

- [x] Demo added (demo.html works by opening directly in a browser — interactive tabbed guide)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

Ready to be added to the docs site as a new section. The demo uses a simple tab UI (vanilla JS, no dependencies) to switch between Vite, webpack, and CDN instructions. Content can be directly integrated into docs/index.html.

---

> Reminder: Only the repository maintainer may merge pull requests.