### PR TITLE
Add tag input component submission

### DIFF
--- a/submissions/examples/tag-input-component/README.md
+++ b/submissions/examples/tag-input-component/README.md
@@ -1,0 +1,22 @@
+# Tag Input Component
+
+## What does this do?
+
+Adds a styled CSS-only tag input wrapper where chips are displayed inline with a text input.
+
+## How is it used?
+
+```html
+<div class="ease-tag-input">
+  <span class="ease-tag">
+    HTML
+    <button type="button" aria-label="Remove HTML tag">×</button>
+  </span>
+
+  <span class="ease-tag">
+    CSS
+    <button type="button" aria-label="Remove CSS tag">×</button>
+  </span>
+
+  <input type="text" placeholder="Add a tag..." aria-label="Add a tag" />
+</div>

--- a/submissions/examples/tag-input-component/demo.html
+++ b/submissions/examples/tag-input-component/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tag Input Component Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-page">
+    <section class="demo-header">
+      <h1>Tag Input Component</h1>
+      <p>
+        A CSS-only tag input wrapper that displays selected tags inline with a text input.
+      </p>
+    </section>
+
+    <section class="demo-panel" aria-labelledby="tag-input-title">
+      <label id="tag-input-title" class="tag-input-label" for="tag-input">
+        Skills
+      </label>
+
+      <div class="ease-tag-input" role="group" aria-labelledby="tag-input-title">
+        <span class="ease-tag">
+          HTML
+          <button type="button" aria-label="Remove HTML tag">×</button>
+        </span>
+
+        <span class="ease-tag">
+          CSS
+          <button type="button" aria-label="Remove CSS tag">×</button>
+        </span>
+
+        <span class="ease-tag">
+          Accessibility
+          <button type="button" aria-label="Remove Accessibility tag">×</button>
+        </span>
+
+        <input
+          id="tag-input"
+          type="text"
+          placeholder="Add a tag..."
+          aria-label="Add a tag"
+        />
+      </div>
+
+      <p class="demo-hint">
+        This demo shows the visual structure only. Tag creation and removal can be connected with JavaScript in an application.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/tag-input-component/style.css
+++ b/submissions/examples/tag-input-component/style.css
@@ -1,0 +1,132 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  color: #172033;
+  background: #f6f8fb;
+}
+
+.demo-page {
+  width: min(760px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.demo-header {
+  margin-bottom: 28px;
+}
+
+.demo-header h1 {
+  margin: 0 0 12px;
+  font-size: 2rem;
+  line-height: 1.2;
+}
+
+.demo-header p {
+  margin: 0;
+  color: #526071;
+  line-height: 1.6;
+}
+
+.demo-panel {
+  padding: 24px;
+  border: 1px solid #d8dee8;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.tag-input-label {
+  display: inline-block;
+  margin-bottom: 10px;
+  font-weight: 700;
+}
+
+.ease-tag-input {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  min-height: 48px;
+  padding: 8px;
+  border: 1px solid #b9c3d1;
+  border-radius: 8px;
+  background: #ffffff;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.ease-tag-input:focus-within {
+  border-color: #2f6fed;
+  box-shadow: 0 0 0 3px rgba(47, 111, 237, 0.18);
+}
+
+.ease-tag-input input {
+  flex: 1 1 140px;
+  min-width: 120px;
+  border: 0;
+  outline: 0;
+  padding: 8px 4px;
+  color: #172033;
+  font: inherit;
+  background: transparent;
+}
+
+.ease-tag-input input::placeholder {
+  color: #7a8797;
+}
+
+.ease-tag {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  max-width: 100%;
+  padding: 6px 8px 6px 10px;
+  border-radius: 999px;
+  color: #173b2f;
+  background: #dff5ea;
+  font-size: 0.92rem;
+  line-height: 1;
+}
+
+.ease-tag button {
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border: 0;
+  border-radius: 50%;
+  padding: 0;
+  color: #173b2f;
+  background: rgba(23, 59, 47, 0.12);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+}
+
+.ease-tag button:hover {
+  background: rgba(23, 59, 47, 0.2);
+}
+
+.ease-tag button:focus-visible {
+  outline: 2px solid #2f6fed;
+  outline-offset: 2px;
+}
+
+.demo-hint {
+  margin: 12px 0 0;
+  color: #526071;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+@media (max-width: 520px) {
+  .demo-page {
+    padding: 32px 0;
+  }
+
+  .demo-panel {
+    padding: 18px;
+  }
+}


### PR DESCRIPTION
Fixes #288 
## Pull Request Description

Adds a new CSS-only tag input component submission. It provides a styled wrapper where chips/tags are displayed inline with an input field, useful for skills, labels, filters, and multi-value form inputs.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/tag-input-component/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a styled CSS-only tag input area where chips/tags are displayed inline with a text input field.

**How does a developer use it?**

```html
<div class="ease-tag-input">
  <span class="ease-tag">
    HTML
    <button type="button" aria-label="Remove HTML tag">×</button>
  </span>

  <span class="ease-tag">
    CSS
    <button type="button" aria-label="Remove CSS tag">×</button>
  </span>

  <input type="text" placeholder="Add a tag..." aria-label="Add a tag" />
</div>


**Why does it fit EaseMotion CSS?**

It fits EaseMotion CSS by offering a simple, human-readable, reusable UI pattern built with plain CSS. The component keeps the structure lightweight and composable while still supporting accessible form controls and a polished interface.

**Demo**
Demo added (demo.html works by opening directly in a browser)

**Browser Testing**
[x]Chrome
[]Firefox
[]Edge
[]Safari (optional but appreciated)

**Notes for Maintainer**
The submission is limited to submissions/examples/tag-input-component/ and includes only the required demo.html, style.css, and README.md files. The demo is CSS-only and shows the visual wrapper, inline chips, remove buttons, focus state, and input field.


