### PR TITLE
fix: add animation-fill-mode to looping animations in core/animations.css

### DIFF
--- a/submissions/core_changes/bug-2038/animations.css
+++ b/submissions/core_changes/bug-2038/animations.css
@@ -1,0 +1,32 @@
+/* Bug: Looping animations missing animation-fill-mode */
+/* This fix adds animation-fill-mode: forwards to looping animation classes */
+/* to prevent the element from returning to its pre-animation state briefly */
+
+/* Note: These are copies of the looping animation classes from core/animations.css */
+/* with animation-fill-mode: forwards added */
+
+/* Looping Animations */
+:root {
+  --ease-animation-iterations: infinite;
+}
+
+.ease-bounce {
+  animation: ease-kf-bounce 1s var(--ease-animation-iterations, infinite);
+  animation-fill-mode: forwards;
+}
+
+.ease-rotate {
+  animation: ease-kf-rotate 1.2s linear var(--ease-animation-iterations, infinite);
+  animation-fill-mode: forwards;
+}
+
+.ease-pulse {
+  animation: ease-kf-pulse 2s var(--ease-ease) var(--ease-animation-iterations, infinite);
+  animation-fill-mode: forwards;
+}
+
+.ease-wave {
+  display: inline-block;
+  animation: ease-kf-wave 2s ease-in-out var(--ease-animation-iterations, infinite);
+  animation-fill-mode: forwards;
+}


### PR DESCRIPTION
## Description

Looping animations like .ease-bounce, .ease-pulse, .ease-wave, .ease-rotate were missing animation-fill-mode. They defaulted to animation-fill-mode: none, which means the element returns to its pre-animation state between iterations and after the animation completes.

The fix adds animation-fill-mode: forwards to all looping animation classes in core/animations.css to ensure smooth transitions.

The modified file is in submissions/core_changes/bug-2038/animations.css - no core files were modified.

## Related Issue

Fixes #2038