### PR TITLE
fix: remove duplicate delay/duration classes from easemotion/timing.css (#1146)

### DIFF
--- a/easemotion/timing.css
+++ b/easemotion/timing.css
@@ -1,16 +1,5 @@
-/* EaseMotion CSS — timing helpers and reduced motion support */
-
-.ease-delay-75  { animation-delay: 75ms; }
-.ease-delay-100 { animation-delay: 100ms; }
-.ease-delay-150 { animation-delay: 150ms; }
-.ease-delay-200 { animation-delay: 200ms; }
-.ease-delay-300 { animation-delay: 300ms; }
-.ease-delay-500 { animation-delay: 500ms; }
-.ease-delay-700 { animation-delay: 700ms; }
-
-.ease-duration-fast   { animation-duration: var(--ease-speed-fast); }
-.ease-duration-medium { animation-duration: var(--ease-speed-medium); }
-.ease-duration-slow   { animation-duration: var(--ease-speed-slow); }
+/* EaseMotion CSS — reduced motion support only */
+/* Stagger delay helpers and duration overrides live in core/animations.css */
 
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
## Description

The `.ease-delay-*` and `.ease-duration-*` classes were defined in both `core/animations.css` (with `animation-delay` AND `transition-delay`) and `easemotion/timing.css` (with only `animation-delay`). Since `easemotion/all.css` imports both files, this created redundant duplicate definitions.

Removed the duplicate from `timing.css` — `core/animations.css` is the canonical source with complete property coverage.

Closes #1146