### PR TITLE
feat: add ease-split-pane - draggable split panel resizer

### DIFF
--- a/submissions/examples/ease-split-pane/README.md
+++ b/submissions/examples/ease-split-pane/README.md
@@ -1,0 +1,68 @@
+# ease-split-pane — Draggable Split Panel Resizer
+
+## What does this do?
+
+Creates two resizable panels separated by a draggable divider handle. Supports horizontal (left/right) and vertical (top/bottom) orientations, nested layouts, collapsible panels, and configurable minimum size.
+
+## Variants
+
+| Variant | Class | Description |
+|---------|-------|-------------|
+| Horizontal | `.ease-split-pane--horizontal` | Left/right panels with vertical divider (default) |
+| Vertical | `.ease-split-pane--vertical` | Top/bottom panels with horizontal divider |
+| Nested | *(nest `.ease-split-pane` inside)* | Split pane within a split pane |
+| Collapsible | *(add toggle button)* | First panel collapses/expands via toggle button |
+
+## How is it used?
+
+```html
+<div class="ease-split-pane ease-split-pane--horizontal" data-ease-min-panel-width="100">
+  <div class="ease-split-pane__panel" style="width:250px;">
+    <!-- Left panel content -->
+  </div>
+  <div class="ease-split-pane__divider">
+    <button class="ease-split-pane__toggle">&#9664;</button>
+  </div>
+  <div class="ease-split-pane__panel">
+    <!-- Right panel content (fills remaining space) -->
+  </div>
+</div>
+```
+
+JavaScript initialisation:
+
+```js
+initSplitPane(document.getElementById('my-split-pane'));
+```
+
+## Behaviour
+
+- **Drag** the divider to resize panels
+- **Double-click** the divider to reset to 50/50 split
+- **Minimum panel size**: configurable via `data-ease-min-panel-width` attribute (default: 100px)
+- **Toggle button** on divider collapses/expands the first panel
+- **Drag state**: adds `.ease-split-pane--dragging` to disable text selection during drag
+- **Nesting**: fully supported — drop a `.ease-split-pane` inside a panel
+
+## Why is it useful?
+
+Split panes are essential for code editors (file tree + editor), documentation sites (sidebar + content), comparison views, and any layout where the user controls space division. This component provides a lightweight, framework-agnostic implementation.
+
+## Tech Stack
+
+- HTML
+- CSS (flexbox, transitions)
+- JavaScript (drag handling, double-click reset, collapse toggle)
+
+## Preview
+
+Open `demo.html` directly in your browser to see horizontal, vertical, and nested variants with drag, double-click reset, and collapse toggle.
+
+## Browser Support
+
+Uses `mousedown`/`mousemove`/`mouseup` and `touchstart`/`touchmove`/`touchend` events for both desktop and touch drag support.
+
+## Contribution Notes
+
+- Class naming follows EaseMotion BEM convention (`ease-split-pane__*`)
+- Maintainer may adjust naming before merging

--- a/submissions/examples/ease-split-pane/demo.html
+++ b/submissions/examples/ease-split-pane/demo.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-split-pane — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 32px 24px;
+    }
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+    }
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 1.75rem;
+      margin-bottom: 4px;
+    }
+    .subtitle {
+      color: #64748b;
+      margin-bottom: 32px;
+    }
+    @media (prefers-color-scheme: dark) {
+      .subtitle { color: #94a3b8; }
+    }
+    section {
+      margin-bottom: 40px;
+    }
+    section h2 {
+      font-size: 1.1rem;
+      margin-bottom: 4px;
+      color: #6366f1;
+    }
+    section .desc {
+      font-size: 0.85rem;
+      color: #64748b;
+      margin-bottom: 16px;
+    }
+    @media (prefers-color-scheme: dark) {
+      section .desc { color: #94a3b8; }
+    }
+    .demo-pane {
+      border-radius: 12px;
+      border: 1px solid #e2e8f0;
+      height: 350px;
+      overflow: hidden;
+    }
+    @media (prefers-color-scheme: dark) {
+      .demo-pane { border-color: #334155; }
+    }
+    .panel-content {
+      padding: 20px;
+      height: 100%;
+    }
+    .panel-content h3 {
+      font-size: 0.95rem;
+      margin-bottom: 12px;
+    }
+    .panel-content p {
+      font-size: 0.85rem;
+      line-height: 1.5;
+      color: #64748b;
+    }
+    @media (prefers-color-scheme: dark) {
+      .panel-content p { color: #94a3b8; }
+    }
+    .panel-content ul {
+      list-style: none;
+    }
+    .panel-content ul li {
+      padding: 6px 0;
+      font-size: 0.85rem;
+      color: #475569;
+      cursor: pointer;
+    }
+    .panel-content ul li:hover {
+      color: #6366f1;
+    }
+    @media (prefers-color-scheme: dark) {
+      .panel-content ul li { color: #94a3b8; }
+      .panel-content ul li:hover { color: #a5b4fc; }
+    }
+    .panel-content ul li::before {
+      content: '\25B6';
+      margin-right: 8px;
+      font-size: 0.65rem;
+      color: #6366f1;
+    }
+    .panel-content .code {
+      background: #f1f5f9;
+      border-radius: 6px;
+      padding: 12px;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.8rem;
+      line-height: 1.6;
+      white-space: pre;
+      overflow-x: auto;
+    }
+    @media (prefers-color-scheme: dark) {
+      .panel-content .code {
+        background: #1e293b;
+        color: #e2e8f0;
+      }
+    }
+    .demo-pane--nested {
+      height: 400px;
+    }
+    .panel-content--nested-h {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      text-align: center;
+    }
+    .panel-content--nested-h h3 {
+      margin-bottom: 8px;
+    }
+    .instructions {
+      background: #f1f5f9;
+      border-radius: 8px;
+      padding: 12px 16px;
+      font-size: 0.85rem;
+      color: #475569;
+      margin-bottom: 16px;
+    }
+    @media (prefers-color-scheme: dark) {
+      .instructions {
+        background: #1e293b;
+        color: #94a3b8;
+      }
+    }
+    .instructions kbd {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 4px;
+      padding: 1px 6px;
+      font-size: 0.8rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      .instructions kbd {
+        background: #1e293b;
+        border-color: #475569;
+      }
+    }
+    /* Nested inner split-pane needs explicit height in demo */
+    .ease-split-pane .ease-split-pane {
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>ease-split-pane</h1>
+    <p class="subtitle">Draggable split panel resizer — drag the divider, double-click to reset</p>
+
+    <div class="instructions">
+      Drag the <strong>gray divider</strong> to resize panels. <strong>Double-click</strong> the divider to reset to 50/50. Minimum panel size: 100px.
+    </div>
+
+    <!-- Horizontal split -->
+    <section>
+      <h2>Horizontal (left / right)</h2>
+      <p class="desc">Default orientation — side-by-side panels with vertical divider</p>
+      <div class="demo-pane">
+        <div class="ease-split-pane ease-split-pane--horizontal" id="split-horizontal" data-ease-min-panel-width="100">
+          <div class="ease-split-pane__panel" style="width:250px;">
+            <div class="panel-content" style="background:#fafafa;">
+              <h3>Files</h3>
+              <ul>
+                <li>src/app.js</li>
+                <li>src/components/</li>
+                <li>src/utils/</li>
+                <li>src/styles/</li>
+                <li>public/index.html</li>
+                <li>package.json</li>
+                <li>README.md</li>
+              </ul>
+            </div>
+          </div>
+          <div class="ease-split-pane__divider">
+            <button class="ease-split-pane__toggle" aria-label="Toggle panel">&#9664;</button>
+          </div>
+          <div class="ease-split-pane__panel">
+            <div class="panel-content">
+              <h3>Editor</h3>
+              <div class="code">import { useState } from 'react';
+
+function App() {
+  const [count, setCount] = useState(0);
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Hello World&lt;/h1&gt;
+      &lt;p&gt;Count: {count}&lt;/p&gt;
+      &lt;button onClick={() =&gt;
+        setCount(c =&gt; c + 1)
+      }&gt;Increment&lt;/button&gt;
+    &lt;/div&gt;
+  );
+}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Vertical split -->
+    <section>
+      <h2>Vertical (top / bottom)</h2>
+      <p class="desc">Top and bottom panels with horizontal divider</p>
+      <div class="demo-pane">
+        <div class="ease-split-pane ease-split-pane--vertical" id="split-vertical">
+          <div class="ease-split-pane__panel" style="height:180px;">
+            <div class="panel-content" style="background:#fafafa;">
+              <h3>Input</h3>
+              <p>Enter your data here. The preview below updates in real time.</p>
+              <textarea style="width:100%;height:80px;margin-top:8px;padding:8px;border:1px solid #e2e8f0;border-radius:6px;font-family:inherit;font-size:0.85rem;resize:none;" placeholder="Type something...">Hello, EaseMotion!</textarea>
+            </div>
+          </div>
+          <div class="ease-split-pane__divider"></div>
+          <div class="ease-split-pane__panel">
+            <div class="panel-content">
+              <h3>Preview</h3>
+              <div style="padding:16px;background:#f1f5f9;border-radius:8px;text-align:center;min-height:100px;display:flex;align-items:center;justify-content:center;color:#64748b;">
+                Preview area
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Nested split -->
+    <section>
+      <h2>Nested</h2>
+      <p class="desc">A split pane inside a split pane — horizontal outer, vertical inner (right panel)</p>
+      <div class="demo-pane demo-pane--nested">
+        <div class="ease-split-pane ease-split-pane--horizontal" id="split-nested-outer">
+          <div class="ease-split-pane__panel" style="width:200px;">
+            <div class="panel-content" style="background:#fafafa;">
+              <h3>Sidebar</h3>
+              <ul>
+                <li>Dashboard</li>
+                <li>Projects</li>
+                <li>Settings</li>
+              </ul>
+            </div>
+          </div>
+          <div class="ease-split-pane__divider"></div>
+          <div class="ease-split-pane__panel">
+            <div class="ease-split-pane ease-split-pane--vertical" id="split-nested-inner">
+              <div class="ease-split-pane__panel" style="height:50%;">
+                <div class="panel-content panel-content--nested-h">
+                  <h3>Top Panel</h3>
+                  <p>Content area A</p>
+                </div>
+              </div>
+              <div class="ease-split-pane__divider"></div>
+              <div class="ease-split-pane__panel">
+                <div class="panel-content panel-content--nested-h">
+                  <h3>Bottom Panel</h3>
+                  <p>Content area B</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    function initSplitPane(container) {
+      var divider = container.querySelector('.ease-split-pane__divider');
+      var panels = container.querySelectorAll(':scope > .ease-split-pane__panel');
+      var isHorizontal = container.classList.contains('ease-split-pane--horizontal');
+      var minSize = parseInt(container.dataset.easeMinPanelWidth) || 100;
+      var isDragging = false;
+      var startPos = 0;
+      var startSize = 0;
+
+      if (!divider || panels.length < 2) return;
+
+      function getPanelSize() {
+        return isHorizontal ? panels[0].offsetWidth : panels[0].offsetHeight;
+      }
+
+      function setPanelSize(px) {
+        if (isHorizontal) {
+          panels[0].style.width = px + 'px';
+        } else {
+          panels[0].style.height = px + 'px';
+        }
+      }
+
+      function onStart(e) {
+        var clientX = e.clientX || (e.touches && e.touches[0].clientX);
+        var clientY = e.clientY || (e.touches && e.touches[0].clientY);
+        if (clientX === undefined) return;
+        isDragging = true;
+        startPos = isHorizontal ? clientX : clientY;
+        startSize = getPanelSize();
+        container.classList.add('ease-split-pane--dragging');
+      }
+
+      function onMove(e) {
+        if (!isDragging) return;
+        var clientX = e.clientX || (e.touches && e.touches[0].clientX);
+        var clientY = e.clientY || (e.touches && e.touches[0].clientY);
+        if (clientX === undefined) return;
+        var currentPos = isHorizontal ? clientX : clientY;
+        var delta = currentPos - startPos;
+        var containerSize = isHorizontal ? container.offsetWidth : container.offsetHeight;
+        var dividerSize = divider.offsetWidth || divider.offsetHeight;
+        var newSize = Math.max(minSize, Math.min(containerSize - minSize - dividerSize, startSize + delta));
+        setPanelSize(newSize);
+      }
+
+      function onEnd() {
+        isDragging = false;
+        container.classList.remove('ease-split-pane--dragging');
+      }
+
+      divider.addEventListener('mousedown', onStart);
+      divider.addEventListener('touchstart', onStart, { passive: true });
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('touchmove', onMove, { passive: true });
+      document.addEventListener('mouseup', onEnd);
+      document.addEventListener('touchend', onEnd);
+
+      // Double-click to reset to 50/50
+      divider.addEventListener('dblclick', function() {
+        var containerSize = isHorizontal ? container.offsetWidth : container.offsetHeight;
+        var dividerSize = divider.offsetWidth || divider.offsetHeight;
+        var half = (containerSize - dividerSize) / 2;
+        setPanelSize(half);
+      });
+
+      // Collapse toggle
+      var toggleBtn = container.querySelector('.ease-split-pane__toggle');
+      if (toggleBtn) {
+        toggleBtn.addEventListener('click', function(e) {
+          e.stopPropagation();
+          var collapsed = panels[0].classList.toggle('ease-split-pane__panel--collapsed');
+          toggleBtn.innerHTML = collapsed ? '&#9654;' : '&#9664;';
+          if (collapsed) {
+            // Store original size for restore
+            if (!toggleBtn.dataset.origSize) {
+              toggleBtn.dataset.origSize = getPanelSize();
+            }
+            setPanelSize(0);
+          } else {
+            var origSize = parseInt(toggleBtn.dataset.origSize) || 250;
+            setPanelSize(origSize);
+            toggleBtn.dataset.origSize = '';
+          }
+        });
+      }
+    }
+
+    document.querySelectorAll('.ease-split-pane').forEach(initSplitPane);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-split-pane/style.css
+++ b/submissions/examples/ease-split-pane/style.css
@@ -1,0 +1,210 @@
+.ease-split-pane {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.ease-split-pane--vertical {
+  flex-direction: column;
+}
+
+.ease-split-pane__panel {
+  overflow: auto;
+  flex-shrink: 0;
+}
+
+.ease-split-pane__panel:first-child {
+  flex-shrink: 0;
+}
+
+.ease-split-pane__panel:last-child {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Divider */
+.ease-split-pane__divider {
+  flex-shrink: 0;
+  position: relative;
+  background: var(--ease-border, #e2e8f0);
+  transition: background-color 0.15s ease;
+  z-index: 1;
+}
+
+.ease-split-pane--horizontal .ease-split-pane__divider {
+  width: 4px;
+  cursor: col-resize;
+}
+
+.ease-split-pane--vertical .ease-split-pane__divider {
+  height: 4px;
+  cursor: row-resize;
+}
+
+.ease-split-pane__divider:hover {
+  background: var(--ease-muted, #94a3b8);
+}
+
+/* Grip dots */
+.ease-split-pane__divider::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.ease-split-pane--horizontal .ease-split-pane__divider::after {
+  width: 2px;
+  height: 24px;
+  background: repeating-linear-gradient(
+    0deg,
+    var(--ease-text, #334155) 0px,
+    var(--ease-text, #334155) 2px,
+    transparent 2px,
+    transparent 6px
+  );
+}
+
+.ease-split-pane--vertical .ease-split-pane__divider::after {
+  width: 24px;
+  height: 2px;
+  background: repeating-linear-gradient(
+    90deg,
+    var(--ease-text, #334155) 0px,
+    var(--ease-text, #334155) 2px,
+    transparent 2px,
+    transparent 6px
+  );
+}
+
+.ease-split-pane__divider:hover::after,
+.ease-split-pane--dragging .ease-split-pane__divider::after {
+  opacity: 1;
+}
+
+/* Dragging state */
+.ease-split-pane--dragging {
+  user-select: none;
+  -webkit-user-select: none;
+  cursor: col-resize;
+}
+
+.ease-split-pane--vertical.ease-split-pane--dragging {
+  cursor: row-resize;
+}
+
+.ease-split-pane--dragging .ease-split-pane__divider {
+  background: var(--ease-primary, #6366f1);
+}
+
+/* Collapsed */
+.ease-split-pane__panel--collapsed {
+  width: 0 !important;
+  overflow: hidden;
+  padding: 0;
+  min-width: 0 !important;
+  flex: 0 0 0 !important;
+}
+
+.ease-split-pane--vertical .ease-split-pane__panel--collapsed {
+  height: 0 !important;
+  min-height: 0 !important;
+}
+
+/* Collapse toggle button */
+.ease-split-pane__toggle {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid var(--ease-border, #e2e8f0);
+  background: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  color: var(--ease-muted, #64748b);
+  z-index: 2;
+  padding: 0;
+  line-height: 1;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.ease-split-pane__toggle:hover {
+  background: var(--ease-primary, #6366f1);
+  color: #fff;
+  border-color: var(--ease-primary, #6366f1);
+}
+
+.ease-split-pane--horizontal .ease-split-pane__toggle {
+  right: -10px;
+}
+
+.ease-split-pane--vertical .ease-split-pane__toggle {
+  top: auto;
+  bottom: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .ease-split-pane__divider {
+    background: #334155;
+  }
+
+  .ease-split-pane__divider:hover,
+  .ease-split-pane--dragging .ease-split-pane__divider {
+    background: #6366f1;
+  }
+
+  .ease-split-pane--horizontal .ease-split-pane__divider::after,
+  .ease-split-pane--vertical .ease-split-pane__divider::after {
+    background: repeating-linear-gradient(
+      0deg,
+      #94a3b8 0px,
+      #94a3b8 2px,
+      transparent 2px,
+      transparent 6px
+    );
+  }
+
+  .ease-split-pane--vertical .ease-split-pane__divider::after {
+    background: repeating-linear-gradient(
+      90deg,
+      #94a3b8 0px,
+      #94a3b8 2px,
+      transparent 2px,
+      transparent 6px
+    );
+  }
+
+  .ease-split-pane__toggle {
+    background: #1e293b;
+    border-color: #475569;
+    color: #94a3b8;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-split-pane__divider {
+    transition: none;
+  }
+
+  .ease-split-pane__divider::after {
+    transition: none;
+  }
+
+  .ease-split-pane__toggle {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #1267

## Pull Request Description

Add a new `ease-split-pane` component: two resizable panels separated by a draggable divider handle. Supports horizontal/vertical orientations, nested layouts, collapsible panels, double-click to reset, and configurable minimum size.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-split-pane/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A resizable split pane with:
- **2 orientations**: horizontal (left/right), vertical (top/bottom)
- **Draggable divider**: 4px handle with grip dots on hover, coloured on drag
- **Double-click** divider to reset to 50/50 split
- **Collapsible**: toggle button on divider collapses/expands the first panel
- **Nested**: split pane inside a split pane (fully supported)
- **Configurable min panel size** via `data-ease-min-panel-width` (default: 100px)
- **Drag state**: adds `.ease-split-pane--dragging` class to disable text selection
- **Dark mode**: automatic via `prefers-color-scheme`
- **Reduced motion**: respects `prefers-reduced-motion`

**How does a developer use it?**

```html
<div class="ease-split-pane ease-split-pane--horizontal" data-ease-min-panel-width="100">
  <div class="ease-split-pane__panel" style="width:250px;">
    <!-- Left panel -->
  </div>
  <div class="ease-split-pane__divider">
    <button class="ease-split-pane__toggle">◀</button>
  </div>
  <div class="ease-split-pane__panel">
    <!-- Right panel (fills remaining space) -->
  </div>
</div>
initSplitPane(document.querySelector('.ease-split-pane'));
Why does it fit EaseMotion CSS?
Split panes are essential for code editors, documentation sites, and comparison views — a common UI pattern missing from EaseMotion.
Demo
- Demo added (demo.html works by opening directly in a browser)
Browser Testing
- Chrome
- Firefox
- Edge
- Safari (optional but appreciated)
Notes for Maintainer
JS handles: mousedown/touchstart drag initiation, mousemove/touchmove resize, double-click reset, collapse toggle. CSS manages all visual styling, grip dots, and dark mode. Works with desktop mouse and touch events for mobile. Ready for integration into components/.
Closes #1267
