### PR TITLE
feat: add ease-glossary-az — CSS-only Definition List (Glossary) for Specs & Metadata

### DIFF
--- a/submissions/examples/ease-glossary-az/README.md
+++ b/submissions/examples/ease-glossary-az/README.md
@@ -1,0 +1,27 @@
+# Glossary Component
+
+### What does this do?
+Adds `ease-glossary-az` — a styled definition list component using semantic `<dl>` markup. Ideal for product specs, API documentation, metadata displays, and key-value pair listings.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/glossary.css` and import it.
+
+```html
+<dl class="ease-glossary-az inline striped">
+  <div class="ease-glossary-row-az">
+    <dt class="ease-glossary-term-az">Display</dt>
+    <dd class="ease-glossary-desc-az">15.6" Retina</dd>
+  </div>
+  <div class="ease-glossary-row-az">
+    <dt class="ease-glossary-term-az">Processor</dt>
+    <dd class="ease-glossary-desc-az">M3 Pro</dd>
+  </div>
+</dl>
+```
+
+Variants: `.inline` (horizontal term/desc), `.striped` (alternating rows), `.card` (bordered items), `.sm`.
+
+### Why is it useful?
+1. **Semantic HTML** — uses `<dl>`, `<dt>`, `<dd>` for accessibility and SEO
+2. **Four variants** — default vertical, `.inline` horizontal, `.striped` alternating, `.card` bordered items
+3. **Responsive** — inline mode collapses to vertical on mobile

--- a/submissions/examples/ease-glossary-az/demo.html
+++ b/submissions/examples/ease-glossary-az/demo.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Glossary Component Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-section { margin-bottom: var(--ease-space-8); }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: var(--ease-space-6); }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-glossary-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A styled definition list component for specs, metadata, key-value pairs, and API descriptions. Uses semantic <code>&lt;dl&gt;</code> markup.</p>
+
+  <div class="demo-grid">
+    <div class="demo-section">
+      <h2>Default (Vertical)</h2>
+      <dl class="ease-glossary-az">
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Display</dt>
+          <dd class="ease-glossary-desc-az">15.6" Retina, 2880 x 1800</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Processor</dt>
+          <dd class="ease-glossary-desc-az">M3 Pro, 12-core CPU, 18-core GPU</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Memory</dt>
+          <dd class="ease-glossary-desc-az">36GB Unified Memory</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Storage</dt>
+          <dd class="ease-glossary-desc-az">1TB SSD</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="demo-section">
+      <h2>Inline (Horizontal)</h2>
+      <dl class="ease-glossary-az inline">
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Framework</dt>
+          <dd class="ease-glossary-desc-az">EaseMotion CSS v2.4</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">License</dt>
+          <dd class="ease-glossary-desc-az">MIT</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Package</dt>
+          <dd class="ease-glossary-desc-az"><code>npm install ease-motion</code></dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Version</dt>
+          <dd class="ease-glossary-desc-az">2.4.1</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="demo-section">
+      <h2>Striped</h2>
+      <dl class="ease-glossary-az striped">
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Endpoint</dt>
+          <dd class="ease-glossary-desc-az"><code>/api/v2/users</code></dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Method</dt>
+          <dd class="ease-glossary-desc-az">GET</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Auth</dt>
+          <dd class="ease-glossary-desc-az">Bearer Token</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Rate Limit</dt>
+          <dd class="ease-glossary-desc-az">1000 req/hr</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="demo-section">
+      <h2>Card Variant</h2>
+      <dl class="ease-glossary-az card">
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Status</dt>
+          <dd class="ease-glossary-desc-az">Operational</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Uptime</dt>
+          <dd class="ease-glossary-desc-az">99.97%</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Region</dt>
+          <dd class="ease-glossary-desc-az">us-east-1, eu-west-2, ap-southeast-1</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="demo-section">
+      <h2>Small Size</h2>
+      <dl class="ease-glossary-az sm">
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Author</dt>
+          <dd class="ease-glossary-desc-az">Saptarshi</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Stars</dt>
+          <dd class="ease-glossary-desc-az">93</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Contributors</dt>
+          <dd class="ease-glossary-desc-az">42</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="demo-section">
+      <h2>Mixed Content</h2>
+      <dl class="ease-glossary-az">
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Color</dt>
+          <dd class="ease-glossary-desc-az" style="display:flex;align-items:center;gap:8px;">
+            <span style="display:inline-block;width:14px;height:14px;border-radius:4px;background:#6366f1;"></span>
+            Indigo (#6366f1)
+          </dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Spacing</dt>
+          <dd class="ease-glossary-desc-az"><code>--ease-space-4</code> = 16px</dd>
+        </div>
+        <div class="ease-glossary-row-az">
+          <dt class="ease-glossary-term-az">Border Radius</dt>
+          <dd class="ease-glossary-desc-az"><code>--ease-radius-lg</code> = 12px</dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-glossary-az/style.css
+++ b/submissions/examples/ease-glossary-az/style.css
@@ -1,0 +1,112 @@
+/* ============================================================
+   EaseMotion CSS — ease-glossary-az component (Proposal)
+   Styled definition list for key-value pairs, metadata, specs.
+   ============================================================ */
+
+.ease-glossary-az {
+  display: flex;
+  flex-direction: column;
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  border-radius: var(--ease-radius-lg, 12px);
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  overflow: hidden;
+}
+
+.ease-glossary-az .ease-glossary-row-az {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-1, 4px);
+  padding: var(--ease-space-3, 12px) var(--ease-space-4, 16px);
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f3f4f6);
+  transition: background 0.15s ease;
+}
+
+.ease-glossary-az .ease-glossary-row-az:hover {
+  background: var(--ease-color-neutral-50, #f9fafb);
+}
+
+.ease-glossary-az .ease-glossary-row-az:last-child {
+  border-bottom: none;
+}
+
+.ease-glossary-az .ease-glossary-term-az {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ease-color-neutral-500, #6b7280);
+}
+
+.ease-glossary-az .ease-glossary-desc-az {
+  font-size: 0.875rem;
+  color: var(--ease-color-neutral-800, #1f2937);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.ease-glossary-az.inline .ease-glossary-row-az {
+  flex-direction: row;
+  align-items: baseline;
+  gap: var(--ease-space-3, 12px);
+}
+
+.ease-glossary-az.inline .ease-glossary-term-az {
+  flex: 0 0 140px;
+  text-align: right;
+}
+
+.ease-glossary-az.inline .ease-glossary-desc-az {
+  flex: 1;
+}
+
+.ease-glossary-az.striped .ease-glossary-row-az:nth-child(even) {
+  background: var(--ease-color-neutral-50, #f9fafb);
+}
+
+.ease-glossary-az.card .ease-glossary-row-az {
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  border-radius: var(--ease-radius-md, 8px);
+  margin: var(--ease-space-1, 4px) var(--ease-space-2, 8px);
+  padding: var(--ease-space-3, 12px);
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+}
+
+.ease-glossary-az.card .ease-glossary-row-az:last-child {
+  margin-bottom: var(--ease-space-2, 8px);
+}
+
+.ease-glossary-az.card {
+  border: none;
+  gap: var(--ease-space-1, 4px);
+}
+
+.ease-glossary-az.sm .ease-glossary-row-az {
+  padding: var(--ease-space-2, 8px) var(--ease-space-3, 12px);
+}
+
+.ease-glossary-az.sm .ease-glossary-term-az {
+  font-size: 0.6875rem;
+}
+
+.ease-glossary-az.sm .ease-glossary-desc-az {
+  font-size: 0.8125rem;
+}
+
+.ease-glossary-az .ease-glossary-desc-az code {
+  font-size: 0.8125rem;
+  padding: 2px 6px;
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  border-radius: var(--ease-radius-sm, 4px);
+  color: var(--ease-color-primary, #6366f1);
+}
+
+@media (max-width: 640px) {
+  .ease-glossary-az.inline .ease-glossary-row-az {
+    flex-direction: column;
+  }
+
+  .ease-glossary-az.inline .ease-glossary-term-az {
+    flex: none;
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Description
Adds `ease-glossary-az` — a CSS-only definition list component using semantic `<dl>` markup with vertical, inline, striped, card, and compact variants.
## Changes
- `submissions/examples/ease-glossary-az/style.css` — Glossary styles with 4 variants, responsive inline collapse, code styling, small size
- `submissions/examples/ease-glossary-az/demo.html` — Interactive demo with 6 use cases (specs, API, config, status, about, design tokens)
- `submissions/examples/ease-glossary-az/README.md` — Usage docs
## Related Issue
Closes #2843 