### PR TITLE
test: validate component selectors using CSSOM

### DIFF
--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -54,15 +54,22 @@ describe('EaseMotion-css Smoke Tests', () => {
   });
 
   it('should have component classes defined', () => {
-    expect(css).toContain('.ease-btn');
-    expect(css).toContain('.ease-btn-primary');
-    expect(css).toContain('.ease-card');
-    expect(css).toContain('.ease-chip');
-    expect(css).toContain('.ease-footer');
-    expect(css).toContain('.ease-masonry');
-    expect(css).toContain('.ease-navbar-glass');
-    expect(css).toContain('.ease-scroll-progress');
-    expect(css).toContain('.ease-sidebar');
+    const sheet = document.styleSheets[0];
+    const rules = [...sheet.cssRules];
+
+    const selectors = rules
+      .filter(rule => rule.selectorText)
+      .map(rule => rule.selectorText);
+
+    expect(selectors).toContain('.ease-btn');
+    expect(selectors).toContain('.ease-btn-primary');
+    expect(selectors).toContain('.ease-card');
+    expect(selectors).toContain('.ease-chip');
+    expect(selectors).toContain('.ease-footer');
+    expect(selectors).toContain('.ease-masonry');
+    expect(selectors).toContain('.ease-navbar-glass');
+    expect(selectors).toContain('.ease-scroll-progress');
+    expect(selectors).toContain('.ease-sidebar');
   });
 
   it('should hide plain text in loading buttons and keep the spinner visible', () => {


### PR DESCRIPTION
## Summary

This PR replaces string-based selector validation with CSSOM-based rule validation in the smoke tests.

## Changes Made

* Removed selector checks based on:

```js
expect(css).toContain('.ease-btn-primary');
```

* Added CSSOM-based validation using the parsed stylesheet:

```js
const sheet = document.styleSheets[0];
const rules = [...sheet.cssRules];
```

* Verified that component selectors exist as actual CSS rules rather than simple text matches.

## Why

The previous implementation relied on string matching against the raw CSS source. This could produce false positives if a selector appeared inside comments, documentation, or malformed CSS while not actually existing as a valid stylesheet rule.

Using CSSOM ensures the test validates the parsed stylesheet and confirms that selectors are genuinely defined.

## Testing

* [x] Test suite passes locally
* [x] Verified component selectors are detected from parsed CSS rules
* [x] Eliminated potential false positives from string matching
* [x] No functional changes to the generated CSS
