### PR TITLE
feat: add ease-ripple click effect — composable ripple animation for interactive elements

### DIFF
--- a/submissions/examples/ease-ripple/README.md
+++ b/submissions/examples/ease-ripple/README.md
@@ -1,21 +1,74 @@
-# Ease Ripple
+# EaseMotion — `ease-ripple`
 
-**What does this do?**  
-Adds a pure CSS click ripple that expands and fades inside a button without JavaScript.
-
-**How is it used?**  
-```html
-<button class="ripple-button">Save changes</button>
-<button class="ripple-button ripple-pill" style="--ease-ripple-color: rgba(255,255,255,0.5)">
-  Continue
-</button>
-```
-
-**Why is it useful?**  
-Ripple feedback makes buttons feel tactile on mouse and touch devices. This submission keeps the effect self-contained with `::after`, supports rounded and pill-shaped buttons through `overflow: hidden`, and lets developers tune the ripple color through `--ease-ripple-color`.
+A composable click ripple effect for interactive elements. Add `.ease-ripple` to any button, card, or interactive element to get a circular wave animation on click/tap.
 
 ---
 
-Submitted by: @saurabhhhcodes  
-Issue: #128  
-Status: **Pending review**
+## Features
+
+- **Composable** — add `.ease-ripple` to any element (buttons, cards, list items, etc.)
+- **Pure CSS** — uses `::after` pseudo-element and `:active` state, no JavaScript
+- **`currentColor` by default** — ripple colour automatically matches the element's text colour
+- **Customisable** — override via `--ease-ripple-color` and `--ease-ripple-duration`
+- **Reduced motion** — disables ripple when `prefers-reduced-motion: reduce`
+
+---
+
+## Usage
+
+```html
+<button class="ease-btn ease-ripple">Click me</button>
+
+<div class="ease-card ease-ripple">
+  Clickable card content
+</div>
+
+<li class="ease-ripple">Menu item</li>
+```
+
+### Custom colour
+
+```html
+<button class="ease-ripple" style="--ease-ripple-color: rgba(34,197,94,0.5)">
+  Green ripple
+</button>
+```
+
+### Custom duration
+
+```html
+<button class="ease-ripple" style="--ease-ripple-duration: 0.3s">
+  Fast ripple
+</button>
+```
+
+---
+
+## CSS Variables
+
+| Variable                  | Default        | Description                     |
+|---------------------------|----------------|---------------------------------|
+| `--ease-ripple-color`     | `currentColor` | Colour of the ripple circle     |
+| `--ease-ripple-duration`  | `0.5s`         | Animation duration              |
+
+---
+
+## Why does it fit EaseMotion CSS?
+
+Ripple click feedback is a widely adopted Material Design pattern that provides tactile feedback on interactive elements. EaseMotion already has hover effects (`ease-hover-glow`, `ease-hover-shimmer`, `ease-card-lift`) and press feedback (`ease-squish-button`), but was missing a composable click ripple — this fills that gap with a minimal, no-JS implementation.
+
+---
+
+## Files
+
+1. **`style.css`** — component CSS with `.ease-ripple` utility and keyframes
+2. **`demo.html`** — interactive demo with buttons, cards, and customisation examples
+3. **`README.md`** — documentation and usage examples
+
+---
+
+## Notes
+
+- The element must have `position: relative` (or equivalent) for `::after` to position correctly — `.ease-ripple` applies this automatically.
+- `overflow: hidden` clips the ripple to the element's border box.
+- The ripple always emanates from the centre of the element (`top: 50%; left: 50%`), not from the exact click point — this is a known trade-off for a pure CSS `:active` approach without JS pointer events.

--- a/submissions/examples/ease-ripple/demo.html
+++ b/submissions/examples/ease-ripple/demo.html
@@ -1,39 +1,82 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Submission - Ease Ripple</title>
-  <link rel="stylesheet" href="style.css" />
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EaseMotion — ease-ripple Demo</title>
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <main class="demo-shell">
-    <section class="intro">
-      <p class="eyebrow">Pure CSS interaction</p>
-      <h1>Ease Ripple</h1>
-      <p>
-        Press any button to see a radial ripple expand and fade inside its
-        bounds. The effect uses only a pseudo-element and the active state.
-      </p>
-    </section>
 
-    <section class="button-grid" aria-label="Ripple button examples">
-      <button class="ripple-button ripple-primary">Primary Action</button>
-      <button class="ripple-button ripple-success">Confirm</button>
-      <button class="ripple-button ripple-alert">Delete</button>
-      <button class="ripple-button ripple-pill">Pill Button</button>
-      <button class="ripple-button ripple-outline">Outline Button</button>
-      <button class="ripple-button ripple-soft">Soft Surface</button>
-    </section>
+<h1>ease-ripple</h1>
+<p class="sub">Composable click ripple effect — add to any interactive element</p>
 
-    <section class="usage-card" aria-label="Configuration example">
-      <h2>Configurable color</h2>
-      <p>
-        Set <code>--ease-ripple-color</code> on the button to match any brand
-        surface. Border radius is inherited automatically because the ripple is
-        clipped by the button.
-      </p>
-    </section>
-  </main>
+<section>
+  <h2>Buttons</h2>
+  <div class="btn-row">
+    <button class="demo-btn demo-btn--primary ease-ripple">Primary</button>
+    <button class="demo-btn demo-btn--success ease-ripple">Success</button>
+    <button class="demo-btn demo-btn--danger ease-ripple">Danger</button>
+    <button class="demo-btn demo-btn--outline ease-ripple">Outline</button>
+    <button class="demo-btn demo-btn--ghost ease-ripple">Ghost</button>
+  </div>
+  <p class="note">Add <code>class="ease-ripple"</code> to any button.</p>
+</section>
+
+<section>
+  <h2>Cards</h2>
+  <p style="font-size:0.85rem;color:#64748b;margin:0 0 12px">Ripple also works on larger elements like cards.</p>
+  <div class="card-row">
+    <div class="demo-card ease-ripple">
+      <h3>Clickable Card</h3>
+      <p>Tap or click to see the ripple effect emanate from the center.</p>
+    </div>
+    <div class="demo-card ease-ripple" style="--ease-ripple-color: rgba(34,197,94,0.5)">
+      <h3>Custom Colour</h3>
+      <p>Uses <code>--ease-ripple-color</code> for a green ripple.</p>
+    </div>
+  </div>
+  <p class="note">Ripple center is fixed at 50% / 50% — adjust <code>--ease-ripple-color</code> to match the element.</p>
+</section>
+
+<section>
+  <h2>Customisation</h2>
+  <div style="display:flex;flex-wrap:wrap;gap:16px">
+    <div>
+      <button class="demo-btn demo-btn--primary ease-ripple" style="--ease-ripple-color: rgba(255,255,255,0.6); --ease-ripple-duration: 0.8s;">
+        Slow (0.8s)
+      </button>
+    </div>
+    <div>
+      <button class="demo-btn demo-btn--primary ease-ripple" style="--ease-ripple-color: rgba(255,255,255,0.6); --ease-ripple-duration: 0.3s;">
+        Fast (0.3s)
+      </button>
+    </div>
+    <div>
+      <button class="demo-btn demo-btn--primary ease-ripple" style="--ease-ripple-color: rgba(255,209,102,0.6);">
+        Custom Colour
+      </button>
+    </div>
+  </div>
+  <p class="note">Customise via <code>--ease-ripple-color</code> (default: <code>currentColor</code>) and <code>--ease-ripple-duration</code> (default: <code>0.5s</code>).</p>
+</section>
+
+<section>
+  <h2>CSS Variables</h2>
+  <dl class="var-ref">
+    <dt>--ease-ripple-color</dt>
+    <dd>Ripple colour — defaults to <code>currentColor</code> of the element</dd>
+    <dt>--ease-ripple-duration</dt>
+    <dd>Animation duration — defaults to <code>0.5s</code></dd>
+  </dl>
+</section>
+
+<section>
+  <h2>Usage</h2>
+  <pre><code>&lt;button class=&quot;ease-btn ease-ripple&quot;&gt;Click me&lt;/button&gt;
+&lt;div class=&quot;ease-card ease-ripple&quot;&gt;Clickable card&lt;/div&gt;</code></pre>
+  <p class="note" style="margin-top:8px">Works with any element that has <code>position: relative</code> context. <code>overflow: hidden</code> clips the ripple to the element bounds.</p>
+</section>
+
 </body>
 </html>

--- a/submissions/examples/ease-ripple/style.css
+++ b/submissions/examples/ease-ripple/style.css
@@ -1,198 +1,219 @@
-/* ============================================================
-   SUBMISSION - ease-ripple
-   Pure CSS button ripple using :active and ::after.
-   No JavaScript, no external assets, no framework dependencies.
-   ============================================================ */
+/* =============================================
+   EaseMotion CSS — ease-ripple Click Effect
+   Composable ripple animation for any element
+   ============================================= */
 
-:root {
-  color-scheme: dark;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: #101014;
-  color: #f8f7f2;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-body {
-  min-height: 100vh;
-  margin: 0;
-  display: grid;
-  place-items: center;
-  padding: 42px 20px;
-  background:
-    radial-gradient(circle at 15% 15%, rgba(255, 209, 102, 0.18), transparent 28rem),
-    radial-gradient(circle at 85% 10%, rgba(17, 138, 178, 0.2), transparent 32rem),
-    linear-gradient(145deg, #101014 0%, #191b22 54%, #111317 100%);
-}
-
-.demo-shell {
-  width: min(820px, 100%);
-}
-
-.intro {
-  margin-bottom: 28px;
-}
-
-.eyebrow {
-  margin: 0 0 10px;
-  color: #ffd166;
-  font-size: 0.78rem;
-  font-weight: 850;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-h1 {
-  margin: 0 0 12px;
-  font-size: clamp(2.4rem, 8vw, 4.8rem);
-  line-height: 0.95;
-}
-
-.intro p:not(.eyebrow),
-.usage-card p {
-  max-width: 620px;
-  margin: 0;
-  color: rgba(248, 247, 242, 0.68);
-  line-height: 1.7;
-}
-
-.button-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
-  margin-bottom: 24px;
-}
-
-.ripple-button {
-  --ease-ripple-color: rgba(255, 255, 255, 0.42);
+.ease-ripple {
   position: relative;
-  isolation: isolate;
   overflow: hidden;
-  min-height: 52px;
-  padding: 0 22px;
-  border: 0;
-  border-radius: 12px;
-  background: #2d7ff9;
-  color: #ffffff;
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.96rem;
-  font-weight: 800;
-  letter-spacing: 0;
-  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.24);
-  transition:
-    transform 180ms ease,
-    box-shadow 220ms ease,
-    filter 220ms ease;
 }
 
-.ripple-button:hover {
-  filter: brightness(1.08);
-  transform: translateY(-1px);
-  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.28);
-}
-
-.ripple-button:active {
-  transform: translateY(0) scale(0.985);
-}
-
-.ripple-button:focus-visible {
-  outline: 3px solid rgba(255, 209, 102, 0.74);
-  outline-offset: 3px;
-}
-
-.ripple-button::after {
-  content: "";
+.ease-ripple::after {
+  content: '';
   position: absolute;
-  z-index: 0;
-  inset-block-start: 50%;
-  inset-inline-start: 50%;
-  inline-size: 38%;
-  aspect-ratio: 1;
-  border-radius: 999px;
-  background: var(--ease-ripple-color);
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin: -10px 0 0 -10px;
+  border-radius: 50%;
+  background: var(--ease-ripple-color, currentColor);
   opacity: 0;
   pointer-events: none;
-  transform: translate(-50%, -50%) scale(4);
-  transition:
-    transform 520ms cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 700ms ease-out;
+  z-index: 1;
 }
 
-.ripple-button:active::after {
-  opacity: 0.55;
-  transform: translate(-50%, -50%) scale(0);
-  transition: none;
+.ease-ripple:active::after {
+  animation: ease-kf-ripple var(--ease-ripple-duration, 0.5s) ease-out forwards;
 }
 
-.ripple-primary {
-  background: linear-gradient(135deg, #2d7ff9, #4f46e5);
-}
-
-.ripple-success {
-  --ease-ripple-color: rgba(236, 255, 240, 0.52);
-  background: linear-gradient(135deg, #118a5a, #19b86d);
-}
-
-.ripple-alert {
-  --ease-ripple-color: rgba(255, 241, 230, 0.5);
-  background: linear-gradient(135deg, #d33f49, #f15a24);
-}
-
-.ripple-pill {
-  --ease-ripple-color: rgba(255, 255, 255, 0.48);
-  border-radius: 999px;
-  background: linear-gradient(135deg, #6d5dfc, #c471ed);
-}
-
-.ripple-outline {
-  --ease-ripple-color: rgba(45, 127, 249, 0.22);
-  border: 1px solid rgba(45, 127, 249, 0.72);
-  background: rgba(45, 127, 249, 0.08);
-  color: #9fc7ff;
-}
-
-.ripple-soft {
-  --ease-ripple-color: rgba(255, 209, 102, 0.24);
-  background: rgba(255, 209, 102, 0.12);
-  color: #ffe2a3;
-}
-
-.usage-card {
-  border: 1px solid rgba(248, 247, 242, 0.12);
-  border-radius: 14px;
-  padding: 22px;
-  background: rgba(248, 247, 242, 0.065);
-}
-
-.usage-card h2 {
-  margin: 0 0 8px;
-  font-size: 1rem;
-}
-
-code {
-  border-radius: 6px;
-  padding: 2px 6px;
-  background: rgba(255, 209, 102, 0.13);
-  color: #ffe2a3;
-  font-size: 0.92em;
+@keyframes ease-kf-ripple {
+  from {
+    opacity: 0.4;
+    transform: scale(0);
+  }
+  to {
+    opacity: 0;
+    transform: scale(6);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .ripple-button,
-  .ripple-button::after {
-    transition-duration: 1ms;
+  .ease-ripple::after {
+    display: none !important;
   }
 }
 
-@media (max-width: 680px) {
-  .button-grid {
-    grid-template-columns: 1fr;
-  }
+/* =============================================
+   Demo Styles
+   ============================================= */
 
-  .ripple-button {
-    width: 100%;
-  }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 40px 24px;
+  line-height: 1.6;
+  color: #1e293b;
+  background: #f8fafc;
+}
+
+h1 { font-size: 1.5rem; margin: 0 0 4px; }
+p.sub { color: #64748b; margin: 0 0 32px; font-size: 0.9rem; }
+
+h2 {
+  font-size: 1rem;
+  margin: 0 0 16px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #e2e8f0;
+}
+
+section {
+  margin-bottom: 32px;
+  padding: 20px;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+
+.demo-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 24px;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 100ms ease, box-shadow 200ms ease;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.demo-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+}
+
+.demo-btn:active {
+  transform: translateY(0) scale(0.98);
+}
+
+.demo-btn--primary {
+  background: #6c63ff;
+  color: #fff;
+}
+
+.demo-btn--success {
+  background: #22c55e;
+  color: #fff;
+}
+
+.demo-btn--danger {
+  background: #ef4444;
+  color: #fff;
+}
+
+.demo-btn--outline {
+  background: transparent;
+  border: 2px solid #6c63ff;
+  color: #6c63ff;
+}
+
+.demo-btn--ghost {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.demo-card {
+  padding: 24px;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  transition: transform 150ms ease, box-shadow 200ms ease;
+}
+
+.demo-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.1);
+}
+
+.demo-card:active {
+  transform: translateY(0) scale(0.99);
+}
+
+.demo-card h3 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.demo-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.btn-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.card-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.card-row .demo-card {
+  flex: 1;
+  min-width: 180px;
+}
+
+code {
+  background: #f1f5f9;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+.note {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin-top: 12px;
+}
+
+.var-ref {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 16px;
+  font-size: 0.85rem;
+}
+
+.var-ref dt {
+  font-family: monospace;
+  font-weight: 600;
+  color: #6c63ff;
+}
+
+.var-ref dd {
+  margin: 0;
+  color: #475569;
+}
+
+@media (prefers-color-scheme: dark) {
+  body { color: #e2e8f0; background: #0f172a; }
+  h2 { border-bottom-color: #334155; }
+  section { background: #1e293b; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+  code { background: #334155; }
+  .note { color: #94a3b8; }
+  .demo-btn--ghost { background: #334155; color: #cbd5e1; }
+  .demo-card { border-color: #334155; background: #1e293b; }
+  .demo-card p { color: #94a3b8; }
+  .var-ref dd { color: #94a3b8; }
 }


### PR DESCRIPTION
Closes #1176

---

## Pull Request Description

Replaces the previous non-composable `.ripple-button` implementation with a proper `.ease-ripple` utility class that can be added to any interactive element.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-ripple/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A composable `.ease-ripple` utility class that adds a circular wave click/tap animation to any interactive element — buttons, cards, list items, etc.

**How does a developer use it?**

```html
<button class="ease-btn ease-ripple">Click me</button>
<div class="ease-card ease-ripple">Clickable card</div>
<li class="ease-ripple">Menu item</li>

<!-- Custom colour -->
<button class="ease-ripple" style="--ease-ripple-color: rgba(34,197,94,0.5)">
  Green ripple
</button>

<!-- Custom duration -->
<button class="ease-ripple" style="--ease-ripple-duration: 0.3s">
  Fast ripple
</button>
Why does it fit EaseMotion CSS?
EaseMotion already has hover effects and press feedback but lacked a composable click ripple — a widely adopted interaction pattern. This fills the gap with a minimal, no-JS implementation using ::after and :active.
Demo
- Demo added (demo.html works by opening directly in a browser)
Browser Testing
- Chrome
- Firefox
- Edge
- Safari (optional but appreciated)
Notes for Maintainer
The ripple always emanates from the element's center (top: 50%; left: 50%), not from the exact click point — this is a known trade-off for a pure CSS :active approach without JS pointer events. Customise via --ease-ripple-color (defaults to currentColor) and --ease-ripple-duration (default 0.5s). Disabled entirely under prefers-reduced-motion: reduce.