### PR TITLE
Fix Components navbar navigation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -634,7 +634,7 @@
       <li><a href="#getting-started">Getting Started</a></li>
       <li><a href="#utilities">Utilities</a></li>
       <li><a href="#animations">Animations</a></li>
-      <li><a href="#buttons">Components</a></li>
+      <li><a href="#components">Components</a></li>
       <li><a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/blob/main/examples/demo.html">
           <button class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill">Live Demo →</button>
         </a></li>
@@ -1680,6 +1680,16 @@
             <br><a href="https://caniuse.com/?search=scroll-timeline" target="_blank">Scroll-Driven Animations</a>
           </div>
         </div>
+      </section>
+
+      <hr class="docs-divider" />
+
+      <!-- ══════════════ COMPONENTS ══════════════ -->
+      <section id="components" class="docs-section">
+        <h2 class="docs-h2">Components</h2>
+        <p class="docs-p">
+          EaseMotion CSS includes reusable UI components such as Buttons, Cards and Scroll Progress indicators.
+        </p>
       </section>
 
       <hr class="docs-divider" />


### PR DESCRIPTION
## Pull Request Description

This PR fixes the Components navigation link in the documentation.
Previously, clicking the "Components" item in the top navigation directed users to the Buttons subsection instead of a dedicated Components section. This change adds a Components section and updates the navigation target so users are taken to the correct location in the documentation.

---

## Type of Change

- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes the Components navigation link in the documentation.

**How does a developer use it?**

No API or usage changes. Users can now click the Components item in the documentation navbar and be taken to the Components section as expected.

**Why does it fit EaseMotion CSS?**

Improves documentation usability and navigation consistency by ensuring navbar links point to the correct section.

---

## Browser Testing

- [ ] Chrome

---

## Notes for Maintainer

The Components navbar item previously pointed directly to the Buttons subsection. A dedicated Components section was added and the navigation target was updated so users are taken to the Components overview section when clicking Components in the navbar.

---

Fixes #1319