### PR TITLE
feat: add dark mode token layer demo

### DIFF
--- a/submissions/examples/dark-mode-token-layer/README.md
+++ b/submissions/examples/dark-mode-token-layer/README.md
@@ -1,0 +1,75 @@
+# Dark Mode Token Layer
+
+## What does this do?
+
+Adds a reusable CSS custom property layer for light and dark themes with both automatic system preference support and manual `data-theme` overrides.
+
+## How is it used?
+
+Use the default token layer for system preference-based theming:
+
+```html
+<section class="theme-preview">
+  <div class="theme-card">
+    <h2>System Theme</h2>
+    <p>This follows the user's device preference.</p>
+  </div>
+</section>
+```
+
+Use manual light mode by applying `data-theme="light"`:
+
+```html
+<section class="theme-preview" data-theme="light">
+  <div class="theme-card">
+    <h2>Manual Light Theme</h2>
+    <p>This section always uses light theme tokens.</p>
+  </div>
+</section>
+```
+
+Use manual dark mode by applying `data-theme="dark"`:
+
+```html
+<section class="theme-preview" data-theme="dark">
+  <div class="theme-card">
+    <h2>Manual Dark Theme</h2>
+    <p>This section always uses dark theme tokens.</p>
+  </div>
+</section>
+```
+
+## Why is it useful?
+
+This fits EaseMotion CSS because it keeps theming readable, composable, dependency-free, and easy to reuse across cards, buttons, surfaces, borders, text, hover states, and focus states.
+
+## Features
+
+* Uses CSS custom properties for reusable design tokens
+* Supports automatic dark mode through `prefers-color-scheme`
+* Supports manual overrides with `data-theme="light"` and `data-theme="dark"`
+* Keeps backgrounds, text, borders, buttons, hover states, and focus states theme-safe
+* Provides accessible contrast between foreground and background colors
+* Requires no build step and no external dependency
+
+## Tech Stack
+
+* HTML
+* CSS only
+* No external frameworks
+* No build tools
+
+## Preview
+
+Open `demo.html` directly in the browser to preview:
+
+1. System preference-based theme
+2. Manual light theme
+3. Manual dark theme
+4. Reusable token swatches
+
+## Contribution Notes
+
+* This submission only adds files inside `submissions/examples/dark-mode-token-layer/`
+* No changes are made to `core/`, `components/`, `docs/`, or root examples
+* Class names are intentionally simple and readable; the maintainer can standardize naming later

--- a/submissions/examples/dark-mode-token-layer/demo.html
+++ b/submissions/examples/dark-mode-token-layer/demo.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dark Mode Token Layer</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="theme-page">
+      <section class="hero-section">
+        <p class="eyebrow">Theme Tokens</p>
+        <h1>Dark Mode Token Layer</h1>
+        <p class="hero-text">
+          A reusable CSS variable layer that supports system preference themes
+          and manual light or dark mode overrides using data-theme attributes.
+        </p>
+
+        <div class="theme-controls" aria-label="Theme controls">
+          <button class="theme-button" type="button" data-set-theme="system">
+            System Mode
+          </button>
+          <button class="theme-button" type="button" data-set-theme="light">
+            Light Mode
+          </button>
+          <button class="theme-button" type="button" data-set-theme="dark">
+            Dark Mode
+          </button>
+        </div>
+      </section>
+
+      <section class="theme-grid" aria-label="Theme mode previews">
+        <article class="theme-preview theme-system">
+          <span class="theme-label">System / Page Theme</span>
+          <div class="theme-card">
+            <div class="theme-icon" aria-hidden="true">◐</div>
+            <h2>Active Theme</h2>
+            <p>
+              Use the buttons above to switch the whole page between system,
+              light, and dark theme modes.
+            </p>
+          </div>
+        </article>
+
+        <article class="theme-preview" data-theme="light">
+          <span class="theme-label">Manual Light</span>
+          <div class="theme-card">
+            <div class="theme-icon" aria-hidden="true">☀</div>
+            <h2>Light Override</h2>
+            <p>
+              This section stays light because it uses
+              <code>data-theme="light"</code>.
+            </p>
+          </div>
+        </article>
+
+        <article class="theme-preview" data-theme="dark">
+          <span class="theme-label">Manual Dark</span>
+          <div class="theme-card">
+            <div class="theme-icon" aria-hidden="true">☾</div>
+            <h2>Dark Override</h2>
+            <p>
+              This section stays dark because it uses
+              <code>data-theme="dark"</code>.
+            </p>
+          </div>
+        </article>
+      </section>
+
+      <section class="token-section" aria-label="Theme token preview">
+        <h2>Theme Token Preview</h2>
+        <p class="token-description">
+          These swatches show the reusable CSS variables used for backgrounds,
+          surfaces, text, borders, and primary accents.
+        </p>
+
+        <div class="token-grid">
+          <div class="token-box token-bg">Background</div>
+          <div class="token-box token-surface">Surface</div>
+          <div class="token-box token-text">Text</div>
+          <div class="token-box token-muted">Muted</div>
+          <div class="token-box token-border">Border</div>
+          <div class="token-box token-primary">Primary</div>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const root = document.documentElement;
+      const themeButtons = document.querySelectorAll("[data-set-theme]");
+
+      themeButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          const selectedTheme = button.dataset.setTheme;
+
+          if (selectedTheme === "system") {
+            root.removeAttribute("data-theme");
+            return;
+          }
+
+          root.setAttribute("data-theme", selectedTheme);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/dark-mode-token-layer/style.css
+++ b/submissions/examples/dark-mode-token-layer/style.css
@@ -1,0 +1,327 @@
+:root {
+  color-scheme: light;
+
+  --theme-bg: #f8fafc;
+  --theme-surface: #ffffff;
+  --theme-surface-soft: #eef2ff;
+  --theme-text: #0f172a;
+  --theme-muted-text: #475569;
+  --theme-border: #cbd5e1;
+  --theme-primary: #2563eb;
+  --theme-primary-hover: #1d4ed8;
+  --theme-button-text: #ffffff;
+  --theme-ring: rgba(37, 99, 235, 0.32);
+  --theme-shadow: rgba(15, 23, 42, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+
+    --theme-bg: #020617;
+    --theme-surface: #0f172a;
+    --theme-surface-soft: #172554;
+    --theme-text: #f8fafc;
+    --theme-muted-text: #cbd5e1;
+    --theme-border: #334155;
+    --theme-primary: #60a5fa;
+    --theme-primary-hover: #93c5fd;
+    --theme-button-text: #020617;
+    --theme-ring: rgba(96, 165, 250, 0.36);
+    --theme-shadow: rgba(0, 0, 0, 0.4);
+  }
+}
+
+[data-theme="light"] {
+  color-scheme: light;
+
+  --theme-bg: #f8fafc;
+  --theme-surface: #ffffff;
+  --theme-surface-soft: #eef2ff;
+  --theme-text: #0f172a;
+  --theme-muted-text: #475569;
+  --theme-border: #cbd5e1;
+  --theme-primary: #2563eb;
+  --theme-primary-hover: #1d4ed8;
+  --theme-button-text: #ffffff;
+  --theme-ring: rgba(37, 99, 235, 0.32);
+  --theme-shadow: rgba(15, 23, 42, 0.12);
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+
+  --theme-bg: #020617;
+  --theme-surface: #0f172a;
+  --theme-surface-soft: #172554;
+  --theme-text: #f8fafc;
+  --theme-muted-text: #cbd5e1;
+  --theme-border: #334155;
+  --theme-primary: #60a5fa;
+  --theme-primary-hover: #93c5fd;
+  --theme-button-text: #020617;
+  --theme-ring: rgba(96, 165, 250, 0.36);
+  --theme-shadow: rgba(0, 0, 0, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, var(--theme-surface-soft), transparent 32rem),
+    var(--theme-bg);
+  color: var(--theme-text);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.theme-page {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.hero-section {
+  max-width: 980px;
+  margin-bottom: 40px;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--theme-primary);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 16px;
+  max-width: 980px;
+  font-size: clamp(2.4rem, 5.8vw, 4.8rem);
+  line-height: 0.98;
+  letter-spacing: -0.06em;
+}
+
+.hero-text {
+  max-width: 620px;
+  color: var(--theme-muted-text);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.theme-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 22px;
+  margin-bottom: 36px;
+}
+
+.theme-preview {
+  padding: 18px;
+  border: 1px solid var(--theme-border);
+  border-radius: 24px;
+  background: var(--theme-bg);
+  color: var(--theme-text);
+  transition:
+    background-color 240ms ease,
+    border-color 240ms ease,
+    color 240ms ease;
+}
+
+.theme-label {
+  display: inline-flex;
+  margin-bottom: 14px;
+  padding: 7px 12px;
+  border: 1px solid var(--theme-border);
+  border-radius: 999px;
+  background: var(--theme-surface);
+  color: var(--theme-muted-text);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.theme-card {
+  min-height: 280px;
+  padding: 26px;
+  border: 1px solid var(--theme-border);
+  border-radius: 20px;
+  background: var(--theme-surface);
+  box-shadow: 0 24px 70px var(--theme-shadow);
+  transition:
+    transform 220ms ease,
+    background-color 240ms ease,
+    border-color 240ms ease,
+    box-shadow 240ms ease;
+}
+
+.theme-card:hover {
+  transform: translateY(-6px);
+}
+
+.theme-icon {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 24px;
+  border-radius: 16px;
+  background: var(--theme-surface-soft);
+  color: var(--theme-primary);
+  font-size: 1.45rem;
+  font-weight: 900;
+}
+
+.theme-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.35rem;
+}
+
+.theme-card p {
+  margin-bottom: 24px;
+  color: var(--theme-muted-text);
+  line-height: 1.65;
+}
+
+code {
+  color: var(--theme-primary);
+  font-size: 0.95em;
+  font-weight: 700;
+}
+
+.theme-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--theme-primary);
+  color: var(--theme-button-text);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  transition:
+    background-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.theme-button:hover {
+  background: var(--theme-primary-hover);
+  transform: translateY(-2px);
+}
+
+.theme-button:focus-visible {
+  outline: 3px solid var(--theme-ring);
+  outline-offset: 3px;
+}
+
+.token-section {
+  padding: 28px;
+  border: 1px solid var(--theme-border);
+  border-radius: 24px;
+  background: var(--theme-surface);
+  box-shadow: 0 24px 70px var(--theme-shadow);
+}
+
+.token-section h2 {
+  margin-bottom: 18px;
+}
+
+.token-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.token-box {
+  display: grid;
+  min-height: 76px;
+  place-items: center;
+  border: 1px solid var(--theme-border);
+  border-radius: 16px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.token-bg {
+  background: var(--theme-bg);
+  color: var(--theme-text);
+}
+
+.token-surface {
+  background: var(--theme-surface);
+  color: var(--theme-text);
+}
+
+.token-text {
+  background: var(--theme-text);
+  color: var(--theme-surface);
+}
+
+.token-muted {
+  background: var(--theme-muted-text);
+  color: var(--theme-surface);
+}
+
+.token-border {
+  background: var(--theme-border);
+  color: var(--theme-text);
+}
+
+.token-description {
+  max-width: 620px;
+  margin-bottom: 20px;
+  color: var(--theme-muted-text);
+  line-height: 1.6;
+}
+
+.token-primary {
+  background: var(--theme-primary);
+  color: var(--theme-button-text);
+}
+
+@media (max-width: 900px) {
+  .theme-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .token-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .theme-page {
+    width: min(100% - 24px, 1120px);
+    padding: 36px 0;
+  }
+
+  .theme-card,
+  .token-section {
+    padding: 22px;
+  }
+
+  .token-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a dark mode token layer demo using reusable CSS custom properties for light and dark themes.

This submission supports both automatic system preference theming through prefers-color-scheme and manual theme overrides using `data-theme="light"` and `data-theme="dark`".

Fixes #704

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
Theme token layer / CSS variable based feature demo.

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A reusable light/dark theme token layer using CSS custom properties with system preference support and manual theme overrides.

**How does a developer use it?**

```html
<section class="theme-preview" data-theme="dark"> 
   <div class="theme-card"> 
      <h2>Manual Dark Theme</h2> 
      <p>This section uses dark theme tokens.</p> 
   </div> 
</section>
```

**Why does it fit EaseMotion CSS?**

For automatic system-based theming, developers can use the default token layer without adding a `data-theme` attribute.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

Screenshots added for:

- Full dark mode preview
<img width="1984" height="2130" alt="_D__GSSoC_EaseMotion-css_submissions_examples_dark-mode-token-layer_demo html (5)" src="https://github.com/user-attachments/assets/0795a1ec-aa7e-43b0-baaf-20abb71169f0" />
<br></br>

- Full light mode preview
<img width="1984" height="2130" alt="_D__GSSoC_EaseMotion-css_submissions_examples_dark-mode-token-layer_demo html (4)" src="https://github.com/user-attachments/assets/38517f52-9172-4bb7-8708-91638bbb376f" />
<br></br>

- Manual light and manual dark override preview
<img width="1919" height="885" alt="image(111)" src="https://github.com/user-attachments/assets/58423b71-8d87-4faf-b5ee-7da00d67c41d" />

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission only adds files inside `submissions/examples/dark-mode-token-layer/`.

No changes were made to `core/`, `components/`, `docs/`, or root example files. The class names and token names are intentionally simple and readable, and can be adjusted by the maintainer if needed during standardization.

---