### PR TITLE
fix: add descriptive alt text to images in masonry grid demo

### DIFF
--- a/submissions/examples/masonry-grid/demo.html
+++ b/submissions/examples/masonry-grid/demo.html
@@ -11,7 +11,7 @@
   <div class="ease-masonry-grid ease-masonry-grid--cols-3">
 
     <div class="ease-masonry-item">
-      <img src="https://picsum.photos/seed/a/400/300" alt="" loading="lazy" />
+      <img src="https://picsum.photos/seed/a/400/300" alt="Mountain Retreat" loading="lazy" />
       <div class="ease-masonry-item-body">
         <h3>Mountain Retreat</h3>
         <p>Peaceful escape in the hills with panoramic views.</p>
@@ -19,7 +19,7 @@
     </div>
 
     <div class="ease-masonry-item">
-      <img src="https://picsum.photos/seed/b/400/500" alt="" loading="lazy" />
+      <img src="https://picsum.photos/seed/b/400/500" alt="City Skyline" loading="lazy" />
       <div class="ease-masonry-item-body">
         <h3>City Skyline</h3>
         <p>Urban architecture at golden hour.</p>
@@ -27,7 +27,7 @@
     </div>
 
     <div class="ease-masonry-item">
-      <img src="https://picsum.photos/seed/c/400/250" alt="" loading="lazy" />
+      <img src="https://picsum.photos/seed/c/400/250" alt="Coastal Walk" loading="lazy" />
       <div class="ease-masonry-item-body">
         <h3>Coastal Walk</h3>
         <p>Stroll along the shoreline at sunset.</p>
@@ -35,7 +35,7 @@
     </div>
 
     <div class="ease-masonry-item">
-      <img src="https://picsum.photos/seed/d/600/280" alt="" loading="lazy" />
+      <img src="https://picsum.photos/seed/d/600/280" alt="Forest Canopy" loading="lazy" />
       <div class="ease-masonry-item-body">
         <h3>Forest Canopy</h3>
         <p>Lush greenery stretching as far as the eye can see.</p>
@@ -43,7 +43,7 @@
     </div>
 
     <div class="ease-masonry-item">
-      <img src="https://picsum.photos/seed/e/400/350" alt="" loading="lazy" />
+      <img src="https://picsum.photos/seed/e/400/350" alt="Desert Dunes" loading="lazy" />
       <div class="ease-masonry-item-body">
         <h3>Desert Dunes</h3>
         <p>Endless waves of sand under a blazing sun.</p>
@@ -51,7 +51,7 @@
     </div>
 
     <div class="ease-masonry-item">
-      <img src="https://picsum.photos/seed/f/400/200" alt="" loading="lazy" />
+      <img src="https://picsum.photos/seed/f/400/200" alt="Night Sky" loading="lazy" />
       <div class="ease-masonry-item-body">
         <h3>Night Sky</h3>
         <p>Stars scattered across a clear, dark canvas.</p>
@@ -59,7 +59,7 @@
     </div>
 
     <div class="ease-masonry-item">
-      <img src="https://picsum.photos/seed/g/400/550" alt="" loading="lazy" />
+      <img src="https://picsum.photos/seed/g/400/550" alt="Waterfall" loading="lazy" />
       <div class="ease-masonry-item-body">
         <h3>Waterfall</h3>
         <p>Cascading water cutting through ancient rock.</p>
@@ -67,7 +67,7 @@
     </div>
 
     <div class="ease-masonry-item">
-      <img src="https://picsum.photos/seed/h/400/280" alt="" loading="lazy" />
+      <img src="https://picsum.photos/seed/h/400/280" alt="Lavender Fields" loading="lazy" />
       <div class="ease-masonry-item-body">
         <h3>Lavender Fields</h3>
         <p>Purple rows stretching to the horizon.</p>
@@ -75,7 +75,7 @@
     </div>
 
     <div class="ease-masonry-item">
-      <img src="https://picsum.photos/seed/i/400/320" alt="" loading="lazy" />
+      <img src="https://picsum.photos/seed/i/400/320" alt="Snow Peaks" loading="lazy" />
       <div class="ease-masonry-item-body">
         <h3>Snow Peaks</h3>
         <p>Majestic mountains capped in eternal white.</p>


### PR DESCRIPTION
### Description
This PR resolves an accessibility issue in the `submissions/examples/masonry-grid/demo.html` example. Previously, all images within the masonry grid had empty `alt=""` attributes. Because these images are content-bearing and represent specific subjects like "Mountain Retreat" and "City Skyline", they should be properly described for screen readers.

Descriptive `alt` text has been added to each of the 9 images, corresponding to their respective titles, improving the overall accessibility and SEO of the demo.

### Related Issue
Fixes #1715

### Changes Made
- Added descriptive `alt` text to the `<img>` tags in `submissions/examples/masonry-grid/demo.html` to align with web accessibility standards.

### Labels
Maintainers, please ensure the following labels are added to this PR:
- `gssoc:approved`
- `difficulty`
- `type`
- `quality`
