### PR TITLE
fix(a11y): prevent chip hover transform snap under reduced motion

### DIFF
--- a/components/chip.css
+++ b/components/chip.css
@@ -102,4 +102,7 @@
   .ease-chip {
     transition: none !important;
   }
+  .ease-chip:hover {
+    transform: none !important;
+  }
 }


### PR DESCRIPTION
## Pull Request Description

Resets the hover transform to `none !important` on `.ease-chip:hover` under the `prefers-reduced-motion: reduce` query.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission (Accessibility/UX Fix)

---

## Submission Checklist

- [x] One feature/bugfix per PR
- [x] Build, lint, and tests pass successfully

---

## Notes for Maintainer

This PR resolves issue #1438 by preventing the chips component from instantly jumping/snapping via `translateY(-1px)` when hovered on devices with reduced motion enabled, satisfying WCAG 2.1 AAA Motion Animation guidelines.

Closes #1438
