### PR TITLE
fix: update duplicate checking script regex and deduplication logic

### DIFF
--- a/scripts/check-duplicates.mjs
+++ b/scripts/check-duplicates.mjs
@@ -8,7 +8,7 @@ const rootDir = path.resolve(__dirname, "..");
 const baselinePath = path.join(__dirname, "duplicate-baseline.json");
 
 const dirs = ["core", "components"];
-const classPattern = /^\.([a-zA-Z0-9_-]+)\s*\{/;
+const classPattern = /^\s*\.([a-zA-Z0-9_-]+)(?::[a-z-]+)?(?:\s*,\s*\.[a-zA-Z0-9_-]+)*\s*\{/;
 const keyframePattern = /@keyframes\s+(\S+)/;
 
 async function readBaseline() {
@@ -49,14 +49,22 @@ async function findDuplicates() {
 
         const cm = line.match(classPattern);
         if (cm) {
-          if (!classes[cm[1]]) classes[cm[1]] = [];
-          classes[cm[1]].push(`${dir}/${entry.name}:${i + 1}`);
+          const className = cm[1];
+          if (!classes[className]) classes[className] = [];
+          const fileLoc = `${dir}/${entry.name}`;
+          if (!classes[className].some(loc => loc.startsWith(fileLoc + ":"))) {
+            classes[className].push(`${dir}/${entry.name}:${i + 1}`);
+          }
         }
 
         const km = line.match(keyframePattern);
         if (km) {
-          if (!keyframes[km[1]]) keyframes[km[1]] = [];
-          keyframes[km[1]].push(`${dir}/${entry.name}:${i + 1}`);
+          const keyframeName = km[1];
+          if (!keyframes[keyframeName]) keyframes[keyframeName] = [];
+          const fileLoc = `${dir}/${entry.name}`;
+          if (!keyframes[keyframeName].some(loc => loc.startsWith(fileLoc + ":"))) {
+            keyframes[keyframeName].push(`${dir}/${entry.name}:${i + 1}`);
+          }
         }
       }
     }

--- a/scripts/duplicate-baseline.json
+++ b/scripts/duplicate-baseline.json
@@ -18,7 +18,8 @@
     "ease-rotate-image-exit": 2,
     "ease-expand-border-exit": 2,
     "ease-skeleton-pulse": 2,
-    "ease-fade-out": 2
+    "ease-fade-out": 2,
+    "ease-btn-hover": 2
   },
   "keyframes": {}
 }


### PR DESCRIPTION
## Pull Request Description

Closes #1291. Upgrades the regular expression and logic inside `scripts/check-duplicates.mjs` to correctly match:
1. Indented class definitions (e.g. inside media queries).
2. Classes with pseudo-classes (e.g. `:hover`, `:active`, `:focus-visible`).
3. Grouped class selectors (e.g. `.class1, .class2`).

To prevent false duplicate detections from multiple states/rules in the same file (such as `.ease-btn`, `.ease-btn:hover`, and `.ease-btn:active` all residing inside `components/buttons.css`), the script now deduplicates class name definitions at the file level. A class name is only flagged as a duplicate if it is defined across multiple different files in the `core` and `components` directories.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission (duplicate checker script and its baseline config)
- [ ] Other

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.
> Note: This checklist is geared towards new community example submissions. Since this is a tooling/maintenance bug fix resolving an open issue (#1291), changes to `scripts/` are required.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It improves the duplicate detector script to recognize indented selectors, pseudo-classes, and grouped selectors, while ignoring multiple declarations of the same class in a single file.

---

## Notes for Maintainer

All styles have been validated using `npm run lint` and all unit tests pass.
The baseline configuration was updated to reflect the cross-file duplicate `ease-btn-hover` which is defined in both `core/animations.css` and `components/buttons.css` (the latter overrides the transition when inside preferred reduced motion settings).
