### PR TITLE
DevOps : Implement automated CSS bundle size tracking on PRs

### DIFF
--- a/.github/workflows/css-size-benchmark.yml
+++ b/.github/workflows/css-size-benchmark.yml
@@ -1,0 +1,123 @@
+name: CSS Size Benchmark
+
+on:
+  pull_request:
+    paths:
+      - 'core/**'
+      - 'components/**'
+      - 'scripts/build-minified-css.mjs'
+      - 'easemotion.css'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark:
+    name: Benchmark CSS Size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Create Measurement Script
+        run: |
+          cat << 'EOF' > measure.mjs
+          import fs from 'fs';
+          import zlib from 'zlib';
+          if (!fs.existsSync('easemotion.min.css')) {
+            console.log('0,0,0');
+            process.exit(0);
+          }
+          const fileBuffer = fs.readFileSync('easemotion.min.css');
+          console.log(`${fileBuffer.length},${zlib.gzipSync(fileBuffer).length},${zlib.brotliCompressSync(fileBuffer).length}`);
+          EOF
+
+      - name: Measure PR Branch
+        run: |
+          npm run build || true
+          SIZES=$(node measure.mjs)
+          echo "PR_RAW=$(echo $SIZES | cut -d',' -f1)" >> $GITHUB_ENV
+          echo "PR_GZIP=$(echo $SIZES | cut -d',' -f2)" >> $GITHUB_ENV
+          echo "PR_BROTLI=$(echo $SIZES | cut -d',' -f3)" >> $GITHUB_ENV
+
+      - name: Checkout Base Branch
+        run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Measure Base Branch
+        run: |
+          npm run build || true
+          SIZES=$(node measure.mjs)
+          echo "MAIN_RAW=$(echo $SIZES | cut -d',' -f1)" >> $GITHUB_ENV
+          echo "MAIN_GZIP=$(echo $SIZES | cut -d',' -f2)" >> $GITHUB_ENV
+          echo "MAIN_BROTLI=$(echo $SIZES | cut -d',' -f3)" >> $GITHUB_ENV
+
+      - name: Post Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const formatBytes = (bytes) => (bytes / 1024).toFixed(2) + ' KB';
+            const getDiff = (pr, main) => {
+              const diff = pr - main;
+              const sign = diff > 0 ? '+' : '';
+              return `${sign}${(diff / 1024).toFixed(2)} KB`;
+            };
+            const getIcon = (pr, main) => {
+              if (pr > main) return '📈';
+              if (pr < main) return '📉';
+              return '➖';
+            };
+
+            const prRaw = parseInt(process.env.PR_RAW) || 0;
+            const prGzip = parseInt(process.env.PR_GZIP) || 0;
+            const prBrotli = parseInt(process.env.PR_BROTLI) || 0;
+            
+            const mainRaw = parseInt(process.env.MAIN_RAW) || 0;
+            const mainGzip = parseInt(process.env.MAIN_GZIP) || 0;
+            const mainBrotli = parseInt(process.env.MAIN_BROTLI) || 0;
+
+            let body = `### 📊 CSS Bundle Size Benchmark\n\n`;
+            
+            if (prRaw === mainRaw && prGzip === mainGzip) {
+              body += `No change in CSS bundle size. ✨\n`;
+            } else {
+              body += `This PR changes the size of \`easemotion.min.css\`.\n\n`;
+              body += `| Metric | Base Branch | This PR | Difference |\n`;
+              body += `|---|---|---|---|\n`;
+              body += `| **Raw** | ${formatBytes(mainRaw)} | ${formatBytes(prRaw)} | ${getIcon(prRaw, mainRaw)} ${getDiff(prRaw, mainRaw)} |\n`;
+              body += `| **Gzip** | ${formatBytes(mainGzip)} | ${formatBytes(prGzip)} | ${getIcon(prGzip, mainGzip)} ${getDiff(prGzip, mainGzip)} |\n`;
+              body += `| **Brotli** | ${formatBytes(mainBrotli)} | ${formatBytes(prBrotli)} | ${getIcon(prBrotli, mainBrotli)} ${getDiff(prBrotli, mainBrotli)} |\n`;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && comment.body.includes('CSS Bundle Size Benchmark')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: body
+              });
+            }


### PR DESCRIPTION
## Pull Request Description

### 📊 CSS Bundle Size Benchmark Automation

This PR introduces a GitHub Actions workflow that automatically tracks CSS bundle size changes for `easemotion.min.css` on relevant pull requests.

It helps ensure the framework remains lightweight by automatically measuring and reporting the impact of every change.

Closes #998 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] ⚙️ Other (DevOps / CI improvement)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `.github/workflows/css-size-benchmark.yml`
- [x] Includes `measure.mjs` script for size calculation
- [x] Measures Raw, Gzip, and Brotli sizes using Node.js `fs` + `zlib`
- [x] Compares PR branch with base branch (`main`)
- [x] Automatically posts or updates PR comment with results
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (CI improvement only)

---

## Feature Description

**What does this add?**

Automates CSS bundle size tracking for `easemotion.min.css` using GitHub Actions.

**How does a developer use it?**

No manual usage required.

When a PR modifies:
- `core/**`
- `components/**`
- `scripts/build-minified-css.mjs`
- `easemotion.css`

the workflow automatically:
- Builds PR version
- Measures CSS size (Raw, Gzip, Brotli)
- Builds base branch version (`main`)
- Compares results
- Posts/updates a PR comment with a size table

**Why does it fit EaseMotion CSS?**

EaseMotion CSS focuses on lightweight, performance-first animations.

This system ensures:
- No accidental CSS bloat
- Instant visibility of performance impact
- Cleaner code reviews for maintainers
- Long-term framework optimization

---

## Demo

- [x] GitHub Actions workflow runs automatically on PR
- [x] PR comment is updated (no duplicate spam)
- [x] Size comparison table is generated correctly

Demo tested PR :- https://github.com/Abhay-1704/EaseMotion-css/pull/1
You can see bot lefts comment whenever the core file CSS is changed giving total bundle size

---

## Browser Testing

- [x] GitHub Actions (Ubuntu latest runner)
- [x] Node.js 20
- [x] GitHub API PR comment system

---

## Notes for Maintainer

This PR is a **non-breaking CI improvement only**.

- No changes to core framework behavior
- No changes to CSS output logic
- Fully dependency-free (Node.js built-in modules only)
- Comment system is designed to update existing comment instead of creating new ones

Optional future improvements:
- Add threshold alerts for size increase limits
- Add weekly bundle size trend report
- Add README badge for size tracking

---

> 📊 CSS Bundle Size Benchmark Example Output:

| Metric | Base Branch | This PR | Difference |
|--------|-------------|---------|------------|
| Raw | 35.10 KB | 35.30 KB | 📈 +0.20 KB |
| Gzip | 10.05 KB | 10.15 KB | 📈 +0.10 KB |
| Brotli | 8.50 KB | 8.55 KB | 📈 +0.05 KB |

---

> This PR does not modify UI/UX or CSS features — it only adds automated performance tracking infrastructure.