### PR TITLE
feat: add role-based content access layout dashboard

### DIFF
--- a/submissions/examples/rbac-auth-middleware/README.md
+++ b/submissions/examples/rbac-auth-middleware/README.md
@@ -1,0 +1,11 @@
+# rbac-auth-middleware
+
+## What does this do?
+Provides a clean frontend representation layout for Role-Based Access Control (RBAC) visibility structures.
+
+## How is it used?
+Incorporate structural input targets matched against container block classes to selectively mount layouts depending on the active state selection:
+```html
+<input type="radio" id="role-admin" name="rbac-toggle" class="role-radio">
+...
+<div class="admin-only">...</div>

--- a/submissions/examples/rbac-auth-middleware/demo.html
+++ b/submissions/examples/rbac-auth-middleware/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RBAC Access Panel - Sandbox Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0f172a;
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="rbac-container">
+    <h1 style="margin-top: 0; margin-bottom: 0.5rem;">Role-Based Content Authorization</h1>
+    <p style="color: #94a3b8; margin-bottom: 2rem;">Simulate client-side view permissions toggle via CSS states.</p>
+
+    <input type="radio" name="rbac-toggle" id="role-student" class="role-radio" checked>
+    <input type="radio" name="rbac-toggle" id="role-admin" class="role-radio">
+
+    <div class="role-selector-bar">
+      <label for="role-student" class="role-label">Student Account View</label>
+      <label for="role-admin" class="role-label">System Administrator View</label>
+    </div>
+
+    <div class="dashboard-view">
+      
+      <div class="student-only">
+        <span class="access-badge">Student Access Granted</span>
+        <h2 style="margin: 0 0 1rem 0;">Welcome to your Learning Dashboard</h2>
+        <p style="color: #94a3b8; line-height: 1.6; margin: 0;">You have read-only access to view courses, submit assignments, and browse the public student board postings.</p>
+      </div>
+
+      <div class="admin-only">
+        <span class="access-badge">Root Admin Override</span>
+        <h2 style="margin: 0 0 1rem 0;">System Control Console</h2>
+        <p style="color: #94a3b8; line-height: 1.6; margin: 0 0 1.5rem 0;">Critical actions unlocked. You hold permissions to delete repositories, modify schemas, and authorize global scope middleware hooks.</p>
+        <button style="background: var(--admin-color); color: white; border: none; padding: 0.6rem 1.2rem; font-weight: bold; border-radius: 4px; cursor: pointer;">Flush System Cache</button>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/rbac-auth-middleware/style.css
+++ b/submissions/examples/rbac-auth-middleware/style.css
@@ -1,0 +1,97 @@
+/* ==========================================================================
+   Custom Submission: Pure CSS Role-Based View Switcher Matrix
+   ========================================================================== */
+
+:root {
+  --bg-dark: #0f172a;
+  --bg-card: #1e293b;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --admin-color: #ef4444;
+  --student-color: #10b981;
+}
+
+.rbac-container {
+  max-width: 900px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--text-main);
+}
+
+/* Hide Radio Controllers Completely */
+.role-radio {
+  display: none;
+}
+
+/* Selector Switch Bar Layout */
+.role-selector-bar {
+  display: flex;
+  gap: 1rem;
+  background: #1e293b;
+  padding: 0.5rem;
+  border-radius: 8px;
+  margin-bottom: 2.5rem;
+  border: 1px solid #334155;
+}
+
+.role-label {
+  flex: 1;
+  text-align: center;
+  padding: 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s ease;
+  user-select: none;
+}
+
+/* Dynamic Active Tab Label Highlighting via :checked */
+#role-student:checked ~ .role-selector-bar [for="role-student"] {
+  background: var(--student-color);
+  color: #0f172a;
+}
+
+#role-admin:checked ~ .role-selector-bar [for="role-admin"] {
+  background: var(--admin-color);
+  color: #ffffff;
+}
+
+/* Control Panel Content Shell */
+.dashboard-view {
+  background: var(--bg-card);
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 2rem;
+  min-height: 250px;
+}
+
+/* Security Authorization Badges */
+.access-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  margin-bottom: 1.5rem;
+}
+
+.student-only .access-badge {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--student-color);
+  border: 1px solid var(--student-color);
+}
+
+.admin-only .access-badge {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--admin-color);
+  border: 1px solid var(--admin-color);
+}
+
+/* Core RBAC Access Visibility Display Toggle Logic */
+#role-student:checked ~ .dashboard-view .admin-only,
+#role-admin:checked ~ .dashboard-view .student-only {
+  display: none;
+}


### PR DESCRIPTION
### What does this do?
This adds a self-contained, pure CSS dashboard simulation interface showing conditional views based on simulated role authorization (Student vs. Admin), utilizing structural radio states and combinators without JavaScript.

### Checklist
- [x] My files are added **only** inside `submissions/examples/your-feature-name/`
- [x] I have included all three required files (`demo.html`, `style.css`, `README.md`)
- [x] This PR focuses on exactly one feature
- [x] I have verified the demo works by opening it directly in a browser
- [x] I have not modified any files in `core/`, `components/`, `docs/`, or `examples/`