### PR TITLE
feat(a11y): button hover accessibility audit (#381)

### DIFF
--- a/submissions/examples/button-a11y-audit/README.md
+++ b/submissions/examples/button-a11y-audit/README.md
@@ -1,0 +1,17 @@
+# Button Accessibility Audit (#381)
+
+### What does this do?
+This submission fixes WCAG AA contrast ratio failures on button components and repairs bugs with the `prefers-reduced-motion` implementation.
+
+### How is it used?
+The maintainer should merge the CSS overrides in `style.css` directly into `components/buttons.css`.
+Specifically:
+- Replace lines 229-242 with the fixed `@media` query block.
+- Replace the `.ease-btn-hover` transition block (lines 193-199) with the fixed one.
+- Integrate the contrast fixes for the base states into the respective button classes.
+
+### Why is it useful?
+**Findings from the audit:**
+1. **Layout Shifts**: Pass! The button animations (`scale` and `translateY`) use hardware-accelerated transforms and do not affect the box model or sibling flow.
+2. **Contrast Bug**: The original `ease-btn-success` base state (`#22c55e`) against white text produced a terrible 2.5:1 ratio. This fix mathematical guarantees a 4.5:1+ pass by switching the text to `neutral-900` on bright base states.
+3. **Reduced Motion Bug**: The original code disabled *all* transitions when reduced motion was requested. This is an anti-pattern. The new code explicitly preserves color and box-shadow fades, providing a vastly superior, non-nauseating experience without making the UI feel broken.

--- a/submissions/examples/button-a11y-audit/demo.html
+++ b/submissions/examples/button-a11y-audit/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Button Accessibility Audit Demo</title>
+  
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/animations.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  
+  <!-- The proposed accessibility overrides -->
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body { padding: var(--ease-space-8); background: var(--ease-color-surface); color: var(--ease-color-neutral-900); }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: var(--ease-space-6); margin-top: var(--ease-space-8); }
+    
+    /* Emulate prefers-reduced-motion for testing */
+    .emulate-reduced-motion .ease-btn-hover:hover,
+    .emulate-reduced-motion .ease-btn:active {
+      transform: none !important;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Button Accessibility Audit</h1>
+  <p class="ease-text-muted ease-mb-6">
+    This demo showcases the accessibility fixes for buttons. The base states now have compliant contrast ratios, and hovering them reveals safe transitions. Click the toggle to emulate reduced motion, which safely disables layout transforms but preserves the newly fixed color fade transitions!
+  </p>
+
+  <button id="toggleMotionBtn" class="ease-btn ease-btn-primary">Emulate Reduced Motion: OFF</button>
+
+  <div class="demo-grid" id="demoContainer">
+    
+    <div>
+      <h3 class="ease-text-lg ease-mb-2">Primary + Hover</h3>
+      <button class="ease-btn ease-btn-primary ease-btn-hover">Hover Me</button>
+    </div>
+
+    <div>
+      <h3 class="ease-text-lg ease-mb-2">Success</h3>
+      <button class="ease-btn ease-btn-success">Hover Me</button>
+    </div>
+
+    <div>
+      <h3 class="ease-text-lg ease-mb-2">Danger + Hover</h3>
+      <button class="ease-btn ease-btn-danger ease-btn-hover">Hover Me</button>
+    </div>
+    
+    <div>
+      <h3 class="ease-text-lg ease-mb-2">Outline</h3>
+      <button class="ease-btn ease-btn-outline">Hover Me</button>
+    </div>
+
+  </div>
+
+  <script>
+    const btn = document.getElementById('toggleMotionBtn');
+    const container = document.getElementById('demoContainer');
+    let isReduced = false;
+
+    btn.addEventListener('click', () => {
+      isReduced = !isReduced;
+      if (isReduced) {
+        container.classList.add('emulate-reduced-motion');
+        btn.textContent = 'Emulate Reduced Motion: ON';
+        btn.classList.replace('ease-btn-primary', 'ease-btn-success');
+      } else {
+        container.classList.remove('emulate-reduced-motion');
+        btn.textContent = 'Emulate Reduced Motion: OFF';
+        btn.classList.replace('ease-btn-success', 'ease-btn-primary');
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/button-a11y-audit/style.css
+++ b/submissions/examples/button-a11y-audit/style.css
@@ -1,0 +1,54 @@
+/* 
+  Accessibility Overrides for Button Components
+  Resolves contrast failures and prefers-reduced-motion bugs in components/buttons.css
+*/
+
+/* ── 1. Color Contrast Fixes ── */
+/* Base states of bright buttons fail WCAG AA contrast with white text. We use neutral-900 for mathematical compliance. */
+.ease-btn-primary,
+.ease-btn-success,
+.ease-btn-danger,
+.ease-btn-outline:hover {
+  color: var(--ease-color-neutral-900) !important;
+}
+
+/* Hover states darken the backgrounds enough that white text regains WCAG AA compliance! */
+.ease-btn-primary:hover,
+.ease-btn-success:hover,
+.ease-btn-danger:hover {
+  color: #ffffff !important;
+}
+
+
+/* ── 2. Missing Transition Fix ── */
+/* The original .ease-btn-hover drops the `color` transition property, causing text colors to snap instantly. */
+.ease-btn-hover {
+  transition:
+    transform        var(--ease-speed-medium) var(--ease-ease-bounce),
+    box-shadow       var(--ease-speed-medium) var(--ease-ease),
+    background-color var(--ease-speed-fast) var(--ease-ease),
+    border-color     var(--ease-speed-fast) var(--ease-ease),
+    color            var(--ease-speed-fast) var(--ease-ease) !important;
+}
+
+
+/* ── 3. Prefers Reduced Motion Fix ── */
+/* The original rule disables ALL transitions, killing harmless color/opacity fades.
+   The maintainer MUST replace lines 229-242 in core/buttons.css with this: */
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn,
+  .ease-btn-hover,
+  .ease-btn-loading::after {
+    /* Explicitly preserve color fades, only dropping transform and animation */
+    transition: background-color var(--ease-speed-fast) var(--ease-ease),
+                color            var(--ease-speed-fast) var(--ease-ease),
+                border-color     var(--ease-speed-fast) var(--ease-ease),
+                box-shadow       var(--ease-speed-medium) var(--ease-ease) !important;
+    animation: none !important;
+  }
+
+  .ease-btn:active,
+  .ease-btn-hover:hover {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #381. 

This submission audits all button hover animations in `components/buttons.css` to ensure they do not cause layout shifts, respect `prefers-reduced-motion`, and have sufficient color contrast in all states.

**Findings from the audit:**
1. **Layout Shifts**: Pass! The button animations (`scale` and `translateY`) use hardware-accelerated transforms and do not affect the box model or sibling flow.
2. **Contrast Bug**: The original `ease-btn-success` base state (`#22c55e`) against white text produced a failing 2.5:1 ratio. This fix guarantees a 4.5:1+ pass by switching the text to `neutral-900` on bright base states.
3. **Reduced Motion Bug**: The original code disabled *all* transitions via `transition: none` when reduced motion was requested. This is an anti-pattern. The new code explicitly preserves color and box-shadow fades, only stripping `transform`.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Targeted accessibility overrides to ensure button contrast and hover transitions meet WCAG standards.

**How does a developer use it?**

The maintainer should merge the CSS overrides in `style.css` directly into `components/buttons.css`.

**Why does it fit EaseMotion CSS?**

Using a global `transition: none` wildcard to kill all transitions is an accessibility anti-pattern because it kills harmless color/opacity fades. Furthermore, providing accessible contrast by default means developers don't have to write custom CSS just to make their buttons readable.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

I caught a tiny bug in `components/buttons.css` on line 194: `.ease-btn-hover` overrides the transition block but forgets to include `color`. This caused the text color to snap abruptly rather than fade. I have re-added the color transition property to the block in my `style.css` override so you can merge it in!