### PR TITLE
fix: replace literal fallback icon with unicode escape sequence

### DIFF
--- a/components/footer.css
+++ b/components/footer.css
@@ -126,7 +126,7 @@
 
 .ease-footer-social a:where(:not([href*="github.com"],[href*="twitter.com"],[href*="x.com"],[href*="youtube.com"],[href*="linkedin.com"],[href*="facebook.com"],[href*="instagram.com"],[href*="discord"]))::before {
   --icon: none;
-  content: "✦";
+  content: "\2726";
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Description

Replaced the literal fallback icon character:

```css
content: "✦";

content: "\2726";

Why?

Using a literal Unicode character in CSS can lead to encoding issues when files are:

Minified
Bundled
Processed by build tools
Served without a proper UTF-8 charset declaration

In such environments, the icon may render as corrupted text (e.g. âœ¦).

Using the Unicode escape sequence ensures consistent rendering across all environments and browsers.

Changes Made
Replaced content: "✦"; with content: "\2726";
No visual or behavioral changes intended
Improves cross-environment compatibility
Testing
Verified the fallback icon still renders correctly as ✦
No regressions observed

fixes #2860