### PR TITLE
fix: replace render-blocking @import with <link> tags for Google Fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ Write UI like you describe it in English. No build steps. No memorizing shorthan
 
 ---
 
-### 🚀 One line. That's all you need.
+### 🚀 Quick Start
 
 ```html
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css" />
 ```
 
@@ -120,6 +123,9 @@ EaseMotion CSS is a curated, animation-first CSS framework where **class names r
 <!DOCTYPE html>
 <html>
 <head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css" />
 </head>
 <body>
@@ -153,6 +159,11 @@ Or in CSS / PostCSS / Sass:
 ### Option 3 — Granular imports *(pick only what you need)*
 
 ```html
+<!-- Font (optional — for Inter typography) -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+
 <!-- Core (always required — load in this exact order) -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />

--- a/core/base.css
+++ b/core/base.css
@@ -3,8 +3,6 @@
    Resets, base element styles, and typographic foundation
    ============================================================ */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
-
 /* ── Box Model Reset ───────────────────────────────────────── */
 *,
 *::before,

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,11 @@
   <title>EaseMotion CSS — Documentation</title>
   <meta name="description" content="Official documentation for EaseMotion CSS — the animation-first, human-readable CSS framework." />
 
+  <!-- Inter font — loaded via <link> instead of CSS @import for performance -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+
   <!-- EaseMotion CSS — loaded from jsDelivr CDN -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />


### PR DESCRIPTION
- Removed `@import url('...Inter...')` from core/base.css (render-blocking)
- Added `<link rel=preconnect>` + `<link rel=stylesheet>` for Inter font
  to README Quick Start, full HTML example, and granular imports
- Updated docs/index.html with the same font `<link>` tags in `<head>`

Closes #844

## Pull Request Description

CSS @import is render-blocking — it halts CSS parsing until the
font stylesheet downloads. Replaced with <link> tags in HTML so
fonts start downloading immediately (no dependency on CSS parsing).

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)

Performance fix — removes render-blocking font @import.

## Submission Checklist

> N/A — this PR fixes core framework files, not a user submission.

## Notes for Maintainer

Users who add the CDN link without the Inter font <link> will get
system font fallback (graceful degradation). Font preconnects
reduce DNS + TCP round trips before the font stylesheet is fetched.