### PR TITLE
fix: add consistent dark mode support to buttons.css and cards.css

### DIFF
--- a/submissions/core_changes/bug-2042/dark-mode-fix.css
+++ b/submissions/core_changes/bug-2042/dark-mode-fix.css
@@ -1,0 +1,57 @@
+/* Bug: inconsistent dark mode implementation across component files */
+/* Fix: Add @media (prefers-color-scheme: dark) to buttons.css and cards.css for consistency */
+
+/* === BUTTONS dark mode === */
+@media (prefers-color-scheme: dark) {
+  .ease-btn-primary {
+    background-color: var(--ease-color-primary-dark, #4b44cc);
+    border-color: var(--ease-color-primary-dark, #4b44cc);
+    color: #ffffff;
+  }
+
+  .ease-btn-secondary {
+    background-color: var(--ease-color-neutral-700, #374151);
+    border-color: var(--ease-color-neutral-600, #4b5563);
+    color: var(--ease-color-neutral-100, #f3f4f6);
+  }
+
+  .ease-btn-ghost {
+    background-color: transparent;
+    color: var(--ease-color-neutral-100, #f3f4f6);
+  }
+
+  .ease-btn-outline {
+    background-color: transparent;
+    border-color: var(--ease-color-neutral-500, #6b7280);
+    color: var(--ease-color-neutral-100, #f3f4f6);
+  }
+}
+
+/* === CARDS dark mode === */
+@media (prefers-color-scheme: dark) {
+  .ease-card-basic {
+    background-color: var(--ease-color-neutral-800, #1f2937);
+    border-color: var(--ease-color-neutral-700, #374151);
+    color: var(--ease-color-neutral-100, #f3f4f6);
+  }
+
+  .ease-card-outlined {
+    background-color: transparent;
+    border-color: var(--ease-color-neutral-600, #4b5563);
+    color: var(--ease-color-neutral-100, #f3f4f6);
+  }
+
+  .ease-card-glass {
+    background: var(--ease-glass-bg-dark, rgba(30, 30, 30, 0.75));
+    border: 1px solid var(--ease-glass-border-dark, rgba(255, 255, 255, 0.1));
+    color: var(--ease-color-neutral-100, #f3f4f6);
+  }
+
+  .ease-card-neumorphic {
+    background-color: var(--ease-color-neutral-800, #1f2937);
+    color: var(--ease-color-neutral-100, #f3f4f6);
+    box-shadow:
+      8px 8px 20px rgba(0, 0, 0, 0.4),
+      -8px -8px 20px rgba(60, 60, 60, 0.1);
+  }
+}


### PR DESCRIPTION
## Description

The codebase has inconsistent dark mode implementation. Only some components (like tooltips.css) have @media (prefers-color-scheme: dark) overrides, while buttons.css and cards.css lack dark mode support.

The fix adds consistent @media (prefers-color-scheme: dark) blocks to buttons.css and cards.css, ensuring all major components respond to the user's OS dark mode preference.

The modified file is in submissions/core_changes/bug-2042/dark-mode-fix.css - no core files were modified.

## Related Issue

Fixes #2042