### PR TITLE
Add dark mode docs and submission demo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -343,6 +343,7 @@
         <div class="sidebar-group-label">Core</div>
         <ul class="sidebar-nav">
           <li><a href="#variables">Variables</a></li>
+          <li><a href="#dark-mode">Dark Mode</a></li>
           <li><a href="#utilities">Utilities</a></li>
           <li><a href="#animations">Animations</a></li>
           <li><a href="#browser-compatibility">Browser Compatibility</a></li>
@@ -459,24 +460,23 @@
       <hr class="docs-divider" />
 
       <!-- ══════════════ VARIABLES ══════════════ -->
-      <<section id="variables" class="docs-section">
+      <section id="variables" class="docs-section">
         <h2 class="docs-h2">Variables</h2>
 
         <p class="docs-p">
-        All values are defined as CSS custom properties in <code>:root</code>.
-        Override any token to theme the framework.
+          All values are defined as CSS custom properties in <code>:root</code>.
+          Override any token to theme the framework.
         </p>
 
         <h3 class="docs-h3">CSS Custom Properties Reference</h3>
 
         <p class="docs-p">
-    The table below documents every <code>--ease-*</code> design token,
-    its default value, purpose, and an example override.
+          The table below documents every <code>--ease-*</code> design token,
+          its default value, purpose, and an example override.
         </p>
 
         <h3 class="docs-h3">Transition Speeds</h3>
-
-  <     table class="docs-table">
+        <table class="docs-table">
           <thead><tr><th>Variable</th><th>Value</th></tr></thead>
           <tbody>
             <tr><td><code>--ease-speed-fast</code></td><td>150ms</td></tr>
@@ -484,6 +484,7 @@
             <tr><td><code>--ease-speed-slow</code></td><td>600ms</td></tr>
           </tbody>
         </table>
+
         <h3 class="docs-h3">Colors</h3>
         <table class="docs-table">
           <thead><tr><th>Variable</th><th>Value</th></tr></thead>
@@ -492,10 +493,96 @@
             <tr><td><code>--ease-color-success</code></td><td>#22c55e</td></tr>
             <tr><td><code>--ease-color-danger</code></td><td>#ef4444</td></tr>
             <tr><td><code>--ease-color-warning</code></td><td>#f59e0b</td></tr>
+            <tr><td><code>--ease-color-bg</code></td><td>var(--ease-color-neutral-50)</td></tr>
+            <tr><td><code>--ease-color-surface</code></td><td>#ffffff</td></tr>
+            <tr><td><code>--ease-color-text</code></td><td>var(--ease-color-neutral-800)</td></tr>
+            <tr><td><code>--ease-color-muted</code></td><td>var(--ease-color-neutral-500)</td></tr>
           </tbody>
         </table>
+
         <h3 class="docs-h3">Spacing Scale</h3>
         <p class="docs-p">Based on a 4px base unit: <code>--ease-space-1</code> (4px) → <code>--ease-space-16</code> (64px).</p>
+      </section>
+
+      <hr class="docs-divider" />
+
+      <!-- ══════════════ DARK MODE ══════════════ -->
+      <section id="dark-mode" class="docs-section">
+        <h2 class="docs-h2">Dark Mode</h2>
+
+        <p class="docs-p">
+          EaseMotion CSS uses CSS custom properties for theming.
+          Override color tokens in <code>:root</code>, then use a system preference
+          media query or a manual theme toggle.
+        </p>
+
+        <h3 class="docs-h3">System dark mode</h3>
+        <p class="docs-p">
+          Add a dark-mode override with <code>@media (prefers-color-scheme: dark)</code>.
+          This lets the browser switch automatically when the user prefers dark mode.
+        </p>
+
+        <div class="docs-code">
+          <span class="docs-code-lang">css</span>
+          <pre><code>:root {
+  --ease-color-bg:      var(--ease-color-neutral-50);
+  --ease-color-surface: #ffffff;
+  --ease-color-text:    var(--ease-color-neutral-800);
+  --ease-color-muted:   var(--ease-color-neutral-500);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-color-bg:      #0f172a;
+    --ease-color-surface: #111827;
+    --ease-color-text:    #f8fafc;
+    --ease-color-muted:   #94a3b8;
+    --ease-color-primary: #8b5cf6;
+  }
+}</code></pre>
+        </div>
+
+        <h3 class="docs-h3">Manual theme toggle</h3>
+        <p class="docs-p">
+          Use a theme attribute like <code>data-theme="dark"</code> to override tokens on demand.
+          This allows users to switch themes without relying on OS settings.
+        </p>
+
+        <div class="docs-code">
+          <span class="docs-code-lang">css</span>
+          <pre><code>[data-theme="dark"] {
+  --ease-color-bg:      #0f172a;
+  --ease-color-surface: #111827;
+  --ease-color-text:    #f8fafc;
+  --ease-color-muted:   #94a3b8;
+}</code></pre>
+        </div>
+
+        <div class="docs-code">
+          <span class="docs-code-lang">html</span>
+          <pre><code>&lt;html data-theme="dark"&gt;
+  ...
+&lt;/html&gt;</code></pre>
+        </div>
+
+        <h3 class="docs-h3">Recommended variables to override</h3>
+        <ul class="docs-p">
+          <li><code>--ease-color-bg</code></li>
+          <li><code>--ease-color-surface</code></li>
+          <li><code>--ease-color-text</code></li>
+          <li><code>--ease-color-muted</code></li>
+          <li><code>--ease-color-primary</code></li>
+          <li><code>--ease-color-primary-light</code></li>
+          <li><code>--ease-color-primary-dark</code></li>
+        </ul>
+
+        <div class="docs-info">
+          <span class="docs-info-icon">✨</span>
+          <div>
+            Because EaseMotion is built on custom properties, dark mode works cleanly without
+            rewriting component or utility rules.
+          </div>
+        </div>
       </section>
 
       <hr class="docs-divider" />

--- a/submissions/examples/dark-mode-theme/README.md
+++ b/submissions/examples/dark-mode-theme/README.md
@@ -1,0 +1,20 @@
+1. What does this do?
+
+This submission demonstrates how to implement dark mode for EaseMotion CSS by overriding shared `--ease-*` design tokens with `@media (prefers-color-scheme: dark)` and a manual `data-theme="dark"` toggle.
+
+2. How is it used?
+
+Add a theme attribute to the page and override the core variables:
+
+```html
+<html data-theme="dark">
+  <body>
+    <button class="theme-toggle">Toggle dark mode</button>
+    <div class="theme-card">...</div>
+  </body>
+</html>
+```
+
+3. Why is it useful?
+
+Dark mode is a modern UI requirement, and EaseMotion's variable system makes it easy to swap theme colors globally without changing utility or component rules.

--- a/submissions/examples/dark-mode-theme/demo.html
+++ b/submissions/examples/dark-mode-theme/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion Dark Mode Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="theme-demo">
+    <div class="theme-panel">
+      <div class="theme-header">
+        <h1>EaseMotion Dark Mode</h1>
+        <button class="theme-toggle" id="toggle-theme">Toggle dark mode</button>
+      </div>
+      <p class="theme-copy">
+        This demo uses CSS custom property overrides to switch the color palette for both automatic
+        system dark mode and a manual theme toggle.
+      </p>
+      <div class="theme-card">
+        <h2>Theme tokens in action</h2>
+        <p>
+          Background, surface, text, and accent colors all update with the same shared
+          <code>--ease-*</code> variables.
+        </p>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const root = document.documentElement;
+    const button = document.getElementById('toggle-theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const storedTheme = localStorage.getItem('theme');
+    const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
+
+    root.dataset.theme = initialTheme;
+
+    const updateButton = (darkMode) => {
+      button.textContent = darkMode ? 'Switch to light mode' : 'Switch to dark mode';
+    };
+
+    updateButton(initialTheme === 'dark');
+
+    button.addEventListener('click', () => {
+      const nextTheme = root.dataset.theme === 'dark' ? 'light' : 'dark';
+      root.dataset.theme = nextTheme;
+      localStorage.setItem('theme', nextTheme);
+      updateButton(nextTheme === 'dark');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/dark-mode-theme/style.css
+++ b/submissions/examples/dark-mode-theme/style.css
@@ -1,0 +1,127 @@
+:root {
+  --ease-speed-fast: 150ms;
+  --ease-speed-medium: 300ms;
+  --ease-ease: cubic-bezier(0.4, 0, 0.2, 1);
+
+  --ease-color-bg: #f8fafc;
+  --ease-color-surface: #ffffff;
+  --ease-color-text: #0f172a;
+  --ease-color-muted: #64748b;
+  --ease-color-primary: #6c63ff;
+  --ease-color-primary-light: #a09af8;
+  --ease-color-primary-dark: #4b44cc;
+
+  --ease-space-4: 1rem;
+  --ease-space-6: 1.5rem;
+  --ease-space-8: 2rem;
+  --ease-radius-lg: 1rem;
+  --ease-radius-full: 9999px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: system-ui, sans-serif;
+  transition: background var(--ease-speed-medium) var(--ease-ease),
+              color var(--ease-speed-medium) var(--ease-ease);
+}
+
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ease-space-8);
+}
+
+.theme-demo {
+  width: min(100%, 740px);
+}
+
+.theme-panel {
+  background: var(--ease-color-surface);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--ease-radius-lg);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.12);
+  padding: var(--ease-space-8);
+}
+
+.theme-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-4);
+  margin-bottom: var(--ease-space-6);
+}
+
+.theme-toggle {
+  border: none;
+  border-radius: var(--ease-radius-full);
+  padding: 0.75rem 1rem;
+  background: var(--ease-color-primary);
+  color: #fff;
+  cursor: pointer;
+  transition: transform var(--ease-speed-fast) var(--ease-ease);
+}
+
+.theme-toggle:hover {
+  transform: translateY(-1px);
+}
+
+.theme-copy {
+  margin: 0 0 var(--ease-space-6);
+  color: var(--ease-color-muted);
+  line-height: 1.75;
+}
+
+.theme-card {
+  background: var(--ease-color-surface);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--ease-radius-lg);
+  padding: var(--ease-space-6);
+}
+
+.theme-card h2 {
+  margin-top: 0;
+}
+
+.theme-card p {
+  margin: 0;
+  color: var(--ease-color-muted);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-color-bg: #0f172a;
+    --ease-color-surface: #111827;
+    --ease-color-text: #f8fafc;
+    --ease-color-muted: #94a3b8;
+    --ease-color-primary: #8b5cf6;
+  }
+}
+
+[data-theme="dark"] {
+  --ease-color-bg: #0f172a;
+  --ease-color-surface: #111827;
+  --ease-color-text: #f8fafc;
+  --ease-color-muted: #94a3b8;
+  --ease-color-primary: #8b5cf6;
+  --ease-color-primary-light: #c4b5fd;
+  --ease-color-primary-dark: #7c3aed;
+}
+
+[data-theme="light"] {
+  --ease-color-bg: #f8fafc;
+  --ease-color-surface: #ffffff;
+  --ease-color-text: #0f172a;
+  --ease-color-muted: #64748b;
+  --ease-color-primary: #6c63ff;
+  --ease-color-primary-light: #a09af8;
+  --ease-color-primary-dark: #4b44cc;
+}


### PR DESCRIPTION
## Pull Request Description

Adds an EaseMotion dark mode submission and documentation section that explains how to use the CSS variable system for automatic and manual dark theme switching.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A dark mode example showing how to override EaseMotion CSS variables with @media (prefers-color-scheme: dark) and a manual data-theme="dark" toggle.

**How does a developer use it?**

```html
<html data-theme="dark">
  ...
</html>
```

**Why does it fit EaseMotion CSS?**

It uses the same --ease-* design tokens that EaseMotion already exposes, enabling theme switching without rewriting utility or component styles.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer


This submission demonstrates both automatic system dark mode and a manual theme toggle using data-theme="dark". The docs section also lists the key --ease-* variables to override for dark themes.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.

closes #603 
