### PR TITLE
fix: rename badges classes from em-badge to ease-badge for naming consistency

### DIFF
--- a/submissions/core_changes/bug-1928/badges.css
+++ b/submissions/core_changes/bug-1928/badges.css
@@ -1,0 +1,46 @@
+@layer easemotion-components {
+  .ease-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 var(--ease-space-2);
+    height: 20px;
+    min-width: 20px;
+    font-size: var(--ease-text-xs);
+    font-weight: 700;
+    color: #ffffff;
+    background-color: var(--ease-color-primary);
+    border-radius: var(--ease-radius-full);
+    box-shadow: var(--ease-shadow-sm);
+  }
+
+  .ease-badge-danger {
+    background-color: var(--ease-color-danger);
+  }
+
+  .ease-badge-success {
+    background-color: var(--ease-color-success);
+  }
+
+  /* Pulsing glow variant */
+  .ease-badge-pulse {
+    position: relative;
+  }
+
+  .ease-badge-pulse::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-radius: inherit;
+    box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.7);
+    animation: ease-kf-ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+    z-index: -1;
+  }
+
+  .ease-badge-danger.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
+  }
+}


### PR DESCRIPTION
## Description

The badges component used `em-` prefix (`em-badge`, `em-badge-danger`, `em-badge-success`, `em-badge-pulse`) while all other components use the `ease-` prefix. This breaks naming convention consistency.

## Fix

Renamed all `em-badge` classes to `ease-badge` in `components/badges.css`. The modified file is in `submissions/core_changes/bug-1928/badges.css` — no core files were modified.

## Related Issue

Fixes #1928
