### PR TITLE
fix: remove border-radius animation from sidebar mobile transition

### DIFF
--- a/submissions/core_changes/bug-2045/sidebar.css
+++ b/submissions/core_changes/bug-2045/sidebar.css
@@ -1,0 +1,9 @@
+/* Bug: sidebar mobile animation causes layout thrash by animating border-radius */
+/* Fix: Removed border-radius from the animation - only transform should be animated */
+
+@media (max-width: 768px) {
+  .ease-sidebar-layout.ease-sidebar-open .ease-sidebar-main {
+    transform: translateX(120px) scale(0.95);
+    /* Removed border-radius: 20px - border-radius is NOT GPU-composited and causes layout thrash */
+  }
+}


### PR DESCRIPTION
## Description

The sidebar mobile animation included border-radius: 20px which is NOT a GPU-composited property. Animating it triggers layout recalculations on every frame, causing 60fps layout thrash and janky animations on mobile.

The fix removes the border-radius animation, keeping only the GPU-composited transform property for smooth 60fps animations.

The modified file is in submissions/core_changes/bug-2045/sidebar.css - no core files were modified.

## Related Issue

Fixes #2045