### PR TITLE
feat: add button group composition fix example

### DIFF
--- a/submissions/examples/button-group-composition-fix-tejaswani/README.md
+++ b/submissions/examples/button-group-composition-fix-tejaswani/README.md
@@ -1,13 +1,41 @@
-# Button Group Composition Fix
+# Button Group Composition Fix Demo
 
 ## What does this do?
 
-Demonstrates properly grouped buttons with correct border radius handling.
+This demo showcases button groups with proper border-radius composition for different button variants, including pill-shaped, small, and large buttons. It also demonstrates symmetric border handling between grouped buttons.
 
 ## How is it used?
 
-Place buttons inside a button-group container and apply shape modifiers.
+### Pill Button Group
+
+```html
+<div class="button-group pill">
+    <button>Left</button>
+    <button>Middle</button>
+    <button>Right</button>
+</div>
+```
+
+### Small Button Group
+
+```html
+<div class="button-group small">
+    <button>Left</button>
+    <button>Middle</button>
+    <button>Right</button>
+</div>
+```
+
+### Large Button Group
+
+```html
+<div class="button-group large">
+    <button>Left</button>
+    <button>Middle</button>
+    <button>Right</button>
+</div>
+```
 
 ## Why is it useful?
 
-It keeps button groups visually consistent and composable.
+This example demonstrates how grouped buttons can maintain their intended shapes and sizes while avoiding uneven border rendering between adjacent buttons. It improves visual consistency and helps create reusable, composable button group patterns.

--- a/submissions/examples/button-group-composition-fix-tejaswani/README.md
+++ b/submissions/examples/button-group-composition-fix-tejaswani/README.md
@@ -1,0 +1,13 @@
+# Button Group Composition Fix
+
+## What does this do?
+
+Demonstrates properly grouped buttons with correct border radius handling.
+
+## How is it used?
+
+Place buttons inside a button-group container and apply shape modifiers.
+
+## Why is it useful?
+
+It keeps button groups visually consistent and composable.

--- a/submissions/examples/button-group-composition-fix-tejaswani/demo.html
+++ b/submissions/examples/button-group-composition-fix-tejaswani/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<h2>Pill Button Group</h2>
+
+<div class="button-group pill">
+    <button>Left</button>
+    <button>Middle</button>
+    <button>Right</button>
+</div>
+
+<h2>Small Button Group</h2>
+
+<div class="button-group small">
+    <button>Left</button>
+    <button>Middle</button>
+    <button>Right</button>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/button-group-composition-fix-tejaswani/demo.html
+++ b/submissions/examples/button-group-composition-fix-tejaswani/demo.html
@@ -1,25 +1,34 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <title>Button Group Composition Fix Demo</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
-<h2>Pill Button Group</h2>
+    <h1>Button Group Composition Demo</h1>
 
-<div class="button-group pill">
-    <button>Left</button>
-    <button>Middle</button>
-    <button>Right</button>
-</div>
+    <h2>Pill Button Group</h2>
+    <div class="button-group pill">
+        <button>Left</button>
+        <button>Middle</button>
+        <button>Right</button>
+    </div>
 
-<h2>Small Button Group</h2>
+    <h2>Small Button Group</h2>
+    <div class="button-group small">
+        <button>Left</button>
+        <button>Middle</button>
+        <button>Right</button>
+    </div>
 
-<div class="button-group small">
-    <button>Left</button>
-    <button>Middle</button>
-    <button>Right</button>
-</div>
+    <h2>Large Button Group</h2>
+    <div class="button-group large">
+        <button>Left</button>
+        <button>Middle</button>
+        <button>Right</button>
+    </div>
 
 </body>
 </html>

--- a/submissions/examples/button-group-composition-fix-tejaswani/style.css
+++ b/submissions/examples/button-group-composition-fix-tejaswani/style.css
@@ -1,15 +1,37 @@
+body {
+    font-family: Arial, sans-serif;
+    padding: 40px;
+}
+
 .button-group {
     display: inline-flex;
+    margin-bottom: 30px;
 }
 
 .button-group button {
     border: 2px solid black;
-    padding: 10px 16px;
+    background: white;
+    cursor: pointer;
+}
+
+/* Symmetric border overlay */
+.button-group button:not(:last-child) {
+    margin-right: -2px;
+}
+
+.button-group button:hover {
+    position: relative;
+    z-index: 1;
+}
+
+/* Remove middle rounding */
+.button-group button {
     border-radius: 0;
 }
 
-.button-group button:not(:last-child) {
-    margin-right: -2px;
+/* Pill Group */
+.pill button {
+    padding: 10px 18px;
 }
 
 .pill button:first-child {
@@ -20,10 +42,30 @@
     border-radius: 0 999px 999px 0;
 }
 
+/* Small Group */
+.small button {
+    padding: 6px 12px;
+    font-size: 12px;
+}
+
 .small button:first-child {
     border-radius: 4px 0 0 4px;
 }
 
 .small button:last-child {
     border-radius: 0 4px 4px 0;
+}
+
+/* Large Group */
+.large button {
+    padding: 14px 24px;
+    font-size: 18px;
+}
+
+.large button:first-child {
+    border-radius: 12px 0 0 12px;
+}
+
+.large button:last-child {
+    border-radius: 0 12px 12px 0;
 }

--- a/submissions/examples/button-group-composition-fix-tejaswani/style.css
+++ b/submissions/examples/button-group-composition-fix-tejaswani/style.css
@@ -1,0 +1,29 @@
+.button-group {
+    display: inline-flex;
+}
+
+.button-group button {
+    border: 2px solid black;
+    padding: 10px 16px;
+    border-radius: 0;
+}
+
+.button-group button:not(:last-child) {
+    margin-right: -2px;
+}
+
+.pill button:first-child {
+    border-radius: 999px 0 0 999px;
+}
+
+.pill button:last-child {
+    border-radius: 0 999px 999px 0;
+}
+
+.small button:first-child {
+    border-radius: 4px 0 0 4px;
+}
+
+.small button:last-child {
+    border-radius: 0 4px 4px 0;
+}


### PR DESCRIPTION
## Pull Request Description

Added a standalone demo showcasing button group composition with proper border-radius handling for pill, small, and large button groups. The demo also demonstrates symmetric border rendering between grouped buttons

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/button-group-composition-fix/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A button group composition demo showcasing pill, small, and large grouped buttons.

**How does a developer use it?**

```html
<div class="button-group pill"> 
   <button>Left</button> 
   <button>Middle</button> 
   <button>Right</button> 
</div>
```

**Why does it fit EaseMotion CSS?**

It demonstrates reusable and composable button group patterns while maintaining clean, readable CSS and consistent visual behavior.
---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission demonstrates proper button group composition for different button shapes and sizes while maintaining symmetric borders and consistent rounded corners.

Fixes #881

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
