### PR TITLE
fix: fully disable animations for reduced motion users

### DIFF
--- a/submissions/prefers-reduced-motion/style.css
+++ b/submissions/prefers-reduced-motion/style.css
@@ -2,23 +2,20 @@
    Global Accessibility Override: Prefers Reduced Motion
    ========================================================================== */
 
-@media (prefers-reduced-motion: reduce) {
+  @media (prefers-reduced-motion: reduce) {
   *,
-  ::before,
-  ::after {
-    /* Fast-forward animations to their end state instantly */
-    animation-delay: -1ms !important;
-    animation-duration: 1ms !important;
-    animation-iteration-count: 1 !important;
-    
-    /* Prevent parallax background movement issues */
-    background-attachment: scroll !important;
-    
-    /* Disable smooth scrolling which can cause disorientation */
+  *::before,
+  *::after {
+    /* Completely disable motion */
+    animation: none !important;
+
+    /* Remove transitions */
+    transition: none !important;
+
+    /* Disable smooth scrolling */
     scroll-behavior: auto !important;
-    
-    /* Drop transitions immediately to zero */
-    transition-duration: 0s !important;
-    transition-delay: 0s !important;
+
+    /* Prevent parallax effects */
+    background-attachment: scroll !important;
   }
 }


### PR DESCRIPTION
## Summary

Replaces the current reduced-motion implementation that fast-forwards animations with a stricter implementation that completely disables animations and transitions.

## Changes

- Replaced animation duration override with `animation: none`
- Replaced transition duration override with `transition: none`
- Kept smooth scrolling disabled
- Kept parallax backgrounds disabled

## Why

The previous implementation still executed animations briefly by reducing their duration to 1ms. Users who enable `prefers-reduced-motion` expect motion to be removed entirely.

This update ensures keyframe animations and transitions are fully disabled, providing a more accessible experience.