### PR TITLE
tooling: add .editorconfig for consistent editor formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Pull Request Description

Adds `.editorconfig` to the repository root for consistent editor formatting across all IDEs and code editors. Closes #494.

A single root-level file that enforces consistent indentation, line endings, and whitespace handling for every contributor — regardless of whether they use VS Code, IntelliJ, Vim, Sublime, or any other editor. Works without plugins or build steps.

---

## Type of Change

- [x] Other — Tooling / Developer Experience

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside a single root-level `.editorconfig` file
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] No changes to `submissions/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `.editorconfig` file at the repository root that enforces the exact formatting rules specified in issue #494 — plus a `[*.md]` override to protect existing markdown documentation.

**What does each rule do?**

```ini
# EditorConfig — https://editorconfig.org
root = true

[*]
indent_style = space       # spaces not tabs across all file types
indent_size = 2            # 2-space indentation
end_of_line = lf           # Unix line endings — prevents CRLF conflicts on Windows
charset = utf-8            # consistent encoding
trim_trailing_whitespace = true   # removes invisible whitespace noise from diffs
insert_final_newline = true       # POSIX-compliant — every file ends with a newline

[*.md]
trim_trailing_whitespace = false  # markdown uses trailing spaces as hard line breaks
                                  # stripping them silently breaks documentation formatting
```

**Why does it fit EaseMotion CSS?**

The recently merged `.prettierrc` and `.stylelintrc.json` handle code style at the **tooling level** — they run during build/lint steps. `.editorconfig` operates at the **editor level** — it applies formatting rules live as contributors type, before any tooling runs. The three files complement each other with zero overlap:

- `.editorconfig` — editor-level, works in every IDE without plugins
- `.prettierrc` — formatter-level, runs on save or in CI
- `.stylelintrc.json` — linter-level, catches CSS-specific issues

Together they form a complete formatting safety net that prevents whitespace conflicts in PRs permanently.

---

## Demo

- [x] N/A — tooling file, no visual demo required

---

## Browser Testing

- [x] N/A — tooling file, no browser testing required

---

## Notes for Maintainer

- `root = true` is set so editors don't search parent directories for another `.editorconfig` — important for contributors who have a global `.editorconfig` in their home directory
- The `[*.md]` override is intentional — markdown hard line breaks require two trailing spaces. Without this override, auto-formatting would silently break existing documentation
- Single file addition at repo root, zero changes to any existing file