### PR TITLE
feat: add GitHub Actions PR auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+contribution:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "submissions/examples/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+
+core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "core/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: PR Auto Labeler
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Label PR
+        uses: actions/labeler@v5


### PR DESCRIPTION
## Pull Request Description

Added automatic PR labeling using GitHub Actions and `actions/labeler@v5`.

This workflow automatically applies labels based on the folders modified in a pull request, helping maintainers categorize contributions more efficiently.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [x] Other (GitHub Actions automation)

---

## Submission Checklist

* [ ] All changes are inside `submissions/examples/your-feature-name/`
* [ ] Includes `demo.html`
* [ ] Includes `style.css`
* [ ] Includes `README.md`
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds automatic pull request labeling based on modified file paths.

**How does a developer use it?**

No manual usage required. Labels are automatically applied when a pull request is opened or updated.

**Why does it fit EaseMotion CSS?**

Improves repository maintenance and contributor workflow by automatically categorizing pull requests.

---

## Demo

* [ ] Demo added (Not applicable)

---

## Browser Testing

* [ ] Chrome
* [ ] Firefox
* [ ] Edge
* [ ] Safari

Not applicable for this GitHub Actions workflow.

---

## Notes for Maintainer

Implemented Issue #492.

Added:

* `.github/workflows/labeler.yml`
* `.github/labeler.yml`

Label mappings:

* `submissions/examples/**` → `contribution`
* `docs/**` → `documentation`
* `core/**` → `core`

Uses `actions/labeler@v5`.

Fixes #492
