### PR TITLE
fix(a11y): add prefers-reduced-motion safety to modular animation files

### DIFF
--- a/easemotion/fade.css
+++ b/easemotion/fade.css
@@ -32,3 +32,12 @@
 .ease-fade-icon-exit {
   animation: ease-kf-fade-icon-exit var(--ease-speed-medium) var(--ease-ease) both;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-fade-in,
+  .ease-fade-out,
+  .ease-fade-icon-exit {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/easemotion/hover.css
+++ b/easemotion/hover.css
@@ -181,3 +181,32 @@
     var(--ease-speed-medium)
     var(--ease-ease-bounce);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-squish-button:hover,
+  .ease-hover-grow:hover,
+  .ease-hover-lift-shadow:hover,
+  .ease-hover-shrink:hover,
+  .ease-hover-lift:hover,
+  .ease-card-lift:hover,
+  .ease-hover-squish-border:hover,
+  .ease-hover-morph-card:hover,
+  .ease-hover-bounce-text:hover {
+    animation: none !important;
+    transform: none !important;
+    transition: none !important;
+  }
+  .ease-hover-grow,
+  .ease-hover-lift-shadow,
+  .ease-hover-shrink,
+  .ease-hover-glow,
+  .ease-hover-lift,
+  .ease-hover-underline::after,
+  .ease-card-lift,
+  .ease-hover-shimmer::before,
+  .ease-hover-squish-border,
+  .ease-hover-morph-card {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/easemotion/misc.css
+++ b/easemotion/misc.css
@@ -272,3 +272,27 @@
 
   will-change: width;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-float,
+  .ease-pulse,
+  .ease-ping,
+  .ease-shake,
+  .ease-blur-to-focus,
+  .ease-contract-bg-exit,
+  .ease-pulse-border-emphasis,
+  .ease-shake-card-exit,
+  .ease-expand-border-exit,
+  .ease-scale-text-exit,
+  .ease-glow-shadow-exit,
+  .ease-contract-shadow-emphasis,
+  .ease-shimmer-sweep,
+  .ease-gradient-rotation,
+  .ease-skeleton-shimmer,
+  .ease-skeleton-pulse,
+  .ease-typewriter-loop {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/easemotion/slide.css
+++ b/easemotion/slide.css
@@ -146,3 +146,23 @@
 .ease-slide-image-exit {
   animation: ease-kf-slide-image-exit var(--ease-speed-medium) var(--ease-ease) both;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-slide-up,
+  .ease-slide-down,
+  .ease-slide-in-left,
+  .ease-slide-in-right,
+  .ease-slide-in-from-top,
+  .ease-slide-in-from-bottom,
+  .ease-slide-in-from-left,
+  .ease-slide-in-from-right,
+  .ease-slide-in-from-top-left,
+  .ease-slide-in-from-top-right,
+  .ease-slide-in-from-bottom-left,
+  .ease-slide-in-from-bottom-right,
+  .ease-slide-image-exit {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transform: none !important;
+  }
+}

--- a/easemotion/zoom.css
+++ b/easemotion/zoom.css
@@ -42,3 +42,13 @@
 .ease-contract-image-entrance {
   animation: ease-kf-contract-image-entrance var(--ease-speed-medium) var(--ease-ease) both;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-zoom-in,
+  .ease-zoom-out,
+  .ease-contract-image-entrance {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Appends `prefers-reduced-motion` media query blocks at the end of each modular animation stylesheet (`fade.css`, `slide.css`, `zoom.css`, `hover.css`, `misc.css`) in the `easemotion/` directory.

---

## Type of Change

- [x] ♿ Accessibility / Animation Safety Fix

---

## Submission Checklist

- [x] One feature/bugfix per PR
- [x] Build, lint, and tests pass successfully
- [x] All animation files updated

---

## Notes for Maintainer

This PR resolves issue #1437 by ensuring that when these modular animation stylesheets are imported individually (e.g. via CDN or modern CSS import maps), they correctly respect the user's prefers-reduced-motion preferences, complying with WCAG 2.1 AAA Motion Animation guidelines.

Closes #1437
