### PR TITLE
docs: add alternative CDN hosting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,30 @@ EaseMotion CSS is a curated, animation-first CSS framework where **class names r
 
 > Powered by jsDelivr — globally cached, always fast, no account needed. The CDN link is live the moment you paste it.
 
+## Alternative CDN Providers
+
+EaseMotion CSS can also be loaded using alternative CDN providers.
+
+### jsDelivr (recommended)
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css" />
+```
+
+### unpkg
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/easemotion-css/easemotion.min.css" />
+```
+
+### GitHub Raw CDN
+
+```html
+<link rel="stylesheet" href="https://raw.githubusercontent.com/SAPTARSHI-coder/EaseMotion-css/main/easemotion.min.css" />
+```
+
+> jsDelivr is recommended for production usage because it provides global caching and better reliability.
+
 ### Option 2 — npm
 
 ```bash


### PR DESCRIPTION
## Description
Expanded README CDN documentation by adding alternative CDN provider examples.

## Added
- unpkg CDN example
- GitHub raw CDN example
- Ready-to-use `<link>` tags
- Recommendation note for jsDelivr

Closes #343