### PR TITLE
Fix: Add proper z-index layer priority context for dropdown nav elements

### DIFF
--- a/submissions/examples/nav-clipping-fix/README.md
+++ b/submissions/examples/nav-clipping-fix/README.md
@@ -1,0 +1,10 @@
+# Animated Navigation Dropdown Clipping Fix
+
+Resolves a layout stacking error where expanding mobile navigation slide windows drop underneath subsequent block layers.
+
+## Resolution
+- Enforced an explicit stacking layer priority threshold (`z-index: 1000`) on the navigation container parent wrapper.
+- Isolated container layers to ensure drop components overlap surrounding document fragments predictably.
+
+## Linked Issue
+Closes #1239

--- a/submissions/examples/nav-clipping-fix/demo.html
+++ b/submissions/examples/nav-clipping-fix/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nav Menu Clipping Fix Demo - #1239</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="ease-nav-menu">
+    <h1 class="ease-nav-title">CommitPulse Navigation</h1>
+    <div class="ease-dropdown-animated">
+      <a href="#">?? Dashboard Hub</a>
+      <a href="#">?? Contribution Metrics</a>
+      <a href="#">?? Profile Settings</a>
+    </div>
+  </nav>
+
+  <div class="hero-section">
+    <h2>Main Application Hero Window<br><span style="font-size: 1rem; color: #a1a1aa;">The dropdown overlay above should stack cleanly over this area without getting cut off.</span></h2>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/nav-clipping-fix/style.css
+++ b/submissions/examples/nav-clipping-fix/style.css
@@ -1,0 +1,70 @@
+/* Global Styles */
+body {
+  margin: 0;
+  padding: 0;
+  background-color: #0b0f19;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #f1f5f9;
+}
+
+/* Fixed Navigation Container */
+.ease-nav-menu {
+  position: relative;
+  background: #111827;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  border-bottom: 1px solid #1f2937;
+  /* CRITICAL FIX: Establish high stacking context priority */
+  z-index: 1000; 
+}
+
+.ease-nav-title {
+  color: #38bdf8;
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+/* Animated Menu Content Window */
+.ease-dropdown-animated {
+  position: absolute;
+  top: 60px;
+  left: 0;
+  width: 100%;
+  background: #1f2937;
+  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.5);
+  border-bottom: 2px solid #38bdf8;
+  padding: 15px 20px;
+  box-sizing: border-box;
+}
+
+.ease-dropdown-animated a {
+  display: block;
+  color: #9ca3af;
+  text-decoration: none;
+  padding: 10px 0;
+  font-size: 1rem;
+  transition: color 0.2s ease;
+}
+
+.ease-dropdown-animated a:hover {
+  color: #38bdf8;
+}
+
+/* Underlying Page Element (The Broken Component) */
+.hero-section {
+  position: relative;
+  background: linear-gradient(135deg, #1e1b4b, #0f172a);
+  height: 250px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* Keeps layout stacked beneath z-index: 1000 */
+  z-index: 1; 
+}
+
+.hero-section h2 {
+  font-size: 1.8rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces a layout stacking priority patch inside the submissions directory to resolve issue #1239. It configures an explicit stacking context boundary on the animated mobile navigation headers, ensuring expanding layout elements overlap surrounding page items cleanly instead of clipping beneath adjacent blocks.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Establishes clear vertical depth hierarchy guidelines using explicit stacking properties on responsive layout bars.

**How does a developer use it?**

```html
<nav class="ease-nav-menu">
  </nav>

Why does it fit EaseMotion CSS?
It addresses a vital interface overlap bug, allowing drop and slide disclosure menus to expand cleanly without unexpected visual breaks across core pages.

Demo
[x] Demo added (demo.html works by opening directly in a browser)

Browser Testing
[x] Chrome

[x] Edge

[ ] Firefox

[ ] Safari (optional but appreciated)

Notes for Maintainer
Closes #1239. Viewport layer priorities evaluated across local dark-theme structural variations.

Reminder: Only the repository maintainer may merge pull requests.

Do not self-merge, even if you have write access.

Maximum 2 active assigned issues per contributor — unassign extras before opening a PR.