### PR TITLE
feat: add motion accessibility studio example submission

### DIFF
--- a/submissions/examples/motion-accessibility-studio/README.md
+++ b/submissions/examples/motion-accessibility-studio/README.md
@@ -1,0 +1,15 @@
+# Motion Accessibility Studio
+
+### 1. What does this do?
+This accessibility-first development utility lets developers test standard vs. safe animation intensity side-by-side, score animations against sensory motion safety benchmarks, and generate media queries (`prefers-reduced-motion`) dynamically.
+
+### 2. How is it used?
+Open `demo.html` directly in any web browser to access the dashboard:
+- **Simulated Profiles**: Switch between Normal, Reduced, and No-Motion profiles to simulate user comfort preferences.
+- **Dynamic Controllers**: Tune sliders to adjust travel distance, scale zoom shifts, rotation angles, and blur intensity factor.
+- **Compare Mode**: Inspect standard framework animations against accessibility-safe versions side-by-side.
+- **Safety Analyzer**: Review real-time safety scores (A to C rating) and list safety recommendations (e.g. slowing down speeds or disabling loops).
+- **CSS generator**: Copy generated media queries to safe-guard layouts for vestibular-sensitive users.
+
+### 3. Why is it useful?
+It fits EaseMotion CSS's philosophy by making motion accessibility simple and developer-friendly. Accessibility should not be an afterthought; this dashboard makes visual scaling and vestibular comfort planning visual and straight-forward, enabling GSSoC developers to easily ship safer, fully compliant designs using the framework.

--- a/submissions/examples/motion-accessibility-studio/demo.html
+++ b/submissions/examples/motion-accessibility-studio/demo.html
@@ -1,0 +1,545 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Motion Accessibility Studio — EaseMotion CSS</title>
+  
+  <!-- EaseMotion CSS — local imports for dogfooding -->
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/animations.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  <link rel="stylesheet" href="../../../components/cards.css" />
+  
+  <!-- Studio Custom Styles -->
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body class="mas-body">
+
+  <div class="mas-container">
+    
+    <!-- ── Header ───────────────────────────────────────────── -->
+    <header class="mas-header">
+      <span class="mas-badge">Accessibility & Motion Tool</span>
+      <h1 class="mas-title">⚡ Motion Accessibility Studio</h1>
+      <p class="mas-subtitle">
+        Design inclusive, motion-safe interactions. Tweak animation scale, preview compliance scores, and generate prefers-reduced-motion queries.
+      </p>
+    </header>
+
+    <!-- ── Main Grid ────────────────────────────────────────── -->
+    <div class="mas-grid">
+      
+      <!-- ── Left Column: Preview screens & scoring ──────────── -->
+      <div class="mas-left-column">
+        
+        <!-- Preview Screen Container -->
+        <div class="mas-card">
+          <div class="mas-card-title">
+            <span>Visual Workspace</span>
+            <div class="mas-tab-container">
+              <button class="mas-tab-btn active" id="tabStandard">Standard Preview</button>
+              <button class="mas-tab-btn" id="tabCompare">Compare Side-by-Side</button>
+            </div>
+          </div>
+          
+          <!-- Standard Preview Mode -->
+          <div class="mas-preview-container" id="standardWorkspace">
+            <div id="target-main" class="mas-target-element ease-card-shadow">
+              <strong>EaseMotion</strong>
+              <span>Interactive Box</span>
+            </div>
+          </div>
+
+          <!-- Compare Mode Screen (Side-by-side) -->
+          <div class="mas-compare-grid ease-hidden" id="compareWorkspace">
+            <!-- Left: Standard / Original -->
+            <div class="mas-compare-pane">
+              <div class="mas-pane-header">Original Animation</div>
+              <div class="mas-pane-screen">
+                <div id="target-compare-original" class="mas-target-element ease-card-shadow">
+                  <strong>Original</strong>
+                  <span>Full Intensity</span>
+                </div>
+              </div>
+            </div>
+            
+            <!-- Right: Accessible / Scaled -->
+            <div class="mas-compare-pane">
+              <div class="mas-pane-header accent">Accessibility Friendly</div>
+              <div class="mas-pane-screen">
+                <div id="target-compare-safe" class="mas-target-element ease-card-shadow">
+                  <strong>Safe Version</strong>
+                  <span>Scaled-down</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Workspace Actions -->
+          <div class="mas-toolbar">
+            <button class="ease-btn ease-btn-outline ease-btn-sm" id="replayBtn">▶ Trigger Preview</button>
+            <button class="mas-theme-btn" id="themeToggle" aria-label="Toggle light/dark theme">🌙</button>
+          </div>
+        </div>
+
+        <!-- Scoring Analysis Panel -->
+        <div class="mas-card">
+          <div class="mas-card-title">Motion Safety Analysis</div>
+          <div class="mas-score-panel">
+            <div class="mas-score-circle" id="scoreValue">90</div>
+            <div class="mas-score-info">
+              <div class="mas-score-rating" id="scoreRating">A+ Safe Motion</div>
+              <div class="mas-score-desc" id="scoreTips">No risks detected. The animation parameters fit accessibility criteria.</div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ── Right Column: Accessibility Settings ────────────── -->
+      <div class="mas-card">
+        <div class="mas-card-title">Accessibility Settings</div>
+        
+        <form class="mas-control-form" onsubmit="event.preventDefault();">
+          
+          <!-- Select Animation -->
+          <div class="mas-form-group">
+            <label class="mas-label" for="animSelect">Framework Animation</label>
+            <select id="animSelect" class="mas-select">
+              <optgroup label="Entrance Animations">
+                <option value="ease-fade-in" selected>ease-fade-in</option>
+                <option value="ease-slide-up">ease-slide-up</option>
+                <option value="ease-slide-in-left">ease-slide-in-left</option>
+                <option value="ease-zoom-in">ease-zoom-in</option>
+                <option value="ease-bounce-in">ease-bounce-in</option>
+                <option value="ease-flip">ease-flip</option>
+                <option value="ease-blur-to-focus">ease-blur-to-focus</option>
+              </optgroup>
+              <optgroup label="Looping Animations">
+                <option value="ease-bounce">ease-bounce</option>
+                <option value="ease-rotate">ease-rotate</option>
+                <option value="ease-pulse">ease-pulse</option>
+                <option value="ease-ping">ease-ping</option>
+                <option value="ease-float">ease-float</option>
+                <option value="ease-shake">ease-shake</option>
+              </optgroup>
+            </select>
+          </div>
+
+          <!-- Motion Sensitivity Selector -->
+          <div class="mas-form-group">
+            <label class="mas-label">Simulated Motion Profile</label>
+            <div class="mas-mode-selector">
+              <button type="button" class="mas-mode-btn active" data-mode="normal">Normal</button>
+              <button type="button" class="mas-mode-btn" data-mode="reduced">Reduced</button>
+              <button type="button" class="mas-mode-btn" data-mode="none">No Motion</button>
+            </div>
+          </div>
+
+          <!-- Intensity Modifiers -->
+          <div class="mas-form-group">
+            <label class="mas-label" for="translateSlider">
+              Translation Scale (Distance)
+              <span class="mas-label-val" id="translateVal">100%</span>
+            </label>
+            <input type="range" id="translateSlider" class="mas-slider" min="0" max="150" value="100" />
+          </div>
+
+          <div class="mas-form-group">
+            <label class="mas-label" for="scaleSlider">
+              Scale Shift Intensity
+              <span class="mas-label-val" id="scaleVal">100%</span>
+            </label>
+            <input type="range" id="scaleSlider" class="mas-slider" min="0" max="150" value="100" />
+          </div>
+
+          <div class="mas-form-group">
+            <label class="mas-label" for="rotateSlider">
+              Rotation Angle Scale
+              <span class="mas-label-val" id="rotateVal">100%</span>
+            </label>
+            <input type="range" id="rotateSlider" class="mas-slider" min="0" max="150" value="100" />
+          </div>
+
+          <div class="mas-form-group">
+            <label class="mas-label" for="blurSlider">
+              Blur Shift Scale
+              <span class="mas-label-val" id="blurVal">100%</span>
+            </label>
+            <input type="range" id="blurSlider" class="mas-slider" min="0" max="150" value="100" />
+          </div>
+
+          <div class="mas-form-group">
+            <label class="mas-label" for="durationSlider">
+              Base Speed Duration
+              <span class="mas-label-val" id="durationVal">300ms</span>
+            </label>
+            <input type="range" id="durationSlider" class="mas-slider" min="100" max="2000" step="50" value="300" />
+          </div>
+
+          <!-- Loop Mode & Trigger settings -->
+          <div class="mas-check-row">
+            <input type="checkbox" id="loopInfiniteCheck" />
+            <label for="loopInfiniteCheck" style="cursor: pointer;">Force Infinite Loop (Check warning impact)</label>
+          </div>
+
+          <hr class="mas-divider" />
+
+          <!-- CSS Generated Queries -->
+          <div class="mas-form-group">
+            <label class="mas-label">Accessible CSS Snippet</label>
+            <div class="mas-code-container">
+              <button type="button" class="mas-copy-btn" id="copyBtn">Copy</button>
+              <pre class="mas-code"><code id="codeOutput"></code></pre>
+            </div>
+          </div>
+
+        </form>
+      </div>
+
+    </div>
+
+  </div>
+
+  <!-- ── Motion Accessibility Logic ──────────────────────── -->
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      // Elements
+      const targetMain = document.getElementById('target-main');
+      const targetCompareOriginal = document.getElementById('target-compare-original');
+      const targetCompareSafe = document.getElementById('target-compare-safe');
+      
+      const tabStandard = document.getElementById('tabStandard');
+      const tabCompare = document.getElementById('tabCompare');
+      const standardWorkspace = document.getElementById('standardWorkspace');
+      const compareWorkspace = document.getElementById('compareWorkspace');
+      
+      const animSelect = document.getElementById('animSelect');
+      const modeBtns = document.querySelectorAll('.mas-mode-btn');
+      
+      const translateSlider = document.getElementById('translateSlider');
+      const scaleSlider = document.getElementById('scaleSlider');
+      const rotateSlider = document.getElementById('rotateSlider');
+      const blurSlider = document.getElementById('blurSlider');
+      const durationSlider = document.getElementById('durationSlider');
+      const loopInfiniteCheck = document.getElementById('loopInfiniteCheck');
+      
+      const translateVal = document.getElementById('translateVal');
+      const scaleVal = document.getElementById('scaleVal');
+      const rotateVal = document.getElementById('rotateVal');
+      const blurVal = document.getElementById('blurVal');
+      const durationVal = document.getElementById('durationVal');
+      
+      const scoreValue = document.getElementById('scoreValue');
+      const scoreRating = document.getElementById('scoreRating');
+      const scoreTips = document.getElementById('scoreTips');
+      
+      const codeOutput = document.getElementById('codeOutput');
+      const copyBtn = document.getElementById('copyBtn');
+      const replayBtn = document.getElementById('replayBtn');
+      const themeToggle = document.getElementById('themeToggle');
+
+      let currentMode = 'normal'; // normal, reduced, none
+      let isCompareMode = false;
+
+      // ── Tab Management ──────────────────────────────────────
+      tabStandard.addEventListener('click', () => {
+        tabStandard.classList.add('active');
+        tabCompare.classList.remove('active');
+        standardWorkspace.classList.remove('ease-hidden');
+        compareWorkspace.classList.add('ease-hidden');
+        isCompareMode = false;
+        updateWorkspace();
+      });
+
+      tabCompare.addEventListener('click', () => {
+        tabCompare.classList.add('active');
+        tabStandard.classList.remove('active');
+        compareWorkspace.classList.remove('ease-hidden');
+        standardWorkspace.classList.add('ease-hidden');
+        isCompareMode = true;
+        updateWorkspace();
+      });
+
+      // ── Mode pill selectors ──────────────────────────────────
+      modeBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+          modeBtns.forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          currentMode = btn.dataset.mode;
+          
+          // Auto-adjust sliders on profile toggle for demonstration
+          if (currentMode === 'reduced') {
+            translateSlider.value = 20;
+            scaleSlider.value = 40;
+            rotateSlider.value = 10;
+            blurSlider.value = 0;
+            durationSlider.value = Math.max(parseInt(durationSlider.value), 400); // make longer for comfort
+          } else if (currentMode === 'none') {
+            translateSlider.value = 0;
+            scaleSlider.value = 0;
+            rotateSlider.value = 0;
+            blurSlider.value = 0;
+          } else {
+            translateSlider.value = 100;
+            scaleSlider.value = 100;
+            rotateSlider.value = 100;
+            blurSlider.value = 100;
+          }
+          
+          updateSliderLabels();
+          updateWorkspace();
+        });
+      });
+
+      // ── Update values display ────────────────────────────────
+      function updateSliderLabels() {
+        translateVal.textContent = `${translateSlider.value}%`;
+        scaleVal.textContent = `${scaleSlider.value}%`;
+        rotateVal.textContent = `${rotateSlider.value}%`;
+        blurVal.textContent = `${blurSlider.value}%`;
+        durationVal.textContent = `${durationSlider.value}ms`;
+      }
+
+      [translateSlider, scaleSlider, rotateSlider, blurSlider, durationSlider].forEach(slider => {
+        slider.addEventListener('input', () => {
+          updateSliderLabels();
+          updateWorkspace();
+        });
+      });
+
+      loopInfiniteCheck.addEventListener('change', updateWorkspace);
+      animSelect.addEventListener('change', updateWorkspace);
+
+      // ── Workspace Refresh / Apply Style Overrides ────────────
+      function updateWorkspace() {
+        const animClass = animSelect.value;
+        const duration = `${durationSlider.value}ms`;
+        const loops = loopInfiniteCheck.checked ? 'infinite' : '1';
+
+        // 1. Clean previous targets
+        [targetMain, targetCompareOriginal, targetCompareSafe].forEach(el => {
+          el.className = 'mas-target-element ease-card-shadow';
+          el.style.animation = 'none';
+          el.offsetHeight; // force reflow
+          el.style.animation = '';
+        });
+
+        if (!isCompareMode) {
+          // Standard preview target
+          targetMain.classList.add(animClass);
+          if (currentMode === 'none') {
+            targetMain.style.animation = 'none';
+          } else {
+            targetMain.style.animationDuration = duration;
+            targetMain.style.animationIterationCount = loops;
+            applyTargetOverrides(targetMain, translateSlider.value, scaleSlider.value, rotateSlider.value, blurSlider.value);
+          }
+        } else {
+          // Compare preview targets
+          // Original: Full motion
+          targetCompareOriginal.classList.add(animClass);
+          targetCompareOriginal.style.animationDuration = duration;
+          targetCompareOriginal.style.animationIterationCount = loops;
+
+          // Safe Version: Scaled
+          targetCompareSafe.classList.add(animClass);
+          if (currentMode === 'none') {
+            targetCompareSafe.style.animation = 'none';
+          } else {
+            targetCompareSafe.style.animationDuration = duration;
+            targetCompareSafe.style.animationIterationCount = loops;
+            
+            // Reduced settings
+            const safeTranslate = Math.min(translateSlider.value, 30);
+            const safeScale = Math.min(scaleSlider.value, 40);
+            const safeRotate = Math.min(rotateSlider.value, 15);
+            const safeBlur = Math.min(blurSlider.value, 10);
+            
+            applyTargetOverrides(targetCompareSafe, safeTranslate, safeScale, safeRotate, safeBlur);
+          }
+        }
+
+        analyzeAccessibility();
+        generateCSSOutput();
+      }
+
+      // Helper to apply dynamic scaling using inline transform properties
+      function applyTargetOverrides(el, trans, scale, rot, blur) {
+        // We override transform scales by updating custom transition variables 
+        // or modifying CSS transform scales inline
+        const anim = animSelect.value;
+        let transX = '0px', transY = '0px', scaleVal = '1', rotVal = '0deg', blurFilter = 'none';
+
+        if (anim.includes('up')) transY = `${-24 * (trans / 100)}px`;
+        if (anim.includes('down')) transY = `${24 * (trans / 100)}px`;
+        if (anim.includes('left')) transX = `${-32 * (trans / 100)}px`;
+        if (anim.includes('right')) transX = `${32 * (trans / 100)}px`;
+        
+        if (anim.includes('zoom')) {
+          scaleVal = `${0.85 + (0.15 * (scale / 100))}`;
+        }
+        if (anim.includes('flip')) {
+          rotVal = `${90 * (rot / 100)}deg`;
+        }
+        if (anim.includes('blur')) {
+          blurFilter = `blur(${12 * (blur / 100)}px)`;
+        }
+
+        // Apply scaling
+        el.style.setProperty('--ease-translate-x', transX);
+        el.style.setProperty('--ease-translate-y', transY);
+        el.style.setProperty('--ease-scale', scaleVal);
+        el.style.setProperty('--ease-rotate', rotVal);
+        el.style.setProperty('--ease-blur', blurFilter);
+      }
+
+      // ── Accessibility Scoring & Rating Engine ────────────────
+      function analyzeAccessibility() {
+        let score = 100;
+        let tips = [];
+
+        const isLooping = loopInfiniteCheck.checked;
+        const duration = parseInt(durationSlider.value);
+        const trans = parseInt(translateSlider.value);
+        const scale = parseInt(scaleSlider.value);
+        const rot = parseInt(rotateSlider.value);
+        const blur = parseInt(blurSlider.value);
+        
+        // 1. Loop issues (infinite loops cause sensory fatigue)
+        if (isLooping) {
+          score -= 30;
+          tips.push("Infinite looping causes cognitive fatigue. Avoid loops or stop them after 3 iterations.");
+        }
+
+        // 2. High translation scale (abrupt shifts trigger vestibular reactions)
+        if (trans > 100) {
+          score -= 20;
+          tips.push("Large translation moves can trigger vertigo. Reduce travel distance below 15px.");
+        } else if (trans > 40 && trans <= 100) {
+          score -= 5;
+        }
+
+        // 3. Heavy rotation
+        if (rot > 100) {
+          score -= 15;
+          tips.push("Spinning/rotations can cause nausea. Limit angle offsets.");
+        }
+
+        // 4. Excessive speeds
+        if (duration < 150) {
+          score -= 20;
+          tips.push("Extremely fast animation shifts (>150ms) can trigger visual sensitivity. Slow down transitions.");
+        } else if (duration > 1500) {
+          score -= 10;
+          tips.push("Animations longer than 1.5s delay users. Keep speeds responsive.");
+        }
+
+        // Apply Simulated mode impact
+        if (currentMode === 'reduced') {
+          score = Math.min(score + 15, 100);
+        } else if (currentMode === 'none') {
+          score = 100;
+        }
+
+        // Format Score Circle
+        score = Math.max(score, 10);
+        scoreValue.textContent = score;
+        scoreValue.className = "mas-score-circle";
+
+        if (score >= 85) {
+          scoreRating.textContent = "A — Accessible Motion";
+          scoreRating.style.color = "var(--mas-success)";
+          scoreValue.classList.remove('warning', 'danger');
+        } else if (score >= 60) {
+          scoreRating.textContent = "B — Moderate Motion Risk";
+          scoreRating.style.color = "var(--mas-warning)";
+          scoreValue.classList.add('warning');
+          scoreValue.classList.remove('danger');
+        } else {
+          scoreRating.textContent = "C — High Accessibility Risk";
+          scoreRating.style.color = "var(--mas-danger)";
+          scoreValue.classList.add('danger');
+          scoreValue.classList.remove('warning');
+        }
+
+        if (tips.length === 0) {
+          scoreTips.textContent = "Great! Excellent settings. Safe for motion-sensitive users.";
+        } else {
+          scoreTips.innerHTML = `<ul>${tips.map(tip => `<li>${tip}</li>`).join('')}</ul>`;
+        }
+      }
+
+      // ── Accessible CSS Media Query Generator ────────────────
+      function generateCSSOutput() {
+        const animClass = animSelect.value;
+        const duration = `${durationSlider.value}ms`;
+        const trans = translateSlider.value;
+        const scale = scaleSlider.value;
+        const rot = rotateSlider.value;
+        const blur = blurSlider.value;
+
+        // Generate properties to override under media query
+        let queryOverrides = '';
+        if (trans < 50) {
+          queryOverrides += `  transform: translateY(0) translateX(0); /* scale down travel */\n`;
+        }
+        if (scale < 50) {
+          queryOverrides += `  transform: scale(1); /* disable scale zoom shifts */\n`;
+        }
+        if (rot < 50) {
+          queryOverrides += `  transform: rotate(0deg); /* disable rotation offsets */\n`;
+        }
+        if (blur < 50) {
+          queryOverrides += `  filter: blur(0px); /* disable intensive blurs */\n`;
+        }
+
+        const cssTemplate = `/* Standard Animation styling */\n.my-animated-element {\n  animation-name: ${animClass.replace('ease-', 'ease-kf-')};\n  animation-duration: ${duration};\n}\n\n/* Accessible styling for users with vestibular / motion sensitivities */\n@media (prefers-reduced-motion: reduce) {\n  .my-animated-element {\n    animation-duration: 800ms; /* longer duration for smooth shift */\n${queryOverrides || '    animation-name: ease-kf-fade-in; /* fall back to a simple, safe fade */\n'}  }\n}`;
+        
+        codeOutput.textContent = cssTemplate;
+      }
+
+      // ── Trigger action button ──────────────────────────────
+      replayBtn.addEventListener('click', updateWorkspace);
+
+      // ── Copy to Clipboard ──────────────────────────────────
+      copyBtn.addEventListener('click', async () => {
+        const text = codeOutput.textContent;
+        try {
+          await navigator.clipboard.writeText(text);
+          copyBtn.textContent = 'Copied!';
+          copyBtn.style.background = 'var(--mas-success)';
+          setTimeout(() => {
+            copyBtn.textContent = 'Copy';
+            copyBtn.style.background = '';
+          }, 1500);
+        } catch (err) {
+          console.error('Failed to copy code snippet', err);
+        }
+      });
+
+      // ── Theme toggle ───────────────────────────────────────
+      const setTheme = (theme) => {
+        document.body.setAttribute('data-theme', theme);
+        themeToggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+        localStorage.setItem('masTheme', theme);
+      };
+
+      const currentTheme = localStorage.getItem('masTheme') || 'dark';
+      setTheme(currentTheme);
+
+      themeToggle.addEventListener('click', () => {
+        const theme = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        setTheme(theme);
+      });
+
+      // ── Init ───────────────────────────────────────────────
+      updateSliderLabels();
+      updateWorkspace();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/motion-accessibility-studio/style.css
+++ b/submissions/examples/motion-accessibility-studio/style.css
@@ -1,0 +1,510 @@
+/* ============================================================
+   EaseMotion CSS — Motion Accessibility Studio custom styling
+   ============================================================ */
+
+/* ── Custom Theme Tokens ───────────────────────────────── */
+:root {
+  --mas-primary: #6c63ff;
+  --mas-primary-glow: rgba(108, 99, 255, 0.25);
+  --mas-success: #10b981;
+  --mas-warning: #f59e0b;
+  --mas-danger: #ef4444;
+
+  /* Dark Theme */
+  --mas-bg: #0a0d16;
+  --mas-surface: #121826;
+  --mas-surface-border: rgba(255, 255, 255, 0.08);
+  --mas-text: #f8fafc;
+  --mas-text-muted: #94a3b8;
+  --mas-input-bg: #1e293b;
+  --mas-input-border: #334155;
+  --mas-code-bg: #07090f;
+  --mas-rail-bg: rgba(255, 255, 255, 0.05);
+}
+
+[data-theme="light"] {
+  --mas-bg: #f8fafc;
+  --mas-surface: #ffffff;
+  --mas-surface-border: rgba(0, 0, 0, 0.08);
+  --mas-text: #0f172a;
+  --mas-text-muted: #64748b;
+  --mas-input-bg: #f1f5f9;
+  --mas-input-border: #cbd5e1;
+  --mas-code-bg: #0f172a;
+  --mas-rail-bg: rgba(0, 0, 0, 0.05);
+}
+
+body.mas-body {
+  background-color: var(--mas-bg);
+  color: var(--mas-text);
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.mas-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem;
+}
+
+/* ── Header Area ────────────────────────────────────────── */
+.mas-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.mas-badge {
+  display: inline-block;
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.15), rgba(108, 99, 255, 0.15));
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  color: #34d399;
+  padding: 0.35rem 0.85rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.75rem;
+}
+
+.mas-title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  margin: 0 0 0.5rem 0;
+  background: linear-gradient(135deg, var(--mas-text), #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.mas-subtitle {
+  font-size: 1.05rem;
+  color: var(--mas-text-muted);
+  max-width: 650px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+/* ── Split Layout Grid ───────────────────────────────────── */
+.mas-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+@media (max-width: 1024px) {
+  .mas-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Glassmorphic Dashboard Cards ───────────────────────── */
+.mas-card {
+  background: var(--mas-surface);
+  border: 1px solid var(--mas-surface-border);
+  border-radius: 1rem;
+  padding: 1.75rem;
+  box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.25);
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.mas-card-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--mas-surface-border);
+  padding-bottom: 0.75rem;
+}
+
+/* ── Left Side: Previews & Compare Modes ────────────────── */
+.mas-left-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.mas-preview-container {
+  position: relative;
+  min-height: 280px;
+  background-image: radial-gradient(var(--mas-rail-bg) 1.5px, transparent 1.5px);
+  background-size: 20px 20px;
+  border: 2px dashed var(--mas-surface-border);
+  border-radius: 0.75rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  transition: border-color 0.3s ease;
+}
+
+.mas-compare-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 580px) {
+  .mas-compare-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mas-compare-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mas-pane-header {
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-align: center;
+  color: var(--mas-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--mas-input-bg);
+  padding: 0.35rem;
+  border-radius: 0.35rem;
+}
+
+.mas-pane-header.accent {
+  background: var(--mas-primary-glow);
+  color: var(--mas-primary);
+}
+
+.mas-pane-screen {
+  min-height: 220px;
+  background: rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--mas-surface-border);
+  border-radius: 0.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Preview Target Styling */
+.mas-target-element {
+  width: 130px;
+  height: 130px;
+  background: linear-gradient(135deg, var(--mas-primary), #a78bfa);
+  color: white;
+  border-radius: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-weight: 700;
+  text-align: center;
+  padding: 1rem;
+  box-shadow: 0 10px 25px -5px var(--mas-primary-glow);
+  box-sizing: border-box;
+}
+
+.mas-target-element span {
+  font-size: 0.75rem;
+  font-weight: 400;
+  opacity: 0.8;
+  margin-top: 0.25rem;
+}
+
+/* Tab selector buttons */
+.mas-tab-container {
+  display: flex;
+  background: var(--mas-input-bg);
+  padding: 0.2rem;
+  border-radius: 0.5rem;
+  gap: 0.2rem;
+}
+
+.mas-tab-btn {
+  background: transparent;
+  border: none;
+  color: var(--mas-text-muted);
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.mas-tab-btn.active {
+  background: var(--mas-surface);
+  color: var(--mas-primary);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+/* Toolbar actions */
+.mas-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1rem;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+/* ── Right Side: Accessibility Controls ────────────────── */
+.mas-control-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.mas-form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.mas-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--mas-text-muted);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mas-label-val {
+  color: var(--mas-primary);
+  font-family: monospace;
+  font-size: 0.8rem;
+}
+
+.mas-select, .mas-input {
+  background: var(--mas-input-bg);
+  border: 1px solid var(--mas-input-border);
+  color: var(--mas-text);
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.5rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.mas-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 5px;
+  border-radius: 3px;
+  background: var(--mas-input-border);
+  outline: none;
+  margin: 0.4rem 0;
+}
+
+.mas-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--mas-primary);
+  cursor: pointer;
+  transition: transform 0.1s ease;
+}
+
+.mas-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.25);
+}
+
+/* Intensity group with checkbox */
+.mas-check-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+/* Mode Pills (Sensitivity selector) */
+.mas-mode-selector {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  background: var(--mas-input-bg);
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+  gap: 0.25rem;
+}
+
+.mas-mode-btn {
+  background: transparent;
+  border: none;
+  color: var(--mas-text-muted);
+  padding: 0.5rem;
+  border-radius: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: center;
+}
+
+.mas-mode-btn.active[data-mode="normal"] {
+  background: var(--mas-primary);
+  color: #fff;
+}
+
+.mas-mode-btn.active[data-mode="reduced"] {
+  background: var(--mas-warning);
+  color: #fff;
+}
+
+.mas-mode-btn.active[data-mode="none"] {
+  background: var(--mas-danger);
+  color: #fff;
+}
+
+/* ── Accessibility Score & Recommendations ────────────── */
+.mas-score-panel {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 1.25rem;
+  background: var(--mas-input-bg);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--mas-surface-border);
+  align-items: center;
+}
+
+.mas-score-circle {
+  width: 76px;
+  height: 76px;
+  border-radius: 50%;
+  border: 4px solid var(--mas-success);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: var(--mas-success);
+  background: rgba(16, 185, 129, 0.05);
+}
+
+.mas-score-circle.warning {
+  border-color: var(--mas-warning);
+  color: var(--mas-warning);
+  background: rgba(245, 158, 11, 0.05);
+}
+
+.mas-score-circle.danger {
+  border-color: var(--mas-danger);
+  color: var(--mas-danger);
+  background: rgba(239, 110, 110, 0.05);
+}
+
+.mas-score-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.mas-score-rating {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.mas-score-desc {
+  font-size: 0.8rem;
+  color: var(--mas-text-muted);
+  line-height: 1.4;
+}
+
+/* ── Code Output block ──────────────────────────────────── */
+.mas-code-container {
+  position: relative;
+  background: var(--mas-code-bg);
+  border: 1px solid var(--mas-surface-border);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-top: 0.5rem;
+  max-height: 250px;
+  overflow-y: auto;
+}
+
+.mas-code {
+  margin: 0;
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: #e2e8f0;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.mas-copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #fff;
+  padding: 0.25rem 0.55rem;
+  border-radius: 0.35rem;
+  font-size: 0.7rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  z-index: 5;
+}
+
+.mas-copy-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.mas-theme-btn {
+  background: transparent;
+  border: 1px solid var(--mas-surface-border);
+  color: var(--mas-text);
+  border-radius: 50%;
+  width: 34px;
+  height: 34px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.mas-theme-btn:hover {
+  background: var(--mas-input-bg);
+}
+
+/* Dark/Light mode theme sets */
+body[data-theme="dark"] {
+  --mas-bg: #0a0d16;
+  --mas-surface: #121826;
+  --mas-text: #f8fafc;
+  background: var(--mas-bg);
+  color: var(--mas-text);
+}
+
+body[data-theme="light"] {
+  --mas-bg: #f8fafc;
+  --mas-surface: #ffffff;
+  --mas-text: #0f172a;
+  background: var(--mas-bg);
+  color: var(--mas-text);
+}
+
+.mas-divider {
+  border: none;
+  height: 1px;
+  background: var(--mas-surface-border);
+  margin: 1rem 0;
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces the **Motion Accessibility Studio** as a self-contained tooling submission. It provides a visual dashboard for testing standard vs. vestibular-safe animation parameters side-by-side, checking real-time sensory motion compliance scores, and copying generated `prefers-reduced-motion` media queries directly.

---

## Type of Change

- [x] ✨ New animation / hover effect (Motion Accessibility Studio Utility)
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (Accessibility Development Tooling)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/motion-accessibility-studio/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A motion accessibility sandbox that lets developers simulate Normal, Reduced, and No-Motion profiles, adjust scale/translation intensities, calculate compliance scores, and export prefers-reduced-motion overrides.

**How does a developer use it?**
1. Open `submissions/examples/motion-accessibility-studio/demo.html` in a web browser.
2. Select animation class and toggle Motion Profiles (e.g. Reduced).
3. Copy generated accessible CSS queries from the code panel.

**Why does it fit EaseMotion CSS?**
It aligns with EaseMotion's accessibility-first design goals, making it easy to test comfort boundaries and ship inclusive motion presets.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

