### PR TITLE
fix: make sidebar Components label clickable (mobile navigation)

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -201,6 +201,11 @@
       color: var(--ease-color-primary-light);
       margin-bottom: var(--ease-space-2);
       padding: 0 var(--ease-space-2);
+      text-decoration: none;
+    }
+
+    a.sidebar-group-label:hover {
+      color: var(--page-text);
     }
 
     .sidebar-nav {

--- a/docs/index.html
+++ b/docs/index.html
@@ -685,7 +685,7 @@
         </ul>
       </div>
       <div class="sidebar-group">
-        <div class="sidebar-group-label">Components</div>
+        <a href="#components" class="sidebar-group-label">Components</a>
         <ul class="sidebar-nav">
           <li><a href="#buttons">Buttons</a></li>
           <li><a href="#cards">Cards</a></li>


### PR DESCRIPTION
## Description

Fixes #1286

On mobile viewports (≤768px), the header navbar links are `display: none`, but the sidebar "Components" group label was just a plain `<div>` — not clickable. Users on mobile had no way to navigate to the Components section.

## Changes

- `docs/index.html`: Changed `<div class="sidebar-group-label">Components</div>` → `<a href="#components" class="sidebar-group-label">Components</a>`
- `docs/docs.css`: Added `text-decoration: none` on the label and `a.sidebar-group-label:hover` color for visual feedback

## Verification

- `npm run lint` — ✅
- `npm run test` — ✅ (4/4)
- `npm run lint:duplicates` — ✅
- CI Release Validation skipped (only `docs/` files changed)