### PR TITLE
docs: clarify submissions workflow

### DIFF
--- a/submissions/README.md
+++ b/submissions/README.md
@@ -21,6 +21,27 @@ All three files are required. Missing any one of them will result in the PR bein
 
 ---
 
+## Step-by-Step Workflow
+
+1. Pick one approved issue or one small effect idea.
+2. Create a kebab-case folder name that describes the idea clearly.
+3. Add only these three files inside that folder: `demo.html`, `style.css`, and `README.md`.
+4. Open `demo.html` directly in your browser and make sure the effect works without a local server.
+5. Check that your demo uses local `style.css` only. Do not add CDN links, framework imports, remote fonts, or build-tool output.
+6. Keep the PR focused on the new submission folder. Do not edit `core/`, `components/`, `docs/`, or unrelated examples.
+7. In the PR body, link the issue and briefly explain how the demo should be reviewed.
+
+Example path:
+
+```text
+submissions/examples/focus-ring-button/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
 ## What Each File Should Contain
 
 ### `demo.html`
@@ -45,6 +66,27 @@ Answer exactly three questions:
 2. How is it used?        (show the HTML class applied to an element)
 3. Why is it useful?      (how does it fit EaseMotion CSS's philosophy?)
 ```
+
+---
+
+## What Makes a Good Submission
+
+- The effect is easy to understand within a few seconds.
+- The HTML is small, semantic, and readable.
+- The CSS is scoped to the demo and does not rely on global framework files.
+- Class names describe behavior clearly, even if the maintainer later renames them.
+- The demo shows default, hover, focus, or reduced-motion behavior when relevant.
+- The README explains the value of the idea instead of repeating the code line by line.
+
+## What Gets Rejected
+
+- Missing one of the three required files.
+- Editing framework source such as `core/`, `components/`, or existing examples.
+- Submitting generated build output, minified code, screenshots, or large binary files.
+- Using external libraries, CDN scripts, remote fonts, or framework-specific markup.
+- Combining multiple unrelated effects in one PR.
+- Copying another contributor's pending submission.
+- Using `ease-` class names as if the utility is already part of the framework.
 
 ---
 
@@ -92,6 +134,45 @@ The submission in `submissions/examples/hover-grow/` was reviewed and integrated
 | Hard-coded `cubic-bezier(...)` | `var(--ease-ease-bounce)` |
 
 The class now lives in `core/animations.css` tagged `[INTEGRATED]`.
+
+---
+
+## Well-Structured Submission Example
+
+```html
+<!-- submissions/examples/focus-ring-button/demo.html -->
+<link rel="stylesheet" href="./style.css">
+
+<button class="focus-ring-button">
+  Save changes
+</button>
+```
+
+```css
+/* submissions/examples/focus-ring-button/style.css */
+.focus-ring-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.8rem 1.2rem;
+  background: #6c63ff;
+  color: white;
+}
+
+.focus-ring-button:focus-visible {
+  outline: 3px solid #f59e0b;
+  outline-offset: 4px;
+}
+```
+
+```markdown
+# Focus Ring Button
+
+1. What does this do? Adds a clear keyboard focus ring to a button.
+2. How is it used? Apply `.focus-ring-button` to a button element.
+3. Why is it useful? It improves keyboard navigation while staying readable.
+```
+
+This is enough for review: one small behavior, one local stylesheet, and one short explanation.
 
 ---
 


### PR DESCRIPTION
## Pull Request Description

Improves the submissions workflow guide so new contributors can understand the expected folder structure, review standards, rejection reasons, and a compact example before opening a PR.

Fixes #347

---

## Type of Change

- [ ] New animation / hover effect
- [ ] New component
- [x] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [ ] All changes are inside submissions/examples/your-feature-name/
- [ ] Includes demo.html - self-contained, opens in browser with no server
- [ ] Includes style.css - raw CSS for the proposed feature
- [ ] Includes README.md - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to core/
- [x] No changes to components/
- [x] One feature per PR (no bundled unrelated changes)

Note: this issue explicitly asks for documentation changes in submissions/README.md, so the demo/style/submission-folder checklist items are not applicable to this PR.

---

## Feature Description

**What does this add?**

A clearer contributor workflow for building submission folders, understanding what reviewers look for, and avoiding common rejection reasons.

**How does a developer use it?**

Developers read submissions/README.md before creating a new folder under submissions/examples/.

**Why does it fit EaseMotion CSS?**

It keeps the curated submission model easier to follow and reduces review churn for new contributors.

---

## Demo

- [ ] Demo added (demo.html works by opening directly in a browser)

Not applicable: documentation-only workflow guide update.

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari (optional but appreciated)

Not applicable: documentation-only Markdown update.

---

## Validation

- submission README checks passed
- git diff --check -- submissions/README.md

Note: the local clone has a pre-existing case-collision dirty file at submissions/examples/parallax-tilt-effect/README.md; it was not staged or committed.

---

## Notes for Maintainer

I kept this limited to submissions/README.md because #347 specifically asks for the submissions workflow docs. No core/components files were touched.
