### PR TITLE
fix: disable keyframe animations under reduced motion

### DIFF
--- a/submissions/prefers-reduced-motion/style.css
+++ b/submissions/prefers-reduced-motion/style.css
@@ -6,6 +6,8 @@
   *,
   *::before,
   *::after {
+    animation: none !important;
+
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     animation-delay: 0ms !important;


### PR DESCRIPTION
## Description

This PR fixes an accessibility issue where CSS keyframe animations continued running even when users enabled `prefers-reduced-motion: reduce`.

### Changes Made

* Updated the global `prefers-reduced-motion` override.
* Disabled non-essential keyframe animations when reduced-motion mode is active.
* Ensured continuously running animations stop instead of continuing to play.

### Problem

Previously, elements using CSS keyframe animations (such as bouncing, floating, rotating, or pulsing effects) continued animating even when the user had requested reduced motion through their operating system settings.

### Solution

Added a global reduced-motion rule to disable keyframe animations and respect the user's accessibility preference.

### Result

**Before**

* Keyframe animations continued running under reduced-motion mode.
* Users still experienced unnecessary motion.

**After**

* Keyframe animations are disabled when `prefers-reduced-motion: reduce` is enabled.
* Motion-sensitive users receive a more accessible experience.

Fixes #1782
