### PR TITLE
fix: remove malformed HTML tags in variables section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,432 +1,475 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>EaseMotion CSS — Documentation</title>
-  <meta name="description" content="Official documentation for EaseMotion CSS — the animation-first, human-readable CSS framework." />
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>EaseMotion CSS — Documentation</title>
+        <meta
+            name="description"
+            content="Official documentation for EaseMotion CSS — the animation-first, human-readable CSS framework."
+        />
 
-  <!-- EaseMotion CSS -->
-  <link rel="stylesheet" href="../core/variables.css" />
-  <link rel="stylesheet" href="../core/base.css" />
-  <link rel="stylesheet" href="../core/animations.css" />
-  <link rel="stylesheet" href="../core/utilities.css" />
-  <link rel="stylesheet" href="../components/buttons.css" />
-  <link rel="stylesheet" href="../components/cards.css" />
+        <!-- EaseMotion CSS -->
+        <link rel="stylesheet" href="../core/variables.css" />
+        <link rel="stylesheet" href="../core/base.css" />
+        <link rel="stylesheet" href="../core/animations.css" />
+        <link rel="stylesheet" href="../core/utilities.css" />
+        <link rel="stylesheet" href="../components/buttons.css" />
+        <link rel="stylesheet" href="../components/cards.css" />
 
-  <style>
-    /* ── Docs Layout ──────────────────────────────────────── */
-    :root {
-      --docs-sidebar-w: 260px;
-      --docs-header-h: 60px;
-    }
+        <style>
+            /* ── Docs Layout ──────────────────────────────────────── */
+            :root {
+                --docs-sidebar-w: 260px;
+                --docs-header-h: 60px;
+            }
 
-    body {
-      background: #0f0e17;
-      color: #fffffe;
-    }
+            body {
+                background: #0f0e17;
+                color: #fffffe;
+            }
 
-    /* ── Header ───────────────────────────────────────────── */
-    .docs-header {
-      position: fixed;
-      top: 0; left: 0; right: 0;
-      height: var(--docs-header-h);
-      z-index: var(--ease-z-overlay);
-      background: rgba(15,14,23,0.9);
-      backdrop-filter: blur(12px);
-      border-bottom: 1px solid rgba(255,255,255,0.07);
-      display: flex;
-      align-items: center;
-      padding: 0 var(--ease-space-6);
-      justify-content: space-between;
-    }
+            /* ── Header ───────────────────────────────────────────── */
+            .docs-header {
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                height: var(--docs-header-h);
+                z-index: var(--ease-z-overlay);
+                background: rgba(15, 14, 23, 0.9);
+                backdrop-filter: blur(12px);
+                border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+                display: flex;
+                align-items: center;
+                padding: 0 var(--ease-space-6);
+                justify-content: space-between;
+            }
 
-    .docs-logo {
-      font-size: var(--ease-text-xl);
-      font-weight: 800;
-      background: linear-gradient(135deg, #6c63ff, #a78bfa);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-      letter-spacing: -0.02em;
-      text-decoration: none;
-    }
+            .docs-logo {
+                font-size: var(--ease-text-xl);
+                font-weight: 800;
+                background: linear-gradient(135deg, #6c63ff, #a78bfa);
+                -webkit-background-clip: text;
+                -webkit-text-fill-color: transparent;
+                background-clip: text;
+                letter-spacing: -0.02em;
+                text-decoration: none;
+            }
 
-    .docs-header-links {
-      display: flex;
-      gap: var(--ease-space-5);
-      align-items: center;
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
+            .docs-header-links {
+                display: flex;
+                gap: var(--ease-space-5);
+                align-items: center;
+                list-style: none;
+                padding: 0;
+                margin: 0;
+            }
 
-    .docs-header-links a {
-      color: rgba(255,255,255,0.55);
-      font-size: var(--ease-text-sm);
-      font-weight: 500;
-      text-decoration: none;
-      transition: color var(--ease-speed-fast) var(--ease-ease);
-    }
+            .docs-header-links a {
+                color: rgba(255, 255, 255, 0.55);
+                font-size: var(--ease-text-sm);
+                font-weight: 500;
+                text-decoration: none;
+                transition: color var(--ease-speed-fast) var(--ease-ease);
+            }
 
-    .docs-header-links a:hover { color: #fff; }
+            .docs-header-links a:hover {
+                color: #fff;
+            }
 
-    /* ── Layout Shell ─────────────────────────────────────── */
-    .docs-shell {
-      display: flex;
-      min-height: 100vh;
-      padding-top: var(--docs-header-h);
-    }
+            /* ── Layout Shell ─────────────────────────────────────── */
+            .docs-shell {
+                display: flex;
+                min-height: 100vh;
+                padding-top: var(--docs-header-h);
+            }
 
-    /* ── Sidebar ──────────────────────────────────────────── */
-    .docs-sidebar {
-      width: var(--docs-sidebar-w);
-      position: fixed;
-      top: var(--docs-header-h);
-      left: 0;
-      bottom: 0;
-      overflow-y: auto;
-      padding: var(--ease-space-8) var(--ease-space-5);
-      border-right: 1px solid rgba(255,255,255,0.06);
-      background: rgba(255,255,255,0.02);
-    }
+            /* ── Sidebar ──────────────────────────────────────────── */
+            .docs-sidebar {
+                width: var(--docs-sidebar-w);
+                position: fixed;
+                top: var(--docs-header-h);
+                left: 0;
+                bottom: 0;
+                overflow-y: auto;
+                padding: var(--ease-space-8) var(--ease-space-5);
+                border-right: 1px solid rgba(255, 255, 255, 0.06);
+                background: rgba(255, 255, 255, 0.02);
+            }
 
-    .docs-sidebar::-webkit-scrollbar { width: 4px; }
-    .docs-sidebar::-webkit-scrollbar-thumb {
-      background: rgba(255,255,255,0.1);
-      border-radius: 4px;
-    }
+            .docs-sidebar::-webkit-scrollbar {
+                width: 4px;
+            }
+            .docs-sidebar::-webkit-scrollbar-thumb {
+                background: rgba(255, 255, 255, 0.1);
+                border-radius: 4px;
+            }
 
-    .sidebar-group {
-      margin-bottom: var(--ease-space-6);
-    }
+            .sidebar-group {
+                margin-bottom: var(--ease-space-6);
+            }
 
-    .sidebar-group-label {
-      font-size: var(--ease-text-xs);
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--ease-color-primary-light);
-      margin-bottom: var(--ease-space-2);
-      padding: 0 var(--ease-space-2);
-    }
+            .sidebar-group-label {
+                font-size: var(--ease-text-xs);
+                font-weight: 700;
+                text-transform: uppercase;
+                letter-spacing: 0.1em;
+                color: var(--ease-color-primary-light);
+                margin-bottom: var(--ease-space-2);
+                padding: 0 var(--ease-space-2);
+            }
 
-    .sidebar-nav {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
+            .sidebar-nav {
+                list-style: none;
+                padding: 0;
+                margin: 0;
+            }
 
-    .sidebar-nav a {
-      display: block;
-      padding: var(--ease-space-2) var(--ease-space-2);
-      font-size: var(--ease-text-sm);
-      color: rgba(255,255,255,0.6);
-      border-radius: var(--ease-radius-sm);
-      text-decoration: none;
-      transition: color var(--ease-speed-fast) var(--ease-ease),
-                  background var(--ease-speed-fast) var(--ease-ease);
-    }
+            .sidebar-nav a {
+                display: block;
+                padding: var(--ease-space-2) var(--ease-space-2);
+                font-size: var(--ease-text-sm);
+                color: rgba(255, 255, 255, 0.6);
+                border-radius: var(--ease-radius-sm);
+                text-decoration: none;
+                transition:
+                    color var(--ease-speed-fast) var(--ease-ease),
+                    background var(--ease-speed-fast) var(--ease-ease);
+            }
 
-    .sidebar-nav a:hover,
-    .sidebar-nav a.active {
-      color: #ffffff;
-      background: rgba(108,99,255,0.12);
-    }
+            .sidebar-nav a:hover,
+            .sidebar-nav a.active {
+                color: #ffffff;
+                background: rgba(108, 99, 255, 0.12);
+            }
 
-    /* ── Content ──────────────────────────────────────────── */
-    .docs-content {
-      margin-left: var(--docs-sidebar-w);
-      flex: 1;
-      padding: var(--ease-space-12) var(--ease-space-12);
-      max-width: 860px;
-    }
+            /* ── Content ──────────────────────────────────────────── */
+            .docs-content {
+                margin-left: var(--docs-sidebar-w);
+                flex: 1;
+                padding: var(--ease-space-12) var(--ease-space-12);
+                max-width: 860px;
+            }
 
-    /* ── Section headings ─────────────────────────────────── */
-    .docs-section {
-      margin-bottom: var(--ease-space-16);
-      scroll-margin-top: calc(var(--docs-header-h) + var(--ease-space-4));
-    }
+            /* ── Section headings ─────────────────────────────────── */
+            .docs-section {
+                margin-bottom: var(--ease-space-16);
+                scroll-margin-top: calc(
+                    var(--docs-header-h) + var(--ease-space-4)
+                );
+            }
 
-    .docs-eyebrow {
-      font-size: var(--ease-text-xs);
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      color: var(--ease-color-primary-light);
-      margin-bottom: var(--ease-space-2);
-    }
+            .docs-eyebrow {
+                font-size: var(--ease-text-xs);
+                font-weight: 700;
+                text-transform: uppercase;
+                letter-spacing: 0.12em;
+                color: var(--ease-color-primary-light);
+                margin-bottom: var(--ease-space-2);
+            }
 
-    .docs-h1 {
-      font-size: clamp(2rem, 4vw, 3rem);
-      font-weight: 800;
-      letter-spacing: -0.04em;
-      background: linear-gradient(135deg, #ffffff, #a78bfa);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-      margin-bottom: var(--ease-space-4);
-    }
+            .docs-h1 {
+                font-size: clamp(2rem, 4vw, 3rem);
+                font-weight: 800;
+                letter-spacing: -0.04em;
+                background: linear-gradient(135deg, #ffffff, #a78bfa);
+                -webkit-background-clip: text;
+                -webkit-text-fill-color: transparent;
+                background-clip: text;
+                margin-bottom: var(--ease-space-4);
+            }
 
-    .docs-h2 {
-      font-size: var(--ease-text-2xl);
-      font-weight: 700;
-      color: #ffffff;
-      margin-bottom: var(--ease-space-4);
-      padding-bottom: var(--ease-space-3);
-      border-bottom: 1px solid rgba(255,255,255,0.07);
-    }
+            .docs-h2 {
+                font-size: var(--ease-text-2xl);
+                font-weight: 700;
+                color: #ffffff;
+                margin-bottom: var(--ease-space-4);
+                padding-bottom: var(--ease-space-3);
+                border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+            }
 
-    .docs-h3 {
-      font-size: var(--ease-text-lg);
-      font-weight: 600;
-      color: rgba(255,255,255,0.9);
-      margin-bottom: var(--ease-space-3);
-    }
+            .docs-h3 {
+                font-size: var(--ease-text-lg);
+                font-weight: 600;
+                color: rgba(255, 255, 255, 0.9);
+                margin-bottom: var(--ease-space-3);
+            }
 
-    .docs-p {
-      color: rgba(255,255,255,0.65);
-      line-height: 1.75;
-      margin-bottom: var(--ease-space-4);
-    }
+            .docs-p {
+                color: rgba(255, 255, 255, 0.65);
+                line-height: 1.75;
+                margin-bottom: var(--ease-space-4);
+            }
 
-    /* ── Code Block ───────────────────────────────────────── */
-    .docs-code {
-      background: rgba(255,255,255,0.04);
-      border: 1px solid rgba(255,255,255,0.08);
-      border-radius: var(--ease-radius-md);
-      padding: var(--ease-space-5);
-      margin-bottom: var(--ease-space-6);
-      overflow-x: auto;
-      position: relative;
-    }
+            /* ── Code Block ───────────────────────────────────────── */
+            .docs-code {
+                background: rgba(255, 255, 255, 0.04);
+                border: 1px solid rgba(255, 255, 255, 0.08);
+                border-radius: var(--ease-radius-md);
+                padding: var(--ease-space-5);
+                margin-bottom: var(--ease-space-6);
+                overflow-x: auto;
+                position: relative;
+            }
 
-    .docs-code pre {
-      background: none;
-      color: #e2e8f0;
-      padding: 0;
-      margin: 0;
-      font-size: var(--ease-text-sm);
-      line-height: 1.7;
-      border-radius: 0;
-    }
+            .docs-code pre {
+                background: none;
+                color: #e2e8f0;
+                padding: 0;
+                margin: 0;
+                font-size: var(--ease-text-sm);
+                line-height: 1.7;
+                border-radius: 0;
+            }
 
-    .docs-code-lang {
-      position: absolute;
-      top: var(--ease-space-3);
-      right: var(--ease-space-4);
-      font-size: 10px;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: rgba(255,255,255,0.25);
-      font-family: var(--ease-font-mono);
-    }
+            .docs-code-lang {
+                position: absolute;
+                top: var(--ease-space-3);
+                right: var(--ease-space-4);
+                font-size: 10px;
+                font-weight: 700;
+                text-transform: uppercase;
+                letter-spacing: 0.08em;
+                color: rgba(255, 255, 255, 0.25);
+                font-family: var(--ease-font-mono);
+            }
 
-    /* Inline code */
-    .docs-content code {
-      background: rgba(108,99,255,0.12);
-      color: var(--ease-color-primary-light);
-      border: 1px solid rgba(108,99,255,0.2);
-      padding: 0.1em 0.45em;
-      border-radius: var(--ease-radius-sm);
-      font-size: 0.87em;
-    }
+            /* Inline code */
+            .docs-content code {
+                background: rgba(108, 99, 255, 0.12);
+                color: var(--ease-color-primary-light);
+                border: 1px solid rgba(108, 99, 255, 0.2);
+                padding: 0.1em 0.45em;
+                border-radius: var(--ease-radius-sm);
+                font-size: 0.87em;
+            }
 
-    .docs-code pre code {
-      background: none;
-      border: none;
-      color: inherit;
-      padding: 0;
-      font-size: inherit;
-    }
+            .docs-code pre code {
+                background: none;
+                border: none;
+                color: inherit;
+                padding: 0;
+                font-size: inherit;
+            }
 
-    /* ── Table ────────────────────────────────────────────── */
-    .docs-table {
-      width: 100%;
-      border-collapse: collapse;
-      font-size: var(--ease-text-sm);
-      margin-bottom: var(--ease-space-8);
-    }
+            /* ── Table ────────────────────────────────────────────── */
+            .docs-table {
+                width: 100%;
+                border-collapse: collapse;
+                font-size: var(--ease-text-sm);
+                margin-bottom: var(--ease-space-8);
+            }
 
-    .docs-table th {
-      text-align: left;
-      padding: var(--ease-space-3) var(--ease-space-4);
-      background: rgba(255,255,255,0.04);
-      color: rgba(255,255,255,0.55);
-      font-weight: 600;
-      font-size: var(--ease-text-xs);
-      text-transform: uppercase;
-      letter-spacing: 0.07em;
-      border-bottom: 1px solid rgba(255,255,255,0.08);
-    }
+            .docs-table th {
+                text-align: left;
+                padding: var(--ease-space-3) var(--ease-space-4);
+                background: rgba(255, 255, 255, 0.04);
+                color: rgba(255, 255, 255, 0.55);
+                font-weight: 600;
+                font-size: var(--ease-text-xs);
+                text-transform: uppercase;
+                letter-spacing: 0.07em;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+            }
 
-    .docs-table td {
-      padding: var(--ease-space-3) var(--ease-space-4);
-      border-bottom: 1px solid rgba(255,255,255,0.05);
-      color: rgba(255,255,255,0.7);
-    }
+            .docs-table td {
+                padding: var(--ease-space-3) var(--ease-space-4);
+                border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+                color: rgba(255, 255, 255, 0.7);
+            }
 
-    .docs-table tr:hover td {
-      background: rgba(255,255,255,0.02);
-    }
+            .docs-table tr:hover td {
+                background: rgba(255, 255, 255, 0.02);
+            }
 
-    /* ── Info Box ─────────────────────────────────────────── */
-    .docs-info {
-      background: rgba(108,99,255,0.08);
-      border: 1px solid rgba(108,99,255,0.25);
-      border-radius: var(--ease-radius-md);
-      padding: var(--ease-space-4) var(--ease-space-5);
-      color: rgba(255,255,255,0.75);
-      font-size: var(--ease-text-sm);
-      line-height: 1.7;
-      margin-bottom: var(--ease-space-6);
-      display: flex;
-      gap: var(--ease-space-3);
-    }
+            /* ── Info Box ─────────────────────────────────────────── */
+            .docs-info {
+                background: rgba(108, 99, 255, 0.08);
+                border: 1px solid rgba(108, 99, 255, 0.25);
+                border-radius: var(--ease-radius-md);
+                padding: var(--ease-space-4) var(--ease-space-5);
+                color: rgba(255, 255, 255, 0.75);
+                font-size: var(--ease-text-sm);
+                line-height: 1.7;
+                margin-bottom: var(--ease-space-6);
+                display: flex;
+                gap: var(--ease-space-3);
+            }
 
-    .docs-info-icon {
-      font-size: 1.1rem;
-      flex-shrink: 0;
-    }
+            .docs-info-icon {
+                font-size: 1.1rem;
+                flex-shrink: 0;
+            }
 
-    /* ── Divider ──────────────────────────────────────────── */
-    .docs-divider {
-      border: none;
-      border-top: 1px solid rgba(255,255,255,0.07);
-      margin: var(--ease-space-10) 0;
-    }
+            /* ── Divider ──────────────────────────────────────────── */
+            .docs-divider {
+                border: none;
+                border-top: 1px solid rgba(255, 255, 255, 0.07);
+                margin: var(--ease-space-10) 0;
+            }
 
-    /* ── Pill badge ───────────────────────────────────────── */
-    .docs-badge {
-      display: inline-block;
-      padding: 0.15em 0.65em;
-      border-radius: var(--ease-radius-full);
-      font-size: var(--ease-text-xs);
-      font-weight: 700;
-      background: rgba(108,99,255,0.15);
-      color: var(--ease-color-primary-light);
-      border: 1px solid rgba(108,99,255,0.25);
-      margin-right: var(--ease-space-1);
-    }
-  </style>
-</head>
-<body>
+            /* ── Pill badge ───────────────────────────────────────── */
+            .docs-badge {
+                display: inline-block;
+                padding: 0.15em 0.65em;
+                border-radius: var(--ease-radius-full);
+                font-size: var(--ease-text-xs);
+                font-weight: 700;
+                background: rgba(108, 99, 255, 0.15);
+                color: var(--ease-color-primary-light);
+                border: 1px solid rgba(108, 99, 255, 0.25);
+                margin-right: var(--ease-space-1);
+            }
+        </style>
+    </head>
+    <body>
+        <!-- Header -->
+        <header class="docs-header">
+            <a href="#" class="docs-logo">EaseMotion CSS</a>
+            <ul class="docs-header-links">
+                <li><a href="#getting-started">Getting Started</a></li>
+                <li><a href="#utilities">Utilities</a></li>
+                <li><a href="#animations">Animations</a></li>
+                <li><a href="#components">Components</a></li>
+                <li>
+                    <a href="../examples/demo.html">
+                        <button
+                            class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
+                        >
+                            Live Demo →
+                        </button>
+                    </a>
+                </li>
+            </ul>
+        </header>
 
-  <!-- Header -->
-  <header class="docs-header">
-    <a href="#" class="docs-logo">EaseMotion CSS</a>
-    <ul class="docs-header-links">
-      <li><a href="#getting-started">Getting Started</a></li>
-      <li><a href="#utilities">Utilities</a></li>
-      <li><a href="#animations">Animations</a></li>
-      <li><a href="#components">Components</a></li>
-      <li><a href="../examples/demo.html">
-        <button class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill">Live Demo →</button>
-      </a></li>
-    </ul>
-  </header>
+        <div class="docs-shell">
+            <!-- Sidebar -->
+            <aside class="docs-sidebar">
+                <div class="sidebar-group">
+                    <div class="sidebar-group-label">Introduction</div>
+                    <ul class="sidebar-nav">
+                        <li>
+                            <a href="#getting-started" class="active"
+                                >Getting Started</a
+                            >
+                        </li>
+                        <li><a href="#philosophy">Design Philosophy</a></li>
+                        <li><a href="#installation">Installation</a></li>
+                    </ul>
+                </div>
+                <div class="sidebar-group">
+                    <div class="sidebar-group-label">Core</div>
+                    <ul class="sidebar-nav">
+                        <li><a href="#variables">Variables</a></li>
+                        <li><a href="#utilities">Utilities</a></li>
+                        <li><a href="#animations">Animations</a></li>
+                    </ul>
+                </div>
+                <div class="sidebar-group">
+                    <div class="sidebar-group-label">Components</div>
+                    <ul class="sidebar-nav">
+                        <li><a href="#buttons">Buttons</a></li>
+                        <li><a href="#cards">Cards</a></li>
+                    </ul>
+                </div>
+                <div class="sidebar-group">
+                    <div class="sidebar-group-label">Contributing</div>
+                    <ul class="sidebar-nav">
+                        <li><a href="#contributing">How to Contribute</a></li>
+                        <li><a href="#naming">Naming Rules</a></li>
+                    </ul>
+                </div>
+            </aside>
 
-  <div class="docs-shell">
+            <!-- Main content -->
+            <main class="docs-content">
+                <!-- ══════════════ GETTING STARTED ══════════════ -->
+                <section id="getting-started" class="docs-section ease-fade-in">
+                    <div class="docs-eyebrow">Introduction</div>
+                    <h1 class="docs-h1">EaseMotion CSS</h1>
+                    <p class="docs-p">
+                        EaseMotion CSS is a human-readable, animation-first CSS
+                        library. Write UI with simple, English-like class names
+                        — no memorizing utilities, no complex configuration.
+                        Just readable HTML that looks great and moves
+                        beautifully.
+                    </p>
+                    <div class="docs-info">
+                        <span class="docs-info-icon">💡</span>
+                        <div>
+                            EaseMotion CSS bridges the gap between raw vanilla
+                            CSS and utility-heavy frameworks like Tailwind. You
+                            get structure and power, with none of the cognitive
+                            overhead.
+                        </div>
+                    </div>
+                </section>
 
-    <!-- Sidebar -->
-    <aside class="docs-sidebar">
-      <div class="sidebar-group">
-        <div class="sidebar-group-label">Introduction</div>
-        <ul class="sidebar-nav">
-          <li><a href="#getting-started" class="active">Getting Started</a></li>
-          <li><a href="#philosophy">Design Philosophy</a></li>
-          <li><a href="#installation">Installation</a></li>
-        </ul>
-      </div>
-      <div class="sidebar-group">
-        <div class="sidebar-group-label">Core</div>
-        <ul class="sidebar-nav">
-          <li><a href="#variables">Variables</a></li>
-          <li><a href="#utilities">Utilities</a></li>
-          <li><a href="#animations">Animations</a></li>
-        </ul>
-      </div>
-      <div class="sidebar-group">
-        <div class="sidebar-group-label">Components</div>
-        <ul class="sidebar-nav">
-          <li><a href="#buttons">Buttons</a></li>
-          <li><a href="#cards">Cards</a></li>
-        </ul>
-      </div>
-      <div class="sidebar-group">
-        <div class="sidebar-group-label">Contributing</div>
-        <ul class="sidebar-nav">
-          <li><a href="#contributing">How to Contribute</a></li>
-          <li><a href="#naming">Naming Rules</a></li>
-        </ul>
-      </div>
-    </aside>
+                <hr class="docs-divider" />
 
-    <!-- Main content -->
-    <main class="docs-content">
+                <!-- ══════════════ PHILOSOPHY ══════════════ -->
+                <section id="philosophy" class="docs-section">
+                    <h2 class="docs-h2">Design Philosophy</h2>
+                    <p class="docs-p">
+                        EaseMotion CSS is built on four core principles:
+                    </p>
+                    <table class="docs-table">
+                        <thead>
+                            <tr>
+                                <th>Principle</th>
+                                <th>What it means</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>Human-readable</code></td>
+                                <td>
+                                    Class names read like plain English, e.g.
+                                    <code>ease-fade-in</code>,
+                                    <code>ease-hover-glow</code>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>Animation-first</code></td>
+                                <td>
+                                    Animations are first-class citizens, not
+                                    accessories bolted on later
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>Composable</code></td>
+                                <td>
+                                    Stack modifier classes freely — no
+                                    specificity wars
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>Clean & minimal</code></td>
+                                <td>
+                                    No dependencies, no build steps, no
+                                    JavaScript required
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
 
-      <!-- ══════════════ GETTING STARTED ══════════════ -->
-      <section id="getting-started" class="docs-section ease-fade-in">
-        <div class="docs-eyebrow">Introduction</div>
-        <h1 class="docs-h1">EaseMotion CSS</h1>
-        <p class="docs-p">
-          EaseMotion CSS is a human-readable, animation-first CSS library. Write UI with simple,
-          English-like class names — no memorizing utilities, no complex configuration.
-          Just readable HTML that looks great and moves beautifully.
-        </p>
-        <div class="docs-info">
-          <span class="docs-info-icon">💡</span>
-          <div>
-            EaseMotion CSS bridges the gap between raw vanilla CSS and utility-heavy frameworks like Tailwind.
-            You get structure and power, with none of the cognitive overhead.
-          </div>
-        </div>
-      </section>
+                <hr class="docs-divider" />
 
-      <hr class="docs-divider" />
-
-      <!-- ══════════════ PHILOSOPHY ══════════════ -->
-      <section id="philosophy" class="docs-section">
-        <h2 class="docs-h2">Design Philosophy</h2>
-        <p class="docs-p">EaseMotion CSS is built on four core principles:</p>
-        <table class="docs-table">
-          <thead>
-            <tr>
-              <th>Principle</th>
-              <th>What it means</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>Human-readable</code></td>
-              <td>Class names read like plain English, e.g. <code>ease-fade-in</code>, <code>ease-hover-glow</code></td>
-            </tr>
-            <tr>
-              <td><code>Animation-first</code></td>
-              <td>Animations are first-class citizens, not accessories bolted on later</td>
-            </tr>
-            <tr>
-              <td><code>Composable</code></td>
-              <td>Stack modifier classes freely — no specificity wars</td>
-            </tr>
-            <tr>
-              <td><code>Clean & minimal</code></td>
-              <td>No dependencies, no build steps, no JavaScript required</td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
-
-      <hr class="docs-divider" />
-
-      <!-- ══════════════ INSTALLATION ══════════════ -->
-      <section id="installation" class="docs-section">
-        <h2 class="docs-h2">Installation</h2>
-        <p class="docs-p">Copy the <code>core/</code> and <code>components/</code> folders into your project. Then link the stylesheets in your HTML <code>&lt;head&gt;</code>:</p>
-        <div class="docs-code">
-          <span class="docs-code-lang">html</span>
-          <pre><code>&lt;!-- Core (required) --&gt;
+                <!-- ══════════════ INSTALLATION ══════════════ -->
+                <section id="installation" class="docs-section">
+                    <h2 class="docs-h2">Installation</h2>
+                    <p class="docs-p">
+                        Copy the <code>core/</code> and
+                        <code>components/</code> folders into your project. Then
+                        link the stylesheets in your HTML
+                        <code>&lt;head&gt;</code>:
+                    </p>
+                    <div class="docs-code">
+                        <span class="docs-code-lang">html</span>
+                        <pre><code>&lt;!-- Core (required) --&gt;
 &lt;link rel="stylesheet" href="path/to/easemotion/core/variables.css" /&gt;
 &lt;link rel="stylesheet" href="path/to/easemotion/core/base.css" /&gt;
 &lt;link rel="stylesheet" href="path/to/easemotion/core/animations.css" /&gt;
@@ -435,56 +478,95 @@
 &lt;!-- Components (add as needed) --&gt;
 &lt;link rel="stylesheet" href="path/to/easemotion/components/buttons.css" /&gt;
 &lt;link rel="stylesheet" href="path/to/easemotion/components/cards.css" /&gt;</code></pre>
-        </div>
-        <div class="docs-info">
-          <span class="docs-info-icon">⚠️</span>
-          <div>
-            Always load <code>variables.css</code> first — all other modules depend on the CSS custom properties it defines.
-          </div>
-        </div>
-      </section>
+                    </div>
+                    <div class="docs-info">
+                        <span class="docs-info-icon">⚠️</span>
+                        <div>
+                            Always load <code>variables.css</code> first — all
+                            other modules depend on the CSS custom properties it
+                            defines.
+                        </div>
+                    </div>
+                </section>
 
-      <hr class="docs-divider" />
+                <hr class="docs-divider" />
 
-      <!-- ══════════════ VARIABLES ══════════════ -->
-      <section id="variables" class="docs-section">
-        <h2 class="docs-h2">Variables</h2>
-        <p class="docs-p">
-          All values are defined as CSS custom properties in <code>:root</code>. Override any token to theme the framework.
-        </p>
-        <h3 class="docs-h3">Speeds</h3>
-        <table class="docs-table">
-          <thead><tr><th>Variable</th><th>Value</th></tr></thead>
-          <tbody>
-            <tr><td><code>--ease-speed-fast</code></td><td>150ms</td></tr>
-            <tr><td><code>--ease-speed-medium</code></td><td>300ms</td></tr>
-            <tr><td><code>--ease-speed-slow</code></td><td>600ms</td></tr>
-          </tbody>
-        </table>
-        <h3 class="docs-h3">Colors</h3>
-        <table class="docs-table">
-          <thead><tr><th>Variable</th><th>Value</th></tr></thead>
-          <tbody>
-            <tr><td><code>--ease-color-primary</code></td><td>#6c63ff</td></tr>
-            <tr><td><code>--ease-color-success</code></td><td>#22c55e</td></tr>
-            <tr><td><code>--ease-color-danger</code></td><td>#ef4444</td></tr>
-            <tr><td><code>--ease-color-warning</code></td><td>#f59e0b</td></tr>
-          </tbody>
-        </table>
-        <h3 class="docs-h3">Spacing Scale</h3>
-        <p class="docs-p">Based on a 4px base unit: <code>--ease-space-1</code> (4px) → <code>--ease-space-16</code> (64px).</p>
-      </section>
+                <!-- ══════════════ VARIABLES ══════════════ -->
+                <section id="variables" class="docs-section">
+                    <h2 class="docs-h2">Variables</h2>
+                    <p class="docs-p">
+                        All values are defined as CSS custom properties in
+                        <code>:root</code>. Override any token to theme the
+                        framework.
+                    </p>
+                    <h3 class="docs-h3">Speeds</h3>
+                    <table class="docs-table">
+                        <thead>
+                            <tr>
+                                <th>Variable</th>
+                                <th>Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>--ease-speed-fast</code></td>
+                                <td>150ms</td>
+                            </tr>
+                            <tr>
+                                <td><code>--ease-speed-medium</code></td>
+                                <td>300ms</td>
+                            </tr>
+                            <tr>
+                                <td><code>--ease-speed-slow</code></td>
+                                <td>600ms</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <h3 class="docs-h3">Colors</h3>
+                    <table class="docs-table">
+                        <thead>
+                            <tr>
+                                <th>Variable</th>
+                                <th>Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>--ease-color-primary</code></td>
+                                <td>#6c63ff</td>
+                            </tr>
+                            <tr>
+                                <td><code>--ease-color-success</code></td>
+                                <td>#22c55e</td>
+                            </tr>
+                            <tr>
+                                <td><code>--ease-color-danger</code></td>
+                                <td>#ef4444</td>
+                            </tr>
+                            <tr>
+                                <td><code>--ease-color-warning</code></td>
+                                <td>#f59e0b</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <h3 class="docs-h3">Spacing Scale</h3>
+                    <p class="docs-p">
+                        Based on a 4px base unit:
+                        <code>--ease-space-1</code> (4px) →
+                        <code>--ease-space-16</code> (64px).
+                    </p>
+                </section>
 
-      <hr class="docs-divider" />
+                <hr class="docs-divider" />
 
-      <!-- ══════════════ UTILITIES ══════════════ -->
-      <section id="utilities" class="docs-section">
-        <h2 class="docs-h2">Utilities</h2>
+                <!-- ══════════════ UTILITIES ══════════════ -->
+                <section id="utilities" class="docs-section">
+                    <h2 class="docs-h2">Utilities</h2>
 
-        <h3 class="docs-h3">Flexbox</h3>
-        <div class="docs-code">
-          <span class="docs-code-lang">html</span>
-          <pre><code>&lt;!-- Center content --&gt;
+                    <h3 class="docs-h3">Flexbox</h3>
+                    <div class="docs-code">
+                        <span class="docs-code-lang">html</span>
+                        <pre><code>&lt;!-- Center content --&gt;
 &lt;div class="ease-center"&gt; ... &lt;/div&gt;
 
 &lt;!-- Flex with gap --&gt;
@@ -492,90 +574,165 @@
 
 &lt;!-- Space between --&gt;
 &lt;div class="ease-flex ease-justify-between"&gt; ... &lt;/div&gt;</code></pre>
-        </div>
+                    </div>
 
-        <h3 class="docs-h3">Grid</h3>
-        <div class="docs-code">
-          <span class="docs-code-lang">html</span>
-          <pre><code>&lt;!-- 3-column grid --&gt;
+                    <h3 class="docs-h3">Grid</h3>
+                    <div class="docs-code">
+                        <span class="docs-code-lang">html</span>
+                        <pre><code>&lt;!-- 3-column grid --&gt;
 &lt;div class="ease-grid ease-grid-cols-3 ease-gap-6"&gt; ... &lt;/div&gt;
 
 &lt;!-- Responsive auto-fit grid --&gt;
 &lt;div class="ease-grid ease-grid-auto ease-gap-4"&gt; ... &lt;/div&gt;</code></pre>
-        </div>
+                    </div>
 
-        <h3 class="docs-h3">Spacing</h3>
-        <div class="docs-code">
-          <span class="docs-code-lang">html</span>
-          <pre><code>&lt;div class="ease-padding-6 ease-margin-4"&gt; ... &lt;/div&gt;
+                    <h3 class="docs-h3">Spacing</h3>
+                    <div class="docs-code">
+                        <span class="docs-code-lang">html</span>
+                        <pre><code>&lt;div class="ease-padding-6 ease-margin-4"&gt; ... &lt;/div&gt;
 &lt;div class="ease-px-8 ease-py-4"&gt; ... &lt;/div&gt;</code></pre>
-        </div>
-      </section>
+                    </div>
+                </section>
 
-      <hr class="docs-divider" />
+                <hr class="docs-divider" />
 
-      <!-- ══════════════ ANIMATIONS ══════════════ -->
-      <section id="animations" class="docs-section">
-        <h2 class="docs-h2">Animations</h2>
-        <p class="docs-p">Add any entrance class to trigger the animation on page load. Combine with delay classes for staggered sequences.</p>
+                <!-- ══════════════ ANIMATIONS ══════════════ -->
+                <section id="animations" class="docs-section">
+                    <h2 class="docs-h2">Animations</h2>
+                    <p class="docs-p">
+                        Add any entrance class to trigger the animation on page
+                        load. Combine with delay classes for staggered
+                        sequences.
+                    </p>
 
-        <h3 class="docs-h3">Entrance</h3>
-        <table class="docs-table">
-          <thead><tr><th>Class</th><th>Effect</th></tr></thead>
-          <tbody>
-            <tr><td><code>ease-fade-in</code></td><td>Fades element from 0 → 1 opacity</td></tr>
-            <tr><td><code>ease-slide-up</code></td><td>Slides element up while fading in</td></tr>
-            <tr><td><code>ease-slide-down</code></td><td>Slides element down while fading in</td></tr>
-            <tr><td><code>ease-slide-in-left</code></td><td>Slides in from the left</td></tr>
-            <tr><td><code>ease-slide-in-right</code></td><td>Slides in from the right</td></tr>
-            <tr><td><code>ease-zoom-in</code></td><td>Scales from 85% with elastic ease</td></tr>
-            <tr><td><code>ease-flip</code></td><td>3D perspective flip from Y-axis</td></tr>
-          </tbody>
-        </table>
+                    <h3 class="docs-h3">Entrance</h3>
+                    <table class="docs-table">
+                        <thead>
+                            <tr>
+                                <th>Class</th>
+                                <th>Effect</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>ease-fade-in</code></td>
+                                <td>Fades element from 0 → 1 opacity</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-slide-up</code></td>
+                                <td>Slides element up while fading in</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-slide-down</code></td>
+                                <td>Slides element down while fading in</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-slide-in-left</code></td>
+                                <td>Slides in from the left</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-slide-in-right</code></td>
+                                <td>Slides in from the right</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-zoom-in</code></td>
+                                <td>Scales from 85% with elastic ease</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-flip</code></td>
+                                <td>3D perspective flip from Y-axis</td>
+                            </tr>
+                        </tbody>
+                    </table>
 
-        <h3 class="docs-h3">Looping</h3>
-        <table class="docs-table">
-          <thead><tr><th>Class</th><th>Effect</th></tr></thead>
-          <tbody>
-            <tr><td><code>ease-bounce</code></td><td>Infinite vertical bounce</td></tr>
-            <tr><td><code>ease-rotate</code></td><td>Infinite 360° rotation</td></tr>
-            <tr><td><code>ease-pulse</code></td><td>Infinite opacity pulse</td></tr>
-            <tr><td><code>ease-ping</code></td><td>Expands and fades (ping effect)</td></tr>
-            <tr><td><code>ease-shake</code></td><td>Horizontal shake (one-shot)</td></tr>
-          </tbody>
-        </table>
+                    <h3 class="docs-h3">Looping</h3>
+                    <table class="docs-table">
+                        <thead>
+                            <tr>
+                                <th>Class</th>
+                                <th>Effect</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>ease-bounce</code></td>
+                                <td>Infinite vertical bounce</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-rotate</code></td>
+                                <td>Infinite 360° rotation</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-pulse</code></td>
+                                <td>Infinite opacity pulse</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-ping</code></td>
+                                <td>Expands and fades (ping effect)</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-shake</code></td>
+                                <td>Horizontal shake (one-shot)</td>
+                            </tr>
+                        </tbody>
+                    </table>
 
-        <h3 class="docs-h3">Hover Animations</h3>
-        <table class="docs-table">
-          <thead><tr><th>Class</th><th>Effect</th></tr></thead>
-          <tbody>
-            <tr><td><code>ease-hover-grow</code></td><td>Scales up on hover (elastic)</td></tr>
-            <tr><td><code>ease-hover-shrink</code></td><td>Scales down on hover</td></tr>
-            <tr><td><code>ease-hover-glow</code></td><td>Adds primary color glow on hover</td></tr>
-            <tr><td><code>ease-hover-lift</code></td><td>Lifts element with deeper shadow on hover</td></tr>
-            <tr><td><code>ease-hover-underline</code></td><td>Animated underline from left on hover</td></tr>
-          </tbody>
-        </table>
+                    <h3 class="docs-h3">Hover Animations</h3>
+                    <table class="docs-table">
+                        <thead>
+                            <tr>
+                                <th>Class</th>
+                                <th>Effect</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>ease-hover-grow</code></td>
+                                <td>Scales up on hover (elastic)</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-hover-shrink</code></td>
+                                <td>Scales down on hover</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-hover-glow</code></td>
+                                <td>Adds primary color glow on hover</td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-hover-lift</code></td>
+                                <td>
+                                    Lifts element with deeper shadow on hover
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>ease-hover-underline</code></td>
+                                <td>Animated underline from left on hover</td>
+                            </tr>
+                        </tbody>
+                    </table>
 
-        <h3 class="docs-h3">Delay Helpers</h3>
-        <div class="docs-code">
-          <span class="docs-code-lang">html</span>
-          <pre><code>&lt;!-- Staggered entrance sequence --&gt;
+                    <h3 class="docs-h3">Delay Helpers</h3>
+                    <div class="docs-code">
+                        <span class="docs-code-lang">html</span>
+                        <pre><code>&lt;!-- Staggered entrance sequence --&gt;
 &lt;div class="ease-slide-up ease-delay-100"&gt;First&lt;/div&gt;
 &lt;div class="ease-slide-up ease-delay-200"&gt;Second&lt;/div&gt;
 &lt;div class="ease-slide-up ease-delay-300"&gt;Third&lt;/div&gt;</code></pre>
-        </div>
-      </section>
+                    </div>
+                </section>
 
-      <hr class="docs-divider" />
+                <hr class="docs-divider" />
 
-      <!-- ══════════════ BUTTONS ══════════════ -->
-      <section id="buttons" class="docs-section">
-        <h2 class="docs-h2">Buttons</h2>
-        <p class="docs-p">All buttons require the base <code>ease-btn</code> class plus one or more modifier classes.</p>
-        <div class="docs-code">
-          <span class="docs-code-lang">html</span>
-          <pre><code>&lt;!-- Variants --&gt;
+                <!-- ══════════════ BUTTONS ══════════════ -->
+                <section id="buttons" class="docs-section">
+                    <h2 class="docs-h2">Buttons</h2>
+                    <p class="docs-p">
+                        All buttons require the base <code>ease-btn</code> class
+                        plus one or more modifier classes.
+                    </p>
+                    <div class="docs-code">
+                        <span class="docs-code-lang">html</span>
+                        <pre><code>&lt;!-- Variants --&gt;
 &lt;button class="ease-btn ease-btn-primary"&gt;Primary&lt;/button&gt;
 &lt;button class="ease-btn ease-btn-success"&gt;Success&lt;/button&gt;
 &lt;button class="ease-btn ease-btn-danger"&gt;Danger&lt;/button&gt;
@@ -591,17 +748,17 @@
 
 &lt;!-- Pill shape --&gt;
 &lt;button class="ease-btn ease-btn-primary ease-btn-pill"&gt;Pill&lt;/button&gt;</code></pre>
-        </div>
-      </section>
+                    </div>
+                </section>
 
-      <hr class="docs-divider" />
+                <hr class="docs-divider" />
 
-      <!-- ══════════════ CARDS ══════════════ -->
-      <section id="cards" class="docs-section">
-        <h2 class="docs-h2">Cards</h2>
-        <div class="docs-code">
-          <span class="docs-code-lang">html</span>
-          <pre><code>&lt;!-- Basic card --&gt;
+                <!-- ══════════════ CARDS ══════════════ -->
+                <section id="cards" class="docs-section">
+                    <h2 class="docs-h2">Cards</h2>
+                    <div class="docs-code">
+                        <span class="docs-code-lang">html</span>
+                        <pre><code>&lt;!-- Basic card --&gt;
 &lt;div class="ease-card"&gt;
   &lt;h3 class="ease-card-title"&gt;Title&lt;/h3&gt;
   &lt;p&gt;Card content goes here.&lt;/p&gt;
@@ -619,31 +776,38 @@
 
 &lt;!-- Accent border --&gt;
 &lt;div class="ease-card ease-card-accent"&gt;...&lt;/div&gt;</code></pre>
-        </div>
-      </section>
+                    </div>
+                </section>
 
-      <hr class="docs-divider" />
+                <hr class="docs-divider" />
 
-      <!-- ══════════════ CONTRIBUTING ══════════════ -->
-      <section id="contributing" class="docs-section">
-        <h2 class="docs-h2">Contributing</h2>
-        <p class="docs-p">
-          Contributions are welcome. Please read the
-          <a href="../CONTRIBUTING.md">CONTRIBUTING.md</a> before submitting a pull request.
-          All PRs are reviewed by the maintainer before merging.
-        </p>
-        <div class="docs-info">
-          <span class="docs-info-icon">🔒</span>
-          <div>Only maintainers can merge pull requests. Please do not merge your own PRs.</div>
-        </div>
-      </section>
+                <!-- ══════════════ CONTRIBUTING ══════════════ -->
+                <section id="contributing" class="docs-section">
+                    <h2 class="docs-h2">Contributing</h2>
+                    <p class="docs-p">
+                        Contributions are welcome. Please read the
+                        <a href="../CONTRIBUTING.md">CONTRIBUTING.md</a> before
+                        submitting a pull request. All PRs are reviewed by the
+                        maintainer before merging.
+                    </p>
+                    <div class="docs-info">
+                        <span class="docs-info-icon">🔒</span>
+                        <div>
+                            Only maintainers can merge pull requests. Please do
+                            not merge your own PRs.
+                        </div>
+                    </div>
+                </section>
 
-      <section id="naming" class="docs-section">
-        <h2 class="docs-h2">Naming Rules</h2>
-        <p class="docs-p">All class names must follow the <code>ease-</code> prefix convention:</p>
-        <div class="docs-code">
-          <span class="docs-code-lang">text</span>
-          <pre><code>✅  ease-fade-in
+                <section id="naming" class="docs-section">
+                    <h2 class="docs-h2">Naming Rules</h2>
+                    <p class="docs-p">
+                        All class names must follow the
+                        <code>ease-</code> prefix convention:
+                    </p>
+                    <div class="docs-code">
+                        <span class="docs-code-lang">text</span>
+                        <pre><code>✅  ease-fade-in
 ✅  ease-btn-primary
 ✅  ease-card-hover
 ✅  ease-hover-glow
@@ -652,35 +816,40 @@
 ❌  easeFadeIn          (camelCase not allowed)
 ❌  ease_slide_up       (underscores not allowed)
 ❌  f-fade              (too abbreviated)</code></pre>
+                    </div>
+                </section>
+            </main>
         </div>
-      </section>
+        <script>
+            const sections = document.querySelectorAll(".docs-section")
+            const navLinks = document.querySelectorAll(".sidebar-nav a")
+            let currentActive = null
 
-    </main>
-  </div>
-<script>
-const sections = document.querySelectorAll(".docs-section");
-const navLinks = document.querySelectorAll(".sidebar-nav a");
-let currentActive = null;
+            const observer = new IntersectionObserver(
+                entries => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            const id = entry.target.getAttribute("id")
+                            const activeLink = document.querySelector(
+                                `.sidebar-nav a[href="#${id}"]`
+                            )
 
-const observer = new IntersectionObserver((entries) => {
-  entries.forEach(entry => {
-    if (entry.isIntersecting) {
-      const id = entry.target.getAttribute("id");
-      const activeLink = document.querySelector(`.sidebar-nav a[href="#${id}"]`);
+                            if (activeLink && currentActive !== activeLink) {
+                                if (currentActive)
+                                    currentActive.classList.remove("active")
 
-      if (activeLink && currentActive !== activeLink) {
-        if (currentActive) currentActive.classList.remove("active");
+                                activeLink.classList.add("active")
+                                currentActive = activeLink
+                            }
+                        }
+                    })
+                },
+                {
+                    threshold: 0.4,
+                }
+            )
 
-        activeLink.classList.add("active");
-        currentActive = activeLink;
-      }
-    }
-  });
-}, {
-  threshold: 0.4
-});
-
-sections.forEach(section => observer.observe(section));
-</script>
-</body>
+            sections.forEach(section => observer.observe(section))
+        </script>
+    </body>
 </html>


### PR DESCRIPTION
# Fix: Remove Malformed HTML Tag in Variables Section

## Summary

Fixes the double `<<` typo on the opening tag of the Variables section in `docs/index.html` that was causing the entire section to break in the browser.

## Related Issue

Closes #[issue-number]

## What Changed

Removed the extra `<` from the opening tag of the Variables section.

```html
<!-- Before ❌ -->
<<section id="variables" class="docs-section">

<!-- After ✅ -->
<section id="variables" class="docs-section">
```

## Why

`fetch` `<<section` is not a valid HTML tag. The browser could not parse it correctly, causing the Variables section to either fail to render or display broken markup — making all `--ease-*` design token documentation unreadable.

## Testing

- [ ] Opened `docs/index.html` in browser
- [ ] Variables section renders correctly
- [ ] Sidebar link navigates to the section without issues
- [ ] No other sections affected
