### PR TITLE
fix: wrap scroll-progress.css in @layer easemotion-components - Fixes…

### DIFF
--- a/components/scroll-progress.css
+++ b/components/scroll-progress.css
@@ -3,6 +3,8 @@
    Pure CSS Scroll-Driven Progress Bar Component
    ============================================================ */
 
+@layer easemotion-components {
+
 /* ── Keyframes ─────────────────────────────────────────────── */
 @keyframes ease-kf-scroll-progress {
   from {
@@ -87,4 +89,5 @@
 /* Use viewport/root timeline specifically, ignoring nearest ancestors if inside small scroll containers */
 .ease-scroll-progress-root {
   animation-timeline: scroll(root);
+}
 }


### PR DESCRIPTION
 Adds missing @layer easemotion-components { ... } wrapper to scroll-progress.css. Prevents fixed-position scroll bar from escaping the cascade system. Closes #2167