### PR TITLE
fix: add screen-reader-only text to footer social links for accessibility

### DIFF
--- a/submissions/core_changes/bug-2041/footer.css
+++ b/submissions/core_changes/bug-2041/footer.css
@@ -1,0 +1,101 @@
+/* Bug: footer social links missing aria-label causing accessibility violation */
+/* Fix: Add screen-reader-only text via CSS ::after pseudo-elements */
+
+/* GitHub */
+.ease-footer-social a[href*="github.com"]::after {
+  content: "(opens GitHub profile)";
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Twitter/X */
+.ease-footer-social a[href*="twitter.com"]::after,
+.ease-footer-social a[href*="x.com"]::after {
+  content: "(opens X profile)";
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* YouTube */
+.ease-footer-social a[href*="youtube.com"]::after {
+  content: "(opens YouTube channel)";
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* LinkedIn */
+.ease-footer-social a[href*="linkedin.com"]::after {
+  content: "(opens LinkedIn profile)";
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Facebook */
+.ease-footer-social a[href*="facebook.com"]::after {
+  content: "(opens Facebook page)";
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Instagram */
+.ease-footer-social a[href*="instagram.com"]::after {
+  content: "(opens Instagram profile)";
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Discord */
+.ease-footer-social a[href*="discord"]::after {
+  content: "(opens Discord server)";
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Description

The footer social links use icon-only styling without any text content, making them inaccessible to screen reader users who cannot determine where each link leads.

Since aria-label is an HTML attribute and the fix must go in CSS-only submissions/core_changes/, this fix uses a CSS-only approach: adding visually-hidden (sr-only style) text via ::after pseudo-elements that describes the link destination for each social platform.

Each social link (GitHub, Twitter/X, YouTube, LinkedIn, Facebook, Instagram, Discord) now has a screen-reader-only description.

The modified file is in submissions/core_changes/bug-2041/footer.css - no core files were modified.

## Related Issue

Fixes #2041