### PR TITLE
feat: add ease-blockquote-az — CSS-only Blockquote with Decorative Quote Mark & Citation

### DIFF
--- a/submissions/examples/ease-blockquote-az/README.md
+++ b/submissions/examples/ease-blockquote-az/README.md
@@ -1,0 +1,28 @@
+# Blockquote Component
+
+### What does this do?
+Adds `ease-blockquote-az` — a styled blockquote component with a large decorative quotation mark, italic quote text, author citation with optional avatar, and multiple color/size variants.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/blockquote.css` and import it.
+
+```html
+<blockquote class="ease-blockquote-az">
+  <p class="ease-blockquote-text-az">The quote text goes here.</p>
+  <div class="ease-blockquote-footer-az">
+    <div class="ease-blockquote-avatar-az">A</div>
+    <div class="ease-blockquote-author-az">
+      <span class="ease-blockquote-author-name-az">Author Name</span>
+      <span class="ease-blockquote-author-title-az">Title</span>
+    </div>
+  </div>
+</blockquote>
+```
+
+Variants: `.bordered`, `.center`, `.color-success`, `.color-warning`, `.color-danger`, `.sm`.
+
+### Why is it useful?
+1. **Decorative quote mark** — large curly quote rendered via CSS `::before`, no extra markup
+2. **Rich citation** — author name, title, and optional avatar slot in naturally
+3. **Color variants** — success (green), warning (amber), danger (red) for contextual quotes
+4. **Centered layout** — top-border accent with centered text, perfect for hero sections

--- a/submissions/examples/ease-blockquote-az/demo.html
+++ b/submissions/examples/ease-blockquote-az/demo.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blockquote Component Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-section { margin-bottom: var(--ease-space-8); }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(380px, 1fr)); gap: var(--ease-space-6); align-items: start; }
+    .demo-content {
+      max-width: 600px;
+      line-height: 1.8;
+      color: var(--ease-color-neutral-600);
+    }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-blockquote-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A styled blockquote component with decorative quote mark, citation, author avatar, and multiple color/size variants.</p>
+
+  <div class="demo-section">
+    <h2>Default</h2>
+    <blockquote class="ease-blockquote-az">
+      <p class="ease-blockquote-text-az">The best way to predict the future is to create it.</p>
+      <div class="ease-blockquote-footer-az">
+        <div class="ease-blockquote-avatar-az">P</div>
+        <div class="ease-blockquote-author-az">
+          <span class="ease-blockquote-author-name-az">Peter Drucker</span>
+          <span class="ease-blockquote-author-title-az">Management Consultant</span>
+        </div>
+      </div>
+    </blockquote>
+  </div>
+
+  <div class="demo-grid">
+    <div class="demo-section">
+      <h2>Bordered</h2>
+      <blockquote class="ease-blockquote-az bordered">
+        <p class="ease-blockquote-text-az">Simplicity is the soul of efficiency.</p>
+        <div class="ease-blockquote-footer-az">
+          <div class="ease-blockquote-author-az">
+            <span class="ease-blockquote-author-name-az">Austin Freeman</span>
+          </div>
+        </div>
+      </blockquote>
+    </div>
+
+    <div class="demo-section">
+      <h2>Centered</h2>
+      <blockquote class="ease-blockquote-az center">
+        <p class="ease-blockquote-text-az">Design is not just what it looks like and feels like. Design is how it works.</p>
+        <div class="ease-blockquote-footer-az">
+          <div class="ease-blockquote-author-az">
+            <span class="ease-blockquote-author-name-az">Steve Jobs</span>
+            <span class="ease-blockquote-author-title-az">Apple</span>
+          </div>
+        </div>
+      </blockquote>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Color Variants</h2>
+    <div class="demo-grid">
+      <blockquote class="ease-blockquote-az color-success">
+        <p class="ease-blockquote-text-az">Success is not final, failure is not fatal: it is the courage to continue that counts.</p>
+        <div class="ease-blockquote-footer-az">
+          <div class="ease-blockquote-author-az">
+            <span class="ease-blockquote-author-name-az">Winston Churchill</span>
+          </div>
+        </div>
+      </blockquote>
+
+      <blockquote class="ease-blockquote-az color-warning">
+        <p class="ease-blockquote-text-az">It does not matter how slowly you go as long as you do not stop.</p>
+        <div class="ease-blockquote-footer-az">
+          <div class="ease-blockquote-author-az">
+            <span class="ease-blockquote-author-name-az">Confucius</span>
+          </div>
+        </div>
+      </blockquote>
+
+      <blockquote class="ease-blockquote-az color-danger">
+        <p class="ease-blockquote-text-az">In the middle of every difficulty lies opportunity.</p>
+        <div class="ease-blockquote-footer-az">
+          <div class="ease-blockquote-author-az">
+            <span class="ease-blockquote-author-name-az">Albert Einstein</span>
+          </div>
+        </div>
+      </blockquote>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Small Size</h2>
+    <blockquote class="ease-blockquote-az sm">
+      <p class="ease-blockquote-text-az">Less is more.</p>
+      <div class="ease-blockquote-footer-az">
+        <div class="ease-blockquote-author-az">
+          <span class="ease-blockquote-author-name-az">Ludwig Mies van der Rohe</span>
+        </div>
+      </div>
+    </blockquote>
+  </div>
+
+  <div class="demo-section">
+    <h2>Inline with Content</h2>
+    <div class="demo-content">
+      <p>EaseMotion is a lightweight CSS framework that provides utility classes and components for rapid UI development. It emphasizes motion, accessibility, and ease of use.</p>
+      
+      <blockquote class="ease-blockquote-az" style="margin:var(--ease-space-6) 0;">
+        <p class="ease-blockquote-text-az">Motion brings interfaces to life. It guides attention, provides feedback, and creates a sense of spatial awareness.</p>
+      </blockquote>
+      
+      <p>The framework includes hundreds of pre-built components, from basic buttons and cards to complex patterns like mega menus and tree views — all with minimal CSS and zero JavaScript dependencies.</p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-blockquote-az/style.css
+++ b/submissions/examples/ease-blockquote-az/style.css
@@ -1,0 +1,147 @@
+/* ============================================================
+   EaseMotion CSS — ease-blockquote-az component (Proposal)
+   Styled blockquote with decorative quote mark, citation, author, variants.
+   ============================================================ */
+
+.ease-blockquote-az {
+  position: relative;
+  margin: 0;
+  padding: var(--ease-space-6, 24px) var(--ease-space-6, 24px) var(--ease-space-6, 24px) var(--ease-space-10, 40px);
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  border-left: 4px solid var(--ease-color-primary, #6366f1);
+  border-radius: 0 var(--ease-radius-md, 8px) var(--ease-radius-md, 8px) 0;
+  background: var(--ease-color-primary-dim, #eef2ff);
+}
+
+.ease-blockquote-az::before {
+  content: "\201C";
+  position: absolute;
+  top: var(--ease-space-3, 12px);
+  left: var(--ease-space-3, 12px);
+  font-size: 2.5rem;
+  line-height: 1;
+  font-weight: 700;
+  color: var(--ease-color-primary, #6366f1);
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+.ease-blockquote-text-az {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--ease-color-neutral-800, #1f2937);
+  font-style: italic;
+  margin: 0 0 var(--ease-space-3, 12px);
+}
+
+.ease-blockquote-footer-az {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 12px);
+  margin-top: var(--ease-space-3, 12px);
+}
+
+.ease-blockquote-author-az {
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-blockquote-author-name-az {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--ease-color-neutral-900, #111827);
+}
+
+.ease-blockquote-author-title-az {
+  font-size: 0.75rem;
+  color: var(--ease-color-neutral-500, #6b7280);
+}
+
+.ease-blockquote-avatar-az {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-color-neutral-200, #e5e7eb);
+  flex-shrink: 0;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--ease-color-neutral-500, #6b7280);
+}
+
+.ease-blockquote-avatar-az img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ease-blockquote-az.bordered {
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  border-left: 4px solid var(--ease-color-primary, #6366f1);
+  background: var(--ease-color-surface, #fff);
+}
+
+.ease-blockquote-az.center {
+  text-align: center;
+  border-left: none;
+  border-top: 4px solid var(--ease-color-primary, #6366f1);
+  border-radius: var(--ease-radius-md, 8px);
+  padding: var(--ease-space-8, 32px) var(--ease-space-6, 24px);
+}
+
+.ease-blockquote-az.center::before {
+  position: static;
+  display: block;
+  text-align: center;
+  margin-bottom: var(--ease-space-2, 8px);
+  font-size: 3rem;
+}
+
+.ease-blockquote-az.center .ease-blockquote-footer-az {
+  justify-content: center;
+}
+
+.ease-blockquote-az.color-success {
+  border-left-color: var(--ease-color-success, #10b981);
+  background: var(--ease-color-success-dim, #d1fae5);
+}
+
+.ease-blockquote-az.color-success::before {
+  color: var(--ease-color-success, #10b981);
+}
+
+.ease-blockquote-az.color-warning {
+  border-left-color: var(--ease-color-warning, #f59e0b);
+  background: var(--ease-color-warning-dim, #fef3c7);
+}
+
+.ease-blockquote-az.color-warning::before {
+  color: var(--ease-color-warning, #f59e0b);
+}
+
+.ease-blockquote-az.color-danger {
+  border-left-color: var(--ease-color-danger, #ef4444);
+  background: var(--ease-color-danger-dim, #fee2e2);
+}
+
+.ease-blockquote-az.color-danger::before {
+  color: var(--ease-color-danger, #ef4444);
+}
+
+.ease-blockquote-az.sm {
+  padding: var(--ease-space-4, 16px) var(--ease-space-4, 16px) var(--ease-space-4, 16px) var(--ease-space-8, 32px);
+}
+
+.ease-blockquote-az.sm::before {
+  font-size: 1.75rem;
+  top: var(--ease-space-2, 8px);
+  left: var(--ease-space-2, 8px);
+}
+
+.ease-blockquote-az.sm .ease-blockquote-text-az {
+  font-size: 0.875rem;
+  margin-bottom: var(--ease-space-2, 8px);
+}


### PR DESCRIPTION
```markdown
## Description
Adds `ease-blockquote-az` — a CSS-only blockquote with decorative curly quote mark, italic text, author citation with avatar, and 6 style variants.
## Changes
- `submissions/examples/ease-blockquote-az/style.css` — Blockquote styles with quote decoration, author footer, avatar, 3 color variants, 3 layout variants, small size
- `submissions/examples/ease-blockquote-az/demo.html` — Interactive demo with 7 examples
- `submissions/examples/ease-blockquote-az/README.md` — Usage docs
## Related Issue
Closes #2867 