### PR TITLE
feat: add perimeter border draw animation effect

### DIFF
--- a/submissions/examples/perimeter-border-draw/README.md
+++ b/submissions/examples/perimeter-border-draw/README.md
@@ -1,0 +1,9 @@
+# perimeter-border-draw
+
+## What does this do?
+This utility creates a smooth, continuous clockwise border drawing effect tracking around any element container upon user hover interaction.
+
+## How is it used?
+Apply the custom class directly to your target HTML component block:
+```html
+<div class="perimeter-draw">Your content here</div>

--- a/submissions/examples/perimeter-border-draw/demo.html
+++ b/submissions/examples/perimeter-border-draw/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Perimeter Draw Sandbox Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0f172a;
+      color: #f8fafc;
+      font-family: system-ui, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .card {
+      padding: 3rem 6rem;
+      background-color: #1e293b;
+      font-weight: bold;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="perimeter-draw card">
+    HOVER TO DRAW
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/perimeter-border-draw/style.css
+++ b/submissions/examples/perimeter-border-draw/style.css
@@ -1,0 +1,59 @@
+:root {
+  --border-draw-color: #a855f7; 
+  --border-draw-speed: 0.25s;   
+}
+
+/* Core target box configuration */
+.perimeter-draw {
+  position: relative;
+  display: inline-block;
+  background: transparent;
+  cursor: pointer;
+  box-sizing: border-box;
+  border: 1px solid transparent; 
+}
+
+/* Pseudo-elements baseline */
+.perimeter-draw::before,
+.perimeter-draw::after {
+  content: '';
+  position: absolute;
+  box-sizing: border-box;
+  width: 0;
+  height: 0;
+  border: 1px solid transparent;
+}
+
+/* ::BEFORE - Animates Top -> Right sequentially */
+.perimeter-draw::before {
+  top: -1px;
+  left: -1px;
+  transition: height var(--border-draw-speed) ease-in, 
+              width var(--border-draw-speed) ease-in var(--border-draw-speed);
+}
+
+.perimeter-draw:hover::before {
+  width: calc(100% + 2px);
+  height: calc(100% + 2px);
+  border-top-color: var(--border-draw-color);
+  border-right-color: var(--border-draw-color);
+  transition: width var(--border-draw-speed) ease-out, 
+              height var(--border-draw-speed) ease-out var(--border-draw-speed);
+}
+
+/* ::AFTER - Animates Bottom -> Left sequentially */
+.perimeter-draw::after {
+  bottom: -1px;
+  right: -1px;
+  transition: height var(--border-draw-speed) ease-in calc(var(--border-draw-speed) * 2), 
+              width var(--border-draw-speed) ease-in calc(var(--border-draw-speed) * 3);
+}
+
+.perimeter-draw:hover::after {
+  width: calc(100% + 2px);
+  height: calc(100% + 2px);
+  border-bottom-color: var(--border-draw-color);
+  border-left-color: var(--border-draw-color);
+  transition: width var(--border-draw-speed) ease-out calc(var(--border-draw-speed) * 2), 
+              height var(--border-draw-speed) ease-out calc(var(--border-draw-speed) * 3);
+}


### PR DESCRIPTION
### What does this do?
This adds a self-contained CSS utility that creates a smooth, continuous clockwise border drawing tracking micro-interaction around any card container element upon mouse hover.

### Checklist
- [x] My files are added **only** inside `submissions/examples/your-feature-name/`
- [x] I have included all three required files (`demo.html`, `style.css`, `README.md`)
- [x] This PR focuses on exactly one feature
- [x] I have verified the demo works by opening it directly in a browser
- [x] I have not modified any files in `core/`, `components/`, `docs/`, or `examples/`