### PR TITLE
Animation: Expand Shadow Emphasis

### DIFF
--- a/submissions/examples/expand-shadow-emphasis/README.md
+++ b/submissions/examples/expand-shadow-emphasis/README.md
@@ -1,0 +1,23 @@
+# Animation: Expand Shadow Emphasis
+
+A shadow-expand emphasis animation for cards and interactive elements. On trigger, the shadow blooms outward with a slight lift and scale, then settles back — perfect for momentary emphasis on selection or focus.
+
+## Features
+
+- **Pure CSS** — `@keyframes ease-shadow-expand` with no JS dependency
+- **Multi-layered shadow** — expands with a colored glow matching the accent
+- **Accompanied lift** — slight `translateY(-4px)` and `scale(1.02)` for depth
+- **GPU-friendly** — animates `box-shadow`, `transform` together
+- **Color variants** — primary (purple), success (green), amber (yellow), rose (red)
+- **Reduced motion** — respects `prefers-reduced-motion`
+- **Cross-browser** — Chrome, Firefox, Safari, Edge
+
+## Usage
+
+```html
+<div class="shadow-card emphasis-active">
+  <!-- content -->
+</div>
+```
+
+Trigger the `.emphasis-active` class on click (or any event) to play the animation. The shadow expands, lifts, and settles back to rest.

--- a/submissions/examples/expand-shadow-emphasis/demo.html
+++ b/submissions/examples/expand-shadow-emphasis/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Expand Shadow Emphasis — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Expand Shadow Emphasis</h1>
+    <p class="subtitle">
+      Click any card to trigger a shadow-expand emphasis animation —<br />
+      the shadow blooms outward with a slight lift and scale.
+    </p>
+
+    <div class="card-grid">
+      <div class="shadow-card" tabindex="0" role="button" data-card="primary">
+        <span class="card-icon">&#9733;</span>
+        <span class="card-label">Primary</span>
+      </div>
+      <div class="shadow-card card-success" tabindex="0" role="button" data-card="success">
+        <span class="card-icon">&#10003;</span>
+        <span class="card-label">Success</span>
+      </div>
+      <div class="shadow-card card-amber" tabindex="0" role="button" data-card="amber">
+        <span class="card-icon">&#9888;</span>
+        <span class="card-label">Warning</span>
+      </div>
+      <div class="shadow-card card-rose" tabindex="0" role="button" data-card="rose">
+        <span class="card-icon">&hearts;</span>
+        <span class="card-label">Danger</span>
+      </div>
+    </div>
+
+    <button id="resetAll" class="reset-btn hidden">Reset All &crarr;</button>
+  </div>
+
+  <script>
+    const cards = document.querySelectorAll('.shadow-card');
+    const resetBtn = document.getElementById('resetAll');
+
+    cards.forEach(card => {
+      card.addEventListener('click', () => {
+        card.classList.add('emphasis-active');
+        setTimeout(() => {
+          resetBtn.classList.remove('hidden');
+        }, 500);
+      });
+    });
+
+    resetBtn.addEventListener('click', () => {
+      cards.forEach(c => c.classList.remove('emphasis-active'));
+      resetBtn.classList.add('hidden');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/expand-shadow-emphasis/style.css
+++ b/submissions/examples/expand-shadow-emphasis/style.css
@@ -1,0 +1,199 @@
+@import url('https://cdn.jsdelivr.net/npm/easemotion-css@latest/dist/easemotion.min.css');
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  background: #0f172a;
+  color: #f1f5f9;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.container {
+  text-align: center;
+  max-width: 720px;
+  padding: 32px;
+}
+
+h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 12px;
+}
+
+.subtitle {
+  color: rgba(241, 245, 249, 0.6);
+  margin-bottom: 48px;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.card-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.shadow-card {
+  width: 200px;
+  padding: 32px 24px;
+  background: linear-gradient(135deg, #1e293b, #334155);
+  border-radius: 16px;
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.2s ease;
+  box-shadow:
+    0 4px 6px rgba(0, 0, 0, 0.3),
+    0 1px 3px rgba(0, 0, 0, 0.2);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.shadow-card:hover {
+  transform: translateY(-2px);
+}
+
+.shadow-card:focus-visible {
+  outline: 2px solid #a78bfa;
+  outline-offset: 4px;
+}
+
+.shadow-card .card-icon {
+  font-size: 2rem;
+  margin-bottom: 12px;
+  display: block;
+}
+
+.shadow-card .card-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: rgba(241, 245, 249, 0.8);
+}
+
+.shadow-card.card-success .card-icon { color: #22c55e; }
+.shadow-card.card-amber .card-icon { color: #f59e0b; }
+.shadow-card.card-rose .card-icon { color: #f43f5e; }
+
+@keyframes ease-shadow-expand {
+  0% {
+    box-shadow:
+      0 4px 6px rgba(0, 0, 0, 0.3),
+      0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+  50% {
+    box-shadow:
+      0 20px 40px rgba(108, 99, 255, 0.35),
+      0 8px 16px rgba(108, 99, 255, 0.25);
+    transform: translateY(-4px) scale(1.02);
+  }
+  100% {
+    box-shadow:
+      0 4px 6px rgba(0, 0, 0, 0.3),
+      0 1px 3px rgba(0, 0, 0, 0.2);
+    transform: translateY(0) scale(1);
+  }
+}
+
+.shadow-card.emphasis-active {
+  animation: ease-shadow-expand 500ms cubic-bezier(0.25, 1, 0.5, 1) both;
+}
+
+.shadow-card.card-success.emphasis-active {
+  animation-name: ease-shadow-expand-success;
+}
+
+.shadow-card.card-amber.emphasis-active {
+  animation-name: ease-shadow-expand-amber;
+}
+
+.shadow-card.card-rose.emphasis-active {
+  animation-name: ease-shadow-expand-rose;
+}
+
+@keyframes ease-shadow-expand-success {
+  0% {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+  50% {
+    box-shadow: 0 20px 40px rgba(34, 197, 94, 0.35), 0 8px 16px rgba(34, 197, 94, 0.25);
+    transform: translateY(-4px) scale(1.02);
+  }
+  100% {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ease-shadow-expand-amber {
+  0% {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+  50% {
+    box-shadow: 0 20px 40px rgba(245, 158, 11, 0.35), 0 8px 16px rgba(245, 158, 11, 0.25);
+    transform: translateY(-4px) scale(1.02);
+  }
+  100% {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ease-shadow-expand-rose {
+  0% {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+  50% {
+    box-shadow: 0 20px 40px rgba(244, 63, 94, 0.35), 0 8px 16px rgba(244, 63, 94, 0.25);
+    transform: translateY(-4px) scale(1.02);
+  }
+  100% {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+    transform: translateY(0) scale(1);
+  }
+}
+
+.reset-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 20px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  font-family: inherit;
+  color: #a78bfa;
+  background-color: rgba(167, 139, 250, 0.1);
+  border: 1px solid rgba(167, 139, 250, 0.3);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, opacity 0.3s ease;
+}
+
+.reset-btn:hover {
+  background-color: rgba(167, 139, 250, 0.2);
+}
+
+.reset-btn.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shadow-card.emphasis-active {
+    animation: none;
+    box-shadow:
+      0 4px 6px rgba(0, 0, 0, 0.3),
+      0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+}


### PR DESCRIPTION
A shadow-expand emphasis animation for cards and interactive elements. On trigger, the shadow blooms outward with a slight lift and scale, then settles back — perfect for momentary emphasis on selection or focus.

**Features:**
- Pure CSS `@keyframes ease-shadow-expand` with no JS dependency
- Multi-layered shadow expands with a colored glow matching the accent
- Accompanied `translateY(-4px)` and `scale(1.02)` for depth
- GPU-friendly (box-shadow + transform)
- Four color variants via distinct keyframe sets
- Respects `prefers-reduced-motion`
- Demo with four interactive cards

Closes #68