### PR TITLE
fix: resolve unclosed media query in cards

### DIFF
--- a/components/cards.css
+++ b/components/cards.css
@@ -258,6 +258,9 @@
   }
   .ease-card-glow {
     transition: none !important;
+  }
+}
+
 @media (max-width: 640px) {
   .ease-card {
     padding: var(--ease-space-4);


### PR DESCRIPTION
## Pull Request Description
Restores card layout styling on mobile viewports by adding missing closing braces to .ease-card-glow and @media (prefers-reduced-motion: reduce) in components/cards.css.

closes #1152 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- One-sentence description -->

**How does a developer use it?**

```html
<!-- Show the class usage in HTML -->
```

**Why does it fit EaseMotion CSS?**

<!-- Explain how this fits the human-readable, animation-first philosophy -->

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
