### PR TITLE
Fix: Add prefers-reduced-motion for accessibility in 5 components

### DIFF
--- a/components/badges.css
+++ b/components/badges.css
@@ -43,4 +43,13 @@
   .em-badge-danger.em-badge-pulse::after {
     box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .em-badge,
+    [class*="em-badge"],
+    .em-badge-pulse::after {
+      animation: none !important;
+      transition: none !important;
+    }
+  }
 }

--- a/components/loaders.css
+++ b/components/loaders.css
@@ -45,4 +45,24 @@
   .em-loader-dot:nth-child(3) {
     animation-delay: 0.4s;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .em-loader-spin,
+    .em-loader-pulse,
+    .em-loader-ping,
+    .em-loader-dot {
+      animation: none !important;
+    }
+   
+    /* Provide a static fallback so loaders are still visible */
+    .em-loader-spin {
+      border-top-color: var(--ease-color-primary);
+      opacity: 0.6;
+    }
+   
+    .em-loader-pulse,
+    .em-loader-ping {
+      opacity: 0.6;
+    }
+  }
 }

--- a/components/navbar.css
+++ b/components/navbar.css
@@ -103,4 +103,11 @@
     min-width: 120px;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-navbar-glass,
+  .ease-navbar-item {
+    transition: none !important;
+  }
+}
 }

--- a/components/scroll-progress.css
+++ b/components/scroll-progress.css
@@ -88,3 +88,11 @@
 .ease-scroll-progress-root {
   animation-timeline: scroll(root);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-scroll-progress,
+  .ease-scroll-progress-root {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/components/tabs.css
+++ b/components/tabs.css
@@ -91,4 +91,16 @@
   .em-tabs-auto #em-tab-4:checked ~ .em-tabs-nav label[for="em-tab-4"] {
     border-bottom: 2px solid var(--ease-color-primary);
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .em-tab-panel {
+      animation: none !important;
+      opacity: 1;
+    }
+   
+    .em-tab-underline,
+    .em-tab-label {
+      transition: none !important;
+    }
+  }
 }


### PR DESCRIPTION
Resolves vestibular accessibility violation by adding `prefers-reduced-motion: reduce` blocks in `loaders.css`, `tabs.css`, `navbar.css`, `scroll-progress.css`, and `badges.css`.
closes #1693 
## Pull Request Description

This PR fixes a critical accessibility violation (WCAG 2.1 SC 2.3.3) for users with vestibular disorders or motion sensitivity. It adds `@media (prefers-reduced-motion: reduce)` blocks to 5 components that previously lacked them, pausing infinite animations and replacing transitions with static fallbacks when the OS "Reduce Motion" setting is enabled.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  - Bug fix in core components for accessibility compliance

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

*(Note: As this PR directly addresses an assigned accessibility bug in the core components, the standard submission checklist for new features does not strictly apply. See notes below.)*

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
Fixex #1693 
## Feature Description

**What does this add?**

Adds `prefers-reduced-motion` support to `loaders.css`, `tabs.css`, `navbar.css`, `scroll-progress.css`, and `badges.css`.

**How does a developer use it?**

```html
<!-- No code changes required for developers. The components will automatically adapt to the user's OS motion preferences. -->