### PR TITLE
feat: liquid reveal typography

### DIFF
--- a/submissions/examples/ease-text-liquid/README.md
+++ b/submissions/examples/ease-text-liquid/README.md
@@ -1,0 +1,26 @@
+# Liquid Reveal Typography Stagger (`ease-text-liquid`)
+
+An ultra-premium, cinematic typography text reveal where an organic purple fluid wave sweeps completely in front of the interface workspace first, cleanly revealing sharp, legible pink header letters directly behind its trailing path.
+
+## Operational Architecture
+
+To prevent text readability degradation or jagged edge blurring across browser engines, the codebase isolates the design parameters across separate rendering layers:
+
+1. **The Foreground Gooey Layer Overlay:** An independent layout container applying an SVG blur filter (`feGaussianBlur`) and contrast matrix (`feColorMatrix`) to synthesize a realistic fluid wave passing directly in front of the typography string plane.
+2. **The Background Typography Mask:** The text layer initiates at `opacity: 0` and employs an entry `clip-path: inset()` reveal vector carefully synchronized right behind the foreground wave path timeline to ensure the text remains perfectly crisp and readable.
+
+## Directory Tree Manifest
+- `demo.html`: Independent standalone preview stage engine workspace.
+- `style.css`: Composed native CSS animation classes and keyframes.
+
+## Usage Layout Integration
+```html
+<div class="ease-liquid-text-stage">
+  <div class="ease-liquid-filter-container">
+    <div class="ease-liquid-wave-blob"></div>
+  </div>
+  <h1 class="ease-liquid-text-strata">Your Text Here</h1>
+</div>
+```
+## Author
+Pari Dubey

--- a/submissions/examples/ease-text-liquid/demo.html
+++ b/submissions/examples/ease-text-liquid/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS — Liquid Reveal Typography Stagger</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <svg class="ease-hidden-svg" xmlns="http://www.w3.org/2000/svg" version="1.1">
+    <defs>
+      <filter id="ease-matrix-liquid">
+        <feGaussianBlur in="SourceGraphic" stdDeviation="14" result="blur" />
+        <feColorMatrix in="blur" mode="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 30 -12" result="liquidGoo" />
+        <feComposite in="SourceGraphic" in2="liquidGoo" operator="atop" />
+      </filter>
+    </defs>
+  </svg>
+
+  <div class="workspace">
+    <div class="ease-liquid-text-stage" id="liquid-stage-wrapper">
+      
+      <div class="ease-liquid-filter-container" aria-hidden="true">
+        <div class="ease-liquid-wave-blob"></div>
+        <div class="ease-liquid-wave-blob"></div>
+        <div class="ease-liquid-wave-blob"></div>
+        <div class="ease-liquid-wave-blob"></div>
+      </div>
+
+      <h1 class="ease-liquid-text-strata">
+        Creative
+      </h1>
+
+    </div>
+  </div>
+
+  <button class="replay-trigger" onclick="replayLiquidReveal()">Replay Liquid Motion</button>
+
+  <script>
+    function replayLiquidReveal() {
+      const container = document.getElementById('liquid-stage-wrapper');
+      
+      // Clean clone pattern completely resets animation states on click
+      const resetClone = container.cloneNode(true);
+      container.parentNode.replaceChild(resetClone, container);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-text-liquid/style.css
+++ b/submissions/examples/ease-text-liquid/style.css
@@ -1,0 +1,140 @@
+/* submissions/examples/ease-text-liquid/style.css */
+
+:root {
+  --animation-speed: 2.6s;
+  --liquid-pink: #f472b6;   /* Sharp final text color */
+  --liquid-purple: #4f46e5; /* The sweeping gooey liquid wave color */
+  --ease-smooth: cubic-bezier(0.76, 0, 0.24, 1);
+}
+
+body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      background-color: #e2e8f0; /* Balanced mid-grey base matching your screen recording canvas */
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      overflow: hidden;
+    }
+    .workspace {
+      position: relative;
+      padding: 40px;
+    }
+    .replay-trigger {
+      margin-top: 60px;
+      background: rgba(15, 23, 42, 0.05);
+      border: 1px solid rgba(15, 23, 42, 0.1);
+      color: #1e293b;
+      padding: 12px 28px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      border-radius: 40px;
+      cursor: pointer;
+      transition: all 200ms ease;
+      z-index: 100;
+    }
+    .replay-trigger:hover {
+      background: #4f46e5;
+      color: #fff;
+      box-shadow: 0 10px 20px rgba(79, 70, 229, 0.2);
+      transform: translateY(-2px);
+    }
+    .ease-hidden-svg {
+      position: absolute;
+      width: 0;
+      height: 0;
+      pointer-events: none;
+    }
+
+/* Master Staging Frame Box */
+.ease-liquid-text-stage {
+  position: relative;
+  width: 650px;
+  height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  overflow: visible;
+}
+
+/* ─── LAYER 1: LIQUID FILTER CONTAINER (NOW PLACED ABOVE THE TEXT) ─── */
+.ease-liquid-filter-container {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  /* Applies the SVG gooey filter matrix only to this background processing box */
+  filter: url('#ease-matrix-liquid');
+  z-index: 20; /* FIXED: Higher z-index forces the wave to ride completely ABOVE the text */
+  pointer-events: none;
+}
+
+/* Explicitly configured wave blobs matching the precise height of the text block */
+.ease-liquid-wave-blob {
+  position: absolute;
+  top: 25%;
+  left: -160px;
+  width: 110px;
+  height: 110px;
+  background: var(--liquid-purple);
+  border-radius: 50%;
+  transform: translate3d(0, 0, 0) scale(0.2);
+  will-change: transform;
+  /* Runs exactly once (forwards locks the final state out of view on the right) */
+  animation: sweepLiquid var(--animation-speed) var(--ease-smooth) forwards;
+}
+
+/* Multi-blob layer staggers to replicate the fluid organic movement from your video */
+.ease-liquid-wave-blob:nth-child(2) { width: 95px;  height: 95px;  animation-delay: 0.08s; }
+.ease-liquid-wave-blob:nth-child(3) { width: 80px;  height: 80px;  animation-delay: 0.16s; }
+.ease-liquid-wave-blob:nth-child(4) { width: 60px;  height: 60px;  animation-delay: 0.24s; }
+
+@keyframes sweepLiquid {
+  0% {
+    transform: translate3d(0, 0, 0) scale(0.2);
+  }
+  42% {
+    /* Expands cleanly over the text center to morph and reveal the typography strings */
+    transform: translate3d(420px, -6px, 0) scale(1.65);
+  }
+  100% {
+    /* Sweeps completely off the right boundary without clipping or freezing */
+    transform: translate3d(950px, 0, 0) scale(0.1);
+  }
+}
+
+/* ─── LAYER 2: CLEAN CRISP TEXT LAYER (PLACED UNDERNEATH THE WAVE) ─── */
+.ease-liquid-text-strata {
+  position: relative;
+  font-size: 6.5rem;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  color: var(--liquid-pink); 
+  margin: 0;
+  z-index: 10; /* FIXED: Lower z-index keeps the text safely below the sweeping wave overlay */
+  pointer-events: none;
+  
+  /* Text starts completely hidden, revealing sequentially right behind the passing wave front */
+  opacity: 0;
+  animation: liquidReveal var(--animation-speed) var(--ease-smooth) forwards;
+}
+
+@keyframes liquidReveal {
+  0%, 22% {
+    opacity: 0;
+    clip-path: inset(0 100% 0 0); /* Hidden behind left viewport edge bounding line */
+  }
+  55% {
+    opacity: 1;
+    clip-path: inset(0 45% 0 0);  /* Unclipping dynamically in flow with the wave speed */
+  }
+  75%, 100% {
+    opacity: 1;
+    clip-path: inset(0 0 0 0);    /* Permanently sharp, stable, visible and solid pink */
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces the highly requested **Liquid Reveal Typography Stagger (`ease-text-liquid`)** workspace utility, establishing an ultra-premium, high-end agency typography mask interaction utilizing hardware-accelerated foreground fluid transitions.

Closes #920

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-text-liquid/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It provides an advanced dual-layered CSS layout template where a highly stylized SVG gooey liquid wave passes directly in front of the viewport axis, dynamically un-clipping sharp pink header characters as it travels.

**Why does it fit EaseMotion CSS?**
It fulfills the core framework philosophy of handling advanced compositor pipeline changes (like combining `feGaussianBlur`, alpha color channels, and `clip-path` masks) smoothly via lightweight, human-readable helper utilities with zero JavaScript canvas footprint.

---

## Demo

https://github.com/user-attachments/assets/354da7a0-6633-4c07-bf8d-75dd960b3c76



---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

- Completely isolated inside the standard `submissions/examples/` module tree.
- Built-in structural loop iteration limits (`animation-iteration-count: 1`) guarantee the reveal finishes cleanly on the pink text vector, locking into view.
- Engineered with custom root speed variables (`--animation-speed`) and an expanded middle keyframe step boundary to simulate gradual, high-end studio pacing benchmarks.