### PR TITLE
fix: add @supports fallback for ease-card-glass backdrop-filter

### DIFF
--- a/submissions/core_changes/bug-2039/cards.css
+++ b/submissions/core_changes/bug-2039/cards.css
@@ -1,0 +1,17 @@
+/* Bug: ease-card-glass has no backdrop-filter fallback for Firefox/older browsers */
+/* Added @supports fallback with solid semi-transparent background */
+
+.ease-card-glass {
+  background: var(--ease-glass-bg, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.2));
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  color: var(--ease-color-text, #1e293b);
+}
+
+@supports not (backdrop-filter: blur(0)) {
+  .ease-card-glass {
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+  }
+}


### PR DESCRIPTION
## Description

The .ease-card-glass class uses backdrop-filter: blur(16px) for glassmorphism effect but has NO fallback for browsers that don't support backdrop-filter (Firefox, older browsers). This causes card content to become invisible or unreadable.

The fix adds a @supports not (backdrop-filter: blur(0)) block that provides a solid semi-transparent background fallback, ensuring cards are readable in all browsers.

The modified file is in submissions/core_changes/bug-2039/cards.css - no core files were modified.

## Related Issue

Fixes #2039