### PR TITLE
fix(design-system): match SCSS easing variables with CSS custom property tokens

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,11 +1,11 @@
-﻿// ============================================
+// ============================================
 // EaseMotion-css — SCSS Animation Tokens
 // Fixes #1116: DRY refactor of repetitive CSS
 // ============================================
 
 // Core easing curves (matching existing CSS vars)
-$ease-ease:         cubic-bezier(0.25, 0.1, 0.25, 1);
-$ease-bounce:       cubic-bezier(0.8, 0, 1, 1);
+$ease-ease:         cubic-bezier(0.4, 0, 0.2, 1);
+$ease-bounce:       cubic-bezier(0.34, 1.56, 0.64, 1);
 $ease-in-out:       cubic-bezier(0, 0, 0.2, 1);
 $ease-ping:         cubic-bezier(0, 0, 0.2, 1);
 


### PR DESCRIPTION
## Pull Request Description

Updates the SCSS variables `$ease-ease` and `$ease-bounce` in `scss/_variables.scss` to match the CSS design token values (`--ease-ease` and `--ease-ease-bounce`) defined in `core/variables.css`.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission (Design System Consistency)

---

## Submission Checklist

- [x] One feature/bugfix per PR
- [x] Build, lint, and tests pass successfully

---

## Notes for Maintainer

This PR resolves issue #1440, ensuring visual consistency of animations regardless of whether components are compiled via SCSS variables or directly use CSS custom properties.

Closes #1440
