### PR TITLE
fix: restore missing CSS styling for docs page (issue #1553)

### DIFF
--- a/submissions/examples/fix-missing-css-styling/README.md
+++ b/submissions/examples/fix-missing-css-styling/README.md
@@ -1,0 +1,77 @@
+# Fix: Missing CSS Styling — Issue #1553
+
+## What does this do?
+Fixes the EaseMotion CSS documentation website rendering without any styles.
+The site was displaying with default browser styling — no layout, no colors,
+no typography — making it completely unusable.
+
+## Root Cause
+The original `docs/index.html` loads stylesheets from jsDelivr CDN using
+SRI (Subresource Integrity) hashes:
+
+```html
+<link rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css"
+  integrity="sha384-u4alaiV9voo/7cfhvrlsJM1LxczXThaPZZd0qYJ9uU..."
+  crossorigin="anonymous" />
+```
+
+SRI works by computing the hash of the downloaded file and comparing it
+to the `integrity` value. If they don't match — the browser **blocks the
+file from loading entirely** with no visible error to the user.
+
+When the CDN package was updated, the file contents changed but the
+`integrity` hashes in `docs/index.html` were not updated. This caused
+every single CSS file to be silently blocked by the browser.
+
+## The Fix
+
+Remove the outdated `integrity` attributes from all CDN stylesheet links
+in `docs/index.html`:
+
+**Before (broken):**
+```html
+<link rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css"
+  integrity="sha384-u4alaiV9voo..."
+  crossorigin="anonymous" />
+```
+
+**After (fixed):**
+```html
+<link rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
+```
+
+Apply this to all 6 CDN stylesheet links in `docs/index.html` (lines 13–18).
+
+## How to integrate into docs/index.html
+
+Replace lines 13–18 in `docs/index.html` with:
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css" />
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `style.css` | Fallback CSS variables and base styles — ensures the page renders correctly even when the CDN is unavailable |
+| `demo.html` | Full working demo of the docs page with all styles loading correctly |
+| `README.md` | This file |
+
+## Tech Stack
+- HTML
+- CSS (CSS custom properties)
+- Vanilla JavaScript (theme toggle, scroll progress, copy buttons)
+
+## Preview
+Open `demo.html` directly in your browser — no server needed.
+The page should render with full layout, sidebar, typography, and working
+theme toggle (dark/light mode).

--- a/submissions/examples/fix-missing-css-styling/demo.html
+++ b/submissions/examples/fix-missing-css-styling/demo.html
@@ -1,0 +1,510 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Missing CSS Styling — Issue #1553 Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    :root {
+      --docs-sidebar-w:260px;
+      --docs-header-h:60px;
+      --page-bg:#0f0e17;
+      --page-text:#fffffe;
+      --page-text-muted:rgba(255,255,255,0.65);
+      --header-bg:rgba(15,14,23,0.95);
+      --border-color:rgba(255,255,255,0.07);
+      --card-bg:rgba(255,255,255,0.04);
+      --sidebar-bg:rgba(255,255,255,0.02);
+      --code-bg:rgba(255,255,255,0.04);
+      --code-border:rgba(255,255,255,0.08);
+      --nav-link-color:rgba(255,255,255,0.6);
+      --nav-link-active-bg:rgba(108,99,255,0.12);
+      --nav-link-active-text:#ffffff;
+      --heading-color:#ffffff;
+      --title-gradient-end:#a78bfa;
+    }
+    [data-theme="light"] {
+      --page-bg:#f8fafc;
+      --page-text:#0f172a;
+      --page-text-muted:#475569;
+      --header-bg:rgba(248,250,252,0.95);
+      --border-color:rgba(15,23,42,0.08);
+      --card-bg:#ffffff;
+      --sidebar-bg:rgba(15,23,42,0.02);
+      --code-bg:#f1f5f9;
+      --code-border:#e2e8f0;
+      --nav-link-color:#475569;
+      --nav-link-active-bg:rgba(108,99,255,0.1);
+      --nav-link-active-text:#6c63ff;
+      --heading-color:#0f172a;
+      --title-gradient-end:#4f46e5;
+    }
+    body{
+      background:var(--page-bg);
+      color:var(--page-text);
+      font-family:var(--ease-font-base, system-ui, sans-serif);
+      overflow-x:hidden;
+    }
+    .docs-header{
+      position:fixed; top:0; left:0; right:0;
+      height:var(--docs-header-h);
+      z-index:var(--ease-z-overlay, 100);
+      background:var(--header-bg);
+      backdrop-filter:blur(12px);
+      border-bottom:1px solid var(--border-color);
+      display:flex; align-items: center;
+      padding:0 1.5rem;
+      justify-content:space-between; gap: 1rem;
+    }
+    .docs-logo{
+      font-size:1.25rem; font-weight: 800;
+      background:linear-gradient(135deg, #6c63ff, #a78bfa);
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:transparent;
+      background-clip:text;
+      letter-spacing:-0.02em; text-decoration: none;
+    }
+    .docs-header-links{
+      display:flex; gap: 1.25rem; align-items: center;
+      list-style:none; padding: 0; margin: 0;
+    }
+    .docs-header-links a{
+      color:var(--nav-link-color);
+      font-size:0.875rem; font-weight: 500;
+      text-decoration:none;
+      transition:color 150ms ease;
+    }
+    .docs-header-links a:hover {color:var(--page-text);}
+    .theme-toggle-btn{
+      background:none; border: 1px solid var(--border-color);
+      color:var(--page-text); cursor: pointer;
+      display:flex; align-items: center; justify-content: center;
+      width:36px; height: 36px;
+      border-radius:9999px;
+      transition:background 150ms ease;
+    }
+    .theme-toggle-btn:hover{background: rgba(255,255,255,0.08);}
+    [data-theme="light"] .theme-toggle-btn:hover{background: rgba(15,23,42,0.08);}
+    [data-theme="light"] .sun-icon{display:none;}
+    [data-theme="light"] .moon-icon{display:block;}
+    :root:not([data-theme="light"]) .sun-icon{display:block;}
+    :root:not([data-theme="light"]) .moon-icon{display:none;}
+    .docs-shell {
+      display: flex; min-height: 100vh;
+      padding-top: var(--docs-header-h);
+    }
+    .docs-sidebar {
+      width:var(--docs-sidebar-w);
+      position:fixed; top: var(--docs-header-h);
+      left:0; bottom: 0; overflow-y: auto;
+      padding:2rem 1.25rem;
+      border-right:1px solid var(--border-color);
+      background:var(--sidebar-bg);
+    }
+    .sidebar-group{margin-bottom:1.5rem;}
+    .sidebar-group-label{
+      font-size:0.75rem; font-weight: 700;
+      text-transform:uppercase; letter-spacing: 0.1em;
+      color: #a78bfa;
+      margin-bottom:0.5rem; padding: 0 0.5rem;
+    }
+    .sidebar-nav {list-style:none;padding:0;margin:0;}
+    .sidebar-nav a{
+      display:block; padding: 0.5rem;
+      font-size:0.875rem; color: var(--nav-link-color);
+      border-radius:4px; text-decoration: none;
+      transition:color 150ms ease, background 150ms ease;
+    }
+    .sidebar-nav a:hover {color:var(--page-text);background: rgba(255,255,255,0.05);}
+    .sidebar-nav a.active{
+      color:var(--nav-link-active-text);
+      background:var(--nav-link-active-bg);
+      border-left:3px solid #6c63ff;
+    }
+    .docs-content{
+      margin-left:var(--docs-sidebar-w);
+      flex:1; padding: 3rem;
+      max-width:860px; min-width: 0;
+    }
+    .docs-section{margin-bottom:4rem;scroll-margin-top:80px;}
+    .docs-eyebrow{
+      font-size:0.75rem; font-weight: 700;
+      text-transform:uppercase; letter-spacing: 0.12em;
+      color: #a78bfa; margin-bottom: 0.5rem;
+    }
+    .docs-h1{
+      font-size:clamp(2rem, 4vw, 3rem); font-weight: 800;
+      letter-spacing:-0.04em;
+      background:linear-gradient(135deg, var(--heading-color), var(--title-gradient-end));
+      -webkit-background-clip:text; -webkit-text-fill-color: transparent;
+      background-clip:text; margin-bottom: 1rem;
+    }
+    .docs-h2{
+      font-size:1.5rem; font-weight: 700;
+      color:var(--heading-color); margin-bottom: 1rem;
+      padding-bottom:0.75rem;
+      border-bottom:1px solid var(--border-color);
+    }
+    .docs-h3{
+      font-size: 1.125rem; font-weight: 600;
+      color:var(--heading-color); margin-bottom: 0.75rem;
+    }
+    .docs-p{
+      color: var(--page-text-muted);
+      line-height:1.75; margin-bottom: 1rem;
+    }
+    .docs-content code{
+      background: rgba(108,99,255,0.12);
+      color: #a78bfa;
+      border:1px solid rgba(108,99,255,0.2);
+      padding:0.1em 0.45em;
+      border-radius:4px; font-size: 0.87em;
+    }
+    .docs-code{
+      background: var(--code-bg);
+      border:1px solid var(--code-border);
+      border-radius: 8px; padding: 1.25rem;
+      margin-bottom:1.5rem; overflow-x: auto;
+      position:relative;
+    }
+    .docs-code pre{
+      background:none; color: var(--page-text);
+      padding:0; margin: 0;
+      font-size:0.875rem; line-height: 1.7;
+    }
+    .docs-code pre code{
+      background:none; border: none;
+      color:inherit; padding: 0; font-size: inherit;
+    }
+    .docs-code-lang{
+      position:absolute; top: 0.75rem; right: 1rem;
+      font-size:10px; font-weight: 700;
+      text-transform:uppercase; letter-spacing: 0.08em;
+      color:var(--page-text-muted); opacity: 0.5;
+    }
+    .docs-table{
+      width:100%; border-collapse: collapse;
+      font-size: 0.875rem; margin-bottom: 2rem;
+    }
+    .docs-table th{
+      text-align: left; padding: 0.75rem 1rem;
+      background: var(--code-bg); color: var(--page-text-muted);
+      font-weight:600; font-size: 0.75rem;
+      text-transform: uppercase; letter-spacing: 0.07em;
+      border-bottom:1px solid var(--border-color);
+    }
+    .docs-table td{
+      padding: 0.75rem 1rem;
+      border-bottom:1px solid var(--border-color);
+      color:var(--page-text-muted);
+      vertical-align: middle;
+    }
+    .docs-info{
+      background: rgba(108,99,255,0.08);
+      border:1px solid rgba(108,99,255,0.25);
+      border-radius:8px; padding: 1rem 1.25rem;
+      color:var(--page-text-muted);
+      font-size:0.875rem; line-height: 1.7;
+      margin-bottom:1.5rem;
+      display:flex; gap: 0.75rem;
+    }
+    .docs-divider {
+      border:none;
+      border-top:1px solid var(--border-color);
+      margin:2.5rem 0;
+    }
+    .docs-badge {
+      display:inline-block; padding: 0.15em 0.65em;
+      border-radius:9999px; font-size: 0.75rem; font-weight: 700;
+      background:rgba(108,99,255,0.15);
+      color:#a78bfa;
+      border:1px solid rgba(108,99,255,0.25);
+      margin-right:0.25rem;
+    }
+    .copy-class-btn{
+      display:inline-flex; align-items: center; gap: 4px;
+      padding:3px 10px; margin-left: 8px;
+      border-radius:4px; border: 1px solid rgba(108,99,255,0.4);
+      background:rgba(108,99,255,0.08); color: rgba(108,99,255,0.9);
+      font-size:11px; font-family: var(--ease-font-mono, monospace);
+      font-weight:500; white-space: nowrap;
+      cursor:pointer; user-select: none;
+      transition:background 0.15s ease, border-color 0.15s ease,
+                  color 0.15s ease, transform 0.1s ease;
+    }
+    .copy-class-btn:hover{
+      background:rgba(108,99,255,0.18);
+      border-color:rgba(108,99,255,0.7);
+      color:#6c63ff; transform: translateY(-1px);
+    }
+    .copy-class-btn.copied{
+      background:rgba(34,197,94,0.12);
+      border-color:rgba(34,197,94,0.5);
+      color:#22c55e;
+    }
+    .fix-banner{
+      background:rgba(34,197,94,0.08);
+      border:1px solid rgba(34,197,94,0.3);
+      border-radius:8px; padding: 1rem 1.25rem;
+      margin-bottom:1.5rem;
+      display:flex; gap: 0.75rem; align-items: flex-start;
+      font-size:0.875rem; color: var(--page-text-muted);
+    }
+    .fix-banner strong{color:#22c55e; }
+    @media (max-width:900px){
+      .docs-sidebar{position: static; width: 100%; border-right: 0; border-bottom: 1px solid var(--border-color); }
+      .docs-content{margin-left: 0; max-width: none; padding: 2rem 1rem; }
+      .docs-shell {flex-direction: column; padding-top: 0; }
+      .docs-header {position: sticky; }
+    }
+  </style>
+</head>
+<body>
+  <div class="ease-scroll-progress" id="scrollProgress"></div>
+  <header class="docs-header">
+    <a href="#" class="docs-logo">EaseMotion CSS</a>
+    <ul class="docs-header-links">
+      <li><a href="#getting-started">Getting Started</a></li>
+      <li><a href="#the-fix">The Fix</a></li>
+      <li><a href="#animations">Animations</a></li>
+      <li>
+        <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
+          <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none">
+            <circle cx="12" cy="12" r="5"></circle>
+            <line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+            <line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line>
+          </svg>
+          <svg class="moon-icon" viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+          </svg>
+        </button>
+      </li>
+    </ul>
+  </header>
+  <div class="docs-shell">
+    <aside class="docs-sidebar">
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Introduction</div>
+        <ul class="sidebar-nav">
+          <li><a href="#getting-started" class="active">Getting Started</a></li>
+          <li><a href="#the-fix">The Fix (#1553)</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Core</div>
+        <ul class="sidebar-nav">
+          <li><a href="#variables">Variables</a></li>
+          <li><a href="#animations">Animations</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Components</div>
+        <ul class="sidebar-nav">
+          <li><a href="#buttons">Buttons</a></li>
+        </ul>
+      </div>
+    </aside>
+    <main class="docs-content">
+      <section id="getting-started" class="docs-section ease-fade-in">
+        <div class="docs-eyebrow">Introduction</div>
+        <h1 class="docs-h1">EaseMotion CSS</h1>
+        <p class="docs-p">
+          EaseMotion CSS is a human-readable, animation-first CSS library.
+          Write UI with simple, English-like class names — no memorizing utilities,
+          no complex configuration.
+        </p>
+        <div class="docs-info">
+          <span>💡</span>
+          <div>
+            EaseMotion CSS bridges the gap between raw vanilla CSS and utility-heavy
+            frameworks like Tailwind. You get structure and power, with none of the
+            cognitive overhead.
+          </div>
+        </div>
+      </section>
+      <hr class="docs-divider" />
+      <section id="the-fix" class="docs-section">
+        <h2 class="docs-h2">Issue #1553 — The Fix</h2>
+        <div class="fix-banner">
+          <span>✅</span>
+          <div>
+            <strong>Root cause identified and fixed.</strong>
+            The docs page was loading with no styles because outdated
+            <code>integrity</code> hashes were blocking all CDN stylesheets.
+          </div>
+        </div>
+        <h3 class="docs-h3">What was broken</h3>
+        <p class="docs-p">
+          The original <code>docs/index.html</code> used SRI (Subresource Integrity)
+          hashes on CDN stylesheet links. When the CDN package was updated, the
+          file hashes changed — but the <code>integrity</code> values in the HTML
+          were not updated. The browser detected the mismatch and blocked every
+          stylesheet from loading.
+        </p>
+        <h3 class="docs-h3">Broken code (before)</h3>
+        <div class="docs-code">
+          <span class="docs-code-lang">html</span>
+          <pre><code>&lt;!-- ❌ BROKEN: outdated integrity hash blocks the file --&gt;
+&lt;link rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css"
+  integrity="sha384-u4alaiV9voo/7cfhvrlsJM1LxczXThaPZZd0qYJ9uU..."
+  crossorigin="anonymous" /&gt;</code></pre>
+        </div>
+        <h3 class="docs-h3">Fixed code (after)</h3>
+        <div class="docs-code">
+          <span class="docs-code-lang">html</span>
+          <pre><code>&lt;!-- ✅ FIXED: remove outdated integrity hashes --&gt;
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" /&gt;
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" /&gt;
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" /&gt;
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" /&gt;
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" /&gt;
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/cards.css" /&gt;</code></pre>
+        </div>
+        <div class="docs-info">
+          <span>⚠️</span>
+          <div>
+            The <code>style.css</code> in this submission also provides all CSS variables
+            as a fallback — so the page still renders correctly even when the CDN is
+            unavailable or slow to load.
+          </div>
+        </div>
+      </section>
+      <hr class="docs-divider" />
+      <section id="variables" class="docs-section">
+        <h2 class="docs-h2">Variables</h2>
+        <p class="docs-p">All values are defined as CSS custom properties. Override any token to theme the framework.</p>
+        <table class="docs-table">
+          <thead>
+            <tr>
+              <th>Variable</th>
+              <th>Default</th>
+              <th>What it controls</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>--ease-color-primary</code> <button class="copy-class-btn">Copy</button></td>
+              <td>#6c63ff</td>
+              <td>Primary brand color</td>
+            </tr>
+            <tr>
+              <td><code>--ease-speed-fast</code> <button class="copy-class-btn">Copy</button></td>
+              <td>150ms</td>
+              <td>Hover and quick transitions</td>
+            </tr>
+            <tr>
+              <td><code>--ease-speed-medium</code> <button class="copy-class-btn">Copy</button></td>
+              <td>300ms</td>
+              <td>Default animation timing</td>
+            </tr>
+            <tr>
+              <td><code>--ease-radius-md</code> <button class="copy-class-btn">Copy</button></td>
+              <td>8px</td>
+              <td>Default border radius</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <hr class="docs-divider" />
+      <section id="animations" class="docs-section">
+        <h2 class="docs-h2">Animations</h2>
+        <p class="docs-p">Add animation classes directly to any HTML element.</p>
+        <table class="docs-table">
+          <thead>
+            <tr><th>Class</th><th>Effect</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>ease-fade-in</code> <button class="copy-class-btn">Copy Class</button></td>
+              <td>Fades element from 0 → 1 opacity</td>
+            </tr>
+            <tr>
+              <td><code>ease-slide-up</code> <button class="copy-class-btn">Copy Class</button></td>
+              <td>Slides element up while fading in</td>
+            </tr>
+            <tr>
+              <td><code>ease-zoom-in</code> <button class="copy-class-btn">Copy Class</button></td>
+              <td>Scales from 85% with elastic ease</td>
+            </tr>
+            <tr>
+              <td><code>ease-bounce</code> <button class="copy-class-btn">Copy Class</button></td>
+              <td>Repeating vertical bounce</td>
+            </tr>
+            <tr>
+              <td><code>ease-pulse</code> <button class="copy-class-btn">Copy Class</button></td>
+              <td>Gentle scale pulse</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <hr class="docs-divider" />
+      <section id="buttons" class="docs-section">
+        <h2 class="docs-h2">Buttons</h2>
+        <p class="docs-p">Ready-to-use button components with variants and sizes.</p>
+        <div style="display:flex; gap:12px; flex-wrap:wrap; margin-bottom:1.5rem;">
+          <button class="ease-btn ease-btn-primary">Primary</button>
+          <button class="ease-btn ease-btn-primary ease-btn-sm">Small</button>
+          <button class="ease-btn ease-btn-primary ease-btn-pill">Pill Button</button>
+        </div>
+        <div class="docs-code">
+          <span class="docs-code-lang">html</span>
+          <pre><code>&lt;button class="ease-btn ease-btn-primary"&gt;Primary&lt;/button&gt;
+&lt;button class="ease-btn ease-btn-primary ease-btn-sm"&gt;Small&lt;/button&gt;
+&lt;button class="ease-btn ease-btn-primary ease-btn-pill"&gt;Pill&lt;/button&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </div>
+  <script>
+    const themeBtn = document.getElementById('theme-toggle');
+    themeBtn.addEventListener('click', () => {
+      const isLight = document.documentElement.getAttribute('data-theme') === 'light';
+      document.documentElement.setAttribute('data-theme', isLight ? '' : 'light');
+      localStorage.setItem('theme', isLight ? '' : 'light');
+    });
+    const saved = localStorage.getItem('theme');
+    if (saved === 'light') document.documentElement.setAttribute('data-theme', 'light');
+    const bar = document.getElementById('scrollProgress');
+    window.addEventListener('scroll', () => {
+      const pct = window.scrollY / (document.body.scrollHeight - window.innerHeight) * 100;
+      bar.style.width = pct + '%';
+    });
+    async function copyToClipboard(text) {
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(text);
+        } else {
+          const ta = document.createElement('textarea');
+          ta.value = text;
+          ta.style.cssText = 'position:fixed;top:-9999px;opacity:0';
+          document.body.appendChild(ta);
+          ta.select();
+          document.execCommand('copy');
+          document.body.removeChild(ta);
+        }
+        return true;
+      } catch { return false; }
+    }
+    document.querySelectorAll('.copy-class-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const className=btn.parentElement.querySelector('code').textContent.trim();
+        const ok =await copyToClipboard(className);
+        if(!ok)return;
+        const orig=btn.textContent;
+        btn.textContent='✓ Copied!';
+        btn.classList.add('copied');
+        setTimeout(()=>{btn.textContent=orig;btn.classList.remove('copied');},2000);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/fix-missing-css-styling/style.css
+++ b/submissions/examples/fix-missing-css-styling/style.css
@@ -1,0 +1,139 @@
+:root {
+  --ease-color-primary:#6c63ff;
+  --ease-color-primary-light:#a78bfa;
+  --ease-color-bg:#0f0e17;
+  --ease-color-surface:#1e1b29;
+  --ease-color-text:#fffffe;
+  --ease-color-muted:rgba(255, 255, 255, 0.65);
+  --ease-font-base:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --ease-font-mono:'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  --ease-text-xs:0.75rem;
+  --ease-text-sm:0.875rem;
+  --ease-text-base:1rem;
+  --ease-text-lg:1.125rem;
+  --ease-text-xl:1.25rem;
+  --ease-text-2xl:1.5rem;
+  --ease-text-3xl:1.875rem;
+  --ease-space-1:0.25rem;
+  --ease-space-2:0.5rem;
+  --ease-space-3:0.75rem;
+  --ease-space-4:1rem;
+  --ease-space-5:1.25rem;
+  --ease-space-6:1.5rem;
+  --ease-space-8:2rem;
+  --ease-space-10:2.5rem;
+  --ease-space-12:3rem;
+  --ease-space-16:4rem;
+  --ease-radius-sm:4px;
+  --ease-radius-md:8px;
+  --ease-radius-lg:12px;
+  --ease-radius-full:9999px;
+  --ease-speed-fast:150ms;
+  --ease-speed-medium:300ms;
+  --ease-ease:cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-z-overlay:100;
+  --docs-sidebar-w:260px;
+  --docs-header-h:60px;
+  --page-bg:#0f0e17;
+  --page-text:#fffffe;
+  --page-text-muted:rgba(255, 255, 255, 0.65);
+  --header-bg:rgba(15, 14, 23, 0.95);
+  --border-color:rgba(255, 255, 255, 0.07);
+  --card-bg:rgba(255, 255, 255, 0.04);
+  --sidebar-bg:rgba(255, 255, 255, 0.02);
+  --code-bg:rgba(255, 255, 255, 0.04);
+  --code-border:rgba(255, 255, 255, 0.08);
+  --table-row-hover:rgba(255, 255, 255, 0.02);
+  --nav-link-color:rgba(255, 255, 255, 0.6);
+  --nav-link-active-bg:rgba(108, 99, 255, 0.12);
+  --nav-link-active-text:#ffffff;
+  --heading-color:#ffffff;
+  --heading-sub-color:rgba(255, 255, 255, 0.9);
+  --title-gradient-end:#a78bfa;
+}
+[data-theme="light"]{
+  --page-bg:#f8fafc;
+  --page-text:#0f172a;
+  --page-text-muted:#475569;
+  --header-bg:rgba(248, 250, 252, 0.95);
+  --border-color:rgba(15, 23, 42, 0.08);
+  --card-bg:#ffffff;
+  --sidebar-bg:rgba(15, 23, 42, 0.02);
+  --code-bg:#f1f5f9;
+  --code-border:#e2e8f0;
+  --table-row-hover:rgba(15, 23, 42, 0.02);
+  --nav-link-color:#475569;
+  --nav-link-active-bg:rgba(108, 99, 255, 0.1);
+  --nav-link-active-text:#6c63ff;
+  --heading-color:#0f172a;
+  --heading-sub-color:#1e293b;
+  --title-gradient-end:#4f46e5;
+  --ease-color-bg:#f8fafc;
+  --ease-color-surface:#ffffff;
+  --ease-color-text:#0f172a;
+  --ease-color-muted:#475569;
+}
+*, *::before, *::after {
+  box-sizing:border-box;
+  margin:0;
+  padding:0;
+}
+html{scroll-behavior:smooth;}
+body{
+  font-family:var(--ease-font-base);
+  font-size:var(--ease-text-base);
+  line-height:1.6;
+  background:var(--page-bg);
+  color:var(--page-text);
+  overflow-x:hidden;
+  -webkit-font-smoothing:antialiased;
+}
+a{color:inherit; text-decoration:none;}
+button{font-family:inherit;}
+code,pre{font-family:var(--ease-font-mono);}
+.ease-btn{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:var(--ease-space-2);
+  padding:var(--ease-space-2) var(--ease-space-5);
+  font-size:var(--ease-text-sm);
+  font-weight:600;
+  border-radius:var(--ease-radius-md);
+  border:1px solid transparent;
+  cursor:pointer;
+  transition:all var(--ease-speed-fast) var(--ease-ease);
+  text-decoration:none;
+  line-height:1.5;
+}
+.ease-btn-primary{
+  background:var(--ease-color-primary);
+  color:#ffffff;
+  border-color:var(--ease-color-primary);
+}
+.ease-btn-primary:hover{
+  background:#5a52e0;
+  border-color:#5a52e0;
+  transform:translateY(-1px);
+}
+.ease-btn-sm{
+  padding:var(--ease-space-1) var(--ease-space-3);
+  font-size:var(--ease-text-xs);
+}
+.ease-btn-pill{
+  border-radius:var(--ease-radius-full);
+}
+.ease-hover-grow{
+  transition:transform var(--ease-speed-fast) var(--ease-ease);
+}
+.ease-hover-grow:hover {transform: scale(1.05);}
+.ease-scroll-progress{
+  position:fixed;
+  top:0;
+  left:0;
+  height:3px;
+  background:linear-gradient(90deg, #6c63ff, #a78bfa);
+  z-index:9999;
+  width:0%;
+  transition:width 0.1s linear;
+}


### PR DESCRIPTION
## Pull Request Description

Fixes the documentation website rendering without CSS styles (Issue #1553).

Root cause: The integrity (SRI) hashes on CDN stylesheet links in docs/index.html were outdated. When the CDN package updated, the hashes no longer matched — so the browser silently blocked all 6 stylesheets.

Fix: Remove the outdated integrity attributes from all CDN links. The style.css also provides fallback CSS variables so the page renders correctly even when CDN is unavailable.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/fix-missing-css-styling/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**
Restores full CSS styling to the EaseMotion CSS documentation page by removing outdated SRI integrity hashes that were blocking all CDN stylesheets.

**How does a developer use it?**
Replace the broken CDN links in docs/index.html with these:

<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" />
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/utilities.css" />

**Why does it fit EaseMotion CSS?**
A properly styled documentation website is essential for showcasing the framework. Without it, users cannot understand or adopt EaseMotion CSS.

---

## Demo
- [x] Demo added (demo.html works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Edge

---

## Notes for Maintainer
The fix is in docs/index.html lines 13–18. Remove the integrity="sha384-..." and crossorigin="anonymous" attributes from all 6 CDN stylesheet link tags. The style.css in this submission provides fallback CSS variables as a safety net when CDN is slow or unavailable.

Fixes #1553