### PR TITLE
feat: add ease-cookie-consent-az — CSS-only Cookie Consent Banner with Slide Animation

### DIFF
--- a/submissions/examples/ease-cookie-consent-az/README.md
+++ b/submissions/examples/ease-cookie-consent-az/README.md
@@ -1,0 +1,28 @@
+# Cookie Consent Banner Component
+
+### What does this do?
+Adds `ease-cookie-consent-az` — a slide-in cookie consent banner with a cookie icon, title/description, and Accept/Decline buttons. Slides up with a smooth cubic-bezier transition, and comes in bottom-bar and center-modal variants.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/cookie-consent.css` and import it.
+
+```html
+<div class="ease-cookie-consent-az show">
+  <div class="ease-cookie-consent-icon-az"><!-- cookie icon --></div>
+  <div class="ease-cookie-consent-text-az">
+    <div class="ease-cookie-consent-title-az">This site uses cookies</div>
+    <p class="ease-cookie-consent-desc-az">Description here</p>
+  </div>
+  <div class="ease-cookie-consent-actions-az">
+    <button class="ease-cookie-consent-btn-az secondary">Decline</button>
+    <button class="ease-cookie-consent-btn-az primary">Accept All</button>
+  </div>
+</div>
+```
+
+Variants: `.center` for modal style, `.sm` for compact. Toggle visibility with `.show`.
+
+### Why is it useful?
+1. **Smooth entrance** — slides up with `cubic-bezier(0.16, 1, 0.3, 1)` and fades in concurrently
+2. **Two layouts** — bottom bar (default) and `.center` modal, both mobile-responsive
+3. **Accessible buttons** — Accept (`.primary`) and Decline (`.secondary`) with `:focus-visible` rings

--- a/submissions/examples/ease-cookie-consent-az/demo.html
+++ b/submissions/examples/ease-cookie-consent-az/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cookie Consent Banner Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-section { margin-bottom: var(--ease-space-8); }
+    .demo-row { display: flex; gap: var(--ease-space-3); flex-wrap: wrap; }
+    .demo-content {
+      max-width: 600px;
+      line-height: 1.7;
+      color: var(--ease-color-neutral-600);
+    }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-cookie-consent-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A slide-in cookie consent banner with icon, description, accept/decline buttons, center modal variant, and mobile responsive.</p>
+
+  <div class="demo-section">
+    <h2>Variants</h2>
+    <div class="demo-row">
+      <button class="ease-btn" onclick="showBanner('bottom')">Bottom Bar</button>
+      <button class="ease-btn" onclick="showBanner('center')">Center Modal</button>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Page Content</h2>
+    <div class="demo-content">
+      <p>This is a demo page. Click the buttons above to trigger different cookie consent banner variants. The banner slides up with a smooth cubic-bezier transition and can be dismissed via Accept or Decline.</p>
+      <p>On mobile, the banner snaps to the bottom edge with rounded top corners and full-width buttons.</p>
+    </div>
+  </div>
+
+  <div id="bannerContainer"></div>
+
+  <script>
+    function showBanner(variant) {
+      const existing = document.querySelector('.ease-cookie-consent-az');
+      if (existing) existing.remove();
+
+      const banner = document.createElement('div');
+      banner.className = 'ease-cookie-consent-az' + (variant === 'center' ? ' center' : '');
+      banner.innerHTML = [
+        '<div class="ease-cookie-consent-icon-az">',
+        '  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">',
+        '    <path d="M12 2a10 10 0 1 0 10 10 4 4 0 0 1-5-5 4 4 0 0 1-5-5"/>',
+        '    <path d="M8.5 8.5v.01"/><path d="M16 15.5v.01"/><path d="M12 12v.01"/>',
+        '  </svg>',
+        '</div>',
+        '<div class="ease-cookie-consent-text-az">',
+        '  <div class="ease-cookie-consent-title-az">This site uses cookies</div>',
+        '  <p class="ease-cookie-consent-desc-az">We use cookies to improve your experience and analyze site usage. By clicking "Accept", you consent to our use of cookies.</p>',
+        '</div>',
+        '<div class="ease-cookie-consent-actions-az">',
+        '  <button class="ease-cookie-consent-btn-az secondary" onclick="dismissBanner(this)">Decline</button>',
+        '  <button class="ease-cookie-consent-btn-az primary" onclick="dismissBanner(this)">Accept All</button>',
+        '</div>'
+      ].join('');
+
+      document.getElementById('bannerContainer').appendChild(banner);
+      requestAnimationFrame(() => banner.classList.add('show'));
+    }
+
+    function dismissBanner(btn) {
+      const banner = btn.closest('.ease-cookie-consent-az');
+      banner.classList.remove('show');
+      setTimeout(() => banner.remove(), 500);
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-cookie-consent-az/style.css
+++ b/submissions/examples/ease-cookie-consent-az/style.css
@@ -1,0 +1,159 @@
+/* ============================================================
+   EaseMotion CSS — ease-cookie-consent-az component (Proposal)
+   Slide-in cookie consent banner with accept/decline actions.
+   ============================================================ */
+
+.ease-cookie-consent-az {
+  position: fixed;
+  bottom: var(--ease-space-4, 16px);
+  left: var(--ease-space-4, 16px);
+  right: var(--ease-space-4, 16px);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-4, 16px);
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--ease-space-4, 16px) var(--ease-space-5, 20px);
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  border-radius: var(--ease-radius-lg, 12px);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  transform: translateY(120%);
+  opacity: 0;
+  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.4s ease;
+}
+
+.ease-cookie-consent-az.show {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.ease-cookie-consent-icon-az {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--ease-radius-md, 8px);
+  background: var(--ease-color-primary-dim, #eef2ff);
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-cookie-consent-text-az {
+  flex: 1;
+  min-width: 0;
+}
+
+.ease-cookie-consent-title-az {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ease-color-neutral-900, #111827);
+  margin-bottom: 2px;
+}
+
+.ease-cookie-consent-desc-az {
+  font-size: 0.8125rem;
+  color: var(--ease-color-neutral-500, #6b7280);
+  line-height: 1.4;
+  margin: 0;
+}
+
+.ease-cookie-consent-actions-az {
+  display: flex;
+  gap: var(--ease-space-2, 8px);
+  flex-shrink: 0;
+}
+
+.ease-cookie-consent-btn-az {
+  padding: 8px 18px;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  border: none;
+  border-radius: var(--ease-radius-md, 8px);
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.15s ease;
+  white-space: nowrap;
+}
+
+.ease-cookie-consent-btn-az.primary {
+  background: var(--ease-color-primary, #6366f1);
+  color: #fff;
+}
+
+.ease-cookie-consent-btn-az.primary:hover {
+  background: var(--ease-color-primary-dark, #4f46e5);
+}
+
+.ease-cookie-consent-btn-az.secondary {
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-700, #374151);
+}
+
+.ease-cookie-consent-btn-az.secondary:hover {
+  background: var(--ease-color-neutral-200, #e5e7eb);
+}
+
+.ease-cookie-consent-btn-az:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+.ease-cookie-consent-az.center {
+  flex-direction: column;
+  text-align: center;
+  max-width: 400px;
+}
+
+.ease-cookie-consent-az.center .ease-cookie-consent-actions-az {
+  width: 100%;
+}
+
+.ease-cookie-consent-az.center .ease-cookie-consent-btn-az {
+  flex: 1;
+}
+
+.ease-cookie-consent-az.sm {
+  padding: var(--ease-space-3, 12px) var(--ease-space-4, 16px);
+}
+
+.ease-cookie-consent-az.sm .ease-cookie-consent-icon-az {
+  width: 32px;
+  height: 32px;
+}
+
+.ease-cookie-consent-az.sm .ease-cookie-consent-title-az {
+  font-size: 0.8125rem;
+}
+
+.ease-cookie-consent-az.sm .ease-cookie-consent-desc-az {
+  font-size: 0.75rem;
+}
+
+.ease-cookie-consent-az.sm .ease-cookie-consent-btn-az {
+  padding: 6px 14px;
+  font-size: 0.75rem;
+}
+
+@media (max-width: 640px) {
+  .ease-cookie-consent-az {
+    flex-direction: column;
+    text-align: center;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border-radius: var(--ease-radius-lg, 12px) var(--ease-radius-lg, 12px) 0 0;
+    max-width: 100%;
+  }
+
+  .ease-cookie-consent-az .ease-cookie-consent-actions-az {
+    width: 100%;
+  }
+
+  .ease-cookie-consent-az .ease-cookie-consent-btn-az {
+    flex: 1;
+  }
+}


### PR DESCRIPTION
```markdown
## Description
Adds `ease-cookie-consent-az` — a CSS-only cookie consent banner with slide-up animation, cookie icon, accept/decline buttons, center modal variant, and mobile responsive layout.
## Changes
- `submissions/examples/ease-cookie-consent-az/style.css` — Cookie consent styles with slide animation, center modal, compact size, mobile breakpoint
- `submissions/examples/ease-cookie-consent-az/demo.html` — Interactive demo with bottom bar and center modal variants
- `submissions/examples/ease-cookie-consent-az/README.md` — Usage docs
## Related Issue
Closes #2848 