### PR TITLE
Fix: Make 'Read Docs' button text visible by moving color style

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -276,7 +276,7 @@
         <h1>Build with EaseMotion</h1>
         <p>Human-readable class names. Animation-first. No memorization required.</p>
         <div class="ease-center ease-gap-3 ease-slide-up ease-delay-200">
-          <a href="./" class="ease-btn ease-btn-primary ease-btn-hover ease-btn-lg ease-btn-pill" style="padding:10px" color:white;>
+          <a href="./" class="ease-btn ease-btn-primary ease-btn-hover ease-btn-lg ease-btn-pill" style="padding:10px; color:white;">
             Read Docs
           </a>
           <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css"

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -91,6 +91,7 @@
       height: var(--docs-header-h);
       z-index: var(--ease-z-overlay);
       background: var(--header-bg);
+      -webkit-backdrop-filter: blur(12px);
       backdrop-filter: blur(12px);
       border-bottom: 1px solid var(--border-color);
       display: flex;


### PR DESCRIPTION
## Pull Request Description
Fixes the "Read Docs" button on the demo page where the text label is not visible to users due to improper CSS styling.

---
## Type of Change
- [x] 🐛 Bug fix in core files (critical UX issue)✅
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## What's the Issue?
The "Read Docs" button HTML had incorrect inline styling:
```html
<!-- BEFORE (broken) -->
<a style="padding:10px" color:white;>Read Docs</a>

<!-- AFTER (fixed) -->
<a style="padding:10px; color:white;">Read Docs</a>
```

The `color:white;` was **outside** the `style="..."` attribute, so it was never applied. This made the button text invisible.

---
## The Fix
Moved `color:white;` **inside** the `style` attribute where it's properly parsed and applied.

**Result:** Button text is now visible ✅

---
## Why This Matters
- 🚫 Without the fix: Users see an invisible button
- ✅ With the fix: Users see "Read Docs" button clearly
- This is a **critical UX blocker** on the demo page

---
## Browser Testing
- [x] Chrome ✅
- [x] Firefox ✅
- [x] Edge ✅
- [ ] Safari (not tested)

---
## Notes for Maintainer
I understand this modifies `demo.html` during the contribution freeze. I'm submitting this as a critical bug fix rather than a feature. If this needs to wait, I completely understand. The issue has been documented in [Issue #2082 
<img width="983" height="433" alt="solvebug" src="https://github.com/user-attachments/assets/d2fbd657-eb8d-47f4-88ed-06445e0598ac" />


Please let me know if any changes are needed. Thanks! 