### PR TITLE
fix: remove malformed duplicate opening character on section tag

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -534,7 +534,7 @@
   --ease-speed-medium: 400ms;
 }</code></pre>
   </div>
-      <<section id="variables" class="docs-section">
+      <section id="variables" class="docs-section">
         <h2 class="docs-h2">Variables</h2>
 
         <p class="docs-p">


### PR DESCRIPTION
## Pull Request Description
Fixes a syntax typo in the documentation file where the opening `section` tag for the variables section accidentally had a duplicate `<` bracket character (`<<section id="variables"`).

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Feature Description
**What does this add?**
Fixes an HTML validation/rendering syntax error in `docs/index.html`.

**How does a developer use it?**
N/A - Documentation typo fix.

closes #645