### PR TITLE
feat : add origami-map-pin

### DIFF
--- a/submissions/examples/origami-map-pin/README.md
+++ b/submissions/examples/origami-map-pin/README.md
@@ -1,0 +1,25 @@
+# Unfolding Origami Map Pin
+
+## What it does
+Location map pins that **unfold like origami paper** on hover, revealing a rich detail card (name, rating, status, CTA button). The card appears to emerge from the pin tip with a 3D perspective fold animation. Child elements inside the card stagger in sequentially for a layered reveal effect.
+
+## Animations & Techniques
+- **`scaleY` + `rotateX` Composite Transform**: The card opens from `scaleY(0) rotateX(-60deg)` to `scaleY(1) rotateX(0deg)` — simulating a flat folded paper unfolding upward in 3D perspective space.
+- **`transform-origin: 50% 100%`**: Anchors the unfolding animation to the bottom of the card (closest to the pin tip), making it appear to hinge open from that point.
+- **Staggered Child Animations**: `.card-header`, `.card-stats`, and `.card-btn` each have increasing `transition-delay` (0.1s → 0.18s → 0.24s) so the content populates line-by-line after the card opens.
+- **Spring Easing**: All transitions use `cubic-bezier(0.34, 1.56, 0.64, 1)` for an organic overshoot that feels physical.
+- **Pin Bounce**: The SVG pin itself `translateY(-6px) scale(1.08)` on hover, with a drop-shadow deepening to feel like it's lifting off the map.
+- **Shadow Pulse**: An `::after` pseudo-element casts an animated soft shadow beneath the pin tip.
+
+## Folder structure
+```
+animations/origami-map-pin/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Why it fits EaseMotion CSS
+- Demonstrates advanced multi-property transition composition (scale + rotate + translate simultaneously).
+- Showcases `transform-origin` as a design tool — the single most important property for making animations feel anchored and physical.
+- Includes `prefers-reduced-motion` and keyboard focus support.

--- a/submissions/examples/origami-map-pin/demo.html
+++ b/submissions/examples/origami-map-pin/demo.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Origami Map Pin – EaseMotion CSS</title>
+  <meta name="description" content="Map location pins that unfold like origami into a detailed card on hover, built with pure CSS 3D transforms." />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Unfolding Origami Map Pin</h1>
+  <p>Hover over any pin to unfold the location card</p>
+
+  <div class="pins-grid">
+
+    <!-- Pin 1: Restaurant -->
+    <div class="pin-wrap" tabindex="0" role="button" aria-label="EaseMotion Kitchen location">
+      <div class="info-card" role="tooltip">
+        <div class="card-header">
+          <div class="card-icon">🍜</div>
+          <div>
+            <div class="card-name">EaseMotion Kitchen</div>
+            <div class="card-type">Restaurant · 0.3 km</div>
+          </div>
+        </div>
+        <div class="card-stats">
+          <div class="stat-row">
+            <span class="stat-label">Rating</span>
+            <span class="stat-value"><span class="rating-stars">★★★★</span>☆ 4.2</span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-label">Status</span>
+            <span class="stat-value" style="color:#4ade80">● Open</span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-label">Wait time</span>
+            <span class="stat-value">~15 min</span>
+          </div>
+        </div>
+        <button class="card-btn">Get Directions →</button>
+      </div>
+      <div class="pin" aria-hidden="true">
+        <svg viewBox="0 0 52 70" xmlns="http://www.w3.org/2000/svg">
+          <path d="M26 2C14.95 2 6 10.95 6 22c0 15.75 20 46 20 46S46 37.75 46 22C46 10.95 37.05 2 26 2z"
+            fill="#ef4444" stroke="#b91c1c" stroke-width="2"/>
+          <circle cx="26" cy="22" r="8" fill="white" opacity="0.9"/>
+          <text x="26" y="26" text-anchor="middle" font-size="10" fill="#ef4444">🍜</text>
+        </svg>
+      </div>
+      <span class="pin-label">Restaurant</span>
+    </div>
+
+    <!-- Pin 2: Coffee -->
+    <div class="pin-wrap blue" tabindex="0" role="button" aria-label="Cascade Brew Co location">
+      <div class="info-card" role="tooltip">
+        <div class="card-header">
+          <div class="card-icon">☕</div>
+          <div>
+            <div class="card-name">Cascade Brew Co.</div>
+            <div class="card-type">Café · 0.7 km</div>
+          </div>
+        </div>
+        <div class="card-stats">
+          <div class="stat-row">
+            <span class="stat-label">Rating</span>
+            <span class="stat-value"><span class="rating-stars">★★★★★</span> 4.9</span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-label">Status</span>
+            <span class="stat-value" style="color:#4ade80">● Open</span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-label">Busy level</span>
+            <span class="stat-value" style="color:#f59e0b">Moderate</span>
+          </div>
+        </div>
+        <button class="card-btn" style="color:#38bdf8;border-color:rgba(56,189,248,0.3)">Get Directions →</button>
+      </div>
+      <div class="pin" aria-hidden="true">
+        <svg viewBox="0 0 52 70" xmlns="http://www.w3.org/2000/svg">
+          <path d="M26 2C14.95 2 6 10.95 6 22c0 15.75 20 46 20 46S46 37.75 46 22C46 10.95 37.05 2 26 2z"
+            fill="#3b82f6" stroke="#2563eb" stroke-width="2"/>
+          <circle cx="26" cy="22" r="8" fill="white" opacity="0.9"/>
+          <text x="26" y="26" text-anchor="middle" font-size="10" fill="#3b82f6">☕</text>
+        </svg>
+      </div>
+      <span class="pin-label">Café</span>
+    </div>
+
+    <!-- Pin 3: Park -->
+    <div class="pin-wrap green" tabindex="0" role="button" aria-label="Motion Park location">
+      <div class="info-card" role="tooltip">
+        <div class="card-header">
+          <div class="card-icon">🌳</div>
+          <div>
+            <div class="card-name">Motion Park</div>
+            <div class="card-type">Park · 1.2 km</div>
+          </div>
+        </div>
+        <div class="card-stats">
+          <div class="stat-row">
+            <span class="stat-label">Rating</span>
+            <span class="stat-value"><span class="rating-stars">★★★★</span>☆ 4.5</span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-label">Facilities</span>
+            <span class="stat-value">Benches, WiFi</span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-label">Open</span>
+            <span class="stat-value" style="color:#4ade80">6am – 10pm</span>
+          </div>
+        </div>
+        <button class="card-btn" style="color:#4ade80;border-color:rgba(74,222,128,0.3)">Get Directions →</button>
+      </div>
+      <div class="pin" aria-hidden="true">
+        <svg viewBox="0 0 52 70" xmlns="http://www.w3.org/2000/svg">
+          <path d="M26 2C14.95 2 6 10.95 6 22c0 15.75 20 46 20 46S46 37.75 46 22C46 10.95 37.05 2 26 2z"
+            fill="#10b981" stroke="#059669" stroke-width="2"/>
+          <circle cx="26" cy="22" r="8" fill="white" opacity="0.9"/>
+          <text x="26" y="26" text-anchor="middle" font-size="10" fill="#10b981">🌳</text>
+        </svg>
+      </div>
+      <span class="pin-label">Park</span>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/origami-map-pin/style.css
+++ b/submissions/examples/origami-map-pin/style.css
@@ -1,0 +1,208 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
+
+:root{
+  --bg:#060d12;
+  --surface:#0c1820;
+  --pin-red:#ef4444;
+  --pin-dark:#b91c1c;
+  --card-bg:#0f2435;
+  --text:#e2e8f0;
+  --muted:#64748b;
+  --accent:#38bdf8;
+}
+
+body{
+  font-family:'Inter',sans-serif;
+  background:var(--bg);
+  color:var(--text);
+  min-height:100vh;
+  display:flex;flex-direction:column;
+  align-items:center;justify-content:center;
+  gap:3rem;
+}
+
+body::before{
+  content:'';position:fixed;inset:0;
+  background:radial-gradient(ellipse 70% 50% at 50% 40%, rgba(56,189,248,0.05) 0%, transparent 60%);
+  pointer-events:none;
+}
+
+h1{
+  font-size:1.8rem;font-weight:700;
+  background:linear-gradient(135deg,#38bdf8,#818cf8);
+  -webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;
+  text-align:center;
+}
+p{color:var(--muted);font-size:0.9rem;text-align:center;}
+
+/* MAP PINS GRID */
+.pins-grid{
+  display:flex;gap:3rem;flex-wrap:wrap;justify-content:center;align-items:flex-end;
+}
+
+/* PIN WRAPPER */
+.pin-wrap{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  cursor:pointer;
+}
+
+/* ---- PIN SVG SHAPE ---- */
+.pin{
+  width:52px;
+  height:70px;
+  position:relative;
+  transition:transform 0.35s cubic-bezier(0.34,1.56,0.64,1);
+  filter:drop-shadow(0 8px 16px rgba(239,68,68,0.45));
+}
+
+.pin-wrap:hover .pin{
+  transform:translateY(-6px) scale(1.08);
+  filter:drop-shadow(0 14px 24px rgba(239,68,68,0.65));
+}
+
+.pin svg{
+  width:100%;height:100%;
+  overflow:visible;
+}
+
+/* Pulse ring on pin */
+.pin::after{
+  content:'';
+  position:absolute;
+  bottom:-4px;left:50%;
+  transform:translateX(-50%);
+  width:14px;height:6px;
+  background:rgba(239,68,68,0.3);
+  border-radius:50%;
+  filter:blur(4px);
+  animation:pin-shadow-pulse 2s ease-in-out infinite;
+}
+
+@keyframes pin-shadow-pulse{
+  0%,100%{transform:translateX(-50%) scale(1);opacity:0.5;}
+  50%{transform:translateX(-50%) scale(1.5);opacity:0.15;}
+}
+
+/* ---- ORIGAMI UNFOLD CARD ---- */
+.info-card{
+  position:absolute;
+  bottom:calc(100% + 16px);
+  left:50%;
+  width:200px;
+  background:var(--card-bg);
+  border:1px solid rgba(56,189,248,0.2);
+  border-radius:16px;
+  padding:16px;
+  box-shadow:0 20px 50px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.04);
+  transform-origin:50% 100%;
+  /* closed: folded flat */
+  transform:translateX(-50%) scaleY(0) perspective(400px) rotateX(-60deg);
+  opacity:0;
+  pointer-events:none;
+  transition:
+    transform 0.45s cubic-bezier(0.34,1.56,0.64,1),
+    opacity 0.3s ease;
+}
+
+/* Connector arrow */
+.info-card::after{
+  content:'';
+  position:absolute;
+  bottom:-8px;left:50%;
+  transform:translateX(-50%);
+  width:16px;height:8px;
+  background:var(--card-bg);
+  clip-path:polygon(0 0,100% 0,50% 100%);
+  border-bottom:none;
+}
+
+.pin-wrap:hover .info-card,
+.pin-wrap:focus-within .info-card{
+  transform:translateX(-50%) scaleY(1) perspective(400px) rotateX(0deg);
+  opacity:1;
+  pointer-events:all;
+}
+
+/* Card inner sections — staggered unfold */
+.card-header{
+  display:flex;align-items:center;gap:10px;
+  margin-bottom:10px;
+  padding-bottom:10px;
+  border-bottom:1px solid rgba(255,255,255,0.06);
+  transform:translateY(8px);opacity:0;
+  transition:transform 0.4s cubic-bezier(0.34,1.56,0.64,1) 0.1s, opacity 0.3s ease 0.1s;
+}
+
+.pin-wrap:hover .card-header{transform:translateY(0);opacity:1;}
+
+.card-icon{
+  width:36px;height:36px;border-radius:10px;
+  display:flex;align-items:center;justify-content:center;
+  font-size:1.1rem;
+  background:rgba(56,189,248,0.12);
+  flex-shrink:0;
+}
+
+.card-name{font-size:0.85rem;font-weight:700;color:var(--text);line-height:1.3;}
+.card-type{font-size:0.7rem;color:var(--muted);}
+
+.card-stats{
+  display:flex;flex-direction:column;gap:6px;
+  transform:translateY(8px);opacity:0;
+  transition:transform 0.4s cubic-bezier(0.34,1.56,0.64,1) 0.18s, opacity 0.3s ease 0.18s;
+}
+
+.pin-wrap:hover .card-stats{transform:translateY(0);opacity:1;}
+
+.stat-row{
+  display:flex;justify-content:space-between;align-items:center;
+  font-size:0.72rem;
+}
+
+.stat-label{color:var(--muted);}
+.stat-value{color:var(--text);font-weight:600;}
+
+.rating-stars{color:#f59e0b;letter-spacing:1px;}
+
+.card-btn{
+  margin-top:12px;
+  width:100%;padding:8px;
+  background:linear-gradient(135deg,rgba(56,189,248,0.15),rgba(129,140,248,0.15));
+  border:1px solid rgba(56,189,248,0.3);
+  border-radius:10px;
+  font-family:'Inter',sans-serif;
+  font-size:0.75rem;font-weight:600;
+  color:var(--accent);cursor:pointer;
+  transition:background 0.2s ease,transform 0.2s ease;
+  transform:translateY(8px);opacity:0;
+  transition:transform 0.4s cubic-bezier(0.34,1.56,0.64,1) 0.24s, opacity 0.3s ease 0.24s, background 0.2s ease;
+}
+
+.pin-wrap:hover .card-btn{transform:translateY(0);opacity:1;}
+.card-btn:hover{background:rgba(56,189,248,0.25);}
+
+/* PIN LABEL */
+.pin-label{
+  margin-top:8px;
+  font-size:0.75rem;font-weight:600;
+  color:var(--muted);
+  transition:color 0.2s ease;
+}
+
+.pin-wrap:hover .pin-label{color:var(--text);}
+
+/* Color variants */
+.pin-wrap.blue .pin{filter:drop-shadow(0 8px 16px rgba(59,130,246,0.45));}
+.pin-wrap.blue:hover .pin{filter:drop-shadow(0 14px 24px rgba(59,130,246,0.65));}
+.pin-wrap.green .pin{filter:drop-shadow(0 8px 16px rgba(16,185,129,0.45));}
+.pin-wrap.green:hover .pin{filter:drop-shadow(0 14px 24px rgba(16,185,129,0.65));}
+
+@media(prefers-reduced-motion:reduce){
+  .pin,.info-card,.card-header,.card-stats,.card-btn{transition:none;}
+  .pin::after{animation:none;}
+}


### PR DESCRIPTION
## Pull Request Description

Submitting a new component: Unfolding Origami Map Pin. Location pins that unfold like origami paper into a detailed card on hover.

Closes #1854 

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An animated map pin that reveals a tooltip card using a 3D hinge effect (`rotateX`) anchored at the bottom (`transform-origin`).

**How does a developer use it?**

```html
<div class="pin-wrap">
  <div class="info-card">
    <div class="card-header">...</div>
    <div class="card-stats">...</div>
  </div>
  <div class="pin">📍</div>
</div>
```

**Why does it fit EaseMotion CSS?**

It demonstrates `transform-origin` as a crucial design tool for grounded, physical motion, and showcases staggered child transitions driven purely by CSS delays.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The component relies entirely on CSS `:hover` and `:focus-within` for the interaction.
