### PR TITLE
fix: resolve sidebar active state tracking on scroll and click

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -753,7 +753,13 @@
 <script>
 const sections = document.querySelectorAll(".docs-section");
 const navLinks = document.querySelectorAll(".sidebar-nav a");
-let currentActive = null;
+let currentActive = document.querySelector(".sidebar-nav a.active"); // Start with whatever is already active
+const observerOptions = {
+  root: null,
+  // Creates a trigger zone in the top half of the screen where headers cross
+  rootMargin: "-10% 0px -55% 0px", 
+  threshold: 0 // Fires instantly when a section enters the margin boundaries
+};
 
 const observer = new IntersectionObserver((entries) => {
   entries.forEach(entry => {
@@ -763,17 +769,21 @@ const observer = new IntersectionObserver((entries) => {
 
       if (activeLink && currentActive !== activeLink) {
         if (currentActive) currentActive.classList.remove("active");
-
         activeLink.classList.add("active");
         currentActive = activeLink;
       }
     }
   });
-}, {
-  threshold: 0.4
-});
+}, observerOptions);
 
 sections.forEach(section => observer.observe(section));
+navLinks.forEach(link => {
+  link.addEventListener("click", () => {
+    if (currentActive) currentActive.classList.remove("active");
+    link.classList.add("active");
+    currentActive = link;
+  });
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
### 🛠️ Description of Changes

This pull request resolves a UI synchronization issue in the documentation sidebar navigation layout. 

**Changes Implemented:**
1. **Enhanced Scroll Observer (ScrollSpy):** Replaced the rigid `threshold: 0.4 "with a dynamic `rootMargin "tracking zone." This ensures that lower or shorter sections (such as "Animations") successfully trigger the active styling highlight when scrolled into view.
2. **Added Direct Click Handlers:** Introduced explicit click event listeners to the `.sidebar-nav a "elements." Clicking any navigation link now instantly updates the blue/purple active background shade, ensuring immediate visual feedback even if the scroll position hasn't caught up yet.

### 🐛 Related Issue
Closes #2094 

### 🧪 How This Was Tested
- Opened `docs/index.html`locally in the browser.
- Verified that scrolling all the way down successfully shifts the active sidebar highlight to lower categories.
- Verified that explicitly clicking on sidebar tabs ("Getting Started", "Dark Mode", "Animations", etc.) instantly updates the active class highlight.