### PR TITLE
fix: protect content property values from colon-stripping regex

### DIFF
--- a/submissions/core_changes/bug-1993/build-minified-css.mjs
+++ b/submissions/core_changes/bug-1993/build-minified-css.mjs
@@ -1,0 +1,10 @@
+function minifyCss(css) {
+  return removeCSSComments(css)
+    .replace(/\r\n/g, "\n")
+    .replace(/\n+/g, "\n")
+    .replace(/\s+/g, " ")
+    .replace(/\s*([{};,])\s*/g, "$1")
+    .replace(/;}/g, "}")
+    .replace(/\)\s+\{/g, "){")
+    .trim();
+}


### PR DESCRIPTION
## Description

fix: protect content property values from colon-stripping regex. The modified file is in `submissions/core_changes/bug-1993/build-minified-css.mjs` — no core files were modified.

## Related Issue

Fixes #1993