### PR TITLE
 add ease hover specific transition 

### DIFF
--- a/submissions/examples/ease-hover-specific-transition/README.md
+++ b/submissions/examples/ease-hover-specific-transition/README.md
@@ -1,0 +1,10 @@
+**What does this do?** 
+This example uses `transition: transform 0.3s ease` together with `transform: scale()` to create a smooth zoom-in effect when a user hovers over an element such as a button.
+
+**How is it used?** 
+```html
+<button class="ease-hover-grow">Hover me</button>
+```
+
+**Why is it useful?**
+This hover effect provides smooth visual feedback and makes interactive elements feel more responsive. Using `transition: transform` instead of `transition: all` improves performance, avoids unnecessary animations, and keeps the code clean and maintainable. The `scale()` function enlarges the element visually without affecting the surrounding layout, making it ideal for buttons, cards, and other clickable UI elements.This utility aligns with EaseMotion CSS by providing a lightweight, performant, and reusable hover animation pattern.

--- a/submissions/examples/ease-hover-specific-transition/demo.html
+++ b/submissions/examples/ease-hover-specific-transition/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset = "UTF-8">
+        <meta name="viewport" content = "width=device-width , intial-scale =1.0">
+        <link rel="stylesheet" href="style.css">
+        <title>Ease Hover Specific Transition</title>
+    </head>
+    <body>
+        <button class = "ease-hover-grow">Hover me</button>
+    </body>
+</html>

--- a/submissions/examples/ease-hover-specific-transition/style.css
+++ b/submissions/examples/ease-hover-specific-transition/style.css
@@ -1,0 +1,19 @@
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background-image: linear-gradient(to bottom right, #070d2e, #3e4672 ,#5e7295 );
+}
+.ease-hover-grow{
+    padding: 16px 32px; 
+    border-radius: 10px;
+    border: none;
+    background:#7288AE;
+    font-size: 15px;
+    cursor: pointer;
+    transition: transform 0.3s ease;
+}
+.ease-hover-grow:hover{
+    transform: scale(1.08);
+}


### PR DESCRIPTION
Fixes #606

## Description

This PR adds a submission example demonstrating how `ease-hover-*` utilities can use specific transition properties instead of `transition: all`.

The example implements an `ease-hover-grow` hover effect using `transition: transform 0.3s ease` together with `transform: scale(1.05)`. This approach prevents overriding user-defined transitions, improves performance, and follows the recommendation in Issue #606 to use explicit transition properties.

## Changes Made

- Added `submissions/examples/ease-hover-specific-transition/demo.html`
- Added `submissions/examples/ease-hover-specific-transition/style.css`
- Added `submissions/examples/ease-hover-specific-transition/README.md`
- Demonstrated a hover-grow animation using `transform: scale()`
- Documented the benefits of `transition: transform` over `transition: all`

## Checklist

- [x] Added implementation inside `submissions/`
- [x] Added demo
- [x] Added documentation
- [x] Followed project contribution guidelines
