### PR TITLE
fix(core): remove duplicate --ease-color-secondary variable block in :root

### DIFF
--- a/core/variables.css
+++ b/core/variables.css
@@ -33,11 +33,7 @@
 
   --ease-color-danger:        #ef4444;
   --ease-color-danger-light:  #fca5a5;
-  --ease-color-danger-dark:   #b91c1c;
-
-  --ease-color-secondary:       #8b5cf6;
-  --ease-color-secondary-light: #a78bfa;
-  --ease-color-secondary-dark:  #7c3aed;
+  --ease-color-danger-dark:  #b91c1c;
 
   --ease-color-warning:       #f59e0b;
   --ease-color-warning-light: #fcd34d;


### PR DESCRIPTION
## Description

The entire secondary color block (`--ease-color-secondary`, `--ease-color-secondary-light`, `--ease-color-secondary-dark`) is defined twice with identical values in `:root`. The first occurrence at lines 26–28 is dead code since CSS uses last-definition-wins.

## Fix

Removed the duplicate block at lines 38–40.

## Changes

- `core/variables.css:38-40` — removed duplicate `--ease-color-secondary` variable definitions

Closes #1206