### PR TITLE
fix: correct text color contrast for badge components

### DIFF
--- a/submissions/examples/ease-badge/style.css
+++ b/submissions/examples/ease-badge/style.css
@@ -28,24 +28,23 @@
 
 /* ── Color Variants ────────────────────────────────────────── */
 /* 
-   We explicitly use neutral-900 for text color on these bright backgrounds 
-   to guarantee WCAG AA 4.5:1 contrast compliance out-of-the-box, 
-   based on the findings from Issue #381. 
+   We use white (#ffffff) for primary, success, and danger backgrounds 
+   to guarantee WCAG AA 4.5:1 contrast compliance. Warning uses neutral-900.
 */
 
 .ease-badge-primary {
   background-color: var(--ease-color-primary);
-  color: var(--ease-color-neutral-900);
+  color: #ffffff;
 }
 
 .ease-badge-success {
   background-color: var(--ease-color-success);
-  color: var(--ease-color-neutral-900);
+  color: #ffffff;
 }
 
 .ease-badge-danger {
   background-color: var(--ease-color-danger);
-  color: var(--ease-color-neutral-900);
+  color: #ffffff;
 }
 
 .ease-badge-warning {


### PR DESCRIPTION
### Description
This PR resolves an accessibility bug within the `submissions/examples/ease-badge` component. Previously, the `primary`, `success`, and `danger` badges explicitly used `neutral-900` dark text on solid, saturated background colors (indigo, green, and red), resulting in a failure to meet the WCAG AA 4.5:1 contrast ratio.

The text color for these variants has been updated to `#ffffff`, and the corresponding comments have been corrected to reflect the accurate contrast logic. The `warning` variant continues to use dark text, as its yellow/orange background naturally provides appropriate contrast against dark text.

### Related Issue
Fixes #1728

### Changes Made
- Updated `color` in `.ease-badge-primary`, `.ease-badge-success`, and `.ease-badge-danger` to `#ffffff` in `submissions/examples/ease-badge/style.css`.
- Updated the rationale comments inside the file.

### Labels
Maintainers, please ensure the following labels are added to this PR:
- `gssoc:approved`
- `difficulty`
- `type`
- `quality`
