### PR TITLE
fix: update github link to repository in demo page

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -555,7 +555,7 @@
           <a href="../docs/index.html" class="ease-btn ease-btn-primary ease-btn-hover ease-btn-lg ease-btn-pill">
             Read Docs
           </a>
-          <a href="https://github.com" class="ease-btn ease-btn-outline ease-btn-lg ease-btn-pill"
+          <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" class="ease-btn ease-btn-outline ease-btn-lg ease-btn-pill"
             style="border-color:var(--github-btn-border); color:var(--github-btn-color);">
             GitHub ↗
           </a>


### PR DESCRIPTION
### Description
This PR fixes the broken GitHub link located in the hero section of `examples/demo.html`. Previously, the button directed users to the `https://github.com` homepage. It has now been updated to point directly to the project's repository: `https://github.com/SAPTARSHI-coder/EaseMotion-css`.

### Related Issue
Fixes #1703

### Changes Made
- Updated the `href` attribute of the GitHub link in `examples/demo.html` to direct to the correct repository URL.

### Labels
Maintainers, please ensure the following labels are added to this PR:
- `gssoc:approved`
- `difficulty`
- `type`
- `quality`
