### PR TITLE
feat: add grid placement utilities demo

### DIFF
--- a/submissions/examples/grid-placement-utilities/README.md
+++ b/submissions/examples/grid-placement-utilities/README.md
@@ -1,0 +1,34 @@
+# Grid Placement Utilities
+
+A collection of CSS Grid utility classes for controlling item placement and column spanning.
+
+## Usage
+
+```html
+<div class="place-center">Centered Item</div>
+
+<div class="place-start">Start Aligned Item</div>
+
+<div class="place-end">End Aligned Item</div>
+
+<div class="col-span-2">Spans Two Columns</div>
+
+<div class="col-span-full">Spans Entire Row</div>
+```
+
+## Classes
+
+| Class           | CSS                         |
+| --------------- | --------------------------- |
+| `place-center`  | `place-items: center;`      |
+| `place-start`   | `place-items: start start;` |
+| `place-end`     | `place-items: end end;`     |
+| `col-span-1`    | `grid-column: span 1;`      |
+| `col-span-2`    | `grid-column: span 2;`      |
+| `col-span-3`    | `grid-column: span 3;`      |
+| `col-span-4`    | `grid-column: span 4;`      |
+| `col-span-full` | `grid-column: 1 / -1;`      |
+
+## Use Case
+
+These utilities reduce repetitive CSS by providing reusable classes for common grid alignment and spanning patterns, making layouts easier to build and maintain.

--- a/submissions/examples/grid-placement-utilities/demo.html
+++ b/submissions/examples/grid-placement-utilities/demo.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Grid Placement Utilities Demo</title>
+
+<link rel="stylesheet" href="style.css" />
+
+<style>
+body 
+    {
+        font-family: Arial, sans-serif;
+        padding: 2rem;
+        background: #f5f7fb;
+        color: #111827;
+        max-width: 1200px;
+        margin: 0 auto;
+    }
+
+h1 
+    {
+        text-align: center;
+        margin-bottom: 0.5rem;
+    }
+
+.intro 
+    {
+        text-align: center;
+        margin-bottom: 2rem;
+        color: #4b5563;
+    }
+
+h2  {
+        margin-top: 2rem;
+    }
+
+.placement-demo 
+    {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+    }
+
+.demo-card 
+    {
+        flex: 1;
+        min-width: 240px;
+    }
+
+.demo-box 
+    {
+        display: grid;
+        height: 160px;
+        border: 2px dashed #888;
+        background: white;
+        border-radius: 8px;
+    }
+
+.item 
+    {
+        background: #4f46e5;
+        color: white;
+        padding: 10px 14px;
+        border-radius: 6px;
+        width: fit-content;
+        height: fit-content;
+    }
+
+.grid-demo 
+    {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 10px;
+        margin-top: 1rem;
+    }
+
+.card 
+    {
+        background: #2563eb;
+        color: white;
+        padding: 15px;
+        text-align: center;
+        border-radius: 6px;
+    }
+</style>
+</head>
+
+<body>
+<h1>Grid Placement Utilities</h1>
+
+<p class="intro">
+      Demonstrates utility classes for CSS Grid item placement and column
+      spanning.
+</p>
+
+<h2>Place Items Utilities</h2>
+
+<div class="placement-demo">
+    <div class="demo-card">
+    <p><strong> place-center </strong></p>
+    <div class="demo-box place-center">
+    <div class="item">Center</div>
+    </div>
+</div>
+
+<div class="demo-card">
+    <p><strong> place-start </strong></p>
+    <div class="demo-box place-start">
+    <div class="item">Start</div>
+    </div>
+</div>
+
+<div class="demo-card">
+    <p><strong> place-end </strong></p>
+    <div class="demo-box place-end">
+    <div class="item">End</div>
+    </div>
+    </div>
+</div>
+
+<h2>Column Span Utilities</h2>
+
+<div class="grid-demo">
+    <div class="card col-span-full">Full Row</div>
+
+    <div class="card col-span-2">Span 2</div>
+    <div class="card col-span-2">Span 2</div>
+
+    <div class="card col-span-3">Span 3</div>
+
+    <div class="card col-span-1">Span 1</div>
+
+    <div class="card col-span-4">Span 4</div>
+</div>
+</body>
+</html>
+

--- a/submissions/examples/grid-placement-utilities/style.css
+++ b/submissions/examples/grid-placement-utilities/style.css
@@ -1,0 +1,9 @@
+
+.place-center  { place-items: center; }
+.place-start   { place-items: start start; }
+.place-end     { place-items: end end; }
+.col-span-1    { grid-column: span 1; }
+.col-span-2    { grid-column: span 2; }
+.col-span-3    { grid-column: span 3; }
+.col-span-4    { grid-column: span 4; }
+.col-span-full { grid-column: 1 / -1; }


### PR DESCRIPTION
Added a new Grid Placement Utilities example under the submissions directory.

This submission includes utility classes for common CSS Grid placement and column spanning use cases:

* place-center
* place-start
* place-end
* col-span-1
* col-span-2
* col-span-3
* col-span-4
* col-span-full

Also added:

* demo.html to demonstrate each utility visually
* style.css containing the utility classes
* README.md with usage examples and documentation

The goal is to make common grid alignment and layout patterns easier to reuse without writing custom CSS each time.

Fixes #323
