### PR TITLE
fix: enhance test infrastructure with stricter stylelint rules and bundle validation (#850)

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -34,6 +34,8 @@
     "color-function-alias-notation": null,
     "property-no-deprecated": null,
     "declaration-block-no-duplicate-custom-properties": null,
+    "no-duplicate-selectors": true,
+    "declaration-block-no-duplicate-properties": true,
     "selector-pseudo-element-colon-notation": null,
     "no-empty-source": null,
     "selector-id-pattern": null

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -367,6 +367,7 @@
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.08em;
+      transition: opacity var(--ease-speed-fast) var(--ease-ease);
       color: var(--page-text-muted);
       opacity: 0.5;
       font-family: var(--ease-font-mono);
@@ -585,10 +586,6 @@
     .docs-copy-btn:hover {
       background: rgba(255,255,255,0.2);
       color: #fff;
-    }
-
-    .docs-code-lang {
-      transition: opacity var(--ease-speed-fast) var(--ease-ease);
     }
 
     .docs-code:hover .docs-code-lang {

--- a/submission/examples/glassmorphism-settings-panel/style.css
+++ b/submission/examples/glassmorphism-settings-panel/style.css
@@ -267,7 +267,7 @@ body:not(.gsp-dark) .gsp-panel__icon {
 
 .gsp-iconBtn {
   appearance: none;
-  border: 0;
+  border: 1px solid rgba(255,255,255,0.14);
   background: rgba(255,255,255,0.06);
   color: var(--gsp-text);
   width: 36px;
@@ -277,7 +277,6 @@ body:not(.gsp-dark) .gsp-panel__icon {
   display: grid;
   place-items: center;
   transition: background 160ms var(--gsp-ease), transform 160ms var(--gsp-ease);
-  border: 1px solid rgba(255,255,255,0.14);
 }
 
 .gsp-iconBtn:hover {

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -39,6 +39,16 @@ describe('EaseMotion-css Smoke Tests', () => {
     expect(css).toContain('@media (prefers-reduced-motion: reduce)');
   });
 
+  it('minified bundle should be valid and contain key classes', () => {
+    const bundle = readFileSync(resolve(__dirname, '../easemotion.min.css'), 'utf8');
+    expect(bundle).toContain('.ease-fade-in');
+    expect(bundle).toContain('.ease-btn');
+    expect(bundle).toContain('.ease-card');
+    expect(bundle).toContain('@keyframes ease-kf-zoom-in');
+    expect(bundle).toContain('prefers-reduced-motion:reduce');
+    expect(bundle.length).toBeGreaterThan(20000);
+  });
+
   it('should not have duplicate @keyframes definitions', () => {
     const keyframeCounts = {};
     const keyframeRegex = /@keyframes\s+([^\s{]+)/g;


### PR DESCRIPTION
## Description

Enhances the test infrastructure to catch more CSS quality issues:

### stylelint rules enabled
- `no-duplicate-selectors` - prevents duplicate CSS selectors
- `declaration-block-no-duplicate-properties` - prevents duplicate properties within a block

### Pre-existing violations fixed
- `docs/docs.css`: merged duplicate `.docs-code-lang` selector into single definition
- `submission/examples/glassmorphism-settings-panel/style.css`: merged duplicate `border` declarations in `.gsp-iconBtn`

### New smoke test
- Added minified bundle validation test that verifies the production CSS contains expected classes, keyframes, and `prefers-reduced-motion` support

Closes #850