### PR TITLE
fix: correct invalid font-weight unit in components showcase

### DIFF
--- a/submissions/examples/components-showcase/style.css
+++ b/submissions/examples/components-showcase/style.css
@@ -39,7 +39,7 @@ body {
     border: none;
     border-radius: 6px;
     cursor: pointer;
-    font-weight: 6px;
+    font-weight: 600;
 }
 
 .card {


### PR DESCRIPTION
### Description
This PR resolves a basic CSS syntax bug in the `submissions/examples/components-showcase` submission. 

In `style.css`, the `.btn` class had its `font-weight` incorrectly set using a pixel unit (`6px`), which is invalid CSS syntax and causes the browser to drop the rule entirely. I have corrected this typo to `font-weight: 600;` so the styling is valid and correctly renders the button text as semi-bold.

### Related Issue
Fixes #1769 

### Changes Made
- Corrected `font-weight: 6px;` to `font-weight: 600;` in `submissions/examples/components-showcase/style.css`.

### Labels
Maintainers, please ensure the following labels are added to this PR:
- `gssoc:approved`
- `difficulty`
- `type`
- `quality`
