### PR TITLE
fix: use css variables for bounce animation durations

### DIFF
--- a/easemotion/bounce.css
+++ b/easemotion/bounce.css
@@ -38,12 +38,12 @@
 }
 
 .ease-bounce {
-  animation: ease-kf-bounce 1s;
+  animation: ease-kf-bounce var(--ease-speed-slow);
   animation-iteration-count: var(--ease-animation-iterations);
 }
 
 .ease-bounce-in {
-  animation: ease-kf-bounce-in 0.8s ease-out forwards;
+  animation: ease-kf-bounce-in var(--ease-speed-slow) ease-out forwards;
 }
 
 .ease-bounce-button-exit {


### PR DESCRIPTION
This PR replaces the raw `1s` and `0.8s` duration values in `easemotion/bounce.css` with the `var(--ease-speed-slow)` CSS variable. Previously, the hardcoded values prevented these bounce animations from responding if a developer customized the global speed tokens. This fix ensures the library behaves consistently and stays truly customizable.

Submission Checklist

 Feature Description

What does this add?

Fixes inconsistent hardcoded animation durations in `bounce.css` to respect global speed tokens.

Closes #1850 