### PR TITLE
feat: add ease-delay-400/600/800/1000 stagger delay helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ EaseMotion CSS v1.0.0 is the first public release of the framework. This version
   - Entrance: `ease-fade-in`, `ease-fade-out`, `ease-slide-up`, `ease-slide-down`, `ease-slide-in-left`, `ease-slide-in-right`, `ease-zoom-in`, `ease-flip`
   - Looping: `ease-bounce`, `ease-rotate`, `ease-pulse`, `ease-ping`, `ease-shake`
   - Hover: `ease-hover-grow`, `ease-hover-shrink`, `ease-hover-glow`, `ease-hover-lift`, `ease-hover-underline`
-  - Stagger delays: `ease-delay-75`, `ease-delay-100`, `ease-delay-150`, `ease-delay-200`, `ease-delay-300`, `ease-delay-500`, `ease-delay-700`
+  - Stagger delays: `ease-delay-75`, `ease-delay-100`, `ease-delay-150`, `ease-delay-200`, `ease-delay-300`, `ease-delay-400`, `ease-delay-500`, `ease-delay-600`, `ease-delay-700`, `ease-delay-800`, `ease-delay-1000`
   - Duration overrides: `ease-duration-fast/medium/slow`
   - `prefers-reduced-motion` support
 

--- a/core/animations.css
+++ b/core/animations.css
@@ -595,8 +595,12 @@ animation:
 .ease-delay-150 { animation-delay: 150ms; }
 .ease-delay-200 { animation-delay: 200ms; }
 .ease-delay-300 { animation-delay: 300ms; }
+.ease-delay-400 { animation-delay: 400ms; }
 .ease-delay-500 { animation-delay: 500ms; }
+.ease-delay-600 { animation-delay: 600ms; }
 .ease-delay-700 { animation-delay: 700ms; }
+.ease-delay-800 { animation-delay: 800ms; }
+.ease-delay-1000 { animation-delay: 1000ms; }
 
 /* ── Duration Overrides ────────────────────────────────────── */
 .ease-duration-fast   { animation-duration: var(--ease-speed-fast); }


### PR DESCRIPTION
## Pull Request Description

Extends the existing stagger animation helper utilities by adding support for:

* `ease-delay-400`
* `ease-delay-600`
* `ease-delay-800`
* `ease-delay-1000`

These additions provide larger stagger delay intervals for animation sequencing while maintaining the existing EaseMotion CSS naming conventions.

---

## Type of Change

* [x] Other (Framework enhancement)

---

## Submission Checklist

* [x] One focused change per PR
* [x] Existing functionality preserved
* [x] Documentation updated (CHANGELOG.md)
* [x] No unrelated files modified

---

## Feature Description

**What does this add?**

Adds four new stagger delay utility classes for larger animation sequences.

**How does a developer use it?**

```html
<div class="ease-slide-up ease-delay-400">Item 1</div>
<div class="ease-slide-up ease-delay-600">Item 2</div>
<div class="ease-slide-up ease-delay-800">Item 3</div>
<div class="ease-slide-up ease-delay-1000">Item 4</div>
```

**Why does it fit EaseMotion CSS?**

The new utilities extend the existing delay helper system using the same human-readable naming convention and animation-first philosophy already used throughout the framework.

---

## Changes Made

* Added `ease-delay-400`
* Added `ease-delay-600`
* Added `ease-delay-800`
* Added `ease-delay-1000`
* Updated `CHANGELOG.md`

---

Closes #224
