### PR TITLE
feat: add ease-scale uniform and single-axis utility classes (#383)

### DIFF
--- a/submissions/examples/ease-scale/README.md
+++ b/submissions/examples/ease-scale/README.md
@@ -1,0 +1,29 @@
+# Scale Transform Utilities
+
+## What does this do?
+Adds atomic scaling utility classes to resize elements uniformly, horizontally (X), or vertically (Y).
+
+## How is it used?
+Apply the scaling utility classes directly to any HTML element:
+
+```html
+<div class="ease-scale-110">Your content here</div>
+```
+
+### Supported Scales
+- **Uniform Scale (`ease-scale-*`)**: `0`, `50` (0.5x), `75` (0.75x), `90` (0.9x), `95` (0.95x), `100` (1x), `105` (1.05x), `110` (1.1x), `125` (1.25x), `150` (1.5x).
+- **Scale X (`ease-scale-x-*`)**: `0`, `50` (0.5x), `75` (0.75x), `90` (0.9x), `95` (0.95x), `100` (1x), `105` (1.05x), `110` (1.1x), `125` (1.25x), `150` (1.5x).
+- **Scale Y (`ease-scale-y-*`)**: `0`, `50` (0.5x), `75` (0.75x), `90` (0.9x), `95` (0.95x), `100` (1x), `105` (1.05x), `110` (1.1x), `125` (1.25x), `150` (1.5x).
+
+## Why is it useful?
+In interactive user interfaces, scaling is a key mechanism for conveying tactile feedback. It is widely used to create micro-animations such as scaling up buttons on hover, scaling down buttons on active click, pop-over modal entrances, and custom cards expanding to fill views. These utilities provide a standardized, plug-and-play way to implement these interactions.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open `demo.html` directly in your browser to see the interactive hover effects.
+
+## Contribution Notes
+- Class naming: `ease-scale-*`, `ease-scale-x-*`, and `ease-scale-y-*`.

--- a/submissions/examples/ease-scale/demo.html
+++ b/submissions/examples/ease-scale/demo.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scale Transform Utilities - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <header>
+      <h1>Scale Utilities</h1>
+      <p class="subtitle">
+        Atomic scaling utility classes for sizing elements uniformly or stretching them along the X or Y axes. Hover over cards to see scaling transitions.
+      </p>
+    </header>
+
+    <!-- SECTION 1: UNIFORM SCALE -->
+    <h2 class="section-title">Uniform Scale (ease-scale-*)</h2>
+    <div class="grid-container">
+      
+      <!-- Card 1: Scale 50 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-50">50%</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-50</span>
+          <h3 class="card-title">Scale Down (0.5x)</h3>
+          <p class="card-desc">Shrinks the element uniformly to half its native dimensions.</p>
+        </div>
+      </div>
+
+      <!-- Card 2: Scale 75 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-75">75%</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-75</span>
+          <h3 class="card-title">Scale Down (0.75x)</h3>
+          <p class="card-desc">Shrinks the element uniformly to 75% of its native dimensions.</p>
+        </div>
+      </div>
+
+      <!-- Card 3: Scale 90 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-90">90%</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-90</span>
+          <h3 class="card-title">Scale Down (0.9x)</h3>
+          <p class="card-desc">Shrinks the element uniformly to 90% of its native dimensions.</p>
+        </div>
+      </div>
+
+      <!-- Card 4: Scale 110 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-110">110%</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-110</span>
+          <h3 class="card-title">Scale Up (1.1x)</h3>
+          <p class="card-desc">Enlarges the element uniformly to 110% of its native dimensions.</p>
+        </div>
+      </div>
+
+      <!-- Card 5: Scale 125 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-125">125%</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-125</span>
+          <h3 class="card-title">Scale Up (1.25x)</h3>
+          <p class="card-desc">Enlarges the element uniformly to 125% of its native dimensions.</p>
+        </div>
+      </div>
+
+      <!-- Card 6: Scale 150 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-150">150%</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-150</span>
+          <h3 class="card-title">Scale Up (1.5x)</h3>
+          <p class="card-desc">Enlarges the element uniformly to 150% (1.5x) of its native dimensions.</p>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- SECTION 2: HORIZONTAL SCALE -->
+    <h2 class="section-title">Horizontal Scale (ease-scale-x-*)</h2>
+    <div class="grid-container">
+      
+      <!-- Card 7: Scale X 50 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-x-50">X</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-x-50</span>
+          <h3 class="card-title">Compress X (0.5x)</h3>
+          <p class="card-desc">Shrinks the width of the element to 50% while height remains unchanged.</p>
+        </div>
+      </div>
+
+      <!-- Card 8: Scale X 125 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-x-125">X</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-x-125</span>
+          <h3 class="card-title">Stretch X (1.25x)</h3>
+          <p class="card-desc">Enlarges the width of the element to 125% while height remains unchanged.</p>
+        </div>
+      </div>
+
+      <!-- Card 9: Scale X 150 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-x-150">X</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-x-150</span>
+          <h3 class="card-title">Stretch X (1.5x)</h3>
+          <p class="card-desc">Enlarges the width of the element to 150% while height remains unchanged.</p>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- SECTION 3: VERTICAL SCALE -->
+    <h2 class="section-title">Vertical Scale (ease-scale-y-*)</h2>
+    <div class="grid-container">
+      
+      <!-- Card 10: Scale Y 50 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-y-50">Y</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-y-50</span>
+          <h3 class="card-title">Compress Y (0.5x)</h3>
+          <p class="card-desc">Shrinks the height of the element to 50% while width remains unchanged.</p>
+        </div>
+      </div>
+
+      <!-- Card 11: Scale Y 125 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-y-125">Y</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-y-125</span>
+          <h3 class="card-title">Stretch Y (1.25x)</h3>
+          <p class="card-desc">Enlarges the height of the element to 125% while width remains unchanged.</p>
+        </div>
+      </div>
+
+      <!-- Card 12: Scale Y 150 -->
+      <div class="showcase-card">
+        <div class="visual-area">
+          <div class="interactive-box trigger-scale-y-150">Y</div>
+        </div>
+        <div class="card-details">
+          <span class="class-badge">.ease-scale-y-150</span>
+          <h3 class="card-title">Stretch Y (1.5x)</h3>
+          <p class="card-desc">Enlarges the height of the element to 150% while width remains unchanged.</p>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- SECTION 4: CODE INTEGRATION GUIDE -->
+    <div class="code-guide">
+      <h2 style="margin-top: 0; font-family: 'Space Grotesk', sans-serif;">Developer Guide</h2>
+      <p style="color: var(--text-secondary); margin-bottom: 1.5rem; line-height: 1.6;">
+        Combine uniform or single-axis scale utilities with animations, hovers, or active clicks to create interactive pop-outs:
+      </p>
+      <pre class="code-block"><code><span class="tag">&lt;button</span> 
+  <span class="attr">class</span>=<span class="val">"btn ease-transition ease-duration-fast hover:ease-scale-115 active:ease-scale-95"</span>
+<span class="tag">&gt;</span>
+  Click Me
+<span class="tag">&lt;/button&gt;</span></code></pre>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-scale/style.css
+++ b/submissions/examples/ease-scale/style.css
@@ -1,0 +1,244 @@
+/* ============================================================
+   EaseMotion CSS — Scale Transform Utilities
+   ============================================================ */
+
+/* ────────────────────────────────────────────────────────────
+   SCALE CORE & RULES
+   ──────────────────────────────────────────────────────────── */
+
+/* Automatically apply transform when a scale class is used */
+[class*="ease-scale-"] {
+  transform: scale(var(--ease-scale-x, var(--ease-scale, 1)), var(--ease-scale-y, var(--ease-scale, 1)));
+}
+
+/* Uniform Scale Utilities */
+.ease-scale-0    { --ease-scale: 0; }
+.ease-scale-50   { --ease-scale: 0.5; }
+.ease-scale-75   { --ease-scale: 0.75; }
+.ease-scale-90   { --ease-scale: 0.9; }
+.ease-scale-95   { --ease-scale: 0.95; }
+.ease-scale-100  { --ease-scale: 1; }
+.ease-scale-105  { --ease-scale: 1.05; }
+.ease-scale-110  { --ease-scale: 1.1; }
+.ease-scale-125  { --ease-scale: 1.25; }
+.ease-scale-150  { --ease-scale: 1.5; }
+
+/* Scale X Utilities */
+.ease-scale-x-0    { --ease-scale-x: 0; }
+.ease-scale-x-50   { --ease-scale-x: 0.5; }
+.ease-scale-x-75   { --ease-scale-x: 0.75; }
+.ease-scale-x-90   { --ease-scale-x: 0.9; }
+.ease-scale-x-95   { --ease-scale-x: 0.95; }
+.ease-scale-x-100  { --ease-scale-x: 1; }
+.ease-scale-x-105  { --ease-scale-x: 1.05; }
+.ease-scale-x-110  { --ease-scale-x: 1.1; }
+.ease-scale-x-125  { --ease-scale-x: 1.25; }
+.ease-scale-x-150  { --ease-scale-x: 1.5; }
+
+/* Scale Y Utilities */
+.ease-scale-y-0    { --ease-scale-y: 0; }
+.ease-scale-y-50   { --ease-scale-y: 0.5; }
+.ease-scale-y-75   { --ease-scale-y: 0.75; }
+.ease-scale-y-90   { --ease-scale-y: 0.9; }
+.ease-scale-y-95   { --ease-scale-y: 0.95; }
+.ease-scale-y-100  { --ease-scale-y: 1; }
+.ease-scale-y-105  { --ease-scale-y: 1.05; }
+.ease-scale-y-110  { --ease-scale-y: 1.1; }
+.ease-scale-y-125  { --ease-scale-y: 1.25; }
+.ease-scale-y-150  { --ease-scale-y: 1.5; }
+
+
+/* ────────────────────────────────────────────────────────────
+   DEMO SHOWCASE STYLING
+   ──────────────────────────────────────────────────────────── */
+
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a0b10;
+  --bg-secondary: #12131a;
+  --text-primary: #f3f4f6;
+  --text-secondary: #9ca3af;
+  --accent-purple: #a855f7;
+  --accent-cyan: #06b6d4;
+  --accent-gradient: linear-gradient(135deg, #a855f7, #06b6d4);
+  --card-border: rgba(255, 255, 255, 0.05);
+  --card-glow: rgba(168, 85, 247, 0.15);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: 'Outfit', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.demo-wrapper {
+  max-width: 1200px;
+  width: 90%;
+  margin: 3rem auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 4rem;
+}
+
+h1 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 3rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  background: var(--accent-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.section-title {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-top: 3.5rem;
+  margin-bottom: 1.5rem;
+  border-left: 4px solid var(--accent-purple);
+  padding-left: 1rem;
+}
+
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  margin-bottom: 4rem;
+}
+
+.showcase-card {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  padding: 1.5rem;
+  overflow: hidden;
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.4);
+}
+
+.showcase-card:hover {
+  border-color: rgba(168, 85, 247, 0.3);
+  box-shadow: 0 10px 30px var(--card-glow);
+}
+
+.visual-area {
+  height: 140px;
+  background-color: #07080c;
+  border-radius: 12px;
+  position: relative;
+  margin-bottom: 1.5rem;
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Reference box representing 100% scale boundaries */
+.visual-area::before {
+  content: '';
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
+  pointer-events: none;
+}
+
+.interactive-box {
+  width: 60px;
+  height: 60px;
+  background: linear-gradient(135deg, #a855f7, #d946ef);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: white;
+  box-shadow: 0 4px 12px rgba(168, 85, 247, 0.3);
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 2;
+}
+
+/* Class details */
+.class-badge {
+  display: inline-block;
+  background: rgba(168, 85, 247, 0.1);
+  border: 1px solid rgba(168, 85, 247, 0.2);
+  color: #c084fc;
+  font-family: 'Space Grotesk', monospace;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 6px;
+  margin-bottom: 0.75rem;
+}
+
+.card-title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem 0;
+}
+
+.card-desc {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.code-guide {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  padding: 2rem;
+  margin-top: 4rem;
+}
+
+.code-block {
+  background-color: #050608;
+  border-radius: 12px;
+  padding: 1.25rem;
+  overflow-x: auto;
+  font-family: 'Space Grotesk', monospace;
+  font-size: 0.95rem;
+  color: #d8b4fe;
+  border: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.tag { color: #f43f5e; }
+.attr { color: #fb923c; }
+.val { color: #34d399; }
+
+/* Interactive Hover Triggers for Demo Showcase */
+.showcase-card:hover .trigger-scale-50   { --ease-scale: 0.5; }
+.showcase-card:hover .trigger-scale-75   { --ease-scale: 0.75; }
+.showcase-card:hover .trigger-scale-90   { --ease-scale: 0.9; }
+.showcase-card:hover .trigger-scale-110  { --ease-scale: 1.1; }
+.showcase-card:hover .trigger-scale-125  { --ease-scale: 1.25; }
+.showcase-card:hover .trigger-scale-150  { --ease-scale: 1.5; }
+
+.showcase-card:hover .trigger-scale-x-50   { --ease-scale-x: 0.5; }
+.showcase-card:hover .trigger-scale-x-125  { --ease-scale-x: 1.25; }
+.showcase-card:hover .trigger-scale-x-150  { --ease-scale-x: 1.5; }
+
+.showcase-card:hover .trigger-scale-y-50   { --ease-scale-y: 0.5; }
+.showcase-card:hover .trigger-scale-y-125  { --ease-scale-y: 1.25; }
+.showcase-card:hover .trigger-scale-y-150  { --ease-scale-y: 1.5; }


### PR DESCRIPTION
## Pull Request Description

This PR implements the scale transform utilities requested in issue #383. It introduces atomic utility classes for uniform, X-axis, and Y-axis scaling, keeping everything self-contained within the `submissions/examples/ease-scale/` folder.

---

## Type of Change

- [x] Other (layout & transform utilities)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scale/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds atomic scaling utility classes to resize elements uniformly, horizontally (X), or vertically (Y).

**How does a developer use it?**

```html
<div class="ease-scale-110">Your content here</div>
```

**Why does it fit EaseMotion CSS?**

In interactive user interfaces, scaling is a fundamental tool for micro-animations and tactile feedback (like expanding hover cards, button press shrinkage, or popup entrances). Standardizing these into atomic, plug-and-play utilities streamlines developers' workflows.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

- Utilizes custom properties (`--ease-scale`, `--ease-scale-x`, `--ease-scale-y`) inside a single `[class*="ease-scale-"]` ruleset to allow mixing uniform and axis-specific scaling rules cleanly on a single element.
- Scales include standard factors from `0` to `150` (e.g. `75`, `90`, `110`, `125`, etc.).
