### PR TITLE
fix: replace hardcoded glow in .ease-btn-hover with per-variant --ease-btn-glow token

### DIFF
--- a/components/buttons.css
+++ b/components/buttons.css
@@ -46,6 +46,7 @@
 
 /* Primary */
 .ease-btn-primary {
+  --ease-btn-glow: var(--ease-glow-primary);
   background-color: var(--ease-color-primary);
   color: #ffffff;
   border-color: var(--ease-color-primary);
@@ -59,6 +60,7 @@
 
 /* Success */
 .ease-btn-success {
+  --ease-btn-glow: var(--ease-glow-success);
   background-color: var(--ease-color-success);
   color: #ffffff;
   border-color: var(--ease-color-success);
@@ -72,6 +74,7 @@
 
 /* Danger */
 .ease-btn-danger {
+  --ease-btn-glow: var(--ease-glow-danger);
   background-color: var(--ease-color-danger);
   color: #ffffff;
   border-color: var(--ease-color-danger);
@@ -85,6 +88,7 @@
 
 /* Outline (Primary) */
 .ease-btn-outline {
+  --ease-btn-glow: var(--ease-glow-primary);
   background-color: transparent;
   color: var(--ease-color-primary);
   border-color: var(--ease-color-primary);
@@ -188,7 +192,9 @@
 }
 
 /* ── Hover Class (composable) ──────────────────────────────── */
-/* Apply ease-btn-hover to any btn to add a lift+glow effect  */
+/* Apply ease-btn-hover to any btn to add a lift+glow effect. */
+/* The glow color is controlled by --ease-btn-glow, which each */
+/* variant sets automatically. Falls back to primary glow.    */
 
 .ease-btn-hover {
   transition:
@@ -200,7 +206,7 @@
 
 .ease-btn-hover:hover {
   transform: translateY(-3px);
-  box-shadow: var(--ease-shadow-lg), var(--ease-glow-primary);
+  box-shadow: var(--ease-shadow-lg), var(--ease-btn-glow, var(--ease-glow-primary));
 }
 
 /* ── Button Group ──────────────────────────────────────────── */


### PR DESCRIPTION
## Pull Request Description

Fixes #638 — The `.ease-btn-hover` composable class hardcoded `var(--ease-glow-primary)` (purple) for its hover `box-shadow`. When applied to `.ease-btn-success` (green) or `.ease-btn-danger` (red), this produced an incorrect purple glow that clashed with the button's color theme.

This PR replaces the hardcoded value with a CSS custom property `--ease-btn-glow` that falls back to `var(--ease-glow-primary)`. Each button variant now declares its own `--ease-btn-glow` value, so the glow automatically inherits the correct color for that theme.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [ ] All changes are inside `submissions/examples/your-feature-name/` (N/A — this is a core component bug fix)
- [ ] Includes `demo.html` (N/A)
- [ ] Includes `style.css` (N/A)
- [ ] Includes `README.md` (N/A)
- [x] **No changes to `core/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**
`.ease-btn-hover:hover` no longer hardcodes the purple primary glow. It now uses `var(--ease-btn-glow, var(--ease-glow-primary))` — a per-variant token with a safe primary fallback.

**How does it work?**

```html
<!-- Green button gets green glow ✅ -->
<button class="ease-btn ease-btn-success ease-btn-hover">Save</button>

<!-- Red button gets red glow ✅ -->
<button class="ease-btn ease-btn-danger ease-btn-hover">Delete</button>

<!-- Custom element can override it too -->
<button class="ease-btn ease-btn-hover" style="--ease-btn-glow: 0 0 12px #f59e0b;">Custom</button>