### PR TITLE
fix: increase specificity of tabs-auto underline display:none rule

### DIFF
--- a/submissions/core_changes/bug-2044/tabs.css
+++ b/submissions/core_changes/bug-2044/tabs.css
@@ -1,0 +1,9 @@
+/* Bug: tabs-auto underline not hidden due to CSS specificity conflict */
+/* Fix: Increase specificity of display:none rule to override checked rules */
+
+.em-tabs-auto .em-tab-underline,
+.em-tabs-auto#em-tab-1:checked ~ .em-tabs-nav label[for="em-tab-1"],
+.em-tabs-auto#em-tab-2:checked ~ .em-tabs-nav label[for="em-tab-2"],
+.em-tabs-auto#em-tab-3:checked ~ .em-tabs-nav label[for="em-tab-3"] {
+  display: none;
+}


### PR DESCRIPTION
## Description

The .em-tabs-auto .em-tab-underline rule had lower specificity (0,2,0) than the checked rules (0,3,0), so display:none was never applied and the underline remained visible when it should be hidden.

The fix increases specificity by including the checked state selectors alongside the base rule, ensuring display:none properly overrides the border-bottom styling.

The modified file is in submissions/core_changes/bug-2044/tabs.css - no core files were modified.

## Related Issue

Fixes #2044