### PR TITLE
feat: add ease-min-h-0 and ease-min-w-0 utilities to fix flex/grid overflow (fixes #1804)

### DIFF
--- a/submissions/examples/flex-overflow-fix/README.md
+++ b/submissions/examples/flex-overflow-fix/README.md
@@ -1,0 +1,62 @@
+# ease-min-h-0 / ease-min-w-0 — Flex & Grid Overflow Fix Utilities
+
+### What does this do?
+
+Adds two utility classes to `core/utilities.css` that fix the most common silent
+flexbox and grid layout bug: content that should scroll or truncate instead
+overflows and expands its container.
+
+### The problem
+
+Flex and grid items have an implicit `min-height: auto` and `min-width: auto`.
+This means:
+
+- A flex column child with `overflow-y: auto` does not scroll — it grows instead
+- A flex row child with `.ease-truncate` does not truncate — text overflows
+
+The fix is `min-height: 0` (column axis) or `min-width: 0` (row axis) on the
+flex/grid child. EaseMotion CSS has no utility for this, so developers hit a
+confusing invisible bug with no in-framework escape hatch.
+
+Notably, `.ease-truncate` **already exists** in `core/utilities.css` but silently
+fails inside a flex row without `min-width: 0` on the parent — making this a
+direct gap in the framework's own utility set.
+
+### The fix (maintainer action on `core/utilities.css`)
+
+Add two classes in the overflow/display section:
+
+```css
+/* Flex / grid overflow fix */
+.ease-min-h-0 { min-height: 0; }
+.ease-min-w-0 { min-width:  0; }
+```
+
+### How is it used?
+
+```html
+<!-- Scrollable panel in a flex column -->
+<div class="ease-flex ease-flex-col" style="height: 400px;">
+  <header class="ease-padding-4">Header</header>
+  <div class="ease-flex-1 ease-overflow-y-auto ease-min-h-0">
+    <!-- This div now scrolls instead of pushing the container -->
+    <p>Long content…</p>
+  </div>
+</div>
+
+<!-- Truncated text in a flex row (ease-truncate alone fails without this) -->
+<div class="ease-flex ease-gap-4">
+  <img src="avatar.jpg" style="width:40px;flex-shrink:0;">
+  <div class="ease-min-w-0">
+    <p class="ease-truncate">Very long display name that must be truncated</p>
+  </div>
+</div>
+```
+
+### Why is it useful?
+
+This is one of the most-searched flexbox issues on Stack Overflow. Since
+EaseMotion CSS ships both `.ease-flex` and `.ease-truncate`, the framework
+creates the conditions for this bug and should also provide the fix.
+`ease-min-h-0` and `ease-min-w-0` are two lines of CSS that unlock correct
+behaviour for entire categories of layouts.

--- a/submissions/examples/flex-overflow-fix/demo.html
+++ b/submissions/examples/flex-overflow-fix/demo.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-min-h-0 / ease-min-w-0 — Issue #1804</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem;
+      max-width: 760px;
+      margin: 0 auto;
+      line-height: 1.6;
+    }
+
+    h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 0.25rem; }
+    h2 { font-size: 0.95rem; color: #64748b; font-weight: 500; margin-bottom: 2rem; }
+    h3 { font-size: 0.78rem; font-weight: 700; text-transform: uppercase;
+         letter-spacing: 0.07em; color: #94a3b8; margin-bottom: 0.75rem; }
+
+    section { margin-bottom: 2.5rem; }
+
+    code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      background: #f1f5f9;
+      color: #4b44cc;
+      padding: 0.15em 0.4em;
+      border-radius: 0.25rem;
+    }
+
+    pre {
+      background: #0f172a;
+      color: #f1f5f9;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      line-height: 1.7;
+      padding: 1.25rem;
+      border-radius: 0.5rem;
+      overflow-x: auto;
+      margin-bottom: 1rem;
+    }
+
+    .ins { color: #86efac; }
+    .del { color: #f87171; }
+    .cmt { color: #64748b; }
+
+    .two-col {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+
+    @media (max-width: 560px) { .two-col { grid-template-columns: 1fr; } }
+
+    .note {
+      background: #fffbeb;
+      border: 1px solid #fcd34d;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      font-size: 0.82rem;
+      color: #92400e;
+      margin-bottom: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1><code>ease-min-h-0</code> / <code>ease-min-w-0</code></h1>
+  <h2>Flex & grid overflow fix utilities — Issue #1804</h2>
+
+  <div class="note">
+    💡 <strong>Why this matters:</strong> <code>.ease-truncate</code> already exists in
+    <code>core/utilities.css</code> but silently fails inside a flex row. These two utilities
+    are the missing pair that make it work correctly.
+  </div>
+
+  <!-- ── Demo 1: Scrollable flex child ── -->
+  <section>
+    <h3>Demo 1 — Scrollable panel in a fixed-height flex column</h3>
+
+    <div class="two-col">
+
+      <!-- Broken -->
+      <div class="demo-box">
+        <div class="demo-label label-bug">❌ Without ease-min-h-0</div>
+        <div class="flex-col-container">
+          <div class="flex-header">Header</div>
+          <!-- flex: 1 + overflow-y: auto — but min-height: auto prevents scrolling -->
+          <div class="flex-scroll-area" style="flex:1; overflow-y:auto;">
+            <p>Line 1 — this should scroll</p>
+            <p>Line 2</p><p>Line 3</p><p>Line 4</p><p>Line 5</p>
+            <p>Line 6</p><p>Line 7</p><p>Line 8</p><p>Line 9</p>
+            <p>Line 10 — container overflows instead of scrolling</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Fixed -->
+      <div class="demo-box">
+        <div class="demo-label label-fix">✅ With ease-min-h-0</div>
+        <div class="flex-col-container">
+          <div class="flex-header">Header</div>
+          <!-- min-height: 0 overrides the implicit auto — scroll works -->
+          <div class="flex-scroll-area" style="flex:1; overflow-y:auto; min-height:0;">
+            <p>Line 1 — scrollable ↕</p>
+            <p>Line 2</p><p>Line 3</p><p>Line 4</p><p>Line 5</p>
+            <p>Line 6</p><p>Line 7</p><p>Line 8</p><p>Line 9</p>
+            <p>Line 10 — container stays contained</p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── Demo 2: Truncated text in flex row ── -->
+  <section>
+    <h3>Demo 2 — Text truncation in a flex row</h3>
+
+    <div class="two-col">
+
+      <!-- Broken -->
+      <div class="demo-box">
+        <div class="demo-label label-bug">❌ Without ease-min-w-0</div>
+        <div class="flex-row-container">
+          <div class="avatar">SK</div>
+          <!-- No min-width: 0 — truncation fails, text overflows -->
+          <div style="flex:1;">
+            <p class="truncate-text">Sumit Kumar — a very long display name that refuses to truncate</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Fixed -->
+      <div class="demo-box">
+        <div class="demo-label label-fix">✅ With ease-min-w-0</div>
+        <div class="flex-row-container">
+          <div class="avatar">SK</div>
+          <!-- min-width: 0 — truncation works correctly -->
+          <div style="flex:1; min-width:0;">
+            <p class="truncate-text">Sumit Kumar — a very long display name that refuses to truncate</p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── Core addition ── -->
+  <section>
+    <h3>Exact addition for core/utilities.css</h3>
+    <pre><span class="cmt">/* OVERFLOW section, around line 166 */</span>
+
+.ease-overflow-hidden  { overflow: hidden; }
+.ease-overflow-auto    { overflow: auto; }
+.ease-overflow-scroll  { overflow: scroll; }
+.ease-overflow-x-auto  { overflow-x: auto; }
+.ease-overflow-y-auto  { overflow-y: auto; }
+
+<span class="ins">/* Flex / grid overflow fix — overrides implicit min-height/width: auto */
+.ease-min-h-0 { min-height: 0; }
+.ease-min-w-0 { min-width:  0; }</span></pre>
+  </section>
+
+  <!-- ── Usage with ease-truncate ── -->
+  <section>
+    <h3>Pairing with the existing ease-truncate utility</h3>
+    <pre><span class="cmt">&lt;!-- ease-truncate alone silently fails in a flex row --&gt;</span>
+&lt;div class="ease-flex ease-gap-4"&gt;
+  &lt;img src="avatar.jpg" style="width:40px; flex-shrink:0;"&gt;
+<span class="del">  &lt;div class="ease-flex-1"&gt;                &lt;!-- ❌ text overflows --&gt;</span>
+<span class="ins">  &lt;div class="ease-flex-1 ease-min-w-0"&gt;  &lt;!-- ✅ truncation works --&gt;</span>
+    &lt;p class="ease-truncate"&gt;Long username that truncates correctly&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</pre>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/flex-overflow-fix/style.css
+++ b/submissions/examples/flex-overflow-fix/style.css
@@ -1,0 +1,93 @@
+/*
+  ease-min-h-0 / ease-min-w-0 — Flex & Grid Overflow Fix
+  ────────────────────────────────────────────────────────
+  Maintainer action: add the two rules below to core/utilities.css,
+  in the OVERFLOW section (around line 166).
+
+  These fix the implicit min-height/min-width: auto on flex/grid items
+  that prevents overflow: auto from scrolling and ease-truncate from
+  working inside flex rows.
+*/
+
+/* ── Core addition (2 lines) ────────────────────────────────── */
+.ease-min-h-0 { min-height: 0; }
+.ease-min-w-0 { min-width:  0; }
+
+/* ────────────────────────────────────────────────────────────
+   Demo-only styles below — not proposed for core
+   ──────────────────────────────────────────────────────────── */
+
+/* Shared demo box */
+.demo-box {
+  border: 2px solid #e2e8f0;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: #fff;
+  margin-bottom: 1.5rem;
+}
+
+.demo-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  padding: 0.4rem 1rem;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.label-bug  { background: #fef2f2; color: #b91c1c; }
+.label-fix  { background: #f0fdf4; color: #15803d; }
+
+/* Fixed-height flex column container */
+.flex-col-container {
+  display: flex;
+  flex-direction: column;
+  height: 200px;
+}
+
+.flex-header {
+  background: #6c63ff;
+  color: #fff;
+  padding: 0.6rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.flex-scroll-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 1rem;
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+/* Flex row with truncation */
+.flex-row-container {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  background: #6c63ff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.truncate-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.85rem;
+  color: #1e293b;
+}


### PR DESCRIPTION
## Pull Request Description

Flex and grid items have an implicit `min-height: auto` / `min-width: auto` that silently breaks two patterns EaseMotion CSS already supports: `overflow-y: auto` scrollable panels inside flex columns, and `.ease-truncate` inside flex rows. This submission adds `ease-min-h-0` and `ease-min-w-0` — two utility classes that fix both scenarios with two lines of CSS.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] Other — layout utility classes

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/flex-overflow-fix/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — the two-line addition for `core/utilities.css`
- [x] Includes `README.md` — problem, fix, usage, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Two utility classes in `core/utilities.css` (overflow section, ~line 166):

```css
/* Flex / grid overflow fix */
.ease-min-h-0 { min-height: 0; }
.ease-min-w-0 { min-width:  0; }
```

**How does a developer use it?**

```html
<!-- Scrollable panel in a flex column -->
<div class="ease-flex ease-flex-col" style="height: 400px;">
  <header class="ease-padding-4">Header</header>
  <div class="ease-flex-1 ease-overflow-y-auto ease-min-h-0">
    <!-- Now scrolls correctly -->
  </div>
</div>

<!-- ease-truncate works correctly inside a flex row -->
<div class="ease-flex ease-gap-4">
  <img src="avatar.jpg" style="width:40px; flex-shrink:0;">
  <div class="ease-flex-1 ease-min-w-0">
    <p class="ease-truncate">Long name that now truncates…</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

`.ease-truncate` already ships in `core/utilities.css` but silently fails inside flex rows without `min-width: 0`. EaseMotion CSS creates the conditions for this bug (`.ease-flex` + `.ease-truncate`) and should also ship the fix. These two classes are the most concise resolution to one of the most-searched flexbox layout issues.

---

## Demo

- [x] Demo added — `demo.html` shows two side-by-side comparisons: (1) a fixed-height flex column where the scroll area either overflows or scrolls correctly, and (2) a flex row avatar + username where text either overflows or truncates correctly. Both broken and fixed states are visible on the same page simultaneously.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The two-line addition slots naturally into the existing OVERFLOW section of `core/utilities.css`. The demo also shows the exact pairing with `ease-truncate` so users understand the relationship between the existing utility and this new one.

Closes #1804

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.