### PR TITLE
feat: add CSS-only scroll-triggered reveal animations (closes #1623)

### DIFF
--- a/submissions/examples/scroll-reveal-animations/README.md
+++ b/submissions/examples/scroll-reveal-animations/README.md
@@ -1,0 +1,115 @@
+# Scroll-Triggered Reveal Animations
+
+**EaseMotion CSS · Feature #1623 · GSSoC '26**
+
+Pure CSS scroll reveal animations using the modern `animation-timeline: view()` property — no JavaScript, no dependencies.
+
+---
+
+## Overview
+
+This feature adds six scroll-triggered reveal animation classes to EaseMotion CSS. Elements animate into view as they enter the viewport, powered entirely by CSS Scroll-Driven Animations.
+
+---
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="em-reveal-up">Slides up as you scroll</div>
+<div class="em-reveal-left">Slides in from the left</div>
+<div class="em-reveal-zoom">Zooms in on scroll</div>
+```
+
+---
+
+## Available Classes
+
+| Class | Effect |
+|---|---|
+| `.em-reveal-up` | Fades in & slides upward |
+| `.em-reveal-down` | Fades in & slides downward |
+| `.em-reveal-left` | Slides in from the left |
+| `.em-reveal-right` | Slides in from the right |
+| `.em-reveal-zoom` | Zooms in from smaller scale |
+| `.em-reveal-fade` | Simple opacity fade |
+
+---
+
+## Modifiers
+
+### Speed
+```html
+<div class="em-reveal-up em-reveal--fast">Fast reveal</div>
+<div class="em-reveal-up em-reveal--slow">Slow, cinematic reveal</div>
+```
+
+### Stagger (CSS-only)
+```html
+<div class="em-reveal-up">First</div>
+<div class="em-reveal-up em-reveal--delay-1">Second</div>
+<div class="em-reveal-up em-reveal--delay-2">Third</div>
+<div class="em-reveal-up em-reveal--delay-3">Fourth</div>
+<div class="em-reveal-up em-reveal--delay-4">Fifth</div>
+```
+
+---
+
+## How It Works
+
+Uses the CSS `animation-timeline: view()` property with `animation-range` to trigger animations as elements scroll into the viewport:
+
+```css
+.em-reveal-up {
+  animation-name: em-fade-up;
+  animation-timeline: view();
+  animation-range: entry 0% entry 40%;
+  animation-fill-mode: both;
+}
+```
+
+The `view()` timeline links animation progress to the element's position relative to the scrollport. `entry 0%` = element just entered from the bottom; `entry 40%` = animation completes when element is 40% into view.
+
+---
+
+## Browser Support
+
+| Feature | Support |
+|---|---|
+| `animation-timeline: view()` | Chrome 115+, Edge 115+, Firefox 110+, Safari 18+ |
+| Fallback (older browsers) | Simple fade via `@supports not (animation-timeline: view())` |
+
+---
+
+## Accessibility
+
+All animations are automatically disabled for users who have enabled **prefers-reduced-motion** in their OS settings:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  [class*="em-reveal-"] {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+```
+
+---
+
+## Files
+
+```
+submissions/examples/scroll-reveal-animations/
+├── style.css     ← Animation classes (library file)
+├── demo.html     ← Live demo of all variants
+└── README.md     ← This file
+```
+
+---
+
+## Related
+
+- Closes #1623
+- Part of EaseMotion CSS — [SAPTARSHI-coder/EaseMotion-css](https://github.com/SAPTARSHI-coder/EaseMotion-css)

--- a/submissions/examples/scroll-reveal-animations/demo.html
+++ b/submissions/examples/scroll-reveal-animations/demo.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion — Scroll Reveal Animations Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    /* ── Demo page styles only — not part of EaseMotion library ── */
+    @import url('https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=Syne:wght@400;700;800&display=swap');
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0d0d0f;
+      --surface: #17171a;
+      --border: #2a2a30;
+      --accent: #7cffd4;
+      --accent2: #ff6b6b;
+      --text: #e8e8ee;
+      --muted: #6b6b7a;
+      --radius: 12px;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: 'Syne', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+    }
+
+    /* ── Hero ── */
+    .hero {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      padding: 2rem;
+      background: radial-gradient(ellipse 80% 60% at 50% 0%, #1a2a1a 0%, var(--bg) 70%);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%237cffd4' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+      pointer-events: none;
+    }
+
+    .hero-badge {
+      font-family: 'Space Mono', monospace;
+      font-size: 0.75rem;
+      color: var(--accent);
+      border: 1px solid var(--accent);
+      padding: 0.3rem 0.8rem;
+      border-radius: 99px;
+      margin-bottom: 1.5rem;
+      letter-spacing: 0.08em;
+    }
+
+    .hero h1 {
+      font-size: clamp(2.5rem, 7vw, 5rem);
+      font-weight: 800;
+      line-height: 1.1;
+      margin-bottom: 1.2rem;
+      background: linear-gradient(135deg, #fff 40%, var(--accent));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    .hero p {
+      font-size: 1.1rem;
+      color: var(--muted);
+      max-width: 500px;
+      margin-bottom: 2.5rem;
+    }
+
+    .scroll-hint {
+      font-family: 'Space Mono', monospace;
+      font-size: 0.75rem;
+      color: var(--muted);
+      letter-spacing: 0.1em;
+      animation: bounce 2s infinite;
+    }
+
+    @keyframes bounce {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(6px); }
+    }
+
+    /* ── Section layout ── */
+    section {
+      padding: 6rem 2rem;
+      max-width: 900px;
+      margin: 0 auto;
+    }
+
+    .section-label {
+      font-family: 'Space Mono', monospace;
+      font-size: 0.7rem;
+      color: var(--accent);
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      margin-bottom: 0.75rem;
+    }
+
+    .section-title {
+      font-size: 2rem;
+      font-weight: 800;
+      margin-bottom: 3rem;
+      color: var(--text);
+    }
+
+    /* ── Cards ── */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 2rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .card h3 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+
+    .card p {
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .card code {
+      font-family: 'Space Mono', monospace;
+      font-size: 0.8rem;
+      background: rgba(124, 255, 212, 0.1);
+      color: var(--accent);
+      padding: 0.15rem 0.5rem;
+      border-radius: 4px;
+    }
+
+    /* ── Grid ── */
+    .grid-2 {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.25rem;
+      margin-bottom: 1.5rem;
+    }
+
+    /* ── Highlight box ── */
+    .highlight {
+      border-left: 3px solid var(--accent);
+      padding-left: 1.25rem;
+      margin: 1rem 0;
+    }
+
+    .highlight p {
+      color: var(--text);
+    }
+
+    /* ── Tag row ── */
+    .tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 0.75rem;
+    }
+
+    .tag {
+      font-family: 'Space Mono', monospace;
+      font-size: 0.7rem;
+      padding: 0.25rem 0.6rem;
+      border-radius: 99px;
+      border: 1px solid var(--border);
+      color: var(--muted);
+    }
+
+    /* ── Stagger demo ── */
+    .stagger-row {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 1.5rem;
+    }
+
+    .stagger-item {
+      flex: 1;
+      min-width: 120px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.25rem;
+      text-align: center;
+    }
+
+    .stagger-item span {
+      font-family: 'Space Mono', monospace;
+      font-size: 0.7rem;
+      color: var(--accent);
+    }
+
+    /* ── Footer ── */
+    footer {
+      border-top: 1px solid var(--border);
+      text-align: center;
+      padding: 3rem 2rem;
+      color: var(--muted);
+      font-family: 'Space Mono', monospace;
+      font-size: 0.75rem;
+    }
+
+    footer a { color: var(--accent); text-decoration: none; }
+
+    /* ── Divider ── */
+    hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 2rem 0;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Hero -->
+  <div class="hero">
+    <div class="hero-badge">EaseMotion CSS · Issue #1623 · GSSoC '26</div>
+    <h1>Scroll Reveal<br>Animations</h1>
+    <p>Pure CSS scroll-triggered reveals using <code style="font-family:monospace;color:#7cffd4;font-size:0.9rem">animation-timeline: view()</code> — zero JavaScript, zero dependencies.</p>
+    <div class="scroll-hint">↓ SCROLL TO SEE DEMOS</div>
+  </div>
+
+  <!-- 1. Basic Reveals -->
+  <section>
+    <div class="section-label">01 — Core Classes</div>
+    <h2 class="section-title">Six Reveal Variants</h2>
+
+    <div class="card em-reveal-up">
+      <h3>↑ .em-reveal-up</h3>
+      <p>Fades in and slides upward as the element enters the viewport. Great for cards, headings, and hero content.</p>
+      <div class="tags"><span class="tag">.em-reveal-up</span></div>
+    </div>
+
+    <div class="card em-reveal-down">
+      <h3>↓ .em-reveal-down</h3>
+      <p>Fades in and slides downward. Works well for navigation dropdowns or elements anchored to the top.</p>
+      <div class="tags"><span class="tag">.em-reveal-down</span></div>
+    </div>
+
+    <div class="grid-2">
+      <div class="card em-reveal-left">
+        <h3>← .em-reveal-left</h3>
+        <p>Slides in from the left side of the viewport.</p>
+        <div class="tags"><span class="tag">.em-reveal-left</span></div>
+      </div>
+      <div class="card em-reveal-right">
+        <h3>→ .em-reveal-right</h3>
+        <p>Slides in from the right side of the viewport.</p>
+        <div class="tags"><span class="tag">.em-reveal-right</span></div>
+      </div>
+    </div>
+
+    <div class="card em-reveal-zoom">
+      <h3>⊕ .em-reveal-zoom</h3>
+      <p>Zooms in from a smaller scale. Ideal for images, badges, and call-to-action elements that deserve emphasis.</p>
+      <div class="tags"><span class="tag">.em-reveal-zoom</span></div>
+    </div>
+
+    <div class="card em-reveal-fade">
+      <h3>◎ .em-reveal-fade</h3>
+      <p>Simple opacity fade with no transform. The most subtle option — great for text blocks and backgrounds.</p>
+      <div class="tags"><span class="tag">.em-reveal-fade</span></div>
+    </div>
+  </section>
+
+  <!-- 2. Speed Modifiers -->
+  <section>
+    <div class="section-label">02 — Modifiers</div>
+    <h2 class="section-title">Speed Control</h2>
+
+    <div class="card em-reveal-up em-reveal--fast">
+      <h3>Fast Reveal</h3>
+      <p>Uses <code>.em-reveal--fast</code> — animation completes earlier as you scroll in.</p>
+      <div class="tags"><span class="tag">.em-reveal-up</span><span class="tag">.em-reveal--fast</span></div>
+    </div>
+
+    <div class="card em-reveal-up">
+      <h3>Default Speed</h3>
+      <p>Default range: <code>entry 0% entry 40%</code></p>
+      <div class="tags"><span class="tag">.em-reveal-up</span></div>
+    </div>
+
+    <div class="card em-reveal-up em-reveal--slow">
+      <h3>Slow Reveal</h3>
+      <p>Uses <code>.em-reveal--slow</code> — animation plays over a longer scroll distance, more cinematic feel.</p>
+      <div class="tags"><span class="tag">.em-reveal-up</span><span class="tag">.em-reveal--slow</span></div>
+    </div>
+  </section>
+
+  <!-- 3. Stagger -->
+  <section>
+    <div class="section-label">03 — Stagger</div>
+    <h2 class="section-title">Stagger Delays</h2>
+
+    <p class="em-reveal-fade" style="color:var(--muted);margin-bottom:2rem;">Use <code style="font-family:monospace;color:#7cffd4;font-size:0.85rem">.em-reveal--delay-1</code> through <code style="font-family:monospace;color:#7cffd4;font-size:0.85rem">.em-reveal--delay-4</code> to offset siblings — pure CSS staggering via <code>animation-range</code> offsets.</p>
+
+    <div class="stagger-row">
+      <div class="stagger-item em-reveal-up">
+        <span>delay-0</span><br>First
+      </div>
+      <div class="stagger-item em-reveal-up em-reveal--delay-1">
+        <span>delay-1</span><br>Second
+      </div>
+      <div class="stagger-item em-reveal-up em-reveal--delay-2">
+        <span>delay-2</span><br>Third
+      </div>
+      <div class="stagger-item em-reveal-up em-reveal--delay-3">
+        <span>delay-3</span><br>Fourth
+      </div>
+      <div class="stagger-item em-reveal-up em-reveal--delay-4">
+        <span>delay-4</span><br>Fifth
+      </div>
+    </div>
+  </section>
+
+  <!-- 4. Highlight / Quote style -->
+  <section>
+    <div class="section-label">04 — Mixed Usage</div>
+    <h2 class="section-title">Real-World Patterns</h2>
+
+    <div class="highlight em-reveal-left">
+      <p>"EaseMotion's scroll reveals align with the animation-first philosophy — native CSS, no JavaScript bundle cost, graceful degradation built in."</p>
+    </div>
+
+    <hr>
+
+    <div class="grid-2">
+      <div class="card em-reveal-zoom em-reveal--delay-1">
+        <h3>✦ No JS</h3>
+        <p>Zero runtime JavaScript. Works entirely in CSS using modern scroll-driven animation APIs.</p>
+      </div>
+      <div class="card em-reveal-zoom em-reveal--delay-2">
+        <h3>♿ Accessible</h3>
+        <p>Respects <code>prefers-reduced-motion</code> — all animations are disabled for users who prefer it.</p>
+      </div>
+      <div class="card em-reveal-zoom em-reveal--delay-3">
+        <h3>🔧 Fallback</h3>
+        <p>Gracefully degrades to a simple fade in browsers without <code>animation-timeline</code> support via <code>@supports</code>.</p>
+      </div>
+      <div class="card em-reveal-zoom em-reveal--delay-4">
+        <h3>⚡ Lightweight</h3>
+        <p>Pure CSS — no dependencies, no build step. Drop in <code>style.css</code> and add classes.</p>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <p>EaseMotion CSS · Scroll Reveal Animations · <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/1623">#1623</a> · GSSoC '26</p>
+    <p style="margin-top:0.5rem">Built by <a href="https://github.com/ramanchauhan2271-dev">ramanchauhan2271-dev</a></p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/scroll-reveal-animations/style.css
+++ b/submissions/examples/scroll-reveal-animations/style.css
@@ -1,0 +1,188 @@
+/**
+ * EaseMotion CSS — Scroll-Triggered Reveal Animations
+ * Issue #1623 | GSSoC '26
+ *
+ * Pure CSS scroll reveal using animation-timeline: view()
+ * No JavaScript required.
+ *
+ * Usage:
+ *   <div class="em-reveal-up">Your content</div>
+ *
+ * Available classes:
+ *   .em-reveal-up     — Fades in & slides up
+ *   .em-reveal-down   — Fades in & slides down
+ *   .em-reveal-left   — Slides in from left
+ *   .em-reveal-right  — Slides in from right
+ *   .em-reveal-zoom   — Zooms in on scroll
+ *   .em-reveal-fade   — Simple fade-in on scroll
+ *
+ * Modifiers:
+ *   .em-reveal--slow  — Slower animation range
+ *   .em-reveal--fast  — Faster animation range
+ *   .em-reveal--delay-1 through .em-reveal--delay-4 — Stagger delays (CSS only fallback)
+ */
+
+/* ─────────────────────────────────────────────
+   Base: shared animation settings
+───────────────────────────────────────────── */
+[class*="em-reveal-"] {
+  animation-fill-mode: both;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+
+  /* animation-timeline: view() — triggers when element enters viewport */
+  animation-timeline: view();
+
+  /* entry 0% = element just entered bottom of viewport
+     entry 25% = element is 25% into the viewport
+     We animate during the entry phase only */
+  animation-range: entry 0% entry 40%;
+}
+
+/* ─────────────────────────────────────────────
+   Keyframes
+───────────────────────────────────────────── */
+@keyframes em-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes em-fade-down {
+  from {
+    opacity: 0;
+    transform: translateY(-40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes em-fade-left {
+  from {
+    opacity: 0;
+    transform: translateX(-60px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes em-fade-right {
+  from {
+    opacity: 0;
+    transform: translateX(60px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes em-zoom {
+  from {
+    opacity: 0;
+    transform: scale(0.75);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes em-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* ─────────────────────────────────────────────
+   Reveal Classes
+───────────────────────────────────────────── */
+.em-reveal-up {
+  animation-name: em-fade-up;
+}
+
+.em-reveal-down {
+  animation-name: em-fade-down;
+}
+
+.em-reveal-left {
+  animation-name: em-fade-left;
+}
+
+.em-reveal-right {
+  animation-name: em-fade-right;
+}
+
+.em-reveal-zoom {
+  animation-name: em-zoom;
+}
+
+.em-reveal-fade {
+  animation-name: em-fade;
+}
+
+/* ─────────────────────────────────────────────
+   Speed Modifiers
+───────────────────────────────────────────── */
+.em-reveal--slow {
+  animation-range: entry 0% entry 60%;
+}
+
+.em-reveal--fast {
+  animation-range: entry 0% entry 20%;
+}
+
+/* ─────────────────────────────────────────────
+   Stagger Delay Modifiers (visual delay via range offset)
+───────────────────────────────────────────── */
+.em-reveal--delay-1 {
+  animation-range: entry 5% entry 45%;
+}
+
+.em-reveal--delay-2 {
+  animation-range: entry 10% entry 50%;
+}
+
+.em-reveal--delay-3 {
+  animation-range: entry 15% entry 55%;
+}
+
+.em-reveal--delay-4 {
+  animation-range: entry 20% entry 60%;
+}
+
+/* ─────────────────────────────────────────────
+   Fallback: older browsers without animation-timeline support
+   Uses @supports to gracefully degrade to a simple fade-in
+───────────────────────────────────────────── */
+@supports not (animation-timeline: view()) {
+  [class*="em-reveal-"] {
+    animation-name: em-fade !important;
+    animation-duration: 0.7s;
+    animation-delay: 0.1s;
+    animation-timeline: unset;
+    animation-range: unset;
+  }
+}
+
+/* ─────────────────────────────────────────────
+   Accessibility: respect prefers-reduced-motion
+───────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  [class*="em-reveal-"] {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds CSS-only scroll-triggered reveal animations using `animation-timeline: view()` — no JavaScript required. Closes #1623.

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/scroll-reveal-animations/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**
Six scroll reveal animation classes powered by CSS `animation-timeline: view()`.

**How does a developer use it?**
```html
<div class="em-reveal-up">Slides up on scroll</div>
<div class="em-reveal-left em-reveal--delay-1">Slides from left</div>