### PR TITLE
docs: add copy-to-clipboard button for code blocks

### DIFF
--- a/submissions/examples/copy-code-button/README.md
+++ b/submissions/examples/copy-code-button/README.md
@@ -1,0 +1,30 @@
+# Code Copy Button
+
+## What does this do?
+
+Adds a copy-to-clipboard button to code blocks, allowing users to copy code snippets with a single click.
+
+---
+
+## How is it used?
+
+A copy icon appears in the top-right corner of each code block. Clicking the icon copies the code content to the clipboard and provides visual feedback to indicate a successful copy.
+
+## where to add 
+
+/index.html
+JS
+add it in the end before </script>
+
+css 
+add it in the style block 
+
+header
+<!-- Font Awesome -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  in the head tag 
+
+
+## Why is it useful?
+
+Documentation often contains code examples that users need to copy and test. This feature improves developer experience by eliminating manual text selection, making code snippets faster and easier to use while keeping the interface clean and intuitive.

--- a/submissions/examples/copy-code-button/demo.html
+++ b/submissions/examples/copy-code-button/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Code Copy Button Demo</title>
+
+  <!-- Font Awesome -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+
+
+
+  <script>
+    document.querySelectorAll(".docs-code").forEach(block => {
+
+      const btn = document.createElement("button");
+
+      btn.className = "copy-btn";
+      btn.innerHTML = '<i class="fa-regular fa-copy"></i>';
+
+      block.appendChild(btn);
+
+      btn.addEventListener("click", async () => {
+
+        try {
+
+          const code = block.querySelector("pre code").innerText;
+
+          await navigator.clipboard.writeText(code);
+
+          btn.textContent = "Copied!";
+          btn.classList.add("copied");
+
+          setTimeout(() => {
+            btn.innerHTML = '<i class="fa-regular fa-copy"></i>';
+            btn.classList.remove("copied");
+          }, 2000);
+
+        } catch (err) {
+          console.error("Copy failed", err);
+        }
+
+      });
+
+    });
+  </script>
+
+</body>
+</html> 

--- a/submissions/examples/copy-code-button/style.css
+++ b/submissions/examples/copy-code-button/style.css
@@ -1,0 +1,30 @@
+/* Copy Button */
+.copy-btn {
+  position: absolute;
+  top: 12px;
+  right: 52px;
+  border: none;
+  background: transparent;
+  color: #9ca3af;
+  cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: all 0.2s ease;
+  padding: 4px 6px;
+  border-radius: 6px;
+}
+
+.copy-btn:hover {
+  color: #ffffff;
+  background: rgba(255,255,255,0.06);
+}
+
+.copy-btn i {
+  font-size: 16px;
+}
+
+.copy-btn.copied {
+  color: #22c55e;
+}


### PR DESCRIPTION
Pull Request Description

Adds a copy-to-clipboard button for code blocks that allows users to quickly copy code with one click. Improves developer experience in documentation and tutorials by reducing manual selection errors.

Type of Change
 ✨ New animation / hover effect
 🧩 New component

Submission Checklist 
 All changes are inside submissions/examples/copy-code-button/
 Includes demo.html — self-contained, opens in browser with no server
 Includes style.css — raw CSS for the proposed feature
 Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
 No changes to core/
 No changes to components/
 One feature per PR (no bundled unrelated changes)

Feature Description

What does this add?
A copy button that appears on code blocks allowing users to copy code instantly.

Why does it fit EaseMotion CSS?
It improves developer experience with a minimal, interaction-focused UI enhancement while keeping the design clean and functional, aligned with EaseMotion’s simplicity-first philosophy.



Notes for Maintainer

The component is kept minimal and framework-agnostic.
Feel free to adjust spacing/timing or rename classes during integration into ease-* standard.