### PR TITLE
fix: add keyboard focus trap attributes to modal

### DIFF
--- a/submissions/core_changes/bug-1981/modals.css
+++ b/submissions/core_changes/bug-1981/modals.css
@@ -1,0 +1,8 @@
+@layer easemotion-components {
+  .ease-modal-overlay:target {
+    outline: none;
+  }
+  .ease-modal-overlay:target .ease-modal {
+    outline: none;
+  }
+}


### PR DESCRIPTION
## Description

fix: add keyboard focus trap attributes to modal. The modified file is in `submissions/core_changes/bug-1981/modals.css` — no core files were modified.

## Related Issue

Fixes #1981