### PR TITLE
fix(packaging): declare missing keyframes in modular misc.css

### DIFF
--- a/easemotion/misc.css
+++ b/easemotion/misc.css
@@ -201,6 +201,17 @@
   animation: ease-kf-contract-shadow-emphasis var(--ease-speed-medium) var(--ease-ease) both;
 }
 
+@keyframes ease-kf-shimmer-sweep {
+  0%   { background-position: -200% center; }
+  100% { background-position: 200% center; }
+}
+
+@keyframes ease-kf-gradient-rotation {
+  0%   { background-position: 0% 50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
 .ease-shimmer-sweep {
   background: linear-gradient(
     120deg,


### PR DESCRIPTION
## Pull Request Description

Declares keyframes `ease-kf-shimmer-sweep` and `ease-kf-gradient-rotation` directly within `easemotion/misc.css` to remove external keyframe dependencies.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission (Modular Isolation Fix)

---

## Submission Checklist

- [x] One feature/bugfix per PR
- [x] Build, lint, and tests pass successfully

---

## Notes for Maintainer

This PR resolves issue #1435, making the modular `easemotion/misc.css` stylesheet completely self-contained and preventing silent failures when loaded modularly.

Closes #1435
