### PR TITLE
fix: wrap animation-timeline in @supports feature query

### DIFF
--- a/submissions/core_changes/bug-1985/scroll-progress.css
+++ b/submissions/core_changes/bug-1985/scroll-progress.css
@@ -1,0 +1,6 @@
+@supports (animation-timeline: scroll()) {
+  .ease-scroll-progress {
+    animation: ease-kf-scroll-progress auto linear;
+    animation-timeline: scroll();
+  }
+}


### PR DESCRIPTION
## Description

fix: wrap animation-timeline in @supports feature query. The modified file is in `submissions/core_changes/bug-1985/scroll-progress.css` — no core files were modified.

## Related Issue

Fixes #1985