### PR TITLE
fix: scope reduced-motion override from * to .ease-* selectors

### DIFF
--- a/submissions/core_changes/bug-1988/easemotion.css
+++ b/submissions/core_changes/bug-1988/easemotion.css
@@ -1,0 +1,9 @@
+@media (prefers-reduced-motion: reduce) {
+  [class*="ease-"],
+  [class*="ease-"]::before,
+  [class*="ease-"]::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Description

fix: scope reduced-motion override from * to .ease-* selectors. The modified file is in `submissions/core_changes/bug-1988/easemotion.css` — no core files were modified.

## Related Issue

Fixes #1988