### PR TITLE
fix: replace CSS custom property double-declarations with single rgba declarations

### DIFF
--- a/submissions/core_changes/bug-2035/variables.css
+++ b/submissions/core_changes/bug-2035/variables.css
@@ -1,0 +1,11 @@
+@layer easemotion-utilities {
+  /* Alpha / semi-transparent tokens — single declaration with rgba fallback */
+  /* color-mix() has limited support; use rgba as reliable fallback */
+  --ease-color-primary-alpha: rgba(108, 99, 255, 0.15);
+  --ease-color-success-alpha: rgba(34, 197, 94, 0.15);
+  --ease-color-danger-alpha: rgba(239, 68, 68, 0.15);
+
+  /* Glassmorphism tokens — single declaration */
+  --ease-glass-bg: rgba(255, 255, 255, 0.12);
+  --ease-glass-border: rgba(255, 255, 255, 0.20);
+}

--- a/submissions/core_changes/bug-2035/variables.css
+++ b/submissions/core_changes/bug-2035/variables.css
@@ -1,6 +1,6 @@
-@layer easemotion-utilities {
-  /* Alpha / semi-transparent tokens — single declaration with rgba fallback */
-  /* color-mix() has limited support; use rgba as reliable fallback */
+/* Alpha / semi-transparent tokens — single declaration with rgba fallback */
+/* color-mix() has limited support; use rgba as reliable fallback */
+:root {
   --ease-color-primary-alpha: rgba(108, 99, 255, 0.15);
   --ease-color-success-alpha: rgba(34, 197, 94, 0.15);
   --ease-color-danger-alpha: rgba(239, 68, 68, 0.15);


### PR DESCRIPTION
## Description

Replace CSS custom property double-declarations with single rgba declarations. CSS custom properties cannot have fallback-then-override behavior through redeclaration - the second declaration always wins, making the first unreachable.

The fix uses single rgba declarations which have universal browser support instead of the double-declaration pattern.

The modified file is in submissions/core_changes/bug-2035/variables.css — no core files were modified.

## Related Issue

Fixes #2035