### PR TITLE
fix: add focus-visible outline to ghost and link button variants

### DIFF
--- a/submissions/core_changes/bug-1990/buttons.css
+++ b/submissions/core_changes/bug-1990/buttons.css
@@ -1,0 +1,7 @@
+.ease-btn:focus-visible,
+.ease-btn-ghost:focus-visible,
+.ease-btn-link:focus-visible,
+.ease-btn-outline:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 3px;
+}


### PR DESCRIPTION
## Description

fix: add focus-visible outline to ghost and link button variants. The modified file is in `submissions/core_changes/bug-1990/buttons.css` — no core files were modified.

## Related Issue

Fixes #1990