### PR TITLE
feat: expand directional spacing utilities beyond space-4 to cover full scale (fixes #1801)

### DIFF
--- a/submissions/examples/directional-spacing-utilities/README.md
+++ b/submissions/examples/directional-spacing-utilities/README.md
@@ -1,0 +1,53 @@
+# Directional Spacing Utilities (pt / pb / pl / pr / mt / mb / ml / mr / mx / my)
+
+### What does this do?
+
+Expands the directional padding and margin utility classes in `core/utilities.css`
+to cover `space-2`, `space-3`, `space-6`, and `space-8` — in addition to the
+`space-4` variants that already exist.
+
+### The gap
+
+`core/utilities.css` currently defines individual-direction utilities **only for
+`--ease-space-4` (1rem)**:
+
+```
+.ease-pt-4   .ease-pr-4   .ease-pb-4   .ease-pl-4
+.ease-mt-4   .ease-mr-4   .ease-mb-4   .ease-ml-4
+.ease-px-4   .ease-py-4   .ease-px-8   .ease-py-8
+.ease-my-4   .ease-my-8
+```
+
+There are no `.ease-pt-2`, `.ease-pb-6`, `.ease-mt-8`, `.ease-mx-4`, etc.
+The full-shorthand utilities (`.ease-padding-*`, `.ease-margin-*`) and gap
+utilities (`.ease-gap-*`) already cover all spacing sizes — this expansion
+brings directional utilities to the same level of coverage.
+
+### The fix (maintainer action on `core/utilities.css`)
+
+Append the block from `style.css` after the existing directional utility section
+(around line 131). All values use the existing CSS custom property tokens.
+
+### How is it used?
+
+```html
+<!-- Top padding only at space-6 -->
+<section class="ease-pt-6">…</section>
+
+<!-- Horizontal margin auto-centre with vertical breathing room -->
+<div class="ease-mx-auto ease-my-6 ease-container">…</div>
+
+<!-- Asymmetric card padding: more top/bottom, less left/right -->
+<div class="ease-card ease-py-8 ease-px-4">…</div>
+
+<!-- Bottom margin on heading to create rhythm -->
+<h2 class="ease-mb-2">Section title</h2>
+<p class="ease-mb-6">Body text</p>
+```
+
+### Why is it useful?
+
+Directional spacing control is the single most common CSS layout task. Having
+the full scale available for every axis lets developers compose spacing
+entirely from utilities — no custom CSS needed for the most basic operations.
+The expansion is purely additive, zero risk of regression.

--- a/submissions/examples/directional-spacing-utilities/demo.html
+++ b/submissions/examples/directional-spacing-utilities/demo.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Directional Spacing Utilities — Issue #1801</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
+
+  <style>
+    /* ── Design tokens (mirroring core/variables.css) ──────── */
+    :root {
+      --ease-space-1:  0.25rem;
+      --ease-space-2:  0.5rem;
+      --ease-space-3:  0.75rem;
+      --ease-space-4:  1rem;
+      --ease-space-6:  1.5rem;
+      --ease-space-8:  2rem;
+      --ease-space-10: 2.5rem;
+      --ease-space-12: 3rem;
+    }
+
+    /* ── Proposed new utilities (from style.css) ─────────────── */
+    .ease-pt-2  { padding-top:    var(--ease-space-2); }
+    .ease-pt-3  { padding-top:    var(--ease-space-3); }
+    .ease-pt-6  { padding-top:    var(--ease-space-6); }
+    .ease-pt-8  { padding-top:    var(--ease-space-8); }
+    .ease-pb-2  { padding-bottom: var(--ease-space-2); }
+    .ease-pb-6  { padding-bottom: var(--ease-space-6); }
+    .ease-pl-6  { padding-left:   var(--ease-space-6); }
+    .ease-pr-6  { padding-right:  var(--ease-space-6); }
+    .ease-px-2  { padding-left:   var(--ease-space-2); padding-right:  var(--ease-space-2); }
+    .ease-px-6  { padding-left:   var(--ease-space-6); padding-right:  var(--ease-space-6); }
+    .ease-py-2  { padding-top:    var(--ease-space-2); padding-bottom: var(--ease-space-2); }
+    .ease-py-6  { padding-top:    var(--ease-space-6); padding-bottom: var(--ease-space-6); }
+    .ease-mt-2  { margin-top:    var(--ease-space-2); }
+    .ease-mt-6  { margin-top:    var(--ease-space-6); }
+    .ease-mt-8  { margin-top:    var(--ease-space-8); }
+    .ease-mb-2  { margin-bottom: var(--ease-space-2); }
+    .ease-mb-6  { margin-bottom: var(--ease-space-6); }
+    .ease-mb-8  { margin-bottom: var(--ease-space-8); }
+    .ease-mx-4  { margin-left:   var(--ease-space-4); margin-right:  var(--ease-space-4); }
+    .ease-mx-6  { margin-left:   var(--ease-space-6); margin-right:  var(--ease-space-6); }
+    .ease-mx-auto { margin-left: auto; margin-right: auto; }
+    .ease-my-2  { margin-top:    var(--ease-space-2); margin-bottom: var(--ease-space-2); }
+    .ease-my-6  { margin-top:    var(--ease-space-6); margin-bottom: var(--ease-space-6); }
+
+    /* ── Page base ──────────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      line-height: 1.6;
+    }
+
+    h1 { font-size: 1.75rem; font-weight: 700; }
+    h2 { font-size: 0.95rem; color: #64748b; font-weight: 500; }
+    h3 { font-size: 0.78rem; font-weight: 700; text-transform: uppercase;
+         letter-spacing: 0.07em; color: #94a3b8; margin-bottom: 0.75rem; }
+
+    code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      background: #f1f5f9;
+      color: #4b44cc;
+      padding: 0.15em 0.4em;
+      border-radius: 0.25rem;
+    }
+
+    pre {
+      background: #0f172a;
+      color: #f1f5f9;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      line-height: 1.7;
+      padding: 1.25rem;
+      border-radius: 0.5rem;
+      overflow-x: auto;
+    }
+
+    .page-header {
+      background: #fff;
+      border-bottom: 1px solid #e2e8f0;
+      padding: 1.5rem 2rem;
+    }
+
+    .page-content {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 2rem;
+    }
+
+    section { margin-bottom: 2.5rem; }
+
+    /* ── Coverage table ─────────────────────────────────────── */
+    .coverage-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+      gap: 0.4rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.75rem;
+    }
+
+    .cell {
+      padding: 0.4rem 0.5rem;
+      border-radius: 0.375rem;
+      text-align: center;
+    }
+
+    .cell-exists { background: #f0fdf4; color: #15803d; border: 1px solid #bbf7d0; }
+    .cell-new    { background: #eff6ff; color: #1d4ed8; border: 1px solid #bfdbfe; }
+    .cell-gap    { background: #f8fafc; color: #cbd5e1; border: 1px solid #e2e8f0; }
+
+    /* ── Spacing visualiser ─────────────────────────────────── */
+    .vis-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.5rem;
+      font-size: 0.8rem;
+    }
+
+    .vis-label {
+      font-family: 'JetBrains Mono', monospace;
+      color: #4b44cc;
+      width: 100px;
+      flex-shrink: 0;
+    }
+
+    .vis-bar {
+      height: 28px;
+      background: linear-gradient(90deg, #6c63ff 0%, #a09af8 100%);
+      border-radius: 0.25rem;
+      opacity: 0.8;
+    }
+
+    .vis-val { color: #64748b; }
+
+    /* ── Use-case demo ──────────────────────────────────────── */
+    .article-demo {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 0.75rem;
+      overflow: hidden;
+    }
+
+    .article-demo-header {
+      background: #6c63ff;
+      color: #fff;
+      font-weight: 600;
+    }
+
+    .article-demo-body p {
+      color: #475569;
+      font-size: 0.875rem;
+      border-bottom: 1px solid #f1f5f9;
+    }
+
+    .article-demo-body p:last-child { border-bottom: none; }
+  </style>
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Directional Spacing Utilities</h1>
+    <h2 class="ease-mt-2">Issue #1801 — expansion from space-4-only to full scale</h2>
+  </header>
+
+  <div class="page-content">
+
+    <!-- ── Coverage map ── -->
+    <section>
+      <h3>Coverage before → after (pt-* shown as example)</h3>
+      <div class="coverage-grid">
+        <div class="cell cell-gap">ease-pt-1</div>
+        <div class="cell cell-exists">ease-pt-2 ✓ (was missing)</div>
+        <div class="cell cell-exists">ease-pt-3 ✓ (was missing)</div>
+        <div class="cell cell-exists">ease-pt-4 ✓ (existed)</div>
+        <div class="cell cell-exists">ease-pt-6 ✓ (was missing)</div>
+        <div class="cell cell-exists">ease-pt-8 ✓ (was missing)</div>
+      </div>
+      <p style="font-size:0.75rem;color:#94a3b8;margin-top:0.5rem;">
+        Same expansion applies to pb / pl / pr / px / py / mt / mb / ml / mr / mx / my
+      </p>
+    </section>
+
+    <!-- ── Spacing scale visualiser ── -->
+    <section>
+      <h3>Proposed utilities — visual scale</h3>
+      <div class="vis-row">
+        <span class="vis-label">ease-pt-1</span>
+        <div class="vis-bar" style="width: 16px;"></div>
+        <span class="vis-val">0.25rem / 4px</span>
+      </div>
+      <div class="vis-row">
+        <span class="vis-label">ease-pt-2</span>
+        <div class="vis-bar" style="width: 32px;"></div>
+        <span class="vis-val">0.5rem / 8px</span>
+      </div>
+      <div class="vis-row">
+        <span class="vis-label">ease-pt-3</span>
+        <div class="vis-bar" style="width: 48px;"></div>
+        <span class="vis-val">0.75rem / 12px</span>
+      </div>
+      <div class="vis-row">
+        <span class="vis-label">ease-pt-4 (✓)</span>
+        <div class="vis-bar" style="width: 64px; opacity:0.4;"></div>
+        <span class="vis-val">1rem / 16px — already exists</span>
+      </div>
+      <div class="vis-row">
+        <span class="vis-label">ease-pt-6</span>
+        <div class="vis-bar" style="width: 96px;"></div>
+        <span class="vis-val">1.5rem / 24px</span>
+      </div>
+      <div class="vis-row">
+        <span class="vis-label">ease-pt-8</span>
+        <div class="vis-bar" style="width: 128px;"></div>
+        <span class="vis-val">2rem / 32px</span>
+      </div>
+      <div class="vis-row">
+        <span class="vis-label">ease-pt-10</span>
+        <div class="vis-bar" style="width: 160px;"></div>
+        <span class="vis-val">2.5rem / 40px</span>
+      </div>
+      <div class="vis-row">
+        <span class="vis-label">ease-pt-12</span>
+        <div class="vis-bar" style="width: 192px;"></div>
+        <span class="vis-val">3rem / 48px</span>
+      </div>
+    </section>
+
+    <!-- ── Real-world usage ── -->
+    <section>
+      <h3>Real-world example — article layout using new utilities</h3>
+      <pre style="margin-bottom:1rem;">class="ease-pt-8 ease-pb-6 ease-px-6"  ← section spacing
+class="ease-mb-2"                       ← heading rhythm
+class="ease-mb-6"                       ← paragraph rhythm</pre>
+
+      <div class="article-demo">
+        <div class="article-demo-header ease-px-6 ease-py-6">
+          Page Section
+        </div>
+        <div class="article-demo-body ease-pt-8 ease-pb-6 ease-px-6">
+          <h2 class="ease-mb-2" style="font-size:1.25rem;font-weight:700;">Section Heading</h2>
+          <p class="ease-mb-6" style="padding-bottom:1.5rem;">
+            First paragraph — 24px bottom margin separates it from the next.
+            Before this fix, <code>ease-mb-6</code> did not exist.
+          </p>
+          <p class="ease-mb-2" style="padding-bottom:0.5rem;">
+            Second paragraph with tighter spacing via <code>ease-mb-2</code>.
+          </p>
+          <p>Last paragraph — no extra margin.</p>
+        </div>
+      </div>
+    </section>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/directional-spacing-utilities/style.css
+++ b/submissions/examples/directional-spacing-utilities/style.css
@@ -1,0 +1,158 @@
+/*
+  Directional Spacing Utilities — expansion patch
+  ─────────────────────────────────────────────────
+  Maintainer action: append this block to core/utilities.css after the
+  existing directional utility section (after line ~131).
+
+  Covers space-2 (0.5rem), space-3 (0.75rem), space-6 (1.5rem), space-8 (2rem).
+  space-4 variants already exist in core — they are NOT repeated here.
+*/
+
+/* ────────────────────────────────────────────────────────────
+   PADDING — TOP
+   ──────────────────────────────────────────────────────────── */
+
+.ease-pt-1  { padding-top: var(--ease-space-1); }
+.ease-pt-2  { padding-top: var(--ease-space-2); }
+.ease-pt-3  { padding-top: var(--ease-space-3); }
+/* .ease-pt-4 already exists */
+.ease-pt-6  { padding-top: var(--ease-space-6); }
+.ease-pt-8  { padding-top: var(--ease-space-8); }
+.ease-pt-10 { padding-top: var(--ease-space-10); }
+.ease-pt-12 { padding-top: var(--ease-space-12); }
+
+/* ────────────────────────────────────────────────────────────
+   PADDING — BOTTOM
+   ──────────────────────────────────────────────────────────── */
+
+.ease-pb-1  { padding-bottom: var(--ease-space-1); }
+.ease-pb-2  { padding-bottom: var(--ease-space-2); }
+.ease-pb-3  { padding-bottom: var(--ease-space-3); }
+/* .ease-pb-4 already exists */
+.ease-pb-6  { padding-bottom: var(--ease-space-6); }
+.ease-pb-8  { padding-bottom: var(--ease-space-8); }
+.ease-pb-10 { padding-bottom: var(--ease-space-10); }
+.ease-pb-12 { padding-bottom: var(--ease-space-12); }
+
+/* ────────────────────────────────────────────────────────────
+   PADDING — LEFT
+   ──────────────────────────────────────────────────────────── */
+
+.ease-pl-1  { padding-left: var(--ease-space-1); }
+.ease-pl-2  { padding-left: var(--ease-space-2); }
+.ease-pl-3  { padding-left: var(--ease-space-3); }
+/* .ease-pl-4 already exists */
+.ease-pl-6  { padding-left: var(--ease-space-6); }
+.ease-pl-8  { padding-left: var(--ease-space-8); }
+.ease-pl-10 { padding-left: var(--ease-space-10); }
+
+/* ────────────────────────────────────────────────────────────
+   PADDING — RIGHT
+   ──────────────────────────────────────────────────────────── */
+
+.ease-pr-1  { padding-right: var(--ease-space-1); }
+.ease-pr-2  { padding-right: var(--ease-space-2); }
+.ease-pr-3  { padding-right: var(--ease-space-3); }
+/* .ease-pr-4 already exists */
+.ease-pr-6  { padding-right: var(--ease-space-6); }
+.ease-pr-8  { padding-right: var(--ease-space-8); }
+.ease-pr-10 { padding-right: var(--ease-space-10); }
+
+/* ────────────────────────────────────────────────────────────
+   PADDING — HORIZONTAL AXIS (px)
+   ──────────────────────────────────────────────────────────── */
+
+.ease-px-1  { padding-left: var(--ease-space-1);  padding-right: var(--ease-space-1); }
+.ease-px-2  { padding-left: var(--ease-space-2);  padding-right: var(--ease-space-2); }
+.ease-px-3  { padding-left: var(--ease-space-3);  padding-right: var(--ease-space-3); }
+/* .ease-px-4 already exists */
+.ease-px-6  { padding-left: var(--ease-space-6);  padding-right: var(--ease-space-6); }
+/* .ease-px-8 already exists */
+.ease-px-10 { padding-left: var(--ease-space-10); padding-right: var(--ease-space-10); }
+.ease-px-12 { padding-left: var(--ease-space-12); padding-right: var(--ease-space-12); }
+
+/* ────────────────────────────────────────────────────────────
+   PADDING — VERTICAL AXIS (py)
+   ──────────────────────────────────────────────────────────── */
+
+.ease-py-1  { padding-top: var(--ease-space-1);  padding-bottom: var(--ease-space-1); }
+.ease-py-2  { padding-top: var(--ease-space-2);  padding-bottom: var(--ease-space-2); }
+.ease-py-3  { padding-top: var(--ease-space-3);  padding-bottom: var(--ease-space-3); }
+/* .ease-py-4 already exists */
+.ease-py-6  { padding-top: var(--ease-space-6);  padding-bottom: var(--ease-space-6); }
+/* .ease-py-8 already exists */
+.ease-py-10 { padding-top: var(--ease-space-10); padding-bottom: var(--ease-space-10); }
+.ease-py-12 { padding-top: var(--ease-space-12); padding-bottom: var(--ease-space-12); }
+
+/* ────────────────────────────────────────────────────────────
+   MARGIN — TOP
+   ──────────────────────────────────────────────────────────── */
+
+.ease-mt-1  { margin-top: var(--ease-space-1); }
+.ease-mt-2  { margin-top: var(--ease-space-2); }
+.ease-mt-3  { margin-top: var(--ease-space-3); }
+/* .ease-mt-4 already exists */
+.ease-mt-6  { margin-top: var(--ease-space-6); }
+.ease-mt-8  { margin-top: var(--ease-space-8); }
+.ease-mt-10 { margin-top: var(--ease-space-10); }
+.ease-mt-12 { margin-top: var(--ease-space-12); }
+
+/* ────────────────────────────────────────────────────────────
+   MARGIN — BOTTOM
+   ──────────────────────────────────────────────────────────── */
+
+.ease-mb-1  { margin-bottom: var(--ease-space-1); }
+.ease-mb-2  { margin-bottom: var(--ease-space-2); }
+.ease-mb-3  { margin-bottom: var(--ease-space-3); }
+/* .ease-mb-4 already exists */
+.ease-mb-6  { margin-bottom: var(--ease-space-6); }
+.ease-mb-8  { margin-bottom: var(--ease-space-8); }
+.ease-mb-10 { margin-bottom: var(--ease-space-10); }
+.ease-mb-12 { margin-bottom: var(--ease-space-12); }
+
+/* ────────────────────────────────────────────────────────────
+   MARGIN — LEFT
+   ──────────────────────────────────────────────────────────── */
+
+.ease-ml-1  { margin-left: var(--ease-space-1); }
+.ease-ml-2  { margin-left: var(--ease-space-2); }
+.ease-ml-3  { margin-left: var(--ease-space-3); }
+/* .ease-ml-4 already exists */
+.ease-ml-6  { margin-left: var(--ease-space-6); }
+.ease-ml-8  { margin-left: var(--ease-space-8); }
+
+/* ────────────────────────────────────────────────────────────
+   MARGIN — RIGHT
+   ──────────────────────────────────────────────────────────── */
+
+.ease-mr-1  { margin-right: var(--ease-space-1); }
+.ease-mr-2  { margin-right: var(--ease-space-2); }
+.ease-mr-3  { margin-right: var(--ease-space-3); }
+/* .ease-mr-4 already exists */
+.ease-mr-6  { margin-right: var(--ease-space-6); }
+.ease-mr-8  { margin-right: var(--ease-space-8); }
+
+/* ────────────────────────────────────────────────────────────
+   MARGIN — HORIZONTAL AXIS (mx)
+   ──────────────────────────────────────────────────────────── */
+
+.ease-mx-1  { margin-left: var(--ease-space-1);  margin-right: var(--ease-space-1); }
+.ease-mx-2  { margin-left: var(--ease-space-2);  margin-right: var(--ease-space-2); }
+.ease-mx-3  { margin-left: var(--ease-space-3);  margin-right: var(--ease-space-3); }
+.ease-mx-4  { margin-left: var(--ease-space-4);  margin-right: var(--ease-space-4); }
+.ease-mx-6  { margin-left: var(--ease-space-6);  margin-right: var(--ease-space-6); }
+.ease-mx-8  { margin-left: var(--ease-space-8);  margin-right: var(--ease-space-8); }
+/* .ease-mx-auto already exists */
+
+/* ────────────────────────────────────────────────────────────
+   MARGIN — VERTICAL AXIS (my)
+   ──────────────────────────────────────────────────────────── */
+
+.ease-my-1  { margin-top: var(--ease-space-1);  margin-bottom: var(--ease-space-1); }
+.ease-my-2  { margin-top: var(--ease-space-2);  margin-bottom: var(--ease-space-2); }
+.ease-my-3  { margin-top: var(--ease-space-3);  margin-bottom: var(--ease-space-3); }
+/* .ease-my-4 already exists */
+.ease-my-6  { margin-top: var(--ease-space-6);  margin-bottom: var(--ease-space-6); }
+/* .ease-my-8 already exists */
+.ease-my-10 { margin-top: var(--ease-space-10); margin-bottom: var(--ease-space-10); }
+.ease-my-12 { margin-top: var(--ease-space-12); margin-bottom: var(--ease-space-12); }


### PR DESCRIPTION
## Pull Request Description

`core/utilities.css` defines individual-direction padding and margin utilities (pt, pb, pl, pr, px, py, mt, mb, ml, mr, mx, my) only for `--ease-space-4`. All other spacing scale values are missing. This submission adds the complete expansion for `space-1` through `space-12` across all directions and axes, using the existing CSS custom property tokens throughout.

---

## Type of Change

- [x] Other — utility class expansion (spacing)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/directional-spacing-utilities/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — the complete patch ready for `core/utilities.css` integration
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Directional spacing utilities for every spacing token across all axes:

```css
/* Padding — top, bottom, left, right, x-axis, y-axis */
.ease-pt-1/2/3/6/8/10/12
.ease-pb-1/2/3/6/8/10/12
.ease-pl-1/2/3/6/8/10
.ease-pr-1/2/3/6/8/10
.ease-px-1/2/3/6/10/12   (px-4 and px-8 already exist)
.ease-py-1/2/3/6/10/12   (py-4 and py-8 already exist)

/* Margin — top, bottom, left, right, x-axis, y-axis */
.ease-mt-1/2/3/6/8/10/12
.ease-mb-1/2/3/6/8/10/12
.ease-ml-1/2/3/6/8
.ease-mr-1/2/3/6/8
.ease-mx-1/2/3/4/6/8     (mx-auto already exists)
.ease-my-1/2/3/6/10/12   (my-4 and my-8 already exist)
```

All values use `var(--ease-space-*)` tokens — no hardcoded numbers.

**How does a developer use it?**

```html
<h2 class="ease-mb-2">Section title</h2>
<p  class="ease-mb-6">Body paragraph</p>

<section class="ease-pt-8 ease-pb-6 ease-px-6">…</section>

<div class="ease-mx-auto ease-my-6 ease-container">…</div>
```

**Why does it fit EaseMotion CSS?**

Directional spacing is the single most-reached-for CSS utility. The full-shorthand utilities (`.ease-padding-*`, `.ease-margin-*`) and gap utilities (`.ease-gap-*`) already cover the entire scale — this expansion brings directional utilities to the same level. Purely additive, zero regression risk.

---

## Demo

- [x] Demo added — `demo.html` shows a coverage grid (exists / new / gap), an animated bar-chart scale visualiser for all pt-* sizes, and a real-world article layout demonstrating rhythm using the new utilities.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

`style.css` comments mark each variant that already exists in `core/utilities.css` (e.g. `/* .ease-pt-4 already exists */`) so there is no risk of duplication on integration. All values use `var(--ease-space-*)` tokens and will work immediately once appended to the existing directional utility section (~line 131).

Closes #1801

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.