### PR TITLE
docs: add comprehensive SECURITY.md policy inside submissions

### DIFF
--- a/submissions/SECURITY.md
+++ b/submissions/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+The EaseMotion-css team takes the security of our framework, components, and users seriously. This document outlines our policy for reporting and handling potential security vulnerabilities responsibly.
+
+---
+
+## Supported Versions
+
+We actively provide security updates and patches for the current major release cycle. Please ensure you are using the latest stable release before filing a report.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| v1.x    | ✅ Active Support  |
+| < v1.0  | ❌ Unsupported     |
+
+---
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability or weakness within this repository, **please do not open a public GitHub issue.** Publicly disclosing vulnerabilities can expose projects using this framework to unnecessary risks.
+
+Instead, please report security vulnerabilities responsibly by reaching out directly to the repository maintainers. 
+
+### Guidelines for Submitting a Report:
+1. **Description:** Detailed description of the vulnerability and its potential impact.
+2. **Steps to Reproduce:** Clear, step-by-step instructions or a minimal proof-of-concept (PoC) to reproduce the behavior.
+3. **Environment Details:** Browser version, OS, and any specific configuration details where the bug occurs.
+
+---
+
+## Our Response Process
+
+Upon receiving a valid vulnerability report, the maintainers will prioritize an evaluation and coordinate a fix:
+
+* **Acknowledgment:** We will acknowledge receipt of your report within 48–72 hours.
+* **Triage & Patching:** Our team will investigate the scope of the impact and work on a clean, stable patch.
+* **Disclosure:** Once a fix is verified and deployed, a security advisory or release update will be publicly logged to protect the community.
+
+Thank you for helping keep EaseMotion-css secure and accessible for everyone!


### PR DESCRIPTION
### 🛠️ Purpose
Closes #349. Adds a comprehensive project security disclosure policy.

### 💡 Changes Made
- Created `SECURITY.md` inside the designated `submissions/` folder as requested by the maintainer.
- Outlined supported software version baselines for active patch maintenance.
- Documented clear step-by-step reporting guidelines for vulnerability submission.
- Set standard response expectations for acknowledgment and triaging timeframes to keep the codebase secure.

### 📸 Verification
- Checked file pathing constraints to ensure it sits perfectly inside the submissions directory tree.
- Verified markdown rendering formats natively across tables and list items.