### PR TITLE
feat: add ease-offcanvas-az  CSS-only Slide-in Panel (Offcanvas) from Any Side

### DIFF
--- a/submissions/examples/ease-offcanvas-az/README.md
+++ b/submissions/examples/ease-offcanvas-az/README.md
@@ -1,0 +1,27 @@
+# Offcanvas Component
+
+### What does this do?
+Adds `ease-offcanvas-az` — a slide-in panel component that opens from any side (left, right, top, bottom) with a backdrop overlay. Uses CSS transforms and a cubic-bezier easing for smooth open/close animation.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/offcanvas.css` and import it.
+
+```html
+<div class="ease-offcanvas-az from-right open">
+  <div class="ease-offcanvas-header-az">
+    <div class="ease-offcanvas-title-az">Title</div>
+    <button class="ease-offcanvas-close-az">&times;</button>
+  </div>
+  <div class="ease-offcanvas-body-az">
+    Content here
+  </div>
+</div>
+<div class="ease-offcanvas-backdrop-az open"></div>
+```
+
+Directions: `.from-left`, `.from-right`, `.from-top`, `.from-bottom`. Sizes: `.sm`, `.lg`. Toggle visibility by adding/removing `.open`.
+
+### Why is it useful?
+1. **Four directions** — slide in from left, right, top, or bottom using a single class switch
+2. **Smooth easing** — uses `cubic-bezier(0.16, 1, 0.3, 1)` for a natural slide that decelerates gently
+3. **Backdrop** — semi-transparent overlay dismisses the panel on click; fades in/out alongside the slide

--- a/submissions/examples/ease-offcanvas-az/demo.html
+++ b/submissions/examples/ease-offcanvas-az/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offcanvas Component Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-section { margin-bottom: var(--ease-space-8); }
+    .demo-row { display: flex; gap: var(--ease-space-3); flex-wrap: wrap; }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-offcanvas-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A slide-in panel that opens from any side with a backdrop overlay. Toggle with <code>.open</code> class.</p>
+
+  <div class="demo-section">
+    <h2>Open From</h2>
+    <div class="demo-row">
+      <button class="ease-btn" onclick="openOffcanvas('left')">Left</button>
+      <button class="ease-btn" onclick="openOffcanvas('right')">Right</button>
+      <button class="ease-btn" onclick="openOffcanvas('top')">Top</button>
+      <button class="ease-btn" onclick="openOffcanvas('bottom')">Bottom</button>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Size Variants</h2>
+    <div class="demo-row">
+      <button class="ease-btn ease-btn-sm" onclick="openOffcanvas('right', 'sm')">Small</button>
+      <button class="ease-btn" onclick="openOffcanvas('right', '')">Default</button>
+      <button class="ease-btn ease-btn-lg" onclick="openOffcanvas('right', 'lg')">Large</button>
+    </div>
+  </div>
+
+  <div id="offcanvasContainer"></div>
+  <div id="backdropContainer"></div>
+
+  <script>
+    let uid = 0;
+
+    function openOffcanvas(side, size) {
+      uid++;
+      const id = 'offcanvas-' + uid;
+      const sideClass = 'from-' + side;
+
+      const backdrop = document.createElement('div');
+      backdrop.className = 'ease-offcanvas-backdrop-az';
+      backdrop.id = 'backdrop-' + id;
+      backdrop.addEventListener('click', () => closeOffcanvas(id));
+      document.getElementById('backdropContainer').appendChild(backdrop);
+
+      const el = document.createElement('div');
+      el.className = 'ease-offcanvas-az ' + sideClass + (size ? ' ' + size : '');
+      el.id = id;
+      el.innerHTML = [
+        '<div class="ease-offcanvas-header-az">',
+        '  <div class="ease-offcanvas-title-az">Offcanvas Panel</div>',
+        '  <button class="ease-offcanvas-close-az" onclick="closeOffcanvas(\'' + id + '\')">&times;</button>',
+        '</div>',
+        '<div class="ease-offcanvas-body-az">',
+        '  <p style="margin-top:0">This panel slides in from the <strong>' + side + '</strong> side.</p>',
+        '  <p>EaseMotion makes it easy to create slide-in panels with smooth cubic-bezier transitions and a backdrop overlay.</p>',
+        '  <p>Content inside the body scrolls independently when it overflows.</p>',
+        '</div>'
+      ].join('');
+      document.getElementById('offcanvasContainer').appendChild(el);
+
+      requestAnimationFrame(() => {
+        el.classList.add('open');
+        backdrop.classList.add('open');
+      });
+    }
+
+    function closeOffcanvas(id) {
+      const el = document.getElementById(id);
+      const backdrop = document.getElementById('backdrop-' + id);
+      if (el) {
+        el.classList.remove('open');
+        setTimeout(() => el.remove(), 350);
+      }
+      if (backdrop) {
+        backdrop.classList.remove('open');
+        setTimeout(() => backdrop.remove(), 350);
+      }
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-offcanvas-az/style.css
+++ b/submissions/examples/ease-offcanvas-az/style.css
@@ -1,0 +1,164 @@
+/* ============================================================
+   EaseMotion CSS — ease-offcanvas-az component (Proposal)
+   Slide-in panel from any side with backdrop overlay.
+   ============================================================ */
+
+.ease-offcanvas-az {
+  position: fixed;
+  z-index: 1000;
+  background: var(--ease-color-surface, #fff);
+  box-shadow: 0 0 40px rgba(0, 0, 0, 0.15);
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-offcanvas-backdrop-az {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  background: rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.ease-offcanvas-az.open ~ .ease-offcanvas-backdrop-az,
+.ease-offcanvas-backdrop-az.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.ease-offcanvas-az.from-left {
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 320px;
+  max-width: 90vw;
+  transform: translateX(-100%);
+}
+
+.ease-offcanvas-az.from-left.open {
+  transform: translateX(0);
+}
+
+.ease-offcanvas-az.from-right {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 320px;
+  max-width: 90vw;
+  transform: translateX(100%);
+}
+
+.ease-offcanvas-az.from-right.open {
+  transform: translateX(0);
+}
+
+.ease-offcanvas-az.from-top {
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 260px;
+  max-height: 40vh;
+  transform: translateY(-100%);
+}
+
+.ease-offcanvas-az.from-top.open {
+  transform: translateY(0);
+}
+
+.ease-offcanvas-az.from-bottom {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 260px;
+  max-height: 40vh;
+  transform: translateY(100%);
+}
+
+.ease-offcanvas-az.from-bottom.open {
+  transform: translateY(0);
+}
+
+.ease-offcanvas-header-az {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--ease-space-4, 16px) var(--ease-space-5, 20px);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f3f4f6);
+  flex-shrink: 0;
+}
+
+.ease-offcanvas-title-az {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--ease-color-neutral-900, #111827);
+}
+
+.ease-offcanvas-close-az {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: var(--ease-radius-md, 8px);
+  background: transparent;
+  color: var(--ease-color-neutral-500, #6b7280);
+  font-size: 20px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ease-offcanvas-close-az:hover {
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-900, #111827);
+}
+
+.ease-offcanvas-close-az:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+.ease-offcanvas-body-az {
+  padding: var(--ease-space-5, 20px);
+  overflow-y: auto;
+  flex: 1;
+  color: var(--ease-color-neutral-700, #374151);
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+.ease-offcanvas-az.sm.from-left,
+.ease-offcanvas-az.sm.from-right {
+  width: 240px;
+}
+
+.ease-offcanvas-az.sm.from-top,
+.ease-offcanvas-az.sm.from-bottom {
+  height: 180px;
+}
+
+.ease-offcanvas-az.lg.from-left,
+.ease-offcanvas-az.lg.from-right {
+  width: 480px;
+}
+
+.ease-offcanvas-az.lg.from-top,
+.ease-offcanvas-az.lg.from-bottom {
+  height: 400px;
+}
+
+@media (max-width: 640px) {
+  .ease-offcanvas-az.from-left,
+  .ease-offcanvas-az.from-right {
+    width: 85vw;
+  }
+
+  .ease-offcanvas-az.lg.from-left,
+  .ease-offcanvas-az.lg.from-right {
+    width: 85vw;
+  }
+}


### PR DESCRIPTION
```markdown
## Description
Adds `ease-offcanvas-az` — a CSS-only offcanvas panel that slides in from left, right, top, or bottom with a backdrop overlay and smooth decelerating easing.
## Changes
- `submissions/examples/ease-offcanvas-az/style.css` — Offcanvas styles with 4 direction classes, backdrop, header/body layout, 3 sizes, mobile responsive
- `submissions/examples/ease-offcanvas-az/demo.html` — Interactive demo with direction and size selectors
- `submissions/examples/ease-offcanvas-az/README.md` — Usage docs
## Variants
| Direction | Class |
|-----------|-------|
| Left | `.from-left` |
| Right | `.from-right` |
| Top | `.from-top` |
| Bottom | `.from-bottom` |
Sizes: `.sm`, default, `.lg`. Toggle with `.open` class.
## Related Issue
Closes #2832 