### PR TITLE
fix: .ease-border-primary is a no-op — replace border-color with full border shorthand (fixes #1797)

### DIFF
--- a/submissions/examples/fix-border-primary-utility/README.md
+++ b/submissions/examples/fix-border-primary-utility/README.md
@@ -1,0 +1,54 @@
+# Fix: .ease-border-primary Utility
+
+### What does this do?
+
+Demonstrates and documents the bug in `.ease-border-primary` where the class silently
+has no visual effect when used on its own, and provides the exact one-line fix for the
+maintainer to apply to `core/utilities.css`.
+
+### The problem
+
+`core/utilities.css` line 238 currently reads:
+
+```css
+.ease-border-primary { border-color: var(--ease-color-primary); }
+```
+
+`border-color` has no visual effect unless `border-style` is also set (it defaults to
+`none`). So `<div class="ease-border-primary">` renders with no visible border at all.
+The class is a silent no-op when used standalone, unlike every other `.ease-border-*`
+modifier in the file.
+
+### The fix (maintainer action on `core/utilities.css`)
+
+```css
+/* BEFORE — line 238 of core/utilities.css */
+.ease-border-primary { border-color: var(--ease-color-primary); }
+
+/* AFTER — replace with the full shorthand */
+.ease-border-primary { border: 1px solid var(--ease-color-primary); }
+```
+
+This makes `.ease-border-primary` consistent with `.ease-border` and `.ease-border-2`,
+which both use the full shorthand. No other classes are affected.
+
+### How is it used?
+
+After the fix, developers can use `.ease-border-primary` standalone:
+
+```html
+<!-- Works after fix — renders a 1px solid primary-color border -->
+<div class="ease-border-primary ease-rounded ease-padding-4">
+  Card with primary border
+</div>
+
+<!-- Composable with size modifier -->
+<input class="ease-border-primary ease-rounded" type="text" placeholder="Primary border input">
+```
+
+### Why is it useful?
+
+`.ease-border-primary` is a natural pairing with `.ease-text-primary` and
+`.ease-bg-primary`. Any developer reaching for a semantic primary-color border will
+try this class first and see nothing, then wonder if the framework is broken. Making it
+self-contained is a correctness fix with zero risk of regression.

--- a/submissions/examples/fix-border-primary-utility/demo.html
+++ b/submissions/examples/fix-border-primary-utility/demo.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>.ease-border-primary Fix — Issue #1797</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem;
+      max-width: 680px;
+      margin: 0 auto;
+      line-height: 1.6;
+    }
+
+    h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 0.25rem; }
+    h2 { font-size: 1rem; font-weight: 500; color: #64748b; margin-bottom: 2rem; }
+    h3 { font-size: 0.875rem; font-weight: 700; text-transform: uppercase;
+         letter-spacing: 0.06em; color: #94a3b8; margin-bottom: 0.75rem; }
+
+    section { margin-bottom: 2rem; }
+
+    code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.82rem;
+      background: #f1f5f9;
+      color: #4b44cc;
+      padding: 0.15em 0.45em;
+      border-radius: 0.25rem;
+    }
+
+    pre {
+      background: #0f172a;
+      color: #f1f5f9;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.82rem;
+      line-height: 1.7;
+      padding: 1.25rem;
+      border-radius: 0.5rem;
+      overflow-x: auto;
+      margin-bottom: 1rem;
+    }
+
+    .del { color: #f87171; }
+    .ins { color: #86efac; }
+
+    /* Simulate current broken utility */
+    .ease-border-primary-broken { border-color: #6c63ff; }
+
+    /* The fixed utility */
+    .ease-border-primary-fixed  { border: 1px solid #6c63ff; }
+
+    /* Shared card look */
+    .card {
+      padding: 1rem 1.5rem;
+      border-radius: 0.5rem;
+      background: #fff;
+      margin-bottom: 0.75rem;
+    }
+
+    .annotation {
+      font-size: 0.75rem;
+      color: #94a3b8;
+      margin-top: 0.25rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>.ease-border-primary Fix</h1>
+  <h2>Issue #1797 — silent no-op when used standalone</h2>
+
+  <!-- ── SIDE BY SIDE DEMO ── -->
+  <section>
+    <h3>Live comparison</h3>
+
+    <!-- Broken -->
+    <div class="card ease-border-primary-broken">
+      <span class="label label-bug">❌ Current (broken)</span>
+      <p><code>class="ease-border-primary"</code></p>
+      <p class="annotation">No border visible — <code>border-color</code> alone has no effect when <code>border-style</code> is <code>none</code> (the default).</p>
+    </div>
+
+    <!-- Fixed -->
+    <div class="card ease-border-primary-fixed">
+      <span class="label label-fix">✅ After fix</span>
+      <p><code>class="ease-border-primary"</code></p>
+      <p class="annotation">1px solid primary-color border — self-contained, no companion class needed.</p>
+    </div>
+  </section>
+
+  <!-- ── ROOT CAUSE ── -->
+  <section>
+    <h3>Root cause — core/utilities.css line 238</h3>
+    <pre><span class="del">/* CURRENT — broken */
+.ease-border-primary { border-color: var(--ease-color-primary); }</span>
+
+<span class="ins">/* FIXED — use full shorthand */
+.ease-border-primary { border: 1px solid var(--ease-color-primary); }</span></pre>
+    <p style="font-size:0.875rem; color:#475569;">
+      Compare with <code>.ease-border</code> (line 236) which correctly uses
+      <code>border: 1px solid …</code>. The fix makes both consistent.
+    </p>
+  </section>
+
+  <!-- ── USAGE AFTER FIX ── -->
+  <section>
+    <h3>Usage after fix</h3>
+    <pre>&lt;!-- Standalone — works without a companion .ease-border class --&gt;
+&lt;div class="ease-border-primary ease-rounded ease-padding-4"&gt;
+  Primary bordered card
+&lt;/div&gt;
+
+&lt;!-- Composable with other utilities --&gt;
+&lt;input class="ease-border-primary ease-rounded" type="text"&gt;</pre>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/fix-border-primary-utility/style.css
+++ b/submissions/examples/fix-border-primary-utility/style.css
@@ -1,0 +1,53 @@
+/*
+  Fix: .ease-border-primary utility
+  ───────────────────────────────────
+  Maintainer action: in core/utilities.css, replace line 238:
+
+  BEFORE:
+    .ease-border-primary { border-color: var(--ease-color-primary); }
+
+  AFTER:
+    .ease-border-primary { border: 1px solid var(--ease-color-primary); }
+
+  The demo below uses local class names to show the broken vs fixed behaviour.
+  No other utility classes need changing.
+*/
+
+/* ── Broken behaviour (current core) ───────────────────────── */
+.broken-border-primary {
+  /* Only border-color — has zero visual effect (border-style defaults to none) */
+  border-color: #6c63ff;
+}
+
+/* ── Fixed behaviour ────────────────────────────────────────── */
+.fixed-border-primary {
+  border: 1px solid #6c63ff;
+}
+
+/* ── Demo layout helpers ────────────────────────────────────── */
+.demo-box {
+  padding: 1rem 1.5rem;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #1e293b;
+  margin-bottom: 1rem;
+}
+
+.demo-box + .demo-box {
+  margin-top: 0;
+}
+
+.label {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.2em 0.5em;
+  border-radius: 9999px;
+  margin-bottom: 0.5rem;
+}
+
+.label-bug  { background: #fef2f2; color: #b91c1c; border: 1px solid #fca5a5; }
+.label-fix  { background: #f0fdf4; color: #15803d; border: 1px solid #86efac; }


### PR DESCRIPTION
## Pull Request Description

`.ease-border-primary` in `core/utilities.css` only sets `border-color`, which has no visual effect because `border-style` defaults to `none`. Any developer using `class="ease-border-primary"` standalone sees nothing. This submission demonstrates the bug with a live comparison and documents the exact one-line fix for the maintainer to apply.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/fix-border-primary-utility/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS showing broken vs fixed behaviour
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

`core/utilities.css` line 238:
```css
/* CURRENT — broken, silent no-op */
.ease-border-primary { border-color: var(--ease-color-primary); }

/* FIXED — full shorthand, self-contained */
.ease-border-primary { border: 1px solid var(--ease-color-primary); }
```

**How does a developer use it after the fix?**

```html
<!-- No companion class needed -->
<div class="ease-border-primary ease-rounded ease-padding-4">
  Primary bordered card
</div>
```

**Why does it fit EaseMotion CSS?**

`.ease-border`, `.ease-border-2`, and `.ease-border-primary` are all part of the same border utility group. The first two correctly use the full `border` shorthand; the third does not. This fix makes the set internally consistent and eliminates a confusing silent failure.

---

## Demo

- [x] Demo added — `demo.html` shows the broken (invisible) border vs the fixed (visible) border side-by-side, with the exact diff for `core/utilities.css`

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Single-line change in `core/utilities.css` line 238. No other classes are affected. Zero risk of regression — the fix only makes an existing class work as documented/expected.

Closes #1797

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.