### PR TITLE
feat : add css-only-tabs

### DIFF
--- a/submissions/examples/css-only-tabs/README.md
+++ b/submissions/examples/css-only-tabs/README.md
@@ -1,0 +1,38 @@
+# CSS-Only Tabs
+
+## What does this do?
+A fully functional tab navigation component powered entirely by hidden radio buttons and CSS — zero JavaScript required.
+
+## How is it used?
+Wrap radio inputs, label nav, and content panels inside a container:
+
+```html
+<div class="tabs-container">
+  <input type="radio" name="tabs" id="tab-1" checked>
+  <input type="radio" name="tabs" id="tab-2">
+
+  <nav class="tab-nav">
+    <label class="tab-label" for="tab-1">Tab 1</label>
+    <label class="tab-label" for="tab-2">Tab 2</label>
+  </nav>
+
+  <div class="tab-panels">
+    <section class="tab-panel">Content 1</section>
+    <section class="tab-panel">Content 2</section>
+  </div>
+</div>
+```
+
+## Why is it useful?
+Tabs are one of the most fundamental UI patterns on the web, yet EaseMotion CSS had no tab component. This submission fills that gap with a pure-CSS solution that features smooth fade + slide transitions, an animated active-state indicator, responsive mobile stacking, and `prefers-reduced-motion` support — fully aligned with the framework's no-JS philosophy.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open `demo.html` directly in your browser to see the effect.
+
+## Contribution Notes
+- Class naming was handled by the contributor
+- Maintainer will rename to `ease-*` convention before merging

--- a/submissions/examples/css-only-tabs/demo.html
+++ b/submissions/examples/css-only-tabs/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Tabs – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="tabs-container">
+
+    <!-- Hidden radio inputs — the engine behind the tabs -->
+    <input type="radio" name="tabs" id="tab-1" checked>
+    <input type="radio" name="tabs" id="tab-2">
+    <input type="radio" name="tabs" id="tab-3">
+    <input type="radio" name="tabs" id="tab-4">
+
+    <!-- Tab navigation labels -->
+    <nav class="tab-nav" aria-label="Tabs">
+      <label class="tab-label" for="tab-1">Overview</label>
+      <label class="tab-label" for="tab-2">Features</label>
+      <label class="tab-label" for="tab-3">Setup</label>
+      <label class="tab-label" for="tab-4">FAQ</label>
+    </nav>
+
+    <!-- Tab content panels -->
+    <div class="tab-panels">
+
+      <section class="tab-panel">
+        <h3><span class="icon">📋</span> Overview</h3>
+        <p>
+          EaseMotion CSS is a curated, utility-first animation framework built
+          entirely with pure CSS. No JavaScript dependencies, no build steps —
+          just drop in a class and watch your UI come alive with beautiful,
+          performant motion.
+        </p>
+        <div class="tag-row">
+          <span class="tag">Pure CSS</span>
+          <span class="tag">Lightweight</span>
+          <span class="tag">No JS</span>
+        </div>
+      </section>
+
+      <section class="tab-panel">
+        <h3><span class="icon">✨</span> Features</h3>
+        <p>
+          Over 200+ ready-to-use animation classes covering hover effects,
+          entrance animations, looping motions, skeleton loaders, text effects,
+          and full UI components — all following a consistent <code>ease-*</code>
+          naming convention for a cohesive developer experience.
+        </p>
+        <div class="tag-row">
+          <span class="tag">200+ Classes</span>
+          <span class="tag">Hover Effects</span>
+          <span class="tag">Entrances</span>
+          <span class="tag">Dark Mode</span>
+        </div>
+      </section>
+
+      <section class="tab-panel">
+        <h3><span class="icon">⚡</span> Quick Setup</h3>
+        <p>
+          Link the compiled CSS file directly in your HTML — no npm install or
+          bundler config required. For advanced setups, individual module imports
+          via Vite or Webpack are fully supported. Add a class, refresh, done.
+        </p>
+        <div class="tag-row">
+          <span class="tag">CDN Ready</span>
+          <span class="tag">Vite Support</span>
+          <span class="tag">Zero Config</span>
+        </div>
+      </section>
+
+      <section class="tab-panel">
+        <h3><span class="icon">❓</span> Frequently Asked</h3>
+        <p>
+          <strong>Is JavaScript required?</strong> No. Every component and
+          animation works with pure HTML and CSS only.
+          <br><br>
+          <strong>Does it support dark mode?</strong> Yes — both manual toggle
+          and automatic <code>prefers-color-scheme</code> detection are
+          supported via CSS custom properties.
+        </p>
+        <div class="tag-row">
+          <span class="tag">CSS Only</span>
+          <span class="tag">Accessible</span>
+        </div>
+      </section>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-only-tabs/style.css
+++ b/submissions/examples/css-only-tabs/style.css
@@ -1,0 +1,202 @@
+/*  CSS Custom Properties  */
+:root {
+  --tab-accent: #6366f1;
+  --tab-accent-glow: rgba(99, 102, 241, 0.35);
+  --tab-bg: #111113;
+  --tab-surface: #1a1a1f;
+  --tab-border: #2a2a32;
+  --tab-text: #a1a1aa;
+  --tab-text-active: #f4f4f5;
+  --tab-radius: 14px;
+  --tab-transition: 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/*  Reset & Page Layout  */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: var(--tab-bg);
+  color: var(--tab-text);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+/*  Tabs Container  */
+.tabs-container {
+  width: 100%;
+  max-width: 640px;
+}
+
+/* Hide native radio inputs */
+.tabs-container input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/*  Tab Navigation  */
+.tab-nav {
+  display: flex;
+  position: relative;
+  background: var(--tab-surface);
+  border-radius: var(--tab-radius);
+  padding: 5px;
+  gap: 4px;
+  border: 1px solid var(--tab-border);
+}
+
+.tab-label {
+  flex: 1;
+  text-align: center;
+  padding: 12px 20px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--tab-text);
+  cursor: pointer;
+  border-radius: calc(var(--tab-radius) - 4px);
+  transition:
+    color var(--tab-transition),
+    background var(--tab-transition),
+    box-shadow var(--tab-transition);
+  position: relative;
+  z-index: 1;
+  user-select: none;
+  letter-spacing: 0.01em;
+}
+
+.tab-label:hover {
+  color: var(--tab-text-active);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+/* Active tab label — triggered by :checked sibling */
+#tab-1:checked ~ .tab-nav label[for="tab-1"],
+#tab-2:checked ~ .tab-nav label[for="tab-2"],
+#tab-3:checked ~ .tab-nav label[for="tab-3"],
+#tab-4:checked ~ .tab-nav label[for="tab-4"] {
+  color: var(--tab-text-active);
+  background: var(--tab-accent);
+  box-shadow:
+    0 2px 12px var(--tab-accent-glow),
+    0 0 0 1px rgba(99, 102, 241, 0.2);
+  font-weight: 600;
+}
+
+/*  Tab Panels  */
+.tab-panels {
+  position: relative;
+  margin-top: 16px;
+  min-height: 200px;
+}
+
+.tab-panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: var(--tab-surface);
+  border: 1px solid var(--tab-border);
+  border-radius: var(--tab-radius);
+  padding: 28px 24px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px) scale(0.98);
+  transition:
+    opacity var(--tab-transition),
+    transform var(--tab-transition),
+    visibility 0s linear 0.35s;
+}
+
+/* Show active panel */
+#tab-1:checked ~ .tab-panels .tab-panel:nth-child(1),
+#tab-2:checked ~ .tab-panels .tab-panel:nth-child(2),
+#tab-3:checked ~ .tab-panels .tab-panel:nth-child(3),
+#tab-4:checked ~ .tab-panels .tab-panel:nth-child(4) {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  transition:
+    opacity var(--tab-transition),
+    transform var(--tab-transition),
+    visibility 0s linear 0s;
+}
+
+/*  Panel Content Styling  */
+.tab-panel h3 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--tab-text-active);
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tab-panel h3 .icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: rgba(99, 102, 241, 0.15);
+  color: var(--tab-accent);
+  font-size: 1rem;
+}
+
+.tab-panel p {
+  font-size: 0.92rem;
+  line-height: 1.7;
+  color: var(--tab-text);
+}
+
+.tab-panel .tag-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
+.tab-panel .tag {
+  padding: 5px 12px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--tab-accent);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+/*  Responsive  */
+@media (max-width: 480px) {
+  .tab-nav {
+    flex-direction: column;
+  }
+
+  .tab-label {
+    padding: 10px 16px;
+    font-size: 0.85rem;
+  }
+
+  .tab-panel {
+    padding: 20px 16px;
+  }
+}
+
+/*  Reduced Motion  */
+@media (prefers-reduced-motion: reduce) {
+  .tab-label,
+  .tab-panel {
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Submitting a new CSS-only tab navigation component powered by hidden radio buttons, featuring smooth fade and slide panel transitions.

Closes #980 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/css-only-tabs/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fully functional, responsive tab navigation component built entirely without JavaScript using hidden radio buttons.

**How does a developer use it?**

```html
<div class="tabs-container">
  <input type="radio" name="tabs" id="tab-1" checked>
  <input type="radio" name="tabs" id="tab-2">
  <nav class="tab-nav">
    <label class="tab-label" for="tab-1">Tab 1</label>
    <label class="tab-label" for="tab-2">Tab 2</label>
  </nav>
  <div class="tab-panels">
    <section class="tab-panel">Content 1</section>
    <section class="tab-panel">Content 2</section>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

Tabs are a fundamental UI pattern, and providing a clean, accessible, and smoothly animated CSS-only solution aligns perfectly with EaseMotion's goals of lightweight, zero-JS motion components.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The tabs currently support up to 4 items using the sibling selector `~` in CSS. I've used standard class names like `tabs-container` which can be renamed to the `ease-*` convention when merged.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
