### PR TITLE
feat: add ease-list-group-az  Versatile CSS-only List Group with Badges, Icons, and Dark Mode

### DIFF
--- a/submissions/examples/ease-list-group-az/README.md
+++ b/submissions/examples/ease-list-group-az/README.md
@@ -1,0 +1,23 @@
+# List Group Component
+
+### What does this do?
+Adds `ease-list-group-az` — a versatile list group component for rendering navigation menus, settings panels, contact lists, and more. Supports badges, icons, linked items, title/subtitle pairs, flush borderless mode, and a dark mode variant.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/list-group.css` and import it.
+
+```html
+<ul class="ease-list-group-az">
+  <li class="ease-list-group-item-az active">Inbox</li>
+  <li class="ease-list-group-item-az">Sent</li>
+  <li class="ease-list-group-item-az disabled">Archived</li>
+</ul>
+```
+
+Variants: `.flush` (no outer border), `.dark` (dark background). Item states: `.active` (highlighted with left bar), `.disabled`.
+
+### Why is it useful?
+1. **Active state** — highlighted item with a 3px left accent bar and primary color tint
+2. **Rich content** — badges (with color variants), icons, title/subtitle pairs all slot in naturally
+3. **Linked items** — use `<a>` tags instead of `<li>` for clickable navigation, with `:focus-visible` outline
+4. **Dark mode** — the `.dark` variant works on dark backgrounds with adjusted hover and active states

--- a/submissions/examples/ease-list-group-az/demo.html
+++ b/submissions/examples/ease-list-group-az/demo.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>List Group Component Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-section { margin-bottom: var(--ease-space-8); }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: var(--ease-space-6); }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-list-group-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A versatile list group with badges, icons, active state with left bar, links, flush, and dark mode.</p>
+
+  <div class="demo-grid">
+    <div class="demo-section">
+      <h2>Basic</h2>
+      <ul class="ease-list-group-az">
+        <li class="ease-list-group-item-az">Inbox</li>
+        <li class="ease-list-group-item-az active">Sent</li>
+        <li class="ease-list-group-item-az">Drafts</li>
+        <li class="ease-list-group-item-az disabled">Archived</li>
+      </ul>
+    </div>
+
+    <div class="demo-section">
+      <h2>With Badges</h2>
+      <ul class="ease-list-group-az">
+        <li class="ease-list-group-item-az">
+          <span class="ease-list-group-item-text-az">Inbox</span>
+          <span class="ease-list-group-item-badge-az primary">12</span>
+        </li>
+        <li class="ease-list-group-item-az">
+          <span class="ease-list-group-item-text-az">Sent</span>
+          <span class="ease-list-group-item-badge-az">4</span>
+        </li>
+        <li class="ease-list-group-item-az">
+          <span class="ease-list-group-item-text-az">Spam</span>
+          <span class="ease-list-group-item-badge-az danger">3</span>
+        </li>
+        <li class="ease-list-group-item-az">
+          <span class="ease-list-group-item-text-az">Updates</span>
+          <span class="ease-list-group-item-badge-az success">2</span>
+        </li>
+      </ul>
+    </div>
+
+    <div class="demo-section">
+      <h2>With Icons</h2>
+      <ul class="ease-list-group-az">
+        <li class="ease-list-group-item-az">
+          <svg class="ease-list-group-item-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+          Dashboard
+        </li>
+        <li class="ease-list-group-item-az active">
+          <svg class="ease-list-group-item-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+          Analytics
+        </li>
+        <li class="ease-list-group-item-az">
+          <svg class="ease-list-group-item-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+          Projects
+        </li>
+      </ul>
+    </div>
+
+    <div class="demo-section">
+      <h2>Linked Items</h2>
+      <div class="ease-list-group-az">
+        <a href="#" class="ease-list-group-item-az" onclick="event.preventDefault()">Getting Started</a>
+        <a href="#" class="ease-list-group-item-az active" onclick="event.preventDefault()">Components</a>
+        <a href="#" class="ease-list-group-item-az" onclick="event.preventDefault()">Utilities</a>
+        <a href="#" class="ease-list-group-item-az" onclick="event.preventDefault()">API Reference</a>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>With Title & Subtitle</h2>
+      <ul class="ease-list-group-az">
+        <li class="ease-list-group-item-az">
+          <div>
+            <div class="ease-list-group-item-title-az">Alice Chen</div>
+            <div class="ease-list-group-item-subtitle-az">Designer @ Acme Corp</div>
+          </div>
+          <span class="ease-list-group-item-badge-az success">Online</span>
+        </li>
+        <li class="ease-list-group-item-az">
+          <div>
+            <div class="ease-list-group-item-title-az">Bob Martinez</div>
+            <div class="ease-list-group-item-subtitle-az">Developer @ Tech Co</div>
+          </div>
+          <span class="ease-list-group-item-badge-az">Away</span>
+        </li>
+        <li class="ease-list-group-item-az">
+          <div>
+            <div class="ease-list-group-item-title-az">Carol Nguyen</div>
+            <div class="ease-list-group-item-subtitle-az">PM @ Startup Inc</div>
+          </div>
+          <span class="ease-list-group-item-badge-az">Offline</span>
+        </li>
+      </ul>
+    </div>
+
+    <div class="demo-section">
+      <h2>Flush</h2>
+      <ul class="ease-list-group-az flush">
+        <li class="ease-list-group-item-az">Notifications</li>
+        <li class="ease-list-group-item-az active">Security</li>
+        <li class="ease-list-group-item-az">Privacy</li>
+        <li class="ease-list-group-item-az">Billing</li>
+      </ul>
+    </div>
+
+    <div class="demo-section">
+      <h2>Dark Mode</h2>
+      <ul class="ease-list-group-az dark">
+        <li class="ease-list-group-item-az">
+          <svg class="ease-list-group-item-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+          Settings
+        </li>
+        <li class="ease-list-group-item-az active">
+          <svg class="ease-list-group-item-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+          Edit Profile
+        </li>
+        <li class="ease-list-group-item-az">
+          <svg class="ease-list-group-item-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+          Logout
+        </li>
+      </ul>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-list-group-az/style.css
+++ b/submissions/examples/ease-list-group-az/style.css
@@ -1,0 +1,181 @@
+/* ============================================================
+   EaseMotion CSS — ease-list-group-az component (Proposal)
+   Versatile list group with badges, icons, links, flush, and dark variants.
+   ============================================================ */
+
+.ease-list-group-az {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  border-radius: var(--ease-radius-lg, 12px);
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  overflow: hidden;
+  background: var(--ease-color-surface, #fff);
+}
+
+.ease-list-group-item-az {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 12px);
+  padding: var(--ease-space-3, 12px) var(--ease-space-4, 16px);
+  font-size: 0.875rem;
+  color: var(--ease-color-neutral-800, #1f2937);
+  background: var(--ease-color-surface, #fff);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f3f4f6);
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ease-list-group-item-az:last-child {
+  border-bottom: none;
+}
+
+.ease-list-group-item-az:hover {
+  background: var(--ease-color-neutral-50, #f9fafb);
+}
+
+.ease-list-group-item-az.active {
+  background: var(--ease-color-primary-dim, #eef2ff);
+  color: var(--ease-color-primary, #6366f1);
+  font-weight: 600;
+}
+
+.ease-list-group-item-az.active::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--ease-color-primary, #6366f1);
+  border-radius: 0 var(--ease-radius-sm, 4px) var(--ease-radius-sm, 4px) 0;
+}
+
+.ease-list-group-item-az.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+a.ease-list-group-item-az {
+  text-decoration: none;
+  color: var(--ease-color-neutral-800, #1f2937);
+}
+
+a.ease-list-group-item-az:hover {
+  background: var(--ease-color-primary-dim, #eef2ff);
+}
+
+a.ease-list-group-item-az:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: -2px;
+}
+
+.ease-list-group-item-icon-az {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--ease-color-neutral-400, #9ca3af);
+  transition: color 0.15s ease;
+}
+
+.ease-list-group-item-az.active .ease-list-group-item-icon-az {
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-list-group-item-text-az {
+  flex: 1;
+  min-width: 0;
+}
+
+.ease-list-group-item-title-az {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--ease-color-neutral-900, #111827);
+}
+
+.ease-list-group-item-subtitle-az {
+  font-size: 0.75rem;
+  color: var(--ease-color-neutral-500, #6b7280);
+  margin-top: 2px;
+}
+
+.ease-list-group-item-badge-az {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 7px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-600, #6b7280);
+  flex-shrink: 0;
+}
+
+.ease-list-group-item-badge-az.primary {
+  background: var(--ease-color-primary-dim, #eef2ff);
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-list-group-item-badge-az.danger {
+  background: var(--ease-color-danger-dim, #fee2e2);
+  color: var(--ease-color-danger, #ef4444);
+}
+
+.ease-list-group-item-badge-az.success {
+  background: var(--ease-color-success-dim, #d1fae5);
+  color: var(--ease-color-success, #10b981);
+}
+
+.ease-list-group-az.flush {
+  border: none;
+  border-radius: 0;
+}
+
+.ease-list-group-az.flush .ease-list-group-item-az {
+  border-radius: 0;
+  border-left: none;
+  border-right: none;
+}
+
+.ease-list-group-az.flush .ease-list-group-item-az:first-child {
+  border-top: none;
+}
+
+.ease-list-group-az.flush .ease-list-group-item-az:last-child {
+  border-bottom: none;
+}
+
+.ease-list-group-az.dark {
+  background: var(--ease-color-neutral-800, #1f2937);
+  border-color: var(--ease-color-neutral-700, #374151);
+}
+
+.ease-list-group-az.dark .ease-list-group-item-az {
+  color: var(--ease-color-neutral-200, #e5e7eb);
+  background: transparent;
+  border-bottom-color: var(--ease-color-neutral-700, #374151);
+}
+
+.ease-list-group-az.dark .ease-list-group-item-az:hover {
+  background: var(--ease-color-neutral-700, #374151);
+}
+
+.ease-list-group-az.dark .ease-list-group-item-az.active {
+  background: rgba(99, 102, 241, 0.15);
+  color: var(--ease-color-primary-light, #a5b4fc);
+}
+
+.ease-list-group-az.dark .ease-list-group-item-title-az {
+  color: var(--ease-color-neutral-100, #f3f4f6);
+}
+
+.ease-list-group-az.dark .ease-list-group-item-subtitle-az {
+  color: var(--ease-color-neutral-400, #9ca3af);
+}


### PR DESCRIPTION
```markdown
## Description
Adds `ease-list-group-az` — a versatile CSS-only list group with active state accent bar, badges, icons, linked items, title/subtitle, flush mode, and dark variant.
## Changes
- `submissions/examples/ease-list-group-az/style.css` — List group styles with 7 demo variants, badge colors, icon support, dark mode
- `submissions/examples/ease-list-group-az/demo.html` — Interactive demo with basic, badges, icons, linked, titles, flush, and dark examples
- `submissions/examples/ease-list-group-az/README.md` — Usage docs
## Related Issue
Closes  #2836 