### PR TITLE
feat(components): add zero-JS ease-modal component (#251)

### DIFF
--- a/submissions/examples/ease-modal/README.md
+++ b/submissions/examples/ease-modal/README.md
@@ -1,0 +1,27 @@
+# Modal Component (#251)
+
+### What does this do?
+Adds a pristine, highly-performant zero-JavaScript `ease-modal` component to the framework. It handles open states, close states, and backdrop-click-to-close entirely natively using the browser's URL hash and the CSS `:target` pseudo-class.
+
+### How is it used?
+
+1. Give the `.ease-modal-overlay` a unique `id`.
+2. Use an `<a>` tag pointing to that ID to open the modal.
+3. Use `href="#"` on the close buttons (and the backdrop) to clear the URL hash and close the modal.
+
+```html
+<!-- Trigger -->
+<a href="#my-modal" class="ease-btn ease-btn-primary">Open Modal</a>
+
+<!-- Modal Structure -->
+<div id="my-modal" class="ease-modal-overlay">
+  <a href="#" class="ease-modal-backdrop-close"></a>
+  <div class="ease-modal-box">
+    <a href="#" class="ease-modal-close">&times;</a>
+    <h2>Hello World</h2>
+  </div>
+</div>
+```
+
+### Why is it useful?
+Modals are typically one of the most JS-heavy components in UI libraries, requiring event listeners for backdrop clicks, escape keys, and close buttons. This CSS-only implementation drastically reduces bundle size and JS execution time. It also features a gorgeous hardware-accelerated slide-and-scale entrance animation that gracefully falls back to a pure opacity fade when `prefers-reduced-motion` is active.

--- a/submissions/examples/ease-modal/demo.html
+++ b/submissions/examples/ease-modal/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>CSS-Only Modal Demo</title>
+  
+  <!-- Core EaseMotion dependencies -->
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  
+  <!-- The proposed modal component -->
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body { padding: var(--ease-space-12); background: var(--ease-color-surface); color: var(--ease-color-neutral-900); font-family: var(--ease-font-sans); }
+    
+    /* Emulate prefers-reduced-motion */
+    .emulate-reduced-motion .ease-modal-box,
+    .emulate-reduced-motion .ease-modal-overlay:target .ease-modal-box {
+      transition: none !important;
+      transform: none !important;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-modal</code></h1>
+  <p class="ease-text-muted ease-mb-8">A brilliant zero-Javascript modal component leveraging the CSS <code>:target</code> pseudo-class.</p>
+
+  <!-- The Trigger Button (Notice the href points to the modal's ID) -->
+  <a href="#demo-modal" class="ease-btn ease-btn-primary">Open Modal Demo</a>
+  
+  <br><br>
+  <button id="toggleMotionBtn" class="ease-btn ease-btn-outline ease-mb-8">Emulate Reduced Motion: OFF</button>
+
+  <!-- ========================================== -->
+  <!-- THE MODAL HTML STRUCTURE                   -->
+  <!-- ========================================== -->
+  <div id="demo-modal" class="ease-modal-overlay">
+    
+    <!-- This invisible link covers the backdrop. Clicking it sets href="#" (closing the modal) -->
+    <a href="#" class="ease-modal-backdrop-close" aria-label="Close modal"></a>
+
+    <!-- The actual modal card -->
+    <div class="ease-modal-box">
+      
+      <!-- The 'X' close button (also points to href="#") -->
+      <a href="#" class="ease-modal-close" aria-label="Close modal">&times;</a>
+      
+      <h2 class="ease-text-2xl ease-mb-4">Zero Javascript Required!</h2>
+      <p class="ease-text-muted ease-mb-6" style="line-height: 1.6;">
+        This modal is fully functional without a single line of JS. It uses the browser's URL hash and the CSS <code>:target</code> selector to handle the open/close state. Even clicking the dark backdrop outside this box closes it cleanly!
+      </p>
+
+      <div style="display: flex; gap: var(--ease-space-4); justify-content: flex-end;">
+        <a href="#" class="ease-btn ease-btn-ghost">Cancel</a>
+        <a href="#" class="ease-btn ease-btn-success">Confirm Action</a>
+      </div>
+
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('toggleMotionBtn');
+    let isReduced = false;
+
+    btn.addEventListener('click', () => {
+      isReduced = !isReduced;
+      if (isReduced) {
+        document.body.classList.add('emulate-reduced-motion');
+        btn.textContent = 'Emulate Reduced Motion: ON';
+        btn.classList.replace('ease-btn-outline', 'ease-btn-primary');
+      } else {
+        document.body.classList.remove('emulate-reduced-motion');
+        btn.textContent = 'Emulate Reduced Motion: OFF';
+        btn.classList.replace('ease-btn-primary', 'ease-btn-outline');
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-modal/style.css
+++ b/submissions/examples/ease-modal/style.css
@@ -1,0 +1,93 @@
+/* ============================================================
+   EaseMotion CSS — ease-modal component (Proposal)
+   A highly clever zero-Javascript modal system using :target
+   ============================================================ */
+
+/* ── 1. The Full-Screen Overlay ────────────────────────────── */
+.ease-modal-overlay {
+  position: fixed;
+  top: 0; left: 0; width: 100vw; height: 100vh;
+  background-color: rgba(15, 23, 42, 0.75); /* var(--ease-color-neutral-900) with opacity */
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--ease-z-modal);
+  
+  /* Hidden by default */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  
+  transition: opacity var(--ease-speed-medium) var(--ease-ease),
+              visibility var(--ease-speed-medium) var(--ease-ease);
+}
+
+/* ── 2. The Magic Activation via URL Hash ──────────────────── */
+.ease-modal-overlay:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+/* ── 3. The Modal Box ──────────────────────────────────────── */
+.ease-modal-box {
+  background-color: var(--ease-color-surface);
+  border-radius: var(--ease-radius-xl);
+  padding: var(--ease-space-8);
+  width: 90%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: var(--ease-shadow-xl);
+  position: relative;
+  z-index: 10;
+  
+  /* Initial resting state (slight drop & scale down) */
+  transform: translateY(20px) scale(0.95);
+  transition: transform var(--ease-speed-medium) var(--ease-ease-bounce);
+}
+
+/* Slide and pop up when the overlay becomes the target */
+.ease-modal-overlay:target .ease-modal-box {
+  transform: translateY(0) scale(1);
+}
+
+/* ── 4. The Close Button (Top Right) ───────────────────────── */
+.ease-modal-close {
+  position: absolute;
+  top: var(--ease-space-4);
+  right: var(--ease-space-4);
+  color: var(--ease-color-neutral-500);
+  text-decoration: none;
+  font-size: var(--ease-text-xl);
+  line-height: 1;
+  padding: var(--ease-space-2);
+  border-radius: var(--ease-radius-full);
+  transition: background-color var(--ease-speed-fast) var(--ease-ease),
+              color var(--ease-speed-fast) var(--ease-ease);
+}
+
+.ease-modal-close:hover {
+  background-color: var(--ease-color-neutral-100);
+  color: var(--ease-color-neutral-900);
+}
+
+/* ── 5. The Backdrop Click-to-Close Area ───────────────────── */
+/* An invisible <a> tag covering the entire screen behind the modal box */
+.ease-modal-backdrop-close {
+  position: absolute;
+  top: 0; left: 0; width: 100%; height: 100%;
+  z-index: 1;
+  cursor: default;
+}
+
+/* ── 6. Accessibility: Reduced Motion ──────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-modal-box,
+  .ease-modal-overlay:target .ease-modal-box {
+    /* Strip the bounce/slide transforms, fallback to purely the overlay's opacity fade */
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #251.

This submission introduces a highly-performant, zero-JavaScript `ease-modal` component. It natively handles open states, close states, and backdrop-click-to-close entirely using the browser's URL hash and the CSS `:target` pseudo-class.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pristine CSS-only modal leveraging the `:target` selector.

**How does a developer use it?**

Give the `.ease-modal-overlay` a unique ID, and use an `<a>` tag pointing to that ID to open it.

```html
<!-- Trigger -->
<a href="#my-modal" class="ease-btn ease-btn-primary">Open Modal</a>

<!-- Modal Structure -->
<div id="my-modal" class="ease-modal-overlay">
  <!-- Invisible backdrop click-to-close -->
  <a href="#" class="ease-modal-backdrop-close"></a>
  
  <div class="ease-modal-box">
    <!-- Close X button -->
    <a href="#" class="ease-modal-close">&times;</a>
    <h2>Modal Content</h2>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

Modals are typically one of the most JS-heavy components in UI libraries, requiring event listeners for backdrop clicks and close buttons. This CSS-only implementation drastically reduces bundle size and JS execution time, perfectly aligning with the framework's CSS-first philosophy. Furthermore, it explicitly handles `prefers-reduced-motion` by gracefully falling back to a pure opacity fade rather than sliding/scaling in.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

I solved the "backdrop click to close" requirement without Javascript by placing a full-screen, invisible `<a>` tag (`.ease-modal-backdrop-close`) directly behind the `.ease-modal-box` that points to `href="#"`. When clicked, it clears the target and naturally closes the modal!