### PR TITLE
fix: remove duplicate keyframes/classes and add lint script

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -330,16 +330,6 @@
   70%  { transform: scaleX(0.96) scaleY(1.06); }
   100% { transform: scale(1); }
 }
-@keyframes ease-kf-slide-image-exit {
-  from {
-    transform: translateX(0);
-    opacity: 1;
-  }
-  to {
-    transform: translateX(100%);
-    opacity: 0;
-  }
-}
 @keyframes ease-kf-shimmer-sweep {
   0% {
     background-position: -200% center;
@@ -379,26 +369,6 @@
     opacity: 0;
   }
 }
-@keyframes ease-kf-shimmer-sweep {
-  0% {
-    background-position: -200% center;
-  }
-  100% {
-    background-position: 200% center;
-  }
-}
-@keyframes ease-kf-slide-image-exit {
-  from {
-    transform: translateX(0);
-    opacity: 1;
-  }
-  to {
-    transform: translateX(100%);
-
-    opacity: 0;
-  }
-}
-
 @keyframes ease-kf-morph-card {
   from {
     border-radius: 8px;
@@ -450,7 +420,7 @@
 }
 /* ── Animation Utility Classes ─────────────────────────────── */
 .ease-zoom-in {
-  animation: ease-zoom-in 0.6s ease-out forwards;
+  animation: ease-kf-zoom-in var(--ease-speed-medium) var(--ease-ease-bounce) both;
 }
 
 .ease-zoom-out {
@@ -495,16 +465,6 @@
     ease-kf-bounce-text
     var(--ease-speed-medium)
     var(--ease-ease-bounce);
-}
-.ease-shimmer-sweep {
-  background: linear-gradient(
-    120deg,
-    transparent 30%,
-    rgba(255, 255, 255, 0.15) 50%,
-    transparent 70%
-  );
-  background-size: 200% auto;
-  animation: ease-kf-shimmer-sweep var(--ease-speed-slow) var(--ease-ease) infinite;
 }
 
 .ease-squish-button:hover,
@@ -618,10 +578,6 @@
 }
 .ease-slide-in-from-bottom-right {
   animation: ease-kf-slide-in-from-bottom-right var(--ease-speed-medium) var(--ease-ease) both;
-}
-
-.ease-zoom-in {
-  animation: ease-kf-zoom-in var(--ease-speed-medium) var(--ease-ease-bounce) both;
 }
 
 .ease-flip {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "components/"
   ],
   "scripts": {
-    "build": "node scripts/build-minified-css.mjs"
+    "build": "node scripts/build-minified-css.mjs",
+    "lint:duplicates": "node scripts/check-duplicates.mjs",
+    "lint": "npm run lint:duplicates"
   },
   "keywords": [
     "css",

--- a/scripts/check-duplicates.mjs
+++ b/scripts/check-duplicates.mjs
@@ -1,0 +1,79 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, "..");
+
+const dirs = ["core", "components"];
+const classPattern = /^\.([a-zA-Z0-9_-]+)\s*\{/;
+const keyframePattern = /@keyframes\s+(\S+)/;
+
+async function findDuplicates() {
+  const classes = {};
+  const keyframes = {};
+
+  for (const dir of dirs) {
+    const dirPath = path.join(rootDir, dir);
+    let entries;
+    try {
+      entries = await readdir(dirPath, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".css")) continue;
+
+      const filePath = path.join(dirPath, entry.name);
+      const content = await readFile(filePath, "utf8");
+      const lines = content.split("\n");
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+
+        const cm = line.match(classPattern);
+        if (cm) {
+          if (!classes[cm[1]]) classes[cm[1]] = [];
+          classes[cm[1]].push(`${dir}/${entry.name}:${i + 1}`);
+        }
+
+        const km = line.match(keyframePattern);
+        if (km) {
+          if (!keyframes[km[1]]) keyframes[km[1]] = [];
+          keyframes[km[1]].push(`${dir}/${entry.name}:${i + 1}`);
+        }
+      }
+    }
+  }
+
+  let exitCode = 0;
+
+  for (const [name, locations] of Object.entries(classes)) {
+    if (locations.length > 1) {
+      console.log(`Duplicate class .${name}:`);
+      locations.forEach((loc) => console.log(`  ${loc}`));
+      exitCode = 1;
+    }
+  }
+
+  for (const [name, locations] of Object.entries(keyframes)) {
+    if (locations.length > 1) {
+      console.log(`Duplicate @keyframes ${name}:`);
+      locations.forEach((loc) => console.log(`  ${loc}`));
+      exitCode = 1;
+    }
+  }
+
+  if (exitCode === 0) {
+    console.log("No duplicate class names or @keyframes found.");
+  }
+
+  process.exit(exitCode);
+}
+
+findDuplicates().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Closes #838

## Pull Request Description

Removes 4 duplicate @keyframes/class definitions in `core/animations.css` that inflate the bundle (~1.4 KB wasted) and cause override conflicts (last-definition-wins). Adds a reusable `lint:duplicates` script to prevent regressions.

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)

Core code quality fix — removes duplicate definitions and adds duplicate-detection lint script.

## Submission Checklist

> N/A — this PR fixes core framework files, not a user submission.

## Feature Description

**What does this add?**

Not a new feature — a code quality fix that deduplicates keyframes and classes in `core/animations.css` and adds a reusable lint script (`npm run lint:duplicates` / `npm run lint`) to keep duplicates out going forward.

## Notes for Maintainer

The `check-duplicates.mjs` script scans `core/` and `components/` for duplicate `.class-name` and `@keyframes name` definitions and exits non-zero if any are found. It requires zero dependencies — only Node.js built-ins. Run it with `npm run lint` or add it to CI.