### PR TITLE
fix: replace hardcoded rgba() colors in cards.css with CSS variables

### DIFF
--- a/components/cards.css
+++ b/components/cards.css
@@ -108,11 +108,11 @@
 /* ── Glass Card (glassmorphism) ────────────────────────────── */
 
 .ease-card-glass {
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: var(--ease-glass-bg);
+  border: 1px solid var(--ease-glass-border);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  color: #ffffff;
+  color: var(--ease-color-text);
 }
 
 /* ── Color Accent Cards ────────────────────────────────────── */
@@ -171,18 +171,18 @@
 /* ── Info / Alert-style Cards ──────────────────────────────── */
 
 .ease-card-info {
-  background-color: rgba(108, 99, 255, 0.06);
+  background-color: var(--ease-color-primary-alpha);
   border-color: var(--ease-color-primary-light);
   color: var(--ease-color-primary-dark);
 }
 
 .ease-card-success-bg {
-  background-color: rgba(34, 197, 94, 0.06);
+  background-color: var(--ease-color-success-alpha);
   border-color: var(--ease-color-success-light);
 }
 
 .ease-card-danger-bg {
-  background-color: rgba(239, 68, 68, 0.06);
+  background-color: var(--ease-color-danger-alpha);
   border-color: var(--ease-color-danger-light);
 }
 

--- a/core/variables.css
+++ b/core/variables.css
@@ -47,6 +47,13 @@
   --ease-color-text:    var(--ease-color-neutral-800);
   --ease-color-muted:   var(--ease-color-neutral-500);
 
+  /* ── Alpha Channel Colors ────────────────────────────────── */
+  --ease-glass-bg:            color-mix(in srgb, var(--ease-color-surface) 12%, transparent);
+  --ease-glass-border:        color-mix(in srgb, var(--ease-color-surface) 20%, transparent);
+  --ease-color-primary-alpha: color-mix(in srgb, var(--ease-color-primary) 6%, transparent);
+  --ease-color-success-alpha: color-mix(in srgb, var(--ease-color-success) 6%, transparent);
+  --ease-color-danger-alpha:  color-mix(in srgb, var(--ease-color-danger) 6%, transparent);
+
   /* ── Spacing Scale ─────────────────────────────────────── */
   --ease-space-1:  0.25rem;   /*  4px */
   --ease-space-2:  0.5rem;    /*  8px */


### PR DESCRIPTION
Closes #840

## Pull Request Description

6 hardcoded rgba() and #ffffff values in cards.css break theming.
Replaced with CSS variables defined in core/variables.css using
color-mix() for opacity support.

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)

Theming fix — replaces hardcoded colors with CSS variables.

## Submission Checklist

> N/A — this PR fixes core framework files, not a user submission.

## Notes for Maintainer

Alpha channel variables use color-mix(in srgb, ...) which is
supported in all modern browsers (Chrome 111+, Firefox 113+,
Safari 16.2+). No runtime dependencies required.