### PR TITLE
feat: add ease-chat-bubble-az — CSS-only Chat Message Bubbles with Grouping & Read Status

### DIFF
--- a/submissions/examples/ease-chat-bubble-az/README.md
+++ b/submissions/examples/ease-chat-bubble-az/README.md
@@ -1,0 +1,41 @@
+# Chat Bubble Component
+
+### What does this do?
+Adds `ease-chat-bubble-az` — a chat message component with sent/received alignment, avatars, sender names, timestamps, read status indicators, intelligent grouping, and date dividers.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/chat-bubble.css` and import it.
+
+```html
+<div class="ease-chat-feed-az">
+  <div class="ease-chat-divider-az">Today</div>
+
+  <div class="ease-chat-row-az">
+    <div class="ease-chat-avatar-az">A</div>
+    <div class="ease-chat-bubble-az">
+      <div class="ease-chat-bubble-meta-az">
+        <span class="ease-chat-bubble-sender-az">Alice</span>
+        <span class="ease-chat-bubble-time-az">2:14 PM</span>
+      </div>
+      <div class="ease-chat-bubble-text-az">Message here</div>
+    </div>
+  </div>
+
+  <div class="ease-chat-row-az sent">
+    <div class="ease-chat-avatar-az">Y</div>
+    <div class="ease-chat-bubble-az">
+      <div class="ease-chat-bubble-text-az">Reply message</div>
+      <div class="ease-chat-bubble-meta-az">
+        <span class="ease-chat-bubble-time-az">2:16 PM</span>
+        <svg class="ease-chat-bubble-status-az read"><polyline points="20 6 9 17 4 12"/></svg>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Why is it useful?
+1. **Sent/received alignment** — `.sent` class right-aligns the bubble with primary color fill
+2. **Smart grouping** — consecutive messages from the same sender collapse avatar and meta, adjust the bubble tail radius
+3. **Read status** — inline checkmark icon with `.read` class for blue double-check
+4. **Date dividers** — horizontal rule with centered date text to separate conversations by day

--- a/submissions/examples/ease-chat-bubble-az/demo.html
+++ b/submissions/examples/ease-chat-bubble-az/demo.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chat Bubble Component Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-section { margin-bottom: var(--ease-space-8); }
+    .demo-window {
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      overflow: hidden;
+      background: var(--ease-color-surface);
+      max-width: 600px;
+    }
+    .demo-window-header {
+      display: flex;
+      align-items: center;
+      gap: var(--ease-space-3);
+      padding: var(--ease-space-3) var(--ease-space-4);
+      border-bottom: 1px solid var(--ease-color-neutral-100);
+      background: var(--ease-color-neutral-50);
+      font-weight: 600;
+      font-size: 0.875rem;
+    }
+    .demo-window-header .dot {
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      background: var(--ease-color-success);
+    }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-chat-bubble-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">Chat message bubbles with sent/received alignment, avatar, sender name, timestamps, read status, grouping, and date dividers.</p>
+
+  <div class="demo-section">
+    <h2>Conversation</h2>
+    <div class="demo-window">
+      <div class="demo-window-header">
+        <span class="dot"></span>
+        <span>Alice Chen</span>
+        <span class="ease-text-muted" style="font-weight:400;font-size:0.8125rem;margin-left:auto;">Online</span>
+      </div>
+      <div class="ease-chat-feed-az">
+        <div class="ease-chat-divider-az">Yesterday</div>
+
+        <div class="ease-chat-row-az">
+          <div class="ease-chat-avatar-az">A</div>
+          <div class="ease-chat-bubble-az">
+            <div class="ease-chat-bubble-meta-az">
+              <span class="ease-chat-bubble-sender-az">Alice</span>
+              <span class="ease-chat-bubble-time-az">2:14 PM</span>
+            </div>
+            <div class="ease-chat-bubble-text-az">Hey! How's the progress on the EaseMotion components?</div>
+          </div>
+        </div>
+
+        <div class="ease-chat-row-az sent">
+          <div class="ease-chat-avatar-az">Y</div>
+          <div class="ease-chat-bubble-az">
+            <div class="ease-chat-bubble-text-az">Going well! Just finished the tree view component.</div>
+            <div class="ease-chat-bubble-meta-az">
+              <span class="ease-chat-bubble-time-az">2:16 PM</span>
+              <svg class="ease-chat-bubble-status-az read" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+            </div>
+          </div>
+        </div>
+
+        <div class="ease-chat-row-az sent">
+          <div class="ease-chat-avatar-az">Y</div>
+          <div class="ease-chat-bubble-az grouped">
+            <div class="ease-chat-bubble-text-az">The details/summary pattern works perfectly for expand/collapse without JS</div>
+            <div class="ease-chat-bubble-meta-az">
+              <span class="ease-chat-bubble-time-az">2:17 PM</span>
+              <svg class="ease-chat-bubble-status-az read" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+            </div>
+          </div>
+        </div>
+
+        <div class="ease-chat-row-az">
+          <div class="ease-chat-avatar-az">A</div>
+          <div class="ease-chat-bubble-az">
+            <div class="ease-chat-bubble-text-az">Nice! That's clever. Have you submitted the PR yet?</div>
+            <div class="ease-chat-bubble-meta-az">
+              <span class="ease-chat-bubble-time-az">2:19 PM</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="ease-chat-divider-az">Today</div>
+
+        <div class="ease-chat-row-az sent">
+          <div class="ease-chat-avatar-az">Y</div>
+          <div class="ease-chat-bubble-az">
+            <div class="ease-chat-bubble-text-az">Not yet, working on another one — chat bubbles!</div>
+            <div class="ease-chat-bubble-meta-az">
+              <span class="ease-chat-bubble-time-az">9:32 AM</span>
+              <svg class="ease-chat-bubble-status-az" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+            </div>
+          </div>
+        </div>
+
+        <div class="ease-chat-row-az">
+          <div class="ease-chat-avatar-az">A</div>
+          <div class="ease-chat-bubble-az">
+            <div class="ease-chat-bubble-text-az">Haha meta. Send me a screenshot when it's ready!</div>
+            <div class="ease-chat-bubble-meta-az">
+              <span class="ease-chat-bubble-sender-az">Alice</span>
+              <span class="ease-chat-bubble-time-az">9:35 AM</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Features</h2>
+    <ul style="color:var(--ease-color-neutral-600);line-height:2;">
+      <li><strong>Sent/received</strong> &mdash; align messages with <code>.sent</code> class</li>
+      <li><strong>Grouping</strong> &mdash; consecutive messages from the same sender hide avatar and meta, tail radius adjusts</li>
+      <li><strong>Read status</strong> &mdash; checkmark icon with <code>.read</code> class</li>
+      <li><strong>Date dividers</strong> &mdash; <code>.ease-chat-divider-az</code> with centered text</li>
+      <li><strong>Sender name</strong> &mdash; shown on first message in a group</li>
+    </ul>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-chat-bubble-az/style.css
+++ b/submissions/examples/ease-chat-bubble-az/style.css
@@ -1,0 +1,155 @@
+/* ============================================================
+   EaseMotion CSS — ease-chat-bubble-az component (Proposal)
+   Chat message bubbles with sent/received alignment, grouping, avatar, timestamp.
+   ============================================================ */
+
+.ease-chat-feed-az {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-4, 16px);
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  padding: var(--ease-space-4, 16px);
+  max-width: 600px;
+}
+
+.ease-chat-row-az {
+  display: flex;
+  gap: var(--ease-space-3, 12px);
+  max-width: 85%;
+}
+
+.ease-chat-row-az.sent {
+  align-self: flex-end;
+  flex-direction: row-reverse;
+}
+
+.ease-chat-avatar-az {
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-neutral-200, #e5e7eb);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--ease-color-neutral-500, #6b7280);
+  overflow: hidden;
+}
+
+.ease-chat-avatar-az img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ease-chat-bubble-az {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ease-chat-bubble-text-az {
+  padding: 10px 14px;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: var(--ease-radius-lg, 12px);
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-800, #1f2937);
+  word-wrap: break-word;
+}
+
+.ease-chat-row-az.sent .ease-chat-bubble-text-az {
+  background: var(--ease-color-primary, #6366f1);
+  color: #fff;
+  border-bottom-right-radius: var(--ease-radius-sm, 4px);
+}
+
+.ease-chat-row-az:not(.sent) .ease-chat-bubble-text-az {
+  border-bottom-left-radius: var(--ease-radius-sm, 4px);
+}
+
+.ease-chat-bubble-meta-az {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 8px);
+  padding: 0 var(--ease-space-1, 4px);
+}
+
+.ease-chat-row-az.sent .ease-chat-bubble-meta-az {
+  justify-content: flex-end;
+}
+
+.ease-chat-bubble-sender-az {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ease-color-neutral-600, #6b7280);
+}
+
+.ease-chat-bubble-time-az {
+  font-size: 0.6875rem;
+  color: var(--ease-color-neutral-400, #9ca3af);
+}
+
+.ease-chat-row-az.sent .ease-chat-bubble-time-az {
+  color: var(--ease-color-neutral-400, #9ca3af);
+}
+
+.ease-chat-bubble-status-az {
+  width: 14px;
+  height: 14px;
+  color: var(--ease-color-neutral-300, #d1d5db);
+}
+
+.ease-chat-bubble-status-az.read {
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-chat-bubble-az.grouped .ease-chat-bubble-text-az {
+  border-radius: var(--ease-radius-lg, 12px);
+}
+
+.ease-chat-row-az.sent + .ease-chat-row-az.sent {
+  margin-top: calc(var(--ease-space-4, 16px) * -1 + 4px);
+}
+
+.ease-chat-row-az:not(.sent) + .ease-chat-row-az:not(.sent) {
+  margin-top: calc(var(--ease-space-4, 16px) * -1 + 4px);
+}
+
+.ease-chat-row-az.sent + .ease-chat-row-az.sent .ease-chat-bubble-text-az {
+  border-bottom-right-radius: var(--ease-radius-lg, 12px);
+}
+
+.ease-chat-row-az:not(.sent) + .ease-chat-row-az:not(.sent) .ease-chat-bubble-text-az {
+  border-bottom-left-radius: var(--ease-radius-lg, 12px);
+}
+
+.ease-chat-row-az.sent + .ease-chat-row-az.sent .ease-chat-avatar-az,
+.ease-chat-row-az:not(.sent) + .ease-chat-row-az:not(.sent) .ease-chat-avatar-az {
+  visibility: hidden;
+}
+
+.ease-chat-row-az.sent + .ease-chat-row-az.sent .ease-chat-bubble-meta-az,
+.ease-chat-row-az:not(.sent) + .ease-chat-row-az:not(.sent) .ease-chat-bubble-meta-az {
+  display: none;
+}
+
+.ease-chat-divider-az {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 12px);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ease-color-neutral-400, #9ca3af);
+  align-self: stretch;
+}
+
+.ease-chat-divider-az::before,
+.ease-chat-divider-az::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--ease-color-neutral-200, #e5e7eb);
+}

--- a/submissions/examples/ease-empty-state-az/README.md
+++ b/submissions/examples/ease-empty-state-az/README.md
@@ -1,0 +1,23 @@
+# Empty State Component
+
+### What does this do?
+Adds `ease-empty-state-az` — an empty state placeholder component for no-data, no-results, and zero-state screens. Includes a circular icon container, title, description, and an optional call-to-action button.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/empty-state.css` and import it.
+
+```html
+<div class="ease-empty-state-az">
+  <div class="ease-empty-state-icon-az"><!-- icon --></div>
+  <div class="ease-empty-state-title-az">No results found</div>
+  <p class="ease-empty-state-desc-az">Try adjusting your search filters.</p>
+  <button class="ease-empty-state-action-az">Clear Filters</button>
+</div>
+```
+
+Variants: `.sm` (compact), `.bordered` (dashed border for drop zones).
+
+### Why is it useful?
+1. **Clear hierarchy** — large icon circle, bold title, muted description, primary CTA
+2. **Two sizes** — default and `.sm` for embedding inside cards or small panels
+3. **Bordered variant** — dashed border for drop-zone style empty states

--- a/submissions/examples/ease-empty-state-az/demo.html
+++ b/submissions/examples/ease-empty-state-az/demo.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Empty State Component Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-section { margin-bottom: var(--ease-space-8); }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: var(--ease-space-6); align-items: start; }
+    .card-demo {
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      overflow: hidden;
+      background: var(--ease-color-surface);
+    }
+    .card-demo-header {
+      padding: var(--ease-space-4);
+      border-bottom: 1px solid var(--ease-color-neutral-100);
+      font-weight: 600;
+      font-size: 0.875rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-empty-state-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">An empty state component for no-data, no-results, and zero-state screens with icon, title, description, and optional CTA.</p>
+
+  <div class="demo-grid">
+    <div class="demo-section">
+      <h2>No Results</h2>
+      <div class="ease-empty-state-az">
+        <div class="ease-empty-state-icon-az">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/>
+          </svg>
+        </div>
+        <div class="ease-empty-state-title-az">No results found</div>
+        <p class="ease-empty-state-desc-az">Try adjusting your search or filters to find what you're looking for.</p>
+        <button class="ease-empty-state-action-az">Clear Filters</button>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Empty Inbox</h2>
+      <div class="card-demo">
+        <div class="card-demo-header">Inbox</div>
+        <div class="ease-empty-state-az sm">
+          <div class="ease-empty-state-icon-az">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M22 12h-4l-3 9L9 3l-3 9H2"/><polyline points="12 2 15 9 22 9"/>
+            </svg>
+          </div>
+          <div class="ease-empty-state-title-az">Inbox zero</div>
+          <p class="ease-empty-state-desc-az">You're all caught up! No new messages.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Bordered (Drop Zone)</h2>
+      <div class="ease-empty-state-az bordered">
+        <div class="ease-empty-state-icon-az">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>
+          </svg>
+        </div>
+        <div class="ease-empty-state-title-az">Drop files here</div>
+        <p class="ease-empty-state-desc-az">Drag and drop your files here, or click to browse.</p>
+        <button class="ease-empty-state-action-az">Browse Files</button>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>No Projects (With Action)</h2>
+      <div class="ease-empty-state-az">
+        <div class="ease-empty-state-icon-az">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
+          </svg>
+        </div>
+        <div class="ease-empty-state-title-az">No projects yet</div>
+        <p class="ease-empty-state-desc-az">Get started by creating your first project.</p>
+        <button class="ease-empty-state-action-az">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          New Project
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Notes</h2>
+    <p class="ease-text-muted">The empty state is fully responsive, works inside cards, and the action button has a subtle hover lift. Use <code>.sm</code> for compact layouts and <code>.bordered</code> for dashed-border containers like drop zones.</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-empty-state-az/style.css
+++ b/submissions/examples/ease-empty-state-az/style.css
@@ -1,0 +1,110 @@
+/* ============================================================
+   EaseMotion CSS — ease-empty-state-az component (Proposal)
+   Empty state placeholder for no data, no results, or zero state.
+   ============================================================ */
+
+.ease-empty-state-az {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--ease-space-10, 40px) var(--ease-space-6, 24px);
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.ease-empty-state-icon-az {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-400, #9ca3af);
+  margin-bottom: var(--ease-space-5, 20px);
+  flex-shrink: 0;
+}
+
+.ease-empty-state-title-az {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--ease-color-neutral-900, #111827);
+  margin-bottom: var(--ease-space-2, 8px);
+}
+
+.ease-empty-state-desc-az {
+  font-size: 0.875rem;
+  color: var(--ease-color-neutral-500, #6b7280);
+  line-height: 1.6;
+  margin: 0 0 var(--ease-space-5, 20px);
+  max-width: 320px;
+}
+
+.ease-empty-state-action-az {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ease-space-2, 8px);
+  padding: 10px 24px;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--ease-color-primary, #6366f1);
+  border: none;
+  border-radius: var(--ease-radius-md, 8px);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.ease-empty-state-action-az:hover {
+  background: var(--ease-color-primary-dark, #4f46e5);
+  transform: translateY(-1px);
+}
+
+.ease-empty-state-action-az:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+.ease-empty-state-az.sm {
+  padding: var(--ease-space-6, 24px) var(--ease-space-4, 16px);
+}
+
+.ease-empty-state-az.sm .ease-empty-state-icon-az {
+  width: 48px;
+  height: 48px;
+  margin-bottom: var(--ease-space-3, 12px);
+}
+
+.ease-empty-state-az.sm .ease-empty-state-icon-az svg {
+  width: 24px;
+  height: 24px;
+}
+
+.ease-empty-state-az.sm .ease-empty-state-title-az {
+  font-size: 1rem;
+}
+
+.ease-empty-state-az.sm .ease-empty-state-desc-az {
+  font-size: 0.8125rem;
+  margin-bottom: var(--ease-space-4, 16px);
+}
+
+.ease-empty-state-az.sm .ease-empty-state-action-az {
+  padding: 8px 20px;
+  font-size: 0.8125rem;
+}
+
+.ease-empty-state-az.bordered {
+  border: 2px dashed var(--ease-color-neutral-200, #e5e7eb);
+  border-radius: var(--ease-radius-lg, 12px);
+  padding: var(--ease-space-12, 48px) var(--ease-space-6, 24px);
+}
+
+.ease-empty-state-az.bordered.sm {
+  padding: var(--ease-space-8, 32px) var(--ease-space-4, 16px);
+}


### PR DESCRIPTION
```markdown
## Description
Adds `ease-chat-bubble-az` — a CSS-only chat component with sent/received alignment, avatars, sender names, timestamps, read status, smart message grouping, and date dividers.
## Changes
- `submissions/examples/ease-chat-bubble-az/style.css` — Chat bubble styles with sent/received, grouping, avatar collapse, read status, date dividers
- `submissions/examples/ease-chat-bubble-az/demo.html` — Interactive demo with a full conversation view
- `submissions/examples/ease-chat-bubble-az/README.md` — Usage docs
## Related Issue
Closes #2865 