### PR TITLE
Fix components navbar navigation

### DIFF
--- a/submissions/examples/interactive-docs/demo.html
+++ b/submissions/examples/interactive-docs/demo.html
@@ -623,7 +623,15 @@
       </section>
 
       <hr class="docs-divider" />
+       <!-- ══════════════ COMPONENTS ══════════════ -->
+<section id="components" class="docs-section">
+  <h2 class="docs-h2">Components</h2>
+  <p class="docs-p">
+    EaseMotion CSS provides reusable UI components such as Buttons and Cards.
+  </p>
+</section>
 
+<hr class="docs-divider" />
       <!-- ══════════════ BUTTONS ══════════════ -->
       <section id="buttons" class="docs-section">
         <h2 class="docs-h2">Buttons</h2>


### PR DESCRIPTION
## Pull Request Description

### Summary

This PR fixes the broken "Components" navigation link in the interactive documentation page.

### Changes Made

* Added a dedicated `Components` section with `id="components"` in `submissions/examples/interactive-docs/demo.html`.
* Ensured the navbar link (`href="#components"`) correctly navigates to the Components section.
* Improved the documentation navigation experience and resolved the broken anchor link.

### Issue Fixed

Fixes #1319

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [x] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/interactive-docs/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [ ] Includes `style.css` — N/A (existing submission)
* [ ] Includes `README.md` — N/A (existing submission)
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a valid Components section target for the navbar link.

**How does a developer use it?**

Users can now click:

```html
<a href="#components">Components</a>
```

and be navigated directly to the Components section.

**Why does it fit EaseMotion CSS?**

It improves documentation usability and ensures consistent navigation throughout the documentation site.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [x] Edge
* [ ] Safari *(optional)*

---

## Notes for Maintainer

Added a missing `Components` section with `id="components"` so the existing navbar anchor link functions correctly.
