### PR TITLE
fix: dark/light mode toggle and sidebar active text color

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -102,8 +102,8 @@
     }
 
     body {
-      background: #0f0e17;
-      color: #fffffe;
+      background: var(--page-bg);
+      color: var(--page-text);
       overflow-x: hidden;
     }
 
@@ -247,8 +247,8 @@
     }
 
     .sidebar-nav a.active {
-      color: #ffffff;
-      background: rgba(108, 99, 255, 0.18);
+      color: var(--nav-link-active-text);
+      background: var(--nav-link-active-bg);
       border-left: 3px solid #6c63ff;
     }
 
@@ -275,7 +275,7 @@
         transition: transform 0.3s ease;
         z-index: 100;
         top: var(--docs-header-h);
-        background: #0f0e17;
+        background: var(--page-bg);
       }
 
       .docs-sidebar.open {
@@ -1847,6 +1847,8 @@
     </main>
   </div>
 
+  
+
   <script>
     // Mobile sidebar toggle logic
     const sidebarToggle = document.getElementById('sidebarToggle');
@@ -1934,6 +1936,25 @@
         }, 2000);
       });
     });
+    // Dark/Light mode toggle
+const themeToggle = document.getElementById('theme-toggle');
+
+themeToggle.addEventListener('click', () => {
+  const html = document.documentElement;
+  if (html.getAttribute('data-theme') === 'light') {
+    html.removeAttribute('data-theme');
+    localStorage.setItem('theme', 'dark');
+  } else {
+    html.setAttribute('data-theme', 'light');
+    localStorage.setItem('theme', 'light');
+  }
+});
+
+// Persist theme on page load
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme === 'light') {
+  document.documentElement.setAttribute('data-theme', 'light');
+}
   </script>
 </body>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -581,6 +581,7 @@
       .docs-info {
         padding: var(--ease-space-4);
       }
+    }  
     /* ── Copy Button ──────────────────────────────────────── */
     .docs-copy-btn {
       position: absolute;


### PR DESCRIPTION
## Pull Request Description
Fixes two bugs in the documentation site (`docs/index.html`) that broke the dark/light mode experience completely.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One fix per PR (both bugs are related to the same theme toggle feature)

---

## Feature Description
**What does this fix?**
The theme toggle button in the docs header was completely non-functional — clicking it had no visible effect.

**Root Causes & Fixes:**

| # | Bug | Fix |
|---|-----|-----|
| 1 | Toggle button had no JS event listener | Added click handler that toggles `data-theme="light"` on `<html>` + persists to `localStorage` |
| 2 | `body` had hardcoded `#0f0e17` background and `#fffffe` text color | Replaced with `var(--page-bg)` and `var(--page-text)` |
| 3 | Sidebar active link `color: #ffffff` was invisible in light mode | Replaced with `var(--nav-link-active-text)` (already defined for both themes) |

**Why no new variables?**
All three fixes use CSS variables already defined in `:root` and `[data-theme="light"]` — zero breaking changes.

---

## Browser Testing
- [x] Chrome
- [x] Edge

---

##Screenshots
<img width="1886" height="914" alt="Screenshot 2026-06-05 005424" src="https://github.com/user-attachments/assets/45c7f48c-7d47-4805-ac2d-79dd5336717b" />
<img width="1891" height="918" alt="Screenshot 2026-06-05 005441" src="https://github.com/user-attachments/assets/7f856883-881b-4b9a-baec-c45872ce6d3a" />


## Notes for Maintainer
All changes are confined to `docs/index.html`. No library code touched. Safe to merge. 🙂