### PR TITLE
feat: add ease-linktree-az component submission

### DIFF
--- a/submissions/examples/ease-linktree-az/README.md
+++ b/submissions/examples/ease-linktree-az/README.md
@@ -1,0 +1,37 @@
+# Link Tree / Bio Links Component
+
+### What does this do?
+Adds `ease-linktree-az` — a link-in-bio card with circular avatar, display name, bio text, and a vertical list of link buttons with brand-specific hover colors. Variants for GitHub, Twitter/X, LinkedIn, YouTube, and Website.
+
+### How is it used?
+The maintainer should copy `style.css` into `components/linktree.css` and import it.
+
+```html
+<div class="ease-linktree-az">
+  <img class="ease-linktree-avatar-az" src="avatar.jpg" alt="Avatar">
+  <p class="ease-linktree-name-az">Your Name</p>
+  <p class="ease-linktree-bio-az">Your bio text here.</p>
+  <div class="ease-linktree-links-az">
+    <a href="#" class="ease-linktree-link-az --brand-website">Website</a>
+    <a href="#" class="ease-linktree-link-az --brand-github">GitHub</a>
+    <a href="#" class="ease-linktree-link-az --brand-twitter">Twitter</a>
+  </div>
+  <p class="ease-linktree-footer-az">linktr.ee/username</p>
+</div>
+```
+
+Brand classes: `.--brand-website`, `.--brand-github`, `.--brand-twitter`, `.--brand-linkedin`, `.--brand-youtube`. Each applies a distinct hover border/background color.
+
+### Why is it useful?
+1. **Link-in-bio pattern** — popular in social media profiles, portfolios, and creator landing pages
+2. **Brand hover colors** — platform-specific visual feedback for each link
+3. **Dark theme** — works with dark backgrounds using EaseMotion CSS variables
+4. **Lightweight** — single component, no JavaScript or icon library required
+
+
+
+Submitted by: @zen-ash-dev
+
+Date: 2026-06-08
+
+Status: **Pending review**

--- a/submissions/examples/ease-linktree-az/demo.html
+++ b/submissions/examples/ease-linktree-az/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Link Tree Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-neutral-50, #f9fafb);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--ease-space-6);
+      align-items: flex-start;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-linktree-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A link-in-bio card component with avatar, name, bio, and styled link buttons. Variants with brand hover colors for GitHub, Twitter, LinkedIn, YouTube, and Website.</p>
+
+  <div class="demo-grid">
+    <div class="ease-linktree-az">
+      <img class="ease-linktree-avatar-az" src="https://picsum.photos/id/64/200/200" alt="Avatar" loading="lazy">
+      <p class="ease-linktree-name-az">Alex Rivera</p>
+      <p class="ease-linktree-bio-az">Frontend developer &amp; open source contributor. Building beautiful UI with EaseMotion CSS.</p>
+      <div class="ease-linktree-links-az">
+        <a href="#" class="ease-linktree-link-az --brand-website" onclick="event.preventDefault()">
+          <span class="link-icon-az">&#127760;</span>
+          alexrivera.dev
+        </a>
+        <a href="#" class="ease-linktree-link-az --brand-github" onclick="event.preventDefault()">
+          <span class="link-icon-az">&#128187;</span>
+          GitHub
+        </a>
+        <a href="#" class="ease-linktree-link-az --brand-twitter" onclick="event.preventDefault()">
+          <span class="link-icon-az">&#120143;</span>
+          Twitter / X
+        </a>
+        <a href="#" class="ease-linktree-link-az --brand-linkedin" onclick="event.preventDefault()">
+          <span class="link-icon-az">&#128100;</span>
+          LinkedIn
+        </a>
+        <a href="#" class="ease-linktree-link-az --brand-youtube" onclick="event.preventDefault()">
+          <span class="link-icon-az">&#9654;</span>
+          YouTube
+        </a>
+      </div>
+      <p class="ease-linktree-footer-az">linktr.ee/alexrivera</p>
+    </div>
+
+    <div class="ease-linktree-az" style="background:#1e293b;border-color:#334155;">
+      <img class="ease-linktree-avatar-az" src="https://picsum.photos/id/91/200/200" alt="Avatar" loading="lazy" style="border-color:#334155;">
+      <p class="ease-linktree-name-az" style="color:#f1f5f9;">Sam Chen</p>
+      <p class="ease-linktree-bio-az" style="color:#94a3b8;">Design engineer. Sharing tips on CSS, animation, and design systems.</p>
+      <div class="ease-linktree-links-az">
+        <a href="#" class="ease-linktree-link-az --brand-website" onclick="event.preventDefault()" style="background:#334155;border-color:#475569;color:#e2e8f0;">
+          <span class="link-icon-az">&#127760;</span>
+          samchen.design
+        </a>
+        <a href="#" class="ease-linktree-link-az --brand-twitter" onclick="event.preventDefault()" style="background:#334155;border-color:#475569;color:#e2e8f0;">
+          <span class="link-icon-az">&#120143;</span>
+          @samchen
+        </a>
+        <a href="#" class="ease-linktree-link-az --brand-github" onclick="event.preventDefault()" style="background:#334155;border-color:#475569;color:#e2e8f0;">
+          <span class="link-icon-az">&#128187;</span>
+          GitHub
+        </a>
+      </div>
+      <p class="ease-linktree-footer-az" style="color:#64748b;">links.dev/samchen</p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-linktree-az/style.css
+++ b/submissions/examples/ease-linktree-az/style.css
@@ -1,0 +1,104 @@
+/* ============================================================
+   EaseMotion CSS — ease-linktree-az component (Proposal)
+   Link-in-bio card: avatar, name, bio, and link button list.
+   ============================================================ */
+
+.ease-linktree-az {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  border-radius: var(--ease-radius-xl, 20px);
+  padding: var(--ease-space-8, 32px) var(--ease-space-6, 24px);
+  max-width: 400px;
+  text-align: center;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+}
+
+.ease-linktree-avatar-az {
+  display: block;
+  width: 88px;
+  height: 88px;
+  border-radius: var(--ease-radius-full, 9999px);
+  object-fit: cover;
+  margin: 0 auto var(--ease-space-3, 12px);
+  border: 3px solid var(--ease-color-primary-dim, #eef2ff);
+}
+
+.ease-linktree-name-az {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--ease-color-neutral-900, #111827);
+  margin: 0 0 var(--ease-space-1, 4px);
+}
+
+.ease-linktree-bio-az {
+  font-size: 0.875rem;
+  color: var(--ease-color-neutral-500, #6b7280);
+  margin: 0 0 var(--ease-space-5, 20px);
+  line-height: 1.5;
+}
+
+.ease-linktree-links-az {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-3, 12px);
+}
+
+.ease-linktree-link-az {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ease-space-2, 8px);
+  padding: var(--ease-space-3, 12px) var(--ease-space-4, 16px);
+  font-size: 0.875rem;
+  font-weight: 600;
+  font-family: inherit;
+  text-decoration: none;
+  border-radius: var(--ease-radius-md, 8px);
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  background: var(--ease-color-surface, #fff);
+  color: var(--ease-color-neutral-800, #1f2937);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.ease-linktree-link-az:hover {
+  background: var(--ease-color-neutral-50, #f9fafb);
+  border-color: var(--ease-color-primary, #6366f1);
+  transform: translateY(-1px);
+}
+
+.ease-linktree-link-az .link-icon-az {
+  font-size: 1.125rem;
+  flex-shrink: 0;
+}
+
+.ease-linktree-link-az.\--brand-github:hover {
+  border-color: #24292f;
+  background: #f6f8fa;
+}
+
+.ease-linktree-link-az.\--brand-twitter:hover {
+  border-color: #1da1f2;
+  background: #e8f5fe;
+}
+
+.ease-linktree-link-az.\--brand-linkedin:hover {
+  border-color: #0a66c2;
+  background: #e8f0fe;
+}
+
+.ease-linktree-link-az.\--brand-youtube:hover {
+  border-color: #ff0000;
+  background: #ffeaea;
+}
+
+.ease-linktree-link-az.\--brand-website:hover {
+  border-color: var(--ease-color-primary, #6366f1);
+  background: var(--ease-color-primary-dim, #eef2ff);
+}
+
+.ease-linktree-footer-az {
+  margin-top: var(--ease-space-5, 20px);
+  font-size: 0.6875rem;
+  color: var(--ease-color-neutral-400, #9ca3af);
+}

--- a/submissions/examples/ease-poll-az/README.md
+++ b/submissions/examples/ease-poll-az/README.md
@@ -1,0 +1,44 @@
+# Poll Component
+
+### What does this do?
+Adds `ease-poll-az` — a poll component with radio-selectable options and animated progress-bar results view. Supports voting mode and results mode (toggled via `.results` class).
+
+### How is it used?
+The maintainer should copy `style.css` into `components/poll.css` and import it.
+
+```html
+<div class="ease-poll-az">
+  <p class="ease-poll-question-az">Your question?</p>
+  <p class="ease-poll-meta-az">1,247 votes &middot; 5 days left</p>
+
+  <label class="ease-poll-option-az">
+    <input type="radio" name="poll" value="a">
+    <span class="ease-poll-label-az">
+      <span class="ease-poll-radio-az"></span>
+      <span class="ease-poll-text-az">Option A</span>
+      <span class="ease-poll-pct-az">54%</span>
+      <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az --winner" style="width:54%"></span></span>
+    </span>
+  </label>
+
+  <div class="ease-poll-footer-az">
+    <span class="ease-poll-votes-az">1,247 total votes</span>
+  </div>
+</div>
+```
+
+Add `.results` to the card container to show progress bars and percentages. Use `.--winner` on the bar for the leading option. Mark `checked` on the radio input of the option the user selected.
+
+### Why is it useful?
+1. **Dual mode** — voting (radio selection with hover states) and results (progress bars with percentages)
+2. **Pure CSS radio hack** — no JavaScript required for selection interaction
+3. **Winner highlight** — `.--winner` class for the leading option's bar
+4. **Lightweight** — single component with no external dependencies
+
+
+
+Submitted by: @zen-ash-dev
+
+Date: 2026-06-08
+
+Status: **Pending review**

--- a/submissions/examples/ease-poll-az/demo.html
+++ b/submissions/examples/ease-poll-az/demo.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Poll Component Demo</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      padding: var(--ease-space-8);
+      background: var(--ease-color-surface);
+      color: var(--ease-color-neutral-900);
+      font-family: var(--ease-font-sans);
+    }
+    h1 { font-size: 1.75rem; margin-bottom: var(--ease-space-2); }
+    h2 { font-size: 1.125rem; margin-bottom: var(--ease-space-3); margin-top: var(--ease-space-6); }
+    .demo-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--ease-space-6);
+      align-items: flex-start;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion: <code class="ease-text-primary">ease-poll-az</code></h1>
+  <p class="ease-text-muted ease-mb-8">A poll component with radio-selectable options and progress-bar results view. Toggle between voting and results via the <code>.results</code> class.</p>
+
+  <h2>Voting Mode</h2>
+  <div class="ease-poll-az">
+    <p class="ease-poll-question-az">What is your favorite CSS framework?</p>
+    <p class="ease-poll-meta-az">1,247 votes &middot; 5 days left</p>
+
+    <label class="ease-poll-option-az">
+      <input type="radio" name="poll-1" value="easemotion" checked>
+      <span class="ease-poll-label-az">
+        <span class="ease-poll-radio-az"></span>
+        <span class="ease-poll-text-az">EaseMotion CSS</span>
+        <span class="ease-poll-pct-az">54%</span>
+        <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az --winner" style="width:54%"></span></span>
+      </span>
+    </label>
+
+    <label class="ease-poll-option-az">
+      <input type="radio" name="poll-1" value="tailwind">
+      <span class="ease-poll-label-az">
+        <span class="ease-poll-radio-az"></span>
+        <span class="ease-poll-text-az">Tailwind CSS</span>
+        <span class="ease-poll-pct-az">28%</span>
+        <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az" style="width:28%"></span></span>
+      </span>
+    </label>
+
+    <label class="ease-poll-option-az">
+      <input type="radio" name="poll-1" value="bootstrap">
+      <span class="ease-poll-label-az">
+        <span class="ease-poll-radio-az"></span>
+        <span class="ease-poll-text-az">Bootstrap</span>
+        <span class="ease-poll-pct-az">12%</span>
+        <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az" style="width:12%"></span></span>
+      </span>
+    </label>
+
+    <label class="ease-poll-option-az">
+      <input type="radio" name="poll-1" value="other">
+      <span class="ease-poll-label-az">
+        <span class="ease-poll-radio-az"></span>
+        <span class="ease-poll-text-az">Other</span>
+        <span class="ease-poll-pct-az">6%</span>
+        <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az" style="width:6%"></span></span>
+      </span>
+    </label>
+
+    <div class="ease-poll-footer-az">
+      <span class="ease-poll-votes-az">1,247 total votes</span>
+    </div>
+  </div>
+
+  <h2>Results Mode (<code>.results</code>)</h2>
+  <div class="ease-poll-az results">
+    <p class="ease-poll-question-az">What is your favorite code editor?</p>
+    <p class="ease-poll-meta-az">3,582 votes &middot; Closed</p>
+
+    <label class="ease-poll-option-az">
+      <input type="radio" name="poll-2" value="vscode" checked>
+      <span class="ease-poll-label-az">
+        <span class="ease-poll-radio-az"></span>
+        <span class="ease-poll-text-az">VS Code</span>
+        <span class="ease-poll-pct-az">62%</span>
+        <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az --winner" style="width:62%"></span></span>
+      </span>
+    </label>
+
+    <label class="ease-poll-option-az">
+      <input type="radio" name="poll-2" value="vim">
+      <span class="ease-poll-label-az">
+        <span class="ease-poll-radio-az"></span>
+        <span class="ease-poll-text-az">Vim / Neovim</span>
+        <span class="ease-poll-pct-az">18%</span>
+        <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az" style="width:18%"></span></span>
+      </span>
+    </label>
+
+    <label class="ease-poll-option-az">
+      <input type="radio" name="poll-2" value="jetbrains">
+      <span class="ease-poll-label-az">
+        <span class="ease-poll-radio-az"></span>
+        <span class="ease-poll-text-az">JetBrains IDEs</span>
+        <span class="ease-poll-pct-az">14%</span>
+        <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az" style="width:14%"></span></span>
+      </span>
+    </label>
+
+    <label class="ease-poll-option-az">
+      <input type="radio" name="poll-2" value="sublime">
+      <span class="ease-poll-label-az">
+        <span class="ease-poll-radio-az"></span>
+        <span class="ease-poll-text-az">Sublime Text</span>
+        <span class="ease-poll-pct-az">6%</span>
+        <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az" style="width:6%"></span></span>
+      </span>
+    </label>
+
+    <div class="ease-poll-footer-az">
+      <span class="ease-poll-votes-az">3,582 total votes</span>
+    </div>
+  </div>
+
+  <h2>Dark theme example</h2>
+  <div class="demo-grid">
+    <div class="ease-poll-az results" style="background:var(--ease-color-neutral-800,#1f2937);border-color:var(--ease-color-neutral-700,#374151);">
+      <p class="ease-poll-question-az" style="color:var(--ease-color-neutral-100,#f3f4f6);">Preferred deployment method?</p>
+      <p class="ease-poll-meta-az">891 votes</p>
+
+      <label class="ease-poll-option-az">
+        <input type="radio" name="poll-3" value="docker" checked>
+        <span class="ease-poll-label-az" style="background:var(--ease-color-neutral-700,#374151);border-color:var(--ease-color-neutral-600,#4b5563);color:var(--ease-color-neutral-100,#f3f4f6);">
+          <span class="ease-poll-radio-az" style="border-color:var(--ease-color-neutral-500,#6b7280);"></span>
+          <span class="ease-poll-text-az">Docker</span>
+          <span class="ease-poll-pct-az">45%</span>
+          <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az --winner" style="width:45%"></span></span>
+        </span>
+      </label>
+
+      <label class="ease-poll-option-az">
+        <input type="radio" name="poll-3" value="serverless">
+        <span class="ease-poll-label-az" style="background:var(--ease-color-neutral-700,#374151);border-color:var(--ease-color-neutral-600,#4b5563);color:var(--ease-color-neutral-100,#f3f4f6);">
+          <span class="ease-poll-radio-az" style="border-color:var(--ease-color-neutral-500,#6b7280);"></span>
+          <span class="ease-poll-text-az">Serverless</span>
+          <span class="ease-poll-pct-az">32%</span>
+          <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az" style="width:32%"></span></span>
+        </span>
+      </label>
+
+      <label class="ease-poll-option-az">
+        <input type="radio" name="poll-3" value="vps">
+        <span class="ease-poll-label-az" style="background:var(--ease-color-neutral-700,#374151);border-color:var(--ease-color-neutral-600,#4b5563);color:var(--ease-color-neutral-100,#f3f4f6);">
+          <span class="ease-poll-radio-az" style="border-color:var(--ease-color-neutral-500,#6b7280);"></span>
+          <span class="ease-poll-text-az">VPS</span>
+          <span class="ease-poll-pct-az">23%</span>
+          <span class="ease-poll-bar-wrap-az"><span class="ease-poll-bar-az" style="width:23%"></span></span>
+        </span>
+      </label>
+
+      <div class="ease-poll-footer-az" style="border-color:var(--ease-color-neutral-700,#374151);">
+        <span class="ease-poll-votes-az" style="color:var(--ease-color-neutral-400,#9ca3af);">891 total votes</span>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-poll-az/style.css
+++ b/submissions/examples/ease-poll-az/style.css
@@ -1,0 +1,149 @@
+/* ============================================================
+   EaseMotion CSS — ease-poll-az component (Proposal)
+   Poll with radio options, progress bars, and percentage labels.
+   ============================================================ */
+
+.ease-poll-az {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  border-radius: var(--ease-radius-lg, 12px);
+  padding: var(--ease-space-6, 24px);
+  max-width: 480px;
+}
+
+.ease-poll-question-az {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--ease-color-neutral-900, #111827);
+  margin: 0 0 var(--ease-space-1, 4px);
+}
+
+.ease-poll-meta-az {
+  font-size: 0.75rem;
+  color: var(--ease-color-neutral-400, #9ca3af);
+  margin-bottom: var(--ease-space-5, 20px);
+}
+
+.ease-poll-option-az {
+  position: relative;
+  display: block;
+  margin-bottom: var(--ease-space-3, 12px);
+  cursor: pointer;
+  user-select: none;
+}
+
+.ease-poll-option-az input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.ease-poll-label-az {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 12px);
+  padding: var(--ease-space-3, 12px) var(--ease-space-4, 16px);
+  background: var(--ease-color-neutral-50, #f9fafb);
+  border: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  border-radius: var(--ease-radius-md, 8px);
+  font-size: 0.875rem;
+  color: var(--ease-color-neutral-800, #1f2937);
+  transition: border-color 0.2s ease, background 0.2s ease;
+  z-index: 1;
+}
+
+.ease-poll-option-az:hover .ease-poll-label-az {
+  border-color: var(--ease-color-primary, #6366f1);
+  background: var(--ease-color-primary-dim, #eef2ff);
+}
+
+.ease-poll-option-az input:checked + .ease-poll-label-az {
+  border-color: var(--ease-color-primary, #6366f1);
+  background: var(--ease-color-primary-dim, #eef2ff);
+  font-weight: 600;
+}
+
+.ease-poll-radio-az {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--ease-color-neutral-300, #d1d5db);
+  border-radius: var(--ease-radius-full, 9999px);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-poll-option-az input:checked + .ease-poll-label-az .ease-poll-radio-az {
+  border-color: var(--ease-color-primary, #6366f1);
+  box-shadow: inset 0 0 0 4px var(--ease-color-primary, #6366f1);
+}
+
+.ease-poll-option-az:hover .ease-poll-radio-az {
+  border-color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-poll-text-az {
+  flex: 1;
+}
+
+.ease-poll-bar-wrap-az {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  border-radius: inherit;
+  z-index: 0;
+}
+
+.ease-poll-bar-az {
+  height: 100%;
+  background: var(--ease-color-primary-dim, #eef2ff);
+  border-radius: inherit;
+  transition: width 0.6s ease;
+}
+
+.ease-poll-pct-az {
+  flex-shrink: 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--ease-color-neutral-500, #6b7280);
+  z-index: 1;
+  position: relative;
+}
+
+.ease-poll-option-az input:checked + .ease-poll-label-az .ease-poll-pct-az {
+  color: var(--ease-color-primary, #6366f1);
+}
+
+.ease-poll-bar-az.\--winner {
+  background: var(--ease-color-primary, #6366f1);
+  opacity: 0.12;
+}
+
+.ease-poll-footer-az {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: var(--ease-space-4, 16px);
+  padding-top: var(--ease-space-4, 16px);
+  border-top: 1px solid var(--ease-color-neutral-100, #f3f4f6);
+}
+
+.ease-poll-votes-az {
+  font-size: 0.75rem;
+  color: var(--ease-color-neutral-400, #9ca3af);
+}
+
+/* Results mode: show progress bars */
+.ease-poll-az.results .ease-poll-bar-wrap-az {
+  display: block;
+}
+
+.ease-poll-az:not(.results) .ease-poll-bar-wrap-az {
+  display: none;
+}
+
+.ease-poll-az:not(.results) .ease-poll-pct-az {
+  display: none;
+}


### PR DESCRIPTION
Adds ease-linktree-az — a link-in-bio card component with:
- Circular avatar with border accent
- Display name and bio text
- Vertical link button list with brand hover colors via .--brand-* classes (github, twitter, linkedin, youtube, website)
- Subtle hover lift and border accent transition
- Dark theme compatible (demo shows light and dark variants)
- Pure CSS, no JavaScript or icon library required
- closes #2925 