### PR TITLE
fix: add missing ease-kf-shimmer-sweep keyframes to animations.css

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -290,6 +290,16 @@
   }
 }
 
+@keyframes ease-kf-shimmer-sweep {
+  0% {
+    background-position: -200% center;
+  }
+
+  100% {
+    background-position: 200% center;
+  }
+}
+
 @keyframes ease-kf-wave {
   0% {
     transform: translateX(0);


### PR DESCRIPTION
### Description
This PR resolves a CSS bug in `core/animations.css` where the `.ease-shimmer-sweep` class was referencing an undefined animation keyframe (`ease-kf-shimmer-sweep`). This resulted in the animation failing to play.

The missing `@keyframes` definition has been ported over and added to the file, ensuring the shimmer sweep effect works seamlessly.

### Related Issue
Fixes #<ISSUE_NUMBER> <!-- Please replace <ISSUE_NUMBER> with the actual issue number -->

### Changes Made
- Added `@keyframes ease-kf-shimmer-sweep` to `core/animations.css`.

### Labels
Maintainers, please ensure the following labels are added to this PR:
- `gssoc:approved`
- `difficulty`
- `type`
- `quality`
