### PR TITLE
fix: add close button for sidebar mobile overlay

### DIFF
--- a/submissions/core_changes/bug-1995/sidebar.css
+++ b/submissions/core_changes/bug-1995/sidebar.css
@@ -1,0 +1,21 @@
+.ease-sidebar-close {
+  display: none;
+  position: absolute;
+  top: var(--ease-space-4, 1rem);
+  right: var(--ease-space-4, 1rem);
+  background: transparent;
+  border: none;
+  color: var(--ease-color-neutral-400, #9ca3af);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+}
+.ease-sidebar-close:hover {
+  color: var(--ease-color-neutral-100, #f3f4f6);
+}
+@media (max-width: 768px) {
+  .ease-sidebar-close {
+    display: block;
+  }
+}


### PR DESCRIPTION
## Description

fix: add close button for sidebar mobile overlay. The modified file is in `submissions/core_changes/bug-1995/sidebar.css` — no core files were modified.

## Related Issue

Fixes #1995