### PR TITLE
fix: replace hardcoded max-width in .ease-container with CSS variable

### DIFF
--- a/core/utilities.css
+++ b/core/utilities.css
@@ -144,7 +144,7 @@
 /* Max-width container */
 .ease-container {
   width: 100%;
-  max-width: 1200px;
+  max-width: var(--ease-container-max);
   margin-left: auto;
   margin-right: auto;
   padding-left: var(--ease-space-6);

--- a/core/variables.css
+++ b/core/variables.css
@@ -97,6 +97,9 @@
   --ease-leading-normal: 1.6;
   --ease-leading-loose:  1.9;
 
+  /* ── Layout ──────────────────────────────────────────── */
+  --ease-container-max: 1200px;
+
   /* ── Z-Index Scale ─────────────────────────────────────── */
   --ease-z-base:    0;
   --ease-z-raised:  10;


### PR DESCRIPTION
- Added `--ease-container-max: 1200px` to `core/variables.css`
- Updated `.ease-container` in `core/utilities.css` to use `var(--ease-container-max)`

Users can now override container width via
`:root { --ease-container-max: 960px; }`
without needing `!important`.

Closes #847

## Pull Request Description

`.ease-container` had a hardcoded `max-width: 1200px` that could not be themed via CSS variables. This PR introduces `--ease-container-max` as a design token, making the container width fully customizable.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)

CSS variable theming fix for `.ease-container`.

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

> Note: This PR changes `core/` (variables.css and utilities.css) because it fixes a core framework issue, not a user submission. The submission checklist above does not apply directly.

---

## Feature Description

**What does this add?**

CSS variable `--ease-container-max` (default `1200px`) to make `.ease-container` width themable.

**How does a developer use it?**

```css
/* Override in your own stylesheet */
:root {
  --ease-container-max: 960px;  /* blog layout */
}
Why does it fit EaseMotion CSS?
Every other token uses CSS variables — this makes .ease-container consistent with the framework's theming philosophy.
Demo
N/A — core framework fix, no new submission.
Browser Testing
- Chrome
- Firefox
- Edge
- Safari (optional but appreciated)
Notes for Maintainer
No behavior change by default — --ease-container-max defaults to 1200px, the original hardcoded value.