### PR TITLE
docs: fix legacy Flow CSS references in feature_request.md template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Propose a new utility, animation, or component for Flow CSS
+about: Propose a new utility, animation, or component for EaseMotion CSS
 title: "[FEATURE] Your feature name here"
 labels: ''
 assignees: ''
@@ -19,9 +19,9 @@ assignees: ''
 
 ---
 
-## Why is this useful for Flow CSS?
+## Why is this useful for EaseMotion CSS?
 
-<!-- Explain how this fits the Flow CSS design philosophy: human-readable, animation-first, composable. -->
+<!-- Explain how this fits the EaseMotion CSS design philosophy: human-readable, animation-first, composable. -->
 
 ---
 
@@ -37,7 +37,7 @@ assignees: ''
 
 ## CSS Snippet
 
-<!-- Paste your raw CSS. You do NOT need to use flow- naming yet — the maintainer handles that. -->
+<!-- Paste your raw CSS. You do NOT need to use ease- naming yet — the maintainer handles that. -->
 
 ```css
 /* Paste your CSS here */
@@ -53,6 +53,6 @@ assignees: ''
 
 ## Checklist
 
-- [ ] This feature does not duplicate an existing Flow CSS class
+- [ ] This feature does not duplicate an existing EaseMotion CSS class
 - [ ] I understand my naming will be standardized by the maintainer
 - [ ] I will submit code inside `submissions/examples/` only — not in `core/` or `components/`


### PR DESCRIPTION
## Pull Request Description

This pull request resolves a branding inconsistency where legacy references to **"Flow CSS"** were left in the `.github/ISSUE_TEMPLATE/feature_request.md` file instead of using **"EaseMotion CSS"**. 

This fix replaces all legacy references (including description blocks and checkbox labels) with the correct current name of the framework.

closes issue number : #766 
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (issue template branding cleanup)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/` *(N/A - direct docs fix)*
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A)*
- [ ] Includes `style.css` — raw CSS for the proposed feature *(N/A)*
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS *(N/A)*
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Updates the Feature Request template to accurately reference "EaseMotion CSS" instead of legacy "Flow CSS" naming.

**How does a developer use it?**

N/A (This is a GitHub issue template update).

**Why does it fit EaseMotion CSS?**

It maintains a clean, professional, and consistent contributor environment across repository issue templates.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser) *(N/A)*

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This is a minor quality-of-life / branding fix in `.github/ISSUE_TEMPLATE/feature_request.md` to replace "Flow CSS" references. 

As stated in the **Strict Rules** of `CONTRIBUTING.md`:
> *"Small fixes (documentation typos, broken demo links) can go directly to a PR."*

Since this is a documentation layout update, it has been submitted directly rather than inside `submissions/examples/`.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
