### PR TITLE
fix: dynamically populate skill chip counts based on mock data

### DIFF
--- a/submissions/examples/job-board-search-filters/demo.html
+++ b/submissions/examples/job-board-search-filters/demo.html
@@ -98,6 +98,16 @@
       }
       computeSkillCounts();
 
+      function updateChipCounts() {
+        document.querySelectorAll('.jb-chip').forEach(function (chip) {
+          var skill = chip.getAttribute('data-skill');
+          var countSpan = chip.querySelector('.jb-chip-count');
+          if (countSpan && skillCounts[skill] !== undefined) {
+            countSpan.textContent = '(' + skillCounts[skill] + ')';
+          }
+        });
+      }
+
       // ── State ─────────────────────────────────────────────────
       var activeSkills = [];
 
@@ -211,6 +221,7 @@
       });
 
       // ── Init ──────────────────────────────────────────────────
+      updateChipCounts();
       render();
 
     })();


### PR DESCRIPTION
## Pull Request Description
This PR links the computed skill counts to the DOM elements:
Implements updateChipCounts() to iterate over each skill filter chip and update the .jb-chip-count text with the correct computed counts from the mock job database.
Invokes updateChipCounts() on page initialization so that correct values (React (3), Python (6), Java (1), etc.) are displayed to the user from the start.

closes #1458 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- One-sentence description -->

**How does a developer use it?**

```html
<!-- Show the class usage in HTML -->
```

**Why does it fit EaseMotion CSS?**

<!-- Explain how this fits the human-readable, animation-first philosophy -->

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
