### PR TITLE
ci: run duplicate linter checks in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,5 +41,9 @@ jobs:
       - name: Run Stylelint
         run: npm run lint
 
+      - name: Run Duplicate Linter
+        run: npm run lint:duplicates
+
       - name: Run Smoke Tests
         run: npm test
+


### PR DESCRIPTION
Closes #1290. Add duplicate linter execution step to the test and validation GitHub workflow.