### PR TITLE
fix: update active navigation highlighting to left-border style

### DIFF
--- a/submissions/examples/active-navigation-highlighting/README.md
+++ b/submissions/examples/active-navigation-highlighting/README.md
@@ -2,20 +2,23 @@
 
 ## What does this do?
 
-Automatically highlights the navigation item corresponding to the section currently visible on screen.
+Automatically highlights the navigation item corresponding to the section currently visible on screen using a left border indicator.
 
 ## How is it used?
 
 ```html
 <nav class="docs-nav">
-  <a href="#getting-started">Getting Started</a>
+  <a href="#getting-started" class="active">Getting Started</a>
   <a href="#utilities">Utilities</a>
   <a href="#components">Components</a>
 </nav>
 ```
 
-The active class is applied automatically as users scroll through sections.
+The active class is applied automatically as users scroll through sections. The active link features:
+- `font-weight: 600` for emphasis
+- `border-left: 3px solid currentColor` for visual indicator
+- `padding-left: 8px` to accommodate the border
 
 ## Why is it useful?
 
-This improves documentation usability by helping users understand their current location within long pages. It provides clear visual feedback and makes navigation easier to follow.
+This improves documentation usability by helping users understand their current location within long pages. The left border indicator provides clear visual feedback and makes navigation easier to follow, especially in sidebar navigation layouts.

--- a/submissions/examples/active-navigation-highlighting/demo.html
+++ b/submissions/examples/active-navigation-highlighting/demo.html
@@ -9,7 +9,7 @@
 <body>
 
   <nav class="docs-nav">
-    <a href="#getting-started">Getting Started</a>
+    <a href="#getting-started" class="active">Getting Started</a>
     <a href="#utilities">Utilities</a>
     <a href="#animations">Animations</a>
     <a href="#components">Components</a>
@@ -18,7 +18,7 @@
   <main>
     <section id="getting-started">
       <h2>Getting Started</h2>
-      <p>Scroll down to see active navigation highlighting update automatically.</p>
+      <p>Scroll down to see active navigation highlighting update automatically. The active link will have a left border indicator.</p>
     </section>
 
     <section id="utilities">

--- a/submissions/examples/active-navigation-highlighting/style.css
+++ b/submissions/examples/active-navigation-highlighting/style.css
@@ -10,30 +10,41 @@ body {
 
 .docs-nav {
   position: fixed;
+  left: 0;
   top: 0;
-  width: 100%;
+  width: 250px;
+  height: 100vh;
   background: #111827;
   display: flex;
-  gap: 20px;
-  padding: 16px 24px;
+  flex-direction: column;
+  gap: 8px;
+  padding: 24px 16px;
   box-sizing: border-box;
+  overflow-y: auto;
 }
 
 .docs-nav a {
   color: #cbd5e1;
   text-decoration: none;
-  padding: 6px 10px;
+  padding: 8px 12px;
   transition: all 0.2s ease;
+  border-radius: 4px;
+}
+
+.docs-nav a:hover {
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .docs-nav a.active {
-  color: #ffffff;
-  border-bottom: 3px solid #6366f1;
   font-weight: 600;
+  border-left: 3px solid currentColor;
+  padding-left: 8px;
+  background: rgba(255, 255, 255, 0.05);
 }
 
 main {
-  padding-top: 70px;
+  margin-left: 250px;
+  padding: 40px;
 }
 
 section {


### PR DESCRIPTION
## Pull Request Description
This PR updates the active navigation highlighting feature to use a left-border indicator, providing better visual feedback for documentation sidebars as requested in issue #1320.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/active-navigation-highlighting/`
- [x] Includes `demo.html` — self-contained
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — updated with styling details
- [x] No changes to `core/` or `components/`

---

## Feature Description
**What does this add?**
It adds a `border-left` indicator and bold font weight to the active navigation link to clearly show the current section.

**How does a developer use it?**
Add the `.active` class to an `<a>` tag inside the `.docs-nav` container:
```html
<a href="#section-id" class="active">Link Name</a>