### PR TITLE
fix: add columns: 1 to .ease-masonry base class to activate CSS colum…

### DIFF
--- a/components/masonry.css
+++ b/components/masonry.css
@@ -11,6 +11,7 @@
    ──────────────────────────────────────────────────────────── */
 
 .ease-masonry {
+  columns: 1;
   column-gap: var(--ease-space-4, 1rem);
   break-inside: avoid-column;
 }
@@ -117,77 +118,79 @@
 }
 
 /* ────────────────────────────────────────────────────────────
-   MASONRY GAP VARIANTS
-   – Override default gap spacing using ease-space-* variables
+   MASONRY COLUMN-GAP VARIANTS
+   – Use .ease-masonry-gap-* classes (not .ease-gap-*) to avoid
+     conflicts with utilities.css !important gap utilities.
+   – These set column-gap only; row spacing uses margin-bottom.
    ──────────────────────────────────────────────────────────── */
 
-.ease-masonry.ease-gap-1,
-.ease-masonry-2.ease-gap-1,
-.ease-masonry-3.ease-gap-1,
-.ease-masonry-4.ease-gap-1 {
+.ease-masonry.ease-masonry-gap-1,
+.ease-masonry-2.ease-masonry-gap-1,
+.ease-masonry-3.ease-masonry-gap-1,
+.ease-masonry-4.ease-masonry-gap-1 {
   column-gap: var(--ease-space-1, 0.25rem);
 }
 
-.ease-masonry.ease-gap-1 > *,
-.ease-masonry-2.ease-gap-1 > *,
-.ease-masonry-3.ease-gap-1 > *,
-.ease-masonry-4.ease-gap-1 > * {
+.ease-masonry.ease-masonry-gap-1 > *,
+.ease-masonry-2.ease-masonry-gap-1 > *,
+.ease-masonry-3.ease-masonry-gap-1 > *,
+.ease-masonry-4.ease-masonry-gap-1 > * {
   margin-bottom: var(--ease-space-1, 0.25rem);
 }
 
-.ease-masonry.ease-gap-2,
-.ease-masonry-2.ease-gap-2,
-.ease-masonry-3.ease-gap-2,
-.ease-masonry-4.ease-gap-2 {
+.ease-masonry.ease-masonry-gap-2,
+.ease-masonry-2.ease-masonry-gap-2,
+.ease-masonry-3.ease-masonry-gap-2,
+.ease-masonry-4.ease-masonry-gap-2 {
   column-gap: var(--ease-space-2, 0.5rem);
 }
 
-.ease-masonry.ease-gap-2 > *,
-.ease-masonry-2.ease-gap-2 > *,
-.ease-masonry-3.ease-gap-2 > *,
-.ease-masonry-4.ease-gap-2 > * {
+.ease-masonry.ease-masonry-gap-2 > *,
+.ease-masonry-2.ease-masonry-gap-2 > *,
+.ease-masonry-3.ease-masonry-gap-2 > *,
+.ease-masonry-4.ease-masonry-gap-2 > * {
   margin-bottom: var(--ease-space-2, 0.5rem);
 }
 
-.ease-masonry.ease-gap-3,
-.ease-masonry-2.ease-gap-3,
-.ease-masonry-3.ease-gap-3,
-.ease-masonry-4.ease-gap-3 {
+.ease-masonry.ease-masonry-gap-3,
+.ease-masonry-2.ease-masonry-gap-3,
+.ease-masonry-3.ease-masonry-gap-3,
+.ease-masonry-4.ease-masonry-gap-3 {
   column-gap: var(--ease-space-3, 0.75rem);
 }
 
-.ease-masonry.ease-gap-3 > *,
-.ease-masonry-2.ease-gap-3 > *,
-.ease-masonry-3.ease-gap-3 > *,
-.ease-masonry-4.ease-gap-3 > * {
+.ease-masonry.ease-masonry-gap-3 > *,
+.ease-masonry-2.ease-masonry-gap-3 > *,
+.ease-masonry-3.ease-masonry-gap-3 > *,
+.ease-masonry-4.ease-masonry-gap-3 > * {
   margin-bottom: var(--ease-space-3, 0.75rem);
 }
 
-.ease-masonry.ease-gap-6,
-.ease-masonry-2.ease-gap-6,
-.ease-masonry-3.ease-gap-6,
-.ease-masonry-4.ease-gap-6 {
+.ease-masonry.ease-masonry-gap-6,
+.ease-masonry-2.ease-masonry-gap-6,
+.ease-masonry-3.ease-masonry-gap-6,
+.ease-masonry-4.ease-masonry-gap-6 {
   column-gap: var(--ease-space-6, 1.5rem);
 }
 
-.ease-masonry.ease-gap-6 > *,
-.ease-masonry-2.ease-gap-6 > *,
-.ease-masonry-3.ease-gap-6 > *,
-.ease-masonry-4.ease-gap-6 > * {
+.ease-masonry.ease-masonry-gap-6 > *,
+.ease-masonry-2.ease-masonry-gap-6 > *,
+.ease-masonry-3.ease-masonry-gap-6 > *,
+.ease-masonry-4.ease-masonry-gap-6 > * {
   margin-bottom: var(--ease-space-6, 1.5rem);
 }
 
-.ease-masonry.ease-gap-8,
-.ease-masonry-2.ease-gap-8,
-.ease-masonry-3.ease-gap-8,
-.ease-masonry-4.ease-gap-8 {
+.ease-masonry.ease-masonry-gap-8,
+.ease-masonry-2.ease-masonry-gap-8,
+.ease-masonry-3.ease-masonry-gap-8,
+.ease-masonry-4.ease-masonry-gap-8 {
   column-gap: var(--ease-space-8, 2rem);
 }
 
-.ease-masonry.ease-gap-8 > *,
-.ease-masonry-2.ease-gap-8 > *,
-.ease-masonry-3.ease-gap-8 > *,
-.ease-masonry-4.ease-gap-8 > * {
+.ease-masonry.ease-masonry-gap-8 > *,
+.ease-masonry-2.ease-masonry-gap-8 > *,
+.ease-masonry-3.ease-masonry-gap-8 > *,
+.ease-masonry-4.ease-masonry-gap-8 > * {
   margin-bottom: var(--ease-space-8, 2rem);
 }
 


### PR DESCRIPTION
Fixes two related masonry bugs:

#2173 — Missing columns property: The .ease-masonry base class was missing the columns property entirely. Without it, CSS column layout never activates, making the base class non-functional. Added columns: 1 as the default.

#2178 — Gap utilities conflict: Masonry used .ease-gap-* compound selectors (e.g. .ease-masonry.ease-gap-1) to control column-gap. However utilities.css applies .ease-gap-* with !important, which always wins over the masonry column-gap rules, making all masonry gap variants silently broken. Renamed all masonry gap modifiers to .ease-masonry-gap-N to avoid the conflict.

Files: components/masonry.css · Closes: #2173 #2178