### PR TITLE
[Security] Add Subresource Integrity hashes to CDN CSS links

### DIFF
--- a/components/chip-demo.html
+++ b/components/chip-demo.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>ease-chip-group Demo — EaseMotion CSS</title>
   <link rel="stylesheet" href="chip.css">
 </head>

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -3,16 +3,17 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>EaseMotion CSS — Interactive Demo</title>
   <meta name="description" content="Live demo showcasing EaseMotion CSS utilities, animations, buttons, and card components." />
 
   <!-- EaseMotion CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" integrity="sha384-u4alaiV9voo/7cfhvrlsJM1LxczXThaPZZd0qYJ9uU/GcD0yYWvNpYUtxKSpQss+" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" integrity="sha384-AsMBzWcRzfyNTvGunukSBn+STpI4j/N0jD4K9cGcz4yt4J6J5ywJ8ZsxQpeChACZ" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" integrity="sha384-NtJ5ykloBafTw5bMeppPfLikC+O5h6DjvwfNtYAvfdB5JgYTjQuf4w96EiYOFUHZ" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" integrity="sha384-D0aTwI6DmYseuLNFb+hHO7TJs6BiY3xoIrRcgvaIwAPX1ymAUVMiiK4qVCGM+Ems" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" integrity="sha384-H5bIG5QdU3kEin/DKekP85FpkWVi39X1u9XmyfqyhdHr9nqlfOPPJDyeUMMY7CkM" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css" integrity="sha384-blU1Snn5oMev2zg1q3KYoGqQM+9vcpO31N6/lEpFJkuLOhC2GbDGrUuJNxwX/knw" crossorigin="anonymous" />
 
   <style>
     /* ── Demo-specific styles ─────────────────────────────── */

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,12 +15,12 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 
   <!-- EaseMotion CSS — loaded from jsDelivr CDN -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" integrity="sha384-u4alaiV9voo/7cfhvrlsJM1LxczXThaPZZd0qYJ9uU/GcD0yYWvNpYUtxKSpQss+" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" integrity="sha384-AsMBzWcRzfyNTvGunukSBn+STpI4j/N0jD4K9cGcz4yt4J6J5ywJ8ZsxQpeChACZ" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" integrity="sha384-NtJ5ykloBafTw5bMeppPfLikC+O5h6DjvwfNtYAvfdB5JgYTjQuf4w96EiYOFUHZ" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" integrity="sha384-D0aTwI6DmYseuLNFb+hHO7TJs6BiY3xoIrRcgvaIwAPX1ymAUVMiiK4qVCGM+Ems" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" integrity="sha384-H5bIG5QdU3kEin/DKekP85FpkWVi39X1u9XmyfqyhdHr9nqlfOPPJDyeUMMY7CkM" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css" integrity="sha384-blU1Snn5oMev2zg1q3KYoGqQM+9vcpO31N6/lEpFJkuLOhC2GbDGrUuJNxwX/knw" crossorigin="anonymous" />
   <link rel="stylesheet" href="../components/scroll-progress.css" />
 
   <style>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>EaseMotion CSS — Documentation</title>
   <meta name="description"
     content="Official documentation for EaseMotion CSS — the animation-first, human-readable CSS framework." />

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>EaseMotion CSS — Interactive Demo</title>
   <meta name="description" content="Live demo showcasing EaseMotion CSS utilities, animations, buttons, and card components." />
 

--- a/examples/skeleton-loading.html
+++ b/examples/skeleton-loading.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>Skeleton Loading - EaseMotion CSS</title>
   
   <link rel="stylesheet" href="../core/variables.css">


### PR DESCRIPTION
Fixes #1275

Added SHA-384 integrity hashes and crossorigin=anonymous attributes to all 6 CDN CSS link tags across docs/index.html and docs/demo.html. This mitigates CDN compromise attacks by ensuring the browser verifies file integrity.