### PR TITLE
fix: guard scroll-behavior: smooth with prefers-reduced-motion in base.css (fixes #1798)

### DIFF
--- a/submissions/examples/scroll-behavior-reduced-motion/README.md
+++ b/submissions/examples/scroll-behavior-reduced-motion/README.md
@@ -1,0 +1,57 @@
+# Fix: scroll-behavior Reduced Motion Guard
+
+### What does this do?
+
+Documents and demonstrates the missing `prefers-reduced-motion` guard around
+`scroll-behavior: smooth` in `core/base.css`, and provides the exact replacement
+for the maintainer to apply.
+
+### The problem
+
+`core/base.css` applies `scroll-behavior: smooth` unconditionally on the `<html>`
+element. Users who have enabled "Reduce Motion" in their OS accessibility settings
+(macOS, Windows, Linux GNOME) still get smooth animated scrolling on every anchor
+click and programmatic scroll call. For people with vestibular disorders, this can
+cause nausea and disorientation.
+
+WCAG 2.3.3 (Animation from Interactions) and the MDN/W3C guidance both recommend
+disabling smooth scrolling when the user has expressed a reduced-motion preference.
+
+### The fix (maintainer action on `core/base.css`)
+
+```css
+/* BEFORE — core/base.css, inside the html { … } block */
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;        /* ← remove this line */
+  -webkit-text-size-adjust: 100%;
+}
+
+/* AFTER — opt-in smooth scroll only when no motion preference is set */
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+```
+
+This is an inversion of the default: instant jump for everyone (safe), smooth scroll
+only when the user has not requested reduced motion.
+
+### How is it used?
+
+No class changes. The fix is entirely in base styles. The `demo.html` includes a
+JavaScript toggle that simulates the `prefers-reduced-motion: reduce` state so the
+maintainer can verify both scroll modes without changing OS settings.
+
+### Why is it useful?
+
+EaseMotion CSS already ships `prefers-reduced-motion` guards in `buttons.css` and
+`cards.css` for hover transitions. `scroll-behavior` is the same category of
+motion-sensitive property and deserves the same treatment. This fix closes the
+consistency gap and brings the framework into full alignment with WCAG 2.3.3.

--- a/submissions/examples/scroll-behavior-reduced-motion/demo.html
+++ b/submissions/examples/scroll-behavior-reduced-motion/demo.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>scroll-behavior Reduced Motion Fix — Issue #1798</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    /*
+      THE FIX — this is how core/base.css should declare scroll-behavior.
+      Default: instant (safe for all users).
+      Smooth only when the user has no motion preference.
+    */
+    html { scroll-behavior: auto; }
+
+    @media (prefers-reduced-motion: no-preference) {
+      html { scroll-behavior: smooth; }
+    }
+
+    /*
+      JS override for demo purposes only — simulates reduced-motion toggle
+      without requiring OS settings change.
+    */
+    html.force-smooth  { scroll-behavior: smooth  !important; }
+    html.force-instant { scroll-behavior: auto    !important; }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      color: #1e293b;
+    }
+
+    h2 {
+      font-size: 2rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+
+    p {
+      font-size: 0.95rem;
+      color: #475569;
+      max-width: 480px;
+    }
+
+    code {
+      font-family: monospace;
+      font-size: 0.85rem;
+      background: #f1f5f9;
+      color: #4b44cc;
+      padding: 0.15em 0.4em;
+      border-radius: 0.25rem;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      padding: 0.3em 0.8em;
+      border-radius: 9999px;
+    }
+    .badge-a11y { background: #fef3c7; color: #92400e; border: 1px solid #fcd34d; }
+    .badge-wcag { background: #eff6ff; color: #1e40af; border: 1px solid #bfdbfe; }
+  </style>
+</head>
+<body>
+
+  <!-- Fixed nav for jumping between sections -->
+  <nav class="demo-nav" aria-label="Demo navigation">
+    <a href="#section-1">Section 1</a>
+    <a href="#section-2">Section 2</a>
+    <a href="#section-3">Section 3</a>
+    <a href="#section-4">Section 4</a>
+  </nav>
+
+  <!-- Section 1 -->
+  <section class="demo-section" id="section-1">
+    <span class="badge badge-wcag">WCAG 2.3.3</span>
+    <h2>scroll-behavior Fix</h2>
+    <p>
+      Click the nav links above to scroll between sections.<br>
+      Use the toggle below to switch between <strong>smooth</strong> and
+      <strong>instant</strong> scroll modes and observe the difference.
+    </p>
+    <p style="margin-top:0.75rem;">
+      <code>core/base.css</code> currently forces smooth scroll on all users —
+      including those with "Reduce Motion" enabled in their OS.
+    </p>
+  </section>
+
+  <!-- Section 2 -->
+  <section class="demo-section" id="section-2">
+    <span class="badge badge-a11y">Accessibility</span>
+    <h2>The Problem</h2>
+    <p>
+      <code>scroll-behavior: smooth</code> applied unconditionally on
+      <code>&lt;html&gt;</code> causes animated scrolling for users with vestibular
+      disorders who have enabled "Reduce Motion" in their OS accessibility settings.
+    </p>
+    <p style="margin-top:0.75rem;">
+      For these users, smooth scrolling can trigger nausea and disorientation —
+      the exact symptoms the OS setting is designed to prevent.
+    </p>
+  </section>
+
+  <!-- Section 3 -->
+  <section class="demo-section" id="section-3">
+    <span class="badge badge-wcag">The Fix</span>
+    <h2>Inverted Default</h2>
+    <p>
+      Default to instant scroll (safe for everyone), opt-in to smooth only when
+      the user has expressed no motion preference:
+    </p>
+    <pre style="
+      background:#0f172a;color:#f1f5f9;
+      font-family:monospace;font-size:0.82rem;line-height:1.7;
+      padding:1.25rem;border-radius:0.5rem;
+      text-align:left;margin-top:1rem;max-width:480px;
+    ">html { scroll-behavior: auto; }
+
+@media (prefers-reduced-motion: no-preference) {
+  html { scroll-behavior: smooth; }
+}</pre>
+  </section>
+
+  <!-- Section 4 -->
+  <section class="demo-section" id="section-4">
+    <span class="badge badge-a11y">Consistency</span>
+    <h2>Already in EaseMotion CSS</h2>
+    <p>
+      <code>buttons.css</code> and <code>cards.css</code> already ship
+      <code>prefers-reduced-motion</code> guards for hover transitions.
+      This fix extends the same treatment to <code>scroll-behavior</code>
+      in <code>core/base.css</code>.
+    </p>
+    <p style="margin-top:0.75rem;">
+      One property, one media query, zero risk of regression.
+    </p>
+  </section>
+
+  <!-- Scroll mode toggle (demo only) -->
+  <div class="toggle-bar" role="region" aria-label="Scroll mode toggle">
+    <span id="status-label" class="status-pill status-smooth">Smooth scroll ON</span>
+    <button id="toggle-btn" onclick="toggleMode()">Simulate Reduce Motion</button>
+  </div>
+
+  <script>
+    let reduced = false;
+
+    function toggleMode() {
+      reduced = !reduced;
+      const html = document.documentElement;
+      const label = document.getElementById('status-label');
+      const btn   = document.getElementById('toggle-btn');
+
+      if (reduced) {
+        html.classList.add('force-instant');
+        html.classList.remove('force-smooth');
+        label.textContent = 'Instant scroll (reduced motion)';
+        label.className = 'status-pill status-instant';
+        btn.textContent  = 'Restore Smooth Scroll';
+      } else {
+        html.classList.add('force-smooth');
+        html.classList.remove('force-instant');
+        label.textContent = 'Smooth scroll ON';
+        label.className = 'status-pill status-smooth';
+        btn.textContent  = 'Simulate Reduce Motion';
+      }
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/scroll-behavior-reduced-motion/style.css
+++ b/submissions/examples/scroll-behavior-reduced-motion/style.css
@@ -1,0 +1,114 @@
+/*
+  Fix: scroll-behavior reduced-motion guard
+  ──────────────────────────────────────────
+  Maintainer action: in core/base.css, replace the scroll-behavior line
+  inside the html {} block with the media-query-guarded version below.
+
+  BEFORE (core/base.css):
+  html {
+    font-size: 16px;
+    scroll-behavior: smooth;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  AFTER (core/base.css):
+  html {
+    font-size: 16px;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    html {
+      scroll-behavior: smooth;
+    }
+  }
+*/
+
+/* ── Demo-only styles (not for core integration) ────────────── */
+
+.demo-section {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.demo-section:nth-child(odd)  { background: #f8fafc; }
+.demo-section:nth-child(even) { background: #eff6ff; }
+
+.demo-nav {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.75rem;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 9999px;
+  padding: 0.5rem 1rem;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  z-index: 100;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.demo-nav a {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #6c63ff;
+  text-decoration: none;
+  padding: 0.3rem 0.75rem;
+  border-radius: 9999px;
+  transition: background 150ms;
+}
+
+.demo-nav a:hover { background: #f1f5f9; }
+
+.toggle-bar {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1e293b;
+  color: #f1f5f9;
+  border-radius: 9999px;
+  padding: 0.6rem 1.25rem;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+  z-index: 100;
+}
+
+.toggle-bar button {
+  background: #6c63ff;
+  color: #fff;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.toggle-bar button:hover { background: #4b44cc; }
+
+.status-pill {
+  display: inline-block;
+  padding: 0.25em 0.7em;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.status-smooth  { background: #f0fdf4; color: #15803d; border: 1px solid #86efac; }
+.status-instant { background: #fef2f2; color: #b91c1c; border: 1px solid #fca5a5; }


### PR DESCRIPTION
## Pull Request Description

`core/base.css` applies `scroll-behavior: smooth` unconditionally on `<html>`, ignoring the user's OS "Reduce Motion" accessibility preference. For users with vestibular disorders this can cause nausea and disorientation. This submission demonstrates the problem, provides an interactive demo with a toggle to simulate both states, and documents the exact patch for the maintainer to apply to `core/base.css`.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/scroll-behavior-reduced-motion/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — demo layout styles only
- [x] Includes `README.md` — problem, fix, and why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

`core/base.css` — replace the unconditional `scroll-behavior: smooth` with a `prefers-reduced-motion: no-preference` guard:

```css
/* BEFORE */
html {
  font-size: 16px;
  scroll-behavior: smooth;
  -webkit-text-size-adjust: 100%;
}

/* AFTER */
html {
  font-size: 16px;
  -webkit-text-size-adjust: 100%;
}

@media (prefers-reduced-motion: no-preference) {
  html { scroll-behavior: smooth; }
}
```

**How does a developer use it?**

No API change — this is a base style fix. Smooth scrolling continues to work for all users who have not enabled Reduce Motion. Users who have enabled it get instant jumps, as their OS preference requests.

**Why does it fit EaseMotion CSS?**

`buttons.css` and `cards.css` already ship `prefers-reduced-motion: reduce` guards for hover transitions. This fix applies the same treatment to `scroll-behavior` in `core/base.css`, making the framework's accessibility story fully consistent. It aligns with WCAG 2.3.3 (Animation from Interactions).

---

## Demo

- [x] Demo added — `demo.html` has four tall sections with anchor navigation and a JavaScript toggle at the bottom that simulates reduced-motion without requiring OS settings changes. The maintainer can click through both modes instantly in the browser.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The fix is 5 lines in `core/base.css` — remove `scroll-behavior: smooth` from the `html {}` block and add the `@media (prefers-reduced-motion: no-preference)` wrapper. Zero functional change for users without a motion preference; instant scroll for those who have enabled Reduce Motion in their OS.

Closes #1798

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.