### PR TITLE
[BUG FIX] Add missing keyboard focus states for footer components

### DIFF
--- a/components/footer.css
+++ b/components/footer.css
@@ -48,8 +48,11 @@
   transition: color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
 }
 
-.ease-footer-links a:hover {
+/* FIXED: Added :focus-visible and outline:none */
+.ease-footer-links a:hover,
+.ease-footer-links a:focus-visible {
   color: var(--ease-color-primary, #6366f1);
+  outline: none;
 }
 
 /* ── Footer Social ──────────────────────────────────────────── */
@@ -75,10 +78,13 @@
               transform var(--ease-speed-fast, 150ms) var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1));
 }
 
-.ease-footer-social a:hover {
+/* FIXED: Added :focus-visible and outline:none */
+.ease-footer-social a:hover,
+.ease-footer-social a:focus-visible {
   background: var(--ease-color-primary, #6366f1);
   color: #fff;
   transform: translateY(-2px);
+  outline: none;
 }
 
 /* ── Social Icons (no external deps) ────────────────────────── */


### PR DESCRIPTION
## Pull Request Description

<!-- This PR fixes an accessibility bug where keyboard-only users navigating via the `Tab` key did not receive any visual focus indication on the footer links and social icons. I added the `:focus-visible` pseudo-class alongside the existing `:hover` states so keyboard users get the same visual feedback (color changes and hover animations) without leaving lingering focus rings for mouse users. -->

---

close #2851 

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- It adds keyboard accessibility (`:focus-visible`) to the existing footer links and social icons. -->

**How does a developer use it?**

```html
<!-- ```html
<div class="ease-footer-links">
  <a href="#">Focus Me with Tab</a>
</div>
<div class="ease-footer-social">
  <a href="#">Focus Me with Tab</a>
</div> -->
```

**Why does it fit EaseMotion CSS?**

<!-- EaseMotion CSS aims to provide beautiful, human-readable animations. This fix ensures those beautiful hover interactions are accessible to all users, regardless of how they navigate the web, without compromising the visual design for mouse users.-->

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!--I noticed the PR template strongly restricts changes to the components/ folder. Since this PR directly addresses an accessibility bug in the existing footer.css component, I had to modify that file. Please let me know if there's a different preferred workflow for submitting core bug fixes during GSSoC!-->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
