### PR TITLE
feat: add ease-tabs component (closes #260)

### DIFF
--- a/submissions/examples/ease-tabs-component/README.md
+++ b/submissions/examples/ease-tabs-component/README.md
@@ -1,0 +1,36 @@
+# ease-tabs — CSS-Only Tabs Component
+
+A tabs component using only radio inputs and CSS sibling selectors. Features an animated underline indicator with bounce easing.
+
+## Classes
+
+| Class | Description |
+|---|---|
+| `ease-tabs` | Wrapper element |
+| `ease-tabs-nav` | Tab button row |
+| `ease-tab-label` | Individual tab button (label for radio) |
+| `ease-tabs-panels` | Panel container |
+| `ease-tab-content` | Individual panel (needs `data-tab="N"`) |
+
+## Usage
+
+```html
+<div class="ease-tabs">
+  <input type="radio" name="tabs" id="tab1" checked />
+  <input type="radio" name="tabs" id="tab2" />
+
+  <div class="ease-tabs-nav">
+    <label class="ease-tab-label" for="tab1">Tab 1</label>
+    <label class="ease-tab-label" for="tab2">Tab 2</label>
+  </div>
+
+  <div class="ease-tabs-panels">
+    <div class="ease-tab-content" data-tab="1">Panel 1</div>
+    <div class="ease-tab-content" data-tab="2">Panel 2</div>
+  </div>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+Pure CSS using radio inputs + sibling combinator. Animated underline uses `ease-bounce` cubic-bezier. Respects `prefers-reduced-motion`.

--- a/submissions/examples/ease-tabs-component/demo.html
+++ b/submissions/examples/ease-tabs-component/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-tabs — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      background: #0f0e17;
+      color: #fff;
+      font-family: 'Inter', system-ui, sans-serif;
+      padding: 3rem 2rem;
+      min-height: 100vh;
+    }
+    h1 { font-size: 2rem; margin-bottom: 0.25rem; }
+    .subtitle { color: rgba(255,255,255,0.5); margin-bottom: 2.5rem; }
+    .demo-wrap { max-width: 560px; }
+    .ease-tab-content { color: rgba(255,255,255,0.7); line-height: 1.7; }
+    /* dark overrides */
+    .ease-tabs-nav { border-bottom-color: rgba(255,255,255,0.12); }
+  </style>
+</head>
+<body>
+  <h1>ease-tabs</h1>
+  <p class="subtitle">CSS-only tabs with animated underline — Issue #260</p>
+
+  <div class="demo-wrap">
+    <div class="ease-tabs">
+      <!-- Radio inputs -->
+      <input type="radio" name="demo-tabs" id="tab1" checked />
+      <input type="radio" name="demo-tabs" id="tab2" />
+      <input type="radio" name="demo-tabs" id="tab3" />
+
+      <!-- Tab nav -->
+      <div class="ease-tabs-nav">
+        <label class="ease-tab-label" for="tab1">Overview</label>
+        <label class="ease-tab-label" for="tab2">Features</label>
+        <label class="ease-tab-label" for="tab3">Usage</label>
+      </div>
+
+      <!-- Panels -->
+      <div class="ease-tabs-panels">
+        <div class="ease-tab-content" data-tab="1">
+          <strong>Overview</strong>
+          <p>A CSS-only tabs component using hidden radio inputs and the sibling combinator. No JavaScript needed. The animated underline uses a <code>scaleX</code> transform with a bounce easing.</p>
+        </div>
+        <div class="ease-tab-content" data-tab="2">
+          <strong>Features</strong>
+          <ul>
+            <li>Pure CSS — zero JavaScript</li>
+            <li>Animated underline indicator with bounce easing</li>
+            <li>Fade-in panel transition</li>
+            <li>Accessible via keyboard (radio inputs)</li>
+            <li>Respects <code>prefers-reduced-motion</code></li>
+          </ul>
+        </div>
+        <div class="ease-tab-content" data-tab="3">
+          <strong>Usage</strong>
+          <p>Wrap in <code>.ease-tabs</code>, add radio inputs with matching <code>id</code>/<code>for</code> pairs, then use <code>.ease-tabs-nav</code> + <code>.ease-tab-label</code> for buttons and <code>.ease-tabs-panels</code> + <code>.ease-tab-content</code> for panels.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-tabs-component/style.css
+++ b/submissions/examples/ease-tabs-component/style.css
@@ -1,0 +1,90 @@
+/* ============================================================
+   EaseMotion CSS — ease-tabs component (CSS-only, radio inputs)
+   Issue #260
+   ============================================================ */
+
+.ease-tabs {
+  --_tab-accent: var(--ease-color-primary, #6c63ff);
+  position: relative;
+}
+
+/* Hide radio inputs visually */
+.ease-tabs input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* Tab button row */
+.ease-tabs-nav {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+  position: relative;
+}
+
+/* Each tab label */
+.ease-tab-label {
+  position: relative;
+  padding: 0.625rem 1.25rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--ease-color-muted, #64748b);
+  cursor: pointer;
+  user-select: none;
+  transition: color var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4,0,0.2,1));
+}
+
+/* Animated underline indicator */
+.ease-tab-label::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--_tab-accent);
+  transform: scaleX(0);
+  transition: transform var(--ease-speed-medium, 300ms) var(--ease-ease-bounce, cubic-bezier(0.34,1.56,0.64,1));
+  transform-origin: center;
+}
+
+/* Active tab when radio is checked — match by sibling/general combinator */
+#tab1:checked ~ .ease-tabs-nav label[for="tab1"],
+#tab2:checked ~ .ease-tabs-nav label[for="tab2"],
+#tab3:checked ~ .ease-tabs-nav label[for="tab3"],
+#tab4:checked ~ .ease-tabs-nav label[for="tab4"] {
+  color: var(--_tab-accent);
+}
+
+#tab1:checked ~ .ease-tabs-nav label[for="tab1"]::after,
+#tab2:checked ~ .ease-tabs-nav label[for="tab2"]::after,
+#tab3:checked ~ .ease-tabs-nav label[for="tab3"]::after,
+#tab4:checked ~ .ease-tabs-nav label[for="tab4"]::after {
+  transform: scaleX(1);
+}
+
+/* Panel content */
+.ease-tab-content {
+  display: none;
+  padding: var(--ease-space-6, 1.5rem) 0;
+  animation: ease-tab-fadein var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4,0,0.2,1)) both;
+}
+
+#tab1:checked ~ .ease-tabs-panels [data-tab="1"],
+#tab2:checked ~ .ease-tabs-panels [data-tab="2"],
+#tab3:checked ~ .ease-tabs-panels [data-tab="3"],
+#tab4:checked ~ .ease-tabs-panels [data-tab="4"] {
+  display: block;
+}
+
+@keyframes ease-tab-fadein {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tab-label::after { transition: none; }
+  .ease-tab-content { animation: none; }
+}


### PR DESCRIPTION
added ease tab component

Feature Request
Add a CSS-only tabs component using radio inputs:

ease-tabs wrapper
ease-tab-label for tab buttons
ease-tab-content for panels
Animated underline indicator
