### PR TITLE
fix: resolve keyboard focus deformation for issue #1221

### DIFF
--- a/submissions/examples/fix-focus-deformation-1221/README.md
+++ b/submissions/examples/fix-focus-deformation-1221/README.md
@@ -1,0 +1,32 @@
+# Keyboard Focus Shape Preservation
+
+Fixes issue #1221 where keyboard focus deforms rounded buttons and cards.
+
+## What does this do?
+
+Preserves each component's intended `border-radius` when it receives keyboard focus, so pill buttons stay fully rounded and cards keep their corner radius.
+
+## How is it used?
+
+Load `style.css` after EaseMotion CSS. The overrides restore shape on focus for pill buttons and cards:
+
+```html
+<link rel="stylesheet" href="easemotion.css">
+<link rel="stylesheet" href="style.css">
+
+<button class="ease-btn ease-btn-primary ease-btn-pill">Focus Me</button>
+
+<div class="ease-card ease-card-shadow" tabindex="0">
+  <div class="ease-card-body">Card content</div>
+</div>
+```
+
+## Why is it useful?
+
+EaseMotion CSS is animation-first and accessibility-minded. A visible focus ring should not change a component's shape. The bug comes from `core/base.css` forcing `border-radius: var(--ease-radius-sm)` on unlayered `:focus-visible` rules, which overrides layered utilities like `.ease-btn-pill`.
+
+**Recommended maintainer integration:** remove `border-radius` from the global `:focus-visible` block in `core/base.css`. The outline will follow each element's existing corners without extra overrides.
+
+## Linked Issue
+
+Closes #1221

--- a/submissions/examples/fix-focus-deformation-1221/demo.html
+++ b/submissions/examples/fix-focus-deformation-1221/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Focus Deformation Fix — Issue #1221</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo">
+    <h1>Keyboard Focus Shape Preservation</h1>
+    <p>Press <kbd>Tab</kbd> to move focus. Pill buttons and rounded cards should keep their shape when focused.</p>
+
+    <section>
+      <h2>Pill Button</h2>
+      <button class="ease-btn ease-btn-primary ease-btn-pill">
+        Focus Me
+      </button>
+    </section>
+
+    <section>
+      <h2>Rounded Card</h2>
+      <div class="ease-card ease-card-shadow" tabindex="0">
+        <div class="ease-card-header">
+          <h3 class="ease-card-title">Sample Card</h3>
+          <p class="ease-card-subtitle">Large corner radius should not collapse on focus</p>
+        </div>
+        <div class="ease-card-body">
+          <p>Tab to this card and verify the focus ring follows its rounded corners.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fix-focus-deformation-1221/style.css
+++ b/submissions/examples/fix-focus-deformation-1221/style.css
@@ -1,0 +1,69 @@
+/**
+ * Fix for issue #1221
+ *
+ * core/base.css applies border-radius: var(--ease-radius-sm) on :focus-visible
+ * in an unlayered stylesheet, which overrides layered component radii such as
+ * .ease-btn-pill and .ease-card.
+ *
+ * Recommended core integration: remove border-radius from the global
+ * :focus-visible rule in core/base.css. Outlines follow the element's
+ * existing border-radius without forcing a new value.
+ *
+ * This submission demonstrates the override until the maintainer integrates
+ * the core change.
+ */
+
+button.ease-btn.ease-btn-pill:focus-visible {
+  border-radius: var(--ease-radius-full, 9999px);
+}
+
+.ease-card:focus-visible {
+  border-radius: var(--ease-radius-lg, 1rem);
+}
+
+/* Demo layout */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.demo {
+  max-width: 32rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.demo h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.demo p {
+  margin: 0;
+  color: var(--ease-color-muted, #64748b);
+}
+
+.demo section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.demo h2 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+kbd {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.875em;
+  padding: 0.1em 0.4em;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+}


### PR DESCRIPTION
## Pull Request Description
Submission-only fix for #1221. Rounded pill buttons and cards no longer lose their border radius when focused via keyboard navigation.

## Type of Change
- [x] 🐛 Bug fix in an existing submission

## Submission Checklist
- [x] All changes inside `submissions/examples/fix-focus-deformation-1221/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`

## Notes for Maintainer
Recommended core integration: remove `border-radius` from the global `:focus-visible` block in `core/base.css`. This prevents the global rule from overriding component-specific radii.

Closes #1221