### PR TITLE
fix: remove overflow:hidden from .ease-card to prevent clipping shadows and hover effects

### DIFF
--- a/submissions/core_changes/bug-1924/cards.css
+++ b/submissions/core_changes/bug-1924/cards.css
@@ -1,0 +1,302 @@
+@layer easemotion-components {
+/* ============================================================
+   EaseMotion CSS — cards.css
+   Composable card components with hover animations
+   ============================================================ */
+
+/* ── Base Card ─────────────────────────────────────────────── */
+
+.ease-card {
+  background-color: var(--ease-color-surface, #141e33);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-6, 1.5rem);
+  position: relative;
+  max-width: 100%;
+  overflow-wrap: break-word;
+}
+
+/* ── Card Sections ─────────────────────────────────────────── */
+
+.ease-card-header {
+  padding-bottom: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.ease-card-body {
+  flex: 1;
+}
+
+.ease-card-footer {
+  padding-top: var(--ease-space-4, 1rem);
+  margin-top: var(--ease-space-4, 1rem);
+  border-top: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+/* Card title & subtitle helpers */
+.ease-card-title {
+  font-size: var(--ease-text-2xl, 1.5rem);
+  font-weight: 700;
+  color: var(--ease-color-neutral-900, #0f172a);
+  margin-bottom: var(--ease-space-1, 0.25rem);
+  line-height: var(--ease-leading-tight, 1.25);
+}
+
+.ease-card-subtitle {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #64748b);
+  font-weight: 400;
+}
+
+.ease-card-body p:last-child {
+  margin-bottom: 0;
+}
+
+/* ── Shadow Modifier ───────────────────────────────────────── */
+
+.ease-card-shadow {
+  box-shadow: var(--ease-shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.40),
+                       0 4px 6px -2px rgba(0, 0, 0, 0.25));
+  border-color: transparent;
+}
+
+/* ── Hover Card ────────────────────────────────────────────── */
+
+.ease-card-hover {
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+  transition:
+    transform    var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    box-shadow   var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    border-color var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+  will-change: transform, box-shadow;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-card-hover:hover {
+    transform: translateY(-6px);
+    box-shadow: var(--ease-shadow-xl, 0 20px 25px -5px rgba(0, 0, 0, 0.45),
+                       0 10px 10px -5px rgba(0, 0, 0, 0.30));
+    border-color: var(--ease-color-primary-light, #a09af8);
+    z-index: 2;
+  }
+}
+
+/* ── Glow Hover Card ───────────────────────────────────────── */
+
+.ease-card-glow {
+  transition:
+    box-shadow var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    border-color var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-card-glow:hover {
+    box-shadow: var(--ease-glow-primary, 0 0 16px rgba(108, 99, 255, 0.45)), var(--ease-shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.40),
+                       0 4px 6px -2px rgba(0, 0, 0, 0.25));
+    border-color: var(--ease-color-primary-light, #a09af8);
+  }
+}
+
+/* ── Flat Card (no border) ─────────────────────────────────── */
+
+.ease-card-flat {
+  border-color: transparent;
+  background-color: var(--ease-color-neutral-100, #f1f5f9);
+}
+
+/* ── Outlined Card ─────────────────────────────────────────── */
+
+.ease-card-outlined {
+  background-color: transparent;
+  border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+/* ── Glass Card (glassmorphism) ────────────────────────────── */
+
+.ease-card-glass {
+  background: var(--ease-glass-bg, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.2));
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  color: var(--ease-color-text, #1e293b);
+}
+
+/* Neumorphic Card (Soft UI) */
+.ease-card-neumorphic {
+  background-color: var(--ease-color-bg, #f8fafc);
+  border-color: transparent;
+  box-shadow:
+    8px 8px 20px rgba(15, 23, 42, 0.12),
+    -8px -8px 20px rgba(255, 255, 255, 0.78);
+  transition:
+    transform  var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    box-shadow var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+  will-change: transform, box-shadow;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-card-neumorphic:hover {
+    transform: translateY(-4px);
+    box-shadow:
+      12px 12px 26px rgba(15, 23, 42, 0.14),
+      -10px -10px 24px rgba(255, 255, 255, 0.86);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-card-neumorphic {
+    background-color: var(--ease-color-surface, #141e33);
+    box-shadow:
+      8px 8px 20px rgba(0, 0, 0, 0.32),
+      -8px -8px 20px rgba(255, 255, 255, 0.04);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .ease-card-neumorphic:hover {
+      box-shadow:
+        12px 12px 26px rgba(0, 0, 0, 0.36),
+        -10px -10px 24px rgba(255, 255, 255, 0.055);
+    }
+  }
+}
+
+/* ── Color Accent Cards ────────────────────────────────────── */
+
+/* Left border accent */
+.ease-card-accent {
+  border-left: 4px solid var(--ease-color-primary, #6c63ff);
+}
+
+.ease-card-accent-success {
+  border-left: 4px solid var(--ease-color-success, #22c55e);
+}
+
+.ease-card-accent-danger {
+  border-left: 4px solid var(--ease-color-danger, #ef4444);
+}
+
+.ease-card-accent-warning {
+  border-left: 4px solid var(--ease-color-warning, #f59e0b);
+}
+
+/* ── Image Card ────────────────────────────────────────────── */
+
+.ease-card-image {
+  padding: 0;
+}
+
+.ease-card-image .ease-card-img {
+  width: 100%;
+  height: auto;
+  aspect-ratio: var(--ease-card-ratio, 16 / 9);
+  object-fit: cover;
+  display: block;
+  border-radius: var(--ease-radius-lg, 1rem) var(--ease-radius-lg, 1rem) 0 0;
+}
+
+.ease-card-image .ease-card-body {
+  padding: var(--ease-space-6, 1.5rem);
+}
+
+/* ── Compact Card ──────────────────────────────────────────── */
+
+.ease-card-compact {
+  padding: var(--ease-space-4, 1rem);
+}
+
+/* ── Horizontal Card ───────────────────────────────────────── */
+
+.ease-card-horizontal {
+  display: flex;
+  flex-direction: row;
+  gap: var(--ease-space-4, 1rem);
+  align-items: flex-start;
+  padding: var(--ease-space-4, 1rem);
+}
+
+/* ── Info / Alert-style Cards ──────────────────────────────── */
+
+.ease-card-info {
+  background-color: color-mix(in srgb, var(--ease-color-primary, #6c63ff) 6%, transparent);
+  border-color: var(--ease-color-primary-light, #a09af8);
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.ease-card-success-bg {
+  background-color: color-mix(in srgb, var(--ease-color-success, #22c55e) 6%, transparent);
+  border-color: var(--ease-color-success-light, #86efac);
+}
+
+.ease-card-danger-bg {
+  background-color: color-mix(in srgb, var(--ease-color-danger, #ef4444) 6%, transparent);
+  border-color: var(--ease-color-danger-light, #fca5a5);
+}
+
+/* ── Stat Card ─────────────────────────────────────────────── */
+
+.ease-card-stat {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem);
+  font-size: var(--ease-text-base, 16px);
+}
+
+.ease-card-stat .ease-stat-value {
+  font-size: 2.5em;
+  font-weight: 700;
+  color: var(--ease-color-primary, #6c63ff);
+  line-height: 1;
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.ease-card-stat .ease-stat-label {
+  font-size: 0.875em;
+  color: var(--ease-color-muted, #64748b);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ── Reduced Motion: Respect user preference ───────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-card-hover {
+    transition: none !important;
+    transform: none !important;
+  }
+  .ease-card-glow {
+    transition: none !important;
+  }
+}
+
+@media (max-width: 640px) {
+  .ease-card {
+    padding: var(--ease-space-4, 1rem);
+  }
+
+  .ease-card-title {
+    font-size: var(--ease-text-xl, 1.25rem);
+  }
+
+  .ease-card-footer {
+    flex-wrap: wrap;
+  }
+
+  .ease-card-horizontal {
+    flex-direction: column;
+  }
+
+  .ease-card-image .ease-card-img {
+    aspect-ratio: var(--ease-card-ratio, 4 / 3);
+  }
+
+  .ease-card-image .ease-card-body,
+  .ease-card-stat {
+    padding: var(--ease-space-4, 1rem);
+  }
+}
+}


### PR DESCRIPTION
## Description

The `overflow: hidden` on `.ease-card` clipped `box-shadow` from child elements and prevented hover lift/shadow effects like `.ease-card-hover:hover` from rendering properly.

## Fix

Removed `overflow: hidden` from the base `.ease-card` rule. The modified file is in `submissions/core_changes/bug-1924/cards.css` — no core files were modified.

## Related Issue

Fixes #1924
