### PR TITLE
feat: add Code Snippet Preview Card submission for #1162

### DIFF
--- a/submissions/examples/ease-code-snippet-card/README.md
+++ b/submissions/examples/ease-code-snippet-card/README.md
@@ -1,0 +1,49 @@
+# Code Snippet Preview Card
+
+A developer-friendly code snippet card for displaying code examples, API responses, configuration snippets, and documentation samples in an elegant editor-inspired layout.
+
+## Features
+
+- **Window control dots** — macOS-style traffic light dots in the header bar
+- **Language badge** — uppercase label identifying the programming language
+- **Copy button** — copies code to clipboard with "Copied!" feedback and a toast notification
+- **Syntax highlighting** — token-level colorization using semantic CSS classes (`kw`, `fn`, `str`, etc.)
+- **Dark theme** — seamless dark editor aesthetic matching EaseMotion's design language
+- **Hover effect** — card border glows with the accent color on hover
+- **Responsive** — adapts to small screens with adjusted font sizes
+
+## Languages Demonstrated
+
+- JavaScript (default on first card)
+- HTML (second card)
+- CSS (third card)
+
+## Usage
+
+Copy the `ease-snippet-card` block and customize:
+
+1. Replace the language badge text in `.ease-snippet-lang`
+2. Update the code inside `<pre><code>` with token-level span classes
+3. Wire the copy button to the actual snippet text in JavaScript
+
+## File Structure
+
+```
+ease-code-snippet-card/
+├── demo.html       # Demo page with 3 language examples
+├── style.css       # All card and syntax styles
+└── README.md       # This file
+```
+
+## Classes
+
+| Class | Purpose |
+|---|---|
+| `.ease-snippet-card` | Outer card container |
+| `.ease-snippet-header` | Top bar with dots, language, and copy button |
+| `.ease-snippet-dots` | Container for window control dots |
+| `.ease-snippet-dot` | Individual colored dot |
+| `.ease-snippet-lang` | Language badge text |
+| `.ease-snippet-copy` | Copy-to-clipboard button |
+| `.ease-snippet-pre` | `<pre>` wrapper for the code block |
+| `.ease-toast` | Toast notification for copy confirmation |

--- a/submissions/examples/ease-code-snippet-card/demo.html
+++ b/submissions/examples/ease-code-snippet-card/demo.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Code Snippet Card — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="demo-root">
+    <header class="demo-header">
+      <h1>Code Snippet Card</h1>
+      <p>Elegant code preview cards with language badges, window controls, and copy buttons.</p>
+    </header>
+
+    <div class="ease-snippet-grid">
+      <div class="ease-snippet-card">
+        <div class="ease-snippet-header">
+          <div class="ease-snippet-dots">
+            <span class="ease-snippet-dot" style="background:#ef4444"></span>
+            <span class="ease-snippet-dot" style="background:#f59e0b"></span>
+            <span class="ease-snippet-dot" style="background:#10b981"></span>
+            <span class="ease-snippet-lang">JavaScript</span>
+          </div>
+          <button class="ease-snippet-copy" data-code="0">Copy</button>
+        </div>
+        <pre class="ease-snippet-pre"><code><span class="kw">const</span> <span class="fn">greet</span> <span class="op">=</span> <span class="kw">(</span><span class="pv">name</span><span class="kw">)</span> <span class="op">=></span> <span class="kw">{</span>
+  <span class="kw">return</span> <span class="str">`Hello, <span class="iv">${</span><span class="pv">name</span><span class="iv">}</span>!`</span><span class="op">;</span>
+<span class="kw">}</span>
+
+<span class="kw">const</span> <span class="fn">app</span> <span class="op">=</span> <span class="str">"EaseMotion CSS"</span><span class="op">;</span>
+
+<span class="kw">function</span> <span class="fn">start</span><span class="kw">()</span> <span class="kw">{</span>
+  <span class="bu">console</span><span class="op">.</span><span class="fn">log</span><span class="kw">(</span><span class="fn">greet</span><span class="kw">(</span><span class="pv">app</span><span class="kw">))</span><span class="op">;</span>
+<span class="kw">}</span>
+
+<span class="fn">start</span><span class="kw">()</span><span class="op">;</span></code></pre>
+      </div>
+
+      <div class="ease-snippet-card">
+        <div class="ease-snippet-header">
+          <div class="ease-snippet-dots">
+            <span class="ease-snippet-dot" style="background:#ef4444"></span>
+            <span class="ease-snippet-dot" style="background:#f59e0b"></span>
+            <span class="ease-snippet-dot" style="background:#10b981"></span>
+            <span class="ease-snippet-lang">HTML</span>
+          </div>
+          <button class="ease-snippet-copy" data-code="1">Copy</button>
+        </div>
+        <pre class="ease-snippet-pre"><code><span class="tag">&lt;div</span> <span class="attr">class</span>=<span class="str">"ease-card ease-card-shadow"</span><span class="tag">&gt;</span>
+  <span class="tag">&lt;h3&gt;</span>Hello World<span class="tag">&lt;/h3&gt;</span>
+  <span class="tag">&lt;p&gt;</span>Styled with EaseMotion.<span class="tag">&lt;/p&gt;</span>
+<span class="tag">&lt;/div&gt;</span></code></pre>
+      </div>
+
+      <div class="ease-snippet-card">
+        <div class="ease-snippet-header">
+          <div class="ease-snippet-dots">
+            <span class="ease-snippet-dot" style="background:#ef4444"></span>
+            <span class="ease-snippet-dot" style="background:#f59e0b"></span>
+            <span class="ease-snippet-dot" style="background:#10b981"></span>
+            <span class="ease-snippet-lang">CSS</span>
+          </div>
+          <button class="ease-snippet-copy" data-code="2">Copy</button>
+        </div>
+        <pre class="ease-snippet-pre"><code><span class="sel">.ease-btn-primary</span> <span class="kw">{</span>
+  <span class="prop">background</span><span class="op">:</span> <span class="clr">#6c63ff</span><span class="op">;</span>
+  <span class="prop">color</span><span class="op">:</span> <span class="clr">#ffffff</span><span class="op">;</span>
+  <span class="prop">border</span><span class="op">:</span> <span class="num">none</span><span class="op">;</span>
+  <span class="prop">border-radius</span><span class="op">:</span> <span class="num">8px</span><span class="op">;</span>
+  <span class="prop">padding</span><span class="op">:</span> <span class="num">12px 24px</span><span class="op">;</span>
+  <span class="prop">font-weight</span><span class="op">:</span> <span class="num">600</span><span class="op">;</span>
+  <span class="prop">cursor</span><span class="op">:</span> <span class="num">pointer</span><span class="op">;</span>
+  <span class="prop">transition</span><span class="op">:</span> <span class="num">all 0.2s</span><span class="op">;</span>
+<span class="kw">}</span></code></pre>
+      </div>
+    </div>
+
+    <footer class="demo-footer">
+      <span>Part of <strong>EaseMotion CSS</strong></span>
+    </footer>
+  </div>
+
+  <div id="toast" class="ease-toast" hidden></div>
+
+  <script>
+    const snippets = [
+      `const greet = (name) => {\n  return \`Hello, \${name}!\`;\n}\n\nconst app = "EaseMotion CSS";\n\nfunction start() {\n  console.log(greet(app));\n}\n\nstart();`,
+      `<div class="ease-card ease-card-shadow">\n  <h3>Hello World</h3>\n  <p>Styled with EaseMotion.</p>\n</div>`,
+      `.ease-btn-primary {\n  background: #6c63ff;\n  color: #ffffff;\n  border: none;\n  border-radius: 8px;\n  padding: 12px 24px;\n  font-weight: 600;\n  cursor: pointer;\n  transition: all 0.2s;\n}`
+    ];
+
+    document.querySelectorAll('.ease-snippet-copy').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const idx = parseInt(btn.dataset.code);
+        const text = snippets[idx];
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(text);
+        }
+        btn.textContent = '✓ Copied!';
+        btn.classList.add('copied');
+        const toast = document.getElementById('toast');
+        toast.textContent = '✓ Code copied to clipboard';
+        toast.hidden = false;
+        toast.classList.add('show');
+        clearTimeout(toast._t);
+        toast._t = setTimeout(() => {
+          toast.classList.remove('show');
+          setTimeout(() => { toast.hidden = true; }, 300);
+        }, 2000);
+        setTimeout(() => {
+          btn.textContent = 'Copy';
+          btn.classList.remove('copied');
+        }, 2000);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-code-snippet-card/style.css
+++ b/submissions/examples/ease-code-snippet-card/style.css
@@ -1,0 +1,208 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg-page: #0f0e17;
+  --bg-card: #1a1926;
+  --bg-code: #12112a;
+  --text-primary: #fffffe;
+  --text-secondary: #a7a9be;
+  --text-muted: #6e6f8a;
+  --border-color: #2a2940;
+  --accent: #6c63ff;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 16px rgba(0,0,0,0.4);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.5);
+
+  /* Syntax colors */
+  --syn-kw: #c084fc;
+  --syn-fn: #38bdf8;
+  --syn-str: #34d399;
+  --syn-num: #fbbf24;
+  --syn-op: #f472b6;
+  --syn-pv: #a78bfa;
+  --syn-iv: #e879f9;
+  --syn-bu: #fbbf24;
+  --syn-tag: #f472b6;
+  --syn-attr: #a78bfa;
+  --syn-sel: #38bdf8;
+  --syn-prop: #34d399;
+  --syn-clr: #fbbf24;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--bg-page);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 40px 16px;
+}
+
+.demo-root { width: 100%; max-width: 680px; }
+
+.demo-header { text-align: center; margin-bottom: 36px; }
+
+.demo-header h1 {
+  font-size: clamp(24px, 4vw, 32px);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, var(--accent), #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 6px;
+}
+
+.demo-header p {
+  color: var(--text-secondary);
+  font-size: 15px;
+}
+
+/* ── Snippet Grid ──────────────────────────────────────── */
+
+.ease-snippet-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ── Snippet Card ──────────────────────────────────────── */
+
+.ease-snippet-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.ease-snippet-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-md);
+}
+
+/* Header bar with window dots + language badge + copy button */
+.ease-snippet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-card);
+}
+
+/* Mac-style window control dots */
+.ease-snippet-dots {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ease-snippet-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ease-snippet-lang {
+  margin-left: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Copy button */
+.ease-snippet-copy {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 5px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.ease-snippet-copy:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(108, 99, 255, 0.08);
+}
+
+.ease-snippet-copy.copied {
+  border-color: #10b981;
+  color: #10b981;
+  background: rgba(16, 185, 129, 0.08);
+}
+
+/* Code block */
+.ease-snippet-pre {
+  margin: 0;
+  padding: 20px;
+  background: var(--bg-code);
+  overflow-x: auto;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 13px;
+  line-height: 1.7;
+  color: #e2e8f0;
+  tab-size: 2;
+}
+
+/* Syntax highlighting tokens */
+.kw { color: var(--syn-kw); }
+.fn { color: var(--syn-fn); }
+.str { color: var(--syn-str); }
+.num { color: var(--syn-num); }
+.op { color: var(--syn-op); }
+.pv { color: var(--syn-pv); }
+.iv { color: var(--syn-iv); }
+.bu { color: var(--syn-bu); }
+.tag { color: var(--syn-tag); }
+.attr { color: var(--syn-attr); }
+.sel { color: var(--syn-sel); }
+.prop { color: var(--syn-prop); }
+.clr { color: var(--syn-clr); }
+
+/* Toast */
+.ease-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%) translateY(12px);
+  background: var(--accent);
+  color: #fff;
+  padding: 10px 24px;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-weight: 600;
+  box-shadow: var(--shadow-lg);
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 1000;
+}
+
+.ease-toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.demo-footer {
+  text-align: center;
+  margin-top: 40px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+@media (max-width: 500px) {
+  .ease-snippet-pre { font-size: 12px; padding: 16px; }
+  .ease-snippet-header { flex-wrap: wrap; gap: 8px; }
+}


### PR DESCRIPTION
## Description

Adds a Code Snippet Preview Card component under `submissions/examples/ease-code-snippet-card/` with:

- macOS-style window control dots
- Language badge (JavaScript / HTML / CSS)
- Copy-to-clipboard button with visual feedback and toast notification
- Syntax highlighting using semantic CSS classes
- Dark editor-themed design

Closes #1162