### PR TITLE
fix: add @layer easemotion-components wrapper to chip.css

### DIFF
--- a/submissions/core_changes/bug-1919/chip.css
+++ b/submissions/core_changes/bug-1919/chip.css
@@ -1,0 +1,112 @@
+@layer easemotion-components {
+.ease-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.ease-chip-group input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.ease-chip-group input[type="checkbox"]:focus-visible + .ease-chip {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+.ease-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.875rem;
+  border-radius: 9999px;
+  border: 1px solid var(--ease-color-neutral-300, #d1d5db);
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-700, #374151);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+              border-color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+              color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+              transform var(--ease-speed-fast, 150ms) var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1)),
+              box-shadow var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.ease-chip:hover {
+  border-color: var(--ease-color-primary, #6366f1);
+  background: var(--ease-color-neutral-200, #e5e7eb);
+  transform: translateY(-1px);
+}
+
+.ease-chip::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 14px;
+  overflow: hidden;
+  transition: width var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+  background: var(--ease-color-primary, #6366f1);
+  border-color: var(--ease-color-primary, #6366f1);
+  color: #ffffff;
+  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
+}
+
+.ease-chip-group input[type="checkbox"]:checked + .ease-chip::before {
+  content: '✓';
+  width: 14px;
+  color: #ffffff;
+  font-size: 0.75rem;
+  line-height: 14px;
+}
+
+.ease-chip-group input[type="checkbox"]:disabled + .ease-chip {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.ease-chip-sm {
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+}
+
+.ease-chip-lg {
+  padding: 0.5rem 1.125rem;
+  font-size: 0.9rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-chip {
+    transition: none !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .ease-chip {
+    outline: 1px solid CanvasText;
+    outline-offset: 1px;
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+    background-color: Highlight;
+    border-color: Highlight;
+    color: HighlightText;
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip::before {
+    color: HighlightText;
+  }
+}
+}


### PR DESCRIPTION
## Description

The chip.css component was missing the `@layer easemotion-components` cascade layer wrapper that most other component files use. The fix wraps all CSS rules inside `@layer easemotion-components { ... }`.

The modified file is in `submissions/core_changes/bug-1919/chip.css` — no core files were modified.

## Related Issue

Fixes #1919
