### PR TITLE
fix: add backdrop-filter fallback for Firefox

### DIFF
--- a/submissions/core_changes/bug-1986/cards.css
+++ b/submissions/core_changes/bug-1986/cards.css
@@ -1,0 +1,16 @@
+.ease-card-glass {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+@media (prefers-color-scheme: dark) {
+  .ease-card-glass {
+    background: rgba(15, 23, 42, 0.85);
+  }
+}
+@supports (backdrop-filter: blur(16px)) or (-webkit-backdrop-filter: blur(16px)) {
+  .ease-card-glass {
+    background: var(--ease-glass-bg, rgba(255, 255, 255, 0.12));
+  }
+}


### PR DESCRIPTION
## Description

fix: add backdrop-filter fallback for Firefox. The modified file is in `submissions/core_changes/bug-1986/cards.css` — no core files were modified.

## Related Issue

Fixes #1986