### PR TITLE
fix(core): add missing closing brace for .ease-shimmer-sweep block

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -723,6 +723,7 @@
       transparent 70%);
   background-size: 200% auto;
   animation: ease-kf-shimmer-sweep var(--ease-speed-slow) var(--ease-ease) infinite;
+}
 
 .ease-squish-button:hover,
 .ease-squish-button:focus-visible,


### PR DESCRIPTION
## Description

The `.ease-shimmer-sweep` class declaration block is missing its closing `}` at line 725. This causes the `.ease-squish-button:hover`, `.ease-squish-button:focus-visible`, and `.ease-squish-button:active` selectors on lines 727–731 to be parsed inside the broken block, making the squish-button hover animation never apply.

## Fix

Added the missing closing `}` after the animation declaration in `.ease-shimmer-sweep`.

## Changes

- `core/animations.css:726` — added `}` to close the `.ease-shimmer-sweep` block

Closes #1204