### PR TITLE
fix: remove synchronous getBoundingClientRect() from reveal.js to prevent layout thrash

### DIFF
--- a/submissions/core_changes/bug-1926/reveal.js
+++ b/submissions/core_changes/bug-1926/reveal.js
@@ -1,0 +1,48 @@
+(function () {
+  'use strict';
+
+  var revealClass = 'ease-reveal';
+  var activeClass = 'active';
+
+  var supportsObserver = 'IntersectionObserver' in window;
+
+  if (supportsObserver) {
+    var observer = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add(activeClass);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.15 }
+    );
+
+    var ready = function () {
+      var els = document.querySelectorAll('.' + revealClass);
+      Array.prototype.forEach.call(els, function (el) {
+        observer.observe(el);
+      });
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', ready);
+    } else {
+      ready();
+    }
+  } else {
+    var readyFallback = function () {
+      var els = document.querySelectorAll('.' + revealClass);
+      Array.prototype.forEach.call(els, function (el) {
+        el.classList.add(activeClass);
+      });
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', readyFallback);
+    } else {
+      readyFallback();
+    }
+  }
+})();


### PR DESCRIPTION
## Description

The `isCentered()` function called `getBoundingClientRect()` for every `.ease-reveal` element synchronously on DOMContentLoaded, forcing layout before the page finished painting (layout thrash).

## Fix

- Removed the `isCentered()` function
- All elements are now handled by the `IntersectionObserver` instead of being eagerly checked with `getBoundingClientRect()`
- The observer fires immediately for visible elements with `threshold: 0.15`, so there's no functional loss

The modified file is in `submissions/core_changes/bug-1926/reveal.js` — no core files were modified.

## Related Issue

Fixes #1926
