### PR TITLE
fix: resolve mobile responsiveness layout overlap (#715)

### DIFF
--- a/submissions/examples/responsive-docs-layout/README.md
+++ b/submissions/examples/responsive-docs-layout/README.md
@@ -1,0 +1,9 @@
+# Mobile-Responsive Documentation Layout
+
+An interactive standalone submission built for GSSoC '26 to demonstrate a completely responsive, non-overlapping sidebar design for documentation systems.
+
+## 🛠️ Architecture Mechanics & Fixes
+
+- **Overflow-X Bounds Locking**: Clips container bounds completely cleanly via strict layout boundaries (`max-width: 100%; overflow-x: hidden`). This stops text from breaking out of view and completely disables erratic horizontal scrolling.
+- **Hardware-Accelerated Off-Canvas Shifts**: On viewports smaller than `768px`, the sidebar shifts cleanly out of view via CSS transitions (`transform: translateX(-100%)`). This guarantees that it never covers or wraps around the text area uninvited.
+- **Micro-Interaction Hamburger Toggle**: Implements an interactive morphing navbar menu icon using clean, fluid transitions to toggle navigation states seamlessly.

--- a/submissions/examples/responsive-docs-layout/demo.html
+++ b/submissions/examples/responsive-docs-layout/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Responsive Documentation Layout - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <header class="mobile-header">
+        <button id="menu-toggle" class="menu-btn" aria-label="Toggle Navigation Menu">
+            <span class="hamburger"></span>
+        </button>
+        <div class="logo">EaseMotion Docs</div>
+    </header>
+
+    <div class="layout-container">
+        <aside id="sidebar" class="sidebar">
+            <nav class="nav-menu">
+                <h3>Getting Started</h3>
+                <ul>
+                    <li><a href="#" class="active">Introduction</a></li>
+                    <li><a href="#">Installation</a></li>
+                    <li><a href="#">Core Framework</a></li>
+                </ul>
+                <h3>Components</h3>
+                <ul>
+                    <li><a href="#">Buttons & Links</a></li>
+                    <li><a href="#">Cards Layout</a></li>
+                    <li><a href="#">Modals Window</a></li>
+                    <li><a href="#">Motion Utilities</a></li>
+                </ul>
+            </nav>
+        </aside>
+
+        <div id="sidebar-overlay" class="overlay"></div>
+
+        <main class="main-content">
+            <article>
+                <h1>Documentation Layout Fix</h1>
+                <p class="lead">A clean UI demonstration showcasing fluid breakpoint management, preventing viewport clipping and overlap failures on mobile devices.</p>
+                
+                <section class="demo-box">
+                    <h3>💡 How to Test Mobile Responsiveness</h3>
+                    <p>Open your browser Developer Tools (F12) and switch into the device simulator view:</p>
+                    <ul>
+                        <li><strong>Desktop View:</strong> The sidebar menu behaves as a fixed column layout without pinching reading paths or clipping text.</li>
+                        <li><strong>Mobile View (&lt; 768px):</strong> The layout completely drops horizontal scroll tracks. Toggling the top-left menu trigger brings out the off-canvas panel smoothly without overlapping text.</li>
+                    </ul>
+                </section>
+
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sed efficitur lacus. Aliquam elementum tristique massa ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+                <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Aliquam id finibus lorem, ut tincidunt lacus. Vivamus vitae convallis mauris, sit amet hendrerit ante.</p>
+            </article>
+        </main>
+    </div>
+
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const sidebar = document.getElementById('sidebar');
+        const overlay = document.getElementById('sidebar-overlay');
+
+        function toggleMenu() {
+            menuToggle.classList.toggle('open');
+            sidebar.classList.toggle('active');
+            overlay.classList.toggle('active');
+            
+            // Prevent background page body scroll while mobile sidebar modal is active
+            document.body.style.overflow = sidebar.classList.contains('active') ? 'hidden' : '';
+        }
+
+        menuToggle.addEventListener('click', toggleMenu);
+        overlay.addEventListener('click', toggleMenu);
+    </script>
+</body>
+</html>

--- a/submissions/examples/responsive-docs-layout/style.css
+++ b/submissions/examples/responsive-docs-layout/style.css
@@ -1,0 +1,252 @@
+:root {
+  --bg-main: #0b0f19;
+  --bg-card: #151b2c;
+  --sidebar-bg: #111625;
+  --border-color: #1e293b;
+  --text-title: #f8fafc;
+  --text-body: #94a3b8;
+  --accent: #38bdf8;
+  --sidebar-width: 260px;
+  --header-height: 60px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  background-color: var(--bg-main);
+  color: var(--text-body);
+  min-height: 100vh;
+}
+
+/* Master Flexible Frame Layout */
+.layout-container {
+  display: flex;
+  width: 100%;
+  max-width: 100%;
+}
+
+/* Sidebar Layout Architecture */
+.sidebar {
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  background-color: var(--sidebar-bg);
+  border-right: 1px solid var(--border-color);
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  padding: 30px 20px;
+  overflow-y: auto;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 100;
+}
+
+.nav-menu h3 {
+  color: var(--text-title);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin: 24px 0 12px 0;
+}
+
+.nav-menu ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.nav-menu a {
+  display: block;
+  color: var(--text-body);
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 14px;
+  transition: all 0.2s ease;
+}
+
+.nav-menu a:hover,
+.nav-menu a.active {
+  background-color: rgba(56, 189, 248, 0.08);
+  color: var(--accent);
+}
+
+/* Main Documentation Column */
+.main-content {
+  flex-grow: 1;
+  padding: 40px;
+  max-width: calc(100% - var(--sidebar-width));
+  overflow-x: hidden; /* Hard block on breaking horizontal scroll tracks */
+}
+
+.main-content article {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+h1 {
+  color: var(--text-title);
+  font-size: 34px;
+  margin-top: 0;
+  letter-spacing: -0.5px;
+}
+
+.lead {
+  font-size: 18px;
+  line-height: 1.6;
+  color: var(--text-title);
+  opacity: 0.9;
+}
+
+.demo-box {
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 25px;
+  border-radius: 12px;
+  margin: 30px 0;
+}
+
+.demo-box h3 {
+  margin-top: 0;
+  color: var(--text-title);
+}
+
+.demo-box ul {
+  padding-left: 20px;
+  line-height: 1.7;
+}
+
+/* Base structural hidden properties for wider displays */
+.mobile-header {
+  display: none;
+}
+.overlay {
+  display: none;
+}
+
+/* Responsive Mobile Ruleset Matrix */
+@media (max-width: 768px) {
+  .mobile-header {
+    display: flex;
+    align-items: center;
+    background-color: var(--sidebar-bg);
+    border-bottom: 1px solid var(--border-color);
+    height: var(--header-height);
+    padding: 0 20px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 150;
+  }
+
+  .logo {
+    color: var(--text-title);
+    font-weight: 600;
+    margin-left: 15px;
+  }
+
+  .layout-container {
+    padding-top: var(--header-height);
+  }
+
+  /* Shift sidebar layout blocks entirely off-canvas via transforms */
+  .sidebar {
+    position: fixed;
+    top: var(--header-height);
+    left: 0;
+    height: calc(100vh - var(--header-height));
+    transform: translateX(-100%);
+    box-shadow: 20px 0 25px -5px rgba(0, 0, 0, 0.5);
+  }
+
+  .sidebar.active {
+    transform: translateX(0);
+  }
+
+  .main-content {
+    padding: 25px 20px;
+    max-width: 100%;
+  }
+
+  /* Backdrop dim background filter */
+  .overlay.active {
+    display: block;
+    position: fixed;
+    top: var(--header-height);
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(2px);
+    z-index: 90;
+  }
+
+  /* Menu Toggle Hamburger Styles */
+  .menu-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+  }
+
+  .hamburger {
+    position: relative;
+    width: 20px;
+    height: 2px;
+    background-color: var(--text-title);
+    transition: background-color 0.2s ease;
+  }
+
+  .hamburger::before,
+  .hamburger::after {
+    content: "";
+    position: absolute;
+    width: 20px;
+    height: 2px;
+    background-color: var(--text-title);
+    transition:
+      transform 0.2s ease,
+      top 0.2s ease,
+      bottom 0.2s ease;
+  }
+
+  .hamburger::before {
+    top: -6px;
+    left: 0;
+  }
+  .hamburger::after {
+    bottom: -6px;
+    left: 0;
+  }
+
+  /* Morphing transformation rules */
+  .menu-btn.open .hamburger {
+    background-color: transparent;
+  }
+
+  .menu-btn.open .hamburger::before {
+    top: 0;
+    transform: rotate(45deg);
+  }
+
+  .menu-btn.open .hamburger::after {
+    bottom: 0;
+    transform: rotate(-45deg);
+  }
+}


### PR DESCRIPTION
Closes #715

### Description
I have implemented a clean, standalone mobile-responsive documentation layout component inside my custom submission folder to demonstrate fluid layout management on varying screens.

The code completely resolves content-squishing layouts and horizontal view breakage by applying hardware-accelerated off-canvas translation logic alongside an interactive backdrop filter.

### Files Added:
- `demo.html`: Responsive layout container with active toggle states.
- `style.css`: Viewport media queries matching the project rules.
- `README.md`: Technical implementation summary documentation.