### PR TITLE
fix: remove duplicate alpha color variables with stale 6% opacity

### DIFF
--- a/submissions/core_changes/bug-1918/variables.css
+++ b/submissions/core_changes/bug-1918/variables.css
@@ -1,0 +1,174 @@
+/* ============================================================
+   EaseMotion CSS — variables.css
+   Design Tokens: the single source of truth for all values
+   ============================================================ */
+
+:root {
+
+  /* ── Transition Speeds ─────────────────────────────────── */
+  --ease-speed-fast:    150ms;
+  --ease-speed-medium:  300ms;
+  --ease-speed-slow:    600ms;
+
+  --ease-ease:          cubic-bezier(0.4, 0, 0.2, 1);   /* smooth ease-in-out */
+  --ease-ease-out:      cubic-bezier(0, 0, 0.2, 1);
+  --ease-ease-bounce:   cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* ── Animation controls ────────────────────────────────── */
+  /* Controls how many times looping animations run by default. */
+  --ease-animation-iterations: infinite;
+
+  /* ── Color Palette ─────────────────────────────────────── */
+  --ease-color-primary:       #6c63ff;
+  --ease-color-primary-light: #a09af8;
+  --ease-color-primary-dark:  #4b44cc;
+
+  --ease-color-secondary:       #8b5cf6;
+  --ease-color-secondary-light: #a78bfa;
+  --ease-color-secondary-dark:  #7c3aed;
+
+  --ease-color-success:       #22c55e;
+  --ease-color-success-light: #86efac;
+  --ease-color-success-dark:  #15803d;
+
+  --ease-color-danger:        #ef4444;
+  --ease-color-danger-light:  #fca5a5;
+  --ease-color-danger-dark:  #b91c1c;
+
+  --ease-color-warning:       #f59e0b;
+  --ease-color-warning-light: #fcd34d;
+  --ease-color-warning-dark:  #b45309;
+
+  --ease-color-info:          #3b82f6;
+  --ease-color-info-light:    #93c5fd;
+  --ease-color-info-dark:     #1d4ed8;
+
+  --ease-color-neutral-50:  #f8fafc;
+  --ease-color-neutral-100: #f1f5f9;
+  --ease-color-neutral-200: #e2e8f0;
+  --ease-color-neutral-300: #cbd5e1;
+  --ease-color-neutral-400: #94a3b8;
+  --ease-color-neutral-500: #64748b;
+  --ease-color-neutral-600: #475569;
+  --ease-color-neutral-700: #334155;
+  --ease-color-neutral-800: #1e293b;
+  --ease-color-neutral-900: #0f172a;
+
+  --ease-color-bg:      var(--ease-color-neutral-50);
+  --ease-color-surface: #ffffff;
+  --ease-color-text:    var(--ease-color-neutral-800);
+  --ease-color-muted:   var(--ease-color-neutral-600);
+  --ease-selection-color: #ffffff;
+
+  /* ── Alpha Channel Colors ────────────────────────────────── */
+  --ease-glass-bg:            color-mix(in srgb, var(--ease-color-surface) 12%, transparent);
+  --ease-glass-border:        color-mix(in srgb, var(--ease-color-surface) 20%, transparent);
+  /* Alpha / semi-transparent tokens — fallback first, then color-mix() override */
+  --ease-color-primary-alpha:  rgba(108, 99, 255, 0.15);                                   /* fallback */
+  --ease-color-primary-alpha:  color-mix(in srgb, var(--ease-color-primary) 15%, transparent);
+
+  --ease-color-success-alpha:  rgba(34, 197, 94, 0.15);                                    /* fallback */
+  --ease-color-success-alpha:  color-mix(in srgb, var(--ease-color-success) 15%, transparent);
+
+  --ease-color-danger-alpha:   rgba(239, 68, 68, 0.15);                                    /* fallback */
+  --ease-color-danger-alpha:   color-mix(in srgb, var(--ease-color-danger) 15%, transparent);
+
+  /* Glassmorphism tokens — fallback first, then color-mix() override */
+  --ease-glass-bg:     rgba(255, 255, 255, 0.12);                                           /* fallback */
+  --ease-glass-bg:     color-mix(in srgb, var(--ease-color-surface) 12%, transparent);
+
+  --ease-glass-border: rgba(255, 255, 255, 0.20);                                           /* fallback */
+  --ease-glass-border: color-mix(in srgb, var(--ease-color-surface) 20%, transparent);
+
+  /* ── Spacing Scale ─────────────────────────────────────── */
+  --ease-space-1:  0.25rem;   /*  4px */
+  --ease-space-2:  0.5rem;    /*  8px */
+  --ease-space-3:  0.75rem;   /* 12px */
+  --ease-space-4:  1rem;      /* 16px */
+  --ease-space-5:  1.25rem;   /* 20px */
+  --ease-space-6:  1.5rem;    /* 24px */
+  --ease-space-8:  2rem;      /* 32px */
+  --ease-space-10: 2.5rem;    /* 40px */
+  --ease-space-12: 3rem;      /* 48px */
+  --ease-space-16: 4rem;      /* 64px */
+
+  /* ── Border Radius ─────────────────────────────────────── */
+  --ease-radius-sm:   0.25rem;
+  --ease-radius-md:   0.5rem;
+  --ease-radius-lg:   1rem;
+  --ease-radius-xl:   1.5rem;
+  --ease-radius-full: 9999px;
+
+  /* ── Shadows ───────────────────────────────────────────── */
+  --ease-shadow-sm:  0 1px 3px rgba(0, 0, 0, 0.08),
+                     0 1px 2px rgba(0, 0, 0, 0.05);
+  --ease-shadow-md:  0 4px 6px -1px rgba(0, 0, 0, 0.10),
+                     0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --ease-shadow-lg:  0 10px 15px -3px rgba(0, 0, 0, 0.10),
+                     0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --ease-shadow-xl:  0 20px 25px -5px rgba(0, 0, 0, 0.10),
+                     0 10px 10px -5px rgba(0, 0, 0, 0.04);
+
+  --ease-glow-primary:   0 0 16px rgba(108, 99, 255, 0.45);
+  --ease-glow-secondary: 0 0 16px rgba(139, 92, 246, 0.45);
+  --ease-glow-success:   0 0 16px rgba(34, 197, 94, 0.45);
+  --ease-glow-danger:    0 0 16px rgba(239, 68, 68, 0.45);
+  --ease-glow-info:      0 0 16px rgba(59, 130, 246, 0.45);
+
+  /* ── Typography ────────────────────────────────────────── */
+  --ease-font-sans:  'Inter', system-ui, -apple-system, sans-serif;
+  --ease-font-mono:  'JetBrains Mono', 'Fira Code', monospace;
+
+  --ease-text-xs:   0.75rem;
+  --ease-text-sm:   0.875rem;
+  --ease-text-base: 1rem;
+  --ease-text-lg:   1.125rem;
+  --ease-text-xl:   1.25rem;
+  --ease-text-2xl:  1.5rem;
+  --ease-text-3xl:  1.875rem;
+  --ease-text-4xl:  2.25rem;
+
+  --ease-leading-tight:  1.25;
+  --ease-leading-normal: 1.6;
+  --ease-leading-loose:  1.9;
+
+  /* ── Responsive Breakpoints ─────────────────────────── */
+  --ease-bp-sm: 640px;
+  --ease-bp-md: 768px;
+  --ease-bp-lg: 1024px;
+  --ease-bp-xl: 1280px;
+
+  /* ── Layout ──────────────────────────────────────────── */
+  --ease-container-max: 1200px;
+
+  /* ── Z-Index Scale ─────────────────────────────────────── */
+  --ease-z-base:    0;
+  --ease-z-raised:  10;
+  --ease-z-overlay: 100;
+  --ease-z-modal:   1000;
+  --ease-z-toast:   9999;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-color-bg:      #0b1121;
+    --ease-color-surface: #141e33;
+    --ease-color-text:    #e2e8f0;
+    --ease-color-muted:   #94a3b8;
+
+    --ease-shadow-sm:  0 1px 3px rgba(0, 0, 0, 0.30),
+                       0 1px 2px rgba(0, 0, 0, 0.20);
+    --ease-shadow-md:  0 4px 6px -1px rgba(0, 0, 0, 0.35),
+                       0 2px 4px -1px rgba(0, 0, 0, 0.25);
+    --ease-shadow-lg:  0 10px 15px -3px rgba(0, 0, 0, 0.40),
+                       0 4px 6px -2px rgba(0, 0, 0, 0.25);
+    --ease-shadow-xl:  0 20px 25px -5px rgba(0, 0, 0, 0.45),
+                       0 10px 10px -5px rgba(0, 0, 0, 0.30);
+
+    --ease-glow-primary:   0 0 16px rgba(108, 99, 255, 0.45);
+    --ease-glow-secondary: 0 0 16px rgba(139, 92, 246, 0.45);
+    --ease-glow-success:   0 0 16px rgba(34, 197, 94, 0.45);
+    --ease-glow-danger:    0 0 16px rgba(239, 68, 68, 0.45);
+    --ease-glow-info:      0 0 16px rgba(59, 130, 246, 0.45);
+  }
+}


### PR DESCRIPTION
## Description

The `--ease-color-primary-alpha`, `--ease-color-success-alpha`, and `--ease-color-danger-alpha` custom properties were declared twice in `:root` — first at 6% opacity (dead code) then at 15% opacity (the real intended values).

## Fix

Removed the 6% opacity declarations. The modified file is in `submissions/core_changes/bug-1918/variables.css` — no core files were modified.

## Related Issue

Fixes #1918
