### PR TITLE
feat: add ease-mega-menu-az — CSS-only Mega Menu with Multi-Column Dropdown

### DIFF
--- a/submissions/examples/ease-mega-menu-az/README.md
+++ b/submissions/examples/ease-mega-menu-az/README.md
@@ -1,0 +1,31 @@
+# Mega Menu Component
+
+### What does this do?
+Adds `ease-mega-menu-az` — a CSS-only mega menu with a multi-column dropdown grid, chevron rotation, hover and focus activation, icon support, link descriptions, and a footer section.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/mega-menu.css` and import it.
+
+```html
+<div class="ease-mega-menu-az">
+  <button class="ease-mega-menu-trigger-az">
+    Products
+    <svg class="ease-mega-menu-chevron-az"><!-- chevron icon --></svg>
+  </button>
+  <div class="ease-mega-menu-dropdown-az">
+    <div class="ease-mega-menu-col-az">
+      <div class="ease-mega-menu-col-title-az">Column Title</div>
+      <a class="ease-mega-menu-link-az" href="#">Link</a>
+    </div>
+    <div class="ease-mega-menu-footer-az">
+      <span>Footer text</span>
+      <a href="#">Action &rarr;</a>
+    </div>
+  </div>
+</div>
+```
+
+### Why is it useful?
+1. **CSS-only activation** — dropdown opens on hover or `:focus-within` (keyboard accessible), no JS required
+2. **Multi-column grid** — uses CSS Grid for flexible column layouts, collapses to single column on mobile
+3. **Rich content** — icons, descriptions, column titles, dividers, and a footer section all fit naturally

--- a/submissions/examples/ease-mega-menu-az/demo.html
+++ b/submissions/examples/ease-mega-menu-az/demo.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mega Menu Component Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-section { margin-bottom: var(--ease-space-8); }
+    .demo-navbar {
+      display: flex;
+      align-items: center;
+      gap: var(--ease-space-1);
+      padding: var(--ease-space-3) var(--ease-space-4);
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      min-height: 56px;
+    }
+    .demo-navbar .ease-mega-menu-trigger-az { border: none; }
+    .demo-logo { font-weight: 700; font-size: 1.125rem; margin-right: var(--ease-space-4); color: var(--ease-color-primary); }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-mega-menu-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A CSS-only mega menu with multi-column dropdown, hover/focus activation, chevron rotation, and responsive collapse.</p>
+
+  <div class="demo-section">
+    <h2>In a Navbar</h2>
+    <div class="demo-navbar">
+      <div class="demo-logo">EaseMotion</div>
+      <div class="ease-mega-menu-az">
+        <button class="ease-mega-menu-trigger-az">
+          Products
+          <svg class="ease-mega-menu-chevron-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+        <div class="ease-mega-menu-dropdown-az">
+          <div class="ease-mega-menu-col-az">
+            <div class="ease-mega-menu-col-title-az">Design</div>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+              <span class="ease-mega-menu-link-text-az">
+                <span>Dashboard</span>
+                <span class="ease-mega-menu-link-desc-az">Analytics overview</span>
+              </span>
+            </a>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+              <span class="ease-mega-menu-link-text-az">
+                <span>Page Builder</span>
+                <span class="ease-mega-menu-link-desc-az">Drag & drop editor</span>
+              </span>
+            </a>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+              <span class="ease-mega-menu-link-text-az">
+                <span>Templates</span>
+                <span class="ease-mega-menu-link-desc-az">Pre-built layouts</span>
+              </span>
+            </a>
+          </div>
+          <div class="ease-mega-menu-col-az">
+            <div class="ease-mega-menu-col-title-az">Develop</div>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+              <span class="ease-mega-menu-link-text-az">
+                <span>API Reference</span>
+                <span class="ease-mega-menu-link-desc-az">Full API docs</span>
+              </span>
+            </a>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><box x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg>
+              <span class="ease-mega-menu-link-text-az">
+                <span>Integrations</span>
+                <span class="ease-mega-menu-link-desc-az">Connect your tools</span>
+              </span>
+            </a>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+              <span class="ease-mega-menu-link-text-az">
+                <span>Documentation</span>
+                <span class="ease-mega-menu-link-desc-az">Guides & tutorials</span>
+              </span>
+            </a>
+          </div>
+          <div class="ease-mega-menu-col-az">
+            <div class="ease-mega-menu-col-title-az">Collaborate</div>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+              <span class="ease-mega-menu-link-text-az">
+                <span>Team</span>
+                <span class="ease-mega-menu-link-desc-az">Manage members</span>
+              </span>
+            </a>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+              <span class="ease-mega-menu-link-text-az">
+                <span>Comments</span>
+                <span class="ease-mega-menu-link-desc-az">Review & discuss</span>
+              </span>
+            </a>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+              <span class="ease-mega-menu-link-text-az">
+                <span>Activity</span>
+                <span class="ease-mega-menu-link-desc-az">Team activity log</span>
+              </span>
+            </a>
+          </div>
+          <div class="ease-mega-menu-footer-az">
+            <span class="ease-mega-menu-footer-text-az"> Need help choosing?</span>
+            <a href="#" class="ease-mega-menu-footer-link-az" onclick="event.preventDefault()">Compare plans &rarr;</a>
+          </div>
+        </div>
+      </div>
+
+      <div class="ease-mega-menu-az">
+        <button class="ease-mega-menu-trigger-az">
+          Resources
+          <svg class="ease-mega-menu-chevron-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+        <div class="ease-mega-menu-dropdown-az" style="grid-template-columns: repeat(2, 1fr); min-width: 420px;">
+          <div class="ease-mega-menu-col-az">
+            <div class="ease-mega-menu-col-title-az">Learn</div>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Docs
+            </a>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              Help Center
+            </a>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+              Blog
+            </a>
+          </div>
+          <div class="ease-mega-menu-col-az">
+            <div class="ease-mega-menu-col-title-az">Community</div>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+              Forum
+            </a>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+              Changelog
+            </a>
+            <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">
+              <svg class="ease-mega-menu-link-icon-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+              Roadmap
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Standalone</h2>
+    <p class="ease-text-muted ease-mb-4">Hover or focus the button below to see the mega menu.</p>
+    <div class="ease-mega-menu-az">
+      <button class="ease-mega-menu-trigger-az">
+        Browse Categories
+        <svg class="ease-mega-menu-chevron-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <div class="ease-mega-menu-dropdown-az" style="min-width: 520px;">
+        <div class="ease-mega-menu-col-az">
+          <div class="ease-mega-menu-col-title-az">Frontend</div>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">HTML/CSS</a>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">JavaScript</a>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">React</a>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">Vue</a>
+        </div>
+        <div class="ease-mega-menu-col-az">
+          <div class="ease-mega-menu-col-title-az">Backend</div>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">Node.js</a>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">Python</a>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">Go</a>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">Rust</a>
+        </div>
+        <div class="ease-mega-menu-col-az">
+          <div class="ease-mega-menu-col-title-az">DevOps</div>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">Docker</a>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">Kubernetes</a>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">CI/CD</a>
+          <a href="#" class="ease-mega-menu-link-az" onclick="event.preventDefault()">Cloud</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Accessibility Note</h2>
+    <p class="ease-text-muted">The mega menu also opens when any child element receives focus (<code>:focus-within</code>), making it keyboard-accessible. All links have <code>:focus-visible</code> outlines.</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-mega-menu-az/style.css
+++ b/submissions/examples/ease-mega-menu-az/style.css
@@ -1,0 +1,186 @@
+/* ============================================================
+   EaseMotion CSS — ease-mega-menu-az component (Proposal)
+   CSS-only mega menu with multi-column dropdown on hover/focus.
+   ============================================================ */
+
+.ease-mega-menu-az {
+  position: relative;
+  display: inline-flex;
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+}
+
+.ease-mega-menu-trigger-az {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 8px);
+  padding: var(--ease-space-3, 12px) var(--ease-space-4, 16px);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ease-color-neutral-700, #374151);
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  border-radius: var(--ease-radius-lg, 12px);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  user-select: none;
+}
+
+.ease-mega-menu-trigger-az:hover,
+.ease-mega-menu-az:focus-within .ease-mega-menu-trigger-az {
+  color: var(--ease-color-primary, #6366f1);
+  border-color: var(--ease-color-primary, #6366f1);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.ease-mega-menu-chevron-az {
+  width: 16px;
+  height: 16px;
+  transition: transform 0.2s ease;
+  color: var(--ease-color-neutral-400, #9ca3af);
+}
+
+.ease-mega-menu-az:hover .ease-mega-menu-chevron-az,
+.ease-mega-menu-az:focus-within .ease-mega-menu-chevron-az {
+  transform: rotate(180deg);
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-mega-menu-dropdown-az {
+  position: absolute;
+  top: calc(100% + var(--ease-space-2, 8px));
+  left: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--ease-space-1, 4px);
+  min-width: 600px;
+  padding: var(--ease-space-5, 20px);
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  border-radius: var(--ease-radius-lg, 12px);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+  z-index: 100;
+  pointer-events: none;
+}
+
+.ease-mega-menu-az:hover .ease-mega-menu-dropdown-az,
+.ease-mega-menu-az:focus-within .ease-mega-menu-dropdown-az {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.ease-mega-menu-col-az {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-1, 4px);
+}
+
+.ease-mega-menu-col-title-az {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ease-color-neutral-400, #9ca3af);
+  padding: var(--ease-space-1, 4px) var(--ease-space-2, 8px);
+  margin-bottom: var(--ease-space-1, 4px);
+}
+
+.ease-mega-menu-link-az {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 12px);
+  padding: var(--ease-space-2, 8px) var(--ease-space-3, 12px);
+  font-size: 0.875rem;
+  color: var(--ease-color-neutral-700, #374151);
+  text-decoration: none;
+  border-radius: var(--ease-radius-md, 8px);
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ease-mega-menu-link-az:hover {
+  background: var(--ease-color-primary-dim, #eef2ff);
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-mega-menu-link-az:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+.ease-mega-menu-link-icon-az {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  color: var(--ease-color-neutral-400, #9ca3af);
+  transition: color 0.15s ease;
+}
+
+.ease-mega-menu-link-az:hover .ease-mega-menu-link-icon-az {
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-mega-menu-link-desc-az {
+  font-size: 0.75rem;
+  color: var(--ease-color-neutral-400, #9ca3af);
+  margin: 0;
+  line-height: 1.3;
+}
+
+.ease-mega-menu-link-text-az {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.ease-mega-menu-divider-az {
+  grid-column: 1 / -1;
+  height: 1px;
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  margin: var(--ease-space-1, 4px) 0;
+}
+
+.ease-mega-menu-footer-az {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--ease-space-3, 12px) var(--ease-space-2, 8px) 0;
+  margin-top: var(--ease-space-1, 4px);
+  border-top: 1px solid var(--ease-color-neutral-100, #f3f4f6);
+}
+
+.ease-mega-menu-footer-text-az {
+  font-size: 0.8125rem;
+  color: var(--ease-color-neutral-500, #6b7280);
+}
+
+.ease-mega-menu-footer-link-az {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--ease-color-primary, #6366f1);
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+}
+
+.ease-mega-menu-footer-link-az:hover {
+  opacity: 0.8;
+}
+
+@media (max-width: 768px) {
+  .ease-mega-menu-dropdown-az {
+    grid-template-columns: 1fr;
+    min-width: 280px;
+  }
+
+  .ease-mega-menu-az.full-width-mobile .ease-mega-menu-dropdown-az {
+    left: 0;
+    right: 0;
+    min-width: unset;
+  }
+}


### PR DESCRIPTION
## Description
Adds `ease-mega-menu-az` — a CSS-only mega menu with multi-column grid layout, hover/focus activation, chevron rotation, icon links with descriptions, footer section, and responsive collapse.
## Changes
- `submissions/examples/ease-mega-menu-az/style.css` — Mega menu styles with grid columns, hover/focus dropdown, chevron animation, link descriptions, footer, mobile breakpoint
- `submissions/examples/ease-mega-menu-az/demo.html` — Interactive demo with a full navbar example (2 menus) and standalone category browser
- `submissions/examples/ease-mega-menu-az/README.md` — Usage docs
## Related Issue
Closes #2841 