### PR TITLE
feat: add active navigation highlighting example

### DIFF
--- a/submissions/examples/active-navigation-highlighting/README.md
+++ b/submissions/examples/active-navigation-highlighting/README.md
@@ -1,0 +1,61 @@
+# Active Navigation Highlighting
+
+## What does this do?
+
+This example demonstrates automatic active-state highlighting for documentation navigation links. As users scroll through different sections of a page, the corresponding navigation item is highlighted to indicate the current location within the documentation.
+
+## How is it used?
+
+### HTML Structure
+
+```html
+<nav class="sidebar-nav">
+  <a href="#getting-started">Getting Started</a>
+  <a href="#components">Components</a>
+  <a href="#utilities">Utilities</a>
+</nav>
+
+<section id="getting-started">
+  ...
+</section>
+
+<section id="components">
+  ...
+</section>
+
+<section id="utilities">
+  ...
+</section>
+```
+
+### JavaScript
+
+The example uses the Intersection Observer API to detect which section is currently visible and automatically applies the `.active` class to the matching navigation link.
+
+### Active State Styling
+
+```css
+.sidebar-nav a.active {
+  font-weight: 600;
+  border-left: 3px solid currentColor;
+  padding-left: 8px;
+}
+```
+
+## Why is it useful?
+
+Documentation pages often contain multiple sections and long-form content. Active navigation highlighting helps users understand where they are within the page, improves navigation, and creates a more intuitive browsing experience.
+
+This aligns with EaseMotion CSS's goal of providing polished, user-friendly interface patterns that improve usability with minimal implementation effort.
+
+## Features
+
+* Automatic active-state detection while scrolling
+* Smooth section navigation
+* Lightweight implementation using Intersection Observer
+* No external dependencies
+* Responsive documentation-style layout
+
+## Browser Support
+
+This example relies on the Intersection Observer API, which is supported by all modern browsers.

--- a/submissions/examples/active-navigation-highlighting/demo.html
+++ b/submissions/examples/active-navigation-highlighting/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Active Navigation Highlighting</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <aside class="sidebar">
+    <h2>Docs Navigation</h2>
+    <nav class="sidebar-nav">
+      <a href="#getting-started" class="active">Getting Started</a>
+      <a href="#components">Components</a>
+      <a href="#utilities">Utilities</a>
+      <a href="#animations">Animations</a>
+    </nav>
+  </aside>
+
+  <main class="content">
+    <section id="getting-started">
+      <h1>Getting Started</h1>
+      <p>Learn how to install and use EaseMotion CSS.</p>
+    </section>
+
+    <section id="components">
+      <h1>Components</h1>
+      <p>Reusable UI components for modern interfaces.</p>
+    </section>
+
+    <section id="utilities">
+      <h1>Utilities</h1>
+      <p>Utility classes for spacing, layout, and interactions.</p>
+    </section>
+
+    <section id="animations">
+      <h1>Animations</h1>
+      <p>Motion effects and animation helpers available in EaseMotion CSS.</p>
+    </section>
+  </main>
+
+  <script>
+    const sections = document.querySelectorAll("section");
+    const navLinks = document.querySelectorAll(".sidebar-nav a");
+
+    let currentActive = document.querySelector(".sidebar-nav a.active");
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const id = entry.target.id;
+            const activeLink = document.querySelector(
+              `.sidebar-nav a[href="#${id}"]`
+            );
+
+            if (activeLink && currentActive !== activeLink) {
+              currentActive?.classList.remove("active");
+              activeLink.classList.add("active");
+              currentActive = activeLink;
+            }
+          }
+        });
+      },
+      {
+        threshold: 0.4,
+      }
+    );
+
+    sections.forEach((section) => observer.observe(section));
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/active-navigation-highlighting/style.css
+++ b/submissions/examples/active-navigation-highlighting/style.css
@@ -1,0 +1,76 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  display: flex;
+  font-family: Arial, sans-serif;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.sidebar {
+  position: fixed;
+  width: 250px;
+  height: 100vh;
+  padding: 2rem 1rem;
+  background: #111827;
+  border-right: 1px solid #374151;
+}
+
+.sidebar h2 {
+  margin-bottom: 1rem;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sidebar-nav a {
+  text-decoration: none;
+  color: #94a3b8;
+  padding: 0.75rem 1rem;
+  border-left: 3px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.sidebar-nav a:hover {
+  color: #ffffff;
+}
+
+.sidebar-nav a.active {
+  color: #ffffff;
+  font-weight: 600;
+  border-left: 3px solid #8b5cf6;
+  background: rgba(139, 92, 246, 0.15);
+  transform: translateX(4px);
+}
+
+.content {
+  margin-left: 250px;
+  width: calc(100% - 250px);
+}
+
+section {
+  min-height: 100vh;
+  padding: 4rem;
+  border-bottom: 1px solid #374151;
+}
+
+section h1 {
+  margin-bottom: 1rem;
+  color: #8b5cf6;
+}
+
+section p {
+  max-width: 700px;
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Summary
Adds a standalone Active Navigation Highlighting example under `submissions/examples/active-navigation-highlighting`.

The example demonstrates how documentation navigation items can automatically receive an active state based on the currently visible section using the Intersection Observer API.

## Included
* Self-contained documentation-style demo
* Automatic active section detection on scroll
* Active navigation styling with visual indicators
* Responsive layout
* Documentation explaining usage and purpose

## Checklist
* [x] Added files only inside `submissions/examples/active-navigation-highlighting`
* [x] Included `demo.html`
* [x] Included `style.css`
* [x] Included `README.md`
* [x] Demo works without external frameworks
* [x] Followed repository contribution guidelines

Closes #1320
