### PR TITLE
feat : add scratch-off-reveal

### DIFF
--- a/submissions/examples/scratch-off-reveal/README.md
+++ b/submissions/examples/scratch-off-reveal/README.md
@@ -1,0 +1,24 @@
+# Scratch-Off Reveal Ticket
+
+## What it does
+An interactive **scratch-off lottery ticket** built with HTML Canvas and CSS animations. The user scrapes the gold foil surface with their mouse or finger to progressively reveal the hidden prize underneath. Once 55% of the surface is cleared, the prize auto-reveals with a springy CSS entrance animation.
+
+## Animations & Techniques
+- **Canvas `destination-out` compositing**: The scratch effect uses `ctx.globalCompositeOperation = 'destination-out'` to "erase" the gold foil layer as the user drags, revealing the CSS-animated prize layer beneath.
+- **Prize Pop Animation**: The prize icon uses `@keyframes prize-pop` with `cubic-bezier(0.34, 1.56, 0.64, 1)` — a springy overshoot — to bounce into view when revealed.
+- **Progress Meter**: A CSS-transitioned `width` bar tracks percentage of surface uncovered in real-time via `getImageData` pixel analysis.
+- **Procedural Texture**: The gold scratch surface is generated with `createLinearGradient` + random dot noise for a realistic foil appearance.
+- **Touch Support**: Full `touchstart`/`touchmove` event handling for mobile scratch interaction.
+
+## Folder structure
+```
+animations/scratch-off-reveal/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Why it fits EaseMotion CSS
+- A boundary-pushing interactive demo that blends Canvas interactivity with CSS animation for the reward state.
+- The CSS prize-pop animation is the centrepiece — perfectly aligned with EaseMotion's springy, organic motion philosophy.
+- Includes `prefers-reduced-motion` support for the prize animation.

--- a/submissions/examples/scratch-off-reveal/demo.html
+++ b/submissions/examples/scratch-off-reveal/demo.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scratch-Off Reveal Ticket – EaseMotion CSS</title>
+  <meta name="description" content="Interactive scratch-off lottery ticket using HTML Canvas with CSS animations for the prize reveal." />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Scratch-Off Reveal Ticket</h1>
+  <p>Scratch the gold surface to reveal your prize!</p>
+
+  <div class="tickets">
+    <div class="ticket" id="ticket1">
+      <div class="ticket-prize" id="prize1">
+        <div class="prize-icon" style="display:none">🏆</div>
+        <div class="prize-amount" style="display:none">$500</div>
+        <div class="prize-label" style="display:none">You Won!</div>
+      </div>
+      <canvas class="scratch-layer" id="canvas1" width="280" height="180"></canvas>
+      <div class="ticket-footer">
+        <span class="ticket-id">TKT-2024-0417</span>
+        <span>EaseMotion Lottery</span>
+      </div>
+    </div>
+
+    <div class="ticket" id="ticket2">
+      <div class="ticket-prize" id="prize2">
+        <div class="prize-icon" style="display:none">🎁</div>
+        <div class="prize-amount" style="display:none">Free Play</div>
+        <div class="prize-label" style="display:none">Try Again!</div>
+      </div>
+      <canvas class="scratch-layer" id="canvas2" width="280" height="180"></canvas>
+      <div class="ticket-footer">
+        <span class="ticket-id">TKT-2024-0418</span>
+        <span>EaseMotion Lottery</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="scratch-progress">
+    <div class="scratch-track"><div class="scratch-fill" id="scratchFill1"></div></div>
+    <div class="scratch-hint" id="scratchHint1">Scratch to reveal · 0% uncovered</div>
+  </div>
+
+  <button class="btn-reset" id="btnReset">↺ Reset Tickets</button>
+
+  <script>
+    function initScratch(canvasId, prizeId, fillId, hintId, ticketId) {
+      const canvas = document.getElementById(canvasId);
+      const ctx = canvas.getContext('2d');
+      const prize = document.getElementById(prizeId);
+      const fill = document.getElementById(fillId);
+      const hint = document.getElementById(hintId);
+      const ticket = document.getElementById(ticketId);
+      let isScratching = false;
+      let revealed = false;
+
+      function drawScratchSurface() {
+        const grad = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+        grad.addColorStop(0, '#c8941a');
+        grad.addColorStop(0.3, '#f5d060');
+        grad.addColorStop(0.6, '#d4af37');
+        grad.addColorStop(1, '#b8860b');
+        ctx.fillStyle = grad;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        // Texture dots
+        ctx.fillStyle = 'rgba(0,0,0,0.08)';
+        for (let i = 0; i < 600; i++) {
+          ctx.beginPath();
+          ctx.arc(
+            Math.random() * canvas.width,
+            Math.random() * canvas.height,
+            Math.random() * 2, 0, Math.PI * 2
+          );
+          ctx.fill();
+        }
+
+        // Label
+        ctx.fillStyle = 'rgba(0,0,0,0.35)';
+        ctx.font = 'bold 13px Inter, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('✦ SCRATCH HERE ✦', canvas.width / 2, canvas.height / 2 - 6);
+        ctx.font = '11px Inter, sans-serif';
+        ctx.fillText('Reveal your prize', canvas.width / 2, canvas.height / 2 + 14);
+      }
+
+      function scratch(x, y) {
+        ctx.globalCompositeOperation = 'destination-out';
+        ctx.beginPath();
+        ctx.arc(x, y, 22, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.globalCompositeOperation = 'source-over';
+        checkProgress();
+      }
+
+      function checkProgress() {
+        const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+        let transparent = 0;
+        for (let i = 3; i < data.length; i += 4) {
+          if (data[i] < 128) transparent++;
+        }
+        const pct = Math.round((transparent / (canvas.width * canvas.height)) * 100);
+        if (fill) fill.style.width = Math.min(pct, 100) + '%';
+        if (hint) hint.textContent = `Scratch to reveal · ${Math.min(pct,100)}% uncovered`;
+        if (pct > 55 && !revealed) {
+          revealed = true;
+          revealPrize();
+        }
+      }
+
+      function revealPrize() {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ticket.classList.add('revealed');
+        prize.querySelectorAll('[style*="display:none"]').forEach(el => {
+          el.style.display = '';
+        });
+        if (hint) hint.textContent = '🎉 Fully revealed!';
+      }
+
+      function getPos(e) {
+        const rect = canvas.getBoundingClientRect();
+        const src = e.touches ? e.touches[0] : e;
+        return {
+          x: (src.clientX - rect.left) * (canvas.width / rect.width),
+          y: (src.clientY - rect.top) * (canvas.height / rect.height)
+        };
+      }
+
+      canvas.addEventListener('mousedown', e => { isScratching = true; const p = getPos(e); scratch(p.x, p.y); });
+      canvas.addEventListener('mousemove', e => { if (!isScratching) return; const p = getPos(e); scratch(p.x, p.y); });
+      canvas.addEventListener('mouseup', () => isScratching = false);
+      canvas.addEventListener('mouseleave', () => isScratching = false);
+      canvas.addEventListener('touchstart', e => { e.preventDefault(); isScratching = true; const p = getPos(e); scratch(p.x, p.y); }, {passive:false});
+      canvas.addEventListener('touchmove', e => { e.preventDefault(); if (!isScratching) return; const p = getPos(e); scratch(p.x, p.y); }, {passive:false});
+      canvas.addEventListener('touchend', () => isScratching = false);
+
+      drawScratchSurface();
+      return { reset: () => {
+        ctx.clearRect(0,0,canvas.width,canvas.height);
+        revealed = false;
+        ticket.classList.remove('revealed');
+        prize.querySelectorAll('div').forEach(el => el.style.display = 'none');
+        if (fill) fill.style.width = '0%';
+        if (hint) hint.textContent = 'Scratch to reveal · 0% uncovered';
+        drawScratchSurface();
+      }};
+    }
+
+    const t1 = initScratch('canvas1','prize1','scratchFill1','scratchHint1','ticket1');
+    const t2 = initScratch('canvas2','prize2',null,null,'ticket2');
+
+    document.getElementById('btnReset').addEventListener('click', () => {
+      t1.reset(); t2.reset();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/scratch-off-reveal/style.css
+++ b/submissions/examples/scratch-off-reveal/style.css
@@ -1,0 +1,145 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
+
+:root{
+  --bg:#0a0a14;
+  --surface:#12121f;
+  --text:#e2e8f0;
+  --muted:#64748b;
+  --gold:#f59e0b;
+}
+
+body{
+  font-family:'Inter',sans-serif;
+  background:var(--bg);
+  color:var(--text);
+  min-height:100vh;
+  display:flex;flex-direction:column;
+  align-items:center;justify-content:center;
+  gap:3rem;
+}
+
+body::before{
+  content:'';position:fixed;inset:0;
+  background:radial-gradient(ellipse 60% 50% at 50% 50%, rgba(245,158,11,0.06) 0%, transparent 60%);
+  pointer-events:none;
+}
+
+h1{
+  font-size:1.8rem;font-weight:700;
+  background:linear-gradient(135deg,#f59e0b,#fbbf24);
+  -webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;
+  text-align:center;
+}
+p{color:var(--muted);font-size:0.9rem;text-align:center;}
+
+/* TICKETS GRID */
+.tickets{
+  display:flex;gap:2rem;flex-wrap:wrap;justify-content:center;
+}
+
+/* TICKET CARD */
+.ticket{
+  position:relative;
+  width:280px;
+  border-radius:20px;
+  overflow:hidden;
+  box-shadow:0 20px 60px rgba(0,0,0,0.6),0 0 0 1px rgba(255,255,255,0.05);
+  cursor:crosshair;
+  user-select:none;
+  -webkit-user-select:none;
+}
+
+/* HIDDEN PRIZE LAYER (bottom) */
+.ticket-prize{
+  padding:28px 24px;
+  display:flex;flex-direction:column;align-items:center;gap:12px;
+  background:linear-gradient(135deg,#1a2744,#0f1a35);
+  min-height:180px;
+  justify-content:center;
+}
+
+.prize-icon{
+  font-size:3rem;
+  animation:prize-pop 0.5s cubic-bezier(0.34,1.56,0.64,1) both;
+}
+
+@keyframes prize-pop{
+  from{transform:scale(0) rotate(-20deg);opacity:0;}
+  to{transform:scale(1) rotate(0deg);opacity:1;}
+}
+
+.prize-amount{
+  font-size:2rem;font-weight:800;
+  background:linear-gradient(135deg,#f59e0b,#fde68a);
+  -webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;
+}
+
+.prize-label{
+  font-size:0.8rem;color:rgba(255,255,255,0.5);letter-spacing:0.1em;text-transform:uppercase;
+}
+
+/* SCRATCH LAYER (top canvas overlay) */
+.scratch-layer{
+  position:absolute;
+  inset:0;
+  cursor:crosshair;
+}
+
+/* TICKET FOOTER */
+.ticket-footer{
+  background:rgba(0,0,0,0.5);
+  padding:10px 16px;
+  display:flex;justify-content:space-between;align-items:center;
+  font-size:0.7rem;color:rgba(255,255,255,0.4);
+  border-top:1px solid rgba(255,255,255,0.05);
+  position:relative;z-index:1;
+}
+
+.ticket-id{font-variant-numeric:tabular-nums;letter-spacing:0.1em;}
+
+/* REVEALED state */
+.ticket.revealed .scratch-layer{
+  pointer-events:none;
+}
+
+/* PROGRESS */
+.scratch-progress{
+  width:280px;
+  display:flex;flex-direction:column;gap:6px;
+}
+
+.scratch-track{
+  width:100%;height:6px;
+  background:rgba(255,255,255,0.08);
+  border-radius:3px;overflow:hidden;
+}
+
+.scratch-fill{
+  height:100%;width:0%;
+  background:linear-gradient(90deg,#f59e0b,#fbbf24);
+  border-radius:3px;
+  transition:width 0.1s ease;
+}
+
+.scratch-hint{
+  font-size:0.72rem;color:var(--muted);text-align:center;
+}
+
+/* Reset button */
+.btn-reset{
+  background:rgba(245,158,11,0.1);
+  border:1px solid rgba(245,158,11,0.3);
+  border-radius:10px;padding:10px 24px;
+  font-family:'Inter',sans-serif;font-size:0.85rem;font-weight:600;
+  color:var(--gold);cursor:pointer;
+  transition:background 0.2s ease,transform 0.2s ease;
+}
+
+.btn-reset:hover{background:rgba(245,158,11,0.2);transform:translateY(-1px);}
+.btn-reset:active{transform:scale(0.96);}
+
+@media(prefers-reduced-motion:reduce){
+  .prize-icon{animation:none;}
+}


### PR DESCRIPTION
## Pull Request Description

Submitting a new component: Scratch-Off Reveal Ticket. An interactive scratch-off lottery ticket using HTML Canvas with a CSS-animated prize reveal.

Closes #1856 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A canvas-based scratch-off interaction that reveals a CSS-styled, spring-animated prize underneath.

**How does a developer use it?**

```html
<div class="ticket">
  <div class="ticket-prize">
    <div class="prize-icon">🏆</div> <!-- Animates in on reveal -->
  </div>
  <canvas class="scratch-layer"></canvas>
</div>
```

**Why does it fit EaseMotion CSS?**

It highlights that even when integrating with interactive mediums like Canvas, the reward motion and visual feedback can still be cleanly delegated to declarative CSS animations.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The scratch interaction requires JS/Canvas, but the `prize-pop` animation and progress bar transitions are standard CSS.
