### PR TITLE
docs: Add CSS variable reference table [Issue #339]

### DIFF
--- a/README.bn.md
+++ b/README.bn.md
@@ -1,0 +1,563 @@
+<div align="center">
+
+<img src="https://raw.githubusercontent.com/SAPTARSHI-coder/EaseMotion-css/main/docs/assets/banner.svg" alt="EaseMotion CSS" width="100%" />
+
+# ⚡ EaseMotion CSS
+
+**মানুষের ভাষায় লেখা। অ্যানিমেশন-প্রথম। শূন্য নির্ভরতা।**
+
+UI লেখো যেভাবে ইংরেজিতে বলো। কোনো বিল্ড স্টেপ নেই। শর্টহ্যান্ড মুখস্থ করতে হবে না। শুধু একটা ফাইল লিঙ্ক করো আর শিপ করো।
+
+<br/>
+
+[![npm version](https://img.shields.io/npm/v/easemotion-css?style=flat-square&color=6c63ff&label=npm)](https://www.npmjs.com/package/easemotion-css)
+[![npm downloads](https://img.shields.io/npm/dm/easemotion-css?style=flat-square&color=a78bfa&label=downloads%2Fmo)](https://www.npmjs.com/package/easemotion-css)
+[![jsDelivr CDN](https://data.jsdelivr.com/v1/package/npm/easemotion-css/badge)](https://www.jsdelivr.com/package/npm/easemotion-css)
+[![GitHub Stars](https://img.shields.io/github/stars/SAPTARSHI-coder/EaseMotion-css?style=flat-square&color=6c63ff)](https://github.com/SAPTARSHI-coder/EaseMotion-css/stargazers)
+[![GitHub Forks](https://img.shields.io/github/forks/SAPTARSHI-coder/EaseMotion-css?style=flat-square&color=22c55e)](https://github.com/SAPTARSHI-coder/EaseMotion-css/network/members)
+[![GitHub Contributors](https://img.shields.io/github/contributors/SAPTARSHI-coder/EaseMotion-css?style=flat-square&color=f59e0b)](https://github.com/SAPTARSHI-coder/EaseMotion-css/graphs/contributors)
+[![Open PRs](https://img.shields.io/github/issues-pr/SAPTARSHI-coder/EaseMotion-css?style=flat-square&color=a78bfa&label=open%20PRs)](https://github.com/SAPTARSHI-coder/EaseMotion-css/pulls)
+[![Open Issues](https://img.shields.io/github/issues/SAPTARSHI-coder/EaseMotion-css?style=flat-square&color=ef4444&label=issues)](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues)
+[![License: MIT](https://img.shields.io/badge/License-MIT-6c63ff?style=flat-square)](./LICENSE)
+[![GSSoC](https://img.shields.io/badge/GSSoC-2026-orange?style=flat-square)](https://gssoc.girlscript.tech/)
+[![Maintainer](https://img.shields.io/badge/Maintainer-Saptarshi%20Sadhu-a78bfa?style=flat-square)](https://github.com/SAPTARSHI-coder)
+
+<br/>
+
+---
+
+### 🚀 মাত্র একটি লাইন। এটুকুই দরকার।
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />
+```
+
+**[📖 ডকুমেন্টেশন](https://saptarshi-coder.github.io/EaseMotion-css/) · [🎮 লাইভ ডেমো](https://github.com/SAPTARSHI-coder/EaseMotion-css/blob/main/examples/demo.html) · [📦 npm](https://www.npmjs.com/package/easemotion-css) · [🤝 অবদান রাখুন](./CONTRIBUTING.md)**
+
+</div>
+
+---
+
+## ⭐ প্রজেক্টটিকে সাপোর্ট করুন
+
+EaseMotion CSS যদি তোমার সময় বাঁচায় বা শেখার পথে সাহায্য করে, তাহলে সাপোর্ট করার কথা ভাবো।
+
+বেশিরভাগ মানুষ ভুলে যায়। এটা তোমার মনে করিয়ে দেওয়া। 😊
+
+<div align="center">
+
+| কাজ | কেন গুরুত্বপূর্ণ |
+|--------|----------------|
+| [⭐ **রেপো স্টার করো**](https://github.com/SAPTARSHI-coder/EaseMotion-css/stargazers) | আরও ডেভেলপারদের কাছে প্রজেক্টটি পৌঁছাতে সাহায্য করে |
+| [🍴 **ফর্ক করো ও অবদান রাখো**](./CONTRIBUTING.md) | তোমার আইডিয়া একটা আসল ফ্রেমওয়ার্ক ক্লাস হয়ে উঠতে পারে |
+| [🐞 **ইস্যু রিপোর্ট করো**](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/new?template=bug_report.md) | তুমি যে বাগ ধরো সেটা সবার জন্য উপকারী |
+| [💡 **ফিচার সাজেস্ট করো**](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/new?template=feature_request.md) | ভালো আইডিয়া ভাবার চেয়ে দ্রুত শিপ হয় |
+
+</div>
+
+> স্টার করতে কিছু খরচ হয় না, কিন্তু একটি স্বাধীন ওপেন-সোর্স প্রজেক্টের জন্য এর মানে অনেক। যদি এটা তোমার মাত্র ১০ মিনিটও বাঁচিয়ে থাকে, তাহলে একটা ক্লিক করার যোগ্য।
+
+---
+
+## 📊 প্রজেক্ট পরিসংখ্যান
+
+<div align="center">
+
+| মেট্রিক | মান |
+|--------|-------|
+| 📦 **npm প্যাকেজ** | [`easemotion-css`](https://www.npmjs.com/package/easemotion-css) |
+| 🌐 **CDN** | [cdn.jsdelivr.net/npm/easemotion-css](https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css) |
+| ⚡ **ক্লাস** | ৮০+ ইউটিলিটি ক্লাস, ২০+ অ্যানিমেশন ক্লাস |
+| 🎨 **কম্পোনেন্ট** | বাটন (৬ ভেরিয়েন্ট), কার্ড (১২ ভেরিয়েন্ট) |
+| 🔑 **ডিজাইন টোকেন** | ৬০+ CSS কাস্টম প্রপার্টি |
+| ⚖️ **বান্ডেল সাইজ** | ~১৫ kB (আনপ্যাকড: ~৬২ kB) |
+| 📜 **লাইসেন্স** | MIT |
+| 🔧 **বিল্ড স্টেপ** | ❌ প্রয়োজন নেই |
+| 🏗️ **নির্ভরতা** | ❌ শূন্য |
+
+</div>
+
+---
+
+## ✨ EaseMotion CSS কী?
+
+EaseMotion CSS হলো একটি কিউরেটেড, অ্যানিমেশন-প্রথম CSS ফ্রেমওয়ার্ক যেখানে **ক্লাসের নামগুলো সহজ ইংরেজিতে পড়া যায়**। শর্টহ্যান্ড মুখস্থ করতে হয় না। বিল্ড স্টেপ নেই। কনফিগারেশন নেই। শুধু HTML লেখো আর কাজ করো।
+
+```html
+<!-- এটুকুই যথেষ্ট -->
+<div class="ease-center ease-fade-in">
+  <h1 class="ease-slide-up ease-delay-100">দ্রুত তৈরি করো।</h1>
+  <p class="ease-slide-up ease-delay-200">মানুষের জন্য অ্যানিমেশন-প্রথম CSS।</p>
+  <button class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow ease-delay-300">
+    শুরু করো →
+  </button>
+</div>
+```
+
+> ⚡ পঠনযোগ্য CSS ক্লাস ব্যবহার করে সুন্দর অ্যানিমেটেড ইন্টারফেস তৈরি করো। কোনো বিল্ড স্টেপ নেই। কনফিগারেশন নেই। শুধু একটা ফাইল লিঙ্ক করো আর বিল্ড শুরু করো।
+
+---
+
+## 🆚 কেন EaseMotion CSS?
+
+| | Vanilla CSS | Tailwind CSS | **EaseMotion CSS** |
+|---|:---:|:---:|:---:|
+| সেটআপ | স্ক্র্যাচ থেকে লেখো | বিল্ড স্টেপ + কনফিগ | **একটি ফাইল লিঙ্ক করো** |
+| পাঠযোগ্যতা | ✅ বেশি | ❌ কম (`px-4 flex gap-x-2`) | ✅ **বেশি** (`ease-center`) |
+| অ্যানিমেশন | ⚙️ ম্যানুয়াল | 🔸 সীমিত | ✅ **ফার্স্ট-ক্লাস** |
+| জিরো কনফিগ | ✅ | ❌ | ✅ |
+| কোয়ালিটি কন্ট্রোল | তুমি | তুমি | ✅ **মেইনটেইনার কিউরেটেড** |
+| CDN রেডি | N/A | ❌ | ✅ **হ্যাঁ** |
+| শেখার বাধা | বেশি | মাঝারি | ✅ **প্রায় শূন্য** |
+
+---
+
+## ⚡ দ্রুত শুরু
+
+### অপশন ১ — CDN *(সবচেয়ে দ্রুত, জিরো সেটআপ, প্রস্তাবিত)*
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />
+</head>
+<body>
+  <div class="ease-center ease-fade-in">
+    <h1>হ্যালো, EaseMotion!</h1>
+  </div>
+</body>
+</html>
+```
+
+> jsDelivr দ্বারা চালিত — গ্লোবালি ক্যাশড, সবসময় দ্রুত, কোনো অ্যাকাউন্ট লাগে না। CDN লিঙ্ক পেস্ট করার সাথে সাথেই লাইভ।
+
+### অপশন ২ — npm
+
+```bash
+npm install easemotion-css
+```
+
+তারপর HTML-এ:
+
+```html
+<link rel="stylesheet" href="node_modules/easemotion-css/easemotion.css" />
+```
+
+অথবা CSS / PostCSS / Sass-এ:
+
+```css
+@import "easemotion-css/easemotion.css";
+```
+
+### অপশন ৩ — গ্রানুলার ইম্পোর্ট *(শুধু যা দরকার তা নাও)*
+
+```html
+<!-- Core (সবসময় প্রয়োজন — এই নির্দিষ্ট ক্রমে লোড করো) -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" />
+
+<!-- কম্পোনেন্ট — শুধু যা ব্যবহার করো তা যোগ করো -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css" />
+```
+
+> ⚠️ **`variables.css` সবসময় আগে লোড করতে হবে।** অন্য সব মডিউল এর CSS কাস্টম প্রপার্টির উপর নির্ভরশীল।
+
+---
+
+## 🧠 দর্শন
+
+EaseMotion CSS শুধু একটি CSS লাইব্রেরি নয় — এটি একটি ডিজাইন ভাষা।
+
+> *"যদি ইংরেজিতে বলতে পারো, তাহলে ক্লাস হিসেবেও লিখতে পারা উচিত।"*
+
+```html
+<!-- এটাকে কেন্দ্র করো -->      <div class="ease-center">
+<!-- এটাকে ফেড ইন করো -->       <h1 class="ease-fade-in">
+<!-- হোভারে বড় করো -->         <button class="ease-hover-grow">
+<!-- দেরিতে স্লাইড আপ করো --> <p class="ease-slide-up ease-delay-200">
+```
+
+ডকুমেন্টেশন দেখার দরকার নেই। ক্লাসের নামই **হলো** ডকুমেন্টেশন।
+
+### চারটি নীতি যা কখনো ভাঙা হয় না
+
+| নীতি | অর্থ |
+|-----------|---------------|
+| **মানুষের ভাষায়** | ক্লাসের নামগুলো সহজ ইংরেজিতে আচরণ বর্ণনা করে |
+| **অ্যানিমেশন-প্রথম** | মোশন একটি ফার্স্ট-ক্লাস নাগরিক, পরের চিন্তা নয় |
+| **কম্পোজেবল** | যেকোনো ক্লাস স্বাধীনভাবে স্ট্যাক করো — কোনো স্পেসিফিসিটি যুদ্ধ নেই |
+| **কিউরেটেড** | প্রতিটি ক্লাস রিলিজের আগে মেইনটেইনার রিভিউ করেন |
+
+### কিউরেশন পাইপলাইন কীভাবে কাজ করে
+
+```
+১. কন্ট্রিবিউটররা রো HTML + CSS জমা দেয়
+         ↓
+২. মেইনটেইনার রিভিউ করেন ও ফিট মূল্যায়ন করেন
+         ↓
+৩. কোড EaseMotion CSS ফরম্যাটে রূপান্তরিত হয়
+   (ease-* নামকরণ · CSS ভেরিয়েবল · অ্যাক্সেসিবিলিটি)
+         ↓
+৪. core/ বা components/-এ ইন্টিগ্রেট হয়
+         ↓
+৫. রিলিজ, ডকুমেন্ট ও ক্রেডিট দেওয়া হয়
+```
+
+ফ্রেমওয়ার্কের প্রতিটি ক্লাস এই প্রক্রিয়ার মধ্য দিয়ে গেছে। এই কিউরেশনই EaseMotion CSS-কে সামঞ্জস্যপূর্ণ রাখে।
+
+---
+
+## 💡 ব্যবহার ও উদাহরণ
+
+### অ্যানিমেশন
+
+```html
+<!-- প্রবেশ অ্যানিমেশন (পেজ লোডে চালু হয়) -->
+<h1 class="ease-fade-in">ফেড ইন</h1>
+<h2 class="ease-slide-up">স্লাইড আপ</h2>
+<h3 class="ease-slide-in-left">বাম থেকে স্লাইড</h3>
+<h4 class="ease-zoom-in">জুম ইন</h4>
+<h5 class="ease-flip">3D ফ্লিপ</h5>
+
+<!-- স্তরবিন্যাস — প্রতিটি আইটেম আগেরটার ১০০ms পরে -->
+<div class="ease-slide-up ease-delay-100">প্রথম</div>
+<div class="ease-slide-up ease-delay-200">দ্বিতীয়</div>
+<div class="ease-slide-up ease-delay-300">তৃতীয়</div>
+
+<!-- লুপিং অ্যানিমেশন -->
+<div class="ease-bounce">বাউন্সিং</div>
+<div class="ease-pulse">পালসিং</div>
+<div class="ease-rotate">ঘুরছে</div>
+<div class="ease-ping">পিং</div>
+
+<!-- এক্সিট অ্যানিমেশন -->
+<div class="ease-expand-border-exit"></div>
+```
+
+### হোভার ইফেক্ট
+
+```html
+<button class="ease-hover-grow">হোভারে বড় হয়</button>
+<div    class="ease-hover-morph-card">মর্ফ</div>
+<div    class="ease-hover-glow">প্রাইমারি কালার গ্লো</div>
+<div    class="ease-hover-lift">শ্যাডোসহ উপরে ওঠে</div>
+<div    class="ease-hover-shimmer">শিমার সুইপ ইফেক্ট</div>
+<a      class="ease-hover-underline">অ্যানিমেটেড আন্ডারলাইন</a>
+<span   class="ease-hover-bounce-text">বাউন্স!</span>
+```
+
+### লেআউট ইউটিলিটি
+
+```html
+<!-- সেন্টারিং (সবচেয়ে বেশি ব্যবহৃত ইউটিলিটি) -->
+<div class="ease-center">পারফেক্টলি সেন্টারড</div>
+
+<!-- ফ্লেক্সবক্স -->
+<div class="ease-flex ease-justify-between ease-items-center ease-gap-4">
+  <span>বাম</span>
+  <span>ডান</span>
+</div>
+
+<!-- রেসপন্সিভ অটো-ফিট গ্রিড (মিডিয়া কোয়েরি ছাড়া) -->
+<div class="ease-grid ease-grid-auto ease-gap-6">
+  <div class="ease-card">কার্ড ১</div>
+  <div class="ease-card">কার্ড ২</div>
+  <div class="ease-card">কার্ড ৩</div>
+</div>
+```
+
+### বাটন
+
+```html
+<!-- ভেরিয়েন্ট -->
+<button class="ease-btn ease-btn-primary">প্রাইমারি</button>
+<button class="ease-btn ease-btn-success">সাকসেস</button>
+<button class="ease-btn ease-btn-danger">ডেঞ্জার</button>
+<button class="ease-btn ease-btn-outline">আউটলাইন</button>
+<button class="ease-btn ease-btn-ghost">ঘোস্ট</button>
+
+<!-- হোভার অ্যানিমেশনসহ -->
+<button class="ease-btn ease-btn-primary ease-btn-hover">অ্যানিমেটেড</button>
+
+<!-- স্কুইশ বাটন -->
+<button class="ease-btn ease-btn-primary ease-squish-button">স্কুইশ মি</button>
+
+<!-- সাইজ + আকৃতি -->
+<button class="ease-btn ease-btn-primary ease-btn-sm">ছোট</button>
+<button class="ease-btn ease-btn-primary ease-btn-lg ease-btn-pill">বড় পিল</button>
+```
+
+### কার্ড
+
+```html
+<!-- শ্যাডোসহ হোভার কার্ড -->
+<div class="ease-card ease-card-shadow ease-card-hover">
+  <div class="ease-card-header">
+    <h3 class="ease-card-title">শিরোনাম</h3>
+  </div>
+  <div class="ease-card-body"><p>কন্টেন্ট এখানে।</p></div>
+  <div class="ease-card-footer">
+    <button class="ease-btn ease-btn-primary ease-btn-sm">অ্যাকশন</button>
+  </div>
+</div>
+
+<!-- গ্লাসমর্ফিজম -->
+<div class="ease-card ease-card-glass">গ্লাস কার্ড</div>
+
+<!-- অ্যাকসেন্ট বর্ডার -->
+<div class="ease-card ease-card-accent">হাইলাইটেড কার্ড</div>
+```
+
+### ৫ লাইনে একটি হিরো সেকশন তৈরি করো
+
+```html
+<section class="ease-center ease-padding-16">
+  <h1 class="ease-fade-in">দ্রুত তৈরি করো।</h1>
+  <p class="ease-slide-up ease-delay-200">মানুষের জন্য অ্যানিমেশন-প্রথম CSS।</p>
+  <button class="ease-btn ease-btn-primary ease-btn-lg ease-btn-pill ease-hover-grow ease-delay-300">
+    শুরু করো →
+  </button>
+</section>
+```
+
+---
+
+## ⚙️ কাস্টমাইজেশন
+
+পুরো ফ্রেমওয়ার্ক থিম করতে যেকোনো CSS কাস্টম প্রপার্টি ওভাররাইড করো — Sass নেই, PostCSS নেই, শুধু CSS:
+
+```css
+:root {
+  /* রঙ */
+  --ease-color-primary:   #f97316;   /* কমলায় পরিবর্তন */
+  --ease-color-success:   #10b981;   /* টিল গ্রিন */
+
+  /* মোশন */
+  --ease-speed-fast:      100ms;     /* আরও দ্রুত */
+  --ease-speed-medium:    400ms;     /* একটু ধীর */
+  --ease-ease-bounce:     cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* আকৃতি */
+  --ease-radius-md:       1rem;      /* গোলাকার কোণ */
+  --ease-radius-full:     9999px;
+
+  /* শ্যাডো */
+  --ease-shadow-md:       0 4px 20px rgba(0,0,0,0.15);
+}
+```
+
+---
+
+## 📂 ফাইল স্ট্রাকচার
+
+```
+easemotion-css/
+├── easemotion.css              ← একক ইম্পোর্ট এন্ট্রি পয়েন্ট
+│
+├── core/                       ← মেইনটেইনার-অনলি
+│   ├── variables.css           ← ৬০+ ডিজাইন টোকেন
+│   ├── base.css                ← রিসেট + টাইপোগ্রাফি (Inter ফন্ট)
+│   ├── animations.css          ← ২০+ অ্যানিমেশন ক্লাস
+│   └── utilities.css           ← ৮০+ লেআউট ইউটিলিটি
+│
+├── components/                 ← মেইনটেইনার-অনলি
+│   ├── buttons.css             ← ৬ ভেরিয়েন্ট, ৪ সাইজ, পিল, আইকন
+│   └── cards.css               ← ১২ কার্ড ভেরিয়েন্ট
+│
+├── submissions/                ← কন্ট্রিবিউটর এলাকা
+│   ├── README.md               ← সম্পূর্ণ সাবমিশন ওয়ার্কফ্লো
+│   └── examples/
+│       ├── hover-grow/         ← [ইন্টিগ্রেটেড] → ease-hover-grow
+│       ├── hover-shimmer/      ← [ইন্টিগ্রেটেড] → ease-hover-shimmer
+│       ├── card-lift/          ← [ইন্টিগ্রেটেড] → ease-card-lift
+│       └── button-glow/        ← রিভিউ মুলতবি
+│
+├── examples/demo.html          ← ইন্টারেক্টিভ লাইভ শোকেস
+├── docs/index.html             ← সম্পূর্ণ ডকুমেন্টেশন সাইট
+│
+├── .github/
+│   ├── CODEOWNERS
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── feature_request.md
+│   │   └── bug_report.md
+│   └── PULL_REQUEST_TEMPLATE.md
+│
+├── VISION.md                   ← দীর্ঘমেয়াদী প্রজেক্ট দিকনির্দেশনা
+├── CHANGELOG.md                ← সম্পূর্ণ রিলিজ ইতিহাস
+├── CONTRIBUTING.md             ← অবদান গাইড
+├── LICENSE                     ← MIT © ২০২৬ Saptarshi Sadhu
+└── README.md
+```
+
+---
+
+## 🗺️ রোডম্যাপ
+
+> [GitHub Issues](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues)-এর মাধ্যমে অগ্রগতি ট্র্যাক করো ও ফিচারে ভোট দাও।
+
+| ফিচার | স্ট্যাটাস |
+|---------|--------|
+| ✅ মানুষের ভাষায় কোর ইউটিলিটি (৮০+) | **শিপড — v1.0** |
+| ✅ অ্যানিমেশন-প্রথম মোশন লাইব্রেরি (২০+) | **শিপড — v1.0** |
+| ✅ কিউরেটেড কন্ট্রিবিউশন পাইপলাইন | **শিপড — v1.0** |
+| ✅ কম্পোনেন্ট লাইব্রেরি (বাটন, কার্ড) | **শিপড — v1.0** |
+| ✅ npm প্যাকেজ + jsDelivr CDN | **শিপড — v1.0** |
+| ✅ সম্পূর্ণ ডকুমেন্টেশন সাইট | **শিপড — v1.0** |
+| 🔜 ফর্ম কম্পোনেন্ট (ইনপুট, চেকবক্স, টগল) | **পরিকল্পিত — v1.1** |
+| 🔜 ডার্ক মোড টোকেন লেয়ার | **পরিকল্পিত — v1.1** |
+| 🔜 মোডাল ও টুলটিপ কম্পোনেন্ট | **পরিকল্পিত — v1.2** |
+| 🔜 স্ক্রোল-ট্রিগারড অ্যানিমেশন | **পরিকল্পিত — v1.2** |
+| 🔜 নেভিগেশন কম্পোনেন্ট (নেভবার, সাইডবার) | **পরিকল্পিত — v1.3** |
+| 🔜 CSS-অনলি অ্যাকর্ডিয়ন ও ট্যাব | **পরিকল্পিত — v1.3** |
+| 🔜 ব্যাজ, ট্যাগ, অ্যাভাটার, প্রগ্রেস বার | **পরিকল্পিত — v1.3** |
+| 🔜 থিমিং CLI | **অন্বেষণাধীন** |
+
+---
+
+## 🤝 অবদান রাখা
+
+EaseMotion CSS একটি **কিউরেটেড, মেইনটেইনার-রিভিউড ফ্রেমওয়ার্ক**। কন্ট্রিবিউটররা রো আইডিয়া জমা দেন — মেইনটেইনার স্ট্যান্ডার্ডাইজেশন, নামকরণ ও ইন্টিগ্রেশন সামলান।
+
+### ✅ কন্ট্রিবিউটররা যা করেন
+
+```
+✅ submissions/examples/your-feature/ ফোল্ডারে যোগ করো
+✅ অন্তর্ভুক্ত করো: demo.html + style.css + README.md
+✅ যেকোনো ক্লাস নামকরণ ব্যবহার করো — ease- প্রিফিক্স দরকার নেই
+✅ প্রতি PR-এ একটি ফিচার
+```
+
+### ❌ কন্ট্রিবিউটররা যা করেন না
+
+```
+❌ core/ সম্পাদনা → রিভিউ ছাড়া PR বন্ধ
+❌ components/ সম্পাদনা → রিভিউ ছাড়া PR বন্ধ
+❌ নিজের PR মার্জ করা → শুধুমাত্র মেইনটেইনার
+❌ একসাথে ২টির বেশি সক্রিয় ইস্যু দাবি করা
+```
+
+### সাবমিশন পাইপলাইন
+
+```
+তোমার রো CSS  →  মেইনটেইনার স্ট্যান্ডার্ড করেন  →  ease-* ক্লাস শিপ হয়
+.hover-grow       ease-hover-grow                    core/animations.css
+```
+
+### 🌟 কেন অবদান রাখবে?
+
+- **বিগিনার-ফ্রেন্ডলি** — রো CSS লেখো, কোনো কনভেনশন মুখস্থ করতে হয় না
+- **আসল সিস্টেম ডিজাইন শেখো** — দেখো কীভাবে রো আইডিয়া একটি সামঞ্জস্যপূর্ণ API হয়
+- **তোমার আইডিয়া শিপ হয়** — গৃহীত সাবমিশন আসল ফ্রেমওয়ার্ক ক্লাস হয়ে যায়
+- **CHANGELOG-এ ক্রেডিট** — তোমার অবদান স্থায়ীভাবে নথিভুক্ত হয়
+- **README-তে তোমার নাম** — নিচে কন্ট্রিবিউটর ওয়াল দেখো
+
+📖 সম্পূর্ণ গাইড পড়ো → [CONTRIBUTING.md](./CONTRIBUTING.md)
+
+---
+
+## 🏷️ ইস্যু লেবেল
+
+| লেবেল | ব্যবহার |
+|-------|----------|
+| `good first issue` | সহজ এন্ট্রি পয়েন্ট, প্রথমবার কন্ট্রিবিউটরদের জন্য আদর্শ |
+| `animation` | হোভার ইফেক্ট, প্রবেশ অ্যানিমেশন, কীফ্রেম আইডিয়া |
+| `component` | নতুন UI কম্পোনেন্ট (মোডাল, টুলটিপ, ব্যাজ ইত্যাদি) |
+| `enhancement` | বিদ্যমান ক্লাসের উন্নতি |
+| `documentation` | README, ডকস সাইট, সাবমিশন গাইড |
+| `curated` | ফ্রেমওয়ার্কে গৃহীত |
+| `maintainer-approved` | রিভিউড, ইন্টিগ্রেশন মুলতবি |
+| `featured` | অসাধারণ সাবমিশন — শোকেস করা হবে |
+
+> **ইস্যু কুলডাউন নিয়ম:** প্রতি কন্ট্রিবিউটরের সর্বোচ্চ **২টি সক্রিয় অ্যাসাইনড ইস্যু**। ৫ দিন অগ্রগতি না হলে ইস্যু আনঅ্যাসাইন ও পুনরায় খোলা হয়।
+
+---
+
+## 💬 কমিউনিটি
+
+<div align="center">
+
+| প্ল্যাটফর্ম | লিঙ্ক |
+|----------|------|
+| 🐛 **বাগ রিপোর্ট** | [একটি ইস্যু খোলো](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/new?template=bug_report.md) |
+| 💡 **ফিচার রিকোয়েস্ট** | [একটি ফিচার রিকোয়েস্ট করো](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/new?template=feature_request.md) |
+| 🔀 **পুল রিকোয়েস্ট** | [একটি অবদান জমা দাও](https://github.com/SAPTARSHI-coder/EaseMotion-css/pulls) |
+| 📖 **ডকুমেন্টেশন** | [সম্পূর্ণ ডকস সাইট](https://saptarshi-coder.github.io/EaseMotion-css/) |
+| 📦 **npm প্যাকেজ** | [npm-এ easemotion-css](https://www.npmjs.com/package/easemotion-css) |
+| 🌐 **CDN** | [jsDelivr](https://www.jsdelivr.com/package/npm/easemotion-css) |
+| 🏆 **GSSoC 2026** | [GirlScript Summer of Code](https://gssoc.girlscript.tech/) |
+
+</div>
+
+> ⭐ **EaseMotion CSS যদি তোমার সময় বাঁচায়, তাহলে রেপো স্টার করার কথা ভাবো।** এটি আরও ডেভেলপারদের প্রজেক্টটি আবিষ্কার করতে সাহায্য করে এবং চলমান উন্নয়নকে অনুপ্রাণিত করে।
+
+---
+
+## 🏆 কন্ট্রিবিউটররা
+
+যারা PR জমা দিয়েছেন, ইস্যু খুলেছেন বা আইডিয়া দিয়েছেন — এই ওয়াল তোমাদের জন্য। **এটি স্বয়ংক্রিয়ভাবে আপডেট হয়** প্রতিবার নতুন কন্ট্রিবিউটর GitHub-এ দেখা দিলে।
+
+<div align="center">
+
+<a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=SAPTARSHI-coder/EaseMotion-css&max=96&columns=12" alt="EaseMotion CSS Contributors" />
+</a>
+
+*[contrib.rocks](https://contrib.rocks) দ্বারা স্বয়ংক্রিয়ভাবে তৈরি · প্রতি রাতে GitHub থেকে আপডেট হয়*
+
+</div>
+
+---
+
+## 👤 মেইনটেইনার
+
+<div align="center">
+
+**Saptarshi Sadhu**
+
+[![GitHub](https://img.shields.io/badge/GitHub-SAPTARSHI--coder-6c63ff?style=flat-square&logo=github)](https://github.com/SAPTARSHI-coder)
+
+EaseMotion CSS ডিজাইন, কিউরেট এবং সক্রিয়ভাবে রক্ষণাবেক্ষণ করেন Saptarshi Sadhu। সমস্ত অবদান ইন্টিগ্রেশনের আগে রিভিউ ও স্ট্যান্ডার্ডাইজ করা হয়। ফ্রেমওয়ার্ক সরাসরি অরিভিউড এডিট গ্রহণ করে না।
+
+> শুধুমাত্র মেইনটেইনার পুল রিকোয়েস্ট মার্জ করেন। এটি [CODEOWNERS](./.github/CODEOWNERS)-এর মাধ্যমে প্রয়োগ করা হয়।
+
+</div>
+
+---
+
+## 📜 চেঞ্জলগ
+
+সম্পূর্ণ রিলিজ ইতিহাসের জন্য [CHANGELOG.md](./CHANGELOG.md) দেখো।
+
+**সর্বশেষ: [v1.0.0](./CHANGELOG.md)** — প্রাথমিক পাবলিক রিলিজ। ৮০+ ইউটিলিটি, ২০+ অ্যানিমেশন, বাটন, কার্ড, সম্পূর্ণ ডকস সাইট, npm + CDN।
+
+---
+
+## ⚖️ লাইসেন্স
+
+**MIT © ২০২৬ Saptarshi Sadhu** — বিস্তারিতের জন্য [LICENSE](./LICENSE) দেখো।
+
+তুমি ব্যক্তিগত ও বাণিজ্যিক প্রজেক্টে EaseMotion CSS ব্যবহার করতে স্বাধীন। কৃতিত্ব দেওয়া প্রশংসনীয় কিন্তু বাধ্যতামূলক নয়।
+
+---
+
+<div align="center">
+
+**আমার সাথে EaseMotion CSS তৈরি করার জন্য ধন্যবাদ।** 💜
+
+প্রতিটি স্টার, প্রতিটি PR, প্রতিটি ইস্যু — সবকিছুই গুরুত্বপূর্ণ।
+
+*— Saptarshi Sadhu · [@SAPTARSHI-coder](https://github.com/SAPTARSHI-coder)*
+
+<br/>
+
+[![npm](https://img.shields.io/npm/v/easemotion-css?style=flat-square&color=6c63ff)](https://www.npmjs.com/package/easemotion-css)
+[![Stars](https://img.shields.io/github/stars/SAPTARSHI-coder/EaseMotion-css?style=flat-square&color=6c63ff)](https://github.com/SAPTARSHI-coder/EaseMotion-css/stargazers)
+[![License](https://img.shields.io/badge/License-MIT-6c63ff?style=flat-square)](./LICENSE)
+
+যত্নসহকারে তৈরি &nbsp;·&nbsp; শূন্য নির্ভরতা &nbsp;·&nbsp; অ্যানিমেশন-প্রথম &nbsp;·&nbsp; কমিউনিটি-চালিত
+
+</div>

--- a/submissions/examples/css-variable-reference/README.md
+++ b/submissions/examples/css-variable-reference/README.md
@@ -1,0 +1,31 @@
+# CSS Variable Reference Table
+
+## What does this do?
+Documents every `--ease-*` CSS custom property from `core/variables.css` in a clean, searchable reference table.
+
+## How is it used?
+Open `demo.html` directly in your browser to browse all variables. Use the search bar to filter by name, category, or value.
+
+To override any variable in your own project, add this to your CSS:
+
+```css
+:root {
+  --ease-color-primary: #6366f1;
+  --ease-speed-medium: 400ms;
+  --ease-radius-md: 8px;
+}
+```
+
+## Why is it useful?
+Without a reference table, contributors have to open `variables.css` and guess what each token does. This makes all design tokens self-documenting — showing the variable name, default value, what it affects, and a practical example override, all in one place.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open `demo.html` directly in your browser to see the effect.
+
+## Contribution Notes
+- Class naming was handled by the contributor
+- Maintainer will rename to ease-* convention before merging

--- a/submissions/examples/css-variable-reference/demo.html
+++ b/submissions/examples/css-variable-reference/demo.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Variable Reference Table - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+
+    <h1>CSS Variable Reference Table</h1>
+    <p class="subtitle">All <code>--ease-*</code> custom properties from <code>core/variables.css</code></p>
+
+    <input class="search-bar" type="text" id="search" placeholder="Search variables... e.g. color, radius, shadow" oninput="filterTable()" />
+
+    <!-- ── Transition Speeds ── -->
+    <div class="section-title">Transition Speeds</div>
+    <table class="ref-table">
+      <thead>
+        <tr>
+          <th>Variable</th>
+          <th>Default Value</th>
+          <th>What It Affects</th>
+          <th>Example Override</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="var-name">--ease-speed-fast</td>
+          <td class="var-value">150ms</td>
+          <td class="var-affects">Duration of fast transitions (e.g. button hover)</td>
+          <td class="var-example">--ease-speed-fast: 100ms;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-speed-medium</td>
+          <td class="var-value">300ms</td>
+          <td class="var-affects">Duration of standard transitions (e.g. card hover)</td>
+          <td class="var-example">--ease-speed-medium: 400ms;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-speed-slow</td>
+          <td class="var-value">600ms</td>
+          <td class="var-affects">Duration of slow transitions (e.g. page fade-in)</td>
+          <td class="var-example">--ease-speed-slow: 800ms;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-ease</td>
+          <td class="var-value">cubic-bezier(0.4, 0, 0.2, 1)</td>
+          <td class="var-affects">Smooth ease-in-out timing for most animations</td>
+          <td class="var-example">--ease-ease: ease-in-out;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-ease-out</td>
+          <td class="var-value">cubic-bezier(0, 0, 0.2, 1)</td>
+          <td class="var-affects">Deceleration curve for exit/slide animations</td>
+          <td class="var-example">--ease-ease-out: ease-out;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-ease-bounce</td>
+          <td class="var-value">cubic-bezier(0.34, 1.56, 0.64, 1)</td>
+          <td class="var-affects">Overshoot spring effect for playful interactions</td>
+          <td class="var-example">--ease-ease-bounce: cubic-bezier(0.34, 1.3, 0.64, 1);</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- ── Color Palette ── -->
+    <div class="section-title">Color Palette — Primary</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="var-name">--ease-color-primary</td>
+          <td class="var-value"><span class="swatch" style="background:#6c63ff"></span>#6c63ff</td>
+          <td class="var-affects">Primary buttons, links, focus rings</td>
+          <td class="var-example">--ease-color-primary: #6366f1;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-primary-light</td>
+          <td class="var-value"><span class="swatch" style="background:#a09af8"></span>#a09af8</td>
+          <td class="var-affects">Hover states, tinted backgrounds for primary</td>
+          <td class="var-example">--ease-color-primary-light: #c7d2fe;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-primary-dark</td>
+          <td class="var-value"><span class="swatch" style="background:#4b44cc"></span>#4b44cc</td>
+          <td class="var-affects">Active/pressed state for primary elements</td>
+          <td class="var-example">--ease-color-primary-dark: #4338ca;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-success</td>
+          <td class="var-value"><span class="swatch" style="background:#22c55e"></span>#22c55e</td>
+          <td class="var-affects">Success badges, alerts, confirmation states</td>
+          <td class="var-example">--ease-color-success: #16a34a;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-success-light</td>
+          <td class="var-value"><span class="swatch" style="background:#86efac"></span>#86efac</td>
+          <td class="var-affects">Success background tints</td>
+          <td class="var-example">--ease-color-success-light: #bbf7d0;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-success-dark</td>
+          <td class="var-value"><span class="swatch" style="background:#15803d"></span>#15803d</td>
+          <td class="var-affects">Success active/pressed states</td>
+          <td class="var-example">--ease-color-success-dark: #166534;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-danger</td>
+          <td class="var-value"><span class="swatch" style="background:#ef4444"></span>#ef4444</td>
+          <td class="var-affects">Error states, delete buttons, alerts</td>
+          <td class="var-example">--ease-color-danger: #dc2626;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-danger-light</td>
+          <td class="var-value"><span class="swatch" style="background:#fca5a5"></span>#fca5a5</td>
+          <td class="var-affects">Error background tints</td>
+          <td class="var-example">--ease-color-danger-light: #fecaca;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-danger-dark</td>
+          <td class="var-value"><span class="swatch" style="background:#b91c1c"></span>#b91c1c</td>
+          <td class="var-affects">Error active/pressed states</td>
+          <td class="var-example">--ease-color-danger-dark: #991b1b;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-warning</td>
+          <td class="var-value"><span class="swatch" style="background:#f59e0b"></span>#f59e0b</td>
+          <td class="var-affects">Warning badges, caution alerts</td>
+          <td class="var-example">--ease-color-warning: #d97706;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-warning-light</td>
+          <td class="var-value"><span class="swatch" style="background:#fcd34d"></span>#fcd34d</td>
+          <td class="var-affects">Warning background tints</td>
+          <td class="var-example">--ease-color-warning-light: #fde68a;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-warning-dark</td>
+          <td class="var-value"><span class="swatch" style="background:#b45309"></span>#b45309</td>
+          <td class="var-affects">Warning active/pressed states</td>
+          <td class="var-example">--ease-color-warning-dark: #92400e;</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="section-title">Color Palette — Neutrals</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-color-neutral-50</td><td class="var-value"><span class="swatch" style="background:#f8fafc;border-color:#ccc"></span>#f8fafc</td><td class="var-affects">Lightest background tint</td><td class="var-example">--ease-color-neutral-50: #f9fafb;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-100</td><td class="var-value"><span class="swatch" style="background:#f1f5f9;border-color:#ccc"></span>#f1f5f9</td><td class="var-affects">Page background, subtle fills</td><td class="var-example">--ease-color-neutral-100: #f3f4f6;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-200</td><td class="var-value"><span class="swatch" style="background:#e2e8f0"></span>#e2e8f0</td><td class="var-affects">Borders, dividers</td><td class="var-example">--ease-color-neutral-200: #e5e7eb;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-300</td><td class="var-value"><span class="swatch" style="background:#cbd5e1"></span>#cbd5e1</td><td class="var-affects">Disabled element borders</td><td class="var-example">--ease-color-neutral-300: #d1d5db;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-400</td><td class="var-value"><span class="swatch" style="background:#94a3b8"></span>#94a3b8</td><td class="var-affects">Placeholder text, icons</td><td class="var-example">--ease-color-neutral-400: #9ca3af;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-500</td><td class="var-value"><span class="swatch" style="background:#64748b"></span>#64748b</td><td class="var-affects">Muted/secondary text</td><td class="var-example">--ease-color-neutral-500: #6b7280;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-600</td><td class="var-value"><span class="swatch" style="background:#475569"></span>#475569</td><td class="var-affects">Body text on light backgrounds</td><td class="var-example">--ease-color-neutral-600: #4b5563;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-700</td><td class="var-value"><span class="swatch" style="background:#334155"></span>#334155</td><td class="var-affects">Headings on light backgrounds</td><td class="var-example">--ease-color-neutral-700: #374151;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-800</td><td class="var-value"><span class="swatch" style="background:#1e293b"></span>#1e293b</td><td class="var-affects">Primary text color (--ease-color-text)</td><td class="var-example">--ease-color-neutral-800: #1f2937;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-900</td><td class="var-value"><span class="swatch" style="background:#0f172a"></span>#0f172a</td><td class="var-affects">Darkest shade, dark mode backgrounds</td><td class="var-example">--ease-color-neutral-900: #111827;</td></tr>
+        <tr><td class="var-name">--ease-color-bg</td><td class="var-value">var(--ease-color-neutral-50)</td><td class="var-affects">Page/app background color</td><td class="var-example">--ease-color-bg: #ffffff;</td></tr>
+        <tr><td class="var-name">--ease-color-surface</td><td class="var-value"><span class="swatch" style="background:#ffffff;border-color:#ccc"></span>#ffffff</td><td class="var-affects">Card and component surface color</td><td class="var-example">--ease-color-surface: #f8fafc;</td></tr>
+        <tr><td class="var-name">--ease-color-text</td><td class="var-value">var(--ease-color-neutral-800)</td><td class="var-affects">Default body text color</td><td class="var-example">--ease-color-text: #111827;</td></tr>
+        <tr><td class="var-name">--ease-color-muted</td><td class="var-value">var(--ease-color-neutral-500)</td><td class="var-affects">Secondary/muted text, captions</td><td class="var-example">--ease-color-muted: #6b7280;</td></tr>
+      </tbody>
+    </table>
+
+    <!-- ── Spacing ── -->
+    <div class="section-title">Spacing Scale</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-space-1</td><td class="var-value">0.25rem (4px)</td><td class="var-affects">Tight gaps, icon padding</td><td class="var-example">--ease-space-1: 2px;</td></tr>
+        <tr><td class="var-name">--ease-space-2</td><td class="var-value">0.5rem (8px)</td><td class="var-affects">Small padding, badge spacing</td><td class="var-example">--ease-space-2: 6px;</td></tr>
+        <tr><td class="var-name">--ease-space-3</td><td class="var-value">0.75rem (12px)</td><td class="var-affects">Button padding (vertical)</td><td class="var-example">--ease-space-3: 10px;</td></tr>
+        <tr><td class="var-name">--ease-space-4</td><td class="var-value">1rem (16px)</td><td class="var-affects">Base spacing unit, card padding</td><td class="var-example">--ease-space-4: 18px;</td></tr>
+        <tr><td class="var-name">--ease-space-5</td><td class="var-value">1.25rem (20px)</td><td class="var-affects">Medium component padding</td><td class="var-example">--ease-space-5: 22px;</td></tr>
+        <tr><td class="var-name">--ease-space-6</td><td class="var-value">1.5rem (24px)</td><td class="var-affects">Card gap, section spacing</td><td class="var-example">--ease-space-6: 28px;</td></tr>
+        <tr><td class="var-name">--ease-space-8</td><td class="var-value">2rem (32px)</td><td class="var-affects">Large section padding</td><td class="var-example">--ease-space-8: 36px;</td></tr>
+        <tr><td class="var-name">--ease-space-10</td><td class="var-value">2.5rem (40px)</td><td class="var-affects">Hero section padding</td><td class="var-example">--ease-space-10: 44px;</td></tr>
+        <tr><td class="var-name">--ease-space-12</td><td class="var-value">3rem (48px)</td><td class="var-affects">Page-level vertical rhythm</td><td class="var-example">--ease-space-12: 52px;</td></tr>
+        <tr><td class="var-name">--ease-space-16</td><td class="var-value">4rem (64px)</td><td class="var-affects">Extra-large layout gaps</td><td class="var-example">--ease-space-16: 72px;</td></tr>
+      </tbody>
+    </table>
+
+    <!-- ── Border Radius ── -->
+    <div class="section-title">Border Radius</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-radius-sm</td><td class="var-value">0.25rem</td><td class="var-affects">Subtle rounding on small elements (badges, tags)</td><td class="var-example">--ease-radius-sm: 2px;</td></tr>
+        <tr><td class="var-name">--ease-radius-md</td><td class="var-value">0.5rem</td><td class="var-affects">Buttons, inputs, small cards</td><td class="var-example">--ease-radius-md: 8px;</td></tr>
+        <tr><td class="var-name">--ease-radius-lg</td><td class="var-value">1rem</td><td class="var-affects">Cards, modals, panels</td><td class="var-example">--ease-radius-lg: 14px;</td></tr>
+        <tr><td class="var-name">--ease-radius-xl</td><td class="var-value">1.5rem</td><td class="var-affects">Large rounded containers</td><td class="var-example">--ease-radius-xl: 20px;</td></tr>
+        <tr><td class="var-name">--ease-radius-full</td><td class="var-value">9999px</td><td class="var-affects">Pill buttons, circular avatars</td><td class="var-example">--ease-radius-full: 50%;</td></tr>
+      </tbody>
+    </table>
+
+    <!-- ── Shadows ── -->
+    <div class="section-title">Shadows &amp; Glows</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-shadow-sm</td><td class="var-value">0 1px 3px rgba(0,0,0,0.08)…</td><td class="var-affects">Subtle lift on small cards, dropdowns</td><td class="var-example">--ease-shadow-sm: 0 1px 4px rgba(0,0,0,0.12);</td></tr>
+        <tr><td class="var-name">--ease-shadow-md</td><td class="var-value">0 4px 6px -1px rgba(0,0,0,0.10)…</td><td class="var-affects">Standard card elevation</td><td class="var-example">--ease-shadow-md: 0 4px 12px rgba(0,0,0,0.15);</td></tr>
+        <tr><td class="var-name">--ease-shadow-lg</td><td class="var-value">0 10px 15px -3px rgba(0,0,0,0.10)…</td><td class="var-affects">Modals, popovers, hover lift</td><td class="var-example">--ease-shadow-lg: 0 10px 24px rgba(0,0,0,0.18);</td></tr>
+        <tr><td class="var-name">--ease-shadow-xl</td><td class="var-value">0 20px 25px -5px rgba(0,0,0,0.10)…</td><td class="var-affects">Floating panels, drawers</td><td class="var-example">--ease-shadow-xl: 0 24px 40px rgba(0,0,0,0.20);</td></tr>
+        <tr><td class="var-name">--ease-glow-primary</td><td class="var-value">0 0 16px rgba(108,99,255,0.45)</td><td class="var-affects">Glow effect on primary elements</td><td class="var-example">--ease-glow-primary: 0 0 24px rgba(108,99,255,0.6);</td></tr>
+        <tr><td class="var-name">--ease-glow-success</td><td class="var-value">0 0 16px rgba(34,197,94,0.45)</td><td class="var-affects">Glow effect on success elements</td><td class="var-example">--ease-glow-success: 0 0 20px rgba(34,197,94,0.6);</td></tr>
+        <tr><td class="var-name">--ease-glow-danger</td><td class="var-value">0 0 16px rgba(239,68,68,0.45)</td><td class="var-affects">Glow effect on danger/error elements</td><td class="var-example">--ease-glow-danger: 0 0 20px rgba(239,68,68,0.6);</td></tr>
+      </tbody>
+    </table>
+
+    <!-- ── Typography ── -->
+    <div class="section-title">Typography</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-font-sans</td><td class="var-value">'Inter', system-ui, sans-serif</td><td class="var-affects">Default font for all UI text</td><td class="var-example">--ease-font-sans: 'Poppins', sans-serif;</td></tr>
+        <tr><td class="var-name">--ease-font-mono</td><td class="var-value">'JetBrains Mono', monospace</td><td class="var-affects">Code blocks, variable names</td><td class="var-example">--ease-font-mono: 'Fira Code', monospace;</td></tr>
+        <tr><td class="var-name">--ease-text-xs</td><td class="var-value">0.75rem</td><td class="var-affects">Labels, captions, fine print</td><td class="var-example">--ease-text-xs: 0.7rem;</td></tr>
+        <tr><td class="var-name">--ease-text-sm</td><td class="var-value">0.875rem</td><td class="var-affects">Secondary text, badges</td><td class="var-example">--ease-text-sm: 0.85rem;</td></tr>
+        <tr><td class="var-name">--ease-text-base</td><td class="var-value">1rem</td><td class="var-affects">Body text, default font size</td><td class="var-example">--ease-text-base: 1.0625rem;</td></tr>
+        <tr><td class="var-name">--ease-text-lg</td><td class="var-value">1.125rem</td><td class="var-affects">Large body text, card titles</td><td class="var-example">--ease-text-lg: 1.2rem;</td></tr>
+        <tr><td class="var-name">--ease-text-xl</td><td class="var-value">1.25rem</td><td class="var-affects">Section subheadings</td><td class="var-example">--ease-text-xl: 1.3rem;</td></tr>
+        <tr><td class="var-name">--ease-text-2xl</td><td class="var-value">1.5rem</td><td class="var-affects">Section headings</td><td class="var-example">--ease-text-2xl: 1.6rem;</td></tr>
+        <tr><td class="var-name">--ease-text-3xl</td><td class="var-value">1.875rem</td><td class="var-affects">Page headings</td><td class="var-example">--ease-text-3xl: 2rem;</td></tr>
+        <tr><td class="var-name">--ease-text-4xl</td><td class="var-value">2.25rem</td><td class="var-affects">Hero headings</td><td class="var-example">--ease-text-4xl: 2.5rem;</td></tr>
+        <tr><td class="var-name">--ease-leading-tight</td><td class="var-value">1.25</td><td class="var-affects">Line height for headings</td><td class="var-example">--ease-leading-tight: 1.2;</td></tr>
+        <tr><td class="var-name">--ease-leading-normal</td><td class="var-value">1.6</td><td class="var-affects">Line height for body text</td><td class="var-example">--ease-leading-normal: 1.7;</td></tr>
+        <tr><td class="var-name">--ease-leading-loose</td><td class="var-value">1.9</td><td class="var-affects">Line height for relaxed/airy text</td><td class="var-example">--ease-leading-loose: 2.0;</td></tr>
+      </tbody>
+    </table>
+
+    <!-- ── Z-Index ── -->
+    <div class="section-title">Z-Index Scale</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-z-base</td><td class="var-value">0</td><td class="var-affects">Default stacking order</td><td class="var-example">--ease-z-base: 1;</td></tr>
+        <tr><td class="var-name">--ease-z-raised</td><td class="var-value">10</td><td class="var-affects">Raised cards, dropdowns</td><td class="var-example">--ease-z-raised: 20;</td></tr>
+        <tr><td class="var-name">--ease-z-overlay</td><td class="var-value">100</td><td class="var-affects">Overlay backgrounds, backdrops</td><td class="var-example">--ease-z-overlay: 200;</td></tr>
+        <tr><td class="var-name">--ease-z-modal</td><td class="var-value">1000</td><td class="var-affects">Modal dialogs, side drawers</td><td class="var-example">--ease-z-modal: 500;</td></tr>
+        <tr><td class="var-name">--ease-z-toast</td><td class="var-value">9999</td><td class="var-affects">Toast notifications (always on top)</td><td class="var-example">--ease-z-toast: 9000;</td></tr>
+      </tbody>
+    </table>
+
+    <p class="description">
+      Source: <code>core/variables.css</code> · EaseMotion CSS · Issue <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/339" style="color:#a09af8">#339</a>
+    </p>
+
+  </div>
+
+  <script>
+    function filterTable() {
+      const query = document.getElementById('search').value.toLowerCase();
+      const rows = document.querySelectorAll('.ref-table tbody tr');
+      rows.forEach(row => {
+        const text = row.textContent.toLowerCase();
+        row.classList.toggle('hidden', !text.includes(query));
+      });
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/css-variable-reference/style.css
+++ b/submissions/examples/css-variable-reference/style.css
@@ -1,0 +1,172 @@
+/* =============================================
+   EASEMOTION CSS — CSS Variable Reference Table
+   Contributor: NirmalSingh-09
+   Issue: #339
+   ============================================= */
+
+/* TEMPLATE: Basic page layout — keep this */
+body {
+  font-family: 'Inter', sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0f0f;
+  color: white;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+}
+
+.demo-wrapper {
+  text-align: center;
+  width: 100%;
+  max-width: 1100px;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 0.25rem;
+  color: #a09af8;
+}
+
+.subtitle {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+}
+
+/* =============================================
+   SEARCH BAR
+   ============================================= */
+.search-bar {
+  width: 100%;
+  max-width: 480px;
+  padding: 10px 16px;
+  border-radius: 8px;
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: white;
+  font-size: 0.95rem;
+  margin-bottom: 2rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.search-bar:focus {
+  border-color: #6c63ff;
+}
+
+/* =============================================
+   SECTION HEADINGS
+   ============================================= */
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #6c63ff;
+  text-align: left;
+  margin: 2rem 0 0.75rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid #1e293b;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+/* =============================================
+   REFERENCE TABLE
+   ============================================= */
+.ref-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.ref-table thead tr {
+  background: #1e293b;
+}
+
+.ref-table thead th {
+  text-align: left;
+  padding: 10px 14px;
+  color: #94a3b8;
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid #334155;
+}
+
+.ref-table tbody tr {
+  border-bottom: 1px solid #1e293b;
+  transition: background 0.15s ease;
+}
+
+.ref-table tbody tr:hover {
+  background: #1e293b;
+}
+
+.ref-table td {
+  padding: 10px 14px;
+  vertical-align: middle;
+  color: #e2e8f0;
+}
+
+/* Variable name */
+.var-name {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #a09af8;
+  white-space: nowrap;
+  font-size: 0.82rem;
+}
+
+/* Default value */
+.var-value {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #86efac;
+  font-size: 0.82rem;
+}
+
+/* Color swatch */
+.swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  margin-right: 6px;
+  vertical-align: middle;
+  border: 1px solid rgba(255,255,255,0.1);
+}
+
+/* Example override */
+.var-example {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #fcd34d;
+  font-size: 0.78rem;
+}
+
+/* Affects column */
+.var-affects {
+  color: #cbd5e1;
+  font-size: 0.85rem;
+}
+
+/* Hidden rows (search) */
+.ref-table tbody tr.hidden {
+  display: none;
+}
+
+/* No results message */
+.no-results {
+  text-align: center;
+  color: #64748b;
+  padding: 2rem;
+  display: none;
+}
+
+.description {
+  color: #64748b;
+  margin-top: 3rem;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
Closes #339

   ## What I did
   - Created a searchable reference table for all --ease-* CSS variables
   - Covers all 7 categories: Speeds, Colors, Neutrals, Spacing, Radius, Shadows, Typography, Z-Index
   - demo.html works by opening directly in browser, no server needed

   ## Checklist
   - [x] Folder inside submissions/examples/
   - [x] demo.html opens directly (no server needed)
   - [x] style.css has the styles
   - [x] README.md explains the effect
   - [x] No edits to core/ or components/