### PR TITLE
fix: make underline width dynamic based on tab count

### DIFF
--- a/submissions/core_changes/bug-1987/tabs.css
+++ b/submissions/core_changes/bug-1987/tabs.css
@@ -1,0 +1,3 @@
+.em-tab-underline {
+  width: calc(100% / var(--ease-tabs-count, 3));
+}


### PR DESCRIPTION
## Description

fix: make underline width dynamic based on tab count. The modified file is in `submissions/core_changes/bug-1987/tabs.css` — no core files were modified.

## Related Issue

Fixes #1987