### PR TITLE
test: remove fixed bundle size assertion

### DIFF
--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -81,7 +81,7 @@ describe('EaseMotion-css Smoke Tests', () => {
     expect(bundle).toContain('.ease-card');
     expect(bundle).toContain('@keyframes ease-kf-zoom-in');
     expect(bundle).toContain('prefers-reduced-motion:reduce');
-    expect(bundle.length).toBeGreaterThan(20000);
+    expect(bundle.trim().length).toBeGreaterThan(100);
   });
 
   it('should not have duplicate @keyframes definitions', () => {


### PR DESCRIPTION
## Summary

This PR removes the hardcoded bundle size threshold from the smoke test and replaces it with a lightweight validation check.

## Changes Made

* Removed the fixed bundle size assertion:

```js
expect(bundle.length).toBeGreaterThan(20000);
```

* Added a basic non-empty bundle check:

```js
expect(bundle.trim().length).toBeGreaterThan(100);
```

* Retained all existing content-based validations for key classes, animations, and reduced-motion support.

## Why

The previous test relied on an arbitrary minimum bundle size. Legitimate optimizations, CSS cleanup, or improved minification could reduce the bundle size and cause the test to fail even when the generated CSS remained fully functional.

By removing the fixed size requirement, the test now focuses on validating actual bundle contents rather than file size.

## Testing

* [x] Test suite passes locally
* [x] Verified key CSS classes are present in the generated bundle
* [x] Verified animation keyframes are present
* [x] Verified reduced-motion support remains checked
