### PR TITLE
feat: add ease-drawer CSS-only slide-in side panel (issue #2739)

### DIFF
--- a/submissions/examples/drawer/README.md
+++ b/submissions/examples/drawer/README.md
@@ -1,0 +1,93 @@
+# ease-drawer
+
+Submission for EaseMotion CSS — resolves Issue #2739
+
+---
+
+## 1. What does this do?
+
+Adds a CSS-only animated slide-in side panel (drawer / off-canvas panel).
+Uses the checkbox hack — a hidden input[type=checkbox] paired with label
+elements — so the drawer opens and closes with zero JavaScript.
+
+Supports four directions (left, right, top, bottom), three width sizes,
+a backdrop overlay, a close button, and structured header/body/footer regions.
+
+---
+
+## 2. How is it used?
+
+```html
+<!-- 1. Hidden toggle checkbox -->
+<input type="checkbox" id="my-drawer" class="ease-drawer-toggle" />
+
+<!-- 2. Click-outside overlay -->
+<label for="my-drawer" class="ease-drawer-overlay"></label>
+
+<!-- 3. Drawer panel -->
+<div class="ease-drawer">
+  <label for="my-drawer" class="ease-drawer-close">X</label>
+  <div class="ease-drawer-header">Menu</div>
+  <div class="ease-drawer-body">content here</div>
+  <div class="ease-drawer-footer">Footer</div>
+</div>
+
+<!-- 4. Open button -->
+<label for="my-drawer">Open</label>
+```
+
+Direction variants:
+  .ease-drawer                — left (default)
+  .ease-drawer ease-drawer-right   — right
+  .ease-drawer ease-drawer-top     — top
+  .ease-drawer ease-drawer-bottom  — bottom
+
+Width modifiers (left/right only):
+  .ease-drawer-sm   220px
+  .ease-drawer      300px default
+  .ease-drawer-lg   420px
+  .ease-drawer-full 100vw
+
+---
+
+## 3. Why is it useful?
+
+Drawers are one of the most common UI patterns: nav menus, shopping carts,
+filter panels, contact forms. EaseMotion CSS has no drawer component yet.
+
+Zero JavaScript — pure CSS checkbox hack, works in all browsers.
+Composable — direction and width modifiers stack freely.
+Token-aware — uses --ease-color-surface and --ease-color-text.
+Reduced-motion safe — transitions disabled when user prefers it.
+
+---
+
+## Classes
+
+ease-drawer-toggle   — hidden checkbox (state controller)
+ease-drawer-overlay  — backdrop label, click to close
+ease-drawer          — panel, slides from left by default
+ease-drawer-right    — slides from right
+ease-drawer-top      — slides from top
+ease-drawer-bottom   — slides from bottom
+ease-drawer-sm       — 220px width
+ease-drawer-lg       — 420px width
+ease-drawer-full     — 100vw width
+ease-drawer-close    — X close button label
+ease-drawer-header   — titled top region
+ease-drawer-body     — scrollable content region
+ease-drawer-footer   — action region at bottom
+
+---
+
+## Files
+
+style.css  — full component, dark mode, reduced-motion
+demo.html  — 5 demos: nav, cart, filters, announcement, contact form
+README.md  — this file
+
+Proposed ease-* names (maintainer decides):
+ease-drawer, ease-drawer-right, ease-drawer-top, ease-drawer-bottom,
+ease-drawer-sm, ease-drawer-lg, ease-drawer-full, ease-drawer-toggle,
+ease-drawer-overlay, ease-drawer-close, ease-drawer-header,
+ease-drawer-body, ease-drawer-footer

--- a/submissions/examples/drawer/demo.html
+++ b/submissions/examples/drawer/demo.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-drawer — EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #f4f4f5; color: #111; padding: 2rem; min-height: 100vh; }
+    h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #666; font-size: 0.88rem; margin-bottom: 2.5rem; }
+    .section { background: #fff; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; box-shadow: 0 1px 4px rgba(0,0,0,0.07); }
+    .section-label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.12em; color: #aaa; margin-bottom: 0.4rem; }
+    .section-code { font-family: monospace; font-size: 0.78rem; color: #7c3aed; background: #f3f0ff; padding: 0.2rem 0.5rem; border-radius: 4px; display: inline-block; margin-bottom: 1.2rem; }
+    .open-btn { display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.55rem 1.2rem; border-radius: 8px; border: none; background: #7c3aed; color: #fff; font-size: 0.88rem; font-weight: 600; cursor: pointer; text-decoration: none; transition: background 0.2s; }
+    .open-btn:hover { background: #6d28d9; }
+    .open-btn.secondary { background: #111; }
+    .open-btn.secondary:hover { background: #333; }
+    .open-btn.outline { background: transparent; border: 1.5px solid #7c3aed; color: #7c3aed; }
+    .open-btn.outline:hover { background: #f3f0ff; }
+    .drawer-nav { list-style: none; display: flex; flex-direction: column; gap: 0.25rem; }
+    .drawer-nav a { display: flex; align-items: center; gap: 0.6rem; padding: 0.65rem 0.75rem; border-radius: 8px; text-decoration: none; color: inherit; font-size: 0.9rem; transition: background 0.15s; }
+    .drawer-nav a:hover { background: #f4f4f5; }
+    .cart-item { display: flex; align-items: center; gap: 1rem; padding: 0.75rem 0; border-bottom: 1px solid #f0f0f0; }
+    .cart-thumb { width: 48px; height: 48px; border-radius: 8px; background: linear-gradient(135deg,#667eea,#764ba2); flex-shrink: 0; }
+    .cart-info { flex: 1; }
+    .cart-info strong { display: block; font-size: 0.88rem; }
+    .cart-info span { font-size: 0.78rem; color: #888; }
+    .cart-price { font-weight: 700; font-size: 0.9rem; color: #7c3aed; }
+    .drawer-form label { display: block; font-size: 0.82rem; font-weight: 600; margin-bottom: 0.3rem; color: #555; }
+    .drawer-form input, .drawer-form textarea, .drawer-form select { width: 100%; padding: 0.55rem 0.75rem; border: 1px solid #e0e0e0; border-radius: 6px; font-size: 0.88rem; margin-bottom: 1rem; font-family: inherit; }
+    .drawer-form textarea { resize: vertical; min-height: 80px; }
+    .filter-group { margin-bottom: 1rem; }
+    .filter-group h4 { font-size: 0.8rem; font-weight: 700; color: #888; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.5rem; }
+    .filter-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+    .filter-tag { padding: 0.3rem 0.7rem; border-radius: 99px; font-size: 0.78rem; border: 1px solid #e0e0e0; cursor: pointer; transition: all 0.15s; }
+    .filter-tag:hover, .filter-tag.active { background: #7c3aed; color: #fff; border-color: #7c3aed; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #e0e0f0; }
+      .section { background: #1e1e2e; }
+      .drawer-nav a:hover { background: rgba(255,255,255,0.07); }
+      .cart-item { border-color: #2a2a3e; }
+      .drawer-form input, .drawer-form textarea, .drawer-form select { background: #0f172a; border-color: #333; color: #e0e0f0; }
+      .filter-tag { border-color: #333; }
+    }
+  </style>
+</head>
+<body>
+<h1>🗂️ ease-drawer</h1>
+<p class="subtitle">CSS-only animated slide-in side panel — EaseMotion CSS · Issue #2739</p>
+
+<!-- Demo 1: Left nav -->
+<div class="section">
+  <p class="section-label">Demo 1 — Left drawer (default)</p>
+  <code class="section-code">.ease-drawer</code>
+  <input type="checkbox" id="drawer-left" class="ease-drawer-toggle" />
+  <label for="drawer-left" class="ease-drawer-overlay"></label>
+  <nav class="ease-drawer">
+    <label for="drawer-left" class="ease-drawer-close">✕</label>
+    <div class="ease-drawer-header">Navigation</div>
+    <div class="ease-drawer-body">
+      <ul class="drawer-nav">
+        <li><a href="#">🏠 Home</a></li>
+        <li><a href="#">📊 Dashboard</a></li>
+        <li><a href="#">📁 Projects</a></li>
+        <li><a href="#">💬 Messages</a></li>
+        <li><a href="#">🔔 Notifications</a></li>
+        <li><a href="#">⚙️ Settings</a></li>
+      </ul>
+    </div>
+    <div class="ease-drawer-footer"><a href="#" style="font-size:0.85rem;text-decoration:none;color:inherit;">👤 My Account</a></div>
+  </nav>
+  <label for="drawer-left" class="open-btn">☰ Open Left Drawer</label>
+</div>
+
+<!-- Demo 2: Right cart -->
+<div class="section">
+  <p class="section-label">Demo 2 — Right drawer (cart)</p>
+  <code class="section-code">.ease-drawer.ease-drawer-right</code>
+  <input type="checkbox" id="drawer-right" class="ease-drawer-toggle" />
+  <label for="drawer-right" class="ease-drawer-overlay"></label>
+  <div class="ease-drawer ease-drawer-right">
+    <label for="drawer-right" class="ease-drawer-close">✕</label>
+    <div class="ease-drawer-header">🛒 Your Cart (3)</div>
+    <div class="ease-drawer-body">
+      <div class="cart-item">
+        <div class="cart-thumb"></div>
+        <div class="cart-info"><strong>EaseMotion Pro</strong><span>Annual licence</span></div>
+        <span class="cart-price">$49</span>
+      </div>
+      <div class="cart-item">
+        <div class="cart-thumb" style="background:linear-gradient(135deg,#f093fb,#f5576c);"></div>
+        <div class="cart-info"><strong>UI Kit Bundle</strong><span>One-time</span></div>
+        <span class="cart-price">$29</span>
+      </div>
+      <div class="cart-item">
+        <div class="cart-thumb" style="background:linear-gradient(135deg,#4facfe,#00f2fe);"></div>
+        <div class="cart-info"><strong>Icon Pack</strong><span>Commercial</span></div>
+        <span class="cart-price">$15</span>
+      </div>
+    </div>
+    <div class="ease-drawer-footer">
+      <div style="display:flex;justify-content:space-between;margin-bottom:0.75rem;font-weight:700;"><span>Total</span><span style="color:#7c3aed;">$93</span></div>
+      <label for="drawer-right" class="open-btn" style="width:100%;justify-content:center;">Checkout →</label>
+    </div>
+  </div>
+  <label for="drawer-right" class="open-btn secondary">🛒 Open Cart</label>
+</div>
+
+<!-- Demo 3: Bottom filters -->
+<div class="section">
+  <p class="section-label">Demo 3 — Bottom drawer (filters)</p>
+  <code class="section-code">.ease-drawer.ease-drawer-bottom</code>
+  <input type="checkbox" id="drawer-bottom" class="ease-drawer-toggle" />
+  <label for="drawer-bottom" class="ease-drawer-overlay"></label>
+  <div class="ease-drawer ease-drawer-bottom">
+    <label for="drawer-bottom" class="ease-drawer-close">✕</label>
+    <div class="ease-drawer-header">🎛️ Filters</div>
+    <div class="ease-drawer-body">
+      <div class="filter-group">
+        <h4>Category</h4>
+        <div class="filter-tags">
+          <span class="filter-tag active">All</span>
+          <span class="filter-tag">Animation</span>
+          <span class="filter-tag">Components</span>
+          <span class="filter-tag">Utilities</span>
+        </div>
+      </div>
+      <div class="filter-group">
+        <h4>Difficulty</h4>
+        <div class="filter-tags">
+          <span class="filter-tag">Beginner</span>
+          <span class="filter-tag active">Intermediate</span>
+          <span class="filter-tag">Advanced</span>
+        </div>
+      </div>
+    </div>
+    <div class="ease-drawer-footer" style="display:flex;gap:0.75rem;">
+      <label for="drawer-bottom" class="open-btn outline" style="flex:1;justify-content:center;">Reset</label>
+      <label for="drawer-bottom" class="open-btn" style="flex:1;justify-content:center;">Apply</label>
+    </div>
+  </div>
+  <label for="drawer-bottom" class="open-btn outline">🎛️ Open Filters</label>
+</div>
+
+<!-- Demo 4: Top announcement -->
+<div class="section">
+  <p class="section-label">Demo 4 — Top drawer (announcement)</p>
+  <code class="section-code">.ease-drawer.ease-drawer-top</code>
+  <input type="checkbox" id="drawer-top" class="ease-drawer-toggle" />
+  <label for="drawer-top" class="ease-drawer-overlay"></label>
+  <div class="ease-drawer ease-drawer-top">
+    <label for="drawer-top" class="ease-drawer-close">✕</label>
+    <div class="ease-drawer-header">📢 Announcements</div>
+    <div class="ease-drawer-body">
+      <p style="line-height:1.6;font-size:0.9rem;">🎉 <strong>EaseMotion CSS v2.0</strong> is now live! New components include ease-drawer, ease-skeleton, ease-glitch, and 20+ more utilities.</p>
+    </div>
+  </div>
+  <label for="drawer-top" class="open-btn secondary">📢 Show Announcement</label>
+</div>
+
+<!-- Demo 5: Large form -->
+<div class="section">
+  <p class="section-label">Demo 5 — Large right drawer with form</p>
+  <code class="section-code">.ease-drawer.ease-drawer-right.ease-drawer-lg</code>
+  <input type="checkbox" id="drawer-form" class="ease-drawer-toggle" />
+  <label for="drawer-form" class="ease-drawer-overlay"></label>
+  <div class="ease-drawer ease-drawer-right ease-drawer-lg">
+    <label for="drawer-form" class="ease-drawer-close">✕</label>
+    <div class="ease-drawer-header">✉️ Contact Us</div>
+    <div class="ease-drawer-body">
+      <div class="drawer-form">
+        <label>Full Name</label>
+        <input type="text" placeholder="Jane Doe" />
+        <label>Email</label>
+        <input type="email" placeholder="jane@example.com" />
+        <label>Subject</label>
+        <select><option>General enquiry</option><option>Bug report</option><option>Feature request</option></select>
+        <label>Message</label>
+        <textarea placeholder="Tell us more…"></textarea>
+      </div>
+    </div>
+    <div class="ease-drawer-footer" style="display:flex;gap:0.75rem;">
+      <label for="drawer-form" class="open-btn outline" style="flex:1;justify-content:center;">Cancel</label>
+      <label for="drawer-form" class="open-btn" style="flex:1;justify-content:center;">Send →</label>
+    </div>
+  </div>
+  <label for="drawer-form" class="open-btn">✉️ Open Contact Form</label>
+</div>
+</body>
+</html>

--- a/submissions/examples/drawer/style.css
+++ b/submissions/examples/drawer/style.css
@@ -1,0 +1,133 @@
+/* ==========================================================
+   EaseMotion CSS — ease-drawer component
+   CSS-only animated slide-in side panel
+   Uses the checkbox hack: no JavaScript required
+   ========================================================== */
+
+.ease-drawer-toggle {
+  display: none;
+}
+
+.ease-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.35s ease, visibility 0.35s ease;
+  z-index: 200;
+}
+
+.ease-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 300px;
+  height: 100%;
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-text, #111111);
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.15);
+  transform: translateX(-100%);
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 201;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-drawer-right {
+  left: auto;
+  right: 0;
+  transform: translateX(100%);
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.15);
+}
+
+.ease-drawer-top {
+  left: 0;
+  top: 0;
+  right: 0;
+  width: 100%;
+  height: auto;
+  max-height: 60vh;
+  transform: translateY(-100%);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+}
+
+.ease-drawer-bottom {
+  left: 0;
+  top: auto;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: auto;
+  max-height: 60vh;
+  transform: translateY(100%);
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
+}
+
+.ease-drawer-sm   { width: 220px; }
+.ease-drawer-lg   { width: 420px; }
+.ease-drawer-full { width: 100vw; }
+
+.ease-drawer-toggle:checked ~ .ease-drawer-overlay {
+  opacity: 1;
+  visibility: visible;
+}
+
+.ease-drawer-toggle:checked ~ .ease-drawer         { transform: translateX(0); }
+.ease-drawer-toggle:checked ~ .ease-drawer-right   { transform: translateX(0); }
+.ease-drawer-toggle:checked ~ .ease-drawer-top     { transform: translateY(0); }
+.ease-drawer-toggle:checked ~ .ease-drawer-bottom  { transform: translateY(0); }
+
+.ease-drawer-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--ease-color-text, #111111);
+  background: none;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+.ease-drawer-close:hover { background: rgba(0, 0, 0, 0.08); }
+
+.ease-drawer-header {
+  padding: 1.25rem 3rem 1.25rem 1.5rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.ease-drawer-body {
+  padding: 1.5rem;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.ease-drawer-footer {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-drawer {
+    background: var(--ease-color-surface, #1e1e2e);
+    color: var(--ease-color-text, #e0e0f0);
+    box-shadow: 4px 0 24px rgba(0, 0, 0, 0.4);
+  }
+  .ease-drawer-right  { box-shadow: -4px 0 24px rgba(0, 0, 0, 0.4); }
+  .ease-drawer-top    { box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4); }
+  .ease-drawer-bottom { box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4); }
+  .ease-drawer-close:hover { background: rgba(255, 255, 255, 0.1); }
+  .ease-drawer-header,
+  .ease-drawer-footer { border-color: rgba(255, 255, 255, 0.1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-drawer,
+  .ease-drawer-overlay { transition: none !important; }
+}


### PR DESCRIPTION
## Summary
Adds ease-drawer submission for issue #2739.

## Files added
- submissions/examples/drawer/style.css
- submissions/examples/drawer/demo.html
- submissions/examples/drawer/README.md

## Classes submitted
- .ease-drawer — left slide-in panel (default)
- .ease-drawer-right/top/bottom — direction variants
- .ease-drawer-sm/lg/full — width modifiers
- .ease-drawer-toggle — hidden checkbox (zero JS)
- .ease-drawer-overlay — backdrop, click to close
- .ease-drawer-close — X button
- .ease-drawer-header/body/footer — layout regions

Dark mode + prefers-reduced-motion included.

Closes #2739