### PR TITLE
fix(core): correct CSS cascade layer priority order

### DIFF
--- a/easemotion.css
+++ b/easemotion.css
@@ -15,7 +15,7 @@
 /* ── Cascade Layers ──────────────────────────────────────── */
 /* Unique names prefixed with 'easemotion-' to avoid cascade
    conflicts with other frameworks using generic @layer names. */
-@layer easemotion-utilities, easemotion-components;
+@layer easemotion-components, easemotion-utilities;
 
 /* ── Core (required, load in this order) ─────────────────── */
 /* variables.css and base.css intentionally left unlayered so


### PR DESCRIPTION
## Description
Fixes a critical architectural flaw in the CSS Cascade Layer declaration order within `easemotion.css`. 
Closes #1572 
Previously, the layers were declared as `@layer easemotion-utilities, easemotion-components;`. According to the CSS Cascading and Inheritance specification, layers defined *later* in the list take precedence over earlier ones. This caused component styles to incorrectly override utility classes, breaking the fundamental contract of a utility-first CSS framework.

This PR reverses the order to `@layer easemotion-components, easemotion-utilities;` ensuring that utility classes behave deterministically and can successfully override default component styling.

## Changes Made
- Swapped the order of `easemotion-utilities` and `easemotion-components` in the `@layer` declaration at the top of `easemotion.css`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing Performed
- Verified that the layer specificity is now correctly inverted.
- Ensured utility classes (like `.ease-p-0`) successfully override component defaults (like `.ease-card`).
