### PR TITLE
feat: add ease-hover-lift-shadow combined hover utility

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -629,7 +629,18 @@ animation:
 .ease-hover-grow:hover {
   transform: scale(1.06);
 }
-
+/* Lift + Shadow combined hover
+   Most common 'card lift' pattern — translateY with growing box-shadow */
+.ease-hover-lift-shadow {
+  transition: transform var(--ease-speed-medium) var(--ease-ease),
+              box-shadow var(--ease-speed-medium) var(--ease-ease);
+  will-change: transform, box-shadow;
+}
+.ease-hover-lift-shadow:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.15),
+              0 4px 12px rgba(0, 0, 0, 0.1);
+}
 /* Shrink on hover */
 .ease-hover-shrink {
   transition: transform var(--ease-speed-fast) var(--ease-ease);


### PR DESCRIPTION
Closes #242

## Changes
- Added `.ease-hover-lift-shadow` hover utility class
- Combines `translateY(-4px)` with growing `box-shadow`
- Uses CSS transitions, no animation keyframes needed
- Follows EaseMotion CSS naming conventions