### PR TITLE
Add flex-wrap utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ Applies a quick squish animation during hover, focus, and active interactions.
   <span>Right</span>
 </div>
 
+<!-- Flex wrap utilities -->
+<div class="ease-flex ease-flex-wrap ease-gap-3">Wrap</div>
+<div class="ease-flex ease-flex-nowrap ease-gap-3">No wrap</div>
+<div class="ease-flex ease-flex-wrap-reverse ease-gap-3">Reverse wrap</div>
+
 <!-- Responsive auto-fit grid (no media queries needed) -->
 <div class="ease-grid ease-grid-auto ease-gap-6">
   <div class="ease-card">Card 1</div>

--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ Applies a quick squish animation during hover, focus, and active interactions.
 <div class="ease-flex ease-flex-nowrap ease-gap-3">No wrap</div>
 <div class="ease-flex ease-flex-wrap-reverse ease-gap-3">Reverse wrap</div>
 
+<!-- Align self utilities -->
+<div class="ease-flex ease-items-stretch ease-gap-3">
+  <span class="ease-self-start">Start</span>
+  <span class="ease-self-center">Center</span>
+  <span class="ease-self-end">End</span>
+  <span class="ease-self-stretch">Stretch</span>
+</div>
+
 <!-- Responsive auto-fit grid (no media queries needed) -->
 <div class="ease-grid ease-grid-auto ease-gap-6">
   <div class="ease-card">Card 1</div>

--- a/core/utilities.css
+++ b/core/utilities.css
@@ -30,6 +30,7 @@
 .ease-flex-row     { flex-direction: row; }
 .ease-flex-wrap    { flex-wrap: wrap; }
 .ease-flex-nowrap  { flex-wrap: nowrap; }
+.ease-flex-wrap-reverse { flex-wrap: wrap-reverse; }
 
 .ease-items-start    { align-items: flex-start; }
 .ease-items-center   { align-items: center; }

--- a/core/utilities.css
+++ b/core/utilities.css
@@ -37,6 +37,11 @@
 .ease-items-end      { align-items: flex-end; }
 .ease-items-stretch  { align-items: stretch; }
 
+.ease-self-start    { align-self: flex-start; }
+.ease-self-center   { align-self: center; }
+.ease-self-end      { align-self: flex-end; }
+.ease-self-stretch  { align-self: stretch; }
+
 .ease-justify-start    { justify-content: flex-start; }
 .ease-justify-center   { justify-content: center; }
 .ease-justify-end      { justify-content: flex-end; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -513,6 +513,11 @@
 &lt;!-- Flex with gap --&gt;
 &lt;div class="ease-flex ease-gap-4 ease-items-center"&gt; ... &lt;/div&gt;
 
+&lt;!-- Wrap utilities --&gt;
+&lt;div class="ease-flex ease-flex-wrap"&gt; ... &lt;/div&gt;
+&lt;div class="ease-flex ease-flex-nowrap"&gt; ... &lt;/div&gt;
+&lt;div class="ease-flex ease-flex-wrap-reverse"&gt; ... &lt;/div&gt;
+
 &lt;!-- Space between --&gt;
 &lt;div class="ease-flex ease-justify-between"&gt; ... &lt;/div&gt;</code></pre>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -518,6 +518,14 @@
 &lt;div class="ease-flex ease-flex-nowrap"&gt; ... &lt;/div&gt;
 &lt;div class="ease-flex ease-flex-wrap-reverse"&gt; ... &lt;/div&gt;
 
+&lt;!-- Align self utilities --&gt;
+&lt;div class="ease-flex ease-items-stretch"&gt;
+  &lt;div class="ease-self-start"&gt;...&lt;/div&gt;
+  &lt;div class="ease-self-center"&gt;...&lt;/div&gt;
+  &lt;div class="ease-self-end"&gt;...&lt;/div&gt;
+  &lt;div class="ease-self-stretch"&gt;...&lt;/div&gt;
+&lt;/div&gt;
+
 &lt;!-- Space between --&gt;
 &lt;div class="ease-flex ease-justify-between"&gt; ... &lt;/div&gt;</code></pre>
         </div>

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -328,6 +328,28 @@
           <button class="ease-btn ease-btn-primary" disabled>Disabled</button>
           <button class="ease-btn ease-btn-outline ease-btn-loading" style="border-color:rgba(255,255,255,0.3); color:#fff;">Loading</button>
         </div>
+        <div class="demo-chip" style="margin-top: var(--ease-space-8);">// Flex Wrap Utilities</div>
+        <div class="ease-flex ease-flex-wrap ease-gap-3" style="margin-bottom: var(--ease-space-4);">
+          <span class="tag">ease-flex-wrap</span>
+          <span class="tag">Item 1</span>
+          <span class="tag">Item 2</span>
+          <span class="tag">Item 3</span>
+          <span class="tag">Item 4</span>
+        </div>
+        <div class="ease-flex ease-flex-nowrap ease-gap-3" style="margin-bottom: var(--ease-space-4); overflow-x: auto;">
+          <span class="tag">ease-flex-nowrap</span>
+          <span class="tag">Item 1</span>
+          <span class="tag">Item 2</span>
+          <span class="tag">Item 3</span>
+          <span class="tag">Item 4</span>
+        </div>
+        <div class="ease-flex ease-flex-wrap-reverse ease-gap-3">
+          <span class="tag">ease-flex-wrap-reverse</span>
+          <span class="tag">Item 1</span>
+          <span class="tag">Item 2</span>
+          <span class="tag">Item 3</span>
+          <span class="tag">Item 4</span>
+        </div>
       </div>
     </section>
 

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -350,6 +350,13 @@
           <span class="tag">Item 3</span>
           <span class="tag">Item 4</span>
         </div>
+        <div class="demo-chip" style="margin-top: var(--ease-space-8);">// Align Self Utilities</div>
+        <div class="ease-flex ease-gap-3 ease-items-stretch" style="min-height: 96px;">
+          <span class="tag ease-self-start">ease-self-start</span>
+          <span class="tag ease-self-center">ease-self-center</span>
+          <span class="tag ease-self-end">ease-self-end</span>
+          <span class="tag ease-self-stretch">ease-self-stretch</span>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
Added the missing flex wrap utility set for layout helpers.

## Changes
- added `ease-flex-wrap-reverse`
- confirmed existing `ease-flex-wrap` and `ease-flex-nowrap` utilities in source
- documented all three wrap utilities in README and docs
- added demo examples for wrap, nowrap, and reverse wrap

## Notes
- no direct change was needed in `easemotion.css` because it already imports `core/utilities.css`