### PR TITLE
feat : add circular progress ring

### DIFF
--- a/submissions/examples/circular-progress-ring/README.md
+++ b/submissions/examples/circular-progress-ring/README.md
@@ -1,0 +1,51 @@
+# Circular Progress Ring
+
+## What does this do?
+An animated circular/ring progress indicator built with CSS `conic-gradient` and `@property` — set the percentage via a single CSS custom property, and the ring animates to fill on page load.
+
+## How is it used?
+Add the progress ring element with a `--progress` custom property:
+
+```html
+<div class="progress-ring" style="--progress: 75;" data-value="75"></div>
+```
+
+Color variants:
+```html
+<div class="progress-ring ring-emerald" style="--progress: 64;" data-value="64"></div>
+<div class="progress-ring ring-amber" style="--progress: 42;" data-value="42"></div>
+<div class="progress-ring ring-rose" style="--progress: 95;" data-value="95"></div>
+<div class="progress-ring ring-cyan" style="--progress: 23;" data-value="23"></div>
+```
+
+Size variants:
+```html
+<div class="progress-ring ring-sm" style="--progress: 50;" data-value="50"></div>
+<div class="progress-ring ring-lg" style="--progress: 80;" data-value="80"></div>
+```
+
+Optional glow wrapper:
+```html
+<div class="progress-ring-wrapper">
+  <div class="progress-ring" style="--progress: 75;" data-value="75"></div>
+</div>
+```
+
+## Why is it useful?
+Circular progress indicators are essential for dashboards, profile pages, stats sections, and loading states — yet EaseMotion CSS had no such component. This submission uses the modern CSS `@property` rule to animate `conic-gradient` smoothly (something not possible with regular CSS transitions), making it technically novel while staying true to the framework's zero-JS philosophy. Includes 5 color variants, 3 sizes, glow effects, ARIA attributes, and `prefers-reduced-motion` support.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open `demo.html` directly in your browser to see 5 animated rings in different colors and percentages.
+
+## Browser Support
+- Chrome 85+, Edge 85+, Opera 71+ (full `@property` support)
+- Firefox 128+ (recently added `@property`)
+- Safari 15.4+ (partial — `@property` supported, animation may vary)
+
+## Contribution Notes
+- Class naming was handled by the contributor
+- Maintainer will rename to `ease-*` convention before merging

--- a/submissions/examples/circular-progress-ring/demo.html
+++ b/submissions/examples/circular-progress-ring/demo.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Circular Progress Ring – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Circular Progress Ring</h1>
+    <p>
+      Animated circular progress indicators using CSS <code>conic-gradient</code>
+      and <code>@property</code>. Set the percentage via a custom property.
+    </p>
+    <span class="badge">CSS @property + Conic Gradient</span>
+  </header>
+
+  <main>
+
+    <!-- Primary showcase — different percentages -->
+    <div class="ring-showcase">
+
+      <div class="ring-item">
+        <div class="progress-ring-wrapper">
+          <div
+            class="progress-ring"
+            style="--progress: 87;"
+            data-value="87"
+            role="progressbar"
+            aria-valuenow="87"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-label="Project completion: 87%"
+          ></div>
+        </div>
+        <span class="ring-label">Completion</span>
+      </div>
+
+      <div class="ring-item">
+        <div class="progress-ring-wrapper">
+          <div
+            class="progress-ring ring-emerald"
+            style="--progress: 64;"
+            data-value="64"
+            role="progressbar"
+            aria-valuenow="64"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-label="Performance: 64%"
+          ></div>
+        </div>
+        <span class="ring-label">Performance</span>
+      </div>
+
+      <div class="ring-item">
+        <div class="progress-ring-wrapper">
+          <div
+            class="progress-ring ring-amber"
+            style="--progress: 42;"
+            data-value="42"
+            role="progressbar"
+            aria-valuenow="42"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-label="Storage: 42%"
+          ></div>
+        </div>
+        <span class="ring-label">Storage</span>
+      </div>
+
+      <div class="ring-item">
+        <div class="progress-ring-wrapper">
+          <div
+            class="progress-ring ring-rose"
+            style="--progress: 95;"
+            data-value="95"
+            role="progressbar"
+            aria-valuenow="95"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-label="Health: 95%"
+          ></div>
+        </div>
+        <span class="ring-label">Health</span>
+      </div>
+
+      <div class="ring-item">
+        <div class="progress-ring-wrapper">
+          <div
+            class="progress-ring ring-cyan"
+            style="--progress: 23;"
+            data-value="23"
+            role="progressbar"
+            aria-valuenow="23"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-label="Bandwidth: 23%"
+          ></div>
+        </div>
+        <span class="ring-label">Bandwidth</span>
+      </div>
+
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/circular-progress-ring/style.css
+++ b/submissions/examples/circular-progress-ring/style.css
@@ -1,0 +1,251 @@
+
+/*  CSS Custom Properties  */
+:root {
+  --ring-size: 160px;
+  --ring-stroke: 12px;
+  --ring-bg-track: #1e1e24;
+  --ring-color-start: #6366f1;
+  --ring-color-end: #a78bfa;
+  --ring-trail: #27272a;
+  --ring-animation-duration: 1.6s;
+  --ring-animation-easing: cubic-bezier(0.4, 0, 0.2, 1);
+
+  --page-bg: #0f0f11;
+  --page-surface: #18181b;
+  --page-border: #27272a;
+  --page-text: #a1a1aa;
+  --page-heading: #f4f4f5;
+  --page-accent: #6366f1;
+}
+
+/*  Reset & Page Layout  */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: var(--page-bg);
+  color: var(--page-text);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.progress-ring {
+  position: relative;
+  width: var(--ring-size);
+  height: var(--ring-size);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  /* The conic-gradient creates the ring fill */
+  background: conic-gradient(
+    var(--ring-color-start) 0%,
+    var(--ring-color-end) calc(var(--progress, 0) * 1%),
+    var(--ring-trail) calc(var(--progress, 0) * 1%) 100%
+  );
+
+  /* Animate the progress on load */
+  animation: ring-fill var(--ring-animation-duration) var(--ring-animation-easing) forwards;
+}
+
+/* Inner circle cutout — makes it a ring instead of a pie */
+.progress-ring::before {
+  content: '';
+  position: absolute;
+  width: calc(var(--ring-size) - var(--ring-stroke) * 2);
+  height: calc(var(--ring-size) - var(--ring-stroke) * 2);
+  border-radius: 50%;
+  background: var(--ring-bg-track);
+}
+
+/* Percentage label in center */
+.progress-ring::after {
+  content: attr(data-value) '%';
+  position: relative;
+  z-index: 1;
+  font-size: calc(var(--ring-size) * 0.18);
+  font-weight: 700;
+  color: var(--page-heading);
+  letter-spacing: -0.02em;
+}
+
+/*  Fill Animation  */
+@property --progress-anim {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 0;
+}
+
+.progress-ring {
+  --progress-anim: 0;
+  background: conic-gradient(
+    var(--ring-color-start) 0%,
+    var(--ring-color-end) calc(var(--progress-anim) * 1%),
+    var(--ring-trail) calc(var(--progress-anim) * 1%) 100%
+  );
+  animation: ring-fill var(--ring-animation-duration) var(--ring-animation-easing) forwards;
+}
+
+@keyframes ring-fill {
+  from {
+    --progress-anim: 0;
+  }
+  to {
+    --progress-anim: var(--progress);
+  }
+}
+
+/*  Subtle Glow Behind Ring  */
+.progress-ring-wrapper {
+  position: relative;
+}
+
+.progress-ring-wrapper::before {
+  content: '';
+  position: absolute;
+  inset: -12px;
+  border-radius: 50%;
+  background: conic-gradient(
+    rgba(99, 102, 241, 0.2) 0%,
+    rgba(167, 139, 250, 0.15) 50%,
+    transparent 100%
+  );
+  filter: blur(20px);
+  opacity: 0.6;
+  animation: glow-pulse 3s ease-in-out infinite alternate;
+}
+
+@keyframes glow-pulse {
+  from { opacity: 0.4; }
+  to   { opacity: 0.7; }
+}
+
+.progress-ring.ring-emerald {
+  --ring-color-start: #10b981;
+  --ring-color-end: #34d399;
+}
+
+.progress-ring.ring-amber {
+  --ring-color-start: #f59e0b;
+  --ring-color-end: #fbbf24;
+}
+
+.progress-ring.ring-rose {
+  --ring-color-start: #f43f5e;
+  --ring-color-end: #fb7185;
+}
+
+.progress-ring.ring-cyan {
+  --ring-color-start: #06b6d4;
+  --ring-color-end: #22d3ee;
+}
+
+.progress-ring.ring-sm {
+  --ring-size: 100px;
+  --ring-stroke: 8px;
+}
+
+.progress-ring.ring-lg {
+  --ring-size: 200px;
+  --ring-stroke: 14px;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.demo-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--page-heading);
+  margin-bottom: 8px;
+  letter-spacing: -0.02em;
+}
+
+.demo-header p {
+  font-size: 1rem;
+  color: var(--page-text);
+  max-width: 460px;
+}
+
+.demo-header .badge {
+  display: inline-block;
+  margin-top: 16px;
+  padding: 5px 14px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--page-accent);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ring-showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 48px;
+  justify-content: center;
+  align-items: center;
+}
+
+.ring-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.ring-item .ring-label {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--page-text);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ---------- Reduced Motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .progress-ring {
+    animation: none;
+    --progress-anim: var(--progress);
+  }
+
+  .progress-ring-wrapper::before {
+    animation: none;
+    opacity: 0.5;
+  }
+}
+
+/*  Responsive  */
+@media (max-width: 600px) {
+  .ring-showcase {
+    gap: 32px;
+  }
+
+  :root {
+    --ring-size: 120px;
+    --ring-stroke: 10px;
+  }
+
+  .progress-ring.ring-sm {
+    --ring-size: 80px;
+  }
+
+  .progress-ring.ring-lg {
+    --ring-size: 150px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Submitting a new CSS-only animated circular progress ring component that animates its fill percentage using `conic-gradient` and `@property`.

Closes #979 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/circular-progress-ring/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An animated circular progress indicator built entirely with CSS `conic-gradient` and `@property` that fills to a target percentage.

**How does a developer use it?**

```html
<div class="progress-ring ring-emerald ring-lg" style="--progress: 75;" data-value="75"></div>
```

**Why does it fit EaseMotion CSS?**

It solves a common UI need (circular progress) using modern CSS without any JavaScript, fitting perfectly with the framework's zero-JS, animation-first philosophy, while remaining highly composable with size and color classes.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This uses the modern `@property` CSS feature for smoothly animating the `conic-gradient`. Browsers without `@property` support will snap directly to the final percentage instead of animating smoothly. I've left the class names as `progress-ring` for now, but you can rename them to `ease-*` as per the contributing guidelines.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
