### PR TITLE
perf(cards): remove unconditional will-change to prevent GPU memory b…

### DIFF
--- a/components/cards.css
+++ b/components/cards.css
@@ -75,7 +75,6 @@
     transform    var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
     box-shadow   var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
     border-color var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
-  will-change: transform, box-shadow;
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -138,7 +137,6 @@
   transition:
     transform  var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
     box-shadow var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
-  will-change: transform, box-shadow;
 }
 
 @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
## Description
Resolves a significant performance and memory overhead issue caused by the unconditional use of `will-change` in card components.
Closes #1573 
Previously, the base classes `.ease-card-hover` and `.ease-card-neumorphic` applied `will-change: transform, box-shadow;` globally. While `will-change` is a useful hint for browsers to promote elements to the GPU, applying it unconditionally to every instance of a card forces the browser to pre-allocate dedicated VRAM and create independent compositing layers for *all cards* simultaneously. On pages with grid layouts, this causes massive GPU memory bloat and can severely degrade scrolling performance, especially on low-end and mobile devices.

By removing this global declaration, we allow modern browsers to naturally handle hardware acceleration on hover (when the `transform` actually occurs), resulting in a much lighter memory footprint and smoother default scrolling.

## Changes Made
- Removed `will-change: transform, box-shadow;` from `.ease-card-hover` in `components/cards.css`.
- Removed `will-change: transform, box-shadow;` from `.ease-card-neumorphic` in `components/cards.css`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing Performed
- Verified that hover animations (`transform` and `box-shadow`) still execute smoothly.
- Confirmed that rendering layers in browser DevTools are no longer preemptively created for all cards on the page.
