### PR TITLE
fix: preserve strings when removing CSS comments

### DIFF
--- a/scripts/build-minified-css.mjs
+++ b/scripts/build-minified-css.mjs
@@ -10,7 +10,62 @@ const outputFile = path.join(rootDir, "easemotion.min.css");
 
 const localImportPattern =
   /@import\s+(?:url\(\s*)?["']([^"']+)["']\s*\)?\s*;/g;
+function removeCSSComments(source) {
+  let result = "";
+  let i = 0;
 
+  while (i < source.length) {
+    const ch = source[i];
+
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      result += ch;
+      i++;
+
+      while (i < source.length) {
+        const c = source[i];
+        result += c;
+
+        if (c === "\\") {
+          i++;
+          if (i < source.length) {
+            result += source[i];
+            i++;
+          }
+          continue;
+        }
+
+        if (c === quote) {
+          i++;
+          break;
+        }
+
+        i++;
+      }
+
+      continue;
+    }
+
+    if (ch === "/" && source[i + 1] === "*") {
+      i += 2;
+
+      while (i < source.length) {
+        if (source[i] === "*" && source[i + 1] === "/") {
+          i += 2;
+          break;
+        }
+        i++;
+      }
+
+      continue;
+    }
+
+    result += ch;
+    i++;
+  }
+
+  return result;
+}
 async function bundleCss(filePath, state) {
   const normalizedPath = path.normalize(filePath);
 
@@ -27,7 +82,7 @@ async function bundleCss(filePath, state) {
   state.stack.add(normalizedPath);
   state.pathStack.push(normalizedPath);
   const source = await readFile(normalizedPath, "utf8");
-  const sourceWithoutComments = source.replace(/\/\*[\s\S]*?\*\//g, "");
+  const sourceWithoutComments = removeCSSComments(source);
   const directory = path.dirname(normalizedPath);
 
   const bundled = sourceWithoutComments.replace(localImportPattern, (fullMatch, importPath) => {
@@ -62,8 +117,7 @@ async function bundleCss(filePath, state) {
 }
 
 function minifyCss(css) {
-  return css
-    .replace(/\/\*[\s\S]*?\*\//g, "")
+  return removeCSSComments(css)
     .replace(/\r\n/g, "\n")
     .replace(/\n+/g, "\n")
     .replace(/\s+/g, " ")


### PR DESCRIPTION
## Description

### What does this PR do?

This PR fixes an issue where CSS comment removal could unintentionally modify content inside quoted strings, embedded SVGs, and data URLs.

The previous implementation relied on a regular expression:

```js
/\/\*[\s\S]*?\*\//g
```

which removed anything that resembled a CSS comment, even when it appeared inside string literals.

### Changes Made

* Added a token-aware `removeCSSComments()` helper.
* Preserved content inside single-quoted and double-quoted strings.
* Handled escaped characters within strings.
* Replaced regex-based comment removal in `bundleCss()`.
* Replaced regex-based comment removal in `minifyCss()`.

### Example

#### Before

```css
background-image: url("data:image/svg+xml,<svg><!-- /* test */ --></svg>");
```

The comment-removal regex could incorrectly modify the embedded SVG content.

#### After

String contents and data URLs are preserved while actual CSS comments are removed.

### Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

### Testing

* Verified normal CSS comment removal still works.
* Verified quoted strings remain unchanged.
* Verified embedded SVG/data URI content is preserved.
* Confirmed bundling and minification behavior remains unchanged for valid CSS.

Fixes #747
