### PR TITLE
feat: add ease-italic and ease-not-italic text utilities (#378)

### DIFF
--- a/submissions/examples/ease-italic/README.md
+++ b/submissions/examples/ease-italic/README.md
@@ -1,0 +1,28 @@
+# Italic Text Utilities
+
+## What does this do?
+Adds typography utility classes to set font style to italic (`ease-italic`) or normal (`ease-not-italic`).
+
+## How is it used?
+Apply the utility classes directly to any HTML element:
+
+```html
+<p class="ease-italic">Your content here</p>
+```
+
+### Classes
+- `.ease-italic` — Sets `font-style: italic;`
+- `.ease-not-italic` — Sets `font-style: normal;`
+
+## Why is it useful?
+In clean, readable layouts, visual emphasis is key to structural hierarchy. By using atomic typography classes for italicizing (or resetting italicization of nested elements), developer styling is kept cleanly within the HTML structure.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open `demo.html` directly in your browser to view the font-style presentation.
+
+## Contribution Notes
+- Class naming: `ease-italic` and `ease-not-italic`.

--- a/submissions/examples/ease-italic/demo.html
+++ b/submissions/examples/ease-italic/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Italic Text Utilities - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <header>
+      <h1>Italic Text Utilities</h1>
+      <p class="subtitle">
+        Atomic typography utility classes for toggling italicized layouts on any element block.
+      </p>
+    </header>
+
+    <div class="grid-container">
+      
+      <!-- Card 1: Italic -->
+      <div class="showcase-card">
+        <div class="typo-label">Preview</div>
+        <div class="typo-preview ease-italic">
+          The art of coding is the art of organizing complexity.
+        </div>
+        <p class="card-desc">
+          Renders text using italic font-style. Perfect for emphasizing quotes, book titles, or editorial headlines.
+        </p>
+        <span class="class-badge">.ease-italic</span>
+      </div>
+
+      <!-- Card 2: Not Italic -->
+      <div class="showcase-card">
+        <div class="typo-label">Preview</div>
+        <div class="typo-preview ease-not-italic">
+          The art of coding is the art of organizing complexity.
+        </div>
+        <p class="card-desc">
+          Resets or forces text to normal font-style. Useful for overriding parent styling or native browser italic inheritance.
+        </p>
+        <span class="class-badge">.ease-not-italic</span>
+      </div>
+
+    </div>
+
+    <!-- CODE INTEGRATION GUIDE -->
+    <div class="code-guide">
+      <h2 style="margin-top: 0; font-family: 'Space Grotesk', sans-serif;">Developer Guide</h2>
+      <p style="color: var(--text-secondary); margin-bottom: 1.5rem; line-height: 1.6;">
+        Apply the italic classes directly in your markup to control emphasis structure programmatically:
+      </p>
+      <pre class="code-block"><code><span class="tag">&lt;p</span> <span class="attr">class</span>=<span class="val">"ease-text-lg ease-italic"</span><span class="tag">&gt;</span>
+  This sentence will be italicized.
+<span class="tag">&lt;/p&gt;</span></code></pre>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-italic/style.css
+++ b/submissions/examples/ease-italic/style.css
@@ -1,0 +1,170 @@
+/* ============================================================
+   EaseMotion CSS — Italic Text Utilities
+   ============================================================ */
+
+/* ────────────────────────────────────────────────────────────
+   TYPOGRAPHY RULES
+   ──────────────────────────────────────────────────────────── */
+
+.ease-italic {
+  font-style: italic;
+}
+
+.ease-not-italic {
+  font-style: normal;
+}
+
+
+/* ────────────────────────────────────────────────────────────
+   DEMO SHOWCASE STYLING
+   ──────────────────────────────────────────────────────────── */
+
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,600;1,400;1,600&family=Space+Grotesk:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #07080b;
+  --bg-secondary: #0e0f15;
+  --text-primary: #f1f5f9;
+  --text-secondary: #94a3b8;
+  --accent-gold: #fbbf24;
+  --accent-gradient: linear-gradient(135deg, #fbbf24, #f59e0b);
+  --card-border: rgba(255, 255, 255, 0.04);
+  --card-glow: rgba(251, 191, 36, 0.12);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: 'Outfit', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.demo-wrapper {
+  max-width: 1000px;
+  width: 90%;
+  margin: 4rem auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 4.5rem;
+}
+
+h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 3.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  background: var(--accent-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.section-title {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.6rem;
+  font-weight: 600;
+  margin-top: 3.5rem;
+  margin-bottom: 1.5rem;
+  border-left: 4px solid var(--accent-gold);
+  padding-left: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  margin-bottom: 4rem;
+}
+
+.showcase-card {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 2rem;
+  overflow: hidden;
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.4);
+}
+
+.showcase-card:hover {
+  border-color: rgba(251, 191, 36, 0.3);
+  box-shadow: 0 10px 30px var(--card-glow);
+}
+
+/* Typography showcase box */
+.typo-preview {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.8rem;
+  line-height: 1.4;
+  color: #f8fafc;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.typo-label {
+  font-family: 'Space Grotesk', sans-serif;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+/* Class details */
+.class-badge {
+  display: inline-block;
+  background: rgba(251, 191, 36, 0.1);
+  border: 1px solid rgba(251, 191, 36, 0.2);
+  color: #fbbf24;
+  font-family: 'Space Grotesk', monospace;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 6px;
+  margin-top: 1rem;
+}
+
+.card-desc {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.code-guide {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-top: 4rem;
+}
+
+.code-block {
+  background-color: #050608;
+  border-radius: 10px;
+  padding: 1.25rem;
+  overflow-x: auto;
+  font-family: 'Space Grotesk', monospace;
+  font-size: 0.95rem;
+  color: #fde047;
+  border: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.tag { color: #f43f5e; }
+.attr { color: #fb923c; }
+.val { color: #34d399; }


### PR DESCRIPTION
## Pull Request Description

This PR implements the italic text utilities requested in issue #378. It introduces typography classes for setting elements to italic (`ease-italic`) or normal (`ease-not-italic`), keeping everything self-contained within the `submissions/examples/ease-italic/` folder.

---

## Type of Change

- [x] Other (typography utilities)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-italic/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds typography utility classes to set font style to italic (`ease-italic`) or normal (`ease-not-italic`).

**How does a developer use it?**

```html
<p class="ease-italic">Your content here</p>
```

**Why does it fit EaseMotion CSS?**

Emphasis and clean text formatting are core pillars of editorial layouts. Providing atomic typography utility classes directly inside the framework keeps styling unified and fast.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

- Minimal implementation strictly adhering to the submission standards.
