### PR TITLE
feat: add ripple click effect

### DIFF
--- a/submissions/examples/ripple-click-effect/README.md
+++ b/submissions/examples/ripple-click-effect/README.md
@@ -1,0 +1,17 @@
+# Ripple Click Effect
+
+**What does this do?**  
+Creates a pure CSS ripple animation that expands and fades when a user clicks a button or card.
+
+**How is it used?**
+
+```html
+<button class="ripple-btn">Click Me</button>
+
+<div class="ripple-card">
+  Card content
+</div>
+```
+
+**Why is it useful?**  
+Ripple feedback makes clicks feel more responsive and interactive. It works without JavaScript and provides a clean Material Design-inspired interaction.

--- a/submissions/examples/ripple-click-effect/demo.html
+++ b/submissions/examples/ripple-click-effect/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Submission — Ripple Click Effect</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+
+    <h1>Ripple Click Effect</h1>
+    <p>Click the button or card below to see the ripple expand and fade.</p>
+
+    <div class="demo-grid">
+
+        <button class="ripple-btn">Click Me</button>
+
+        <div class="ripple-card">
+            <div class="icon">💧</div>
+            <h3>Ripple Card</h3>
+            <p>Click this card to see a Material Design-style ripple effect.</p>
+        </div>
+
+    </div>
+
+</body>
+
+</html>

--- a/submissions/examples/ripple-click-effect/style.css
+++ b/submissions/examples/ripple-click-effect/style.css
@@ -1,0 +1,114 @@
+/* ============================================================
+   SUBMISSION — ripple-click-effect
+   Raw CSS: no ease- prefix required at submission stage.
+   Maintainer will standardize naming before integrating.
+   ============================================================ */
+
+/*  Demo page scaffold  */
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+    background: #0f0e17;
+    color: #fffffe;
+    padding: 48px 32px;
+    margin: 0;
+}
+
+h1 {
+    font-size: 2rem;
+    font-weight: 800;
+    margin-bottom: 8px;
+}
+
+p {
+    color: rgba(255, 255, 255, 0.55);
+    margin-bottom: 40px;
+}
+
+.demo-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    align-items: center;
+}
+
+/*  The proposed effect */
+
+.ripple-btn,
+.ripple-card {
+    --ease-ripple-color: rgba(255, 255, 255, 0.45);
+
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+    cursor: pointer;
+}
+
+.ripple-btn::after,
+.ripple-card::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 120px;
+    height: 120px;
+    background: var(--ease-ripple-color);
+    border-radius: 50%;
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+    pointer-events: none;
+}
+
+.ripple-btn:active::after,
+.ripple-card:active::after {
+    animation: ripple-click 550ms ease-out;
+}
+
+@keyframes ripple-click {
+    from {
+        transform: translate(-50%, -50%) scale(0);
+        opacity: 0.7;
+    }
+
+    to {
+        transform: translate(-50%, -50%) scale(4);
+        opacity: 0;
+    }
+}
+
+/*  Demo button  */
+
+.ripple-btn {
+    background: #6c63ff;
+    color: #fff;
+    border: none;
+    padding: 12px 28px;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+/*  Demo card shell  */
+
+.ripple-card {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    padding: 24px;
+    width: 240px;
+}
+
+.ripple-card .icon {
+    font-size: 2rem;
+    margin-bottom: 12px;
+}
+
+.ripple-card h3 {
+    margin: 0 0 8px;
+    font-size: 1.1rem;
+}
+
+.ripple-card p {
+    font-size: 0.875rem;
+    margin: 0;
+    color: rgba(255, 255, 255, 0.5);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS Ripple Click Effect inspired by Material Design.

The effect uses a `::after` pseudo-element that expands from `scale(0)` to `scale(4)` while fading out on `:active`. It works on both buttons and cards, uses `overflow: hidden` for clipping, and supports customization through the `--ease-ripple-color` CSS variable.

Fixes #457

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/ripple-click-effect/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A reusable CSS ripple animation that provides visual click feedback for interactive elements.

### How does a developer use it?

```html
<button class="ripple-btn">Click Me</button>

<div class="ripple-card">
  Card content
</div>
```

### Why does it fit EaseMotion CSS?

The effect is simple, reusable, animation-focused, and provides clear visual feedback without JavaScript. It aligns with EaseMotion CSS's animation-first philosophy while keeping implementation lightweight and easy to understand.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Edge
