### PR TITLE
fix: change marquee default pause-on-hover from paused to running

### DIFF
--- a/submissions/core_changes/bug-2043/ease-marquee.css
+++ b/submissions/core_changes/bug-2043/ease-marquee.css
@@ -1,0 +1,10 @@
+/* Bug: marquee animation defaults to paused state instead of playing */
+/* Fix: Changed --marquee-pause-on-hover default from 'paused' to 'running' */
+
+.ease-marquee {
+  --marquee-pause-on-hover: running;  /* Fixed: was 'paused' - marquee should play by default */
+}
+
+.ease-marquee:hover .ease-marquee-track {
+  animation-play-state: var(--marquee-pause-on-hover);
+}


### PR DESCRIPTION
## Description

The marquee animation had --marquee-pause-on-hover defaulting to 'paused', meaning the marquee would only play when hovered. This is the opposite of expected behavior - marquees should scroll by default and optionally pause on hover.

The fix changes the default from 'paused' to 'running' so the marquee scrolls automatically and only pauses when hovered (if the user chooses to set pause-on-hover).

The modified file is in submissions/core_changes/bug-2043/ease-marquee.css - no core files were modified.

## Related Issue

Fixes #2043