### PR TITLE
feat: add pricing comparison table with monthly/yearly toggle

### DIFF
--- a/submissions/examples/ease-pricing-comparison/README.md
+++ b/submissions/examples/ease-pricing-comparison/README.md
@@ -1,0 +1,43 @@
+# Pricing Comparison Table — EaseMotion CSS
+
+A responsive pricing comparison table with monthly/yearly billing toggle, featured plan highlight, feature comparison, and CTA buttons.
+
+## Features
+
+- **3 pricing tiers**: Free ($0), Pro ($19/mo or $15/yr), Enterprise (Custom)
+- **Monthly / Yearly billing toggle** with "Save 20%" label
+- **Featured plan** with "Most Popular" badge and accent border
+- **Feature comparison** with checkmark and cross icons
+- **CTA buttons** in primary, outline, and ghost styles
+- **Hover lift** animation on cards
+- **Responsive grid** — stacks vertically on narrow screens
+- **Dark theme** — matches EaseMotion CSS design system
+
+## Usage
+
+Open `demo.html` in a browser. Toggle between Monthly and Yearly billing to see prices update.
+
+## File Structure
+
+```
+ease-pricing-comparison/
+├── demo.html       — Main demo page
+├── style.css       — Component styling
+└── README.md       — This file
+```
+
+## Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-pricing-table` | Grid container for plan cards |
+| `.ease-pricing-card` | Individual pricing plan card |
+| `.ease-pricing-card.featured` | Highlighted recommended plan |
+| `.ease-plan-badge` | "Most Popular" badge |
+| `.ease-plan-name` | Plan title |
+| `.ease-plan-price` | Price display container |
+| `.price-amount` | Price number (has data-monthly / data-yearly) |
+| `.price-period` | "/month" or "/year" label |
+| `.ease-plan-desc` | Plan description |
+| `.ease-plan-features` | Feature list with check/cross icons |
+| `.ease-plan-btn` | CTA button (variants: `-primary`, `-outline`, `-ghost`) |

--- a/submissions/examples/ease-pricing-comparison/demo.html
+++ b/submissions/examples/ease-pricing-comparison/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pricing Comparison Table — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="demo-root">
+    <header class="demo-header">
+      <h1>Pricing Plans</h1>
+      <p>Choose the plan that fits your needs. No hidden fees.</p>
+      <div class="billing-toggle">
+        <span class="toggle-label" data-active>Monthly</span>
+        <label class="toggle-switch">
+          <input type="checkbox" id="billingToggle" />
+          <span class="toggle-track"></span>
+        </label>
+        <span class="toggle-label">Yearly</span>
+        <span class="toggle-save">Save 20%</span>
+      </div>
+    </header>
+
+    <div class="ease-pricing-table">
+      <div class="ease-pricing-card">
+        <h3 class="ease-plan-name">Free</h3>
+        <div class="ease-plan-price">
+          <span class="price-amount" data-monthly="$0" data-yearly="$0">$0</span>
+          <span class="price-period">/month</span>
+        </div>
+        <p class="ease-plan-desc">Perfect for getting started.</p>
+        <ul class="ease-plan-features">
+          <li class="check">1 Project</li>
+          <li class="check">Basic Support</li>
+          <li class="check">Community Access</li>
+          <li class="cross">Advanced Analytics</li>
+          <li class="cross">Team Collaboration</li>
+        </ul>
+        <button class="ease-plan-btn ease-plan-btn-outline">Get Started</button>
+      </div>
+
+      <div class="ease-pricing-card featured">
+        <span class="ease-plan-badge">Most Popular</span>
+        <h3 class="ease-plan-name">Pro</h3>
+        <div class="ease-plan-price">
+          <span class="price-amount" data-monthly="$19" data-yearly="$15">$19</span>
+          <span class="price-period">/month</span>
+        </div>
+        <p class="ease-plan-desc">Best for professionals and small teams.</p>
+        <ul class="ease-plan-features">
+          <li class="check">Unlimited Projects</li>
+          <li class="check">Priority Support</li>
+          <li class="check">Community Access</li>
+          <li class="check">Advanced Analytics</li>
+          <li class="cross">Custom Integrations</li>
+        </ul>
+        <button class="ease-plan-btn ease-plan-btn-primary">Start Free Trial</button>
+      </div>
+
+      <div class="ease-pricing-card">
+        <h3 class="ease-plan-name">Enterprise</h3>
+        <div class="ease-plan-price">
+          <span class="price-amount price-custom">Custom</span>
+          <span class="price-period"></span>
+        </div>
+        <p class="ease-plan-desc">Built for large organizations.</p>
+        <ul class="ease-plan-features">
+          <li class="check">Unlimited Projects</li>
+          <li class="check">Dedicated Manager</li>
+          <li class="check">Custom Integrations</li>
+          <li class="check">Advanced Analytics</li>
+          <li class="check">SLA Guarantee</li>
+        </ul>
+        <button class="ease-plan-btn ease-plan-btn-ghost">Contact Sales</button>
+      </div>
+    </div>
+
+    <footer class="demo-footer">
+      <span>Part of <strong>EaseMotion CSS</strong></span>
+    </footer>
+  </div>
+
+  <script>
+    document.getElementById('billingToggle').addEventListener('change', function() {
+      const isYearly = this.checked;
+      document.querySelector('.ease-pricing-table').classList.toggle('yearly', isYearly);
+      document.querySelectorAll('.toggle-label')[0].classList.toggle('active', !isYearly);
+      document.querySelectorAll('.toggle-label')[1].classList.toggle('active', isYearly);
+      document.querySelectorAll('.price-amount:not(.price-custom)').forEach(el => {
+        el.textContent = isYearly ? el.dataset.yearly : el.dataset.monthly;
+      });
+      document.querySelectorAll('.price-period').forEach(el => {
+        el.textContent = isYearly ? '/year' : '/month';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-pricing-comparison/style.css
+++ b/submissions/examples/ease-pricing-comparison/style.css
@@ -1,0 +1,320 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg-page: #0f0e17;
+  --bg-card: #1a1926;
+  --bg-card-featured: #1e1b35;
+  --text-primary: #fffffe;
+  --text-secondary: #a7a9be;
+  --text-muted: #6e6f8a;
+  --border-color: #2a2940;
+  --border-featured: #6c63ff;
+  --accent: #6c63ff;
+  --accent-hover: #5a52e0;
+  --success: #10b981;
+  --danger: #ef4444;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 16px rgba(0,0,0,0.4);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.5);
+  --shadow-featured: 0 0 0 1px rgba(108,99,255,0.3), 0 8px 32px rgba(0,0,0,0.5);
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--bg-page);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 40px 16px;
+}
+
+.demo-root {
+  width: 100%;
+  max-width: 1100px;
+}
+
+/* Header */
+.demo-header {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.demo-header h1 {
+  font-size: clamp(28px, 4vw, 36px);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, var(--accent), #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 8px;
+}
+
+.demo-header p {
+  color: var(--text-secondary);
+  font-size: 16px;
+  margin-bottom: 24px;
+}
+
+/* Billing Toggle */
+.billing-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-full);
+}
+
+.toggle-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-muted);
+  transition: color 0.2s;
+  user-select: none;
+}
+
+.toggle-label.active {
+  color: var(--text-primary);
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  cursor: pointer;
+}
+
+.toggle-switch input { opacity: 0; width: 0; height: 0; }
+
+.toggle-track {
+  position: absolute;
+  inset: 0;
+  background: var(--border-color);
+  border-radius: 24px;
+  transition: background 0.3s;
+}
+
+.toggle-track::before {
+  content: '';
+  position: absolute;
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.toggle-switch input:checked + .toggle-track {
+  background: var(--accent);
+}
+
+.toggle-switch input:checked + .toggle-track::before {
+  transform: translateX(20px);
+}
+
+.toggle-save {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--success);
+  background: rgba(16, 185, 129, 0.12);
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+
+/* Pricing Table Grid */
+.ease-pricing-table {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .ease-pricing-table { grid-template-columns: 1fr; max-width: 400px; margin: 0 auto; }
+}
+
+/* Pricing Card */
+.ease-pricing-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+  position: relative;
+}
+
+.ease-pricing-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+}
+
+.ease-pricing-card.featured {
+  border-color: var(--border-featured);
+  box-shadow: var(--shadow-featured);
+  background: var(--bg-card-featured);
+}
+
+.ease-pricing-card.featured:hover {
+  box-shadow: 0 0 0 1px rgba(108,99,255,0.4), 0 12px 40px rgba(0,0,0,0.6);
+}
+
+/* Badge */
+.ease-plan-badge {
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #fff;
+  background: var(--accent);
+  padding: 4px 14px;
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+}
+
+.ease-plan-name {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.ease-plan-price {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.price-amount {
+  font-size: 36px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  transition: opacity 0.3s ease;
+}
+
+.price-custom {
+  font-size: 28px;
+}
+
+.price-period {
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.ease-plan-desc {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Yearly pricing updated via JS */
+
+/* Feature List */
+.ease-plan-features {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+}
+
+.ease-plan-features li {
+  font-size: 14px;
+  color: var(--text-secondary);
+  padding-left: 24px;
+  position: relative;
+  line-height: 1.4;
+}
+
+.ease-plan-features li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+  background: var(--success);
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E") center/contain no-repeat;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E") center/contain no-repeat;
+}
+
+.ease-plan-features li.cross::before {
+  background: var(--danger);
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='18' y1='6' x2='6' y2='18'%3E%3C/line%3E%3Cline x1='6' y1='6' x2='18' y2='18'%3E%3C/line%3E%3C/svg%3E") center/contain no-repeat;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='18' y1='6' x2='6' y2='18'%3E%3C/line%3E%3Cline x1='6' y1='6' x2='18' y2='18'%3E%3C/line%3E%3C/svg%3E") center/contain no-repeat;
+}
+
+/* Plan Buttons */
+.ease-plan-btn {
+  width: 100%;
+  padding: 12px 20px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s;
+  font-family: inherit;
+  text-align: center;
+}
+
+.ease-plan-btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.ease-plan-btn-primary:hover {
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(108, 99, 255, 0.3);
+}
+
+.ease-plan-btn-outline {
+  background: transparent;
+  color: var(--text-primary);
+}
+
+.ease-plan-btn-outline:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.ease-plan-btn-ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: transparent;
+}
+
+.ease-plan-btn-ghost:hover {
+  background: var(--bg-card);
+  color: var(--text-primary);
+  border-color: var(--border-color);
+  transform: translateY(-1px);
+}
+
+.demo-footer {
+  text-align: center;
+  margin-top: 48px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+@media (max-width: 500px) {
+  .ease-pricing-card { padding: 24px 18px; }
+  .billing-toggle { flex-wrap: wrap; justify-content: center; }
+}


### PR DESCRIPTION
## Description

Closes #1168

Adds a **Pricing Comparison Table** component — a responsive 3-tier pricing grid with monthly/yearly billing toggle, featured plan highlight, and feature comparison.

## Features

- **3 plans**: Free ($0), Pro ($19/mo → $15/yr), Enterprise (Custom)
- **Monthly / Yearly toggle** with price switching and "Save 20%" label
- **Featured plan** with "Most Popular" badge and accent border + shadow
- **Feature comparison** with CSS mask checkmark/cross icons
- **CTA buttons** in primary, outline, and ghost styles
- **Hover lift** animation on all cards
- **Responsive grid** — 3 columns on desktop, stacks on mobile
- **Dark theme** — matches EaseMotion CSS design system

## Verification

- `npm run lint` — ✅
- CI Release Validation skipped (only `submissions/examples/` files changed)

## File Structure

```
submissions/examples/ease-pricing-comparison/
├── demo.html       — Main demo page
├── style.css       — Component styling
└── README.md       — Documentation
```