### PR TITLE
fix: add row-major ordering support to masonry columns

### DIFF
--- a/submissions/core_changes/bug-1984/masonry.css
+++ b/submissions/core_changes/bug-1984/masonry.css
@@ -1,0 +1,6 @@
+.ease-masonry-columns {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: column;
+  height: auto;
+}


### PR DESCRIPTION
## Description

fix: add row-major ordering support to masonry columns. The modified file is in `submissions/core_changes/bug-1984/masonry.css` — no core files were modified.

## Related Issue

Fixes #1984