### PR TITLE
fix: remove inconsistent white-space mobile override from buttons

### DIFF
--- a/submissions/core_changes/bug-2046/buttons.css
+++ b/submissions/core_changes/bug-2046/buttons.css
@@ -1,0 +1,9 @@
+/* Bug: button white-space wraps on mobile but is not part of transition property */
+/* Fix: Removed the mobile override - white-space should remain nowrap for consistency */
+
+.ease-btn {
+  white-space: nowrap;
+}
+
+/* Removed @media (max-width: 480px) .ease-btn { white-space: normal; } */
+/* This was creating inconsistency since white-space is not in the transition property */


### PR DESCRIPTION
## Description

The button component had white-space: nowrap in the base state but white-space: normal on mobile screens. However, white-space is not included in the CSS transition property, creating an inconsistency between what the component states it animates and what actually changes.

The fix removes the mobile override so the button consistently uses white-space: nowrap, eliminating the visual inconsistency.

The modified file is in submissions/core_changes/bug-2046/buttons.css - no core files were modified.

## Related Issue

Fixes #2046