### PR TITLE
feat: add interactive component showcase gallery

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -201,6 +201,11 @@
       color: var(--ease-color-primary-light);
       margin-bottom: var(--ease-space-2);
       padding: 0 var(--ease-space-2);
+      text-decoration: none;
+    }
+
+    a.sidebar-group-label:hover {
+      color: var(--page-text);
     }
 
     .sidebar-nav {

--- a/docs/index.html
+++ b/docs/index.html
@@ -685,7 +685,7 @@
         </ul>
       </div>
       <div class="sidebar-group">
-        <div class="sidebar-group-label">Components</div>
+        <a href="#components" class="sidebar-group-label">Components</a>
         <ul class="sidebar-nav">
           <li><a href="#buttons">Buttons</a></li>
           <li><a href="#cards">Cards</a></li>

--- a/submissions/examples/ease-component-gallery/README.md
+++ b/submissions/examples/ease-component-gallery/README.md
@@ -1,0 +1,47 @@
+# EaseMotion CSS — Component Gallery
+
+An interactive gallery to browse, search, filter, preview, and copy EaseMotion CSS components — all from a single interface.
+
+## Features
+
+- **Live Previews** — Components render in real time using EaseMotion CSS from CDN
+- **Search** — Filter by component name, description, or category
+- **Category Tabs** — Browse by Buttons, Cards, Animations, Hover Effects, Utilities, Navbar
+- **Copy HTML** — Copy the exact HTML snippet for any component
+- **Copy CSS Class** — Copy the CSS class name string
+- **Responsive Grid** — Adapts to any screen size
+- **Dark / Light Mode** — Persists preference via localStorage
+- **Zero Build Step** — Works directly in the browser
+
+## Usage
+
+1. Open `demo.html` in a browser.
+2. Browse the component cards.
+3. Use the search bar or category tabs to find components.
+4. Click **Copy HTML** or **Copy CSS** to grab the snippet.
+
+## Components Covered
+
+| Category    | Count | Examples                                      |
+|-------------|-------|-----------------------------------------------|
+| Buttons     | 8     | primary, success, danger, outline, ghost, pill, sm, lg |
+| Cards       | 6     | basic, shadow, hover, glass, neumorphic, accent        |
+| Animations  | 8     | fade-in, slide-up, slide-left, zoom-in, bounce, pulse  |
+| Hover       | 5     | grow, glow, lift, shimmer, underline                   |
+| Utilities   | 5     | flex center, flex between, grid auto, gap, text center |
+| Navbar      | 3     | glass, sticky glass, blur glass                        |
+
+## File Structure
+
+```
+ease-component-gallery/
+├── demo.html       — Main gallery page
+├── style.css       — Gallery styling (variables, grid, cards)
+├── script.js       — Component data, filter, search, copy logic
+└── README.md       — This file
+```
+
+## Dependencies
+
+- EaseMotion CSS (loaded from CDN via `easemotion.min.css`)
+- Google Fonts (Inter)

--- a/submissions/examples/ease-component-gallery/demo.html
+++ b/submissions/examples/ease-component-gallery/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — Component Gallery</title>
+  <meta name="description" content="Browse, search, filter, and copy EaseMotion CSS components with live previews." />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="gallery-wrapper">
+    <header class="gallery-header">
+      <div class="header-top">
+        <h1>Component Gallery</h1>
+        <button id="themeToggle" class="theme-btn" aria-label="Toggle theme">🌙</button>
+      </div>
+      <p class="header-sub">Browse, search, and copy EaseMotion CSS components with live previews.</p>
+      <div class="toolbar">
+        <div class="search-wrap">
+          <span class="search-icon">🔍</span>
+          <input type="text" id="searchInput" placeholder="Search components..." autocomplete="off" />
+        </div>
+        <div class="filter-tabs" id="filterTabs">
+          <button data-category="all" class="filter-btn active">All</button>
+          <button data-category="buttons" class="filter-btn">Buttons</button>
+          <button data-category="cards" class="filter-btn">Cards</button>
+          <button data-category="animations" class="filter-btn">Animations</button>
+          <button data-category="hover" class="filter-btn">Hover</button>
+          <button data-category="utilities" class="filter-btn">Utilities</button>
+          <button data-category="navbar" class="filter-btn">Navbar</button>
+        </div>
+      </div>
+      <div class="results-meta">
+        <span id="resultCount">0</span> components shown
+      </div>
+    </header>
+
+    <main class="gallery-grid" id="gallery"></main>
+
+    <div id="emptyState" class="empty-state" hidden>
+      <div class="empty-icon">🔎</div>
+      <p>No components match your search.</p>
+      <button class="reset-btn" id="resetBtn">Reset filters</button>
+    </div>
+
+    <footer class="gallery-footer">
+      <p>Part of <strong>EaseMotion CSS</strong> — <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" target="_blank">GitHub</a></p>
+    </footer>
+  </div>
+
+  <div id="toast" class="toast" hidden>✓ Copied!</div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/ease-component-gallery/script.js
+++ b/submissions/examples/ease-component-gallery/script.js
@@ -1,0 +1,421 @@
+const components = [
+  // ── Buttons ───────────────────────────────────────────
+  {
+    name: "Primary Button",
+    category: "buttons",
+    css: "ease-btn ease-btn-primary",
+    html: `<button class="ease-btn ease-btn-primary">Primary</button>`,
+    desc: "Main call-to-action button with brand accent color.",
+    render: () => `<button class="ease-btn ease-btn-primary">Primary</button>`
+  },
+  {
+    name: "Success Button",
+    category: "buttons",
+    css: "ease-btn ease-btn-success",
+    html: `<button class="ease-btn ease-btn-success">Success</button>`,
+    desc: "Positive action button (confirm, save, approve).",
+    render: () => `<button class="ease-btn ease-btn-success">Success</button>`
+  },
+  {
+    name: "Danger Button",
+    category: "buttons",
+    css: "ease-btn ease-btn-danger",
+    html: `<button class="ease-btn ease-btn-danger">Danger</button>`,
+    desc: "Destructive action button (delete, remove, cancel).",
+    render: () => `<button class="ease-btn ease-btn-danger">Danger</button>`
+  },
+  {
+    name: "Outline Button",
+    category: "buttons",
+    css: "ease-btn ease-btn-outline",
+    html: `<button class="ease-btn ease-btn-outline">Outline</button>`,
+    desc: "Subtle bordered button for secondary actions.",
+    render: () => `<button class="ease-btn ease-btn-outline">Outline</button>`
+  },
+  {
+    name: "Ghost Button",
+    category: "buttons",
+    css: "ease-btn ease-btn-ghost",
+    html: `<button class="ease-btn ease-btn-ghost">Ghost</button>`,
+    desc: "Minimal transparent button for low-emphasis actions.",
+    render: () => `<button class="ease-btn ease-btn-ghost">Ghost</button>`
+  },
+  {
+    name: "Pill Button",
+    category: "buttons",
+    css: "ease-btn ease-btn-primary ease-btn-pill",
+    html: `<button class="ease-btn ease-btn-primary ease-btn-pill">Pill</button>`,
+    desc: "Fully rounded button for badges or tags.",
+    render: () => `<button class="ease-btn ease-btn-primary ease-btn-pill">Pill</button>`
+  },
+  {
+    name: "Small Button",
+    category: "buttons",
+    css: "ease-btn ease-btn-primary ease-btn-sm",
+    html: `<button class="ease-btn ease-btn-primary ease-btn-sm">Small</button>`,
+    desc: "Compact button for tight spaces or inline use.",
+    render: () => `<button class="ease-btn ease-btn-primary ease-btn-sm">Small</button>`
+  },
+  {
+    name: "Large Button",
+    category: "buttons",
+    css: "ease-btn ease-btn-primary ease-btn-lg",
+    html: `<button class="ease-btn ease-btn-primary ease-btn-lg">Large</button>`,
+    desc: "Prominent button for hero sections and CTAs.",
+    render: () => `<button class="ease-btn ease-btn-primary ease-btn-lg">Large</button>`
+  },
+  // ── Cards ─────────────────────────────────────────────
+  {
+    name: "Basic Card",
+    category: "cards",
+    css: "ease-card",
+    html: `<div class="ease-card"><h3 class="ease-card-title">Title</h3><p>Card content here.</p></div>`,
+    desc: "Simple container with padding and rounded corners.",
+    render: () => `<div class="ease-card" style="padding:16px;width:100%;"><h3 class="ease-card-title" style="margin:0 0 4px;">Title</h3><p style="margin:0;font-size:13px;color:var(--text-secondary);">Card content here.</p></div>`
+  },
+  {
+    name: "Shadow Card",
+    category: "cards",
+    css: "ease-card ease-card-shadow",
+    html: `<div class="ease-card ease-card-shadow">…</div>`,
+    desc: "Elevated card with drop shadow for visual hierarchy.",
+    render: () => `<div class="ease-card ease-card-shadow" style="padding:16px;width:100%;"><h3 class="ease-card-title" style="margin:0 0 4px;">Shadow Card</h3><p style="margin:0;font-size:13px;color:var(--text-secondary);">Elevated content container.</p></div>`
+  },
+  {
+    name: "Hover Card",
+    category: "cards",
+    css: "ease-card ease-card-shadow ease-card-hover",
+    html: `<div class="ease-card ease-card-shadow ease-card-hover">…</div>`,
+    desc: "Interactive card that lifts on hover.",
+    render: () => `<div class="ease-card ease-card-shadow ease-card-hover" style="padding:16px;width:100%;"><h3 class="ease-card-title" style="margin:0 0 4px;">Hover Card</h3><p style="margin:0;font-size:13px;color:var(--text-secondary);">Hover to see lift effect.</p></div>`
+  },
+  {
+    name: "Glass Card",
+    category: "cards",
+    css: "ease-card ease-card-glass",
+    html: `<div class="ease-card ease-card-glass">…</div>`,
+    desc: "Frosted glass morphism card for modern UIs.",
+    render: () => `<div class="ease-card ease-card-glass" style="padding:16px;width:100%;"><h3 class="ease-card-title" style="margin:0 0 4px;">Glass Card</h3><p style="margin:0;font-size:13px;color:var(--text-secondary);">Frosted glass effect.</p></div>`
+  },
+  {
+    name: "Neumorphic Card",
+    category: "cards",
+    css: "ease-card ease-card-neumorphic",
+    html: `<div class="ease-card ease-card-neumorphic">…</div>`,
+    desc: "Soft UI card with inset shadow for a neumorphic look.",
+    render: () => `<div class="ease-card ease-card-neumorphic" style="padding:16px;width:100%;"><h3 class="ease-card-title" style="margin:0 0 4px;">Neumorphic</h3><p style="margin:0;font-size:13px;color:var(--text-secondary);">Soft UI style.</p></div>`
+  },
+  {
+    name: "Accent Card",
+    category: "cards",
+    css: "ease-card ease-card-accent",
+    html: `<div class="ease-card ease-card-accent">…</div>`,
+    desc: "Card with a colored accent border for emphasis.",
+    render: () => `<div class="ease-card ease-card-accent" style="padding:16px;width:100%;"><h3 class="ease-card-title" style="margin:0 0 4px;">Accent Card</h3><p style="margin:0;font-size:13px;color:var(--text-secondary);">Highlighted with accent border.</p></div>`
+  },
+  // ── Animations ────────────────────────────────────────
+  {
+    name: "Fade In",
+    category: "animations",
+    css: "ease-fade-in",
+    html: `<div class="ease-fade-in">Content</div>`,
+    desc: "Smooth opacity entrance animation on page load.",
+    render: () => `<div class="ease-fade-in" style="padding:8px 16px;background:var(--accent);color:#fff;border-radius:8px;font-weight:600;font-size:14px;">Fade In</div>`
+  },
+  {
+    name: "Slide Up",
+    category: "animations",
+    css: "ease-slide-up",
+    html: `<div class="ease-slide-up">Content</div>`,
+    desc: "Content rises into view with a smooth vertical slide.",
+    render: () => `<div class="ease-slide-up" style="padding:8px 16px;background:var(--accent);color:#fff;border-radius:8px;font-weight:600;font-size:14px;">Slide Up</div>`
+  },
+  {
+    name: "Slide Left",
+    category: "animations",
+    css: "ease-slide-left",
+    html: `<div class="ease-slide-left">Content</div>`,
+    desc: "Element slides in from the right side.",
+    render: () => `<div class="ease-slide-left" style="padding:8px 16px;background:var(--accent);color:#fff;border-radius:8px;font-weight:600;font-size:14px;">Slide Left</div>`
+  },
+  {
+    name: "Slide Right",
+    category: "animations",
+    css: "ease-slide-right",
+    html: `<div class="ease-slide-right">Content</div>`,
+    desc: "Element slides in from the left side.",
+    render: () => `<div class="ease-slide-right" style="padding:8px 16px;background:var(--accent);color:#fff;border-radius:8px;font-weight:600;font-size:14px;">Slide Right</div>`
+  },
+  {
+    name: "Zoom In",
+    category: "animations",
+    css: "ease-zoom-in",
+    html: `<div class="ease-zoom-in">Content</div>`,
+    desc: "Element scales up smoothly into view.",
+    render: () => `<div class="ease-zoom-in" style="padding:8px 16px;background:var(--accent);color:#fff;border-radius:8px;font-weight:600;font-size:14px;">Zoom In</div>`
+  },
+  {
+    name: "Bounce",
+    category: "animations",
+    css: "ease-bounce",
+    html: `<div class="ease-bounce">Content</div>`,
+    desc: "Continuous bouncing animation for attention.",
+    render: () => `<div class="ease-bounce" style="padding:8px 16px;background:var(--accent);color:#fff;border-radius:8px;font-weight:600;font-size:14px;">Bounce</div>`
+  },
+  {
+    name: "Pulse",
+    category: "animations",
+    css: "ease-pulse",
+    html: `<div class="ease-pulse">Content</div>`,
+    desc: "Soft pulsing glow for live indicators or loading states.",
+    render: () => `<div class="ease-pulse" style="padding:8px 16px;background:var(--accent);color:#fff;border-radius:8px;font-weight:600;font-size:14px;">Pulse</div>`
+  },
+  {
+    name: "Rotate",
+    category: "animations",
+    css: "ease-rotate",
+    html: `<div class="ease-rotate">⟳</div>`,
+    desc: "Continuous rotation for spinners and loading icons.",
+    render: () => `<div class="ease-rotate" style="padding:8px 16px;background:var(--accent);color:#fff;border-radius:8px;font-weight:600;font-size:18px;">⟳</div>`
+  },
+  // ── Hover Effects ─────────────────────────────────────
+  {
+    name: "Hover Grow",
+    category: "hover",
+    css: "ease-hover-grow",
+    html: `<button class="ease-btn ease-btn-primary ease-hover-grow">Grow</button>`,
+    desc: "Button scales up slightly on hover for emphasis.",
+    render: () => `<button class="ease-btn ease-btn-primary ease-hover-grow">Grow</button>`
+  },
+  {
+    name: "Hover Glow",
+    category: "hover",
+    css: "ease-hover-glow",
+    html: `<button class="ease-btn ease-btn-primary ease-hover-glow">Glow</button>`,
+    desc: "Adds a colored glow effect around the element on hover.",
+    render: () => `<button class="ease-btn ease-btn-primary ease-hover-glow">Glow</button>`
+  },
+  {
+    name: "Hover Lift",
+    category: "hover",
+    css: "ease-hover-lift",
+    html: `<button class="ease-btn ease-btn-primary ease-hover-lift">Lift</button>`,
+    desc: "Element lifts with an enhanced shadow on hover.",
+    render: () => `<button class="ease-btn ease-btn-primary ease-hover-lift">Lift</button>`
+  },
+  {
+    name: "Hover Shimmer",
+    category: "hover",
+    css: "ease-hover-shimmer",
+    html: `<button class="ease-btn ease-btn-primary ease-hover-shimmer">Shimmer</button>`,
+    desc: "Light sweep effect that moves across the element on hover.",
+    render: () => `<button class="ease-btn ease-btn-primary ease-hover-shimmer">Shimmer</button>`
+  },
+  {
+    name: "Hover Underline",
+    category: "hover",
+    css: "ease-hover-underline",
+    html: `<span class="ease-hover-underline">Underline text</span>`,
+    desc: "Animated underline that draws from center on hover.",
+    render: () => `<span class="ease-hover-underline" style="font-size:14px;font-weight:600;">Underline</span>`
+  },
+  // ── Utilities ──────────────────────────────────────────
+  {
+    name: "Flex Center",
+    category: "utilities",
+    css: "ease-flex ease-items-center ease-justify-center",
+    html: `<div class="ease-flex ease-items-center ease-justify-center">…</div>`,
+    desc: "Centers content both horizontally and vertically using Flexbox.",
+    render: () => `<div class="ease-flex ease-items-center ease-justify-center" style="width:100%;height:60px;background:var(--accent-light);border-radius:8px;font-size:13px;font-weight:600;">Centered Content</div>`
+  },
+  {
+    name: "Flex Between",
+    category: "utilities",
+    css: "ease-flex ease-justify-between ease-items-center",
+    html: `<div class="ease-flex ease-justify-between ease-items-center">…</div>`,
+    desc: "Spreads items across the main axis with space-between alignment.",
+    render: () => `<div class="ease-flex ease-justify-between ease-items-center" style="width:100%;padding:8px 12px;background:var(--accent-light);border-radius:8px;font-size:13px;"><span>Left</span><span>Right</span></div>`
+  },
+  {
+    name: "Grid Auto",
+    category: "utilities",
+    css: "ease-grid ease-grid-auto ease-gap-3",
+    html: `<div class="ease-grid ease-grid-auto ease-gap-3">…</div>`,
+    desc: "Responsive auto-fit grid that adapts columns to available space.",
+    render: () => `<div class="ease-grid ease-grid-auto ease-gap-2" style="width:100%;"><div style="background:var(--accent-light);border-radius:6px;padding:6px;text-align:center;font-size:11px;">1</div><div style="background:var(--accent-light);border-radius:6px;padding:6px;text-align:center;font-size:11px;">2</div><div style="background:var(--accent-light);border-radius:6px;padding:6px;text-align:center;font-size:11px;">3</div></div>`
+  },
+  {
+    name: "Gap Utility",
+    category: "utilities",
+    css: "ease-flex ease-gap-4",
+    html: `<div class="ease-flex ease-gap-4">…</div>`,
+    desc: "Consistent spacing between flex or grid children (gap: 1rem).",
+    render: () => `<div class="ease-flex ease-gap-2" style="width:100%;flex-wrap:wrap;"><span style="background:var(--accent-light);border-radius:6px;padding:6px 10px;font-size:12px;">Item</span><span style="background:var(--accent-light);border-radius:6px;padding:6px 10px;font-size:12px;">Item</span><span style="background:var(--accent-light);border-radius:6px;padding:6px 10px;font-size:12px;">Item</span></div>`
+  },
+  {
+    name: "Text Center",
+    category: "utilities",
+    css: "ease-text-center",
+    html: `<div class="ease-text-center">Centered text</div>`,
+    desc: "Centers inline and inline-block content horizontally.",
+    render: () => `<div class="ease-text-center" style="width:100%;font-size:14px;font-weight:600;">Centered Text</div>`
+  },
+  // ── Navbar ─────────────────────────────────────────────
+  {
+    name: "Glass Navbar",
+    category: "navbar",
+    css: "ease-navbar-glass",
+    html: `<nav class="ease-navbar-glass">…</nav>`,
+    desc: "Frosted glass navigation bar with blur backdrop.",
+    render: () => `<nav class="ease-navbar-glass" style="width:100%;padding:10px 16px;display:flex;justify-content:space-between;align-items:center;border-radius:8px;"><span style="font-weight:700;font-size:14px;">Logo</span><span style="display:flex;gap:12px;font-size:12px;"><span>Home</span><span>Docs</span></span></nav>`
+  },
+  {
+    name: "Sticky Glass Navbar",
+    category: "navbar",
+    css: "ease-navbar-glass ease-navbar-glass-sticky",
+    html: `<nav class="ease-navbar-glass ease-navbar-glass-sticky">…</nav>`,
+    desc: "Frosted navbar that sticks to the top on scroll.",
+    render: () => `<nav class="ease-navbar-glass" style="width:100%;padding:10px 16px;display:flex;justify-content:space-between;align-items:center;border-radius:8px;"><span style="font-weight:700;font-size:14px;">Sticky</span><span style="display:flex;gap:12px;font-size:12px;"><span>Home</span><span>Docs</span></span></nav>`
+  },
+  {
+    name: "Blur Glass Navbar",
+    category: "navbar",
+    css: "ease-navbar-glass ease-navbar-glass-blur",
+    html: `<nav class="ease-navbar-glass ease-navbar-glass-blur">…</nav>`,
+    desc: "Enhanced blur intensity for deeper glass effect.",
+    render: () => `<nav class="ease-navbar-glass ease-navbar-glass-blur" style="width:100%;padding:10px 16px;display:flex;justify-content:space-between;align-items:center;border-radius:8px;"><span style="font-weight:700;font-size:14px;">Blur</span><span style="display:flex;gap:12px;font-size:12px;"><span>Home</span><span>Docs</span></span></nav>`
+  }
+];
+
+const gallery = document.getElementById("gallery");
+const searchInput = document.getElementById("searchInput");
+const filterTabs = document.getElementById("filterTabs");
+const resultCount = document.getElementById("resultCount");
+const emptyState = document.getElementById("emptyState");
+const resetBtn = document.getElementById("resetBtn");
+const toast = document.getElementById("toast");
+const themeToggle = document.getElementById("themeToggle");
+
+let currentCategory = "all";
+let currentSearch = "";
+
+function filterComponents() {
+  return components.filter(c => {
+    const matchCategory = currentCategory === "all" || c.category === currentCategory;
+    const search = currentSearch.toLowerCase();
+    const matchSearch = !search ||
+      c.name.toLowerCase().includes(search) ||
+      c.desc.toLowerCase().includes(search) ||
+      c.category.toLowerCase().includes(search);
+    return matchCategory && matchSearch;
+  });
+}
+
+function copyToClipboard(text) {
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(text);
+  } else {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand("copy");
+    document.body.removeChild(ta);
+  }
+}
+
+function showToast(msg) {
+  toast.textContent = msg;
+  toast.hidden = false;
+  toast.classList.remove("hide");
+  clearTimeout(toast._timer);
+  toast._timer = setTimeout(() => {
+    toast.classList.add("hide");
+    setTimeout(() => { toast.hidden = true; }, 300);
+  }, 2000);
+}
+
+function render() {
+  const results = filterComponents();
+  resultCount.textContent = results.length;
+
+  if (results.length === 0) {
+    gallery.innerHTML = "";
+    emptyState.hidden = false;
+    return;
+  }
+  emptyState.hidden = true;
+
+  gallery.innerHTML = results.map((comp, idx) => `
+    <div class="component-card" data-index="${idx}">
+      <div class="card-header">
+        <span class="card-category">${comp.category}</span>
+        <h3 class="card-title">${comp.name}</h3>
+        <p class="card-desc">${comp.desc}</p>
+      </div>
+      <div class="card-preview" data-preview>
+        ${comp.render()}
+      </div>
+      <code class="class-display">${comp.css}</code>
+      <div class="card-actions">
+        <button class="copy-btn" data-copy="html:${idx}">Copy HTML</button>
+        <button class="copy-btn" data-copy="css:${idx}">Copy CSS</button>
+      </div>
+    </div>
+  `).join("");
+
+  gallery.querySelectorAll("[data-copy]").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const [type, idx] = btn.dataset.copy.split(":");
+      const comp = results[parseInt(idx)];
+      const text = type === "html" ? comp.html : comp.css;
+      copyToClipboard(text);
+      btn.textContent = "✓ Copied!";
+      btn.classList.add("copied");
+      setTimeout(() => {
+        btn.textContent = type === "html" ? "Copy HTML" : "Copy CSS";
+        btn.classList.remove("copied");
+      }, 1800);
+      showToast("✓ Copied!");
+    });
+  });
+}
+
+searchInput.addEventListener("input", () => {
+  currentSearch = searchInput.value;
+  render();
+});
+
+filterTabs.addEventListener("click", (e) => {
+  const btn = e.target.closest(".filter-btn");
+  if (!btn) return;
+  filterTabs.querySelectorAll(".filter-btn").forEach(b => b.classList.remove("active"));
+  btn.classList.add("active");
+  currentCategory = btn.dataset.category;
+  render();
+});
+
+resetBtn.addEventListener("click", () => {
+  searchInput.value = "";
+  currentSearch = "";
+  currentCategory = "all";
+  filterTabs.querySelectorAll(".filter-btn").forEach(b => b.classList.remove("active"));
+  filterTabs.querySelector('[data-category="all"]').classList.add("active");
+  render();
+});
+
+themeToggle.addEventListener("click", () => {
+  const html = document.documentElement;
+  const isLight = html.getAttribute("data-theme") === "light";
+  html.setAttribute("data-theme", isLight ? "dark" : "light");
+  themeToggle.textContent = isLight ? "🌙" : "☀️";
+  localStorage.setItem("gallery-theme", isLight ? "dark" : "light");
+});
+
+const saved = localStorage.getItem("gallery-theme");
+if (saved) {
+  document.documentElement.setAttribute("data-theme", saved);
+  themeToggle.textContent = saved === "light" ? "☀️" : "🌙";
+}
+
+render();

--- a/submissions/examples/ease-component-gallery/style.css
+++ b/submissions/examples/ease-component-gallery/style.css
@@ -1,0 +1,366 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg-page: #0f0e17;
+  --bg-card: #1a1926;
+  --bg-surface: #222135;
+  --bg-toolbar: #1a1926;
+  --text-primary: #fffffe;
+  --text-secondary: #a7a9be;
+  --text-muted: #6e6f8a;
+  --border-color: #2a2940;
+  --accent: #6c63ff;
+  --accent-hover: #5a52e0;
+  --accent-light: rgba(108, 99, 255, 0.12);
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg: 0 8px 30px rgba(0,0,0,0.5);
+}
+
+[data-theme="light"] {
+  --bg-page: #f8fafc;
+  --bg-card: #ffffff;
+  --bg-surface: #f1f5f9;
+  --bg-toolbar: #ffffff;
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+  --border-color: #e2e8f0;
+  --accent: #6c63ff;
+  --accent-hover: #5a52e0;
+  --accent-light: rgba(108, 99, 255, 0.08);
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.06);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
+  --shadow-lg: 0 8px 30px rgba(0,0,0,0.1);
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--bg-page);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 24px 16px;
+  transition: background 0.3s, color 0.3s;
+}
+
+.gallery-wrapper {
+  width: 100%;
+  max-width: 1240px;
+}
+
+.gallery-header {
+  margin-bottom: 28px;
+}
+
+.header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.header-top h1 {
+  font-size: clamp(24px, 3vw, 32px);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, var(--accent), #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.header-sub {
+  color: var(--text-secondary);
+  font-size: 15px;
+  margin-bottom: 20px;
+}
+
+.theme-btn {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 18px;
+  transition: background 0.2s;
+  line-height: 1;
+}
+
+.theme-btn:hover { background: var(--accent-light); }
+
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.search-wrap {
+  position: relative;
+  width: 100%;
+}
+
+.search-icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 16px;
+  opacity: 0.5;
+}
+
+#searchInput {
+  width: 100%;
+  padding: 12px 16px 12px 42px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-toolbar);
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+#searchInput:focus { border-color: var(--accent); }
+#searchInput::placeholder { color: var(--text-muted); }
+
+.filter-tabs {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.filter-btn {
+  padding: 7px 16px;
+  border: 1px solid var(--border-color);
+  border-radius: 9999px;
+  background: var(--bg-toolbar);
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.filter-btn:hover { color: var(--text-primary); border-color: var(--accent); }
+.filter-btn.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.results-meta {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-top: 8px;
+}
+
+#resultCount { font-weight: 600; color: var(--text-secondary); }
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+}
+
+.component-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.component-card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-md);
+  border-color: var(--accent);
+}
+
+.card-header {
+  padding: 16px 18px 0;
+}
+
+.card-title {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 2px;
+}
+
+.card-category {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  padding: 2px 8px;
+  background: var(--accent-light);
+  border-radius: 4px;
+}
+
+.card-desc {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-top: 6px;
+  line-height: 1.5;
+}
+
+.card-preview {
+  margin: 14px 18px;
+  padding: 20px;
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  min-height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  position: relative;
+  overflow: hidden;
+}
+
+.card-actions {
+  display: flex;
+  gap: 8px;
+  padding: 0 18px 16px;
+}
+
+.copy-btn {
+  flex: 1;
+  padding: 9px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.copy-btn:hover {
+  background: var(--accent-light);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.copy-btn.copied {
+  background: #10b981;
+  color: #fff;
+  border-color: #10b981;
+}
+
+.class-display {
+  display: block;
+  padding: 8px 12px;
+  margin: 0 18px 4px;
+  background: var(--bg-surface);
+  border-radius: var(--radius-sm);
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 12px;
+  color: var(--accent);
+  word-break: break-all;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  grid-column: 1 / -1;
+}
+
+.empty-icon { font-size: 48px; margin-bottom: 12px; }
+
+.empty-state p {
+  color: var(--text-secondary);
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+
+.reset-btn {
+  padding: 10px 24px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-size: 14px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.2s;
+}
+
+.reset-btn:hover { border-color: var(--accent); background: var(--accent-light); }
+
+.gallery-footer {
+  text-align: center;
+  padding: 40px 0 16px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.gallery-footer a { color: var(--accent); text-decoration: none; }
+.gallery-footer a:hover { text-decoration: underline; }
+
+/* Toast notification */
+.toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent);
+  color: #fff;
+  padding: 10px 24px;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-weight: 600;
+  z-index: 1000;
+  box-shadow: var(--shadow-lg);
+  animation: toast-in 0.3s ease;
+}
+
+.toast.hide { animation: toast-out 0.3s ease forwards; }
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(12px); }
+  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
+@keyframes toast-out {
+  from { opacity: 1; transform: translateX(-50%) translateY(0); }
+  to { opacity: 0; transform: translateX(-50%) translateY(12px); }
+}
+
+/* Code display for copied snippet */
+.code-snippet {
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 10px 14px;
+  margin: 0 18px 4px;
+  background: #0d0d1a;
+  border-radius: var(--radius-sm);
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 12px;
+  color: #a78bfa;
+  white-space: pre;
+  display: none;
+}
+
+.code-snippet.visible { display: block; }
+
+/* Override EaseMotion btn-sm for card context */
+.card-preview .ease-btn-sm { font-size: 12px; padding: 6px 14px; }
+
+@media (max-width: 700px) {
+  .gallery-grid { grid-template-columns: 1fr; }
+  .filter-tabs { overflow-x: auto; flex-wrap: nowrap; padding-bottom: 4px; }
+  body { padding: 16px 12px; }
+}


### PR DESCRIPTION
## Description

Closes #1225

Adds an interactive **Component Showcase Gallery** that lets developers browse, search, filter, preview, and copy EaseMotion CSS components from a single interface.

## Features

- **35 components** across 6 categories: Buttons (8), Cards (6), Animations (8), Hover Effects (5), Utilities (5), Navbar (3)
- **Live previews** using EaseMotion CSS via jsDelivr CDN
- **Real-time search** by name, description, or category
- **Category filter tabs** for quick browsing (All, Buttons, Cards, Animations, Hover, Utilities, Navbar)
- **Copy HTML snippet** and **Copy CSS class** buttons for every component
- **Dark / light mode** with localStorage persistence
- **Responsive grid layout** with smooth hover effects
- **Toast notification** for copy feedback

## Verification

- `npm run lint` — ✅
- `npm run test` — ✅ (4/4)
- `npm run lint:duplicates` — ✅
- CI Release Validation skipped (only `submissions/examples/` files changed)

## File Structure

```
submissions/examples/ease-component-gallery/
├── demo.html       — Main gallery page
├── style.css       — Gallery styling (CSS variables, grid, responsive)
├── script.js       — Component data, filter, search, copy logic
└── README.md       — Documentation
```