### PR TITLE
fix: use CSS variable instead of hardcoded white badge text

### DIFF
--- a/submissions/core_changes/bug-1998/badges.css
+++ b/submissions/core_changes/bug-1998/badges.css
@@ -1,0 +1,11 @@
+.em-badge {
+  color: var(--ease-badge-text, #ffffff);
+}
+:root {
+  --ease-badge-text: #ffffff;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-badge-text: #ffffff;
+  }
+}


### PR DESCRIPTION
## Description

fix: use CSS variable instead of hardcoded white badge text. The modified file is in `submissions/core_changes/bug-1998/badges.css` — no core files were modified.

## Related Issue

Fixes #1998