### PR TITLE
fix: disable chip hover transform in prefers-reduced-motion

### DIFF
--- a/submissions/core_changes/bug-1996/chip.css
+++ b/submissions/core_changes/bug-1996/chip.css
@@ -1,0 +1,6 @@
+@media (prefers-reduced-motion: reduce) {
+  .ease-chip {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Description

fix: disable chip hover transform in prefers-reduced-motion. The modified file is in `submissions/core_changes/bug-1996/chip.css` — no core files were modified.

## Related Issue

Fixes #1996