### PR TITLE
fix: remove synchronous getBoundingClientRect, use IntersectionObserver only

### DIFF
--- a/submissions/core_changes/bug-1992/reveal.js
+++ b/submissions/core_changes/bug-1992/reveal.js
@@ -1,0 +1,27 @@
+(function () {
+  'use strict';
+  var revealClass = 'ease-reveal';
+  var activeClass = 'active';
+  if ('IntersectionObserver' in window) {
+    var observer = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add(activeClass);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.15 }
+    );
+    var els = document.querySelectorAll('.' + revealClass);
+    Array.prototype.forEach.call(els, function (el) {
+      observer.observe(el);
+    });
+  } else {
+    var els = document.querySelectorAll('.' + revealClass);
+    Array.prototype.forEach.call(els, function (el) {
+      el.classList.add(activeClass);
+    });
+  }
+})();


### PR DESCRIPTION
## Description

fix: remove synchronous getBoundingClientRect, use IntersectionObserver only. The modified file is in `submissions/core_changes/bug-1992/reveal.js` — no core files were modified.

## Related Issue

Fixes #1992