### PR TITLE
fix: add max-width and overflow-wrap to tooltip

### DIFF
--- a/submissions/core_changes/bug-1980/tooltips.css
+++ b/submissions/core_changes/bug-1980/tooltips.css
@@ -1,0 +1,5 @@
+.ease-tooltip::after {
+  max-width: 80vw;
+  overflow-wrap: break-word;
+  white-space: normal;
+}


### PR DESCRIPTION
## Description

fix: add max-width and overflow-wrap to tooltip. The modified file is in `submissions/core_changes/bug-1980/tooltips.css` — no core files were modified.

## Related Issue

Fixes #1980