### PR TITLE
docs: Add CSS variable reference table [Issue #339]

### DIFF
--- a/submissions/examples/css-variable-reference/README.md
+++ b/submissions/examples/css-variable-reference/README.md
@@ -1,0 +1,31 @@
+# CSS Variable Reference Table
+
+## What does this do?
+Documents every `--ease-*` CSS custom property from `core/variables.css` in a clean, searchable reference table.
+
+## How is it used?
+Open `demo.html` directly in your browser to browse all variables. Use the search bar to filter by name, category, or value.
+
+To override any variable in your own project, add this to your CSS:
+
+```css
+:root {
+  --ease-color-primary: #6366f1;
+  --ease-speed-medium: 400ms;
+  --ease-radius-md: 8px;
+}
+```
+
+## Why is it useful?
+Without a reference table, contributors have to open `variables.css` and guess what each token does. This makes all design tokens self-documenting — showing the variable name, default value, what it affects, and a practical example override, all in one place.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open `demo.html` directly in your browser to see the effect.
+
+## Contribution Notes
+- Class naming was handled by the contributor
+- Maintainer will rename to ease-* convention before merging

--- a/submissions/examples/css-variable-reference/demo.html
+++ b/submissions/examples/css-variable-reference/demo.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Variable Reference Table - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+
+    <h1>CSS Variable Reference Table</h1>
+    <p class="subtitle">All <code>--ease-*</code> custom properties from <code>core/variables.css</code></p>
+
+    <input class="search-bar" type="text" id="search" placeholder="Search variables... e.g. color, radius, shadow" oninput="filterTable()" />
+
+    <!-- ── Transition Speeds ── -->
+    <div class="section-title">Transition Speeds</div>
+    <table class="ref-table">
+      <thead>
+        <tr>
+          <th>Variable</th>
+          <th>Default Value</th>
+          <th>What It Affects</th>
+          <th>Example Override</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="var-name">--ease-speed-fast</td>
+          <td class="var-value">150ms</td>
+          <td class="var-affects">Duration of fast transitions (e.g. button hover)</td>
+          <td class="var-example">--ease-speed-fast: 100ms;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-speed-medium</td>
+          <td class="var-value">300ms</td>
+          <td class="var-affects">Duration of standard transitions (e.g. card hover)</td>
+          <td class="var-example">--ease-speed-medium: 400ms;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-speed-slow</td>
+          <td class="var-value">600ms</td>
+          <td class="var-affects">Duration of slow transitions (e.g. page fade-in)</td>
+          <td class="var-example">--ease-speed-slow: 800ms;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-ease</td>
+          <td class="var-value">cubic-bezier(0.4, 0, 0.2, 1)</td>
+          <td class="var-affects">Smooth ease-in-out timing for most animations</td>
+          <td class="var-example">--ease-ease: ease-in-out;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-ease-out</td>
+          <td class="var-value">cubic-bezier(0, 0, 0.2, 1)</td>
+          <td class="var-affects">Deceleration curve for exit/slide animations</td>
+          <td class="var-example">--ease-ease-out: ease-out;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-ease-bounce</td>
+          <td class="var-value">cubic-bezier(0.34, 1.56, 0.64, 1)</td>
+          <td class="var-affects">Overshoot spring effect for playful interactions</td>
+          <td class="var-example">--ease-ease-bounce: cubic-bezier(0.34, 1.3, 0.64, 1);</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- ── Color Palette ── -->
+    <div class="section-title">Color Palette — Primary</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="var-name">--ease-color-primary</td>
+          <td class="var-value"><span class="swatch" style="background:#6c63ff"></span>#6c63ff</td>
+          <td class="var-affects">Primary buttons, links, focus rings</td>
+          <td class="var-example">--ease-color-primary: #6366f1;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-primary-light</td>
+          <td class="var-value"><span class="swatch" style="background:#a09af8"></span>#a09af8</td>
+          <td class="var-affects">Hover states, tinted backgrounds for primary</td>
+          <td class="var-example">--ease-color-primary-light: #c7d2fe;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-primary-dark</td>
+          <td class="var-value"><span class="swatch" style="background:#4b44cc"></span>#4b44cc</td>
+          <td class="var-affects">Active/pressed state for primary elements</td>
+          <td class="var-example">--ease-color-primary-dark: #4338ca;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-success</td>
+          <td class="var-value"><span class="swatch" style="background:#22c55e"></span>#22c55e</td>
+          <td class="var-affects">Success badges, alerts, confirmation states</td>
+          <td class="var-example">--ease-color-success: #16a34a;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-success-light</td>
+          <td class="var-value"><span class="swatch" style="background:#86efac"></span>#86efac</td>
+          <td class="var-affects">Success background tints</td>
+          <td class="var-example">--ease-color-success-light: #bbf7d0;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-success-dark</td>
+          <td class="var-value"><span class="swatch" style="background:#15803d"></span>#15803d</td>
+          <td class="var-affects">Success active/pressed states</td>
+          <td class="var-example">--ease-color-success-dark: #166534;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-danger</td>
+          <td class="var-value"><span class="swatch" style="background:#ef4444"></span>#ef4444</td>
+          <td class="var-affects">Error states, delete buttons, alerts</td>
+          <td class="var-example">--ease-color-danger: #dc2626;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-danger-light</td>
+          <td class="var-value"><span class="swatch" style="background:#fca5a5"></span>#fca5a5</td>
+          <td class="var-affects">Error background tints</td>
+          <td class="var-example">--ease-color-danger-light: #fecaca;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-danger-dark</td>
+          <td class="var-value"><span class="swatch" style="background:#b91c1c"></span>#b91c1c</td>
+          <td class="var-affects">Error active/pressed states</td>
+          <td class="var-example">--ease-color-danger-dark: #991b1b;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-warning</td>
+          <td class="var-value"><span class="swatch" style="background:#f59e0b"></span>#f59e0b</td>
+          <td class="var-affects">Warning badges, caution alerts</td>
+          <td class="var-example">--ease-color-warning: #d97706;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-warning-light</td>
+          <td class="var-value"><span class="swatch" style="background:#fcd34d"></span>#fcd34d</td>
+          <td class="var-affects">Warning background tints</td>
+          <td class="var-example">--ease-color-warning-light: #fde68a;</td>
+        </tr>
+        <tr>
+          <td class="var-name">--ease-color-warning-dark</td>
+          <td class="var-value"><span class="swatch" style="background:#b45309"></span>#b45309</td>
+          <td class="var-affects">Warning active/pressed states</td>
+          <td class="var-example">--ease-color-warning-dark: #92400e;</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="section-title">Color Palette — Neutrals</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-color-neutral-50</td><td class="var-value"><span class="swatch" style="background:#f8fafc;border-color:#ccc"></span>#f8fafc</td><td class="var-affects">Lightest background tint</td><td class="var-example">--ease-color-neutral-50: #f9fafb;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-100</td><td class="var-value"><span class="swatch" style="background:#f1f5f9;border-color:#ccc"></span>#f1f5f9</td><td class="var-affects">Page background, subtle fills</td><td class="var-example">--ease-color-neutral-100: #f3f4f6;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-200</td><td class="var-value"><span class="swatch" style="background:#e2e8f0"></span>#e2e8f0</td><td class="var-affects">Borders, dividers</td><td class="var-example">--ease-color-neutral-200: #e5e7eb;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-300</td><td class="var-value"><span class="swatch" style="background:#cbd5e1"></span>#cbd5e1</td><td class="var-affects">Disabled element borders</td><td class="var-example">--ease-color-neutral-300: #d1d5db;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-400</td><td class="var-value"><span class="swatch" style="background:#94a3b8"></span>#94a3b8</td><td class="var-affects">Placeholder text, icons</td><td class="var-example">--ease-color-neutral-400: #9ca3af;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-500</td><td class="var-value"><span class="swatch" style="background:#64748b"></span>#64748b</td><td class="var-affects">Muted/secondary text</td><td class="var-example">--ease-color-neutral-500: #6b7280;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-600</td><td class="var-value"><span class="swatch" style="background:#475569"></span>#475569</td><td class="var-affects">Body text on light backgrounds</td><td class="var-example">--ease-color-neutral-600: #4b5563;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-700</td><td class="var-value"><span class="swatch" style="background:#334155"></span>#334155</td><td class="var-affects">Headings on light backgrounds</td><td class="var-example">--ease-color-neutral-700: #374151;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-800</td><td class="var-value"><span class="swatch" style="background:#1e293b"></span>#1e293b</td><td class="var-affects">Primary text color (--ease-color-text)</td><td class="var-example">--ease-color-neutral-800: #1f2937;</td></tr>
+        <tr><td class="var-name">--ease-color-neutral-900</td><td class="var-value"><span class="swatch" style="background:#0f172a"></span>#0f172a</td><td class="var-affects">Darkest shade, dark mode backgrounds</td><td class="var-example">--ease-color-neutral-900: #111827;</td></tr>
+        <tr><td class="var-name">--ease-color-bg</td><td class="var-value">var(--ease-color-neutral-50)</td><td class="var-affects">Page/app background color</td><td class="var-example">--ease-color-bg: #ffffff;</td></tr>
+        <tr><td class="var-name">--ease-color-surface</td><td class="var-value"><span class="swatch" style="background:#ffffff;border-color:#ccc"></span>#ffffff</td><td class="var-affects">Card and component surface color</td><td class="var-example">--ease-color-surface: #f8fafc;</td></tr>
+        <tr><td class="var-name">--ease-color-text</td><td class="var-value">var(--ease-color-neutral-800)</td><td class="var-affects">Default body text color</td><td class="var-example">--ease-color-text: #111827;</td></tr>
+        <tr><td class="var-name">--ease-color-muted</td><td class="var-value">var(--ease-color-neutral-500)</td><td class="var-affects">Secondary/muted text, captions</td><td class="var-example">--ease-color-muted: #6b7280;</td></tr>
+      </tbody>
+    </table>
+
+    <!-- ── Spacing ── -->
+    <div class="section-title">Spacing Scale</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-space-1</td><td class="var-value">0.25rem (4px)</td><td class="var-affects">Tight gaps, icon padding</td><td class="var-example">--ease-space-1: 2px;</td></tr>
+        <tr><td class="var-name">--ease-space-2</td><td class="var-value">0.5rem (8px)</td><td class="var-affects">Small padding, badge spacing</td><td class="var-example">--ease-space-2: 6px;</td></tr>
+        <tr><td class="var-name">--ease-space-3</td><td class="var-value">0.75rem (12px)</td><td class="var-affects">Button padding (vertical)</td><td class="var-example">--ease-space-3: 10px;</td></tr>
+        <tr><td class="var-name">--ease-space-4</td><td class="var-value">1rem (16px)</td><td class="var-affects">Base spacing unit, card padding</td><td class="var-example">--ease-space-4: 18px;</td></tr>
+        <tr><td class="var-name">--ease-space-5</td><td class="var-value">1.25rem (20px)</td><td class="var-affects">Medium component padding</td><td class="var-example">--ease-space-5: 22px;</td></tr>
+        <tr><td class="var-name">--ease-space-6</td><td class="var-value">1.5rem (24px)</td><td class="var-affects">Card gap, section spacing</td><td class="var-example">--ease-space-6: 28px;</td></tr>
+        <tr><td class="var-name">--ease-space-8</td><td class="var-value">2rem (32px)</td><td class="var-affects">Large section padding</td><td class="var-example">--ease-space-8: 36px;</td></tr>
+        <tr><td class="var-name">--ease-space-10</td><td class="var-value">2.5rem (40px)</td><td class="var-affects">Hero section padding</td><td class="var-example">--ease-space-10: 44px;</td></tr>
+        <tr><td class="var-name">--ease-space-12</td><td class="var-value">3rem (48px)</td><td class="var-affects">Page-level vertical rhythm</td><td class="var-example">--ease-space-12: 52px;</td></tr>
+        <tr><td class="var-name">--ease-space-16</td><td class="var-value">4rem (64px)</td><td class="var-affects">Extra-large layout gaps</td><td class="var-example">--ease-space-16: 72px;</td></tr>
+      </tbody>
+    </table>
+
+    <!-- ── Border Radius ── -->
+    <div class="section-title">Border Radius</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-radius-sm</td><td class="var-value">0.25rem</td><td class="var-affects">Subtle rounding on small elements (badges, tags)</td><td class="var-example">--ease-radius-sm: 2px;</td></tr>
+        <tr><td class="var-name">--ease-radius-md</td><td class="var-value">0.5rem</td><td class="var-affects">Buttons, inputs, small cards</td><td class="var-example">--ease-radius-md: 8px;</td></tr>
+        <tr><td class="var-name">--ease-radius-lg</td><td class="var-value">1rem</td><td class="var-affects">Cards, modals, panels</td><td class="var-example">--ease-radius-lg: 14px;</td></tr>
+        <tr><td class="var-name">--ease-radius-xl</td><td class="var-value">1.5rem</td><td class="var-affects">Large rounded containers</td><td class="var-example">--ease-radius-xl: 20px;</td></tr>
+        <tr><td class="var-name">--ease-radius-full</td><td class="var-value">9999px</td><td class="var-affects">Pill buttons, circular avatars</td><td class="var-example">--ease-radius-full: 50%;</td></tr>
+      </tbody>
+    </table>
+
+    <!-- ── Shadows ── -->
+    <div class="section-title">Shadows &amp; Glows</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-shadow-sm</td><td class="var-value">0 1px 3px rgba(0,0,0,0.08)…</td><td class="var-affects">Subtle lift on small cards, dropdowns</td><td class="var-example">--ease-shadow-sm: 0 1px 4px rgba(0,0,0,0.12);</td></tr>
+        <tr><td class="var-name">--ease-shadow-md</td><td class="var-value">0 4px 6px -1px rgba(0,0,0,0.10)…</td><td class="var-affects">Standard card elevation</td><td class="var-example">--ease-shadow-md: 0 4px 12px rgba(0,0,0,0.15);</td></tr>
+        <tr><td class="var-name">--ease-shadow-lg</td><td class="var-value">0 10px 15px -3px rgba(0,0,0,0.10)…</td><td class="var-affects">Modals, popovers, hover lift</td><td class="var-example">--ease-shadow-lg: 0 10px 24px rgba(0,0,0,0.18);</td></tr>
+        <tr><td class="var-name">--ease-shadow-xl</td><td class="var-value">0 20px 25px -5px rgba(0,0,0,0.10)…</td><td class="var-affects">Floating panels, drawers</td><td class="var-example">--ease-shadow-xl: 0 24px 40px rgba(0,0,0,0.20);</td></tr>
+        <tr><td class="var-name">--ease-glow-primary</td><td class="var-value">0 0 16px rgba(108,99,255,0.45)</td><td class="var-affects">Glow effect on primary elements</td><td class="var-example">--ease-glow-primary: 0 0 24px rgba(108,99,255,0.6);</td></tr>
+        <tr><td class="var-name">--ease-glow-success</td><td class="var-value">0 0 16px rgba(34,197,94,0.45)</td><td class="var-affects">Glow effect on success elements</td><td class="var-example">--ease-glow-success: 0 0 20px rgba(34,197,94,0.6);</td></tr>
+        <tr><td class="var-name">--ease-glow-danger</td><td class="var-value">0 0 16px rgba(239,68,68,0.45)</td><td class="var-affects">Glow effect on danger/error elements</td><td class="var-example">--ease-glow-danger: 0 0 20px rgba(239,68,68,0.6);</td></tr>
+      </tbody>
+    </table>
+
+    <!-- ── Typography ── -->
+    <div class="section-title">Typography</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-font-sans</td><td class="var-value">'Inter', system-ui, sans-serif</td><td class="var-affects">Default font for all UI text</td><td class="var-example">--ease-font-sans: 'Poppins', sans-serif;</td></tr>
+        <tr><td class="var-name">--ease-font-mono</td><td class="var-value">'JetBrains Mono', monospace</td><td class="var-affects">Code blocks, variable names</td><td class="var-example">--ease-font-mono: 'Fira Code', monospace;</td></tr>
+        <tr><td class="var-name">--ease-text-xs</td><td class="var-value">0.75rem</td><td class="var-affects">Labels, captions, fine print</td><td class="var-example">--ease-text-xs: 0.7rem;</td></tr>
+        <tr><td class="var-name">--ease-text-sm</td><td class="var-value">0.875rem</td><td class="var-affects">Secondary text, badges</td><td class="var-example">--ease-text-sm: 0.85rem;</td></tr>
+        <tr><td class="var-name">--ease-text-base</td><td class="var-value">1rem</td><td class="var-affects">Body text, default font size</td><td class="var-example">--ease-text-base: 1.0625rem;</td></tr>
+        <tr><td class="var-name">--ease-text-lg</td><td class="var-value">1.125rem</td><td class="var-affects">Large body text, card titles</td><td class="var-example">--ease-text-lg: 1.2rem;</td></tr>
+        <tr><td class="var-name">--ease-text-xl</td><td class="var-value">1.25rem</td><td class="var-affects">Section subheadings</td><td class="var-example">--ease-text-xl: 1.3rem;</td></tr>
+        <tr><td class="var-name">--ease-text-2xl</td><td class="var-value">1.5rem</td><td class="var-affects">Section headings</td><td class="var-example">--ease-text-2xl: 1.6rem;</td></tr>
+        <tr><td class="var-name">--ease-text-3xl</td><td class="var-value">1.875rem</td><td class="var-affects">Page headings</td><td class="var-example">--ease-text-3xl: 2rem;</td></tr>
+        <tr><td class="var-name">--ease-text-4xl</td><td class="var-value">2.25rem</td><td class="var-affects">Hero headings</td><td class="var-example">--ease-text-4xl: 2.5rem;</td></tr>
+        <tr><td class="var-name">--ease-leading-tight</td><td class="var-value">1.25</td><td class="var-affects">Line height for headings</td><td class="var-example">--ease-leading-tight: 1.2;</td></tr>
+        <tr><td class="var-name">--ease-leading-normal</td><td class="var-value">1.6</td><td class="var-affects">Line height for body text</td><td class="var-example">--ease-leading-normal: 1.7;</td></tr>
+        <tr><td class="var-name">--ease-leading-loose</td><td class="var-value">1.9</td><td class="var-affects">Line height for relaxed/airy text</td><td class="var-example">--ease-leading-loose: 2.0;</td></tr>
+      </tbody>
+    </table>
+
+    <!-- ── Z-Index ── -->
+    <div class="section-title">Z-Index Scale</div>
+    <table class="ref-table">
+      <thead>
+        <tr><th>Variable</th><th>Default Value</th><th>What It Affects</th><th>Example Override</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="var-name">--ease-z-base</td><td class="var-value">0</td><td class="var-affects">Default stacking order</td><td class="var-example">--ease-z-base: 1;</td></tr>
+        <tr><td class="var-name">--ease-z-raised</td><td class="var-value">10</td><td class="var-affects">Raised cards, dropdowns</td><td class="var-example">--ease-z-raised: 20;</td></tr>
+        <tr><td class="var-name">--ease-z-overlay</td><td class="var-value">100</td><td class="var-affects">Overlay backgrounds, backdrops</td><td class="var-example">--ease-z-overlay: 200;</td></tr>
+        <tr><td class="var-name">--ease-z-modal</td><td class="var-value">1000</td><td class="var-affects">Modal dialogs, side drawers</td><td class="var-example">--ease-z-modal: 500;</td></tr>
+        <tr><td class="var-name">--ease-z-toast</td><td class="var-value">9999</td><td class="var-affects">Toast notifications (always on top)</td><td class="var-example">--ease-z-toast: 9000;</td></tr>
+      </tbody>
+    </table>
+
+    <p class="description">
+      Source: <code>core/variables.css</code> · EaseMotion CSS · Issue <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/339" style="color:#a09af8">#339</a>
+    </p>
+
+  </div>
+
+  <script>
+    function filterTable() {
+      const query = document.getElementById('search').value.toLowerCase();
+      const rows = document.querySelectorAll('.ref-table tbody tr');
+      rows.forEach(row => {
+        const text = row.textContent.toLowerCase();
+        row.classList.toggle('hidden', !text.includes(query));
+      });
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/css-variable-reference/style.css
+++ b/submissions/examples/css-variable-reference/style.css
@@ -1,0 +1,172 @@
+/* =============================================
+   EASEMOTION CSS — CSS Variable Reference Table
+   Contributor: NirmalSingh-09
+   Issue: #339
+   ============================================= */
+
+/* TEMPLATE: Basic page layout — keep this */
+body {
+  font-family: 'Inter', sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0f0f;
+  color: white;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+}
+
+.demo-wrapper {
+  text-align: center;
+  width: 100%;
+  max-width: 1100px;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 0.25rem;
+  color: #a09af8;
+}
+
+.subtitle {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+}
+
+/* =============================================
+   SEARCH BAR
+   ============================================= */
+.search-bar {
+  width: 100%;
+  max-width: 480px;
+  padding: 10px 16px;
+  border-radius: 8px;
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: white;
+  font-size: 0.95rem;
+  margin-bottom: 2rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.search-bar:focus {
+  border-color: #6c63ff;
+}
+
+/* =============================================
+   SECTION HEADINGS
+   ============================================= */
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #6c63ff;
+  text-align: left;
+  margin: 2rem 0 0.75rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid #1e293b;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+/* =============================================
+   REFERENCE TABLE
+   ============================================= */
+.ref-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.ref-table thead tr {
+  background: #1e293b;
+}
+
+.ref-table thead th {
+  text-align: left;
+  padding: 10px 14px;
+  color: #94a3b8;
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid #334155;
+}
+
+.ref-table tbody tr {
+  border-bottom: 1px solid #1e293b;
+  transition: background 0.15s ease;
+}
+
+.ref-table tbody tr:hover {
+  background: #1e293b;
+}
+
+.ref-table td {
+  padding: 10px 14px;
+  vertical-align: middle;
+  color: #e2e8f0;
+}
+
+/* Variable name */
+.var-name {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #a09af8;
+  white-space: nowrap;
+  font-size: 0.82rem;
+}
+
+/* Default value */
+.var-value {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #86efac;
+  font-size: 0.82rem;
+}
+
+/* Color swatch */
+.swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  margin-right: 6px;
+  vertical-align: middle;
+  border: 1px solid rgba(255,255,255,0.1);
+}
+
+/* Example override */
+.var-example {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #fcd34d;
+  font-size: 0.78rem;
+}
+
+/* Affects column */
+.var-affects {
+  color: #cbd5e1;
+  font-size: 0.85rem;
+}
+
+/* Hidden rows (search) */
+.ref-table tbody tr.hidden {
+  display: none;
+}
+
+/* No results message */
+.no-results {
+  text-align: center;
+  color: #64748b;
+  padding: 2rem;
+  display: none;
+}
+
+.description {
+  color: #64748b;
+  margin-top: 3rem;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
Closes #339

## What I did
- Created a searchable reference table for all --ease-* CSS variables
- Covers all 7 categories: Speeds, Colors, Neutrals, Spacing, Radius, Shadows, Typography, Z-Index
- demo.html works by opening directly in browser, no server needed

## Checklist
- [x] Folder inside submissions/examples/
- [x] demo.html opens directly (no server needed)
- [x] style.css has the styles
- [x] README.md explains the effect
- [x] No edits to core/ or components/