### PR TITLE
fix: elevate focus-visible specificity for interactive elements

### DIFF
--- a/core/base.css
+++ b/core/base.css
@@ -124,7 +124,12 @@ hr {
 }
 
 /* ── Focus Ring (accessible) ───────────────────────────────── */
-:focus-visible {
+:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+a:focus-visible {
   outline: 2px solid var(--ease-color-primary);
   outline-offset: 3px;
   border-radius: var(--ease-radius-sm);


### PR DESCRIPTION
### 🛠️ Purpose
Closes #360. This PR elevates the CSS specificity of the global focus-visible ring configurations.

### 💡 Changes Made
- Modified `core/base.css` to explicitly target interactive element selectors (`button`, `input`, `textarea`, `select`, and `a`).
- Fixes accessibility focus outlines to reliably override lower-priority user-agent browser styles without modifying mouse-click interactions.

### 📸 Verification
- Keyboard `Tab` navigation correctly highlights all interactive form controls using the native `--ease-color-primary` theme variable token.
