### PR TITLE
fix: remove delete phase from typewriter loop animation

### DIFF
--- a/submissions/core_changes/bug-2040/misc.css
+++ b/submissions/core_changes/bug-2040/misc.css
@@ -1,0 +1,44 @@
+/* Bug: typewriter animation resets to width:0 on each iteration causing jerky restart */
+/* Fixed keyframe: removed the delete phase (100% width:0) - animation now stays at full width on loop */
+
+@keyframes ease-kf-typewriter-loop {
+  0% {
+    width: 0;
+  }
+
+  40% {
+    width: var(--ease-typewriter-length, 12ch);
+  }
+
+  60% {
+    width: var(--ease-typewriter-length, 12ch);
+  }
+
+  /* Fixed: removed width:0 at 100% to prevent jerky reset on each iteration */
+  /* Animation now loops continuously at full width before restarting */
+}
+
+.ease-typewriter-loop {
+  --ease-typewriter-length: 12ch;
+  --ease-typewriter-duration: 6s;
+
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+
+  width: 0;
+  max-width: fit-content;
+
+  border-right: 2px solid currentColor;
+
+  --ease-typewriter-steps: 12;
+
+  animation:
+    ease-kf-typewriter-loop
+    var(--ease-typewriter-duration)
+    steps(var(--ease-typewriter-steps), end),
+    ease-kf-cursor-blink 0.8s step-end;
+  animation-iteration-count: var(--ease-animation-iterations);
+
+  will-change: width;
+}


### PR DESCRIPTION
## Description

The typewriter animation keyframe had 100% set to width:0, causing a "type-delete-restart" jerky behavior on each iteration. When animation-iteration-count is infinite, the element would type out, then quickly delete everything, then restart from scratch.

The fix removes the delete phase (width:0 at 100%) from the keyframe so the animation maintains continuous typing at full width between iterations, eliminating the jerky restart.

The modified file is in submissions/core_changes/bug-2040/misc.css - no core files were modified.

## Related Issue

Fixes #2040