### PR TITLE
fix(core): enforce specificity on utility classes with !important

### DIFF
--- a/core/utilities.css
+++ b/core/utilities.css
@@ -8,338 +8,338 @@
    DISPLAY
    ──────────────────────────────────────────────────────────── */
 
-.ease-block        { display: block; }
-.ease-inline       { display: inline; }
-.ease-inline-block { display: inline-block; }
-.ease-hidden       { display: none; }
+.ease-block        { display: block !important; }
+.ease-inline       { display: inline !important; }
+.ease-inline-block { display: inline-block !important; }
+.ease-hidden       { display: none !important; }
 /* Screen reader only — hide visually but keep available to assistive tech */
 .ease-sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
 }
 /* ────────────────────────────────────────────────────────────
    FLEXBOX
    ──────────────────────────────────────────────────────────── */
 
-.ease-flex         { display: flex; }
-.ease-inline-flex  { display: inline-flex; }
+.ease-flex         { display: flex !important; }
+.ease-inline-flex  { display: inline-flex !important; }
 
 /* Center everything: the most-used utility */
 .ease-center {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
 }
 
-.ease-flex-col     { flex-direction: column; }
-.ease-flex-row     { flex-direction: row; }
-.ease-flex-wrap    { flex-wrap: wrap; }
-.ease-flex-nowrap  { flex-wrap: nowrap; }
-.ease-flex-wrap-reverse { flex-wrap: wrap-reverse; }
+.ease-flex-col     { flex-direction: column !important; }
+.ease-flex-row     { flex-direction: row !important; }
+.ease-flex-wrap    { flex-wrap: wrap !important; }
+.ease-flex-nowrap  { flex-wrap: nowrap !important; }
+.ease-flex-wrap-reverse { flex-wrap: wrap-reverse !important; }
 
 .ease-stack-sm {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ease-space-2);
+  display: flex !important;
+  flex-direction: column !important;
+  gap: var(--ease-space-2) !important;
 }
 
 .ease-stack {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ease-space-4);
+  display: flex !important;
+  flex-direction: column !important;
+  gap: var(--ease-space-4) !important;
 }
 
 .ease-stack-lg {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ease-space-6);
+  display: flex !important;
+  flex-direction: column !important;
+  gap: var(--ease-space-6) !important;
 }
 
 .ease-stack-xl {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ease-space-8);
+  display: flex !important;
+  flex-direction: column !important;
+  gap: var(--ease-space-8) !important;
 }
 
-.ease-items-start    { align-items: flex-start; }
-.ease-items-center   { align-items: center; }
-.ease-items-end      { align-items: flex-end; }
-.ease-items-stretch  { align-items: stretch; }
+.ease-items-start    { align-items: flex-start !important; }
+.ease-items-center   { align-items: center !important; }
+.ease-items-end      { align-items: flex-end !important; }
+.ease-items-stretch  { align-items: stretch !important; }
 
-.ease-self-start    { align-self: flex-start; }
-.ease-self-center   { align-self: center; }
-.ease-self-end      { align-self: flex-end; }
-.ease-self-stretch  { align-self: stretch; }
+.ease-self-start    { align-self: flex-start !important; }
+.ease-self-center   { align-self: center !important; }
+.ease-self-end      { align-self: flex-end !important; }
+.ease-self-stretch  { align-self: stretch !important; }
 
-.ease-justify-start    { justify-content: flex-start; }
-.ease-justify-center   { justify-content: center; }
-.ease-justify-end      { justify-content: flex-end; }
-.ease-justify-between  { justify-content: space-between; }
-.ease-justify-around   { justify-content: space-around; }
-.ease-justify-evenly   { justify-content: space-evenly; }
+.ease-justify-start    { justify-content: flex-start !important; }
+.ease-justify-center   { justify-content: center !important; }
+.ease-justify-end      { justify-content: flex-end !important; }
+.ease-justify-between  { justify-content: space-between !important; }
+.ease-justify-around   { justify-content: space-around !important; }
+.ease-justify-evenly   { justify-content: space-evenly !important; }
 
-.ease-flex-1    { flex: 1 1 0%; }
-.ease-flex-auto { flex: 1 1 auto; }
-.ease-flex-none { flex: none; }
+.ease-flex-1    { flex: 1 1 0% !important; }
+.ease-flex-auto { flex: 1 1 auto !important; }
+.ease-flex-none { flex: none !important; }
 
-.ease-grow   { flex-grow: 1; }
-.ease-shrink { flex-shrink: 1; }
+.ease-grow   { flex-grow: 1 !important; }
+.ease-shrink { flex-shrink: 1 !important; }
 
 /* ────────────────────────────────────────────────────────────
    GRID
    ──────────────────────────────────────────────────────────── */
 
-.ease-grid       { display: grid; }
-.ease-inline-grid { display: inline-grid; }
+.ease-grid       { display: grid !important; }
+.ease-inline-grid { display: inline-grid !important; }
 
-.ease-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.ease-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.ease-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.ease-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.ease-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)) !important; }
+.ease-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }
+.ease-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)) !important; }
+.ease-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)) !important; }
 
-.ease-place-start  { place-items: start; }
-.ease-place-center { place-items: center; }
-.ease-place-end    { place-items: end; }
+.ease-place-start  { place-items: start !important; }
+.ease-place-center { place-items: center !important; }
+.ease-place-end    { place-items: end !important; }
 
 /* Auto-fit responsive columns */
 .ease-grid-auto {
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr)) !important;
 }
 
-.ease-col-span-1 { grid-column: span 1 / span 1; }
-.ease-col-span-2 { grid-column: span 2 / span 2; }
-.ease-col-span-3 { grid-column: span 3 / span 3; }
-.ease-col-span-4 { grid-column: span 4 / span 4; }
-.ease-col-full   { grid-column: 1 / -1; }
+.ease-col-span-1 { grid-column: span 1 / span 1 !important; }
+.ease-col-span-2 { grid-column: span 2 / span 2 !important; }
+.ease-col-span-3 { grid-column: span 3 / span 3 !important; }
+.ease-col-span-4 { grid-column: span 4 / span 4 !important; }
+.ease-col-full   { grid-column: 1 / -1 !important; }
 
 /* ────────────────────────────────────────────────────────────
    GAP
    ──────────────────────────────────────────────────────────── */
 
-.ease-gap-1  { gap: var(--ease-space-1); }
-.ease-gap-2  { gap: var(--ease-space-2); }
-.ease-gap-3  { gap: var(--ease-space-3); }
-.ease-gap    { gap: var(--ease-space-4); }   /* default alias */
-.ease-gap-4  { gap: var(--ease-space-4); }
-.ease-gap-6  { gap: var(--ease-space-6); }
-.ease-gap-8  { gap: var(--ease-space-8); }
-.ease-gap-10 { gap: var(--ease-space-10); }
+.ease-gap-1  { gap: var(--ease-space-1) !important; }
+.ease-gap-2  { gap: var(--ease-space-2) !important; }
+.ease-gap-3  { gap: var(--ease-space-3) !important; }
+.ease-gap    { gap: var(--ease-space-4) !important; }   /* default alias */
+.ease-gap-4  { gap: var(--ease-space-4) !important; }
+.ease-gap-6  { gap: var(--ease-space-6) !important; }
+.ease-gap-8  { gap: var(--ease-space-8) !important; }
+.ease-gap-10 { gap: var(--ease-space-10) !important; }
 
 /* ────────────────────────────────────────────────────────────
    PADDING
    ──────────────────────────────────────────────────────────── */
 
-.ease-padding    { padding: var(--ease-space-4); }  /* default alias */
-.ease-padding-1  { padding: var(--ease-space-1); }
-.ease-padding-2  { padding: var(--ease-space-2); }
-.ease-padding-3  { padding: var(--ease-space-3); }
-.ease-padding-4  { padding: var(--ease-space-4); }
-.ease-padding-6  { padding: var(--ease-space-6); }
-.ease-padding-8  { padding: var(--ease-space-8); }
-.ease-padding-10 { padding: var(--ease-space-10); }
-.ease-padding-12 { padding: var(--ease-space-12); }
+.ease-padding    { padding: var(--ease-space-4) !important; }  /* default alias */
+.ease-padding-1  { padding: var(--ease-space-1) !important; }
+.ease-padding-2  { padding: var(--ease-space-2) !important; }
+.ease-padding-3  { padding: var(--ease-space-3) !important; }
+.ease-padding-4  { padding: var(--ease-space-4) !important; }
+.ease-padding-6  { padding: var(--ease-space-6) !important; }
+.ease-padding-8  { padding: var(--ease-space-8) !important; }
+.ease-padding-10 { padding: var(--ease-space-10) !important; }
+.ease-padding-12 { padding: var(--ease-space-12) !important; }
 
-.ease-pt-4 { padding-top:    var(--ease-space-4); }
-.ease-pr-4 { padding-right:  var(--ease-space-4); }
-.ease-pb-4 { padding-bottom: var(--ease-space-4); }
-.ease-pl-4 { padding-left:   var(--ease-space-4); }
+.ease-pt-4 { padding-top:    var(--ease-space-4) !important; }
+.ease-pr-4 { padding-right:  var(--ease-space-4) !important; }
+.ease-pb-4 { padding-bottom: var(--ease-space-4) !important; }
+.ease-pl-4 { padding-left:   var(--ease-space-4) !important; }
 
-.ease-px-4 { padding-left: var(--ease-space-4); padding-right:  var(--ease-space-4); }
-.ease-py-4 { padding-top:  var(--ease-space-4); padding-bottom: var(--ease-space-4); }
-.ease-px-8 { padding-left: var(--ease-space-8); padding-right:  var(--ease-space-8); }
-.ease-py-8 { padding-top:  var(--ease-space-8); padding-bottom: var(--ease-space-8); }
+.ease-px-4 { padding-left: var(--ease-space-4) !important; padding-right:  var(--ease-space-4) !important; }
+.ease-py-4 { padding-top:  var(--ease-space-4) !important; padding-bottom: var(--ease-space-4) !important; }
+.ease-px-8 { padding-left: var(--ease-space-8) !important; padding-right:  var(--ease-space-8) !important; }
+.ease-py-8 { padding-top:  var(--ease-space-8) !important; padding-bottom: var(--ease-space-8) !important; }
 
 /* ────────────────────────────────────────────────────────────
    MARGIN
    ──────────────────────────────────────────────────────────── */
 
-.ease-margin     { margin: var(--ease-space-4); }   /* default alias */
-.ease-margin-1   { margin: var(--ease-space-1); }
-.ease-margin-2   { margin: var(--ease-space-2); }
-.ease-margin-3   { margin: var(--ease-space-3); }
-.ease-margin-4   { margin: var(--ease-space-4); }
-.ease-margin-6   { margin: var(--ease-space-6); }
-.ease-margin-8   { margin: var(--ease-space-8); }
-.ease-margin-auto { margin: auto; }
+.ease-margin     { margin: var(--ease-space-4) !important; }   /* default alias */
+.ease-margin-1   { margin: var(--ease-space-1) !important; }
+.ease-margin-2   { margin: var(--ease-space-2) !important; }
+.ease-margin-3   { margin: var(--ease-space-3) !important; }
+.ease-margin-4   { margin: var(--ease-space-4) !important; }
+.ease-margin-6   { margin: var(--ease-space-6) !important; }
+.ease-margin-8   { margin: var(--ease-space-8) !important; }
+.ease-margin-auto { margin: auto !important; }
 
-.ease-mx-auto { margin-left: auto; margin-right: auto; }
-.ease-my-4    { margin-top: var(--ease-space-4); margin-bottom: var(--ease-space-4); }
-.ease-my-8    { margin-top: var(--ease-space-8); margin-bottom: var(--ease-space-8); }
+.ease-mx-auto { margin-left: auto !important; margin-right: auto !important; }
+.ease-my-4    { margin-top: var(--ease-space-4) !important; margin-bottom: var(--ease-space-4) !important; }
+.ease-my-8    { margin-top: var(--ease-space-8) !important; margin-bottom: var(--ease-space-8) !important; }
 
-.ease-mt-4  { margin-top:    var(--ease-space-4); }
-.ease-mr-4  { margin-right:  var(--ease-space-4); }
-.ease-mb-4  { margin-bottom: var(--ease-space-4); }
-.ease-ml-4  { margin-left:   var(--ease-space-4); }
+.ease-mt-4  { margin-top:    var(--ease-space-4) !important; }
+.ease-mr-4  { margin-right:  var(--ease-space-4) !important; }
+.ease-mb-4  { margin-bottom: var(--ease-space-4) !important; }
+.ease-ml-4  { margin-left:   var(--ease-space-4) !important; }
 
 /* ────────────────────────────────────────────────────────────
    WIDTH & HEIGHT
    ──────────────────────────────────────────────────────────── */
 
-.ease-w-full    { width: 100%; }
-.ease-w-screen  { width: 100vw; }
-.ease-w-auto    { width: auto; }
-.ease-h-full    { height: 100%; }
+.ease-w-full    { width: 100% !important; }
+.ease-w-screen  { width: 100vw !important; }
+.ease-w-auto    { width: auto !important; }
+.ease-h-full    { height: 100% !important; }
 
-.ease-h-screen  { height: 100vh; }
+.ease-h-screen  { height: 100vh !important; }
 @supports (height: 100dvh) {
-  .ease-h-screen { height: 100dvh; }
+  .ease-h-screen { height: 100dvh !important; }
 }
-.ease-h-auto    { height: auto; }
+.ease-h-auto    { height: auto !important; }
 
 /* Max-width container */
 .ease-container {
-  width: 100%;
-  max-width: var(--ease-container-max);
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: var(--ease-space-6);
-  padding-right: var(--ease-space-6);
+  width: 100% !important;
+  max-width: var(--ease-container-max) !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  padding-left: var(--ease-space-6) !important;
+  padding-right: var(--ease-space-6) !important;
 }
 
 /* ────────────────────────────────────────────────────────────
    POSITIONING
    ──────────────────────────────────────────────────────────── */
 
-.ease-relative  { position: relative; }
-.ease-absolute  { position: absolute; }
-.ease-fixed     { position: fixed; }
-.ease-sticky    { position: sticky; top: 0; }
+.ease-relative  { position: relative !important; }
+.ease-absolute  { position: absolute !important; }
+.ease-fixed     { position: fixed !important; }
+.ease-sticky    { position: sticky !important; top: 0 !important; }
 
 /* ────────────────────────────────────────────────────────────
    OVERFLOW
    ──────────────────────────────────────────────────────────── */
 
-.ease-overflow-hidden  { overflow: hidden; }
-.ease-overflow-auto    { overflow: auto; }
-.ease-overflow-scroll  { overflow: scroll; }
-.ease-overflow-x-auto  { overflow-x: auto; }
-.ease-overflow-y-auto  { overflow-y: auto; }
+.ease-overflow-hidden  { overflow: hidden !important; }
+.ease-overflow-auto    { overflow: auto !important; }
+.ease-overflow-scroll  { overflow: scroll !important; }
+.ease-overflow-x-auto  { overflow-x: auto !important; }
+.ease-overflow-y-auto  { overflow-y: auto !important; }
 
 /* ────────────────────────────────────────────────────────────
    SCROLL SNAP
    ──────────────────────────────────────────────────────────── */
 .ease-snap-x {
-  --ease-snap-axis: x;
-  scroll-snap-type: var(--ease-snap-axis, x) var(--ease-snap-strictness, proximity);
-  -webkit-scroll-snap-type: var(--ease-snap-axis, x) var(--ease-snap-strictness, proximity);
+  --ease-snap-axis: x !important;
+  scroll-snap-type: var(--ease-snap-axis, x) var(--ease-snap-strictness, proximity) !important;
+  -webkit-scroll-snap-type: var(--ease-snap-axis, x) var(--ease-snap-strictness, proximity) !important;
 }
 .ease-snap-y {
-  --ease-snap-axis: y;
-  scroll-snap-type: var(--ease-snap-axis, y) var(--ease-snap-strictness, proximity);
-  -webkit-scroll-snap-type: var(--ease-snap-axis, y) var(--ease-snap-strictness, proximity);
+  --ease-snap-axis: y !important;
+  scroll-snap-type: var(--ease-snap-axis, y) var(--ease-snap-strictness, proximity) !important;
+  -webkit-scroll-snap-type: var(--ease-snap-axis, y) var(--ease-snap-strictness, proximity) !important;
 }
-.ease-snap-center { scroll-snap-align: center; }
-.ease-snap-start  { scroll-snap-align: start; }
-.ease-snap-end    { scroll-snap-align: end; }
+.ease-snap-center { scroll-snap-align: center !important; }
+.ease-snap-start  { scroll-snap-align: start !important; }
+.ease-snap-end    { scroll-snap-align: end !important; }
 .ease-snap-mandatory {
-  --ease-snap-strictness: mandatory;
+  --ease-snap-strictness: mandatory !important;
 }
 
 /* ────────────────────────────────────────────────────────────
    TEXT
    ──────────────────────────────────────────────────────────── */
 
-.ease-text-xs   { font-size: var(--ease-text-xs); }
-.ease-text-sm   { font-size: var(--ease-text-sm); }
-.ease-text-base { font-size: var(--ease-text-base); }
-.ease-text-lg   { font-size: var(--ease-text-lg); }
-.ease-text-xl   { font-size: var(--ease-text-xl); }
-.ease-text-2xl  { font-size: var(--ease-text-2xl); }
-.ease-text-3xl  { font-size: var(--ease-text-3xl); }
-.ease-text-4xl  { font-size: var(--ease-text-4xl); }
+.ease-text-xs   { font-size: var(--ease-text-xs) !important; }
+.ease-text-sm   { font-size: var(--ease-text-sm) !important; }
+.ease-text-base { font-size: var(--ease-text-base) !important; }
+.ease-text-lg   { font-size: var(--ease-text-lg) !important; }
+.ease-text-xl   { font-size: var(--ease-text-xl) !important; }
+.ease-text-2xl  { font-size: var(--ease-text-2xl) !important; }
+.ease-text-3xl  { font-size: var(--ease-text-3xl) !important; }
+.ease-text-4xl  { font-size: var(--ease-text-4xl) !important; }
 
-.ease-text-left    { text-align: left; }
-.ease-text-center  { text-align: center; }
-.ease-text-right   { text-align: right; }
+.ease-text-left    { text-align: left !important; }
+.ease-text-center  { text-align: center !important; }
+.ease-text-right   { text-align: right !important; }
 
-.ease-font-light    { font-weight: 300; }
-.ease-font-regular  { font-weight: 400; }
-.ease-font-medium   { font-weight: 500; }
-.ease-font-semibold { font-weight: 600; }
-.ease-font-bold     { font-weight: 700; }
+.ease-font-light    { font-weight: 300 !important; }
+.ease-font-regular  { font-weight: 400 !important; }
+.ease-font-medium   { font-weight: 500 !important; }
+.ease-font-semibold { font-weight: 600 !important; }
+.ease-font-bold     { font-weight: 700 !important; }
 
-.ease-uppercase   { text-transform: uppercase; }
-.ease-lowercase   { text-transform: lowercase; }
-.ease-capitalize  { text-transform: capitalize; }
+.ease-uppercase   { text-transform: uppercase !important; }
+.ease-lowercase   { text-transform: lowercase !important; }
+.ease-capitalize  { text-transform: capitalize !important; }
 
 .ease-truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
 }
 
 /* ────────────────────────────────────────────────────────────
    COLORS (text + background)
    ──────────────────────────────────────────────────────────── */
 
-.ease-text-primary   { color: var(--ease-color-primary); }
-.ease-text-success   { color: var(--ease-color-success); }
-.ease-text-danger    { color: var(--ease-color-danger); }
-.ease-text-warning   { color: var(--ease-color-warning); }
-.ease-text-muted     { color: var(--ease-color-muted); }
-.ease-text-white     { color: #ffffff; }
+.ease-text-primary   { color: var(--ease-color-primary) !important; }
+.ease-text-success   { color: var(--ease-color-success) !important; }
+.ease-text-danger    { color: var(--ease-color-danger) !important; }
+.ease-text-warning   { color: var(--ease-color-warning) !important; }
+.ease-text-muted     { color: var(--ease-color-muted) !important; }
+.ease-text-white     { color: #ffffff !important; }
 
-.ease-bg-primary     { background-color: var(--ease-color-primary); }
-.ease-bg-success     { background-color: var(--ease-color-success); }
-.ease-bg-danger      { background-color: var(--ease-color-danger); }
-.ease-bg-warning     { background-color: var(--ease-color-warning); }
-.ease-bg-white       { background-color: #ffffff; }
-.ease-bg-surface     { background-color: var(--ease-color-surface); }
-.ease-bg-neutral     { background-color: var(--ease-color-neutral-100); }
+.ease-bg-primary     { background-color: var(--ease-color-primary) !important; }
+.ease-bg-success     { background-color: var(--ease-color-success) !important; }
+.ease-bg-danger      { background-color: var(--ease-color-danger) !important; }
+.ease-bg-warning     { background-color: var(--ease-color-warning) !important; }
+.ease-bg-white       { background-color: #ffffff !important; }
+.ease-bg-surface     { background-color: var(--ease-color-surface) !important; }
+.ease-bg-neutral     { background-color: var(--ease-color-neutral-100) !important; }
 
 /* Background Position Utilities */
-.ease-bg-center  { background-position: center; }
-.ease-bg-top     { background-position: top; }
-.ease-bg-bottom  { background-position: bottom; }
-.ease-bg-left    { background-position: left; }
-.ease-bg-right   { background-position: right; }
+.ease-bg-center  { background-position: center !important; }
+.ease-bg-top     { background-position: top !important; }
+.ease-bg-bottom  { background-position: bottom !important; }
+.ease-bg-left    { background-position: left !important; }
+.ease-bg-right   { background-position: right !important; }
 
 /* ────────────────────────────────────────────────────────────
    BORDER & RADIUS
    ──────────────────────────────────────────────────────────── */
 
-.ease-border        { border: 1px solid var(--ease-color-neutral-200); }
-.ease-border-2      { border: 2px solid var(--ease-color-neutral-200); }
-.ease-border-primary { border-color: var(--ease-color-primary); }
+.ease-border        { border: 1px solid var(--ease-color-neutral-200) !important; }
+.ease-border-2      { border: 2px solid var(--ease-color-neutral-200) !important; }
+.ease-border-primary { border-color: var(--ease-color-primary) !important; }
 
-.ease-rounded-sm   { border-radius: var(--ease-radius-sm); }
-.ease-rounded      { border-radius: var(--ease-radius-md); }
-.ease-rounded-lg   { border-radius: var(--ease-radius-lg); }
-.ease-rounded-xl   { border-radius: var(--ease-radius-xl); }
-.ease-rounded-full { border-radius: var(--ease-radius-full); }
+.ease-rounded-sm   { border-radius: var(--ease-radius-sm) !important; }
+.ease-rounded      { border-radius: var(--ease-radius-md) !important; }
+.ease-rounded-lg   { border-radius: var(--ease-radius-lg) !important; }
+.ease-rounded-xl   { border-radius: var(--ease-radius-xl) !important; }
+.ease-rounded-full { border-radius: var(--ease-radius-full) !important; }
 
 /* ────────────────────────────────────────────────────────────
    SHADOW
    ──────────────────────────────────────────────────────────── */
 
-.ease-shadow-sm  { box-shadow: var(--ease-shadow-sm); }
-.ease-shadow     { box-shadow: var(--ease-shadow-md); }
-.ease-shadow-lg  { box-shadow: var(--ease-shadow-lg); }
-.ease-shadow-xl  { box-shadow: var(--ease-shadow-xl); }
-.ease-shadow-none { box-shadow: none; }
+.ease-shadow-sm  { box-shadow: var(--ease-shadow-sm) !important; }
+.ease-shadow     { box-shadow: var(--ease-shadow-md) !important; }
+.ease-shadow-lg  { box-shadow: var(--ease-shadow-lg) !important; }
+.ease-shadow-xl  { box-shadow: var(--ease-shadow-xl) !important; }
+.ease-shadow-none { box-shadow: none !important; }
 
 /* ────────────────────────────────────────────────────────────
    OPACITY
    ──────────────────────────────────────────────────────────── */
 
-.ease-opacity-0   { opacity: 0; }
-.ease-opacity-25  { opacity: 0.25; }
-.ease-opacity-50  { opacity: 0.50; }
-.ease-opacity-75  { opacity: 0.75; }
-.ease-opacity-100 { opacity: 1; }
+.ease-opacity-0   { opacity: 0 !important; }
+.ease-opacity-25  { opacity: 0.25 !important; }
+.ease-opacity-50  { opacity: 0.50 !important; }
+.ease-opacity-75  { opacity: 0.75 !important; }
+.ease-opacity-100 { opacity: 1 !important; }
 
 /* ────────────────────────────────────────────────────────────
    CURSOR
    ──────────────────────────────────────────────────────────── */
 
-.ease-cursor-pointer  { cursor: pointer; }
-.ease-cursor-default  { cursor: default; }
-.ease-cursor-not-allowed { cursor: not-allowed; }
+.ease-cursor-pointer  { cursor: pointer !important; }
+.ease-cursor-default  { cursor: default !important; }
+.ease-cursor-not-allowed { cursor: not-allowed !important; }
 
 /* ────────────────────────────────────────────────────────────
    RESPONSIVE VARIANTS
@@ -352,227 +352,228 @@
   .ease-grid-cols-2,
   .ease-grid-cols-3,
   .ease-grid-cols-4 {
-    grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) !important;
   }
 }
 
 /* sm: 640px+ (--ease-bp-sm) */
 @media (min-width: 640px) {
   .ease-container {
-    padding-left: var(--ease-space-6);
-    padding-right: var(--ease-space-6);
+    padding-left: var(--ease-space-6) !important;
+    padding-right: var(--ease-space-6) !important;
   }
 
-  .ease-sm-block        { display: block; }
-  .ease-sm-inline       { display: inline; }
-  .ease-sm-hidden       { display: none; }
-  .ease-sm-flex         { display: flex; }
-  .ease-sm-inline-flex  { display: inline-flex; }
-  .ease-sm-grid         { display: grid; }
-  .ease-sm-inline-grid  { display: inline-grid; }
+  .ease-sm-block        { display: block !important; }
+  .ease-sm-inline       { display: inline !important; }
+  .ease-sm-hidden       { display: none !important; }
+  .ease-sm-flex         { display: flex !important; }
+  .ease-sm-inline-flex  { display: inline-flex !important; }
+  .ease-sm-grid         { display: grid !important; }
+  .ease-sm-inline-grid  { display: inline-grid !important; }
 
-  .ease-sm-flex-row    { flex-direction: row; }
-  .ease-sm-flex-col    { flex-direction: column; }
-  .ease-sm-flex-wrap   { flex-wrap: wrap; }
-  .ease-sm-items-center { align-items: center; }
-  .ease-sm-items-start  { align-items: flex-start; }
-  .ease-sm-items-end    { align-items: flex-end; }
-  .ease-sm-justify-center { justify-content: center; }
-  .ease-sm-justify-start  { justify-content: flex-start; }
-  .ease-sm-justify-end    { justify-content: flex-end; }
-  .ease-sm-justify-between { justify-content: space-between; }
-  .ease-sm-center { display: flex; align-items: center; justify-content: center; }
+  .ease-sm-flex-row    { flex-direction: row !important; }
+  .ease-sm-flex-col    { flex-direction: column !important; }
+  .ease-sm-flex-wrap   { flex-wrap: wrap !important; }
+  .ease-sm-items-center { align-items: center !important; }
+  .ease-sm-items-start  { align-items: flex-start !important; }
+  .ease-sm-items-end    { align-items: flex-end !important; }
+  .ease-sm-justify-center { justify-content: center !important; }
+  .ease-sm-justify-start  { justify-content: flex-start !important; }
+  .ease-sm-justify-end    { justify-content: flex-end !important; }
+  .ease-sm-justify-between { justify-content: space-between !important; }
+  .ease-sm-center { display: flex !important; align-items: center !important; justify-content: center !important; }
 
-  .ease-sm-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-  .ease-sm-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .ease-sm-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .ease-sm-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .ease-sm-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)) !important; }
+  .ease-sm-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }
+  .ease-sm-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)) !important; }
+  .ease-sm-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)) !important; }
 
-  .ease-sm-gap-1  { gap: var(--ease-space-1); }
-  .ease-sm-gap-2  { gap: var(--ease-space-2); }
-  .ease-sm-gap-4  { gap: var(--ease-space-4); }
-  .ease-sm-gap-6  { gap: var(--ease-space-6); }
-  .ease-sm-gap-8  { gap: var(--ease-space-8); }
+  .ease-sm-gap-1  { gap: var(--ease-space-1) !important; }
+  .ease-sm-gap-2  { gap: var(--ease-space-2) !important; }
+  .ease-sm-gap-4  { gap: var(--ease-space-4) !important; }
+  .ease-sm-gap-6  { gap: var(--ease-space-6) !important; }
+  .ease-sm-gap-8  { gap: var(--ease-space-8) !important; }
 
-  .ease-sm-padding-4  { padding: var(--ease-space-4); }
-  .ease-sm-padding-6  { padding: var(--ease-space-6); }
-  .ease-sm-padding-8  { padding: var(--ease-space-8); }
-  .ease-sm-px-4       { padding-left: var(--ease-space-4); padding-right: var(--ease-space-4); }
-  .ease-sm-py-4       { padding-top:  var(--ease-space-4); padding-bottom: var(--ease-space-4); }
-  .ease-sm-px-8       { padding-left: var(--ease-space-8); padding-right: var(--ease-space-8); }
-  .ease-sm-py-8       { padding-top:  var(--ease-space-8); padding-bottom: var(--ease-space-8); }
+  .ease-sm-padding-4  { padding: var(--ease-space-4) !important; }
+  .ease-sm-padding-6  { padding: var(--ease-space-6) !important; }
+  .ease-sm-padding-8  { padding: var(--ease-space-8) !important; }
+  .ease-sm-px-4       { padding-left: var(--ease-space-4) !important; padding-right: var(--ease-space-4) !important; }
+  .ease-sm-py-4       { padding-top:  var(--ease-space-4) !important; padding-bottom: var(--ease-space-4) !important; }
+  .ease-sm-px-8       { padding-left: var(--ease-space-8) !important; padding-right: var(--ease-space-8) !important; }
+  .ease-sm-py-8       { padding-top:  var(--ease-space-8) !important; padding-bottom: var(--ease-space-8) !important; }
 
-  .ease-sm-w-full  { width: 100%; }
-  .ease-sm-w-auto  { width: auto; }
+  .ease-sm-w-full  { width: 100% !important; }
+  .ease-sm-w-auto  { width: auto !important; }
 
-  .ease-sm-text-left   { text-align: left; }
-  .ease-sm-text-center { text-align: center; }
-  .ease-sm-text-right  { text-align: right; }
-  .ease-sm-text-sm     { font-size: var(--ease-text-sm); }
-  .ease-sm-text-base   { font-size: var(--ease-text-base); }
-  .ease-sm-text-lg     { font-size: var(--ease-text-lg); }
-  .ease-sm-text-xl     { font-size: var(--ease-text-xl); }
-  .ease-sm-text-2xl    { font-size: var(--ease-text-2xl); }
+  .ease-sm-text-left   { text-align: left !important; }
+  .ease-sm-text-center { text-align: center !important; }
+  .ease-sm-text-right  { text-align: right !important; }
+  .ease-sm-text-sm     { font-size: var(--ease-text-sm) !important; }
+  .ease-sm-text-base   { font-size: var(--ease-text-base) !important; }
+  .ease-sm-text-lg     { font-size: var(--ease-text-lg) !important; }
+  .ease-sm-text-xl     { font-size: var(--ease-text-xl) !important; }
+  .ease-sm-text-2xl    { font-size: var(--ease-text-2xl) !important; }
 }
 
 /* md: 768px+ (--ease-bp-md) */
 @media (min-width: 768px) {
-  .ease-md-block        { display: block; }
-  .ease-md-inline       { display: inline; }
-  .ease-md-hidden       { display: none; }
-  .ease-md-flex         { display: flex; }
-  .ease-md-inline-flex  { display: inline-flex; }
-  .ease-md-grid         { display: grid; }
-  .ease-md-inline-grid  { display: inline-grid; }
+  .ease-md-block        { display: block !important; }
+  .ease-md-inline       { display: inline !important; }
+  .ease-md-hidden       { display: none !important; }
+  .ease-md-flex         { display: flex !important; }
+  .ease-md-inline-flex  { display: inline-flex !important; }
+  .ease-md-grid         { display: grid !important; }
+  .ease-md-inline-grid  { display: inline-grid !important; }
 
-  .ease-md-flex-row    { flex-direction: row; }
-  .ease-md-flex-col    { flex-direction: column; }
-  .ease-md-flex-wrap   { flex-wrap: wrap; }
-  .ease-md-items-center { align-items: center; }
-  .ease-md-items-start  { align-items: flex-start; }
-  .ease-md-items-end    { align-items: flex-end; }
-  .ease-md-justify-center { justify-content: center; }
-  .ease-md-justify-start  { justify-content: flex-start; }
-  .ease-md-justify-end    { justify-content: flex-end; }
-  .ease-md-justify-between { justify-content: space-between; }
-  .ease-md-center { display: flex; align-items: center; justify-content: center; }
+  .ease-md-flex-row    { flex-direction: row !important; }
+  .ease-md-flex-col    { flex-direction: column !important; }
+  .ease-md-flex-wrap   { flex-wrap: wrap !important; }
+  .ease-md-items-center { align-items: center !important; }
+  .ease-md-items-start  { align-items: flex-start !important; }
+  .ease-md-items-end    { align-items: flex-end !important; }
+  .ease-md-justify-center { justify-content: center !important; }
+  .ease-md-justify-start  { justify-content: flex-start !important; }
+  .ease-md-justify-end    { justify-content: flex-end !important; }
+  .ease-md-justify-between { justify-content: space-between !important; }
+  .ease-md-center { display: flex !important; align-items: center !important; justify-content: center !important; }
 
-  .ease-md-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-  .ease-md-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .ease-md-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .ease-md-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .ease-md-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)) !important; }
+  .ease-md-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }
+  .ease-md-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)) !important; }
+  .ease-md-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)) !important; }
 
-  .ease-md-gap-1  { gap: var(--ease-space-1); }
-  .ease-md-gap-2  { gap: var(--ease-space-2); }
-  .ease-md-gap-4  { gap: var(--ease-space-4); }
-  .ease-md-gap-6  { gap: var(--ease-space-6); }
-  .ease-md-gap-8  { gap: var(--ease-space-8); }
+  .ease-md-gap-1  { gap: var(--ease-space-1) !important; }
+  .ease-md-gap-2  { gap: var(--ease-space-2) !important; }
+  .ease-md-gap-4  { gap: var(--ease-space-4) !important; }
+  .ease-md-gap-6  { gap: var(--ease-space-6) !important; }
+  .ease-md-gap-8  { gap: var(--ease-space-8) !important; }
 
-  .ease-md-padding-4  { padding: var(--ease-space-4); }
-  .ease-md-padding-6  { padding: var(--ease-space-6); }
-  .ease-md-padding-8  { padding: var(--ease-space-8); }
-  .ease-md-px-4       { padding-left: var(--ease-space-4); padding-right: var(--ease-space-4); }
-  .ease-md-py-4       { padding-top:  var(--ease-space-4); padding-bottom: var(--ease-space-4); }
-  .ease-md-px-8       { padding-left: var(--ease-space-8); padding-right: var(--ease-space-8); }
-  .ease-md-py-8       { padding-top:  var(--ease-space-8); padding-bottom: var(--ease-space-8); }
+  .ease-md-padding-4  { padding: var(--ease-space-4) !important; }
+  .ease-md-padding-6  { padding: var(--ease-space-6) !important; }
+  .ease-md-padding-8  { padding: var(--ease-space-8) !important; }
+  .ease-md-px-4       { padding-left: var(--ease-space-4) !important; padding-right: var(--ease-space-4) !important; }
+  .ease-md-py-4       { padding-top:  var(--ease-space-4) !important; padding-bottom: var(--ease-space-4) !important; }
+  .ease-md-px-8       { padding-left: var(--ease-space-8) !important; padding-right: var(--ease-space-8) !important; }
+  .ease-md-py-8       { padding-top:  var(--ease-space-8) !important; padding-bottom: var(--ease-space-8) !important; }
 
-  .ease-md-w-full  { width: 100%; }
-  .ease-md-w-auto  { width: auto; }
+  .ease-md-w-full  { width: 100% !important; }
+  .ease-md-w-auto  { width: auto !important; }
 
-  .ease-md-text-left   { text-align: left; }
-  .ease-md-text-center { text-align: center; }
-  .ease-md-text-right  { text-align: right; }
-  .ease-md-text-sm     { font-size: var(--ease-text-sm); }
-  .ease-md-text-base   { font-size: var(--ease-text-base); }
-  .ease-md-text-lg     { font-size: var(--ease-text-lg); }
-  .ease-md-text-xl     { font-size: var(--ease-text-xl); }
-  .ease-md-text-2xl    { font-size: var(--ease-text-2xl); }
+  .ease-md-text-left   { text-align: left !important; }
+  .ease-md-text-center { text-align: center !important; }
+  .ease-md-text-right  { text-align: right !important; }
+  .ease-md-text-sm     { font-size: var(--ease-text-sm) !important; }
+  .ease-md-text-base   { font-size: var(--ease-text-base) !important; }
+  .ease-md-text-lg     { font-size: var(--ease-text-lg) !important; }
+  .ease-md-text-xl     { font-size: var(--ease-text-xl) !important; }
+  .ease-md-text-2xl    { font-size: var(--ease-text-2xl) !important; }
 }
 
 /* lg: 1024px+ (--ease-bp-lg) */
 @media (min-width: 1024px) {
-  .ease-lg-block        { display: block; }
-  .ease-lg-inline       { display: inline; }
-  .ease-lg-hidden       { display: none; }
-  .ease-lg-flex         { display: flex; }
-  .ease-lg-inline-flex  { display: inline-flex; }
-  .ease-lg-grid         { display: grid; }
-  .ease-lg-inline-grid  { display: inline-grid; }
+  .ease-lg-block        { display: block !important; }
+  .ease-lg-inline       { display: inline !important; }
+  .ease-lg-hidden       { display: none !important; }
+  .ease-lg-flex         { display: flex !important; }
+  .ease-lg-inline-flex  { display: inline-flex !important; }
+  .ease-lg-grid         { display: grid !important; }
+  .ease-lg-inline-grid  { display: inline-grid !important; }
 
-  .ease-lg-flex-row    { flex-direction: row; }
-  .ease-lg-flex-col    { flex-direction: column; }
-  .ease-lg-flex-wrap   { flex-wrap: wrap; }
-  .ease-lg-items-center { align-items: center; }
-  .ease-lg-items-start  { align-items: flex-start; }
-  .ease-lg-items-end    { align-items: flex-end; }
-  .ease-lg-justify-center { justify-content: center; }
-  .ease-lg-justify-start  { justify-content: flex-start; }
-  .ease-lg-justify-end    { justify-content: flex-end; }
-  .ease-lg-justify-between { justify-content: space-between; }
-  .ease-lg-center { display: flex; align-items: center; justify-content: center; }
+  .ease-lg-flex-row    { flex-direction: row !important; }
+  .ease-lg-flex-col    { flex-direction: column !important; }
+  .ease-lg-flex-wrap   { flex-wrap: wrap !important; }
+  .ease-lg-items-center { align-items: center !important; }
+  .ease-lg-items-start  { align-items: flex-start !important; }
+  .ease-lg-items-end    { align-items: flex-end !important; }
+  .ease-lg-justify-center { justify-content: center !important; }
+  .ease-lg-justify-start  { justify-content: flex-start !important; }
+  .ease-lg-justify-end    { justify-content: flex-end !important; }
+  .ease-lg-justify-between { justify-content: space-between !important; }
+  .ease-lg-center { display: flex !important; align-items: center !important; justify-content: center !important; }
 
-  .ease-lg-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-  .ease-lg-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .ease-lg-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .ease-lg-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .ease-lg-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)) !important; }
+  .ease-lg-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }
+  .ease-lg-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)) !important; }
+  .ease-lg-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)) !important; }
 
-  .ease-lg-gap-1  { gap: var(--ease-space-1); }
-  .ease-lg-gap-2  { gap: var(--ease-space-2); }
-  .ease-lg-gap-4  { gap: var(--ease-space-4); }
-  .ease-lg-gap-6  { gap: var(--ease-space-6); }
-  .ease-lg-gap-8  { gap: var(--ease-space-8); }
+  .ease-lg-gap-1  { gap: var(--ease-space-1) !important; }
+  .ease-lg-gap-2  { gap: var(--ease-space-2) !important; }
+  .ease-lg-gap-4  { gap: var(--ease-space-4) !important; }
+  .ease-lg-gap-6  { gap: var(--ease-space-6) !important; }
+  .ease-lg-gap-8  { gap: var(--ease-space-8) !important; }
 
-  .ease-lg-padding-4  { padding: var(--ease-space-4); }
-  .ease-lg-padding-6  { padding: var(--ease-space-6); }
-  .ease-lg-padding-8  { padding: var(--ease-space-8); }
-  .ease-lg-px-4       { padding-left: var(--ease-space-4); padding-right: var(--ease-space-4); }
-  .ease-lg-py-4       { padding-top:  var(--ease-space-4); padding-bottom: var(--ease-space-4); }
-  .ease-lg-px-8       { padding-left: var(--ease-space-8); padding-right: var(--ease-space-8); }
-  .ease-lg-py-8       { padding-top:  var(--ease-space-8); padding-bottom: var(--ease-space-8); }
+  .ease-lg-padding-4  { padding: var(--ease-space-4) !important; }
+  .ease-lg-padding-6  { padding: var(--ease-space-6) !important; }
+  .ease-lg-padding-8  { padding: var(--ease-space-8) !important; }
+  .ease-lg-px-4       { padding-left: var(--ease-space-4) !important; padding-right: var(--ease-space-4) !important; }
+  .ease-lg-py-4       { padding-top:  var(--ease-space-4) !important; padding-bottom: var(--ease-space-4) !important; }
+  .ease-lg-px-8       { padding-left: var(--ease-space-8) !important; padding-right: var(--ease-space-8) !important; }
+  .ease-lg-py-8       { padding-top:  var(--ease-space-8) !important; padding-bottom: var(--ease-space-8) !important; }
 
-  .ease-lg-w-full  { width: 100%; }
-  .ease-lg-w-auto  { width: auto; }
+  .ease-lg-w-full  { width: 100% !important; }
+  .ease-lg-w-auto  { width: auto !important; }
 
-  .ease-lg-text-left   { text-align: left; }
-  .ease-lg-text-center { text-align: center; }
-  .ease-lg-text-right  { text-align: right; }
-  .ease-lg-text-sm     { font-size: var(--ease-text-sm); }
-  .ease-lg-text-base   { font-size: var(--ease-text-base); }
-  .ease-lg-text-lg     { font-size: var(--ease-text-lg); }
-  .ease-lg-text-xl     { font-size: var(--ease-text-xl); }
-  .ease-lg-text-2xl    { font-size: var(--ease-text-2xl); }
+  .ease-lg-text-left   { text-align: left !important; }
+  .ease-lg-text-center { text-align: center !important; }
+  .ease-lg-text-right  { text-align: right !important; }
+  .ease-lg-text-sm     { font-size: var(--ease-text-sm) !important; }
+  .ease-lg-text-base   { font-size: var(--ease-text-base) !important; }
+  .ease-lg-text-lg     { font-size: var(--ease-text-lg) !important; }
+  .ease-lg-text-xl     { font-size: var(--ease-text-xl) !important; }
+  .ease-lg-text-2xl    { font-size: var(--ease-text-2xl) !important; }
 }
 
 /* xl: 1280px+ (--ease-bp-xl) */
 @media (min-width: 1280px) {
-  .ease-xl-block        { display: block; }
-  .ease-xl-inline       { display: inline; }
-  .ease-xl-hidden       { display: none; }
-  .ease-xl-flex         { display: flex; }
-  .ease-xl-inline-flex  { display: inline-flex; }
-  .ease-xl-grid         { display: grid; }
-  .ease-xl-inline-grid  { display: inline-grid; }
+  .ease-xl-block        { display: block !important; }
+  .ease-xl-inline       { display: inline !important; }
+  .ease-xl-hidden       { display: none !important; }
+  .ease-xl-flex         { display: flex !important; }
+  .ease-xl-inline-flex  { display: inline-flex !important; }
+  .ease-xl-grid         { display: grid !important; }
+  .ease-xl-inline-grid  { display: inline-grid !important; }
 
-  .ease-xl-flex-row    { flex-direction: row; }
-  .ease-xl-flex-col    { flex-direction: column; }
-  .ease-xl-flex-wrap   { flex-wrap: wrap; }
-  .ease-xl-items-center { align-items: center; }
-  .ease-xl-items-start  { align-items: flex-start; }
-  .ease-xl-items-end    { align-items: flex-end; }
-  .ease-xl-justify-center { justify-content: center; }
-  .ease-xl-justify-start  { justify-content: flex-start; }
-  .ease-xl-justify-end    { justify-content: flex-end; }
-  .ease-xl-justify-between { justify-content: space-between; }
-  .ease-xl-center { display: flex; align-items: center; justify-content: center; }
+  .ease-xl-flex-row    { flex-direction: row !important; }
+  .ease-xl-flex-col    { flex-direction: column !important; }
+  .ease-xl-flex-wrap   { flex-wrap: wrap !important; }
+  .ease-xl-items-center { align-items: center !important; }
+  .ease-xl-items-start  { align-items: flex-start !important; }
+  .ease-xl-items-end    { align-items: flex-end !important; }
+  .ease-xl-justify-center { justify-content: center !important; }
+  .ease-xl-justify-start  { justify-content: flex-start !important; }
+  .ease-xl-justify-end    { justify-content: flex-end !important; }
+  .ease-xl-justify-between { justify-content: space-between !important; }
+  .ease-xl-center { display: flex !important; align-items: center !important; justify-content: center !important; }
 
-  .ease-xl-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-  .ease-xl-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .ease-xl-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .ease-xl-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .ease-xl-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)) !important; }
+  .ease-xl-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }
+  .ease-xl-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)) !important; }
+  .ease-xl-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)) !important; }
 
-  .ease-xl-gap-1  { gap: var(--ease-space-1); }
-  .ease-xl-gap-2  { gap: var(--ease-space-2); }
-  .ease-xl-gap-4  { gap: var(--ease-space-4); }
-  .ease-xl-gap-6  { gap: var(--ease-space-6); }
-  .ease-xl-gap-8  { gap: var(--ease-space-8); }
+  .ease-xl-gap-1  { gap: var(--ease-space-1) !important; }
+  .ease-xl-gap-2  { gap: var(--ease-space-2) !important; }
+  .ease-xl-gap-4  { gap: var(--ease-space-4) !important; }
+  .ease-xl-gap-6  { gap: var(--ease-space-6) !important; }
+  .ease-xl-gap-8  { gap: var(--ease-space-8) !important; }
 
-  .ease-xl-padding-4  { padding: var(--ease-space-4); }
-  .ease-xl-padding-6  { padding: var(--ease-space-6); }
-  .ease-xl-padding-8  { padding: var(--ease-space-8); }
-  .ease-xl-px-4       { padding-left: var(--ease-space-4); padding-right: var(--ease-space-4); }
-  .ease-xl-py-4       { padding-top:  var(--ease-space-4); padding-bottom: var(--ease-space-4); }
-  .ease-xl-px-8       { padding-left: var(--ease-space-8); padding-right: var(--ease-space-8); }
-  .ease-xl-py-8       { padding-top:  var(--ease-space-8); padding-bottom: var(--ease-space-8); }
+  .ease-xl-padding-4  { padding: var(--ease-space-4) !important; }
+  .ease-xl-padding-6  { padding: var(--ease-space-6) !important; }
+  .ease-xl-padding-8  { padding: var(--ease-space-8) !important; }
+  .ease-xl-px-4       { padding-left: var(--ease-space-4) !important; padding-right: var(--ease-space-4) !important; }
+  .ease-xl-py-4       { padding-top:  var(--ease-space-4) !important; padding-bottom: var(--ease-space-4) !important; }
+  .ease-xl-px-8       { padding-left: var(--ease-space-8) !important; padding-right: var(--ease-space-8) !important; }
+  .ease-xl-py-8       { padding-top:  var(--ease-space-8) !important; padding-bottom: var(--ease-space-8) !important; }
 
-  .ease-xl-w-full  { width: 100%; }
-  .ease-xl-w-auto  { width: auto; }
+  .ease-xl-w-full  { width: 100% !important; }
+  .ease-xl-w-auto  { width: auto !important; }
 
-  .ease-xl-text-left   { text-align: left; }
-  .ease-xl-text-center { text-align: center; }
-  .ease-xl-text-right  { text-align: right; }
-  .ease-xl-text-sm     { font-size: var(--ease-text-sm); }
-  .ease-xl-text-base   { font-size: var(--ease-text-base); }
-  .ease-xl-text-lg     { font-size: var(--ease-text-lg); }
-  .ease-xl-text-xl     { font-size: var(--ease-text-xl); }
-  .ease-xl-text-2xl    { font-size: var(--ease-text-2xl); }
+  .ease-xl-text-left   { text-align: left !important; }
+  .ease-xl-text-center { text-align: center !important; }
+  .ease-xl-text-right  { text-align: right !important; }
+  .ease-xl-text-sm     { font-size: var(--ease-text-sm) !important; }
+  .ease-xl-text-base   { font-size: var(--ease-text-base) !important; }
+  .ease-xl-text-lg     { font-size: var(--ease-text-lg) !important; }
+  .ease-xl-text-xl     { font-size: var(--ease-text-xl) !important; }
+  .ease-xl-text-2xl    { font-size: var(--ease-text-2xl) !important; }
+}
 }


### PR DESCRIPTION
## Description
Fixes an architectural fragility in the utility classes by enforcing strict specificity. 
Closes #1574 
A core principle of a utility-first CSS framework is that utility classes (like `.ease-w-full`, `.ease-hidden`, or `.ease-p-4`) must be immutable—when a developer applies one to an element, it should definitively override any conflicting component styles. Previously, the utilities in `core/utilities.css` lacked the `!important` flag, meaning they could easily be overridden by generic ID selectors, inline styles, or slightly more specific component class chains. 

This PR appends the `!important` flag to all single-purpose utility declarations, guaranteeing deterministic and reliable behavior across the framework.

## Changes Made
- Added `!important` to all utility declarations in `core/utilities.css` (e.g., `display: none !important;`, `width: 100% !important;`).
- Retained dynamic behavior for responsive breakpoints and CSS variables (`--ease-snap-axis`).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing Performed
- Verified that utility classes now successfully override complex component styles (e.g., applying `.ease-text-center` on an `.ease-card` with an ID selector now correctly centers the text).
- Ensured responsive utilities (e.g., `.ease-sm-hidden`) still function correctly at their respective breakpoints.
