### PR TITLE
fix: add -webkit-scroll-snap-align prefix for older Safari compatibility

### DIFF
--- a/submissions/core_changes/bug-2047/utilities.css
+++ b/submissions/core_changes/bug-2047/utilities.css
@@ -1,0 +1,17 @@
+/* Bug: scroll-snap-align missing -webkit- prefix for older Safari */
+/* Fix: Added -webkit-scroll-snap-align alongside unprefixed property */
+
+.ease-snap-center {
+  scroll-snap-align: center !important;
+  -webkit-scroll-snap-align: center !important;
+}
+
+.ease-snap-start {
+  scroll-snap-align: start !important;
+  -webkit-scroll-snap-align: start !important;
+}
+
+.ease-snap-end {
+  scroll-snap-align: end !important;
+  -webkit-scroll-snap-align: end !important;
+}


### PR DESCRIPTION
## Description

The scroll-snap utilities only used the unprefixed scroll-snap-align property. Older Safari versions require -webkit-scroll-snap-align. Without it, scroll-snap may not work correctly on older iOS/macOS browsers.

The fix adds -webkit-scroll-snap-align alongside the standard property for backward compatibility.

The modified file is in submissions/core_changes/bug-2047/utilities.css - no core files were modified.

## Related Issue

Fixes #2047