### PR TITLE
feat: add one-click copy button example showcase directory

### DIFF
--- a/submissions/examples/one-click-copy-button/README.md
+++ b/submissions/examples/one-click-copy-button/README.md
@@ -1,0 +1,93 @@
+# one-click-copy-button
+
+**GSSoC · EaseMotion CSS Submission**
+
+A self-contained documentation gallery that pairs live animation previews with a one-click **Copy Class** button, so developers can grab EaseMotion utility class names without manual text selection.
+
+---
+
+## What does this do?
+
+This example demonstrates a reusable **one-click copy** pattern for animation documentation. Each card in the grid shows:
+
+1. A **live preview** of the animation (fade-in, slide-left, bounce, and more).
+2. The **exact class name string** displayed in a monospace badge.
+3. A **[Copy Class]** button that copies that string to the clipboard instantly.
+
+After a successful copy, the button shows **✓ Copied!** for exactly 2 seconds, enters a disabled visual state, then gracefully reverts to **Copy Class**.
+
+---
+
+## Structure
+
+```
+submissions/examples/one-click-copy-button/
+├── demo.html   — Animation card grid + inline clipboard script
+├── style.css   — Layout, card grid, copy-button states, demo animations
+└── README.md   — This file
+```
+
+### `demo.html`
+
+- Renders a responsive grid of six animation cards (`ease-fade-in`, `ease-slide-in-left`, `ease-slide-up`, `ease-bounce`, `ease-zoom-in`, `ease-pulse`).
+- Each card footer pairs a `<code>` class label with a `.copy-class-btn` button.
+- Includes a hidden `<textarea>` (`#clipboard-fallback`) for clipboard fallback in non-secure (HTTP) or older browser environments.
+- Inline script wires up:
+  - `navigator.clipboard.writeText()` on secure contexts.
+  - `textarea` + `document.execCommand('copy')` fallback when the Clipboard API is unavailable.
+  - 2-second success feedback loop on every copy button.
+
+### `style.css`
+
+- Matches the EaseMotion submission layout system: dark surface tokens, DM Serif / DM Sans / JetBrains Mono typography, and responsive card grid.
+- Styles `.copy-class-btn` with hover, focus-visible, and `.copied` / `:disabled` success states.
+- Defines self-contained keyframe previews so the demo runs without linking the full library.
+
+---
+
+## How is it used?
+
+Open `demo.html` in a browser (or serve the folder locally). Click **Copy Class** on any card — the class name is placed on your clipboard ready to paste into HTML:
+
+```html
+<div class="ease-fade-in">Welcome</div>
+```
+
+To integrate the pattern into your own docs, reuse this markup shape:
+
+```html
+<div class="anim-card__footer">
+  <code class="anim-card__class">ease-slide-in-left</code>
+  <button type="button" class="copy-class-btn">Copy Class</button>
+</div>
+```
+
+Attach the same click handler from `demo.html` to all `.copy-class-btn` elements, reading the class string from the adjacent `<code>` node.
+
+---
+
+## Why is it useful?
+
+Copying utility class names from documentation is a small task that adds up quickly:
+
+- **No selection friction** — developers avoid triple-clicking, drag-selecting, or accidentally copying trailing whitespace from tables.
+- **Fewer typos** — the copied string is always the exact class name shown beside the button.
+- **Immediate confirmation** — the 2-second **✓ Copied!** state removes guesswork about whether the action succeeded.
+- **Broad compatibility** — the Clipboard API path covers modern HTTPS contexts; the hidden textarea fallback keeps copy working on HTTP and legacy browsers.
+- **Faster iteration** — browse animations visually, copy a class, paste into your project, and preview in seconds.
+
+This pattern is especially valuable in animation libraries like EaseMotion CSS, where class names are the primary API surface and documentation pages list dozens of utilities side by side.
+
+---
+
+## Browser support
+
+| Feature | Support |
+|---|---|
+| Clipboard API (`navigator.clipboard.writeText`) | Chrome, Firefox, Safari, Edge on HTTPS |
+| Textarea fallback (`execCommand('copy')`) | Older browsers and non-secure (HTTP) contexts |
+| CSS animations | All modern browsers; disabled under `prefers-reduced-motion` |
+
+---
+
+*Submitted for GSSoC · EaseMotion CSS open-source project.*

--- a/submissions/examples/one-click-copy-button/demo.html
+++ b/submissions/examples/one-click-copy-button/demo.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>One-Click Copy Button · EaseMotion CSS</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap"
+    rel="stylesheet"
+  />
+
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- Fallback target for clipboard copy in HTTP / legacy browsers -->
+  <textarea id="clipboard-fallback" class="clipboard-fallback" aria-hidden="true" tabindex="-1" readonly></textarea>
+
+  <main class="copy-demo">
+    <p class="copy-demo__eyebrow">EaseMotion CSS · one-click-copy-button</p>
+
+    <header class="copy-demo__header">
+      <h1 class="copy-demo__title">Animation Class Gallery</h1>
+      <p class="copy-demo__subtitle">
+        Preview entrance and looping animations, then copy any utility class with a single click —
+        no manual text selection required.
+      </p>
+    </header>
+
+    <section class="card-grid" aria-label="Animation class showcase">
+
+      <article class="anim-card" data-replay="entrance">
+        <span class="anim-card__label">Entrance</span>
+        <div class="anim-card__stage" title="Click to replay animation">
+          <div class="anim-card__orb ease-fade-in"></div>
+        </div>
+        <div class="anim-card__footer">
+          <code class="anim-card__class">ease-fade-in</code>
+          <button type="button" class="copy-class-btn" aria-label="Copy ease-fade-in class">Copy Class</button>
+        </div>
+      </article>
+
+      <article class="anim-card" data-replay="entrance">
+        <span class="anim-card__label">Entrance</span>
+        <div class="anim-card__stage" title="Click to replay animation">
+          <div class="anim-card__orb ease-slide-in-left"></div>
+        </div>
+        <div class="anim-card__footer">
+          <code class="anim-card__class">ease-slide-in-left</code>
+          <button type="button" class="copy-class-btn" aria-label="Copy ease-slide-in-left class">Copy Class</button>
+        </div>
+      </article>
+
+      <article class="anim-card" data-replay="entrance">
+        <span class="anim-card__label">Entrance</span>
+        <div class="anim-card__stage" title="Click to replay animation">
+          <div class="anim-card__orb ease-slide-up"></div>
+        </div>
+        <div class="anim-card__footer">
+          <code class="anim-card__class">ease-slide-up</code>
+          <button type="button" class="copy-class-btn" aria-label="Copy ease-slide-up class">Copy Class</button>
+        </div>
+      </article>
+
+      <article class="anim-card">
+        <span class="anim-card__label">Looping</span>
+        <div class="anim-card__stage">
+          <div class="anim-card__orb ease-bounce"></div>
+        </div>
+        <div class="anim-card__footer">
+          <code class="anim-card__class">ease-bounce</code>
+          <button type="button" class="copy-class-btn" aria-label="Copy ease-bounce class">Copy Class</button>
+        </div>
+      </article>
+
+      <article class="anim-card" data-replay="entrance">
+        <span class="anim-card__label">Entrance</span>
+        <div class="anim-card__stage" title="Click to replay animation">
+          <div class="anim-card__orb ease-zoom-in"></div>
+        </div>
+        <div class="anim-card__footer">
+          <code class="anim-card__class">ease-zoom-in</code>
+          <button type="button" class="copy-class-btn" aria-label="Copy ease-zoom-in class">Copy Class</button>
+        </div>
+      </article>
+
+      <article class="anim-card">
+        <span class="anim-card__label">Looping</span>
+        <div class="anim-card__stage">
+          <div class="anim-card__orb ease-pulse"></div>
+        </div>
+        <div class="anim-card__footer">
+          <code class="anim-card__class">ease-pulse</code>
+          <button type="button" class="copy-class-btn" aria-label="Copy ease-pulse class">Copy Class</button>
+        </div>
+      </article>
+
+    </section>
+  </main>
+
+  <script>
+    const COPY_FEEDBACK_MS = 2000;
+    const fallbackTextarea = document.getElementById('clipboard-fallback');
+
+    /**
+     * Copy text using the Clipboard API when available, otherwise the
+     * hidden textarea + document.execCommand fallback for HTTP/legacy envs.
+     */
+    async function copyToClipboard(text) {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return true;
+      }
+
+      try {
+        fallbackTextarea.value = text;
+        fallbackTextarea.removeAttribute('readonly');
+        fallbackTextarea.focus();
+        fallbackTextarea.select();
+        fallbackTextarea.setSelectionRange(0, text.length);
+        const ok = document.execCommand('copy');
+        fallbackTextarea.setAttribute('readonly', '');
+        fallbackTextarea.blur();
+        return ok;
+      } catch (err) {
+        console.error('Clipboard fallback failed:', err);
+        return false;
+      }
+    }
+
+    function replayEntranceAnimation(orb) {
+      const classes = Array.from(orb.classList).filter(
+        (cls) => cls.startsWith('ease-') && cls !== 'ease-bounce' && cls !== 'ease-pulse'
+      );
+      classes.forEach((cls) => orb.classList.remove(cls));
+      void orb.offsetWidth;
+      classes.forEach((cls) => orb.classList.add(cls));
+    }
+
+    document.querySelectorAll('[data-replay="entrance"] .anim-card__stage').forEach((stage) => {
+      stage.addEventListener('click', () => {
+        const orb = stage.querySelector('.anim-card__orb');
+        if (orb) replayEntranceAnimation(orb);
+      });
+    });
+
+    document.querySelectorAll('.copy-class-btn').forEach((button) => {
+      button.addEventListener('click', async () => {
+        if (button.disabled) return;
+
+        const className = button.parentElement.querySelector('code').textContent.trim();
+        const originalText = button.textContent;
+
+        let success = false;
+        try {
+          success = await copyToClipboard(className);
+        } catch (err) {
+          console.error('Copy failed:', err);
+        }
+
+        if (!success) return;
+
+        button.textContent = '✓ Copied!';
+        button.classList.add('copied');
+        button.disabled = true;
+        button.setAttribute('aria-label', `${className} copied to clipboard`);
+
+        setTimeout(() => {
+          button.textContent = originalText;
+          button.classList.remove('copied');
+          button.disabled = false;
+          button.setAttribute('aria-label', `Copy ${className} class`);
+        }, COPY_FEEDBACK_MS);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/one-click-copy-button/style.css
+++ b/submissions/examples/one-click-copy-button/style.css
@@ -1,0 +1,383 @@
+/* ============================================================
+   one-click-copy-button / style.css
+   GSSoC · EaseMotion CSS Submission
+   ============================================================ */
+
+:root {
+  --color-bg:          #0f1117;
+  --color-surface:     #1a1d27;
+  --color-surface-2:   #22263a;
+  --color-border:      #2e3350;
+  --color-text:        #e8eaf6;
+  --color-text-muted:  #7880a8;
+  --color-accent:      #5b6af8;
+  --color-accent-glow: rgba(91, 106, 248, 0.25);
+  --color-success:     #3ecf8e;
+  --color-success-bg:  rgba(62, 207, 142, 0.14);
+  --color-success-border: rgba(62, 207, 142, 0.45);
+
+  --font-display: 'DM Serif Display', Georgia, serif;
+  --font-body:    'DM Sans', 'Segoe UI', sans-serif;
+  --font-mono:    'JetBrains Mono', 'Fira Code', monospace;
+
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+
+  --transition-quick: 0.15s ease;
+  --transition-base:  0.25s ease;
+
+  --ease-speed-medium: 300ms;
+  --ease-ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+  padding: 2.5rem 1.25rem 3rem;
+  background-image:
+    radial-gradient(ellipse 80% 50% at 50% 0%, rgba(91, 106, 248, 0.09) 0%, transparent 65%),
+    radial-gradient(ellipse 60% 40% at 90% 100%, rgba(62, 207, 142, 0.05) 0%, transparent 60%);
+}
+
+/* ----------------------------------------------------------
+   Page layout
+   ---------------------------------------------------------- */
+.copy-demo {
+  width: 100%;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.copy-demo__eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  margin-bottom: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.copy-demo__eyebrow::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  box-shadow: 0 0 8px var(--color-accent);
+}
+
+.copy-demo__header {
+  margin-bottom: 2.25rem;
+}
+
+.copy-demo__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.75rem, 4vw, 2.35rem);
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.55rem;
+}
+
+.copy-demo__subtitle {
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+  max-width: 52ch;
+}
+
+/* ----------------------------------------------------------
+   Animation card grid
+   ---------------------------------------------------------- */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+
+.anim-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.35rem 1.35rem 1.15rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.28),
+    0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  transition:
+    border-color var(--transition-base),
+    transform var(--transition-quick),
+    box-shadow var(--transition-base);
+}
+
+.anim-card:hover {
+  border-color: rgba(91, 106, 248, 0.45);
+  transform: translateY(-2px);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.35),
+    0 0 0 1px rgba(91, 106, 248, 0.12);
+}
+
+.anim-card__label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.anim-card__stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  background: var(--color-surface-2);
+  border: 1px dashed rgba(120, 128, 168, 0.35);
+  border-radius: var(--radius-md);
+  position: relative;
+  overflow: hidden;
+}
+
+.anim-card__stage::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 120%, rgba(91, 106, 248, 0.08), transparent 55%);
+  pointer-events: none;
+}
+
+.anim-card__orb {
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #5b6af8 0%, #7b5ea7 100%);
+  box-shadow: 0 8px 24px rgba(91, 106, 248, 0.4);
+  position: relative;
+  z-index: 1;
+}
+
+.anim-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem 0.65rem;
+  padding-top: 0.15rem;
+}
+
+.anim-card__class {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: #c5caf8;
+  background: rgba(91, 106, 248, 0.12);
+  border: 1px solid rgba(91, 106, 248, 0.28);
+  border-radius: var(--radius-sm);
+  padding: 0.35rem 0.6rem;
+  letter-spacing: 0.02em;
+}
+
+/* ----------------------------------------------------------
+   Copy Class button
+   ---------------------------------------------------------- */
+.copy-class-btn {
+  font-family: var(--font-body);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-text);
+  background: var(--color-surface-2);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.38rem 0.72rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background var(--transition-quick),
+    border-color var(--transition-quick),
+    color var(--transition-quick),
+    transform var(--transition-quick),
+    box-shadow var(--transition-base),
+    opacity var(--transition-quick);
+}
+
+.copy-class-btn:hover:not(:disabled) {
+  border-color: var(--color-accent);
+  background: rgba(91, 106, 248, 0.14);
+  box-shadow: 0 0 0 3px var(--color-accent-glow);
+}
+
+.copy-class-btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.copy-class-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.copy-class-btn.copied,
+.copy-class-btn:disabled {
+  cursor: default;
+  color: var(--color-success);
+  background: var(--color-success-bg);
+  border-color: var(--color-success-border);
+  box-shadow: none;
+  opacity: 0.92;
+}
+
+/* Hidden textarea fallback for non-secure / legacy contexts */
+.clipboard-fallback {
+  position: fixed;
+  left: -9999px;
+  top: 0;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ----------------------------------------------------------
+   Demo animation utilities (self-contained previews)
+   ---------------------------------------------------------- */
+@keyframes ease-kf-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes ease-kf-slide-in-left {
+  from {
+    opacity: 0;
+    transform: translateX(-32px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes ease-kf-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes ease-kf-bounce {
+  0%, 100% {
+    transform: translateY(0);
+    animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  }
+  50% {
+    transform: translateY(-18px);
+    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+}
+
+@keyframes ease-kf-zoom-in {
+  from {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes ease-kf-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.72; transform: scale(0.94); }
+}
+
+.ease-fade-in {
+  animation: ease-kf-fade-in var(--ease-speed-medium) var(--ease-ease) both;
+}
+
+.ease-slide-in-left {
+  animation: ease-kf-slide-in-left var(--ease-speed-medium) var(--ease-ease) both;
+}
+
+.ease-slide-up {
+  animation: ease-kf-slide-up var(--ease-speed-medium) var(--ease-ease) both;
+}
+
+.ease-bounce {
+  animation: ease-kf-bounce 1s infinite;
+}
+
+.ease-zoom-in {
+  animation: ease-kf-zoom-in var(--ease-speed-medium) cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.ease-pulse {
+  animation: ease-kf-pulse 1.4s ease-in-out infinite;
+}
+
+/* Replay helper: cards restart entrance animations on click */
+.anim-card[data-replay="entrance"] .anim-card__stage {
+  cursor: pointer;
+}
+
+.anim-card[data-replay="entrance"] .anim-card__stage:hover .anim-card__orb {
+  filter: brightness(1.08);
+}
+
+/* ----------------------------------------------------------
+   Responsive
+   ---------------------------------------------------------- */
+@media (max-width: 640px) {
+  body {
+    padding: 1.75rem 1rem 2.5rem;
+  }
+
+  .anim-card {
+    padding: 1.15rem;
+  }
+
+  .anim-card__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .copy-class-btn {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-fade-in,
+  .ease-slide-in-left,
+  .ease-slide-up,
+  .ease-bounce,
+  .ease-zoom-in,
+  .ease-pulse {
+    animation: none;
+  }
+
+  .anim-card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #774 by introducing a reusable, self-contained "One-Click Copy Button" component example template. It eliminates the manual text selection friction for developers interacting with animation classes by allowing them to copy the raw class string to their clipboard in a single click.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [X] 🧩 New component
- [X] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [X] All changes are inside `submissions/examples/your-feature-name/`
- [X] Includes `demo.html` — self-contained, opens in browser with no server
- [X] Includes `style.css` — raw CSS for the proposed feature
- [X] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [X] **No changes to `core/`**
- [X] **No changes to `components/`**
- [X] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A clean, lightweight copy-to-clipboard button component designated for animation cards that provides immediate text-swapping UI feedback (`✓ Copied!`) for exactly 2 seconds.

<!-- One-sentence description -->

**How does a developer use it?**


```html
<!-- Show the class usage in HTML -->
```html
<div class="animation-card">
    <span class="class-name">fade-in</span>
    <button class="copy-btn" onclick="copyClass('fade-in', this)">Copy Class</button>
</div>
```

**Why does it fit EaseMotion CSS?**

<!-- Explain how this fits the human-readable, animation-first philosophy -->
It directly enhances the interactive utility of the submission showcase, matching EaseMotion's goal of human-readable, developer-first tooling by letting users seamlessly grab classes without messing up highlight selection.
---

## Demo

- [X] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Integrated the modern asynchronous Clipboard API (navigator.clipboard.writeText) while establishing a solid hidden textarea semantic fallback strategy for non-HTTPS local environments or older mobile layouts.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
