### PR TITLE
feat(ui): Add one-click copy to clipboard for animation preview cards (#619)

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -631,6 +631,43 @@
       void el.offsetWidth; // force reflow
       el.classList.add(cls);
     }
+    
+    // Add copy-to-clipboard functionality to all animation tags
+    document.addEventListener("DOMContentLoaded", () => {
+      const copyIconSvg = `<svg style="margin-left:6px; vertical-align:-0.125em;" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>`;
+      const checkIconSvg = `<svg style="margin-left:6px; vertical-align:-0.125em; color:var(--ease-color-success, #22c55e);" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
+
+      document.querySelectorAll('.anim-cell .tag').forEach(tag => {
+        const className = tag.textContent.trim();
+        
+        // Make the tag look clickable and add a title
+        tag.style.cursor = 'pointer';
+        tag.style.transition = 'all var(--ease-speed-fast) var(--ease-ease)';
+        tag.title = 'Copy class name';
+        
+        // Add hover effect
+        tag.addEventListener('mouseenter', () => tag.style.background = 'rgba(108,99,255,0.25)');
+        tag.addEventListener('mouseleave', () => tag.style.background = '');
+        
+        // Add copy icon
+        const iconSpan = document.createElement('span');
+        iconSpan.innerHTML = copyIconSvg;
+        tag.appendChild(iconSpan);
+
+        tag.addEventListener('click', () => {
+          navigator.clipboard.writeText(className).then(() => {
+            iconSpan.innerHTML = checkIconSvg;
+            
+            // Revert back to copy icon after 1.5 seconds
+            setTimeout(() => {
+              iconSpan.innerHTML = copyIconSvg;
+            }, 1500);
+          }).catch(err => {
+            console.error('Failed to copy: ', err);
+          });
+        });
+      });
+    });
   </script>
 
 </body>


### PR DESCRIPTION
## Description
Resolves #619. 

Currently, users browsing the EaseMotion-css interactive demo must manually highlight and copy the specific CSS class names to use a specific animation. This PR introduces a one-click "Copy to Clipboard" feature on each animation preview card, significantly polishing the developer experience.

## Proposed Changes
- **UI Addition**: Added a small, unobtrusive SVG "Copy" icon next to the class name text in each animation preview card (`.anim-cell .tag`).
- **Interaction**: Added an event listener that copies the corresponding CSS class name (e.g., `ease-fade-in`) to the user's clipboard upon click. Also added `cursor: pointer` and a subtle hover state to indicate interactivity.
- **Visual Feedback**: Temporarily swaps the copy icon with a green checkmark SVG for 1.5 seconds to provide immediate visual confirmation to the user.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x]  UI / UX Polish
