### PR TITLE
fix: replace Google Fonts @import with <link> tags to prevent render blocking (#971)

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -12,6 +12,10 @@
   <!-- EaseMotion CSS — loaded from latest GitHub main branch via jsDelivr CDN -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
 
+  <!-- Google Fonts: Inter — loaded via <link> (not @import) to avoid render blocking -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 
   <style>
     /* ── Demo-specific styles ─────────────────────────────── */

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,10 @@
   <!-- EaseMotion CSS — loaded from latest GitHub main branch via jsDelivr CDN -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
 
+  <!-- Google Fonts: Inter — loaded via <link> (not @import) to avoid render blocking -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 
   <style>
     /* ── Theme Definitions ────────────────────────────────── */

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -9,6 +9,11 @@
   <meta name="description"
     content="Live demo showcasing EaseMotion CSS utilities, animations, buttons, and card components." />
 
+  <!-- Google Fonts: Inter — loaded via <link> (not @import) to avoid render blocking -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+
   <!-- EaseMotion CSS -->
   <link rel="stylesheet" href="../core/variables.css" />
   <link rel="stylesheet" href="../core/base.css" />

--- a/examples/masonry-layouts.html
+++ b/examples/masonry-layouts.html
@@ -8,6 +8,11 @@
   <meta name="description"
     content="Responsive Pinterest-style masonry grids with EaseMotion CSS. Explore portfolio, image gallery, and blog card examples." />
 
+  <!-- Google Fonts: Inter — loaded via <link> (not @import) to avoid render blocking -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+
   <!-- EaseMotion CSS -->
   <link rel="stylesheet" href="../core/variables.css" />
   <link rel="stylesheet" href="../core/base.css" />

--- a/examples/scroll-snap.html
+++ b/examples/scroll-snap.html
@@ -5,6 +5,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Scroll Snap Utilities - EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
   <link rel="stylesheet" href="../core/variables.css">
   <link rel="stylesheet" href="../core/base.css">
   <link rel="stylesheet" href="../core/utilities.css">

--- a/examples/skeleton-loading.html
+++ b/examples/skeleton-loading.html
@@ -7,6 +7,10 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;">
   <title>Skeleton Loading - EaseMotion CSS</title>
 
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
   <link rel="stylesheet" href="../core/variables.css">
   <link rel="stylesheet" href="../core/base.css">
   <link rel="stylesheet" href="../core/utilities.css">


### PR DESCRIPTION
## Description

The `@import url()` for Google Fonts was already removed from `core/base.css` but the docs and example pages were not updated to load the Inter font via proper `<link>` tags. This meant:

1. The documentation pages stopped loading Inter (falling through to system-ui)
2. The `@import` blocking issue described in the issue was already partially fixed, but the font-loading gap remained

**Fix:** Added `preconnect` and `<link>` stylesheet tags to 6 HTML pages so fonts load without blocking CSS rendering:

- `docs/index.html`
- `docs/demo.html`
- `examples/demo.html`
- `examples/skeleton-loading.html`
- `examples/masonry-layouts.html`
- `examples/scroll-snap.html`

Closes #971