### PR TITLE
fix: correct marquee demo variant class names

### DIFF
--- a/examples/marquee-demo.html
+++ b/examples/marquee-demo.html
@@ -121,7 +121,7 @@
             <div class="demo-description">Slow, Normal, Fast, and X-Fast speeds</div>
             
             <div class="demo-description">Slow (40s):</div>
-            <div class="ease-marquee slow" style="margin-bottom: 1rem;">
+            <div class="ease-marquee ease-marquee-slow" style="margin-bottom: 1rem;">
                 <div class="ease-marquee-track">
                     <span class="ticker-item">🐢 Super Slow</span>
                     <span class="ticker-item">🎯 Smooth Scroll</span>
@@ -133,7 +133,7 @@
             </div>
             
             <div class="demo-description">Fast (10s):</div>
-            <div class="ease-marquee fast" style="margin-bottom: 1rem;">
+            <div class="ease-marquee ease-marquee-fast" style="margin-bottom: 1rem;">
                 <div class="ease-marquee-track">
                     <span class="ticker-item">⚡ Fast Motion</span>
                     <span class="ticker-item">🚀 Speed Mode</span>
@@ -149,7 +149,7 @@
         <div class="demo-section">
             <div class="demo-title">🔄 3. Reverse Direction</div>
             <div class="demo-description">Scrolls from left to right instead</div>
-            <div class="ease-marquee reverse">
+            <div class="ease-marquee ease-marquee-reverse">
                 <div class="ease-marquee-track">
                     <span class="ticker-item">← Reverse Direction</span>
                     <span class="ticker-item">Right to Left →</span>
@@ -165,7 +165,7 @@
         <div class="demo-section">
             <div class="demo-title">🌊 4. Fade Edges Effect</div>
             <div class="demo-description">Smooth gradient fade at both ends</div>
-            <div class="ease-marquee fade-edges">
+            <div class="ease-marquee ease-marquee-fade-edges">
                 <div class="ease-marquee-track">
                     <span class="brand-item">✨ EaseMotion</span>
                     <span class="brand-item">🎨 CSS Framework</span>
@@ -183,7 +183,7 @@
         <div class="demo-section">
             <div class="demo-title">🎯 5. Combined Variants</div>
             <div class="demo-description">Reverse + Slow + Fade Edges + Large Gap</div>
-            <div class="ease-marquee reverse slow fade-edges gap-xl">
+            <div class="ease-marquee ease-marquee-reverse ease-marquee-slow ease-marquee-fade-edges ease-marquee-gap-xl">
                 <div class="ease-marquee-track">
                     <span class="ticker-item">🎉 GSSOC 2026</span>
                     <span class="ticker-item">⭐ Open Source</span>
@@ -199,7 +199,7 @@
         <div class="demo-section">
             <div class="demo-title">📰 6. News Ticker</div>
             <div class="demo-description">Perfect for announcements and updates</div>
-            <div class="ease-marquee fast pause-on-hover">
+            <div class="ease-marquee ease-marquee-fast ease-marquee-pause-on-hover">
                 <div class="ease-marquee-track">
                     <span class="ticker-item">🔴 LIVE: GSSOC 2026 is now accepting contributions!</span>
                     <span class="ticker-item">✨ New: ease-marquee animation just added!</span>

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -135,3 +135,37 @@ const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
     expect(duplicates).toEqual([]);
   });
 });
+
+describe('Example HTML markup validation', () => {
+  it('marquee demo uses correct ease-marquee variant classes', () => {
+    const html = readFileSync(resolve(__dirname, '../examples/marquee-demo.html'), 'utf8');
+    
+    // Verify required variant classes are present
+    const requiredVariants = [
+      'ease-marquee-slow',
+      'ease-marquee-fast',
+      'ease-marquee-reverse',
+      'ease-marquee-fade-edges',
+      'ease-marquee-gap-xl',
+      'ease-marquee-pause-on-hover',
+    ];
+    
+    for (const variant of requiredVariants) {
+      expect(html).toContain(variant);
+    }
+    
+    // Verify old bare class names are not used
+    const invalidPatterns = [
+      'class="ease-marquee slow"',
+      'class="ease-marquee fast"',
+      'class="ease-marquee reverse"',
+      'class="ease-marquee fade-edges"',
+      'class="ease-marquee gap-xl"',
+      'class="ease-marquee pause-on-hover"',
+    ];
+    
+    for (const pattern of invalidPatterns) {
+      expect(html).not.toContain(pattern);
+    }
+  });
+});


### PR DESCRIPTION
## Pull Request Description

Fixes incorrect marquee variant class names used in the demo examples.

The demo previously used unprefixed classes such as `slow`, `fast`, `reverse`, `fade-edges`, `gap-xl`, and `pause-on-hover`, while the actual component API uses `ease-marquee-*` variant classes. Users copying the examples would not receive the expected marquee behavior.

Closes #2824.

---

## Type of Change

* [x] 🐛 Bug fix in an existing submission
* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] Other (describe below)

---

## Submission Checklist

* [ ] All changes are inside `submissions/examples/your-feature-name/`
* [ ] Includes `demo.html`
* [ ] Includes `style.css`
* [ ] Includes `README.md`

Not applicable — this PR fixes an existing repository example and adds regression tests.

* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Corrects marquee demo examples so they use the actual shipped variant class names.

**How does a developer use it?**

```html
<div class="ease-marquee ease-marquee-slow">
  ...
</div>
```

**Why does it fit EaseMotion CSS?**

The demo should accurately reflect the public API exposed by the framework so users can copy examples and obtain the documented behavior.

---

## Demo

* [x] Existing demo updated

---

## Browser Testing

* [x] Chrome

---

## Notes for Maintainer

Updated marquee-demo.html to use the correct variant classes:

* ease-marquee-slow
* ease-marquee-fast
* ease-marquee-reverse
* ease-marquee-fade-edges
* ease-marquee-gap-xl
* ease-marquee-pause-on-hover

Also added regression coverage in smoke.test.js to ensure valid marquee variant classes remain present and legacy invalid class names are not reintroduced.
