### PR TITLE
feat: add ease-color-swatch-az — CSS-only Color Swatch Picker

### DIFF
--- a/submissions/examples/ease-color-swatch-az/README.md
+++ b/submissions/examples/ease-color-swatch-az/README.md
@@ -1,0 +1,16 @@
+# Color Swatch Picker Component
+
+### What does this do?
+This submission adds `ease-color-swatch-az` — a CSS-only color swatch picker for selecting preset colors. Each swatch is an accessible `<button>` that scales on hover, shows a focus ring via `:focus-visible`, and animates a checkmark on selection using a spring-like `cubic-bezier` pop.
+
+### How is it used?
+The maintainer should copy the contents of `style.css` into a new file at `components/color-swatch.css` and import it into the main framework payload.
+
+Developers use it by wrapping a group of swatch buttons in a `.ease-color-swatch-az` container. Each swatch uses `.ease-swatch-az` with an inline `background`. Selection is handled via the `.selected` class (toggled with a sprinkle of JS in the demo, but the visual states are entirely CSS-driven).
+
+Size modifiers: `.sm` (28px) and `.lg` (48px) on the swatch element.
+
+### Why is it useful?
+1. **CSS-only visual states** — Hover scale, focus-visible ring, and the selected checkmark are all pure CSS. The checkmark uses a custom `@keyframes` with an overshoot easing for a satisfying bounce.
+2. **Accessible by default** — Each swatch is a native `<button>` with `:focus-visible` styling, and tooltips appear on hover/selection for screen-reader-friendly color names.
+3. **Framework-native** — Uses EaseMotion's spacing, radius, and color CSS variables so the component fits seamlessly into any project using the framework.

--- a/submissions/examples/ease-color-swatch-az/demo.html
+++ b/submissions/examples/ease-color-swatch-az/demo.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Color Swatch Picker Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    .demo-section {
+      margin-bottom: var(--ease-space-8);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); }
+    .ease-color-swatch-az {
+      margin-bottom: var(--ease-space-4);
+    }
+    .swatch-grid {
+      display: flex;
+      flex-direction: column;
+      gap: var(--ease-space-4);
+    }
+    .swatch-row-label {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--ease-color-neutral-600);
+      margin-bottom: var(--ease-space-1);
+    }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-color-swatch-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A lightweight, CSS-only color swatch picker with hover scale, focus rings, and a bouncy checkmark on selection.</p>
+
+  <div class="swatch-grid">
+    <div class="demo-section">
+      <div class="swatch-row-label">Brand Colors</div>
+      <div class="ease-color-swatch-az">
+        <button class="ease-swatch-az" style="background:#6366f1" data-color="#6366f1" data-name="Indigo" title="Indigo"></button>
+        <button class="ease-swatch-az" style="background:#3b82f6" data-color="#3b82f6" data-name="Blue" title="Blue"></button>
+        <button class="ease-swatch-az" style="background:#06b6d4" data-color="#06b6d4" data-name="Cyan" title="Cyan"></button>
+        <button class="ease-swatch-az" style="background:#10b981" data-color="#10b981" data-name="Emerald" title="Emerald"></button>
+        <button class="ease-swatch-az" style="background:#f59e0b" data-color="#f59e0b" data-name="Amber" title="Amber"></button>
+        <button class="ease-swatch-az" style="background:#ef4444" data-color="#ef4444" data-name="Red" title="Red"></button>
+        <button class="ease-swatch-az" style="background:#ec4899" data-color="#ec4899" data-name="Pink" title="Pink"></button>
+        <button class="ease-swatch-az" style="background:#8b5cf6" data-color="#8b5cf6" data-name="Violet" title="Violet"></button>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <div class="swatch-row-label">Neutrals</div>
+      <div class="ease-color-swatch-az">
+        <button class="ease-swatch-az" style="background:#f8f9fa; border-color:#d1d5db" data-color="#f8f9fa" data-name="White" title="White"></button>
+        <button class="ease-swatch-az" style="background:#e5e7eb" data-color="#e5e7eb" data-name="Light Gray" title="Light Gray"></button>
+        <button class="ease-swatch-az" style="background:#9ca3af" data-color="#9ca3af" data-name="Gray" title="Gray"></button>
+        <button class="ease-swatch-az" style="background:#4b5563" data-color="#4b5563" data-name="Dark Gray" title="Dark Gray"></button>
+        <button class="ease-swatch-az" style="background:#1f2937" data-color="#1f2937" data-name="Dark" title="Dark"></button>
+        <button class="ease-swatch-az" style="background:#111827" data-color="#111827" data-name="Near Black" title="Near Black"></button>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <div class="swatch-row-label">Size Variants</div>
+      <div class="ease-color-swatch-az">
+        <button class="ease-swatch-az sm" style="background:#6366f1" data-color="#6366f1" data-name="Small" title="Small"></button>
+        <button class="ease-swatch-az" style="background:#3b82f6" data-color="#3b82f6" data-name="Default" title="Default"></button>
+        <button class="ease-swatch-az lg" style="background:#10b981" data-color="#10b981" data-name="Large" title="Large"></button>
+      </div>
+    </div>
+  </div>
+
+  <div class="ease-swatch-preview-az" id="preview">
+    <div class="ease-swatch-preview-swatch-az" id="previewSwatch" style="background: #6366f1"></div>
+    <div>
+      <div style="font-weight: 600;">Selected Color</div>
+      <div class="ease-swatch-preview-label-az" id="previewLabel">#6366f1 — Indigo</div>
+    </div>
+  </div>
+
+  <script>
+    const swatches = document.querySelectorAll('.ease-swatch-az');
+    const previewSwatch = document.getElementById('previewSwatch');
+    const previewLabel = document.getElementById('previewLabel');
+
+    swatches.forEach(swatch => {
+      swatch.addEventListener('click', () => {
+        swatches.forEach(s => s.classList.remove('selected'));
+        swatch.classList.add('selected');
+        const color = swatch.dataset.color;
+        const name = swatch.dataset.name;
+        previewSwatch.style.background = color;
+        previewLabel.textContent = color + ' \u2014 ' + name;
+      });
+    });
+
+    swatches[0].click();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-color-swatch-az/style.css
+++ b/submissions/examples/ease-color-swatch-az/style.css
@@ -1,0 +1,156 @@
+/* ============================================================
+   EaseMotion CSS — ease-color-swatch-az component (Proposal)
+   CSS-only color swatch picker with selection animation.
+   ============================================================ */
+
+.ease-color-swatch-az {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 8px);
+  padding: var(--ease-space-3, 12px);
+  background: var(--ease-color-surface, #fafafa);
+  border-radius: var(--ease-radius-lg, 12px);
+  max-width: fit-content;
+}
+
+.ease-swatch-az {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  border: 2px solid transparent;
+  border-radius: var(--ease-radius-full, 9999px);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  outline: none;
+  padding: 0;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.ease-swatch-az:hover {
+  transform: scale(1.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.ease-swatch-az:focus-visible {
+  border-color: var(--ease-color-neutral-900, #1a1a1a);
+  box-shadow: 0 0 0 3px var(--ease-color-primary, #6366f1), 0 4px 12px rgba(0, 0, 0, 0.2);
+  transform: scale(1.15);
+}
+
+.ease-swatch-az.selected {
+  border-color: var(--ease-color-neutral-900, #1a1a1a);
+  transform: scale(1.15);
+  box-shadow: 0 0 0 3px var(--ease-color-primary, #6366f1);
+}
+
+.ease-swatch-az.selected::after {
+  content: "✓";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  animation: ease-swatch-pop-az 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes ease-swatch-pop-az {
+  0% { transform: scale(0); opacity: 0; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.ease-swatch-az.sm {
+  width: 28px;
+  height: 28px;
+}
+
+.ease-swatch-az.sm.selected::after {
+  font-size: 12px;
+}
+
+.ease-swatch-az.lg {
+  width: 48px;
+  height: 48px;
+}
+
+.ease-swatch-az.lg.selected::after {
+  font-size: 22px;
+}
+
+.ease-swatch-az.selected .ease-swatch-tooltip-az {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(-4px);
+}
+
+.ease-swatch-tooltip-az {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  background: var(--ease-color-neutral-900, #1a1a1a);
+  color: #fff;
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: var(--ease-radius-sm, 4px);
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.ease-swatch-tooltip-az::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--ease-color-neutral-900, #1a1a1a);
+}
+
+.ease-swatch-az:hover .ease-swatch-tooltip-az {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+.ease-swatch-selector-az {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 8px);
+}
+
+.ease-swatch-preview-az {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 12px);
+  margin-top: var(--ease-space-4, 16px);
+  padding: var(--ease-space-3, 12px);
+  background: var(--ease-color-surface, #fafafa);
+  border-radius: var(--ease-radius-lg, 12px);
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  font-size: 14px;
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+}
+
+.ease-swatch-preview-swatch-az {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--ease-radius-md, 8px);
+  border: 2px solid var(--ease-color-neutral-200, #e5e7eb);
+  transition: background 0.3s ease;
+  flex-shrink: 0;
+}
+
+.ease-swatch-preview-label-az {
+  color: var(--ease-color-neutral-700, #374151);
+}


### PR DESCRIPTION
## Description
Adds a new `ease-color-swatch-az` component — a CSS-only color swatch picker with hover scale, focus-visible rings, and a spring-animated checkmark on selection.
## Changes
- `submissions/examples/ease-color-swatch-az/style.css` — Component styles with size variants (.sm, .lg), tooltip, and selected-state pop animation
- `submissions/examples/ease-color-swatch-az/demo.html` — Interactive demo with brand colors, neutrals, and size variants
- `submissions/examples/ease-color-swatch-az/README.md` — Usage docs and API reference
## API
```html
<div class="ease-color-swatch-az">
  <button class="ease-swatch-az" style="background: #6366f1"></button>
  <button class="ease-swatch-az selected" style="background: #3b82f6"></button>
</div>
Size modifiers: .sm (28px), .lg (48px). Selection via .selected class.
Related Issue
Closes #2802 