### PR TITLE
fix: add prefers-reduced-motion support to badges pulse animation

### DIFF
--- a/submissions/core_changes/bug-1935/badges.css
+++ b/submissions/core_changes/bug-1935/badges.css
@@ -1,0 +1,52 @@
+@layer easemotion-components {
+  .em-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 var(--ease-space-2);
+    height: 20px;
+    min-width: 20px;
+    font-size: var(--ease-text-xs);
+    font-weight: 700;
+    color: #ffffff;
+    background-color: var(--ease-color-primary);
+    border-radius: var(--ease-radius-full);
+    box-shadow: var(--ease-shadow-sm);
+  }
+
+  .em-badge-danger {
+    background-color: var(--ease-color-danger);
+  }
+
+  .em-badge-success {
+    background-color: var(--ease-color-success);
+  }
+
+  /* Pulsing glow variant */
+  .em-badge-pulse {
+    position: relative;
+  }
+
+  .em-badge-pulse::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-radius: inherit;
+    box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.7);
+    animation: ease-kf-ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+    z-index: -1;
+  }
+
+  .em-badge-danger.em-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
+  }
+}
+
+  @media (prefers-reduced-motion: reduce) {
+    .em-badge-pulse::after {
+      animation: none !important;
+    }
+  }


### PR DESCRIPTION
## Description

The `.em-badge-pulse` variant used `animation: ease-kf-ping 1.5s infinite` with no reduced-motion override, violating WCAG 2.3.3.

## Fix

Added `@media (prefers-reduced-motion: reduce)` block. The modified file is in `submissions/core_changes/bug-1935/badges.css` — no core files were modified.

## Related Issue

Fixes #1935
