### PR TITLE
fix: remove border-radius from will-change in easemotion/hover.css

### DIFF
--- a/submissions/core_changes/bug-2037/hover.css
+++ b/submissions/core_changes/bug-2037/hover.css
@@ -1,0 +1,17 @@
+/* EaseMotion CSS — hover interactions */
+
+/* Note: Removed border-radius from will-change on .ease-hover-morph-card */
+/* border-radius animation is NOT GPU-composited in most browsers */
+/* Only transform should be in will-change for performance */
+
+.ease-hover-morph-card {
+  border-radius: 0;
+  transition:
+    border-radius var(--ease-speed-medium) var(--ease-ease),
+    transform var(--ease-speed-medium) var(--ease-ease);
+  will-change: transform;  /* removed border-radius - only transform is GPU-composited */
+}
+.ease-hover-morph-card:hover {
+  border-radius: 50%;
+  transform: scale(1.08);
+}


### PR DESCRIPTION
## Description

The .ease-hover-morph-card class had . However, border-radius is NOT GPU-composited in most browsers - only transform is. Adding border-radius to will-change causes the browser to create extra memory buffers for a property that won't benefit from GPU acceleration, effectively causing memory bloat instead of performance gains.

The fix removes  from the will-change property, keeping only  which is the only property that actually benefits from GPU compositing.

The modified file is in submissions/core_changes/bug-2037/hover.css - no core files were modified.

## Related Issue

Fixes #2037