### PR TITLE
feat: add student job board filter layout

### DIFF
--- a/submissions/examples/job-board-filters/README.md
+++ b/submissions/examples/job-board-filters/README.md
@@ -1,0 +1,11 @@
+# job-board-filters
+
+## What does this do?
+This module provides a pure HTML5/CSS3 dynamic filtering layout system optimized for student job boards, portals, or directory structures.
+
+## How is it used?
+Configure hidden layout radio elements paired with explicit tracking label items, then assign targeted matching category strings directly to your markup cards:
+```html
+<input type="radio" id="tab-tech" name="job-filter" class="filter-controller">
+...
+<div class="job-card" data-category="tech">...</div>

--- a/submissions/examples/job-board-filters/demo.html
+++ b/submissions/examples/job-board-filters/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Student Job Board Filtering - Demo Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0f172a;
+      margin: 0;
+      padding: 2rem 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="job-board-container">
+    <h1 style="margin-top: 0; margin-bottom: 0.5rem;">Student Job Board</h1>
+    <p style="color: #94a3b8; margin-bottom: 2rem;">Filter engineering, design, and marketing roles using pure CSS states.</p>
+
+    <input type="radio" name="job-filter" id="tab-all" class="filter-controller" checked>
+    <input type="radio" name="job-filter" id="tab-tech" class="filter-controller">
+    <input type="radio" name="job-filter" id="tab-design" class="filter-controller">
+    <input type="radio" name="job-filter" id="tab-marketing" class="filter-controller">
+
+    <div class="filter-tabs-bar">
+      <label for="tab-all" class="filter-label">All Postings</label>
+      <label for="tab-tech" class="filter-label">Development & Tech</label>
+      <label for="tab-design" class="filter-label">UI/UX & Design</label>
+      <label for="tab-marketing" class="filter-label">Marketing & Growth</label>
+    </div>
+
+    <div class="jobs-grid">
+      
+      <div class="job-card" data-category="tech">
+        <span class="job-tag">Tech</span>
+        <h3 class="job-title">Frontend Development Intern</h3>
+        <div class="job-company">Nexus Software Labs</div>
+        <a href="#" class="apply-btn">View Details</a>
+      </div>
+
+      <div class="job-card" data-category="design">
+        <span class="job-tag">Design</span>
+        <h3 class="job-title">UI/UX Product Designer</h3>
+        <div class="job-company">Studio Canvas</div>
+        <a href="#" class="apply-btn">View Details</a>
+      </div>
+
+      <div class="job-card" data-category="marketing">
+        <span class="job-tag">Marketing</span>
+        <h3 class="job-title">Growth Marketing Associate</h3>
+        <div class="job-company">Velocity Media</div>
+        <a href="#" class="apply-btn">View Details</a>
+      </div>
+
+      <div class="job-card" data-category="tech">
+        <span class="job-tag">Tech</span>
+        <h3 class="job-title">Backend Engineer (Node.js)</h3>
+        <div class="job-company">CloudSync Architectures</div>
+        <a href="#" class="apply-btn">View Details</a>
+      </div>
+
+      <div class="job-card" data-category="design">
+        <span class="job-tag">Design</span>
+        <h3 class="job-title">Graphic & Brand Designer</h3>
+        <div class="job-company">Prism Creative Agency</div>
+        <a href="#" class="apply-btn">View Details</a>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/job-board-filters/style.css
+++ b/submissions/examples/job-board-filters/style.css
@@ -1,0 +1,138 @@
+/* ==========================================================================
+   Custom Submission: Pure CSS Student Job Board Filtering Engine
+   ========================================================================== */
+
+:root {
+  --bg-dark: #0f172a;
+  --bg-card: #1e293b;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --accent: #3b82f6;
+  --accent-hover: #2563eb;
+}
+
+/* Container Workspace Layout */
+.job-board-container {
+  max-width: 1000px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--text-main);
+}
+
+/* Hide Radio State Controllers Completely */
+.filter-controller {
+  display: none;
+}
+
+/* Filter Navigation Layout */
+.filter-tabs-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+  border-bottom: 1px solid #334155;
+  padding-bottom: 1.25rem;
+}
+
+.filter-label {
+  padding: 0.5rem 1.25rem;
+  background: #334155;
+  border-radius: 9999px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.875rem;
+  transition: background 0.2s ease, transform 0.1s ease;
+  user-select: none;
+}
+
+.filter-label:hover {
+  background: #475569;
+}
+
+/* --------------------------------------------------------------------------
+   Pure CSS State Handling Engine via :checked Sibling Selector
+   -------------------------------------------------------------------------- */
+
+/* Active Tab Visual Selection State Handling */
+#tab-all:checked ~ .filter-tabs-bar [for="tab-all"],
+#tab-tech:checked ~ .filter-tabs-bar [for="tab-tech"],
+#tab-design:checked ~ .filter-tabs-bar [for="tab-design"],
+#tab-marketing:checked ~ .filter-tabs-bar [for="tab-marketing"] {
+  background: var(--accent);
+  color: #ffffff;
+}
+
+/* Jobs Display Grid Layer */
+.jobs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+/* Content Element Block Cards */
+.job-card {
+  background: var(--bg-card);
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 1.5rem;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.job-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.1);
+}
+
+.job-tag {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.5rem;
+  background: #0f172a;
+  border: 1px solid #475569;
+  border-radius: 4px;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.job-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.job-company {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1.25rem;
+}
+
+.apply-btn {
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+  padding: 0.625rem;
+  background: #334155;
+  color: var(--text-main);
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: background 0.2s ease;
+}
+
+.job-card:hover .apply-btn {
+  background: var(--accent);
+}
+
+/* Exclusive Filtering Processing Selector Rules */
+#tab-tech:checked ~ .jobs-grid .job-card:not([data-category="tech"]),
+#tab-design:checked ~ .jobs-grid .job-card:not([data-category="design"]),
+#tab-marketing:checked ~ .jobs-grid .job-card:not([data-category="marketing"]) {
+  display: none;
+}


### PR DESCRIPTION
### What does this do?
This adds a self-contained pure CSS student job board filtering interface engine using structural hidden radio elements and sibling selectors to toggle categorical grid display states without JavaScript.

### Checklist
- [x] My files are added **only** inside `submissions/examples/your-feature-name/`
- [x] I have included all three required files (`demo.html`, `style.css`, `README.md`)
- [x] This PR focuses on exactly one feature
- [x] I have verified the demo works by opening it directly in a browser
- [x] I have not modified any files in `core/`, `components/`, `docs/`, or `examples/`