### PR TITLE
feat: add ease-table-az — Responsive CSS-only Table Component

### DIFF
--- a/submissions/examples/ease-table-az/README.md
+++ b/submissions/examples/ease-table-az/README.md
@@ -1,0 +1,31 @@
+# Table Component
+
+### What does this do?
+Adds `ease-table-az` — a responsive HTML table component with hover row highlighting, striped rows, bordered, and compact variants. On mobile (sub-640px) the `.responsive` class converts rows into stacked cards with `data-label` headers.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/table.css` and import it.
+
+```html
+<table class="ease-table-az striped responsive">
+  <thead>
+    <tr>
+      <th>Name <span class="ease-sort-icon-az">&#8593;</span></th>
+      <th>Role</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-label="Name">Alice Chen</td>
+      <td data-label="Role">Designer</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+Variants: `.striped`, `.bordered`, `.compact`, `.responsive` (stackable).
+
+### Why is it useful?
+1. **Row hover** — subtle background shift on `:hover` for scannability
+2. **Responsive** — card layout on small screens using `data-label` attributes, no JS
+3. **Flexible** — four orthogonal modifier classes compose into any style needed

--- a/submissions/examples/ease-table-az/demo.html
+++ b/submissions/examples/ease-table-az/demo.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Table Component Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    .demo-section {
+      margin-bottom: var(--ease-space-8);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .table-wrap {
+      overflow-x: auto;
+      border-radius: var(--ease-radius-lg);
+      border: 1px solid var(--ease-color-neutral-200);
+    }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-table-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A responsive table component with striped, bordered, compact, and hover-row variants.</p>
+
+  <h2>Default</h2>
+  <div class="demo-section table-wrap">
+    <table class="ease-table-az">
+      <thead>
+        <tr>
+          <th>Name <span class="ease-sort-icon-az active">&#8593;</span></th>
+          <th>Role <span class="ease-sort-icon-az">&#8595;</span></th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Alice Chen</td>
+          <td>Designer</td>
+          <td><span class="ease-badge-az success">Active</span></td>
+          <td>
+            <button class="ease-btn ease-btn-sm ease-btn-outline" style="padding:2px 10px;font-size:0.75rem">Edit</button>
+          </td>
+        </tr>
+        <tr>
+          <td>Bob Martinez</td>
+          <td>Developer</td>
+          <td><span class="ease-badge-az">Inactive</span></td>
+          <td>
+            <button class="ease-btn ease-btn-sm ease-btn-outline" style="padding:2px 10px;font-size:0.75rem">Edit</button>
+          </td>
+        </tr>
+        <tr>
+          <td>Carol Nguyen</td>
+          <td>PM</td>
+          <td><span class="ease-badge-az warning">Pending</span></td>
+          <td>
+            <button class="ease-btn ease-btn-sm ease-btn-outline" style="padding:2px 10px;font-size:0.75rem">Edit</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Striped</h2>
+  <div class="demo-section table-wrap">
+    <table class="ease-table-az striped">
+      <thead>
+        <tr>
+          <th>Project</th>
+          <th>Lead</th>
+          <th>Progress</th>
+          <th>Deadline</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>EaseMotion Core</td>
+          <td>Saptarshi</td>
+          <td><span class="ease-badge-az success">Done</span></td>
+          <td>Jun 15</td>
+        </tr>
+        <tr>
+          <td>Component Library</td>
+          <td>Alice</td>
+          <td><span class="ease-badge-az warning">In Progress</span></td>
+          <td>Jul 1</td>
+        </tr>
+        <tr>
+          <td>Docs Site</td>
+          <td>Bob</td>
+          <td><span class="ease-badge-az">Not Started</span></td>
+          <td>Jul 20</td>
+        </tr>
+        <tr>
+          <td>Testing Suite</td>
+          <td>Carol</td>
+          <td><span class="ease-badge-az warning">In Progress</span></td>
+          <td>Aug 5</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Bordered + Compact</h2>
+  <div class="demo-section table-wrap">
+    <table class="ease-table-az bordered compact">
+      <thead>
+        <tr>
+          <th>Metric</th>
+          <th>Q1</th>
+          <th>Q2</th>
+          <th>Q3</th>
+          <th>Q4</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Revenue</td>
+          <td>$12.4k</td>
+          <td>$18.2k</td>
+          <td>$24.1k</td>
+          <td>$31.5k</td>
+        </tr>
+        <tr>
+          <td>Users</td>
+          <td>1,240</td>
+          <td>2,180</td>
+          <td>3,950</td>
+          <td>6,200</td>
+        </tr>
+        <tr>
+          <td>Load Time</td>
+          <td>320ms</td>
+          <td>280ms</td>
+          <td>210ms</td>
+          <td>145ms</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Responsive (mobile — resize browser to see cards)</h2>
+  <div class="demo-section table-wrap">
+    <table class="ease-table-az striped responsive">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Plan</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td data-label="Name">Diana Park</td>
+          <td data-label="Email">diana@example.com</td>
+          <td data-label="Plan">Pro</td>
+          <td data-label="Status"><span class="ease-badge-az success">Active</span></td>
+        </tr>
+        <tr>
+          <td data-label="Name">Evan Torres</td>
+          <td data-label="Email">evan@example.com</td>
+          <td data-label="Plan">Free</td>
+          <td data-label="Status"><span class="ease-badge-az">Inactive</span></td>
+        </tr>
+        <tr>
+          <td data-label="Name">Fiona Gray</td>
+          <td data-label="Email">fiona@example.com</td>
+          <td data-label="Plan">Enterprise</td>
+          <td data-label="Status"><span class="ease-badge-az success">Active</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-table-az/style.css
+++ b/submissions/examples/ease-table-az/style.css
@@ -1,0 +1,160 @@
+/* ============================================================
+   EaseMotion CSS — ease-table-az component (Proposal)
+   Responsive table with hover, striped, bordered, and compact variants.
+   ============================================================ */
+
+.ease-table-az {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  font-size: 0.875rem;
+  background: var(--ease-color-surface, #fff);
+  border-radius: var(--ease-radius-lg, 12px);
+  overflow: hidden;
+}
+
+.ease-table-az thead {
+  background: var(--ease-color-neutral-100, #f3f4f6);
+}
+
+.ease-table-az th {
+  text-align: left;
+  padding: var(--ease-space-3, 12px) var(--ease-space-4, 16px);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ease-color-neutral-600, #6b7280);
+  border-bottom: 2px solid var(--ease-color-neutral-200, #e5e7eb);
+  white-space: nowrap;
+}
+
+.ease-table-az td {
+  padding: var(--ease-space-3, 12px) var(--ease-space-4, 16px);
+  color: var(--ease-color-neutral-800, #1f2937);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f3f4f6);
+}
+
+.ease-table-az tbody tr {
+  transition: background 0.15s ease;
+}
+
+.ease-table-az tbody tr:hover {
+  background: var(--ease-color-primary-50, #eef2ff);
+}
+
+.ease-table-az tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.ease-table-az.striped tbody tr:nth-child(even) {
+  background: var(--ease-color-neutral-50, #f9fafb);
+}
+
+.ease-table-az.striped tbody tr:nth-child(even):hover {
+  background: var(--ease-color-primary-50, #eef2ff);
+}
+
+.ease-table-az.bordered {
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+}
+
+.ease-table-az.bordered th,
+.ease-table-az.bordered td {
+  border-right: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+}
+
+.ease-table-az.bordered th:last-child,
+.ease-table-az.bordered td:last-child {
+  border-right: none;
+}
+
+.ease-table-az.compact th,
+.ease-table-az.compact td {
+  padding: var(--ease-space-2, 8px) var(--ease-space-3, 12px);
+  font-size: 0.8125rem;
+}
+
+.ease-table-az .ease-badge-az {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-700, #374151);
+}
+
+.ease-table-az .ease-badge-az.success {
+  background: var(--ease-color-success-dim, #d1fae5);
+  color: var(--ease-color-success, #10b981);
+}
+
+.ease-table-az .ease-badge-az.warning {
+  background: var(--ease-color-warning-dim, #fef3c7);
+  color: var(--ease-color-warning, #f59e0b);
+}
+
+.ease-table-az .ease-badge-az.danger {
+  background: var(--ease-color-danger-dim, #fee2e2);
+  color: var(--ease-color-danger, #ef4444);
+}
+
+.ease-table-az .ease-sort-icon-az {
+  display: inline-block;
+  margin-left: 4px;
+  opacity: 0.3;
+  transition: opacity 0.15s ease;
+}
+
+.ease-table-az th:hover .ease-sort-icon-az {
+  opacity: 0.7;
+}
+
+.ease-table-az .ease-sort-icon-az.active {
+  opacity: 1;
+  color: var(--ease-color-primary, #6366f1);
+}
+
+@media (max-width: 640px) {
+  .ease-table-az.responsive {
+    display: block;
+  }
+
+  .ease-table-az.responsive thead {
+    display: none;
+  }
+
+  .ease-table-az.responsive tbody,
+  .ease-table-az.responsive tr,
+  .ease-table-az.responsive td {
+    display: block;
+  }
+
+  .ease-table-az.responsive tr {
+    padding: var(--ease-space-3, 12px);
+    margin-bottom: var(--ease-space-3, 12px);
+    background: var(--ease-color-surface, #fff);
+    border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+    border-radius: var(--ease-radius-lg, 12px);
+  }
+
+  .ease-table-az.responsive td {
+    padding: var(--ease-space-2, 8px) 0;
+    border: none;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--ease-space-2, 8px);
+  }
+
+  .ease-table-az.responsive td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--ease-color-neutral-500, #6b7280);
+    white-space: nowrap;
+  }
+}


### PR DESCRIPTION
```markdown
## Description
Adds `ease-table-az` — a responsive CSS-only table component with hover, striped, bordered, and compact variants, plus an automatic mobile card layout.
## Changes
- `submissions/examples/ease-table-az/style.css` — Table styles with 4 modifier classes, responsive breakpoint, inline status badges, sort icons
- `submissions/examples/ease-table-az/demo.html` — Interactive demo showing default, striped, bordered+compact, and responsive modes
- `submissions/examples/ease-table-az/README.md` — Usage docs with examples
## API
| Modifier | Effect |
|----------|--------|
| `.striped` | Alternating row backgrounds |
| `.bordered` | Full border grid |
| `.compact` | Tighter padding |
| `.responsive` | Card layout below 640px |
## Related Issue
Closes #2810 