### PR TITLE
perf: remove redundant Google Font preloads from docs index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,11 +8,6 @@
   <meta name="description"
     content="Official documentation for EaseMotion CSS — the animation-first, human-readable CSS framework." />
 
-  <!-- Inter font — loaded via <link> instead of CSS @import for performance -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-
   <!-- EaseMotion CSS — loaded from jsDelivr CDN -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />


### PR DESCRIPTION
## Pull Request Description

Closes #1298. Removes redundant preconnect and stylesheet link tags loading the Google Fonts 'Inter' inside `docs/index.html`.

Since the core framework (`core/base.css`) already imports this font directly using CSS `@import`, loading it again via static HTML `<link>` tags in the documentation header results in redundant network requests and blocks rendering thread validation on load.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement (removed duplicate font preload links)
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html`
- [ ] Includes `style.css`
- [ ] Includes `README.md`
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Optimized load performance for the documentation pages by eliminating double loading of the Inter font.

---

## Notes for Maintainer

Tested locally. Linting and all tests pass perfectly.
