### PR TITLE
fix: remove duplicate --ease-color-secondary CSS variable declarations

### DIFF
--- a/core/variables.css
+++ b/core/variables.css
@@ -35,10 +35,6 @@
   --ease-color-danger-light:  #fca5a5;
   --ease-color-danger-dark:   #b91c1c;
 
-  --ease-color-secondary:       #8b5cf6;
-  --ease-color-secondary-light: #a78bfa;
-  --ease-color-secondary-dark:  #7c3aed;
-
   --ease-color-warning:       #f59e0b;
   --ease-color-warning-light: #fcd34d;
   --ease-color-warning-dark:  #b45309;


### PR DESCRIPTION
## Description
Fixes #1414 - Removes duplicate --ease-color-secondary CSS custom property declarations from core/variables.css.

### Root Cause
The :root block in core/variables.css declared --ease-color-secondary, --ease-color-secondary-light, and --ease-color-secondary-dark twice with identical values (lines 26-28 and lines 38-40). The second set completely overrode the first at parse time, creating dead code that bloated the bundle.

### Change
Removed the duplicate declaration block (lines 38-40). The first declaration at lines 26-28 is preserved unchanged.
