### PR TITLE
fix: add missing percentage unit to mask-image gradient in cinema marquee

### DIFF
--- a/submissions/examples/ease-cinema-marquee/style.css
+++ b/submissions/examples/ease-cinema-marquee/style.css
@@ -64,7 +64,7 @@ body {
     transparent 0%,
     #000000 25%,
     #000000 75%,
-    transparent 100
+    transparent 100%
   );
   -webkit-mask-image: linear-gradient(
     to right,


### PR DESCRIPTION
### Description
This PR resolves a basic CSS syntax bug in the `submissions/examples/ease-cinema-marquee` component. 

In `style.css`, the `mask-image` property had a `linear-gradient` rule missing a `%` unit on its final color stop (`transparent 100` instead of `transparent 100%`). This invalid syntax breaks the mask effect on standard browsers. I have added the missing `%` unit to ensure the CSS is perfectly valid and the alpha mask renders correctly.

### Related Issue
Fixes #1771 

### Changes Made
- Added missing `%` to `transparent 100` in the `mask-image` property in `submissions/examples/ease-cinema-marquee/style.css`.

### Labels
Maintainers, please ensure the following labels are added to this PR:
- `gssoc:approved`
- `difficulty`
- `type`
- `quality`
