### PR TITLE
feat: add ease-tree-view-az — CSS-only File Tree using <details>/<summary> Expand/Collapse

### DIFF
--- a/submissions/examples/ease-tree-view-az/README.md
+++ b/submissions/examples/ease-tree-view-az/README.md
@@ -1,0 +1,32 @@
+# Tree View Component
+
+### What does this do?
+Adds `ease-tree-view-az` — a CSS-only file tree / hierarchical navigation component using native `<details>` / `<summary>` elements for expand/collapse, with folder/file icons, chevron rotation, selection state, badges, and size variants.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/tree-view.css` and import it.
+
+```html
+<div class="ease-tree-view-az">
+  <details open>
+    <summary>
+      <svg class="ease-tree-chevron-az"><!-- chevron --></svg>
+      <svg class="ease-tree-icon-az folder"><!-- folder --></svg>
+      <span class="ease-tree-label-az">src</span>
+    </summary>
+    <div class="ease-tree-children-az">
+      <a href="#" class="ease-tree-leaf-az">
+        <svg class="ease-tree-icon-az file"><!-- file --></svg>
+        <span class="ease-tree-label-az">index.ts</span>
+      </a>
+    </div>
+  </details>
+</div>
+```
+
+Variants: `.flush` (no border), `.sm` / `.lg` sizes. Item states: `.selected`.
+
+### Why is it useful?
+1. **Zero JS** — expand/collapse uses native `<details>` / `<summary>`, fully keyboard accessible
+2. **Visual hierarchy** — chevron rotates 90deg on open, folder icon turns blue when expanded, children are indented
+3. **Rich leaves** — supports linked items (anchors), selected state, inline badges for counts

--- a/submissions/examples/ease-tree-view-az/demo.html
+++ b/submissions/examples/ease-tree-view-az/demo.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tree View Component Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-section { margin-bottom: var(--ease-space-8); }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: var(--ease-space-6); align-items: start; }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-tree-view-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A CSS-only file tree using <code>&lt;details&gt;</code> / <code>&lt;summary&gt;</code> for expand/collapse — no JS required.</p>
+
+  <div class="demo-grid">
+    <div class="demo-section">
+      <h2>Project Structure</h2>
+      <div class="ease-tree-view-az">
+        <details open>
+          <summary>
+            <svg class="ease-tree-chevron-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            <svg class="ease-tree-icon-az folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+            <span class="ease-tree-label-az">src</span>
+          </summary>
+          <div class="ease-tree-children-az">
+            <details open>
+              <summary>
+                <svg class="ease-tree-chevron-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+                <svg class="ease-tree-icon-az folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+                <span class="ease-tree-label-az">components</span>
+              </summary>
+              <div class="ease-tree-children-az">
+                <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+                  <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  <span class="ease-tree-label-az">Button<span class="ext">.tsx</span></span>
+                </a>
+                <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+                  <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  <span class="ease-tree-label-az">Card<span class="ext">.tsx</span></span>
+                </a>
+                <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+                  <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  <span class="ease-tree-label-az">Navbar<span class="ext">.tsx</span></span>
+                </a>
+              </div>
+            </details>
+            <details>
+              <summary>
+                <svg class="ease-tree-chevron-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+                <svg class="ease-tree-icon-az folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+                <span class="ease-tree-label-az">utils</span>
+              </summary>
+              <div class="ease-tree-children-az">
+                <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+                  <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  <span class="ease-tree-label-az">helpers<span class="ext">.ts</span></span>
+                </a>
+                <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+                  <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  <span class="ease-tree-label-az">constants<span class="ext">.ts</span></span>
+                </a>
+              </div>
+            </details>
+            <a href="#" class="ease-tree-leaf-az selected" onclick="event.preventDefault()">
+              <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+              <span class="ease-tree-label-az">App<span class="ext">.tsx</span></span>
+            </a>
+            <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+              <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+              <span class="ease-tree-label-az">main<span class="ext">.tsx</span></span>
+            </a>
+          </div>
+        </details>
+        <details>
+          <summary>
+            <svg class="ease-tree-chevron-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            <svg class="ease-tree-icon-az folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+            <span class="ease-tree-label-az">public</span>
+            <span class="ease-tree-badge-az">4</span>
+          </summary>
+          <div class="ease-tree-children-az">
+            <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+              <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+              <span class="ease-tree-label-az">index<span class="ext">.html</span></span>
+            </a>
+            <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+              <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+              <span class="ease-tree-label-az">favicon<span class="ext">.ico</span></span>
+            </a>
+          </div>
+        </details>
+        <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+          <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+          <span class="ease-tree-label-az">package<span class="ext">.json</span></span>
+        </a>
+        <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+          <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+          <span class="ease-tree-label-az">README<span class="ext">.md</span></span>
+        </a>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Settings Navigation</h2>
+      <div class="ease-tree-view-az flush">
+        <details open>
+          <summary>
+            <svg class="ease-tree-chevron-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            <svg class="ease-tree-icon-az folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+            <span class="ease-tree-label-az">Account</span>
+          </summary>
+          <div class="ease-tree-children-az">
+            <div class="ease-tree-leaf-az">
+              <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+              Profile
+            </div>
+            <div class="ease-tree-leaf-az selected">
+              <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+              Security
+            </div>
+          </div>
+        </details>
+        <details>
+          <summary>
+            <svg class="ease-tree-chevron-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            <svg class="ease-tree-icon-az folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+            <span class="ease-tree-label-az">Preferences</span>
+          </summary>
+          <div class="ease-tree-children-az">
+            <div class="ease-tree-leaf-az">
+              <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+              Appearance
+            </div>
+            <div class="ease-tree-leaf-az">
+              <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+              Notifications
+            </div>
+          </div>
+        </details>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Size: Small</h2>
+      <div class="ease-tree-view-az sm">
+        <details>
+          <summary>
+            <svg class="ease-tree-chevron-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            <svg class="ease-tree-icon-az folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+            <span class="ease-tree-label-az">node_modules</span>
+            <span class="ease-tree-badge-az">1204</span>
+          </summary>
+        </details>
+        <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+          <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+          <span class="ease-tree-label-az">.gitignore</span>
+        </a>
+        <a href="#" class="ease-tree-leaf-az" onclick="event.preventDefault()">
+          <svg class="ease-tree-icon-az file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+          <span class="ease-tree-label-az">tsconfig<span class="ext">.json</span></span>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Notes</h2>
+    <p class="ease-text-muted">The tree uses native <code>&lt;details&gt;</code> / <code>&lt;summary&gt;</code> for expand/collapse — fully keyboard accessible (Tab, Enter/Space to toggle). The chevron rotates 90deg when open. Folders turn blue when expanded.</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-tree-view-az/style.css
+++ b/submissions/examples/ease-tree-view-az/style.css
@@ -1,0 +1,183 @@
+/* ============================================================
+   EaseMotion CSS — ease-tree-view-az component (Proposal)
+   CSS-only file tree using <details>/<summary> for expand/collapse.
+   ============================================================ */
+
+.ease-tree-view-az {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  font-size: 0.875rem;
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  border-radius: var(--ease-radius-lg, 12px);
+  padding: var(--ease-space-2, 8px) 0;
+  background: var(--ease-color-surface, #fff);
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.ease-tree-view-az,
+.ease-tree-view-az details,
+.ease-tree-view-az .ease-tree-branch-az {
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-tree-view-az details {
+  width: 100%;
+}
+
+.ease-tree-view-az summary {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 8px);
+  padding: var(--ease-space-1, 4px) var(--ease-space-3, 12px);
+  cursor: pointer;
+  user-select: none;
+  color: var(--ease-color-neutral-800, #1f2937);
+  border-radius: var(--ease-radius-sm, 4px);
+  transition: background 0.12s ease;
+  list-style: none;
+}
+
+.ease-tree-view-az summary::-webkit-details-marker {
+  display: none;
+}
+
+.ease-tree-view-az summary:hover {
+  background: var(--ease-color-neutral-50, #f9fafb);
+}
+
+.ease-tree-view-az summary:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: -2px;
+  border-radius: var(--ease-radius-sm, 4px);
+}
+
+.ease-tree-view-az .ease-tree-chevron-az {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--ease-color-neutral-400, #9ca3af);
+  transition: transform 0.2s ease;
+}
+
+.ease-tree-view-az details[open] > summary .ease-tree-chevron-az {
+  transform: rotate(90deg);
+}
+
+.ease-tree-view-az .ease-tree-icon-az {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--ease-color-neutral-400, #9ca3af);
+}
+
+.ease-tree-view-az .ease-tree-icon-az.folder {
+  color: var(--ease-color-warning, #f59e0b);
+}
+
+.ease-tree-view-az details[open] > summary .ease-tree-icon-az.folder {
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-tree-view-az .ease-tree-icon-az.file {
+  color: var(--ease-color-neutral-400, #9ca3af);
+}
+
+.ease-tree-view-az .ease-tree-label-az {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ease-tree-view-az .ease-tree-label-az .ext {
+  color: var(--ease-color-neutral-400, #9ca3af);
+}
+
+.ease-tree-view-az .ease-tree-badge-az {
+  font-size: 0.6875rem;
+  padding: 1px 7px;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-500, #6b7280);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.ease-tree-view-az .ease-tree-children-az {
+  display: flex;
+  flex-direction: column;
+  padding-left: var(--ease-space-5, 20px);
+}
+
+.ease-tree-view-az .ease-tree-leaf-az {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 8px);
+  padding: var(--ease-space-1, 4px) var(--ease-space-3, 12px);
+  color: var(--ease-color-neutral-700, #374151);
+  border-radius: var(--ease-radius-sm, 4px);
+  transition: background 0.12s ease;
+  text-decoration: none;
+  cursor: default;
+}
+
+.ease-tree-view-az a.ease-tree-leaf-az {
+  cursor: pointer;
+  text-decoration: none;
+  color: var(--ease-color-neutral-700, #374151);
+}
+
+.ease-tree-view-az a.ease-tree-leaf-az:hover {
+  background: var(--ease-color-primary-dim, #eef2ff);
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-tree-view-az a.ease-tree-leaf-az:hover .ease-tree-icon-az.file {
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-tree-view-az.selected > summary,
+.ease-tree-view-az .ease-tree-leaf-az.selected {
+  background: var(--ease-color-primary-dim, #eef2ff);
+  color: var(--ease-color-primary, #6366f1);
+  font-weight: 600;
+}
+
+.ease-tree-view-az.selected > summary .ease-tree-icon-az,
+.ease-tree-view-az .ease-tree-leaf-az.selected .ease-tree-icon-az {
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-tree-view-az.sm {
+  font-size: 0.8125rem;
+}
+
+.ease-tree-view-az.sm summary,
+.ease-tree-view-az.sm .ease-tree-leaf-az {
+  padding: 2px var(--ease-space-2, 8px);
+}
+
+.ease-tree-view-az.sm .ease-tree-children-az {
+  padding-left: var(--ease-space-4, 16px);
+}
+
+.ease-tree-view-az.lg {
+  font-size: 1rem;
+}
+
+.ease-tree-view-az.lg summary,
+.ease-tree-view-az.lg .ease-tree-leaf-az {
+  padding: var(--ease-space-2, 8px) var(--ease-space-4, 16px);
+}
+
+.ease-tree-view-az.lg .ease-tree-children-az {
+  padding-left: var(--ease-space-6, 24px);
+}
+
+.ease-tree-view-az.flush {
+  border: none;
+  border-radius: 0;
+  padding: 0;
+}


### PR DESCRIPTION
```markdown
## Description
Adds `ease-tree-view-az` — a CSS-only file tree using native `<details>`/`<summary>` for expand/collapse, with folder/file icons, chevron rotation, selected state, badges, and size variants.
## Changes
- `submissions/examples/ease-tree-view-az/style.css` — Tree styles with details/summary expand, chevron rotation, folder/file icons, selected state, badges, flush mode, 3 sizes
- `submissions/examples/ease-tree-view-az/demo.html` — Interactive demo with project structure tree, settings navigation, and small size variant
- `submissions/examples/ease-tree-view-az/README.md` — Usage docs
## Related Issue
Closes #2862 