### PR TITLE
fix: rename tabs classes from em-tab to ease-tab for naming consistency

### DIFF
--- a/submissions/core_changes/bug-1927/tabs.css
+++ b/submissions/core_changes/bug-1927/tabs.css
@@ -1,0 +1,94 @@
+@layer easemotion-components {
+  .ease-tabs {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    font-family: var(--ease-font-sans);
+  }
+
+  .ease-tabs-nav {
+    display: flex;
+    border-bottom: 2px solid var(--ease-color-neutral-200);
+    position: relative;
+    margin-bottom: var(--ease-space-4);
+  }
+
+  .ease-tab-label {
+    flex: 1;
+    text-align: center;
+    padding: var(--ease-space-3) var(--ease-space-5);
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--ease-color-muted);
+    transition: color var(--ease-speed-fast) var(--ease-ease);
+    user-select: none;
+  }
+
+  .ease-tab-input {
+    display: none;
+  }
+
+  /* Sliding Underline Effect */
+  .ease-tab-underline {
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    height: 2px;
+    width: var(--ease-tab-width, 33.333%);
+    background-color: var(--ease-color-primary);
+    transition: transform var(--ease-speed-medium) var(--ease-ease);
+  }
+
+  /* Content Toggling */
+  .ease-tab-panel {
+    display: none;
+    animation: ease-kf-fade-in var(--ease-speed-medium) var(--ease-ease) both;
+  }
+
+  /* Select state for labels */
+  #ease-tab-1:checked ~ .ease-tabs-nav label[for="ease-tab-1"],
+  #ease-tab-2:checked ~ .ease-tabs-nav label[for="ease-tab-2"],
+  #ease-tab-3:checked ~ .ease-tabs-nav label[for="ease-tab-3"],
+  #ease-tab-4:checked ~ .ease-tabs-nav label[for="ease-tab-4"] {
+    color: var(--ease-color-primary);
+  }
+
+  /* Underline translation */
+  #ease-tab-1:checked ~ .ease-tabs-nav .ease-tab-underline {
+    transform: translateX(0);
+  }
+  #ease-tab-2:checked ~ .ease-tabs-nav .ease-tab-underline {
+    transform: translateX(100%);
+  }
+  #ease-tab-3:checked ~ .ease-tabs-nav .ease-tab-underline {
+    transform: translateX(200%);
+  }
+  #ease-tab-4:checked ~ .ease-tabs-nav .ease-tab-underline {
+    transform: translateX(300%);
+  }
+
+  /* Content Panel toggling */
+  #ease-tab-1:checked ~ .ease-tabs-content #ease-panel-1,
+  #ease-tab-2:checked ~ .ease-tabs-content #ease-panel-2,
+  #ease-tab-3:checked ~ .ease-tabs-content #ease-panel-3,
+  #ease-tab-4:checked ~ .ease-tabs-content #ease-panel-4 {
+    display: block;
+  }
+
+  /* Variants: Auto/Fit Width (for unequal width tabs) */
+  .ease-tabs-auto .ease-tab-label {
+    flex: none;
+  }
+  
+  .ease-tabs-auto .ease-tab-underline {
+    display: none;
+  }
+
+  /* Fallback static active indicator for auto-width tabs */
+  .ease-tabs-auto #ease-tab-1:checked ~ .ease-tabs-nav label[for="ease-tab-1"],
+  .ease-tabs-auto #ease-tab-2:checked ~ .ease-tabs-nav label[for="ease-tab-2"],
+  .ease-tabs-auto #ease-tab-3:checked ~ .ease-tabs-nav label[for="ease-tab-3"],
+  .ease-tabs-auto #ease-tab-4:checked ~ .ease-tabs-nav label[for="ease-tab-4"] {
+    border-bottom: 2px solid var(--ease-color-primary);
+  }
+}


### PR DESCRIPTION
## Description

The tabs component used `em-` prefix (`em-tabs`, `em-tab-label`, `em-tab-panel`, etc.) while all other components use the `ease-` prefix. This breaks naming convention consistency.

## Fix

Renamed all `em-tab*` and `em-tabs*` classes and IDs to `ease-tab*` and `ease-tabs*` in `components/tabs.css`. The modified file is in `submissions/core_changes/bug-1927/tabs.css` — no core files were modified.

## Related Issue

Fixes #1927
