### PR TITLE
fix(accessibility): add descriptive accessible names to documentation copy buttons

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1914,9 +1914,15 @@
     }
 
     document.querySelectorAll(".copy-class-btn").forEach(button => {
+      const codeElement = button.parentElement.querySelector("code");
+      if (!codeElement) return;
+
+      const copiedText = codeElement.textContent.trim();
+      const itemType = button.textContent.includes("Variable") ? "variable" : "class";
+      button.setAttribute("aria-label", `Copy ${copiedText} ${itemType}`);
+
       button.addEventListener("click", async () => {
-        const className =
-          button.parentElement.querySelector("code").textContent.trim();
+        const className = copiedText;
 
         const success = await copyToClipboard(className);
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes an accessibility issue in the documentation where multiple **Copy Variable** and **Copy Class** buttons used generic accessible names, making it difficult for screen reader users to identify which variable or class would be copied.

The fix adds descriptive, context-specific `aria-label` attributes while preserving the existing UI and copy functionality.

---

## Type of Change

* [x] 🐛 Bug fix in an existing submission
* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] Other (describe below)

---

## Submission Checklist

* [x] Only files related to the accessibility fix were modified
* [x] No changes to existing functionality
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One issue addressed in this PR

---

## Feature Description

**What does this add?**

Adds descriptive accessible names to documentation copy buttons so assistive technology users can identify the exact variable or class being copied.

**How does a developer use it?**

No API or usage changes. The improvement is automatically available in the documentation UI.

Example:

```html
<button aria-label="Copy --ease-speed-fast variable">
  Copy Variable
</button>

<button aria-label="Copy ease-btn-primary class">
  Copy Class
</button>
```

**Why does it fit EaseMotion CSS?**

This improves documentation accessibility and usability while maintaining the project's focus on a clean and developer-friendly experience.

---

## Demo

* [x] Verified locally

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [ ] Edge
* [ ] Safari

---

## Notes for Maintainer

* Fix is intentionally minimal and scoped only to accessibility.
* Existing copy-to-clipboard behavior remains unchanged.
* No visual UI changes were introduced.

---

Closes #1831
