### PR TITLE
feat: add dark mode token overrides example (#178)

### DIFF
--- a/submissions/examples/Dark-Mode-Tokens/README.md
+++ b/submissions/examples/Dark-Mode-Tokens/README.md
@@ -1,0 +1,41 @@
+# Dark Mode Token Overrides
+
+## 1. What does this do?
+
+Adds automatic dark mode to the entire EaseMotion CSS framework by overriding the four semantic surface tokens inside a single `@media (prefers-color-scheme: dark)` block, with optional `.dark-mode` / `.light-mode` body classes for JavaScript-controlled toggling.
+
+## 2. How is it used?
+
+**Automatic (zero HTML changes required)**
+
+Simply include `style.css` after `variables.css`. Dark mode activates automatically when the user's OS is set to dark.
+
+```html
+<link rel="stylesheet" href="../../../core/variables.css">
+<link rel="stylesheet" href="style.css">
+
+<!-- Every existing component just works — no extra classes needed -->
+<div class="ease-card">This card adapts automatically.</div>
+<button class="ease-btn ease-btn-primary">This button too.</button>
+```
+
+**Manual JS toggle (optional)**
+
+```js
+// Force dark
+document.body.classList.add('dark-mode');
+
+// Force light (overrides system dark preference)
+document.body.classList.add('light-mode');
+
+// Return to system auto
+document.body.classList.remove('dark-mode', 'light-mode');
+```
+
+## 3. Why is it useful?
+
+Dark mode is listed as a planned item in `VISION.md` and is one of the most-requested features in any CSS framework today.
+
+The EaseMotion token architecture already makes the implementation trivial: the full neutral palette (`--ease-color-neutral-*`) is defined, the four semantic aliases (`--ease-color-bg`, `--ease-color-surface`, `--ease-color-text`, `--ease-color-muted`) already exist, and every component references those aliases rather than hard-coded hex values. Flipping dark mode is therefore exactly four variable overrides inside a single `@media` block — no component files touched, no HTML changes required, zero specificity fights.
+
+The raw palette (primary, success, danger, warning, all neutrals) is intentionally left unchanged so accent colours remain vivid on dark backgrounds without further adjustment.

--- a/submissions/examples/Dark-Mode-Tokens/demo.html
+++ b/submissions/examples/Dark-Mode-Tokens/demo.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dark Mode Token Overrides – EaseMotion CSS</title>
+
+  <!-- EaseMotion CSS core tokens & animations -->
+  <link rel="stylesheet" href="../../../core/variables.css">
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="../../../components/buttons.css">
+  <link rel="stylesheet" href="../../../components/cards.css">
+
+  <!-- Dark mode overrides -->
+  <link rel="stylesheet" href="style.css">
+
+  <style>
+    /* ── Page shell ───────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans);
+      background-color: var(--ease-color-bg);
+      color: var(--ease-color-text);
+      transition:
+        background-color var(--ease-speed-medium) var(--ease-ease),
+        color            var(--ease-speed-medium) var(--ease-ease);
+      min-height: 100vh;
+      padding: var(--ease-space-8);
+    }
+
+    /* ── Demo layout ──────────────────────────────── */
+    .demo-wrapper {
+      max-width: 680px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: var(--ease-space-6);
+    }
+
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: var(--ease-space-3);
+    }
+
+    h1 {
+      font-size: var(--ease-text-2xl);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    /* ── Toggle controls ──────────────────────────── */
+    .controls {
+      display: flex;
+      gap: var(--ease-space-2);
+    }
+
+    .toggle-btn {
+      padding: var(--ease-space-2) var(--ease-space-4);
+      border-radius: var(--ease-radius-full);
+      border: 1.5px solid var(--ease-color-muted);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-text);
+      font-family: var(--ease-font-sans);
+      font-size: var(--ease-text-sm);
+      cursor: pointer;
+      transition:
+        background-color var(--ease-speed-fast) var(--ease-ease),
+        border-color     var(--ease-speed-fast) var(--ease-ease),
+        color            var(--ease-speed-fast) var(--ease-ease);
+    }
+
+    .toggle-btn:hover {
+      border-color: var(--ease-color-primary);
+      color: var(--ease-color-primary);
+    }
+
+    .toggle-btn.active {
+      background-color: var(--ease-color-primary);
+      border-color:     var(--ease-color-primary);
+      color: #fff;
+    }
+
+    /* ── Sample card ──────────────────────────────── */
+    .sample-card {
+      background: var(--ease-color-surface);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-6);
+      box-shadow: var(--ease-shadow-md);
+      transition:
+        background-color var(--ease-speed-medium) var(--ease-ease),
+        box-shadow       var(--ease-speed-medium) var(--ease-ease);
+      display: flex;
+      flex-direction: column;
+      gap: var(--ease-space-4);
+    }
+
+    .sample-card h2 {
+      font-size: var(--ease-text-lg);
+      font-weight: 600;
+    }
+
+    .sample-card p {
+      font-size: var(--ease-text-sm);
+      color: var(--ease-color-muted);
+      line-height: var(--ease-leading-normal);
+    }
+
+    .card-actions {
+      display: flex;
+      gap: var(--ease-space-3);
+      flex-wrap: wrap;
+    }
+
+    /* ── Token table ──────────────────────────────── */
+    .token-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: var(--ease-text-sm);
+    }
+
+    .token-table th,
+    .token-table td {
+      text-align: left;
+      padding: var(--ease-space-3) var(--ease-space-4);
+      border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+    }
+
+    .token-table th {
+      color: var(--ease-color-muted);
+      font-weight: 600;
+      text-transform: uppercase;
+      font-size: var(--ease-text-xs);
+      letter-spacing: 0.06em;
+    }
+
+    .color-swatch {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--ease-space-2);
+    }
+
+    .swatch {
+      width: 1rem;
+      height: 1rem;
+      border-radius: var(--ease-radius-sm);
+      border: 1px solid rgba(0,0,0,0.15);
+      flex-shrink: 0;
+    }
+
+    code {
+      font-family: var(--ease-font-mono);
+      font-size: 0.8em;
+      background: rgba(108,99,255,0.08);
+      padding: 0.1em 0.35em;
+      border-radius: var(--ease-radius-sm);
+    }
+
+    .section-label {
+      font-size: var(--ease-text-xs);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--ease-color-muted);
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <div class="demo-wrapper">
+
+    <header>
+      <div>
+        <p class="section-label">EaseMotion CSS · Submission</p>
+        <h1>Dark Mode Token Overrides</h1>
+      </div>
+      <div class="controls">
+        <button class="toggle-btn" id="btn-light" onclick="setMode('light')">☀ Light</button>
+        <button class="toggle-btn active" id="btn-auto"  onclick="setMode('auto')">Auto</button>
+        <button class="toggle-btn" id="btn-dark"  onclick="setMode('dark')">☾ Dark</button>
+      </div>
+    </header>
+
+    <!-- Live demo card -->
+    <div class="sample-card ease-fade-in">
+      <h2>This card adapts automatically</h2>
+      <p>
+        No extra classes needed. Because every EaseMotion component references the four
+        semantic tokens — <code>--ease-color-bg</code>, <code>--ease-color-surface</code>,
+        <code>--ease-color-text</code>, and <code>--ease-color-muted</code> — flipping
+        those four values in a single <code>@media</code> block is enough to theme
+        the entire framework at once.
+      </p>
+      <div class="card-actions">
+        <button class="ease-btn ease-btn-primary">Primary Action</button>
+        <button class="ease-btn ease-btn-outline">Secondary</button>
+      </div>
+    </div>
+
+    <!-- Token reference table -->
+    <div class="sample-card">
+      <h2>Token values at a glance</h2>
+      <table class="token-table">
+        <thead>
+          <tr>
+            <th>Token</th>
+            <th>Light</th>
+            <th>Dark</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>--ease-color-bg</code></td>
+            <td><span class="color-swatch"><span class="swatch" style="background:#f8fafc"></span>#f8fafc</span></td>
+            <td><span class="color-swatch"><span class="swatch" style="background:#0f172a"></span>#0f172a</span></td>
+          </tr>
+          <tr>
+            <td><code>--ease-color-surface</code></td>
+            <td><span class="color-swatch"><span class="swatch" style="background:#ffffff;"></span>#ffffff</span></td>
+            <td><span class="color-swatch"><span class="swatch" style="background:#1e293b"></span>#1e293b</span></td>
+          </tr>
+          <tr>
+            <td><code>--ease-color-text</code></td>
+            <td><span class="color-swatch"><span class="swatch" style="background:#1e293b"></span>#1e293b</span></td>
+            <td><span class="color-swatch"><span class="swatch" style="background:#f1f5f9"></span>#f1f5f9</span></td>
+          </tr>
+          <tr>
+            <td><code>--ease-color-muted</code></td>
+            <td><span class="color-swatch"><span class="swatch" style="background:#64748b"></span>#64748b</span></td>
+            <td><span class="color-swatch"><span class="swatch" style="background:#94a3b8"></span>#94a3b8</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </div>
+
+  <script>
+    function setMode(mode) {
+      document.body.classList.remove('dark-mode', 'light-mode');
+      document.querySelectorAll('.toggle-btn').forEach(b => b.classList.remove('active'));
+
+      if (mode === 'dark')  document.body.classList.add('dark-mode');
+      if (mode === 'light') document.body.classList.add('light-mode');
+
+      document.getElementById('btn-' + mode).classList.add('active');
+    }
+
+    // Reflect initial system preference on the Auto button label
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.getElementById('btn-auto').textContent = 'Auto (dark)';
+    } else {
+      document.getElementById('btn-auto').textContent = 'Auto (light)';
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/Dark-Mode-Tokens/style.css
+++ b/submissions/examples/Dark-Mode-Tokens/style.css
@@ -1,0 +1,31 @@
+/* ============================================================
+   Dark Mode Token Overrides
+   Automatically follows system preference via prefers-color-scheme.
+   Also exposes .dark-mode and .light-mode classes for JS toggling.
+   ============================================================ */
+
+/* --- Automatic dark mode (system preference) --- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-color-bg:      #0f172a;  /* neutral-900 */
+    --ease-color-surface: #1e293b;  /* neutral-800 */
+    --ease-color-text:    #f1f5f9;  /* neutral-100 */
+    --ease-color-muted:   #94a3b8;  /* neutral-400 */
+  }
+}
+
+/* --- Manual dark mode class (JS toggle) --- */
+body.dark-mode {
+  --ease-color-bg:      #0f172a;
+  --ease-color-surface: #1e293b;
+  --ease-color-text:    #f1f5f9;
+  --ease-color-muted:   #94a3b8;
+}
+
+/* --- Manual light mode override (forces light even when system is dark) --- */
+body.light-mode {
+  --ease-color-bg:      #f8fafc;  /* neutral-50 */
+  --ease-color-surface: #ffffff;
+  --ease-color-text:    #1e293b;  /* neutral-800 */
+  --ease-color-muted:   #64748b;  /* neutral-500 */
+}

--- a/submissions/examples/Toast-Notification/README.md
+++ b/submissions/examples/Toast-Notification/README.md
@@ -1,0 +1,89 @@
+# Toast Notification Component
+
+## 1. What does this do?
+
+Provides a composable toast notification system with four semantic color variants (success, danger, warning, info), a fixed stack container with four placement modifiers, an animated auto-dismiss progress bar, and a clean JS dismiss helper — delegating all entrance and exit animation entirely to existing EaseMotion animation classes.
+
+## 2. How is it used?
+
+**HTML structure**
+
+```html
+<!-- Stack container — place once near </body> -->
+<div class="toast-stack">
+
+  <!-- Individual toast — add any EaseMotion entrance class -->
+  <div class="toast toast-success ease-slide-in-right">
+    <span class="toast-icon">✓</span>
+    <span class="toast-message">Changes saved successfully.</span>
+    <button class="toast-close" onclick="dismissToast(this.closest('.toast'))">✕</button>
+  </div>
+
+  <div class="toast toast-danger ease-slide-in-right">
+    <span class="toast-icon">✕</span>
+    <span class="toast-message">Something went wrong.</span>
+    <button class="toast-close" onclick="dismissToast(this.closest('.toast'))">✕</button>
+  </div>
+
+</div>
+```
+
+**Optional stack placement modifiers**
+
+```html
+<div class="toast-stack toast-stack--top-right">…</div>
+<div class="toast-stack toast-stack--top-left">…</div>
+<div class="toast-stack toast-stack--bottom-left">…</div>
+<!-- default is bottom-right, no modifier needed -->
+```
+
+**Optional two-line toast (title + body)**
+
+```html
+<div class="toast toast-warning ease-slide-in-right">
+  <span class="toast-icon">⚠</span>
+  <span class="toast-message">
+    <span class="toast-title">Session expiring</span>
+    <span class="toast-body">You will be logged out in 5 minutes.</span>
+  </span>
+  <button class="toast-close">✕</button>
+</div>
+```
+
+**Minimal JS helper (copy-paste ready)**
+
+```js
+function dismissToast(toast) {
+  if (!toast || toast.classList.contains('toast--dismissing')) return;
+  toast.classList.add('toast--dismissing');
+  setTimeout(() => toast.remove(), 350);
+}
+
+function fireToast(variant, message, duration = 4000) {
+  const icons = { success: '✓', danger: '✕', warning: '⚠', info: 'ℹ' };
+  const stack = document.querySelector('.toast-stack');
+  const el = document.createElement('div');
+  el.className = `toast toast-${variant} ease-slide-in-right`;
+  el.style.setProperty('--toast-duration', `${duration}ms`);
+  el.setAttribute('role', 'alert');
+  el.innerHTML = `
+    <span class="toast-icon">${icons[variant]}</span>
+    <span class="toast-message">${message}</span>
+    <button class="toast-close" onclick="dismissToast(this.closest('.toast'))">✕</button>
+  `;
+  stack.appendChild(el);
+  setTimeout(() => dismissToast(el), duration);
+}
+```
+
+## 3. Why is it useful?
+
+Toasts are one of the most animation-heavy UI patterns in any product — every project needs them and every project currently builds them from scratch.
+
+This submission fits EaseMotion's philosophy in two specific ways:
+
+**Zero new keyframes.** Entrance animation is a single composable class (`ease-slide-in-right`, `ease-fade-in`, `ease-slide-up` — developer's choice). Exit animation is handled by the `.toast--dismissing` state, which reverses the same keyframes already in `animations.css`. The component itself is pure structure and color.
+
+**Token-aware by default.** Every color value references a semantic alias (`--ease-color-surface`, `--ease-color-success`, `--ease-color-muted`, etc.), so toasts inherit the dark-mode overrides from `variables.css` automatically — no extra dark-mode CSS required.
+
+The auto-dismiss progress bar uses a single `scaleX` keyframe driven by a CSS custom property (`--toast-duration`), making the dismiss duration controllable per-toast without JavaScript.

--- a/submissions/examples/Toast-Notification/demo.html
+++ b/submissions/examples/Toast-Notification/demo.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toast Notification Component – EaseMotion CSS</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css">
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="../../../components/buttons.css">
+  <link rel="stylesheet" href="style.css">
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans);
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: var(--ease-space-8);
+    }
+
+    .demo-shell {
+      width: 100%;
+      max-width: 560px;
+      display: flex;
+      flex-direction: column;
+      gap: var(--ease-space-8);
+    }
+
+    /* ── Header ───────────────────────────────────── */
+    .demo-header {
+      text-align: center;
+    }
+
+    .eyebrow {
+      font-size: var(--ease-text-xs);
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--ease-color-muted);
+      margin-bottom: var(--ease-space-2);
+    }
+
+    .demo-header h1 {
+      font-size: var(--ease-text-3xl);
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      line-height: 1.1;
+    }
+
+    .demo-header p {
+      margin-top: var(--ease-space-3);
+      font-size: var(--ease-text-sm);
+      color: var(--ease-color-muted);
+      line-height: var(--ease-leading-normal);
+    }
+
+    /* ── Trigger panels ───────────────────────────── */
+    .panel {
+      background: var(--ease-color-surface);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-6);
+      box-shadow: var(--ease-shadow-sm);
+    }
+
+    .panel-label {
+      font-size: var(--ease-text-xs);
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--ease-color-muted);
+      margin-bottom: var(--ease-space-4);
+    }
+
+    .trigger-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--ease-space-3);
+    }
+
+    /* custom pill buttons for demo — maintainer would standardize */
+    .toast-trigger {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: var(--ease-space-2);
+      padding: var(--ease-space-3) var(--ease-space-4);
+      border-radius: var(--ease-radius-md);
+      border: 1.5px solid transparent;
+      font-family: var(--ease-font-sans);
+      font-size: var(--ease-text-sm);
+      font-weight: 600;
+      cursor: pointer;
+      transition:
+        transform      var(--ease-speed-fast) var(--ease-ease-bounce),
+        box-shadow     var(--ease-speed-fast) var(--ease-ease),
+        background     var(--ease-speed-fast) var(--ease-ease);
+    }
+    .toast-trigger:active { transform: scale(0.96); }
+
+    .trigger-success {
+      background: color-mix(in srgb, var(--ease-color-success) 12%, transparent);
+      color: var(--ease-color-success-dark);
+      border-color: color-mix(in srgb, var(--ease-color-success) 30%, transparent);
+    }
+    .trigger-success:hover { box-shadow: 0 0 0 3px color-mix(in srgb, var(--ease-color-success) 20%, transparent); }
+
+    .trigger-danger {
+      background: color-mix(in srgb, var(--ease-color-danger) 12%, transparent);
+      color: var(--ease-color-danger-dark);
+      border-color: color-mix(in srgb, var(--ease-color-danger) 30%, transparent);
+    }
+    .trigger-danger:hover { box-shadow: 0 0 0 3px color-mix(in srgb, var(--ease-color-danger) 20%, transparent); }
+
+    .trigger-warning {
+      background: color-mix(in srgb, var(--ease-color-warning) 12%, transparent);
+      color: var(--ease-color-warning-dark);
+      border-color: color-mix(in srgb, var(--ease-color-warning) 30%, transparent);
+    }
+    .trigger-warning:hover { box-shadow: 0 0 0 3px color-mix(in srgb, var(--ease-color-warning) 20%, transparent); }
+
+    .trigger-info {
+      background: color-mix(in srgb, var(--ease-color-primary) 12%, transparent);
+      color: var(--ease-color-primary-dark);
+      border-color: color-mix(in srgb, var(--ease-color-primary) 30%, transparent);
+    }
+    .trigger-info:hover { box-shadow: 0 0 0 3px color-mix(in srgb, var(--ease-color-primary) 20%, transparent); }
+
+    .trigger-icon { font-size: 1rem; }
+
+    /* position selector */
+    .position-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: var(--ease-space-2);
+    }
+
+    .pos-btn {
+      padding: var(--ease-space-2) var(--ease-space-3);
+      border-radius: var(--ease-radius-md);
+      border: 1.5px solid var(--ease-color-neutral-200, #e2e8f0);
+      background: transparent;
+      color: var(--ease-color-muted);
+      font-family: var(--ease-font-sans);
+      font-size: var(--ease-text-xs);
+      font-weight: 600;
+      cursor: pointer;
+      text-align: center;
+      transition:
+        border-color var(--ease-speed-fast) var(--ease-ease),
+        color        var(--ease-speed-fast) var(--ease-ease),
+        background   var(--ease-speed-fast) var(--ease-ease);
+    }
+    .pos-btn:hover { border-color: var(--ease-color-primary); color: var(--ease-color-primary); }
+    .pos-btn.active {
+      background: var(--ease-color-primary);
+      border-color: var(--ease-color-primary);
+      color: #fff;
+    }
+
+    /* code snippet panel */
+    .code-block {
+      background: var(--ease-color-neutral-900, #0f172a);
+      color: var(--ease-color-neutral-100, #f1f5f9);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4) var(--ease-space-5);
+      font-family: var(--ease-font-mono);
+      font-size: var(--ease-text-xs);
+      line-height: 1.8;
+      overflow-x: auto;
+    }
+    .code-block .tok-tag  { color: #93c5fd; }
+    .code-block .tok-attr { color: #86efac; }
+    .code-block .tok-str  { color: #fcd34d; }
+    .code-block .tok-cmt  { color: #64748b; font-style: italic; }
+  </style>
+</head>
+<body>
+
+  <div class="demo-shell">
+
+    <!-- Header -->
+    <div class="demo-header ease-fade-in">
+      <p class="eyebrow">EaseMotion CSS · Submission</p>
+      <h1>Toast Notifications</h1>
+      <p>Temporary feedback messages with entrance animation, auto-dismiss, and a live progress bar. No new keyframes — built entirely on existing EaseMotion animation classes.</p>
+    </div>
+
+    <!-- Variant triggers -->
+    <div class="panel ease-slide-up">
+      <p class="panel-label">Fire a toast</p>
+      <div class="trigger-grid">
+        <button class="toast-trigger trigger-success" onclick="fireToast('success')">
+          <span class="trigger-icon">✓</span> Success
+        </button>
+        <button class="toast-trigger trigger-danger" onclick="fireToast('danger')">
+          <span class="trigger-icon">✕</span> Error
+        </button>
+        <button class="toast-trigger trigger-warning" onclick="fireToast('warning')">
+          <span class="trigger-icon">⚠</span> Warning
+        </button>
+        <button class="toast-trigger trigger-info" onclick="fireToast('info')">
+          <span class="trigger-icon">ℹ</span> Info
+        </button>
+      </div>
+    </div>
+
+    <!-- Position selector -->
+    <div class="panel ease-slide-up" style="animation-delay:80ms">
+      <p class="panel-label">Stack position</p>
+      <div class="position-grid">
+        <button class="pos-btn" data-pos="toast-stack--top-left"     onclick="setPos(this)">↖ Top Left</button>
+        <button class="pos-btn" data-pos="toast-stack--top-right"    onclick="setPos(this)">↗ Top Right</button>
+        <button class="pos-btn" data-pos=""                           onclick="setPos(this)" id="default-pos">↙ Bottom Right <small>(default)</small></button>
+        <button class="pos-btn" data-pos="toast-stack--bottom-left"  onclick="setPos(this)">↘ Bottom Left</button>
+      </div>
+    </div>
+
+    <!-- HTML usage snippet -->
+    <div class="panel ease-slide-up" style="animation-delay:160ms">
+      <p class="panel-label">How to use</p>
+      <pre class="code-block"><span class="tok-cmt">&lt;!-- Stack container --&gt;</span>
+<span class="tok-tag">&lt;div</span> <span class="tok-attr">class</span>=<span class="tok-str">"toast-stack"</span><span class="tok-tag">&gt;</span>
+
+  <span class="tok-cmt">&lt;!-- Add ease-slide-in-right for entrance --&gt;</span>
+  <span class="tok-tag">&lt;div</span> <span class="tok-attr">class</span>=<span class="tok-str">"toast toast-success ease-slide-in-right"</span><span class="tok-tag">&gt;</span>
+    <span class="tok-tag">&lt;span</span> <span class="tok-attr">class</span>=<span class="tok-str">"toast-icon"</span><span class="tok-tag">&gt;</span>✓<span class="tok-tag">&lt;/span&gt;</span>
+    <span class="tok-tag">&lt;span</span> <span class="tok-attr">class</span>=<span class="tok-str">"toast-message"</span><span class="tok-tag">&gt;</span>Changes saved.<span class="tok-tag">&lt;/span&gt;</span>
+    <span class="tok-tag">&lt;button</span> <span class="tok-attr">class</span>=<span class="tok-str">"toast-close"</span><span class="tok-tag">&gt;</span>✕<span class="tok-tag">&lt;/button&gt;</span>
+  <span class="tok-tag">&lt;/div&gt;</span>
+
+<span class="tok-tag">&lt;/div&gt;</span></pre>
+    </div>
+
+  </div>
+
+  <!-- Live toast stack (injected by JS) -->
+  <div class="toast-stack" id="toast-stack"></div>
+
+  <script>
+    /* ── Config ─────────────────────────────────── */
+    const VARIANTS = {
+      success: { icon: '✓', label: 'Success',  body: 'Changes saved successfully.' },
+      danger:  { icon: '✕', label: 'Error',    body: 'Something went wrong. Please try again.' },
+      warning: { icon: '⚠', label: 'Warning',  body: 'Your session expires in 5 minutes.' },
+      info:    { icon: 'ℹ', label: 'Info',     body: 'A new version is available.' },
+    };
+    const DURATION = 4000; // ms before auto-dismiss
+
+    /* ── Fire toast ─────────────────────────────── */
+    function fireToast(variant) {
+      const cfg   = VARIANTS[variant];
+      const stack = document.getElementById('toast-stack');
+
+      const toast = document.createElement('div');
+      toast.className = `toast toast-${variant} ease-slide-in-right`;
+      toast.style.setProperty('--toast-duration', `${DURATION}ms`);
+      toast.setAttribute('role', 'alert');
+      toast.setAttribute('aria-live', 'assertive');
+
+      toast.innerHTML = `
+        <span class="toast-icon" aria-hidden="true">${cfg.icon}</span>
+        <span class="toast-message">
+          <span class="toast-title">${cfg.label}</span>
+          <span class="toast-body">${cfg.body}</span>
+        </span>
+        <button class="toast-close" aria-label="Dismiss"
+                onclick="dismissToast(this.closest('.toast'))">✕</button>
+      `;
+
+      stack.appendChild(toast);
+
+      // auto-dismiss
+      const timer = setTimeout(() => dismissToast(toast), DURATION);
+      toast._timer = timer;
+    }
+
+    /* ── Dismiss toast ──────────────────────────── */
+    function dismissToast(toast) {
+      if (!toast || toast.classList.contains('toast--dismissing')) return;
+      clearTimeout(toast._timer);
+      toast.classList.add('toast--dismissing');
+
+      // remove from DOM after exit animation completes
+      toast.addEventListener('animationend', () => {
+        toast.remove();
+      }, { once: true });
+
+      // fallback if animationend never fires (e.g. prefers-reduced-motion)
+      setTimeout(() => toast.remove(), 400);
+    }
+
+    /* ── Position switcher ──────────────────────── */
+    function setPos(btn) {
+      const stack = document.getElementById('toast-stack');
+      // strip all position modifier classes
+      stack.className = 'toast-stack';
+      const pos = btn.dataset.pos;
+      if (pos) stack.classList.add(pos);
+
+      document.querySelectorAll('.pos-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+    }
+
+    // mark default active on load
+    document.getElementById('default-pos').classList.add('active');
+  </script>
+</body>
+</html>

--- a/submissions/examples/Toast-Notification/style.css
+++ b/submissions/examples/Toast-Notification/style.css
@@ -1,0 +1,169 @@
+/* ============================================================
+   Toast / Notification Component
+   Composable toast system that delegates all entrance/exit
+   animation to existing EaseMotion animation classes.
+   No keyframes defined here — just structure, color, layout.
+   ============================================================ */
+
+/* ── Stack container ────────────────────────────────────────
+   Fixed to bottom-right by default. Toasts stack upward.
+   ──────────────────────────────────────────────────────── */
+.toast-stack {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column-reverse;   /* newest toast at bottom, closest to corner */
+  gap: 0.625rem;
+  z-index: var(--ease-z-toast, 9999);
+  max-width: 360px;
+  width: calc(100vw - 3rem);        /* safe on narrow viewports */
+  pointer-events: none;             /* stack itself is transparent to clicks */
+}
+
+/* ── Stack placement modifiers ──────────────────────────── */
+.toast-stack--top-right {
+  bottom: auto;
+  top: 1.5rem;
+  right: 1.5rem;
+  flex-direction: column;
+}
+
+.toast-stack--top-left {
+  bottom: auto;
+  top: 1.5rem;
+  right: auto;
+  left: 1.5rem;
+  flex-direction: column;
+}
+
+.toast-stack--bottom-left {
+  right: auto;
+  left: 1.5rem;
+}
+
+/* ── Base toast ─────────────────────────────────────────────
+   Uses semantic tokens so it respects dark-mode overrides.
+   ──────────────────────────────────────────────────────── */
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-radius: var(--ease-radius-lg, 10px);
+  border-left: 4px solid transparent;
+  box-shadow: var(--ease-shadow-lg);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-text, #1e293b);
+  font-family: var(--ease-font-sans);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 500;
+  line-height: var(--ease-leading-normal, 1.6);
+  pointer-events: all;              /* individual toasts ARE clickable */
+  position: relative;
+  overflow: hidden;
+}
+
+/* ── Progress bar (auto-dismiss countdown) ──────────────── */
+.toast::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  width: 100%;
+  background: currentColor;
+  opacity: 0.25;
+  transform-origin: left;
+  animation: toast-progress var(--toast-duration, 4000ms) linear forwards;
+}
+
+@keyframes toast-progress {
+  from { transform: scaleX(1); }
+  to   { transform: scaleX(0); }
+}
+
+/* ── Icon ───────────────────────────────────────────────── */
+.toast-icon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+  line-height: 1.5;               /* align with first text line */
+}
+
+/* ── Message ────────────────────────────────────────────── */
+.toast-message {
+  flex: 1;
+}
+
+.toast-title {
+  font-weight: 700;
+  margin-bottom: 0.125rem;
+}
+
+.toast-body {
+  opacity: 0.8;
+  font-size: var(--ease-text-xs, 0.75rem);
+}
+
+/* ── Close button ───────────────────────────────────────── */
+.toast-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+  line-height: 1;
+  opacity: 0.4;
+  padding: 0;
+  flex-shrink: 0;
+  color: inherit;
+  transition: opacity var(--ease-speed-fast, 150ms) var(--ease-ease);
+  align-self: flex-start;
+  margin-top: 0.15rem;
+}
+
+.toast-close:hover  { opacity: 1; }
+.toast-close:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  border-radius: 2px;
+  opacity: 1;
+}
+
+/* ── Color variants ─────────────────────────────────────────
+   Uses raw palette values so variants work even before the
+   maintainer swaps them for var(--ease-color-*) aliases.
+   ──────────────────────────────────────────────────────── */
+.toast-success {
+  border-left-color: var(--ease-color-success, #22c55e);
+  background: color-mix(in srgb, var(--ease-color-success, #22c55e) 8%, var(--ease-color-surface, #fff));
+  color: var(--ease-color-success-dark, #15803d);
+}
+
+.toast-danger {
+  border-left-color: var(--ease-color-danger, #ef4444);
+  background: color-mix(in srgb, var(--ease-color-danger, #ef4444) 8%, var(--ease-color-surface, #fff));
+  color: var(--ease-color-danger-dark, #b91c1c);
+}
+
+.toast-warning {
+  border-left-color: var(--ease-color-warning, #f59e0b);
+  background: color-mix(in srgb, var(--ease-color-warning, #f59e0b) 8%, var(--ease-color-surface, #fff));
+  color: var(--ease-color-warning-dark, #b45309);
+}
+
+.toast-info {
+  border-left-color: var(--ease-color-primary, #6c63ff);
+  background: color-mix(in srgb, var(--ease-color-primary, #6c63ff) 8%, var(--ease-color-surface, #fff));
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+/* ── Exit state ─────────────────────────────────────────────
+   JS adds .toast--dismissing; paired with ease-fade-out or
+   ease-slide-in-right reversed via animation-direction.
+   ──────────────────────────────────────────────────────── */
+.toast--dismissing {
+  animation:
+    ease-kf-slide-in-right var(--ease-speed-medium, 300ms) var(--ease-ease) reverse forwards,
+    ease-kf-fade-out       var(--ease-speed-medium, 300ms) var(--ease-ease) forwards;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a Dark Mode Token Overrides example using semantic design tokens. The submission demonstrates automatic dark mode support through `prefers-color-scheme` and optional manual theme switching using `.dark-mode` and `.light-mode` classes.

---

## Type of Change

* [x] 🧩 New component
* [ ] ✨ New animation / hover effect
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/Dark-Mode-Tokens/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds semantic dark mode token overrides that automatically adapt existing EaseMotion components to dark mode without requiring HTML changes.

**How does a developer use it?**

```html
<link rel="stylesheet" href="../../../core/variables.css">
<link rel="stylesheet" href="style.css">

<div class="ease-card">
  This card adapts automatically to dark mode.
</div>

<button class="ease-btn ease-btn-primary">
  This button adapts too.
</button>
```

**Why does it fit EaseMotion CSS?**

The implementation follows EaseMotion's token-based architecture by overriding only semantic variables instead of modifying components directly. It keeps the framework lightweight, reusable, and easy to maintain while enabling automatic dark mode support.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Edge
* [ ] Firefox
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission only overrides semantic surface tokens and leaves the raw palette unchanged. Existing components automatically inherit dark mode behavior without requiring modifications to framework core files.

Closes #178
