### PR TITLE
[Security] Add Content-Security-Policy meta tag across all HTML pages

### DIFF
--- a/components/chip-demo.html
+++ b/components/chip-demo.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>ease-chip-group Demo — EaseMotion CSS</title>
   <link rel="stylesheet" href="chip.css">
 </head>

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -3,16 +3,17 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>EaseMotion CSS — Interactive Demo</title>
   <meta name="description" content="Live demo showcasing EaseMotion CSS utilities, animations, buttons, and card components." />
 
   <!-- EaseMotion CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" integrity="sha384-u4alaiV9voo/7cfhvrlsJM1LxczXThaPZZd0qYJ9uU/GcD0yYWvNpYUtxKSpQss+" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" integrity="sha384-AsMBzWcRzfyNTvGunukSBn+STpI4j/N0jD4K9cGcz4yt4J6J5ywJ8ZsxQpeChACZ" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" integrity="sha384-NtJ5ykloBafTw5bMeppPfLikC+O5h6DjvwfNtYAvfdB5JgYTjQuf4w96EiYOFUHZ" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" integrity="sha384-D0aTwI6DmYseuLNFb+hHO7TJs6BiY3xoIrRcgvaIwAPX1ymAUVMiiK4qVCGM+Ems" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" integrity="sha384-H5bIG5QdU3kEin/DKekP85FpkWVi39X1u9XmyfqyhdHr9nqlfOPPJDyeUMMY7CkM" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css" integrity="sha384-blU1Snn5oMev2zg1q3KYoGqQM+9vcpO31N6/lEpFJkuLOhC2GbDGrUuJNxwX/knw" crossorigin="anonymous" />
 
   <style>
     /* ── Demo-specific styles ─────────────────────────────── */

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>EaseMotion CSS — Documentation</title>
   <meta name="description"
     content="Official documentation for EaseMotion CSS — the animation-first, human-readable CSS framework." />

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>EaseMotion CSS — Interactive Demo</title>
   <meta name="description" content="Live demo showcasing EaseMotion CSS utilities, animations, buttons, and card components." />
 

--- a/examples/skeleton-loading.html
+++ b/examples/skeleton-loading.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>Skeleton Loading - EaseMotion CSS</title>
   
   <link rel="stylesheet" href="../core/variables.css">


### PR DESCRIPTION
﻿Fixes #1276

## Description
Added Content-Security-Policy meta tags to all HTML pages to mitigate XSS and data injection attacks. The policy allows inline scripts (required by existing onclick handlers) while restricting external resources to trusted CDN origins.

## Files Modified
- examples/demo.html
- docs/index.html
- docs/demo.html
- components/chip-demo.html
- examples/skeleton-loading.html

## Policy Details
`default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:`
