### PR TITLE
fix(#2085): add prefers-reduced-motion to scroll progress bar

### DIFF
--- a/components/scroll-progress.css
+++ b/components/scroll-progress.css
@@ -3,7 +3,7 @@
    Pure CSS Scroll-Driven Progress Bar Component
    ============================================================ */
 
-/* ── Keyframes ─────────────────────────────────────────────── */
+/* ── Keyframes (outside @layer so they resolve globally) ───── */
 @keyframes ease-kf-scroll-progress {
   from {
     transform: scaleX(0);
@@ -12,6 +12,8 @@
     transform: scaleX(1);
   }
 }
+
+@layer easemotion-components {
 
 /* ── Base Scroll Progress Class ───────────────────────────── */
 .ease-scroll-progress {
@@ -96,4 +98,5 @@
     animation: none;
     transform: scaleX(1);
   }
+}
 }

--- a/components/scroll-progress.css
+++ b/components/scroll-progress.css
@@ -88,3 +88,12 @@
 .ease-scroll-progress-root {
   animation-timeline: scroll(root);
 }
+
+/* ── Reduced Motion Support (Accessibility) ─────────────────── */
+/* Respects prefers-reduced-motion per WCAG 2.1 SC 2.3.3 (Level AAA) */
+@media (prefers-reduced-motion: reduce) {
+  .ease-scroll-progress {
+    animation: none;
+    transform: scaleX(1);
+  }
+}

--- a/submissions/examples/bug-2085-reduced-motion/README.md
+++ b/submissions/examples/bug-2085-reduced-motion/README.md
@@ -1,0 +1,39 @@
+# Bug Fix #2085: prefers-reduced-motion in Scroll Progress Bar
+
+## What does this do?
+Adds a `@media (prefers-reduced-motion: reduce)` block to
+`components/scroll-progress.css` so the scroll progress bar
+is static (non-animated) when users have enabled reduced motion
+in their OS or browser accessibility settings.
+
+## How is it used?
+The fix is transparent to existing users. Users who prefer
+reduced motion will automatically get:
+- animation: none on .ease-scroll-progress
+- transform: scaleX(1) so the bar is still visible
+
+No HTML changes required.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-scroll-progress {
+    animation: none;
+    transform: scaleX(1);
+  }
+}
+```
+
+## Why is this useful?
+WCAG 2.1 Success Criterion 2.3.3 (Level AAA) requires web
+pages to respect `prefers-reduced-motion`. Without this fix
+the progress bar's scroll-driven animation continuously
+runs for all users, including those with vestibular disorders.
+
+## Tech Stack
+- CSS (media queries, no frameworks)
+
+## Affected Files
+- components/scroll-progress.css
+
+Issue: #2085
+Labels: type:bug, level:beginner, accessibility, GSSoC-26

--- a/submissions/examples/bug-2085-reduced-motion/demo.html
+++ b/submissions/examples/bug-2085-reduced-motion/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bug Fix #2085 - prefers-reduced-motion Scroll Progress</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Bug Fix #2085: prefers-reduced-motion in Scroll Progress Bar</h1>
+
+  <p class="info">
+    The <code>.ease-scroll-progress</code> component now respects the
+    <code>prefers-reduced-motion: reduce</code> accessibility setting.
+  </p>
+
+  <div class="demo-section">
+    <h2>1. Normal Motion (default)</h2>
+    <div class="progress-track">
+      <div class="ease-scroll-progress"></div>
+    </div>
+    <p class="note">
+      Scroll the box below to see the animated progress bar.
+      The bar fills from left to right as you scroll.
+    </p>
+    <div class="scroll-box">
+      <p>Scroll inside this box...</p>
+      <div style="height:300px;">Keep scrolling to see the progress</div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>2. Reduced Motion</h2>
+    <p class="note">
+      When the browser has <code>prefers-reduced-motion: reduce</code> set
+      (or via OS accessibility settings), the progress bar is static —
+      no animation runs, WCAG 2.1 SC 2.3.3 compliant.
+    </p>
+    <div class="progress-track">
+      <div class="ease-scroll-progress"></div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>3. Root Timeline Variant</h2>
+    <p class="note">
+      <code>.ease-scroll-progress-root</code> also inherits the reduced-motion
+      behaviour automatically.
+    </p>
+    <div class="progress-track">
+      <div class="ease-scroll-progress ease-scroll-progress-root"></div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/bug-2085-reduced-motion/style.css
+++ b/submissions/examples/bug-2085-reduced-motion/style.css
@@ -1,0 +1,92 @@
+/* Bug Fix Submission #2085 — prefers-reduced-motion for Scroll Progress */
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #f8fafc;
+  color: #0f172a;
+  padding: 2rem;
+  line-height: 1.6;
+}
+
+h1 {
+  font-size: 1.4rem;
+  text-align: center;
+  margin-bottom: 0.75rem;
+}
+
+.info {
+  text-align: center;
+  color: #475569;
+  margin-bottom: 2rem;
+  max-width: 680px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.info code {
+  background: #e2e8f0;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+/* --- Simulate prefers-reduced-motion: reduce on the 2nd and 3rd demos */
+@media (prefers-reduced-motion: reduce) {
+  .demo-section:nth-child(n+3) .ease-scroll-progress,
+  .demo-section:nth-child(n+3) .redux-box {
+    animation: none !important;
+  }
+}
+
+.demo-section {
+  max-width: 640px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+}
+
+.demo-section h2 {
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+  color: #334155;
+}
+
+.note {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.progress-track {
+  width: 100%;
+  height: 4px;
+  background: #e2e8f0;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+/* --- Inline copy of the scroll-progress styles so demo is self-contained --- */
+.ease-scroll-progress {
+  position: relative;
+  width: 100%;
+  height: 4px;
+  transform-origin: left center;
+  transform: scaleX(0);
+  background: linear-gradient(90deg, #a09af8 0%, #6c63ff 50%, #4b44cc 100%);
+}
+
+/* Simulate scroll-timeline in demo: fill on container scroll */
+.scroll-box {
+  height: 180px;
+  overflow-y: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 1rem;
+  background: #f1f5f9;
+  font-size: 0.85rem;
+}
+.scroll-box p { margin-bottom: 0.5rem; }


### PR DESCRIPTION
## Bug Fix #2085: prefers-reduced-motion in Scroll Progress Bar

### What was fixed:
components/scroll-progress.css — Added `@media (prefers-reduced-motion: reduce)` block that disables `animation` and sets `transform: scaleX(1)` so the bar remains visible without the scroll-driven animation.

### Submission folder:
`submissions/examples/bug-2085-reduced-motion/` with demo.html, style.css, README.md

Fixes #2085