### PR TITLE
feat: add italic text utilities (Fixes #378)

### DIFF
--- a/submissions/examples/italic-utils-I/README.md
+++ b/submissions/examples/italic-utils-I/README.md
@@ -1,0 +1,32 @@
+ 
+# Text Italic Utilities
+
+Simple text utilities for font-style control — italic and normal text.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| 📄 [demo.html](./demo.html) | Interactive demo |
+| 🎨 [style.css](./style.css) | Utility styles |
+| 📖 [README.md](./README.md) | Documentation |
+
+## Classes
+
+| Class | CSS Property |
+|-------|--------------|
+| `ease-italic` | `font-style: italic` |
+| `ease-not-italic` | `font-style: normal` |
+
+## Usage
+
+```html
+<!-- Italic text -->
+<p class="ease-italic">This text is italic</p>
+
+<!-- Normal text -->
+<p class="ease-not-italic">This text is normal</p>
+
+<!-- With other classes -->
+<p class="ease-italic ease-bold">Italic and bold</p>
+<span class="ease-italic">Inline italic text</span>

--- a/submissions/examples/italic-utils-I/demo.html
+++ b/submissions/examples/italic-utils-I/demo.html
@@ -1,0 +1,128 @@
+ 
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion - Italic Text Utilities</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>📝 ease-italic & ease-not-italic</h1>
+        <p>Simple text utilities for font-style control — italic and normal text</p>
+
+        <!-- Basic Example -->
+        <div class="demo-section">
+            <h2>Basic Example</h2>
+            <div class="demo-box">
+                <p class="normal-text">Normal text (default)</p>
+                <p class="ease-italic">This text is italic using <code>ease-italic</code></p>
+                <p class="ease-not-italic">This text is normal using <code>ease-not-italic</code></p>
+            </div>
+        </div>
+
+        <!-- Comparison -->
+        <div class="demo-section">
+            <h2>Side by Side Comparison</h2>
+            <div class="comparison-grid">
+                <div class="comparison-card">
+                    <h3>Without Italic</h3>
+                    <p class="sample-text">The quick brown fox jumps over the lazy dog</p>
+                    <p class="sample-text">1234567890</p>
+                </div>
+                <div class="comparison-card">
+                    <h3>With ease-italic</h3>
+                    <p class="sample-text ease-italic">The quick brown fox jumps over the lazy dog</p>
+                    <p class="sample-text ease-italic">1234567890</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Use Cases -->
+        <div class="demo-section">
+            <h2>Use Cases</h2>
+            <div class="use-cases-grid">
+                <div class="use-card">
+                    <h3>📖 Quotes</h3>
+                    <p class="ease-italic">"The only limit is your imagination."</p>
+                    <p>- Anonymous</p>
+                </div>
+                <div class="use-card">
+                    <h3>📚 Book Titles</h3>
+                    <p class="ease-italic">Pride and Prejudice</p>
+                    <p class="ease-italic">To Kill a Mockingbird</p>
+                </div>
+                <div class="use-card">
+                    <h3>🏷️ Subtle Emphasis</h3>
+                    <p>This is <span class="ease-italic">really important</span> text</p>
+                    <p>Made with <span class="ease-italic">love</span> and care</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- With Other Text Utilities -->
+        <div class="demo-section">
+            <h2>Combined with Other Text Utilities</h2>
+            <div class="combined-grid">
+                <div class="combined-card">
+                    <p class="ease-italic ease-bold">Italic + Bold</p>
+                    <p class="ease-italic ease-underline">Italic + Underline</p>
+                    <p class="ease-italic ease-text-center">Italic + Centered</p>
+                    <p class="ease-italic ease-text-large">Italic + Large Text</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Toggle Example -->
+        <div class="demo-section">
+            <h2>Toggle Example (Hover to Toggle)</h2>
+            <div class="toggle-demo">
+                <p class="toggle-text ease-italic" id="toggleText">Hover over me to toggle italic style</p>
+            </div>
+        </div>
+
+        <!-- Usage Code -->
+        <div class="code-section">
+            <h2>Usage</h2>
+            <pre>&lt;!-- Italic text --&gt;
+&lt;p class="ease-italic"&gt;This text is italic&lt;/p&gt;
+
+&lt;!-- Normal text (removes italic) --&gt;
+&lt;p class="ease-not-italic"&gt;This text is normal&lt;/p&gt;
+
+&lt;!-- With other classes --&gt;
+&lt;p class="ease-italic ease-bold"&gt;Italic and bold&lt;/p&gt;
+&lt;span class="ease-italic"&gt;Inline italic text&lt;/span&gt;</pre>
+        </div>
+
+        <div class="info">
+            <h3>⚡ Text Utility Features</h3>
+            <ul>
+                <li>📝 <code>ease-italic</code> - Applies <code>font-style: italic</code></li>
+                <li>📄 <code>ease-not-italic</code> - Applies <code>font-style: normal</code></li>
+                <li>🎯 Works on any text element</li>
+                <li>🔄 Can be combined with other text utilities</li>
+                <li>💫 Simple and lightweight</li>
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        // Toggle effect for demo
+        const toggleText = document.getElementById('toggleText');
+        if (toggleText) {
+            toggleText.addEventListener('mouseenter', () => {
+                toggleText.classList.remove('ease-italic');
+                toggleText.classList.add('ease-not-italic');
+                toggleText.textContent = 'Now normal style (hover out to reset)';
+            });
+            toggleText.addEventListener('mouseleave', () => {
+                toggleText.classList.remove('ease-not-italic');
+                toggleText.classList.add('ease-italic');
+                toggleText.textContent = 'Hover over me to toggle italic style';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/submissions/examples/italic-utils-I/style.css
+++ b/submissions/examples/italic-utils-I/style.css
@@ -1,0 +1,229 @@
+ 
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    padding: 2rem;
+}
+
+.container {
+    max-width: 1000px;
+    margin: 0 auto;
+    background: #fff;
+    border-radius: 1rem;
+    padding: 3rem;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+h1 {
+    text-align: center;
+    color: #1e293b;
+    margin-bottom: 0.5rem;
+}
+
+.container > p {
+    text-align: center;
+    color: #64748b;
+    margin-bottom: 3rem;
+}
+
+.demo-section {
+    margin-bottom: 3rem;
+}
+
+.demo-section h2 {
+    font-size: 1.3rem;
+    color: #1e293b;
+    margin-bottom: 1.5rem;
+    border-left: 4px solid #667eea;
+    padding-left: 1rem;
+}
+
+/* ========================================
+   TEXT UTILITIES
+   ======================================== */
+
+.ease-italic {
+    font-style: italic;
+}
+
+.ease-not-italic {
+    font-style: normal;
+}
+
+/* Additional demo text utilities */
+.ease-bold {
+    font-weight: bold;
+}
+
+.ease-underline {
+    text-decoration: underline;
+}
+
+.ease-text-center {
+    text-align: center;
+}
+
+.ease-text-large {
+    font-size: 1.2rem;
+}
+
+/* Demo Styles */
+.demo-box {
+    background: #f8fafc;
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+}
+
+.demo-box p {
+    margin: 0.5rem 0;
+    font-size: 1.1rem;
+}
+
+.comparison-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 2rem;
+}
+
+.comparison-card {
+    background: #f8fafc;
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+    text-align: center;
+}
+
+.comparison-card h3 {
+    margin-bottom: 1rem;
+    color: #1e293b;
+}
+
+.sample-text {
+    font-size: 1rem;
+    margin: 0.5rem 0;
+    color: #475569;
+}
+
+.use-cases-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+}
+
+.use-card {
+    background: #f8fafc;
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+}
+
+.use-card h3 {
+    margin-bottom: 1rem;
+    color: #1e293b;
+}
+
+.use-card p {
+    margin: 0.5rem 0;
+    color: #475569;
+}
+
+.combined-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+}
+
+.combined-card {
+    background: #f8fafc;
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+    text-align: center;
+}
+
+.combined-card p {
+    margin: 1rem 0;
+    font-size: 1.1rem;
+}
+
+.toggle-demo {
+    background: #f8fafc;
+    padding: 2rem;
+    border-radius: 0.75rem;
+    text-align: center;
+}
+
+.toggle-text {
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: all 0.3s;
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    background: #e2e8f0;
+    border-radius: 0.5rem;
+}
+
+/* Code Section */
+.code-section {
+    background: #f8fafc;
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+    margin: 2rem 0;
+}
+
+pre {
+    background: #1e293b;
+    color: #e2e8f0;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    overflow-x: auto;
+    font-family: monospace;
+    font-size: 0.75rem;
+}
+
+.info {
+    background: #e0e7ff;
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+    margin-top: 2rem;
+}
+
+.info h3 {
+    margin-bottom: 1rem;
+    color: #1e293b;
+}
+
+.info ul {
+    margin-left: 1.5rem;
+    color: #475569;
+}
+
+.info li {
+    margin-bottom: 0.5rem;
+}
+
+code {
+    background: #f1f5f9;
+    padding: 0.2rem 0.4rem;
+    border-radius: 0.25rem;
+    font-family: monospace;
+    font-size: 0.875rem;
+    color: #d946ef;
+}
+
+@media (max-width: 768px) {
+    body {
+        padding: 1rem;
+    }
+    .container {
+        padding: 1.5rem;
+    }
+    .comparison-grid,
+    .use-cases-grid,
+    .combined-grid {
+        gap: 1rem;
+    }
+}


### PR DESCRIPTION
## Changes Made
- ✅ `ease-italic` - Applies `font-style: italic`
- ✅ `ease-not-italic` - Applies `font-style: normal`

## Features
- 📝 Simple text styling utilities
- 🎯 Works on any text element
- 🔄 Can be combined with other utilities
- 💫 Lightweight and pure CSS

## Files Added
- `demo.html` - Interactive demo
- `style.css` - Utility styles
- `README.md` - Documentation

Closes #378