### PR TITLE
fix: add easemotion dir to duplicate scanner

### DIFF
--- a/submissions/core_changes/bug-1994/check-duplicates.mjs
+++ b/submissions/core_changes/bug-1994/check-duplicates.mjs
@@ -1,0 +1,1 @@
+const dirs = ["core", "components", "easemotion"];


### PR DESCRIPTION
## Description

fix: add easemotion dir to duplicate scanner. The modified file is in `submissions/core_changes/bug-1994/check-duplicates.mjs` — no core files were modified.

## Related Issue

Fixes #1994