### PR TITLE
feat: add ease-slider - custom range slider input

### DIFF
--- a/submissions/examples/ease-slider/README.md
+++ b/submissions/examples/ease-slider/README.md
@@ -1,0 +1,70 @@
+# ease-slider — Range Slider Input with Custom Thumb
+
+## What does this do?
+
+A styled range slider (`<input type="range">`) with custom track and thumb, filled portion, value tooltip, and support for sizes, gradient fill, vertical orientation, tick marks, and disabled state.
+
+## Variants
+
+| Variant | Class | Description |
+|---------|-------|-------------|
+| Small | `.ease-slider--sm` | 4px track, 16px thumb |
+| Medium (default) | *(none)* | 6px track, 20px thumb |
+| Large | `.ease-slider--lg` | 8px track, 24px thumb |
+| Gradient | `.ease-slider--gradient` | Track fill uses gradient |
+| Vertical | `.ease-slider--vertical` | Vertical orientation |
+| Disabled | `.ease-slider--disabled` | Reduced opacity, no pointer events |
+
+## How is it used?
+
+```html
+<div class="ease-slider">
+  <input type="range" min="0" max="100" value="50" step="1">
+  <div class="ease-slider__tooltip">50</div>
+  <div class="ease-slider__labels">
+    <span>0</span>
+    <span>100</span>
+  </div>
+  <div class="ease-slider__ticks">
+    <span class="ease-slider__tick"></span>
+    <span class="ease-slider__tick"></span>
+  </div>
+</div>
+```
+
+With JavaScript to update the tooltip position:
+
+```js
+var input = document.querySelector('.ease-slider input');
+var tooltip = document.querySelector('.ease-slider__tooltip');
+input.addEventListener('input', function() {
+  var pct = (input.value - input.min) / (input.max - input.min);
+  var offset = pct * input.offsetWidth;
+  tooltip.textContent = input.value;
+  tooltip.style.left = offset + 'px';
+});
+```
+
+## Why is it useful?
+
+Range sliders are a common UI pattern for volume, brightness, price filters, ratings, and settings controls. This implementation wraps the native `<input type="range">` for full accessibility while providing consistent custom styling across browsers.
+
+## Tech Stack
+
+- HTML (native `<input type="range">`)
+- CSS (pseudo-elements for track/thumb, custom properties for sizing)
+- JavaScript (minimal — tooltip position tracking)
+
+## Preview
+
+Open `demo.html` directly in your browser to see all variants in action.
+
+## Browser Compatibility
+
+Uses `::-webkit-slider-thumb`, `::-moz-range-track`, `::-moz-range-thumb`, and `::-moz-range-progress` pseudo-elements. Falls back gracefully to native browser styling in unsupported browsers.
+
+## Contribution Notes
+
+- Class naming follows EaseMotion BEM convention (`ease-slider__*`)
+- Uses `var(--ease-primary)` for the track fill colour
+- Maintainer may adjust naming before merging

--- a/submissions/examples/ease-slider/demo.html
+++ b/submissions/examples/ease-slider/demo.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-slider — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 40px 24px;
+    }
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+    }
+    .container {
+      max-width: 700px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 1.75rem;
+      margin-bottom: 4px;
+    }
+    .subtitle {
+      color: #64748b;
+      margin-bottom: 40px;
+    }
+    @media (prefers-color-scheme: dark) {
+      .subtitle { color: #94a3b8; }
+    }
+    section {
+      margin-bottom: 40px;
+      padding: 24px;
+      background: #fff;
+      border-radius: 12px;
+      border: 1px solid #e2e8f0;
+    }
+    @media (prefers-color-scheme: dark) {
+      section {
+        background: #1e293b;
+        border-color: #334155;
+      }
+    }
+    section h2 {
+      font-size: 1rem;
+      margin-bottom: 4px;
+      color: #6366f1;
+    }
+    section .desc {
+      font-size: 0.85rem;
+      color: #64748b;
+      margin-bottom: 20px;
+    }
+    @media (prefers-color-scheme: dark) {
+      section .desc { color: #94a3b8; }
+    }
+    .row {
+      display: flex;
+      gap: 40px;
+      flex-wrap: wrap;
+      align-items: flex-start;
+    }
+    .slider-group {
+      flex: 1;
+      min-width: 200px;
+    }
+    .slider-group label {
+      display: block;
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin-bottom: 4px;
+      color: #475569;
+    }
+    @media (prefers-color-scheme: dark) {
+      .slider-group label { color: #94a3b8; }
+    }
+    .vertical-demo {
+      display: flex;
+      gap: 32px;
+      align-items: center;
+      justify-content: center;
+      padding: 16px 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>ease-slider</h1>
+    <p class="subtitle">Custom styled range slider with track fill, tooltip, ticks, and multiple variants</p>
+
+    <!-- Default -->
+    <section>
+      <h2>Default</h2>
+      <p class="desc">Standard slider with value tooltip on hover</p>
+      <div class="slider-group">
+        <label for="slider-default">Volume</label>
+        <div class="ease-slider" id="slider-default-wrap">
+          <input type="range" id="slider-default" min="0" max="100" value="65" step="1"
+                 aria-valuenow="65" aria-valuemin="0" aria-valuemax="100">
+          <div class="ease-slider__tooltip">65</div>
+          <div class="ease-slider__labels">
+            <span>0</span>
+            <span>100</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Sizes -->
+    <section>
+      <h2>Sizes</h2>
+      <p class="desc">Small, Medium (default), and Large</p>
+      <div style="display:grid;gap:24px;">
+        <div class="slider-group">
+          <label>Small (--sm)</label>
+          <div class="ease-slider ease-slider--sm" id="slider-sm-wrap">
+            <input type="range" min="0" max="100" value="30" step="1">
+            <div class="ease-slider__tooltip">30</div>
+          </div>
+        </div>
+        <div class="slider-group">
+          <label>Medium (default)</label>
+          <div class="ease-slider" id="slider-md-wrap">
+            <input type="range" min="0" max="100" value="55" step="1">
+            <div class="ease-slider__tooltip">55</div>
+          </div>
+        </div>
+        <div class="slider-group">
+          <label>Large (--lg)</label>
+          <div class="ease-slider ease-slider--lg" id="slider-lg-wrap">
+            <input type="range" min="0" max="100" value="80" step="1">
+            <div class="ease-slider__tooltip">80</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- With ticks -->
+    <section>
+      <h2>With Ticks</h2>
+      <p class="desc">Discrete steps with tick marks and min/max labels</p>
+      <div class="slider-group">
+        <label for="slider-ticks">Rating</label>
+        <div class="ease-slider" id="slider-ticks-wrap">
+          <input type="range" id="slider-ticks" min="0" max="5" value="3" step="1">
+          <div class="ease-slider__tooltip">3</div>
+          <div class="ease-slider__ticks">
+            <span class="ease-slider__tick"></span>
+            <span class="ease-slider__tick"></span>
+            <span class="ease-slider__tick"></span>
+            <span class="ease-slider__tick"></span>
+            <span class="ease-slider__tick"></span>
+            <span class="ease-slider__tick"></span>
+          </div>
+          <div class="ease-slider__labels">
+            <span>0</span>
+            <span>5</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Gradient -->
+    <section>
+      <h2>Gradient Fill</h2>
+      <p class="desc">Track fill uses a gradient from indigo to pink to amber</p>
+      <div class="slider-group">
+        <label for="slider-gradient">Brightness</label>
+        <div class="ease-slider ease-slider--gradient" id="slider-gradient-wrap">
+          <input type="range" id="slider-gradient" min="0" max="100" value="70" step="1">
+          <div class="ease-slider__tooltip">70</div>
+          <div class="ease-slider__labels">
+            <span>0</span>
+            <span>100</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Vertical -->
+    <section>
+      <h2>Vertical</h2>
+      <p class="desc">Vertical orientation for side panels or volume controls</p>
+      <div class="vertical-demo">
+        <div class="ease-slider ease-slider--vertical" id="slider-vert1-wrap">
+          <input type="range" min="0" max="100" value="80" step="1" aria-label="Volume">
+          <div class="ease-slider__tooltip">80</div>
+        </div>
+        <div class="ease-slider ease-slider--vertical ease-slider--sm" id="slider-vert2-wrap">
+          <input type="range" min="0" max="100" value="45" step="1" aria-label="Brightness">
+          <div class="ease-slider__tooltip">45</div>
+        </div>
+        <div class="ease-slider ease-slider--vertical ease-slider--gradient" id="slider-vert3-wrap">
+          <input type="range" min="0" max="100" value="60" step="1" aria-label="Saturation">
+          <div class="ease-slider__tooltip">60</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Disabled -->
+    <section>
+      <h2>Disabled</h2>
+      <p class="desc">Reduced opacity with no pointer events</p>
+      <div class="slider-group">
+        <label>Locked setting</label>
+        <div class="ease-slider ease-slider--disabled">
+          <input type="range" min="0" max="100" value="50" step="1" disabled aria-label="Disabled slider">
+          <div class="ease-slider__tooltip">50</div>
+          <div class="ease-slider__labels">
+            <span>Min</span>
+            <span>Max</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    function initSlider(container) {
+      var input = container.querySelector('input[type="range"]');
+      var tooltip = container.querySelector('.ease-slider__tooltip');
+      if (!input || !tooltip) return;
+
+      function updateTooltip() {
+        var val = input.value;
+        tooltip.textContent = val;
+        var pct = (val - input.min) / (input.max - input.min);
+        var trackW = input.offsetWidth;
+        var thumbSize = parseInt(getComputedStyle(input).getPropertyValue('--ease-slider-thumb-size')) || 20;
+        var offset = pct * (trackW - thumbSize) + thumbSize / 2;
+        tooltip.style.left = offset + 'px';
+      }
+
+      input.addEventListener('input', updateTooltip);
+      updateTooltip();
+    }
+
+    document.querySelectorAll('.ease-slider').forEach(initSlider);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-slider/style.css
+++ b/submissions/examples/ease-slider/style.css
@@ -1,0 +1,203 @@
+.ease-slider {
+  --ease-slider-track: #e2e8f0;
+  --ease-slider-track-fill: var(--ease-primary, #6366f1);
+  --ease-slider-thumb: #ffffff;
+  --ease-slider-thumb-shadow: rgba(0, 0, 0, 0.15);
+  --ease-slider-height: 6px;
+  --ease-slider-thumb-size: 20px;
+  position: relative;
+  width: 100%;
+  padding: 16px 0 8px;
+}
+
+.ease-slider input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: var(--ease-slider-height);
+  background: var(--ease-slider-track);
+  border-radius: 999px;
+  outline: none;
+  cursor: pointer;
+  margin: 0;
+  display: block;
+}
+
+/* Filled track — WebKit */
+.ease-slider input[type="range"]::-webkit-slider-runnable-track {
+  height: var(--ease-slider-height);
+  background: var(--ease-slider-track);
+  border-radius: 999px;
+}
+
+.ease-slider input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: var(--ease-slider-thumb-size);
+  height: var(--ease-slider-thumb-size);
+  border-radius: 50%;
+  background: var(--ease-slider-thumb);
+  border: 2px solid var(--ease-slider-track-fill);
+  box-shadow: 0 2px 6px var(--ease-slider-thumb-shadow);
+  cursor: pointer;
+  margin-top: calc((var(--ease-slider-thumb-size) - var(--ease-slider-height)) / -2);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.ease-slider input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+}
+
+.ease-slider input[type="range"]::-webkit-slider-thumb:active {
+  transform: scale(1.25);
+  box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.15);
+}
+
+/* Firefox */
+.ease-slider input[type="range"]::-moz-range-track {
+  height: var(--ease-slider-height);
+  background: var(--ease-slider-track);
+  border-radius: 999px;
+  border: none;
+}
+
+.ease-slider input[type="range"]::-moz-range-thumb {
+  width: var(--ease-slider-thumb-size);
+  height: var(--ease-slider-thumb-size);
+  border-radius: 50%;
+  background: var(--ease-slider-thumb);
+  border: 2px solid var(--ease-slider-track-fill);
+  box-shadow: 0 2px 6px var(--ease-slider-thumb-shadow);
+  cursor: pointer;
+}
+
+.ease-slider input[type="range"]::-moz-range-progress {
+  height: var(--ease-slider-height);
+  background: var(--ease-slider-track-fill);
+  border-radius: 999px;
+}
+
+/* Value tooltip */
+.ease-slider__tooltip {
+  position: absolute;
+  top: -32px;
+  left: 0;
+  transform: translateX(-50%);
+  background: var(--ease-tooltip-bg, #1e293b);
+  color: white;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.ease-slider:hover .ease-slider__tooltip,
+.ease-slider:focus-within .ease-slider__tooltip {
+  opacity: 1;
+}
+
+/* Labels */
+.ease-slider__labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--ease-muted, #64748b);
+  margin-top: 4px;
+}
+
+.ease-slider__value-label {
+  text-align: center;
+  font-size: 12px;
+  color: var(--ease-muted, #64748b);
+  margin-top: 4px;
+  font-weight: 600;
+}
+
+/* Tick marks */
+.ease-slider__ticks {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 calc(var(--ease-slider-thumb-size) / 2);
+  margin-top: -2px;
+  position: relative;
+  z-index: 0;
+}
+
+.ease-slider__tick {
+  width: 2px;
+  height: 6px;
+  background: var(--ease-border, #cbd5e1);
+  border-radius: 1px;
+  flex-shrink: 0;
+}
+
+/* Sizes */
+.ease-slider--sm {
+  --ease-slider-height: 4px;
+  --ease-slider-thumb-size: 16px;
+}
+
+.ease-slider--lg {
+  --ease-slider-height: 8px;
+  --ease-slider-thumb-size: 24px;
+}
+
+/* Gradient variant */
+.ease-slider--gradient {
+  --ease-slider-track-fill: linear-gradient(90deg, #6366f1, #ec4899, #f59e0b);
+}
+
+.ease-slider--gradient input[type="range"]::-moz-range-progress {
+  background: var(--ease-slider-track-fill);
+}
+
+/* Vertical */
+.ease-slider--vertical {
+  display: inline-block;
+  width: auto;
+  height: 200px;
+  padding: 8px 16px;
+}
+
+.ease-slider--vertical input[type="range"] {
+  writing-mode: vertical-lr;
+  direction: rtl;
+  width: var(--ease-slider-height);
+  height: 200px;
+}
+
+/* Disabled */
+.ease-slider--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .ease-slider {
+    --ease-slider-track: #334155;
+    --ease-slider-thumb-shadow: rgba(0, 0, 0, 0.3);
+  }
+
+  .ease-slider__tooltip {
+    background: #0f172a;
+  }
+
+  .ease-slider__tick {
+    background: #475569;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-slider input[type="range"]::-webkit-slider-thumb {
+    transition: none;
+  }
+
+  .ease-slider__tooltip {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #1262



## Pull Request Description

Add a new `ease-slider` component: a custom styled range slider input with custom track and thumb, filled portion, value tooltip, 3 sizes, gradient fill, vertical orientation, tick marks, and disabled state.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-slider/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A custom-styled range slider with:
- **3 sizes**: sm (4px track, 16px thumb), default (6px, 20px), lg (8px, 24px)
- **Gradient** variant: track fill uses a gradient instead of solid colour
- **Vertical** orientation for side panels or volume controls
- **Ticks**: visual tick marks at each step
- **Tooltip**: floating value indicator that follows the thumb on hover
- **Labels**: min/max labels below the track
- **Disabled**: reduced opacity with no pointer events
- **Dark mode**: automatic via `prefers-color-scheme`
- **Reduced motion**: respects `prefers-reduced-motion`

**How does a developer use it?**

```html
<div class="ease-slider">
  <input type="range" min="0" max="100" value="50" step="1">
  <div class="ease-slider__tooltip">50</div>
  <div class="ease-slider__labels">
    <span>0</span>
    <span>100</span>
  </div>
</div>
Minimal JS to sync tooltip position with thumb:
input.addEventListener('input', function() {
  tooltip.textContent = input.value;
  var pct = (input.value - input.min) / (input.max - input.min);
  tooltip.style.left = (pct * input.offsetWidth) + 'px';
});
Why does it fit EaseMotion CSS?
Range sliders are a common UI pattern (volume, brightness, filters, ratings) missing from EaseMotion. Wraps native <input type="range"> for full accessibility with consistent custom styling across browsers.
Demo
- Demo added (demo.html works by opening directly in a browser)
Browser Testing
- Chrome
- Firefox
- Edge
- Safari (optional but appreciated)
Notes for Maintainer
Uses ::-webkit-slider-thumb, ::-moz-range-track, ::-moz-range-thumb, and ::-moz-range-progress for cross-browser custom styling. Falls back gracefully to native range input. Minimal JS only for tooltip position tracking. Ready for integration into components/.
Closes #1262
