### PR TITLE
fix(ease-skew-lh): resolve animation locks and a11y issues

### DIFF
--- a/submissions/examples/ease-skew-lh/demo.html
+++ b/submissions/examples/ease-skew-lh/demo.html
@@ -90,6 +90,17 @@
         <span class="demo-code">.ease-skew-reverse-x-lh</span>
       </div>
 
+      <!-- Card 4.5: Skew Reverse Y -->
+      <div class="demo-card">
+        <div>
+          <span class="badge-interactive">Hover</span>
+          <h2 class="demo-card-title">Skew Reverse Y</h2>
+          <p class="demo-card-desc">Applies a negative vertical tilt, shifting the edge in the opposite direction.</p>
+        </div>
+        <div class="ease-skew-reverse-y-lh demo-box demo-box-alt">Rev Y</div>
+        <span class="demo-code">.ease-skew-reverse-y-lh</span>
+      </div>
+
       <!-- Card 5: Click / Active Modifier -->
       <div class="demo-card">
         <div>

--- a/submissions/examples/ease-skew-lh/style.css
+++ b/submissions/examples/ease-skew-lh/style.css
@@ -154,62 +154,50 @@ body {
 
 /* ── Interactive Skew Utilities ── */
 
-.ease-skew-x-lh {
+.ease-skew-x-lh,
+.ease-skew-y-lh,
+.ease-skew-xy-lh,
+.ease-skew-reverse-x-lh,
+.ease-skew-reverse-y-lh {
+  --e-skew-curr-x: 0deg;
+  --e-skew-curr-y: 0deg;
   transition: transform var(--ease-skew-speed) var(--ease-skew-timing);
   will-change: transform;
+  transform: skew(var(--e-skew-curr-x), var(--e-skew-curr-y));
 }
 
 .ease-skew-x-lh:hover,
 .ease-skew-x-lh:focus-visible {
-  transform: skewX(var(--ease-skew-x));
-}
-
-.ease-skew-y-lh {
-  transition: transform var(--ease-skew-speed) var(--ease-skew-timing);
-  will-change: transform;
+  --e-skew-curr-x: var(--ease-skew-x);
 }
 
 .ease-skew-y-lh:hover,
 .ease-skew-y-lh:focus-visible {
-  transform: skewY(var(--ease-skew-y));
-}
-
-.ease-skew-xy-lh {
-  transition: transform var(--ease-skew-speed) var(--ease-skew-timing);
-  will-change: transform;
+  --e-skew-curr-y: var(--ease-skew-y);
 }
 
 .ease-skew-xy-lh:hover,
 .ease-skew-xy-lh:focus-visible {
-  transform: skew(var(--ease-skew-x), var(--ease-skew-y));
+  --e-skew-curr-x: var(--ease-skew-x);
+  --e-skew-curr-y: var(--ease-skew-y);
 }
 
 /* ── Reversed Interactive Skew Utilities ── */
 
-.ease-skew-reverse-x-lh {
-  transition: transform var(--ease-skew-speed) var(--ease-skew-timing);
-  will-change: transform;
-}
-
 .ease-skew-reverse-x-lh:hover,
 .ease-skew-reverse-x-lh:focus-visible {
-  transform: skewX(calc(-1 * var(--ease-skew-x)));
-}
-
-.ease-skew-reverse-y-lh {
-  transition: transform var(--ease-skew-speed) var(--ease-skew-timing);
-  will-change: transform;
+  --e-skew-curr-x: calc(-1 * var(--ease-skew-x));
 }
 
 .ease-skew-reverse-y-lh:hover,
 .ease-skew-reverse-y-lh:focus-visible {
-  transform: skewY(calc(-1 * var(--ease-skew-y)));
+  --e-skew-curr-y: calc(-1 * var(--ease-skew-y));
 }
 
 /* ── Click / Active Animation Modifier ── */
 
 .ease-skew-active-lh:active {
-  transform: skew(calc(var(--ease-skew-x) * 1.5), calc(var(--ease-skew-y) * 1.5)) scale(0.95);
+  transform: skew(calc(var(--e-skew-curr-x, 0deg) * 1.5), calc(var(--e-skew-curr-y, 0deg) * 1.5)) scale(0.95);
   transition-duration: 0.1s;
 }
 
@@ -229,7 +217,7 @@ body {
 }
 
 .ease-skew-entrance-lh {
-  animation: ease-kf-skew-entrance-lh 0.75s var(--ease-skew-timing) both;
+  animation: ease-kf-skew-entrance-lh 0.75s var(--ease-skew-timing) backwards;
 }
 
 /* ── Looping Animation Utility ── */
@@ -267,7 +255,8 @@ body {
   .ease-skew-y-lh:hover,
   .ease-skew-xy-lh:hover,
   .ease-skew-reverse-x-lh:hover,
-  .ease-skew-reverse-y-lh:hover {
+  .ease-skew-reverse-y-lh:hover,
+  .ease-skew-active-lh:active {
     transform: none !important;
   }
   .ease-skew-entrance-lh,


### PR DESCRIPTION
## Pull Request Description

This PR fixes multiple edge cases reported in Issue #1709 regarding the `ease-skew-lh` utility, specifically resolving animation specificity locks, accessibility issues, and active state composability.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-skew-lh/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It refactors the `ease-skew-lh` CSS to use custom properties for cleaner active states, adds missing accessibility `prefers-reduced-motion` blocks, and fixes the entrance animation so it doesn't break hover interactions.

**How does a developer use it?**

```html
<!-- The usage remains identical, but now safely composes without locking bugs -->
<button class="ease-skew-entrance-lh ease-skew-xy-lh ease-skew-active-lh">Hover/Click Me</button>

---
```
## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Fixes #1709.

Key technical fixes implemented:

Changed animation-fill-mode: both to backwards on the entrance animation.
Refactored the transform utilities to use --e-skew-curr-x and --e-skew-curr-y so the active modifier scales cleanly instead of abruptly overriding X-only classes with Y-axis skews.
Added .ease-skew-active-lh:active to the prefers-reduced-motion block.
Added the missing .ease-skew-reverse-y-lh demo to demo.html.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
