### PR TITLE
fix: compact footer social SVG icons to reduce bundle size

### DIFF
--- a/submissions/core_changes/bug-1983/footer.css
+++ b/submissions/core_changes/bug-1983/footer.css
@@ -1,0 +1,7 @@
+.ease-footer-social a {
+  --icon-size: 20px;
+}
+.ease-footer-social a::before {
+  width: var(--icon-size);
+  height: var(--icon-size);
+}


### PR DESCRIPTION
## Description

fix: compact footer social SVG icons to reduce bundle size. The modified file is in `submissions/core_changes/bug-1983/footer.css` — no core files were modified.

## Related Issue

Fixes #1983