### PR TITLE
fix: add transform:none to chip reduced-motion media query

### DIFF
--- a/submissions/core_changes/bug-2050/chip.css
+++ b/submissions/core_changes/bug-2050/chip.css
@@ -1,0 +1,14 @@
+/* Bug: chip hover translateY still applies in prefers-reduced-motion */
+/* Fix: Add transform: none !important to completely disable motion */
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-chip {
+    transition: none !important;
+    transform: none !important;
+  }
+
+  .ease-chip:hover {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Description

The chip component's reduced motion query only set transition: none but transform: translateY(-1px) on hover still applied. Users with vestibular disorders still experienced the chip "jumping" motion even with reduced motion enabled.

The fix adds transform: none !important to the prefers-reduced-motion media query for both .ease-chip and .ease-chip:hover to completely disable the motion.

The modified file is in submissions/core_changes/bug-2050/chip.css - no core files were modified.

## Related Issue

Fixes #2050