### PR TITLE
fix: remove duplicate ease-kf-bounce keyframe from easemotion/bounce.css

### DIFF
--- a/submissions/core_changes/bug-2036/bounce.css
+++ b/submissions/core_changes/bug-2036/bounce.css
@@ -1,0 +1,43 @@
+/* EaseMotion CSS — bounce and spring animations */
+
+/* Note: ease-kf-bounce keyframe removed - it is already defined in core/animations.css */
+/* The modular bounce.css should only contain utility classes, not duplicate keyframes */
+
+@keyframes ease-kf-bounce-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.3);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+  70% {
+    transform: scale(0.95);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes ease-kf-bounce-button-exit {
+  0%   { transform: scale(1);    opacity: 1; }
+  20%  { transform: scale(1.15); }
+  40%  { transform: scale(0.90); }
+  60%  { transform: scale(1.05); }
+  80%  { transform: scale(0.95); }
+  100% { transform: scale(0);    opacity: 0; }
+}
+
+.ease-bounce {
+  animation: ease-kf-bounce var(--ease-speed-slow);
+  animation-iteration-count: var(--ease-animation-iterations);
+}
+
+.ease-bounce-in {
+  animation: ease-kf-bounce-in var(--ease-speed-slow) ease-out forwards;
+}
+
+.ease-bounce-button-exit {
+  animation: ease-kf-bounce-button-exit var(--ease-speed-medium) var(--ease-ease) both;
+}


### PR DESCRIPTION
## Description

The ease-kf-bounce keyframe is defined in BOTH easemotion/bounce.css and core/animations.css. When both files are imported, the second definition silently overwrites the first, causing unpredictable animation behavior.

The fix removes the duplicate keyframe definition from easemotion/bounce.css since it is already available in core/animations.css. The modular file should only contain utility classes, not keyframe definitions.

The modified file is in submissions/core_changes/bug-2036/bounce.css - no core files were modified.

## Related Issue

Fixes #2036