### PR TITLE
feat: add --ease-glow-warning token to complete the semantic glow set (fixes #1799)

### DIFF
--- a/submissions/examples/glow-warning-token/README.md
+++ b/submissions/examples/glow-warning-token/README.md
@@ -1,0 +1,56 @@
+# --ease-glow-warning Design Token
+
+### What does this do?
+
+Adds the missing `--ease-glow-warning` CSS custom property to complete the
+semantic glow token set in `core/variables.css`.
+
+### The gap
+
+`core/variables.css` defines glow tokens for three of the four semantic colours:
+
+```css
+--ease-glow-primary: 0 0 16px rgba(108, 99, 255, 0.45);
+--ease-glow-success: 0 0 16px rgba(34,  197, 94,  0.45);
+--ease-glow-danger:  0 0 16px rgba(239, 68,  68,  0.45);
+/* --ease-glow-warning ← missing */
+```
+
+`--ease-color-warning: #f59e0b` is fully defined (base, light, dark variants),
+but there is no corresponding glow token. Developers who reach for
+`var(--ease-glow-warning)` get a silent `unset`, and are forced to hardcode
+`box-shadow` values that duplicate the framework's own colour system.
+
+### The fix (maintainer action on `core/variables.css`)
+
+Add one line immediately after `--ease-glow-danger`:
+
+```css
+--ease-glow-warning: 0 0 16px rgba(245, 158, 11, 0.45);
+```
+
+The RGBA value is derived directly from `--ease-color-warning: #f59e0b`
+(`rgb(245, 158, 11)`), keeping the pattern identical to the other three tokens.
+
+### How is it used?
+
+```html
+<!-- Warning glow card -->
+<div class="ease-card ease-card-accent-warning"
+     style="box-shadow: var(--ease-glow-warning);">
+  Low disk space — please clean up.
+</div>
+
+<!-- Warning glow button -->
+<button class="ease-btn ease-btn-hover"
+        style="box-shadow: var(--ease-glow-warning); background: var(--ease-color-warning); color: #fff;">
+  Confirm risky action
+</button>
+```
+
+### Why is it useful?
+
+EaseMotion CSS is a token-first framework. Having three out of four semantic glow
+tokens is an incomplete API. Adding `--ease-glow-warning` makes the design system
+internally consistent and lets developers compose warning states the same way they
+compose primary, success, and danger states — without leaving the token system.

--- a/submissions/examples/glow-warning-token/demo.html
+++ b/submissions/examples/glow-warning-token/demo.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>--ease-glow-warning Token — Issue #1799</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem;
+      max-width: 760px;
+      margin: 0 auto;
+      line-height: 1.6;
+    }
+
+    h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 0.25rem; }
+    h2 { font-size: 0.95rem; font-weight: 500; color: #64748b; margin-bottom: 2rem; }
+    h3 { font-size: 0.8rem; font-weight: 700; text-transform: uppercase;
+         letter-spacing: 0.07em; color: #94a3b8; margin-bottom: 1rem; }
+
+    section { margin-bottom: 2.5rem; }
+
+    code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.82rem;
+      background: #f1f5f9;
+      color: #4b44cc;
+      padding: 0.15em 0.45em;
+      border-radius: 0.25rem;
+    }
+
+    pre {
+      background: #0f172a;
+      color: #f1f5f9;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.82rem;
+      line-height: 1.7;
+      padding: 1.25rem;
+      border-radius: 0.5rem;
+      overflow-x: auto;
+      margin-bottom: 1rem;
+    }
+
+    .del { color: #f87171; }
+    .ins { color: #86efac; }
+    .cmt { color: #64748b; }
+
+    .grid-4 {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 1rem;
+    }
+
+    .card-label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: #94a3b8;
+      margin-bottom: 0.5rem;
+    }
+
+    .card-title {
+      font-size: 0.95rem;
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+
+    .card-body {
+      font-size: 0.8rem;
+      color: #64748b;
+    }
+
+    .hint {
+      text-align: center;
+      font-size: 0.75rem;
+      color: #94a3b8;
+      margin-top: 0.5rem;
+      font-style: italic;
+    }
+
+    .token-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.6rem 0;
+      border-bottom: 1px solid #f1f5f9;
+      font-size: 0.85rem;
+    }
+
+    .token-row:last-child { border-bottom: none; }
+
+    .swatch {
+      width: 36px;
+      height: 36px;
+      border-radius: 0.375rem;
+      flex-shrink: 0;
+      border: 1px solid rgba(0,0,0,0.06);
+    }
+
+    .token-name { font-family: 'JetBrains Mono', monospace; color: #4b44cc; flex: 1; }
+
+    .tag-exists  { background: #f0fdf4; color: #15803d; border: 1px solid #86efac;
+                   font-size: 0.7rem; font-weight: 700; padding: 0.2em 0.6em;
+                   border-radius: 9999px; white-space: nowrap; }
+    .tag-missing { background: #fef2f2; color: #b91c1c; border: 1px solid #fca5a5;
+                   font-size: 0.7rem; font-weight: 700; padding: 0.2em 0.6em;
+                   border-radius: 9999px; white-space: nowrap; }
+    .tag-added   { background: #fffbeb; color: #92400e; border: 1px solid #fcd34d;
+                   font-size: 0.7rem; font-weight: 700; padding: 0.2em 0.6em;
+                   border-radius: 9999px; white-space: nowrap; }
+  </style>
+</head>
+<body>
+
+  <h1><code>--ease-glow-warning</code></h1>
+  <h2>Missing design token — Issue #1799 (hover all cards to preview)</h2>
+
+  <!-- ── TOKEN INVENTORY ── -->
+  <section>
+    <h3>Current glow token set</h3>
+
+    <div class="token-row">
+      <div class="swatch" style="background: rgba(108,99,255,0.45); box-shadow: 0 0 16px rgba(108,99,255,0.45);"></div>
+      <span class="token-name">--ease-glow-primary</span>
+      <span class="tag-exists">✓ exists</span>
+    </div>
+
+    <div class="token-row">
+      <div class="swatch" style="background: rgba(34,197,94,0.45); box-shadow: 0 0 16px rgba(34,197,94,0.45);"></div>
+      <span class="token-name">--ease-glow-success</span>
+      <span class="tag-exists">✓ exists</span>
+    </div>
+
+    <div class="token-row">
+      <div class="swatch" style="background: rgba(239,68,68,0.45); box-shadow: 0 0 16px rgba(239,68,68,0.45);"></div>
+      <span class="token-name">--ease-glow-danger</span>
+      <span class="tag-exists">✓ exists</span>
+    </div>
+
+    <div class="token-row">
+      <div class="swatch" style="background: rgba(245,158,11,0.45); box-shadow: 0 0 16px rgba(245,158,11,0.45);"></div>
+      <span class="token-name">--ease-glow-warning</span>
+      <span class="tag-added">➕ proposed</span>
+    </div>
+  </section>
+
+  <!-- ── HOVER PREVIEW ── -->
+  <section>
+    <h3>All four semantic glow cards (hover to preview)</h3>
+    <div class="grid-4">
+
+      <div class="glow-card glow-card-primary">
+        <p class="card-label">Primary</p>
+        <p class="card-title">var(--ease-glow-primary)</p>
+        <p class="card-body">Exists in core</p>
+      </div>
+
+      <div class="glow-card glow-card-success">
+        <p class="card-label">Success</p>
+        <p class="card-title">var(--ease-glow-success)</p>
+        <p class="card-body">Exists in core</p>
+      </div>
+
+      <div class="glow-card glow-card-danger">
+        <p class="card-label">Danger</p>
+        <p class="card-title">var(--ease-glow-danger)</p>
+        <p class="card-body">Exists in core</p>
+      </div>
+
+      <div class="glow-card glow-card-warning">
+        <p class="card-label" style="color: #b45309;">Warning ✦ new</p>
+        <p class="card-title">var(--ease-glow-warning)</p>
+        <p class="card-body">Proposed — add to core</p>
+      </div>
+
+    </div>
+    <p class="hint">Hover each card to see its glow effect</p>
+  </section>
+
+  <!-- ── BUTTON USAGE ── -->
+  <section>
+    <h3>Warning glow button</h3>
+    <a href="#" class="glow-btn-warning">⚠ Confirm risky action</a>
+  </section>
+
+  <!-- ── EXACT DIFF ── -->
+  <section>
+    <h3>Exact change for core/variables.css</h3>
+    <pre><span class="cmt">/* around line 81, after --ease-glow-danger */</span>
+  --ease-glow-primary: 0 0 16px rgba(108, 99, 255, 0.45);
+  --ease-glow-success: 0 0 16px rgba(34,  197, 94,  0.45);
+  --ease-glow-danger:  0 0 16px rgba(239, 68,  68,  0.45);
+<span class="ins">  --ease-glow-warning: 0 0 16px rgba(245, 158, 11,  0.45);  /* ← add */</span></pre>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/glow-warning-token/style.css
+++ b/submissions/examples/glow-warning-token/style.css
@@ -1,0 +1,90 @@
+/*
+  --ease-glow-warning Design Token
+  ──────────────────────────────────
+  Maintainer action: add the following line to core/variables.css,
+  immediately after --ease-glow-danger (around line 81):
+
+    --ease-glow-warning: 0 0 16px rgba(245, 158, 11, 0.45);
+
+  RGBA breakdown:
+    245, 158, 11  →  #f59e0b  (--ease-color-warning)
+    0.45          →  same opacity used for all other glow tokens
+
+  No other changes are needed. The token slots naturally into the
+  existing glow set and is immediately available via var(--ease-glow-warning).
+*/
+
+/* ── Local token for demo (mirrors the proposed core token exactly) ── */
+:root {
+  --demo-glow-warning: 0 0 16px rgba(245, 158, 11, 0.45);
+  --demo-color-warning: #f59e0b;
+  --demo-color-warning-dark: #b45309;
+}
+
+/* ── Demo card variants ───────────────────────��──────────────── */
+.glow-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1),
+              border-color 300ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Warning glow — proposed token */
+.glow-card-warning {
+  border-left: 4px solid var(--demo-color-warning);
+}
+
+.glow-card-warning:hover {
+  box-shadow: var(--demo-glow-warning);
+  border-color: var(--demo-color-warning);
+}
+
+/* Existing tokens for comparison */
+.glow-card-primary:hover {
+  box-shadow: 0 0 16px rgba(108, 99, 255, 0.45);
+  border-color: #a09af8;
+}
+
+.glow-card-success:hover {
+  box-shadow: 0 0 16px rgba(34, 197, 94, 0.45);
+  border-color: #86efac;
+}
+
+.glow-card-danger:hover {
+  box-shadow: 0 0 16px rgba(239, 68, 68, 0.45);
+  border-color: #fca5a5;
+}
+
+/* ── Demo button ─────────────────────────────────────────────── */
+.glow-btn-warning {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  background: var(--demo-color-warning);
+  color: #ffffff;
+  border: 2px solid var(--demo-color-warning);
+  border-radius: 0.5rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: box-shadow 300ms, transform 300ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  text-decoration: none;
+}
+
+.glow-btn-warning:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--demo-glow-warning), 0 10px 15px -3px rgba(0,0,0,0.1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glow-card, .glow-btn-warning {
+    transition: none !important;
+  }
+  .glow-card-warning:hover,
+  .glow-btn-warning:hover {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

`core/variables.css` defines glow tokens for primary, success, and danger — but not warning. This submission adds a demo showing all four semantic glow states side-by-side and documents the single-line addition for the maintainer to apply to `core/variables.css`.

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/glow-warning-token/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed token and demo components
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

One new design token in `core/variables.css` (after `--ease-glow-danger`, ~line 81):

```css
--ease-glow-warning: 0 0 16px rgba(245, 158, 11, 0.45);
```

The RGBA value is derived directly from `--ease-color-warning: #f59e0b`, matching the exact pattern of all three existing glow tokens.

**How does a developer use it?**

```html
<div class="ease-card ease-card-accent-warning"
     style="box-shadow: var(--ease-glow-warning);">
  Low disk space warning
</div>
```

**Why does it fit EaseMotion CSS?**

The framework is token-first. Having three of four semantic glow tokens is an incomplete API. Adding `--ease-glow-warning` makes the set consistent and lets developers compose warning states the same way they compose primary, success, and danger states — without leaving the token system.

---

## Demo

- [x] Demo added — `demo.html` shows a token inventory table (exists / proposed) and all four semantic glow cards hoverable side-by-side so the maintainer can compare the visual effect. Also includes a warning glow button example.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Single-line addition to `core/variables.css`. Purely additive — no existing class is changed. The `style.css` in this submission also includes a `prefers-reduced-motion` guard on the hover transitions for the demo components.

Closes #1799

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.