### PR TITLE
docs: Add browser compatibility section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,22 @@ Or in CSS / PostCSS / Sass:
 
 ---
 
+## 🌐 Browser Compatibility
+
+EaseMotion CSS is compatible with all modern browsers that support CSS3 animations and custom properties.
+
+| Browser | Minimum Version | Status |
+|---------|-----------------|--------|
+| Chrome  | 49+ | ✅ Fully Supported |
+| Firefox | 31+ | ✅ Fully Supported |
+| Safari  | 9.1+ | ✅ Fully Supported |
+| Edge    | 15+ | ✅ Fully Supported |
+| Opera   | 36+ | ✅ Fully Supported |
+
+**Note:** EaseMotion CSS relies on CSS3 custom properties (`--var`) and CSS animations. Older browsers (IE 11 and below) are not supported.
+
+---
+
 ## 🧠 Philosophy
 
 EaseMotion CSS is not just a CSS library — it is a design language.


### PR DESCRIPTION
## Description

Added a comprehensive Browser Compatibility section to the README that documents which browsers are officially supported by EaseMotion CSS.

## Changes

- Added "Browser Compatibility" section after Quick Start section
- Included compatibility table showing:
  - Chrome 49+
  - Firefox 31+
  - Safari 9.1+
  - Edge 15+
  - Opera 36+
- Added note about IE 11 and older browsers not being supported

## Type of Change

- [x] 📝 Documentation improvement
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 🐛 Bug fix
- [ ] Other

## Related Issue

Closes #435

## Testing

-Verified table renders correctly in markdown format.
- Confirmed placement in README structure