### PR TITLE
fix: ease-slide-up and ease-slide-down cancel each other when both classes are applied

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -505,10 +505,10 @@
 .ease-fade-out {
   animation: ease-kf-fade-out var(--ease-speed-medium) var(--ease-ease) both;
 }
-/* NOTE: :not() guards prevent animation cancellation when both
-   .ease-slide-up and .ease-slide-down are applied to the same element */
-/* Fixed: prevent conflict when both classes applied simultaneously */
-.ease-slide-up:not(.ease-slide-down) {
+/* Priority: .ease-slide-up takes precedence over .ease-slide-down
+   when both classes are applied to the same element, ensuring at
+   least one animation runs instead of both being cancelled. */
+.ease-slide-up {
   animation: ease-kf-slide-up var(--ease-speed-medium) var(--ease-ease) both;
 }
 


### PR DESCRIPTION
## Problem

When both .ease-slide-up and .ease-slide-down were applied to the same element, neither animation ran. Both used :not() guards that excluded the other class, creating a symmetric exclusion.

## Root Cause

Both classes used :not() to prevent the other from matching:
- .ease-slide-up:not(.ease-slide-down)
- .ease-slide-down:not(.ease-slide-up)

When both were present, both selectors failed to match simultaneously - neither animation fired.

## What Changed

- Removed :not(.ease-slide-down) from .ease-slide-up selector - it now always applies
- .ease-slide-down retains :not(.ease-slide-up) so slide-up takes priority when both are present
- Only .ease-slide-down (alone) ? runs slide-down animation
- Only .ease-slide-up (alone) ? runs slide-up animation  
- Both classes ? runs slide-up animation (prioritized)

## Impact
- When both classes are applied, .ease-slide-up takes priority and its animation runs
- When only one class is applied, behavior is unchanged
- No breaking changes for existing usage

Closes #404