### PR TITLE
feat: add animation delay utility submission

### DIFF
--- a/submissions/examples/animation-delay-utilities/README.md
+++ b/submissions/examples/animation-delay-utilities/README.md
@@ -1,0 +1,16 @@
+# Animation Delay Utilities
+
+**What does this do?**
+Adds reusable delay utility classes for staging entrance animations in a predictable sequence.
+
+**How is it used?**
+```html
+<article class="delay-card em-delay-1">First item</article>
+<article class="delay-card em-delay-2">Second item</article>
+<article class="delay-card em-delay-3">Third item</article>
+<article class="delay-card em-delay-4">Fourth item</article>
+<div class="timeline-dot em-delay-custom" style="--em-delay: 2.4s"></div>
+```
+
+**Why is it useful?**
+Delay utilities help developers create staggered cards, timelines, and callouts without repeating custom `animation-delay` values, which fits EaseMotion CSS's goal of small, readable motion primitives.

--- a/submissions/examples/animation-delay-utilities/demo.html
+++ b/submissions/examples/animation-delay-utilities/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Animation Delay Utilities</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro">
+      <p class="eyebrow">Delay utilities</p>
+      <h1>Animation Delay Utilities</h1>
+      <p>
+        Reuse small delay classes to stage entrance motion without writing
+        one-off animation-delay values for each element.
+      </p>
+    </section>
+
+    <section class="delay-grid" aria-label="Animation delay utility examples">
+      <article class="delay-card em-delay-1">
+        <span class="delay-label">.em-delay-1</span>
+        <strong>0.5s</strong>
+        <p>Starts first for the lead item in a staggered group.</p>
+      </article>
+
+      <article class="delay-card em-delay-2">
+        <span class="delay-label">.em-delay-2</span>
+        <strong>1s</strong>
+        <p>Creates a clear second beat for supporting content.</p>
+      </article>
+
+      <article class="delay-card em-delay-3">
+        <span class="delay-label">.em-delay-3</span>
+        <strong>1.5s</strong>
+        <p>Lets secondary cards arrive after the primary action.</p>
+      </article>
+
+      <article class="delay-card em-delay-4">
+        <span class="delay-label">.em-delay-4</span>
+        <strong>2s</strong>
+        <p>Works for final callouts, badges, and helper panels.</p>
+      </article>
+    </section>
+
+    <section class="custom-delay-panel" aria-label="Custom delay example">
+      <div class="timeline-dot em-delay-custom" style="--em-delay: 2.4s"></div>
+      <div>
+        <h2>Custom property timing</h2>
+        <p>
+          Use <code>.em-delay-custom</code> with <code>--em-delay</code> when a
+          sequence needs a value outside the default utility scale.
+        </p>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/animation-delay-utilities/style.css
+++ b/submissions/examples/animation-delay-utilities/style.css
@@ -1,0 +1,221 @@
+:root {
+  color-scheme: light dark;
+  --page-bg: #101314;
+  --panel-bg: #f8faf7;
+  --panel-ink: #18201e;
+  --ink: #f7fbf8;
+  --muted: #a8b4ad;
+  --accent: #76e4b2;
+  --accent-strong: #f9c74f;
+  --border: rgba(255, 255, 255, 0.16);
+  --shadow: rgba(0, 0, 0, 0.26);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(135deg, rgba(118, 228, 178, 0.16), transparent 32%),
+    linear-gradient(315deg, rgba(249, 199, 79, 0.14), transparent 28%),
+    var(--page-bg);
+  color: var(--ink);
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.intro {
+  max-width: 720px;
+  margin-bottom: 40px;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(2.3rem, 7vw, 4.8rem);
+  line-height: 0.98;
+}
+
+.intro p {
+  max-width: 58ch;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.delay-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.delay-card {
+  min-height: 250px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--panel-bg);
+  color: var(--panel-ink);
+  box-shadow: 0 24px 60px var(--shadow);
+  opacity: 0;
+  transform: translateY(22px);
+  animation: em-rise-in 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.delay-card:hover {
+  transform: translateY(-6px);
+}
+
+.delay-label {
+  display: inline-flex;
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: rgba(20, 83, 45, 0.1);
+  color: #14532d;
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.delay-card strong {
+  display: block;
+  margin-top: 56px;
+  font-size: clamp(2.3rem, 6vw, 4rem);
+  line-height: 1;
+}
+
+.delay-card p {
+  margin: 18px 0 0;
+  color: #4b5b55;
+  line-height: 1.6;
+}
+
+.em-delay-1 {
+  animation-delay: 0.5s;
+}
+
+.em-delay-2 {
+  animation-delay: 1s;
+}
+
+.em-delay-3 {
+  animation-delay: 1.5s;
+}
+
+.em-delay-4 {
+  animation-delay: 2s;
+}
+
+.em-delay-custom {
+  animation-delay: var(--em-delay, 0s);
+}
+
+.custom-delay-panel {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  align-items: center;
+  margin-top: 28px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.timeline-dot {
+  width: 56px;
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background: var(--accent-strong);
+  box-shadow: 0 0 0 0 rgba(249, 199, 79, 0.48);
+  opacity: 0;
+  animation: em-pulse-in 900ms ease-out forwards;
+}
+
+.custom-delay-panel h2 {
+  margin-bottom: 8px;
+  font-size: 1.25rem;
+}
+
+.custom-delay-panel p {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+code {
+  color: var(--accent);
+}
+
+@keyframes em-rise-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes em-pulse-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.68);
+  }
+
+  70% {
+    box-shadow: 0 0 0 20px rgba(249, 199, 79, 0);
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(249, 199, 79, 0);
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .delay-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .demo-shell {
+    padding: 40px 0;
+  }
+
+  .delay-grid,
+  .custom-delay-panel {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .delay-card,
+  .timeline-dot {
+    animation-delay: 0s;
+    animation-duration: 1ms;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained animation delay utilities submission under `submissions/examples/animation-delay-utilities/`
- include `.em-delay-1` through `.em-delay-4` plus a custom `--em-delay` example
- keep the PR scoped to the required three submission files only

## Validation
- verified the submission folder contains exactly `demo.html`, `style.css`, and `README.md`
- checked for no external scripts, imports, CDNs, core edits, or component edits
- parsed `demo.html` with Python `html.parser`
- `git diff --check -- submissions/examples/animation-delay-utilities`

GSSoC 2026

Fixes #432