### PR TITLE
fix: replace :target with [data-open] attribute to prevent browser history pollution

### DIFF
--- a/submissions/core_changes/bug-1929/modals.css
+++ b/submissions/core_changes/bug-1929/modals.css
@@ -1,0 +1,216 @@
+@layer easemotion-components {
+  /* ==========================================================================
+     MODAL / DIALOG COMPONENT
+     Pure CSS modal system using the [data-open] pseudo-class overlay technique.
+     ========================================================================== */
+
+  /* ── Modal Overlay Backdrop ─────────────────────────────────────────────── */
+  .ease-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(15, 23, 42, 0.6); /* Slate 900 base opacity */
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: var(--ease-z-index-modal, 1000);
+    
+    /* Hidden state */
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    
+    /* Transitions */
+    transition:
+      opacity var(--ease-speed-medium, 0.25s) var(--ease-ease, ease),
+      visibility var(--ease-speed-medium, 0.25s) var(--ease-ease, ease);
+  }
+
+  /* Activation State */
+  .ease-modal-overlay[data-open] {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  /* ── Modal Container ────────────────────────────────────────────────────── */
+  .ease-modal {
+    background: var(--ease-color-bg, #ffffff);
+    border-radius: var(--ease-radius-lg, 1rem);
+    box-shadow: var(--ease-shadow-2xl, 0 25px 50px -12px rgba(0, 0, 0, 0.25));
+    max-width: 500px;
+    width: 90%;
+    max-height: 90vh;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    
+    /* Default Transition (zoom + fade) */
+    transform: scale(0.9) translateY(-20px);
+    opacity: 0;
+    transition:
+      transform var(--ease-speed-medium, 0.25s) var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1)),
+      opacity var(--ease-speed-medium, 0.25s) var(--ease-ease, ease);
+  }
+
+  /* Modal Container Active State */
+  .ease-modal-overlay[data-open] .ease-modal {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+
+  /* ── Modal Sizing Variations ────────────────────────────────────────────── */
+  .ease-modal-sm {
+    max-width: 400px;
+  }
+
+  .ease-modal-lg {
+    max-width: 700px;
+  }
+
+  /* ── Modal Content Parts ────────────────────────────────────────────────── */
+  
+  /* Modal Header */
+  .ease-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem);
+    border-bottom: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  }
+
+  .ease-modal-header h2,
+  .ease-modal-header h3 {
+    margin: 0;
+    font-size: var(--ease-text-lg, 1.125rem);
+    font-weight: 700;
+    color: var(--ease-color-text, #1f2937);
+  }
+
+  /* Close Button */
+  .ease-modal-close {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: var(--ease-space-8, 2rem);
+    height: var(--ease-space-8, 2rem);
+    border-radius: var(--ease-radius-md, 0.5rem);
+    background: transparent;
+    color: var(--ease-color-neutral-500, #6b7280);
+    font-size: var(--ease-text-xl, 1.25rem);
+    line-height: 1;
+    text-decoration: none;
+    transition:
+      background var(--ease-speed-fast, 0.15s) var(--ease-ease, ease),
+      color var(--ease-speed-fast, 0.15s) var(--ease-ease, ease);
+  }
+
+  .ease-modal-close:hover {
+    background: var(--ease-color-neutral-100, #f3f4f6);
+    color: var(--ease-color-text, #111827);
+  }
+
+  /* Modal Body */
+  .ease-modal-body {
+    padding: var(--ease-space-6, 1.5rem);
+    color: var(--ease-color-text-muted, #4b5563);
+    line-height: 1.6;
+    overflow-y: auto;
+  }
+
+  .ease-modal-body p {
+    margin: 0 0 var(--ease-space-4, 1rem) 0;
+  }
+
+  .ease-modal-body p:last-child {
+    margin-bottom: 0;
+  }
+
+  /* Modal Footer */
+  .ease-modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--ease-space-3, 0.75rem);
+    padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem);
+    border-top: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+    background: var(--ease-color-neutral-50, #f9fafb);
+    border-radius: 0 0 var(--ease-radius-lg, 1rem) var(--ease-radius-lg, 1rem);
+  }
+
+  /* ── Animation Variations ───────────────────────────────────────────────── */
+
+  /* Slide Animation Variant */
+  .ease-modal-slide {
+    transform: translateY(100%);
+    transition: transform var(--ease-speed-medium, 0.25s) var(--ease-ease, ease),
+                opacity var(--ease-speed-medium, 0.25s) var(--ease-ease, ease);
+  }
+
+  .ease-modal-overlay[data-open] .ease-modal-slide {
+    transform: translateY(0);
+  }
+
+  /* Fade Animation Variant */
+  .ease-modal-fade {
+    transform: translateY(-20px);
+    transition: transform var(--ease-speed-medium, 0.25s) var(--ease-ease, ease),
+                opacity var(--ease-speed-medium, 0.25s) var(--ease-ease, ease);
+  }
+
+  .ease-modal-overlay[data-open] .ease-modal-fade {
+    transform: translateY(0);
+  }
+
+  /* Zoom Animation Variant */
+  .ease-modal-zoom {
+    transform: scale(0.8);
+    transition: transform var(--ease-speed-medium, 0.25s) var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1)),
+                opacity var(--ease-speed-medium, 0.25s) var(--ease-ease, ease);
+  }
+
+  .ease-modal-overlay[data-open] .ease-modal-zoom {
+    transform: scale(1);
+  }
+
+  /* ── Responsive Behavior ────────────────────────────────────────────────── */
+  @media (max-width: 640px) {
+    .ease-modal {
+      width: 95%;
+      max-height: 95vh;
+    }
+    
+    .ease-modal-header {
+      padding: var(--ease-space-3, 0.75rem) var(--ease-space-4, 1rem);
+    }
+    
+    .ease-modal-body {
+      padding: var(--ease-space-4, 1rem);
+    }
+    
+    .ease-modal-footer {
+      padding: var(--ease-space-3, 0.75rem) var(--ease-space-4, 1rem);
+      flex-direction: column-reverse;
+    }
+
+    .ease-modal-footer > * {
+      width: 100%;
+      text-align: center;
+    }
+  }
+
+  /* ── prefers-reduced-motion ─────────────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-modal-overlay,
+    .ease-modal,
+    .ease-modal-slide,
+    .ease-modal-fade,
+    .ease-modal-zoom {
+      transition: none !important;
+      transform: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description

The modal used `:target` pseudo-class for visibility toggling, which added URL fragment entries to browser history. Pressing the Back button closed the modal instead of navigating to the previous page.

## Fix

Replaced all `:target` selectors with `[data-open]` data attribute selectors in `components/modals.css`. The overlay can now be toggled via JavaScript by setting `element.setAttribute('data-open', '')` and `element.removeAttribute('data-open')`, which does not affect browser history.

The modified file is in `submissions/core_changes/bug-1929/modals.css` — no core files were modified.

## Related Issue

Fixes #1929
