### PR TITLE
feat: add squish card emphasis animation

### DIFF
--- a/submissions/examples/squish-card-emphasis/README.md
+++ b/submissions/examples/squish-card-emphasis/README.md
@@ -1,0 +1,17 @@
+# Squish Card Emphasis
+
+## 1. What does this do?
+
+Applies a squish animation to a card element on interaction, creating a compressed and bounce-back effect for emphasis.
+
+## 2. How is it used?
+
+```html
+<div class="squish-card">Content</div>
+```
+
+You can apply the `squish-card` class to any container or card element to trigger the animation on hover or focus.
+
+## 3. Why is it useful?
+
+This utility fits EaseMotion CSS’s philosophy by providing a simple, reusable interaction effect that adds expressive motion and feedback using minimal and readable CSS.

--- a/submissions/examples/squish-card-emphasis/demo.html
+++ b/submissions/examples/squish-card-emphasis/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Squish Card Emphasis Demo</title>
+  
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="header">
+    <h1>Squish Card Emphasis</h1>
+    <p>A smooth squish animation that adds subtle emphasis to UI elements.</p>
+  </header>
+
+  <div class="squish-card" tabindex="0" role="button" aria-label="Squish card demo">
+    <div class="icon">✦</div>
+    <h2>Emphasis Effect</h2>
+    <p>A satisfying compress-and-bounce animation that gives tactile feedback without any JavaScript.</p>
+    <span class="hint">Hover me</span>
+  </div>
+
+  
+</body>
+</html>

--- a/submissions/examples/squish-card-emphasis/style.css
+++ b/submissions/examples/squish-card-emphasis/style.css
@@ -1,0 +1,160 @@
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    /* ── Page ── */
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+      background: linear-gradient(160deg, #f0f4ff 0%, #e8edf7 100%);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2.5rem;
+      padding: 2rem;
+    }
+
+    /* ── Header ── */
+    .header {
+      text-align: center;
+    }
+
+    .header h1 {
+      font-size: 1.75rem;
+      font-weight: 750;
+      color: #0f172a;
+      letter-spacing: -0.5px;
+    }
+
+    .header p {
+      margin-top: 0.5rem;
+      font-size: 0.92rem;
+      color: #64748b;
+    }
+
+    /* ── Card ── */
+    .squish-card {
+      width: 300px;
+      background: #ffffff;
+      border-radius: 20px;
+      padding: 2.25rem 2rem;
+      text-align: center;
+      cursor: pointer;
+
+      /* resting shadow */
+      box-shadow:
+        0 4px 8px rgba(0, 0, 0, 0.06),
+        0 12px 32px rgba(0, 0, 0, 0.10);
+
+      /* smooth transitions for non-animated properties */
+      transition:
+        box-shadow 0.18s ease-out,
+        transform 0.18s ease-out;
+
+      /* allow focus-visible outline */
+      outline: none;
+    }
+
+    /* icon circle */
+    .squish-card .icon {
+      width: 56px;
+      height: 56px;
+      background: linear-gradient(135deg, #6366f1, #818cf8);
+      border-radius: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 1.25rem;
+      font-size: 1.5rem;
+    }
+
+    .squish-card h2 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      color: #0f172a;
+      margin-bottom: 0.45rem;
+    }
+
+    .squish-card p {
+      font-size: 0.85rem;
+      color: #64748b;
+      line-height: 1.6;
+    }
+
+    /* hover label */
+    .squish-card .hint {
+      display: inline-block;
+      margin-top: 1.25rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      color: #a5b4fc;
+    }
+
+    /* ── Squish on hover / focus ── */
+    .squish-card:hover,
+    .squish-card:focus-visible {
+      animation: squish 0.42s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+      box-shadow:
+        0 2px 4px rgba(0, 0, 0, 0.04),
+        0 5px 14px rgba(0, 0, 0, 0.08);
+    }
+
+    /* ── Squish keyframes ── */
+    @keyframes squish {
+      /*  Initial press: widen + compress vertically + sink slightly */
+      0%   {
+        transform: scaleX(1)    scaleY(1)    translateY(0);
+      }
+      20%  {
+        transform: scaleX(1.07) scaleY(0.88) translateY(4px);
+      }
+      /* Overshoot bounce-back */
+      45%  {
+        transform: scaleX(0.96) scaleY(1.04) translateY(-3px);
+      }
+      /* Second small oscillation */
+      65%  {
+        transform: scaleX(1.02) scaleY(0.97) translateY(1px);
+      }
+      /* Settle */
+      82%  {
+        transform: scaleX(0.99) scaleY(1.01) translateY(0);
+      }
+      100% {
+        transform: scaleX(1)    scaleY(1)    translateY(0);
+      }
+    }
+
+    /* ── Code snippet ── */
+    .snippet {
+      max-width: 420px;
+      width: 100%;
+      background: #ffffff;
+      border: 1px solid #e2e8f0;
+      border-radius: 14px;
+      padding: 1.1rem 1.4rem;
+    }
+
+    .snippet h3 {
+      font-size: 0.72rem;
+      font-weight: 700;
+      color: #94a3b8;
+      text-transform: uppercase;
+      letter-spacing: 0.7px;
+      margin-bottom: 0.65rem;
+    }
+
+    .snippet pre {
+      overflow-x: auto;
+    }
+
+    .snippet code {
+      font-family: "Fira Code", "Cascadia Code", "Courier New", monospace;
+      font-size: 0.78rem;
+      color: #6366f1;
+      line-height: 1.65;}


### PR DESCRIPTION
## Pull Request Description

Adds a Squish Card Emphasis animation that applies a subtle compression and bounce-back effect to card elements, enhancing interaction and visual feedback.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/squish-card-emphasis/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Adds a squish animation effect that compresses and releases a card element for emphasis.

**How does a developer use it?**

```html
<div class="squish-card">Content</div>
```

**Why does it fit EaseMotion CSS?**
It follows the framework’s philosophy by offering a simple, reusable motion utility that enhances interaction using clean, minimal CSS.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The animation uses scale transforms to simulate a squish effect with a smooth bounce-back. Timing and intensity can be adjusted if needed for a more subtle or pronounced interaction.
