### PR TITLE
fix: replace sidebar width transition with flex-basis to eliminate layout thrashing (#1380)

### DIFF
--- a/components/sidebar.css
+++ b/components/sidebar.css
@@ -5,27 +5,27 @@
 
 /* ── Sidebar Layout Wrapper ─────────────────────────────────── */
 .ease-sidebar-layout {
-  display: grid;
-  grid-template-columns: var(--ease-sidebar-width, 260px) 1fr;
-  grid-template-rows: 1fr;
+  display: flex;
   min-height: 100vh;
-  transition: grid-template-columns var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
 }
 
 /* ── Sidebar Panel ──────────────────────────────────────────── */
 .ease-sidebar {
-  grid-column: 1;
+  flex-shrink: 0;
+  flex-basis: var(--ease-sidebar-width, 260px);
   background: var(--ease-color-neutral-900, #111);
   border-right: 1px solid var(--ease-color-neutral-200, #e5e7eb);
   overflow-y: auto;
   overflow-x: hidden;
-  transition: width var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+  white-space: nowrap;
+  transition: flex-basis var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
               opacity var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
 }
 
 /* ── Main Content Area ──────────────────────────────────────── */
 .ease-sidebar-main {
-  grid-column: 2;
+  flex: 1;
+  min-width: 0;
   overflow-y: auto;
   padding: var(--ease-sidebar-main-padding, 2rem);
   transition:
@@ -34,12 +34,8 @@
 }
 
 /* ── Collapsible Variant ────────────────────────────────────── */
-.ease-sidebar-layout.ease-sidebar-collapsed {
-  grid-template-columns: var(--ease-sidebar-collapsed-width, 64px) 1fr;
-}
-
 .ease-sidebar-layout.ease-sidebar-collapsed .ease-sidebar {
-  width: var(--ease-sidebar-collapsed-width, 64px);
+  flex-basis: var(--ease-sidebar-collapsed-width, 64px);
   overflow: hidden;
 }
 
@@ -69,41 +65,32 @@
   transform: rotate(180deg);
 }
 
-/* ── Responsive: collapse on mobile ────────────────────────── */
+/* ── Responsive: overlay sidebar on mobile ──────────────────── */
 @media (max-width: 768px) {
-  .ease-sidebar-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .ease-sidebar-main {
-    grid-column: 1;
-  }
-
   .ease-sidebar {
-  display: none;
-  transform: translateX(-100%);
-  transition:
-    transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
-    box-shadow 0.3s ease;
-}
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    z-index: 100;
+    width: var(--ease-sidebar-width, 260px);
+    display: none;
+    transform: translateX(-100%);
+    transition:
+      transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+      box-shadow 0.3s ease;
+  }
 
-.ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
-  display: block;
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100vh;
-  z-index: 100;
-  width: var(--ease-sidebar-width, 260px);
+  .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
+    display: block;
+    transform: translateX(0);
+    box-shadow: 12px 0 36px rgba(0, 0, 0, 0.15);
+  }
 
-  transform: translateX(0);
-  box-shadow: 12px 0 36px rgba(0, 0, 0, 0.15);
-}
-
-.ease-sidebar-layout.ease-sidebar-open .ease-sidebar-main {
-  transform: translateX(120px) scale(0.95);
-  border-radius: 20px;
-}
+  .ease-sidebar-layout.ease-sidebar-open .ease-sidebar-main {
+    transform: translateX(120px) scale(0.95);
+    border-radius: 20px;
+  }
 }
 
 /* ── Reduced Motion ─────────────────────────────────────────── */


### PR DESCRIPTION
## Description

The sidebar collapse/expand animation transitioned `width` on `.ease-sidebar` AND `grid-template-columns` on `.ease-sidebar-layout` simultaneously — both layout-triggering properties. This caused double layout recalculation on every animation frame, leading to visible jank on pages with complex DOM trees.

## Root Cause

`width` is a layout-triggering property. When the browser animates it, it must recalculate the layout of the element and all its siblings on every frame. The grid layout also transitioned `grid-template-columns`, doubling the layout work.

## Changes

- **`components/sidebar.css`**:
  - Replaced `display: grid` + `grid-template-columns` with `display: flex` on `.ease-sidebar-layout`
  - Replaced `width` transition with `flex-basis` transition on `.ease-sidebar` — `flex-basis` is a simpler layout property that triggers less work than `width` + `grid-template-columns` combined
  - Added `flex: 1; min-width: 0` to `.ease-sidebar-main` for proper flex layout
  - Added `white-space: nowrap` to `.ease-sidebar` to prevent content wrapping during collapse
  - Fixed the mobile responsive section to remove leftover grid properties (`grid-template-columns`, `grid-column`) since the layout is now flex-based

## Performance Impact

- Before: `width` (layout) + `grid-template-columns` (layout) = double layout thrashing
- After: `flex-basis` (single layout trigger) — significantly fewer layout recalculations per frame

## Testing

- [x] Lint (stylelint) — passed
- [x] Tests (vitest) — 3/3 passed

Closes #1380