### PR TITLE
feat: add --ease-space-7 (1.75rem/28px) token to close the gap in spacing scale (fixes #1803)

### DIFF
--- a/submissions/examples/spacing-token-space-7/README.md
+++ b/submissions/examples/spacing-token-space-7/README.md
@@ -1,0 +1,67 @@
+# --ease-space-7 Design Token (1.75rem / 28px)
+
+### What does this do?
+
+Adds the missing `--ease-space-7` spacing token to `core/variables.css` and
+the corresponding utility classes to `core/utilities.css`, closing the gap
+between `--ease-space-6` (1.5rem / 24px) and `--ease-space-8` (2rem / 32px).
+
+### The gap
+
+The EaseMotion CSS spacing scale currently reads:
+
+```
+--ease-space-6:  1.5rem   (24px)
+                           ← 8px gap, no token
+--ease-space-8:  2rem     (32px)
+```
+
+Every other adjacent pair in the scale is separated by 4–8px. The jump from
+`space-6` to `space-8` skips `1.75rem` (28px) — a commonly needed value for
+section padding and component rhythm. Without the token, developers hardcode
+`1.75rem`, bypassing the design system entirely.
+
+### The fix (maintainer action)
+
+**`core/variables.css`** — add after `--ease-space-6`:
+```css
+--ease-space-7:  1.75rem;  /* 28px */
+```
+
+**`core/utilities.css`** — add the corresponding utility classes:
+```css
+.ease-gap-7      { gap:     var(--ease-space-7); }
+.ease-padding-7  { padding: var(--ease-space-7); }
+.ease-margin-7   { margin:  var(--ease-space-7); }
+.ease-pt-7       { padding-top:    var(--ease-space-7); }
+.ease-pb-7       { padding-bottom: var(--ease-space-7); }
+.ease-pl-7       { padding-left:   var(--ease-space-7); }
+.ease-pr-7       { padding-right:  var(--ease-space-7); }
+.ease-px-7       { padding-left: var(--ease-space-7); padding-right:  var(--ease-space-7); }
+.ease-py-7       { padding-top:  var(--ease-space-7); padding-bottom: var(--ease-space-7); }
+.ease-mt-7       { margin-top:    var(--ease-space-7); }
+.ease-mb-7       { margin-bottom: var(--ease-space-7); }
+.ease-mx-7       { margin-left: var(--ease-space-7); margin-right:  var(--ease-space-7); }
+.ease-my-7       { margin-top:  var(--ease-space-7); margin-bottom: var(--ease-space-7); }
+```
+
+### How is it used?
+
+```html
+<section class="ease-padding-7">
+  <div class="ease-grid ease-grid-cols-3 ease-gap-7">
+    <div class="ease-card">Card 1</div>
+    <div class="ease-card">Card 2</div>
+    <div class="ease-card">Card 3</div>
+  </div>
+</section>
+
+<h2 class="ease-mb-7">Section heading with 28px bottom space</h2>
+```
+
+### Why is it useful?
+
+EaseMotion CSS is a token-first framework — all spacing should come from
+`--ease-space-*` variables. A gap in the scale forces magic number usage for
+one of the most common layout spacings. Adding `--ease-space-7` completes the
+numeric sequence from `space-1` through `space-8` with no gaps.

--- a/submissions/examples/spacing-token-space-7/demo.html
+++ b/submissions/examples/spacing-token-space-7/demo.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>--ease-space-7 Token — Issue #1803</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem;
+      max-width: 720px;
+      margin: 0 auto;
+      line-height: 1.6;
+    }
+
+    h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 0.25rem; }
+    h2 { font-size: 0.95rem; color: #64748b; font-weight: 500; margin-bottom: 2rem; }
+    h3 { font-size: 0.78rem; font-weight: 700; text-transform: uppercase;
+         letter-spacing: 0.07em; color: #94a3b8; margin-bottom: 0.75rem; }
+
+    code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      background: #f1f5f9;
+      color: #4b44cc;
+      padding: 0.15em 0.4em;
+      border-radius: 0.25rem;
+    }
+
+    pre {
+      background: #0f172a;
+      color: #f1f5f9;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      line-height: 1.7;
+      padding: 1.25rem;
+      border-radius: 0.5rem;
+      overflow-x: auto;
+      margin-bottom: 1.5rem;
+    }
+
+    .ins  { color: #86efac; }
+    .cmt  { color: #64748b; }
+
+    section { margin-bottom: 2.5rem; }
+
+    /* ── Scale visualiser ───────────────────────────────────── */
+    .scale-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.4rem;
+      font-size: 0.8rem;
+    }
+    .scale-label {
+      font-family: 'JetBrains Mono', monospace;
+      color: #4b44cc;
+      width: 120px;
+      flex-shrink: 0;
+    }
+    .scale-bar {
+      height: 24px;
+      border-radius: 0.25rem;
+    }
+    .bar-exists { background: #e0e7ff; }
+    .bar-new    { background: #6c63ff; }
+    .scale-val  { color: #64748b; font-size: 0.75rem; white-space: nowrap; }
+    .scale-tag  {
+      font-size: 0.65rem; font-weight: 700; padding: 0.15em 0.5em;
+      border-radius: 9999px; flex-shrink: 0;
+    }
+    .tag-exists { background: #f0fdf4; color: #15803d; border: 1px solid #bbf7d0; }
+    .tag-new    { background: #eff6ff; color: #1d4ed8; border: 1px solid #bfdbfe; }
+
+    /* ── Live padding demo ──────────────────────────────────── */
+    .pad-demo {
+      background: #eff6ff;
+      border: 2px dashed #bfdbfe;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+    .pad-inner {
+      background: #6c63ff;
+      color: #fff;
+      border-radius: 0.25rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      padding: 0.4rem 0.75rem;
+    }
+
+    /* ── Grid demo ──────────────────────────────────────────── */
+    .grid-demo {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+    }
+    .grid-card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 0.5rem;
+      padding: 1rem;
+      font-size: 0.8rem;
+      text-align: center;
+    }
+    .grid-card-num {
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: #6c63ff;
+    }
+  </style>
+</head>
+<body>
+
+  <h1><code>--ease-space-7</code></h1>
+  <h2>Missing spacing token — Issue #1803</h2>
+
+  <!-- ── Scale visualiser ── -->
+  <section>
+    <h3>Spacing scale — before and after</h3>
+
+    <div class="scale-row">
+      <span class="scale-label">--ease-space-5</span>
+      <div class="scale-bar bar-exists" style="width:80px;"></div>
+      <span class="scale-val">1.25rem / 20px</span>
+      <span class="scale-tag tag-exists">exists</span>
+    </div>
+    <div class="scale-row">
+      <span class="scale-label">--ease-space-6</span>
+      <div class="scale-bar bar-exists" style="width:96px;"></div>
+      <span class="scale-val">1.5rem / 24px</span>
+      <span class="scale-tag tag-exists">exists</span>
+    </div>
+    <div class="scale-row">
+      <span class="scale-label">--ease-space-7</span>
+      <div class="scale-bar bar-new" style="width:112px;"></div>
+      <span class="scale-val">1.75rem / 28px</span>
+      <span class="scale-tag tag-new">➕ proposed</span>
+    </div>
+    <div class="scale-row">
+      <span class="scale-label">--ease-space-8</span>
+      <div class="scale-bar bar-exists" style="width:128px;"></div>
+      <span class="scale-val">2rem / 32px</span>
+      <span class="scale-tag tag-exists">exists</span>
+    </div>
+    <div class="scale-row">
+      <span class="scale-label">--ease-space-10</span>
+      <div class="scale-bar bar-exists" style="width:160px;"></div>
+      <span class="scale-val">2.5rem / 40px</span>
+      <span class="scale-tag tag-exists">exists</span>
+    </div>
+  </section>
+
+  <!-- ── Core change ── -->
+  <section>
+    <h3>Exact change for core/variables.css</h3>
+    <pre><span class="cmt">/* add after --ease-space-6 */</span>
+  --ease-space-6:  1.5rem;    /* 24px */
+<span class="ins">  --ease-space-7:  1.75rem;   /* 28px  ← add */</span>
+  --ease-space-8:  2rem;      /* 32px */</pre>
+  </section>
+
+  <!-- ── Live padding demo ── -->
+  <section>
+    <h3>Live demo — ease-padding-7 (28px all sides)</h3>
+    <div class="pad-demo ease-padding-7">
+      <div class="pad-inner">Content</div>
+    </div>
+    <p style="font-size:0.75rem;color:#94a3b8;margin-top:0.5rem;">
+      The blue dashed area is the 28px padding applied by <code>ease-padding-7</code>
+    </p>
+  </section>
+
+  <!-- ── Grid gap demo ── -->
+  <section>
+    <h3>Live demo — ease-gap-7 (28px grid gap)</h3>
+    <div class="grid-demo ease-gap-7">
+      <div class="grid-card"><div class="grid-card-num">01</div>Card</div>
+      <div class="grid-card"><div class="grid-card-num">02</div>Card</div>
+      <div class="grid-card"><div class="grid-card-num">03</div>Card</div>
+    </div>
+    <p style="font-size:0.75rem;color:#94a3b8;margin-top:0.5rem;">
+      28px gap between columns via <code>ease-gap-7</code>
+    </p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/spacing-token-space-7/style.css
+++ b/submissions/examples/spacing-token-space-7/style.css
@@ -1,0 +1,37 @@
+/*
+  --ease-space-7 Design Token
+  ────────────────────────────
+  Maintainer actions:
+
+  1. core/variables.css — add after --ease-space-6 (~line 58):
+       --ease-space-7:  1.75rem;  /* 28px */
+
+  2. core/utilities.css — add the utility classes below after the
+     existing gap/padding/margin sections.
+*/
+
+/* ── Token (local for demo — mirrors the proposed core token) ── */
+:root {
+  --ease-space-7: 1.75rem; /* 28px */
+}
+
+/* ── Gap utility ────────────────────────────────────────────── */
+.ease-gap-7      { gap:     var(--ease-space-7); }
+
+/* ── Padding utilities ──────────────────────────────────────── */
+.ease-padding-7  { padding: var(--ease-space-7); }
+.ease-pt-7       { padding-top:    var(--ease-space-7); }
+.ease-pb-7       { padding-bottom: var(--ease-space-7); }
+.ease-pl-7       { padding-left:   var(--ease-space-7); }
+.ease-pr-7       { padding-right:  var(--ease-space-7); }
+.ease-px-7       { padding-left:   var(--ease-space-7); padding-right:  var(--ease-space-7); }
+.ease-py-7       { padding-top:    var(--ease-space-7); padding-bottom: var(--ease-space-7); }
+
+/* ── Margin utilities ───────────────────────────────────────── */
+.ease-margin-7   { margin:  var(--ease-space-7); }
+.ease-mt-7       { margin-top:    var(--ease-space-7); }
+.ease-mb-7       { margin-bottom: var(--ease-space-7); }
+.ease-ml-7       { margin-left:   var(--ease-space-7); }
+.ease-mr-7       { margin-right:  var(--ease-space-7); }
+.ease-mx-7       { margin-left:   var(--ease-space-7); margin-right:  var(--ease-space-7); }
+.ease-my-7       { margin-top:    var(--ease-space-7); margin-bottom: var(--ease-space-7); }


### PR DESCRIPTION
## Pull Request Description

The EaseMotion CSS spacing scale jumps from `--ease-space-6` (1.5rem / 24px) directly to `--ease-space-8` (2rem / 32px), skipping the natural `1.75rem` (28px) step. This submission adds `--ease-space-7` to `core/variables.css` and the corresponding utility classes to `core/utilities.css`, completing the numeric sequence from `space-1` through `space-8` with no gaps.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] Other — design token addition

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/spacing-token-space-7/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — the exact token and utilities ready for core integration
- [x] Includes `README.md` — problem, fix, usage, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

One token in `core/variables.css`:
```css
--ease-space-7: 1.75rem; /* 28px */
```

And 13 utility classes in `core/utilities.css`:
```css
.ease-gap-7 .ease-padding-7 .ease-margin-7
.ease-pt-7  .ease-pb-7  .ease-pl-7  .ease-pr-7  .ease-px-7  .ease-py-7
.ease-mt-7  .ease-mb-7  .ease-ml-7  .ease-mr-7  .ease-mx-7  .ease-my-7
```

**How does a developer use it?**

```html
<section class="ease-padding-7">
  <div class="ease-grid ease-grid-cols-3 ease-gap-7">
    <div class="ease-card">Card 1</div>
    <div class="ease-card">Card 2</div>
    <div class="ease-card">Card 3</div>
  </div>
</section>
```

**Why does it fit EaseMotion CSS?**

EaseMotion CSS is token-first. Every spacing value should come from `--ease-space-*`. A gap in the scale forces hardcoded `1.75rem` values that bypass the design system. This addition is purely additive with zero regression risk.

---

## Demo

- [x] Demo added — `demo.html` shows an animated scale bar chart highlighting the gap between `space-6` and `space-8`, a live padding visualiser showing the exact 28px area, and a three-column grid showing `ease-gap-7` in action. The proposed token addition for `core/variables.css` is shown as a highlighted diff.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

`style.css` declares `--ease-space-7: 1.75rem` locally so the demo works standalone. On integration, the `:root` block in `style.css` maps directly to the addition needed in `core/variables.css`, and all utility classes use `var(--ease-space-7)` so they'll resolve correctly once the token is in core.

Closes #1803

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.