### PR TITLE
fix: remove unused --ease-btn-glow custom property declarations

### DIFF
--- a/submissions/core_changes/bug-1916/buttons.css
+++ b/submissions/core_changes/bug-1916/buttons.css
@@ -1,0 +1,298 @@
+@layer easemotion-components {
+/* ============================================================
+   EaseMotion CSS — buttons.css
+   Composable, accessible button components
+   ============================================================ */
+
+/* ── Base Button ───────────────────────────────────────────── */
+
+.ease-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ease-space-2, 0.5rem);
+
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-6, 1.5rem);
+  font-family: var(--ease-font-sans, 'Inter', system-ui, -apple-system, sans-serif);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  white-space: nowrap;
+
+  border: 2px solid transparent;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  cursor: pointer;
+  user-select: none;
+  text-decoration: none;
+
+  transition:
+    background-color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    color            var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    border-color     var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    box-shadow       var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    transform        var(--ease-speed-fast, 150ms) var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1));
+}
+
+.ease-btn:active {
+  transform: scale(0.97);
+}
+
+.ease-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 3px;
+}
+
+/* ── Variants ──────────────────────────────────────────────── */
+
+/* Primary */
+.ease-btn-primary {
+  background-color: var(--ease-color-primary, #6c63ff);
+  color: #ffffff;
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-primary:hover {
+    background-color: var(--ease-color-primary-dark, #4b44cc);
+    border-color: var(--ease-color-primary-dark, #4b44cc);
+    box-shadow: var(--ease-glow-primary, 0 0 16px rgba(108, 99, 255, 0.45));
+  }
+}
+
+/* Success */
+.ease-btn-success {
+  background-color: var(--ease-color-success, #22c55e);
+  color: #ffffff;
+  border-color: var(--ease-color-success, #22c55e);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-success:hover {
+    background-color: var(--ease-color-success-dark, #15803d);
+    border-color: var(--ease-color-success-dark, #15803d);
+    box-shadow: var(--ease-glow-success, 0 0 16px rgba(34, 197, 94, 0.45));
+  }
+}
+
+/* Danger */
+.ease-btn-danger {
+  background-color: var(--ease-color-danger, #ef4444);
+  color: #ffffff;
+  border-color: var(--ease-color-danger, #ef4444);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-danger:hover {
+    background-color: var(--ease-color-danger-dark, #b91c1c);
+    border-color: var(--ease-color-danger-dark, #b91c1c);
+    box-shadow: var(--ease-glow-danger, 0 0 16px rgba(239, 68, 68, 0.45));
+  }
+}
+
+/* Outline (Primary) */
+.ease-btn-outline {
+  background-color: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-outline:hover {
+    background-color: var(--ease-color-primary, #6c63ff);
+    color: #ffffff;
+  }
+}
+
+/* Ghost */
+.ease-btn-ghost {
+  background-color: transparent;
+  color: var(--ease-color-neutral-700, #334155);
+  border-color: transparent;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-ghost:hover {
+    background-color: var(--ease-color-neutral-100, #f1f5f9);
+    color: var(--ease-color-neutral-900, #0f172a);
+  }
+}
+
+/* Link style */
+.ease-btn-link {
+  background: none;
+  border: none;
+  color: var(--ease-color-primary, #6c63ff);
+  padding-left: 0;
+  padding-right: 0;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-link:hover {
+    color: var(--ease-color-primary-dark, #4b44cc);
+    text-decoration: none;
+  }
+}
+
+/* ── Sizes ─────────────────────────────────────────────────── */
+
+.ease-btn-sm {
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-4, 1rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+.ease-btn-lg {
+  padding: var(--ease-space-4, 1rem) var(--ease-space-8, 2rem);
+  font-size: var(--ease-text-base, 1rem);
+  border-radius: var(--ease-radius-lg, 1rem);
+}
+
+.ease-btn-xl {
+  padding: var(--ease-space-5, 1.25rem) var(--ease-space-10, 2.5rem);
+  font-size: var(--ease-text-lg, 1.125rem);
+  border-radius: var(--ease-radius-lg, 1rem);
+}
+
+/* Full width */
+.ease-btn-block {
+  width: 100%;
+}
+
+/* Pill shape */
+.ease-btn-pill {
+  border-radius: var(--ease-radius-full, 9999px);
+}
+
+/* Icon only */
+.ease-btn-icon {
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+}
+
+/* ── States ────────────────────────────────────────────────── */
+
+.ease-btn:disabled,
+.ease-btn[disabled],
+.ease-btn-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.ease-btn:disabled:hover,
+.ease-btn:disabled:focus,
+.ease-btn:disabled:focus-visible,
+.ease-btn:disabled:active,
+.ease-btn[disabled]:hover,
+.ease-btn[disabled]:focus,
+.ease-btn[disabled]:focus-visible,
+.ease-btn[disabled]:active,
+.ease-btn-disabled:hover,
+.ease-btn-disabled:focus,
+.ease-btn-disabled:focus-visible,
+.ease-btn-disabled:active {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+  filter: none !important;
+}
+
+/* Loading spinner inside button */
+.ease-btn-loading {
+  pointer-events: none;
+  position: relative;
+}
+
+.ease-btn-loading::after {
+  content: '';
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ease-kf-rotate 0.7s linear infinite;
+  margin-left: var(--ease-space-2, 0.5rem);
+}
+
+/* ── Hover Class (composable) ──────────────────────────────── */
+/* Apply ease-btn-hover to any btn to add a lift+glow effect. */
+/* The glow color is controlled by --ease-btn-glow, which each */
+/* variant sets automatically. Falls back to primary glow.    */
+
+.ease-btn-hover {
+  transition:
+    transform    var(--ease-speed-medium, 300ms) var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1)),
+    box-shadow   var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    background-color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    border-color     var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-hover:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--ease-shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.40),
+                       0 4px 6px -2px rgba(0, 0, 0, 0.25)), var(--ease-glow-primary, 0 0 16px rgba(108, 99, 255, 0.45));
+  }
+}
+
+/* ── Button Group ──────────────────────────────────────────── */
+
+.ease-btn-group {
+  display: inline-flex;
+}
+
+.ease-btn-group .ease-btn {
+  border-radius: 0;
+}
+
+.ease-btn-group .ease-btn:focus-visible {
+  z-index: 1;
+}
+
+.ease-btn-group .ease-btn:first-child {
+  border-radius: var(--ease-radius-md, 0.5rem) 0 0 var(--ease-radius-md, 0.5rem);
+}
+
+.ease-btn-group .ease-btn:last-child {
+  border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+}
+
+.ease-btn-group .ease-btn:not(:last-child) {
+  border-right-width: 1px;
+}
+/* ── Accessibility: Reduced Motion ───────────────────────── */
+
+@media (max-width: 480px) {
+  .ease-btn {
+    max-width: 100%;
+    white-space: normal;
+    text-align: center;
+  }
+
+  .ease-btn-group {
+    display: flex;
+    flex-wrap: wrap;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+  .ease-btn,
+  .ease-btn-hover,
+  .ease-btn-loading::after {
+    transition: none !important;
+    animation: none !important;
+  }
+
+  .ease-btn:active,
+  .ease-btn-hover:hover {
+    transform: none !important;
+  }
+}
+}


### PR DESCRIPTION
## Description

The `--ease-btn-glow` custom property was set on 4 button variant classes (`.ease-btn-primary`, `.ease-btn-success`, `.ease-btn-danger`, `.ease-btn-outline`) but `var(--ease-btn-glow)` was never used in any CSS property — dead code.

## Fix

Removed the 4 unused `--ease-btn-glow` declarations from `components/buttons.css`. The modified file is in `submissions/core_changes/bug-1916/buttons.css` — no core files were modified.

## Related Issue

Fixes #1916
