### PR TITLE
feat: add animation duration utility demo

### DIFF
--- a/submissions/examples/animation-duration-utilities/README.md
+++ b/submissions/examples/animation-duration-utilities/README.md
@@ -1,0 +1,14 @@
+# Animation Duration Utilities
+
+**What does this do?**
+Adds small duration utility classes that let the same transition or keyframe animation run at fast, normal, or slow speeds.
+
+**How is it used?**
+```html
+<button class="motion-card duration-fast">Fast</button>
+<button class="motion-card duration-normal">Normal</button>
+<button class="motion-card duration-slow">Slow</button>
+```
+
+**Why is it useful?**
+Duration utilities make timing consistent across buttons, cards, reveals, and hover states without writing one-off CSS for every component, which fits EaseMotion CSS's goal of readable motion primitives.

--- a/submissions/examples/animation-duration-utilities/demo.html
+++ b/submissions/examples/animation-duration-utilities/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Animation Duration Utilities</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro">
+      <p class="eyebrow">Timing utilities</p>
+      <h1>Animation Duration Utilities</h1>
+      <p>
+        Apply a duration class to reuse the same motion at fast, normal, or
+        slow speeds. Hover each card to compare the timing.
+      </p>
+    </section>
+
+    <section class="duration-grid" aria-label="Animation duration utility examples">
+      <article class="motion-card duration-fast">
+        <span class="duration-label">Fast</span>
+        <strong>160ms</strong>
+        <p>Best for quick buttons, toggles, and compact hover feedback.</p>
+      </article>
+
+      <article class="motion-card duration-normal">
+        <span class="duration-label">Normal</span>
+        <strong>300ms</strong>
+        <p>Balanced timing for cards, menus, and common interface states.</p>
+      </article>
+
+      <article class="motion-card duration-slow">
+        <span class="duration-label">Slow</span>
+        <strong>700ms</strong>
+        <p>Useful for featured reveals, empty states, and more expressive motion.</p>
+      </article>
+    </section>
+
+    <section class="reveal-strip" aria-label="Entrance animation duration examples">
+      <div class="reveal-pill duration-fast">Fast reveal</div>
+      <div class="reveal-pill duration-normal">Normal reveal</div>
+      <div class="reveal-pill duration-slow">Slow reveal</div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/animation-duration-utilities/style.css
+++ b/submissions/examples/animation-duration-utilities/style.css
@@ -1,0 +1,180 @@
+:root {
+  color-scheme: light dark;
+  --page-bg: #0c111d;
+  --panel-bg: #111827;
+  --panel-soft: #182033;
+  --ink: #f8fafc;
+  --muted: #a7b0c3;
+  --accent: #38bdf8;
+  --accent-strong: #22c55e;
+  --ring: rgba(56, 189, 248, 0.34);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 16% 14%, rgba(34, 197, 94, 0.18), transparent 28rem),
+    radial-gradient(circle at 82% 10%, rgba(56, 189, 248, 0.16), transparent 30rem),
+    var(--page-bg);
+  color: var(--ink);
+}
+
+.demo-shell {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.intro {
+  max-width: 720px;
+  margin-bottom: 42px;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(2.4rem, 8vw, 5rem);
+  line-height: 0.95;
+}
+
+.intro p {
+  max-width: 58ch;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.duration-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.motion-card {
+  --motion-duration: 300ms;
+  display: grid;
+  min-height: 250px;
+  padding: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  background: linear-gradient(145deg, var(--panel-bg), var(--panel-soft));
+  box-shadow: 0 22px 60px rgba(2, 6, 23, 0.34);
+  cursor: pointer;
+  transition-duration: var(--motion-duration);
+  transition-property: border-color, box-shadow, transform;
+  transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.motion-card:hover {
+  border-color: var(--ring);
+  box-shadow: 0 28px 80px rgba(56, 189, 248, 0.2);
+  transform: translateY(-10px) scale(1.02);
+}
+
+.duration-label {
+  align-self: start;
+  width: fit-content;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.motion-card strong {
+  align-self: end;
+  margin-top: 44px;
+  font-size: clamp(2rem, 7vw, 3.7rem);
+  line-height: 1;
+}
+
+.motion-card p {
+  margin: 18px 0 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.duration-fast {
+  --motion-duration: 160ms;
+  animation-duration: 160ms;
+}
+
+.duration-normal {
+  --motion-duration: 300ms;
+  animation-duration: 300ms;
+}
+
+.duration-slow {
+  --motion-duration: 700ms;
+  animation-duration: 700ms;
+}
+
+.reveal-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 28px;
+}
+
+.reveal-pill {
+  --motion-duration: 300ms;
+  padding: 14px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ink);
+  font-weight: 700;
+  animation: rise-in var(--motion-duration) cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.reveal-pill:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.reveal-pill:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+@keyframes rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 760px) {
+  .duration-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .motion-card {
+    min-height: 220px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a focused submission for animation duration utility classes so developers can reuse fast, normal, and slow timing presets across hover transitions and entrance animations.

Fixes #437

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [x] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/animation-duration-utilities/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Reusable duration utility classes for fast, normal, and slow animation timing.

**How does a developer use it?**

```html
<button class="motion-card duration-fast">Fast</button>
<button class="motion-card duration-normal">Normal</button>
<button class="motion-card duration-slow">Slow</button>
```

**Why does it fit EaseMotion CSS?**

It keeps motion timing readable and reusable, so the maintainer can standardize the concept into EaseMotion-style timing primitives without one-off component CSS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Static HTML/CSS validation: exactly the three required files, no external scripts/CDNs/imports
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer

The class names are intentionally submission-stage names rather than final `ease-*` API names, following the contribution guide. Feel free to adjust the exact duration values during standardization.