### PR TITLE
fix: add perspective and backface-visibility to .ease-flip

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -625,6 +625,8 @@
 }
 
 .ease-flip {
+  perspective: 1000px;
+  backface-visibility: hidden;
   animation: ease-kf-flip var(--ease-speed-medium) var(--ease-ease) both;
 }
 


### PR DESCRIPTION
- Added `perspective: 1000px` for proper 3D depth rendering
- Added `backface-visibility: hidden` for Firefox/Safari support

Without these, the flip animation appears as a 2D squish
instead of a proper 3D rotation in Firefox and Safari.

Closes #846

## Pull Request Description

.ease-flip uses ease-kf-flip (rotateY) but lacked perspective
and backface-visibility, making the animation appear flat in
Firefox and potentially showing the backside in WebKit.

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)

3D rendering fix for .ease-flip animation.

## Submission Checklist

> N/A — this PR fixes core framework files, not a user submission.

## Notes for Maintainer

Flip works best on elements with explicit width/height.
For complex 3D card flips, users may need a parent wrapper
with `transform-style: preserve-3d`.
