### PR TITLE
Fix/reduced motion disable transitions

### DIFF
--- a/submissions/prefers-reduced-motion/style.css
+++ b/submissions/prefers-reduced-motion/style.css
@@ -2,23 +2,20 @@
    Global Accessibility Override: Prefers Reduced Motion
    ========================================================================== */
 
-@media (prefers-reduced-motion: reduce) {
+  @media (prefers-reduced-motion: reduce) {
   *,
-  ::before,
-  ::after {
-    /* Fast-forward animations to their end state instantly */
-    animation-delay: -1ms !important;
-    animation-duration: 1ms !important;
-    animation-iteration-count: 1 !important;
-    
-    /* Prevent parallax background movement issues */
-    background-attachment: scroll !important;
-    
-    /* Disable smooth scrolling which can cause disorientation */
+  *::before,
+  *::after {
+    /* Completely disable motion */
+    animation: none !important;
+
+    /* Remove transitions */
+    transition: none !important;
+
+    /* Disable smooth scrolling */
     scroll-behavior: auto !important;
-    
-    /* Drop transitions immediately to zero */
-    transition-duration: 0s !important;
-    transition-delay: 0s !important;
+
+    /* Prevent parallax effects */
+    background-attachment: scroll !important;
   }
 }

--- a/submissions/prefers-reduced-motion/style.css
+++ b/submissions/prefers-reduced-motion/style.css
@@ -7,7 +7,9 @@
   *::before,
   *::after {
     /* Completely disable motion */
-    animation: none !important;
+    animation-delay: -1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
 
     /* Remove transitions */
     transition: none !important;


### PR DESCRIPTION
## Summary

Replace transition duration and delay overrides with a complete transition reset for users who prefer reduced motion.

## Changes

- Removed:
  - `transition-duration: 0s !important`
  - `transition-delay: 0s !important`

- Added:
  - `transition: none !important`

## Why

Setting transition duration to zero does not fully disable transition behavior. The transition system can still be invoked even though the animation occurs instantly.

Using `transition: none` completely removes transition effects and better aligns with accessibility expectations for `prefers-reduced-motion`.