### PR TITLE
Add styling for copy-class-btn feature

### DIFF
--- a/submissions/examples/copy-class-button/README.md
+++ b/submissions/examples/copy-class-button/README.md
@@ -1,0 +1,48 @@
+\# Copy Class Button — Issue #774
+
+
+
+\## What does this do?
+
+Adds CSS styling for the .copy-class-btn button that appears next to
+
+every animation class name in the EaseMotion CSS documentation.
+
+
+
+\## How is it used?
+
+Add the button next to any code tag inside a table cell:
+
+
+
+&#x20;   <td>
+
+&#x20;     <code>ease-fade-in</code>
+
+&#x20;     <button class="copy-class-btn">Copy Class</button>
+
+&#x20;   </td>
+
+
+
+\## Why does it fit EaseMotion CSS?
+
+Improves developer experience by making animation class names one-click
+
+copyable, which fits the human-readable philosophy of EaseMotion CSS.
+
+
+
+\## Files
+
+\- style.css — button styles (base, hover, copied state, light theme)
+
+\- demo.html — standalone demo, open directly in browser
+
+
+
+\## Preview
+
+Open demo.html in your browser to see the buttons in action.
+

--- a/submissions/examples/copy-class-button/demo.html
+++ b/submissions/examples/copy-class-button/demo.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Copy Class Button</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    :root {
+      --page-bg: #0f0e17;
+      --page-text:#fffffe;
+      --page-muted:rgba(255,255,255,0.55);
+      --card-bg:rgba(255,255,255,0.04);
+      --border:rgba(255,255,255,0.08);
+      --code-bg:rgba(255,255,255,0.06);
+      --purple:#6c63ff;
+    }
+    *, *::before,*::after{box-sizing:border-box; margin:0; padding:0;}
+    body{
+      background:var(--page-bg);
+      color:var(--page-text);
+      font-family:var(--ease-font-base,system-ui,sans-serif);
+      padding:40px 24px;
+      min-height:100vh;
+    }
+    h1{
+      font-size:1.6rem;
+      font-weight:700;
+      margin-bottom:6px;
+      background:linear-gradient(90deg, #fff 30%, #a78bfa);
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:transparent;
+    }
+    .subtitle {
+      color:var(--page-muted);
+      font-size:0.9rem;
+      margin-bottom: 36px;
+    }
+    .demo-card{
+      background:var(--card-bg);
+      border:1px solid var(--border);
+      border-radius:12px;
+      overflow:hidden;
+      max-width:680px;
+      margin-bottom:32px;
+    }
+    .demo-card-header {
+      padding:14px 20px;
+      font-size:0.75rem;
+      font-weight:600;
+      letter-spacing: 0.08em;
+      text-transform:uppercase;
+      color:var(--page-muted);
+      border-bottom:1px solid var(--border);
+    }
+    table{
+      width: 100%;
+      border-collapse: collapse;
+    }
+    td{
+      padding:12px 20px;
+      font-size:0.875rem;
+      border-bottom:1px solid var(--border);
+      vertical-align:middle;
+    }
+    tr:last-child td {border-bottom: none; }
+    td:first-child {width: 55%; }
+    code {
+      background:var(--code-bg);
+      color:#a78bfa;
+      padding:2px 7px;
+      border-radius: 4px;
+      font-family:var(--ease-font-mono, monospace);
+      font-size:0.8rem;
+    }
+    .effect-desc{
+      color:var(--page-muted);
+      font-size:0.82rem;
+    }
+    .snippet-box{
+      max-width:680px;
+      background: var(--code-bg);
+      border:1px solid var(--border);
+      border-radius:10px;
+      padding:20px 24px;
+    }
+    .snippet-box h3{
+      font-size:0.75rem;
+      letter-spacing:0.08em;
+      text-transform:uppercase;
+      color:var(--page-muted);
+      margin-bottom:14px;
+    }
+    .snippet-box pre{
+      font-family:var(--ease-font-mono, monospace);
+      font-size:0.8rem;
+      line-height:1.7;
+      color: #e2e8f0;
+      white-space:pre-wrap;
+    }
+    .c-purple{color:#a78bfa;}
+    .c-green{color:#86efac;}
+    .c-yellow{color:#fde68a;}
+  </style>
+</head>
+<body>
+  <h1>Copy Class Button</h1>
+  <p class="subtitle">Issue #774 — One-click copy for animation class names. Click any button below to try it.</p>
+  <div class="demo-card">
+    <div class="demo-card-header">Entrance Animations</div>
+    <table>
+      <tbody>
+        <tr>
+          <td>
+            <code>ease-fade-in</code>
+            <button class="copy-class-btn">Copy Class</button>
+          </td>
+          <td class="effect-desc">Fades element from 0 → 1 opacity</td>
+        </tr>
+        <tr>
+          <td>
+            <code>ease-slide-up</code>
+            <button class="copy-class-btn">Copy Class</button>
+          </td>
+          <td class="effect-desc">Slides element up while fading in</td>
+        </tr>
+        <tr>
+          <td>
+            <code>ease-slide-in-left</code>
+            <button class="copy-class-btn">Copy Class</button>
+          </td>
+          <td class="effect-desc">Slides in from the left</td>
+        </tr>
+        <tr>
+          <td>
+            <code>ease-zoom-in</code>
+            <button class="copy-class-btn">Copy Class</button>
+          </td>
+          <td class="effect-desc">Scales from 85% with elastic ease</td>
+        </tr>
+        <tr>
+          <td>
+            <code>ease-flip</code>
+            <button class="copy-class-btn">Copy Class</button>
+          </td>
+          <td class="effect-desc">3D perspective flip from Y-axis</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="demo-card">
+    <div class="demo-card-header">Looping Animations</div>
+    <table>
+      <tbody>
+        <tr>
+          <td>
+            <code>ease-bounce</code>
+            <button class="copy-class-btn">Copy Class</button>
+          </td>
+          <td class="effect-desc">Repeating vertical bounce</td>
+        </tr>
+        <tr>
+          <td>
+            <code>ease-pulse</code>
+            <button class="copy-class-btn">Copy Class</button>
+          </td>
+          <td class="effect-desc">Gentle scale pulse (attention)</td>
+        </tr>
+        <tr>
+          <td>
+            <code>ease-spin</code>
+            <button class="copy-class-btn">Copy Class</button>
+          </td>
+          <td class="effect-desc">Continuous 360° rotation</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="snippet-box">
+    <h3>How it works — the JS</h3>
+    <pre><span class="c-purple">document</span>.querySelectorAll(<span class="c-green">".copy-class-btn"</span>).forEach(<span class="c-yellow">button</span> => {
+  button.addEventListener(<span class="c-green">"click"</span>, <span class="c-purple">async</span> () => {
+    <span class="c-yellow">const</span> className =
+      button.parentElement.querySelector(<span class="c-green">"code"</span>).textContent.trim();
+    <span class="c-yellow">const</span> success = <span class="c-purple">await</span> copyToClipboard(className);
+    <span class="c-purple">if</span> (!success) <span class="c-purple">return</span>;
+    button.textContent = <span class="c-green">"✓ Copied!"</span>;
+    button.classList.add(<span class="c-green">"copied"</span>);
+    setTimeout(() => {
+      button.textContent = <span class="c-green">"Copy Class"</span>;
+      button.classList.remove(<span class="c-green">"copied"</span>);
+    }, <span class="c-yellow">2000</span>);
+  });
+});</pre>
+  </div>
+  <script>
+    async function copyToClipboard(text) {
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(text);
+        } else {
+          const ta = document.createElement("textarea");
+          ta.value = text;
+          ta.style.cssText = "position:fixed;top:-9999px;opacity:0";
+          document.body.appendChild(ta);
+          ta.select();
+          document.execCommand("copy");
+          document.body.removeChild(ta);
+        }
+        return true;
+      } catch (err) {
+        console.error("Copy failed:", err);
+        return false;
+      }
+    }
+    document.querySelectorAll(".copy-class-btn").forEach(button => {
+      button.addEventListener("click", async () => {
+        const className =
+          button.parentElement.querySelector("code").textContent.trim();
+        const success = await copyToClipboard(className);
+        if (!success) return;
+        const originalText = button.textContent;
+        button.textContent = "✓ Copied!";
+        button.classList.add("copied");
+        setTimeout(() => {
+          button.textContent = originalText;
+          button.classList.remove("copied");
+        }, 2000);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/copy-class-button/style.css
+++ b/submissions/examples/copy-class-button/style.css
@@ -1,0 +1,58 @@
+.copy-class-btn {
+  display:inline-flex;
+  align-items:center;
+  gap:4px;
+  padding:3px 10px;
+  margin-left:8px;
+  border-radius:4px;
+  border:1px solid rgba(108, 99, 255, 0.4);
+  background:rgba(108, 99, 255, 0.08);
+  color:rgba(108, 99, 255, 0.9);
+  font-size:11px;
+  font-family:var(--ease-font-mono, monospace);
+  font-weight:500;
+  white-space:nowrap;
+  cursor:pointer;
+  vertical-align:middle;
+  user-select: none;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    transform 0.1s ease,
+    opacity 0.15s ease;
+}
+.copy-class-btn:hover {
+  background:rgba(108, 99, 255, 0.18);
+  border-color: rgba(108, 99, 255, 0.7);
+  color: #6c63ff;
+  transform:translateY(-1px);
+}
+.copy-class-btn:active {
+  transform:scale(0.96);
+}
+.copy-class-btn.copied {
+  background:rgba(34, 197, 94, 0.12);
+  border-color:rgba(34, 197, 94, 0.5);
+  color:#22c55e;
+  cursor:default;
+}
+[data-theme="light"] .copy-class-btn {
+  background:rgba(108, 99, 255, 0.06);
+  border-color:rgba(108, 99, 255, 0.3);
+  color: #5b52d4;
+}
+[data-theme="light"] .copy-class-btn:hover {
+  background: rgba(108, 99, 255, 0.14);
+  border-color:#6c63ff;
+  color:#4338ca;
+}
+[data-theme="light"] .copy-class-btn.copied {
+  background:rgba(34, 197, 94, 0.08);
+  border-color:rgba(34, 197, 94, 0.45);
+  color:#16a34a;
+}
+.copy-class-btn:focus-visible {
+  outline:2px solid rgba(108, 99, 255, 0.6);
+  outline-offset:2px;
+}


### PR DESCRIPTION
## Pull Request Description

Adds CSS styling for `.copy-class-btn` buttons (Issue #774).

The buttons and JavaScript logic already existed in docs/index.html but had zero CSS — they were completely unstyled/invisible.
This submission provides the missing style.css.

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other — Missing CSS for existing copy-class-btn feature (#774) 
## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/copy-class-button/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [ ] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR
  
## Feature Description
**What does this add?**
Styles the `.copy-class-btn` button that appears next to every animation class name in the documentation.

**How does a developer use it?**
<td>
  <code>ease-fade-in</code>
  <button class="copy-class-btn">Copy Class</button>
</td>

**Why does it fit EaseMotion CSS?**

Improves developer experience by making animation class names one-click copyable, which fits the human-readable philosophy of EaseMotion CSS.

## Demo

- [x] Demo added (demo.html works by opening directly in a browser)

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The .copy-class-btn elements and JavaScript already exist in docs/index.html. Only the CSS was missing. The style.css in this submission can be copied into the existing <style> block in docs/index.html after the.docs-copy-btn section.