### PR TITLE
feat: add star rating component

### DIFF
--- a/submissions/examples/rating-I/README.md
+++ b/submissions/examples/rating-I/README.md
@@ -1,0 +1,32 @@
+# Star Rating Component
+
+CSS-only star rating component using radio inputs and reverse sibling selectors.
+
+## Files
+
+- demo.html - Interactive demo
+- style.css - Rating styles
+- README.md - Documentation
+
+## Classes
+
+- ease-rating - Basic 5-star rating
+- ease-rating-half - Half-star rating (0.5 increments)
+- ease-rating-small / large - Size variants
+- ease-rating-gold / blue / green - Color variants
+
+## Usage
+
+```html
+<div class="ease-rating">
+    <input type="radio" name="rating" id="star5" value="5">
+    <label for="star5" class="star">★</label>
+    <input type="radio" name="rating" id="star4" value="4">
+    <label for="star4" class="star">★</label>
+    <input type="radio" name="rating" id="star3" value="3">
+    <label for="star3" class="star">★</label>
+    <input type="radio" name="rating" id="star2" value="2">
+    <label for="star2" class="star">★</label>
+    <input type="radio" name="rating" id="star1" value="1">
+    <label for="star1" class="star">★</label>
+</div>

--- a/submissions/examples/rating-I/demo.html
+++ b/submissions/examples/rating-I/demo.html
@@ -1,0 +1,228 @@
+ 
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion - Star Rating Component</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>⭐ ease-rating</h1>
+        <p>CSS-only star rating component using radio inputs and reverse sibling selectors</p>
+
+        <!-- Basic 5-Star Rating -->
+        <div class="demo-section">
+            <h2>Basic 5-Star Rating</h2>
+            <div class="ease-rating">
+                <input type="radio" name="rating1" id="star5-1" value="5">
+                <label for="star5-1" class="star">★</label>
+                <input type="radio" name="rating1" id="star4-1" value="4">
+                <label for="star4-1" class="star">★</label>
+                <input type="radio" name="rating1" id="star3-1" value="3">
+                <label for="star3-1" class="star">★</label>
+                <input type="radio" name="rating1" id="star2-1" value="2">
+                <label for="star2-1" class="star">★</label>
+                <input type="radio" name="rating1" id="star1-1" value="1">
+                <label for="star1-1" class="star">★</label>
+            </div>
+            <p class="note">Click on stars to rate</p>
+        </div>
+
+        <!-- Half-Star Rating -->
+        <div class="demo-section">
+            <h2>Half-Star Rating</h2>
+            <div class="ease-rating-half">
+                <input type="radio" name="rating2" id="star5-2" value="5">
+                <label for="star5-2" class="star half">★</label>
+                <input type="radio" name="rating2" id="star4-5-2" value="4.5">
+                <label for="star4-5-2" class="star half">★</label>
+                <input type="radio" name="rating2" id="star4-2" value="4">
+                <label for="star4-2" class="star half">★</label>
+                <input type="radio" name="rating2" id="star3-5-2" value="3.5">
+                <label for="star3-5-2" class="star half">★</label>
+                <input type="radio" name="rating2" id="star3-2" value="3">
+                <label for="star3-2" class="star half">★</label>
+                <input type="radio" name="rating2" id="star2-5-2" value="2.5">
+                <label for="star2-5-2" class="star half">★</label>
+                <input type="radio" name="rating2" id="star2-2" value="2">
+                <label for="star2-2" class="star half">★</label>
+                <input type="radio" name="rating2" id="star1-5-2" value="1.5">
+                <label for="star1-5-2" class="star half">★</label>
+                <input type="radio" name="rating2" id="star1-2" value="1">
+                <label for="star1-2" class="star half">★</label>
+                <input type="radio" name="rating2" id="star0-5-2" value="0.5">
+                <label for="star0-5-2" class="star half">★</label>
+            </div>
+            <p class="note">Supports half-star ratings (0.5 increments)</p>
+        </div>
+
+        <!-- Different Sizes -->
+        <div class="demo-section">
+            <h2>Size Variations</h2>
+            <div class="size-demo">
+                <h3>Small</h3>
+                <div class="ease-rating-small">
+                    <input type="radio" name="rating-small" id="star5-small" value="5">
+                    <label for="star5-small" class="star-small">★</label>
+                    <input type="radio" name="rating-small" id="star4-small" value="4">
+                    <label for="star4-small" class="star-small">★</label>
+                    <input type="radio" name="rating-small" id="star3-small" value="3">
+                    <label for="star3-small" class="star-small">★</label>
+                    <input type="radio" name="rating-small" id="star2-small" value="2">
+                    <label for="star2-small" class="star-small">★</label>
+                    <input type="radio" name="rating-small" id="star1-small" value="1">
+                    <label for="star1-small" class="star-small">★</label>
+                </div>
+                <h3>Large</h3>
+                <div class="ease-rating-large">
+                    <input type="radio" name="rating-large" id="star5-large" value="5">
+                    <label for="star5-large" class="star-large">★</label>
+                    <input type="radio" name="rating-large" id="star4-large" value="4">
+                    <label for="star4-large" class="star-large">★</label>
+                    <input type="radio" name="rating-large" id="star3-large" value="3">
+                    <label for="star3-large" class="star-large">★</label>
+                    <input type="radio" name="rating-large" id="star2-large" value="2">
+                    <label for="star2-large" class="star-large">★</label>
+                    <input type="radio" name="rating-large" id="star1-large" value="1">
+                    <label for="star1-large" class="star-large">★</label>
+                </div>
+            </div>
+        </div>
+
+        <!-- Different Colors -->
+        <div class="demo-section">
+            <h2>Color Variations</h2>
+            <div class="color-demo">
+                <div class="ease-rating-gold">
+                    <input type="radio" name="rating-gold" id="star5-gold" value="5">
+                    <label for="star5-gold" class="star-gold">★</label>
+                    <input type="radio" name="rating-gold" id="star4-gold" value="4">
+                    <label for="star4-gold" class="star-gold">★</label>
+                    <input type="radio" name="rating-gold" id="star3-gold" value="3">
+                    <label for="star3-gold" class="star-gold">★</label>
+                    <input type="radio" name="rating-gold" id="star2-gold" value="2">
+                    <label for="star2-gold" class="star-gold">★</label>
+                    <input type="radio" name="rating-gold" id="star1-gold" value="1">
+                    <label for="star1-gold" class="star-gold">★</label>
+                </div>
+                <div class="ease-rating-blue">
+                    <input type="radio" name="rating-blue" id="star5-blue" value="5">
+                    <label for="star5-blue" class="star-blue">★</label>
+                    <input type="radio" name="rating-blue" id="star4-blue" value="4">
+                    <label for="star4-blue" class="star-blue">★</label>
+                    <input type="radio" name="rating-blue" id="star3-blue" value="3">
+                    <label for="star3-blue" class="star-blue">★</label>
+                    <input type="radio" name="rating-blue" id="star2-blue" value="2">
+                    <label for="star2-blue" class="star-blue">★</label>
+                    <input type="radio" name="rating-blue" id="star1-blue" value="1">
+                    <label for="star1-blue" class="star-blue">★</label>
+                </div>
+                <div class="ease-rating-green">
+                    <input type="radio" name="rating-green" id="star5-green" value="5">
+                    <label for="star5-green" class="star-green">★</label>
+                    <input type="radio" name="rating-green" id="star4-green" value="4">
+                    <label for="star4-green" class="star-green">★</label>
+                    <input type="radio" name="rating-green" id="star3-green" value="3">
+                    <label for="star3-green" class="star-green">★</label>
+                    <input type="radio" name="rating-green" id="star2-green" value="2">
+                    <label for="star2-green" class="star-green">★</label>
+                    <input type="radio" name="rating-green" id="star1-green" value="1">
+                    <label for="star1-green" class="star-green">★</label>
+                </div>
+            </div>
+        </div>
+
+        <!-- Read-only Display -->
+        <div class="demo-section">
+            <h2>Read-only Display (Display Rating)</h2>
+            <div class="rating-display">
+                <div class="stars-display" data-rating="4.5">
+                    <span>★</span><span>★</span><span>★</span><span>★</span><span>☆</span>
+                </div>
+                <p>Rating: 4.5 / 5</p>
+            </div>
+            <div class="rating-display">
+                <div class="stars-display" data-rating="3">
+                    <span>★</span><span>★</span><span>★</span><span>☆</span><span>☆</span>
+                </div>
+                <p>Rating: 3 / 5</p>
+            </div>
+        </div>
+
+        <!-- Interactive Rating with Feedback -->
+        <div class="demo-section">
+            <h2>Interactive with Feedback</h2>
+            <div class="ease-rating" id="interactiveRating">
+                <input type="radio" name="rating-feedback" id="star5-fb" value="5">
+                <label for="star5-fb" class="star">★</label>
+                <input type="radio" name="rating-feedback" id="star4-fb" value="4">
+                <label for="star4-fb" class="star">★</label>
+                <input type="radio" name="rating-feedback" id="star3-fb" value="3">
+                <label for="star3-fb" class="star">★</label>
+                <input type="radio" name="rating-feedback" id="star2-fb" value="2">
+                <label for="star2-fb" class="star">★</label>
+                <input type="radio" name="rating-feedback" id="star1-fb" value="1">
+                <label for="star1-fb" class="star">★</label>
+            </div>
+            <p id="ratingFeedback" class="feedback">Select a rating</p>
+        </div>
+
+        <!-- Usage Code -->
+        <div class="code-section">
+            <h2>Usage</h2>
+            <pre>&lt;div class="ease-rating"&gt;
+    &lt;input type="radio" name="rating" id="star5" value="5"&gt;
+    &lt;label for="star5" class="star"&gt;★&lt;/label&gt;
+    &lt;input type="radio" name="rating" id="star4" value="4"&gt;
+    &lt;label for="star4" class="star"&gt;★&lt;/label&gt;
+    &lt;input type="radio" name="rating" id="star3" value="3"&gt;
+    &lt;label for="star3" class="star"&gt;★&lt;/label&gt;
+    &lt;input type="radio" name="rating" id="star2" value="2"&gt;
+    &lt;label for="star2" class="star"&gt;★&lt;/label&gt;
+    &lt;input type="radio" name="rating" id="star1" value="1"&gt;
+    &lt;label for="star1" class="star"&gt;★&lt;/label&gt;
+&lt;/div&gt;
+
+&lt;!-- Half-star variant --&gt;
+&lt;div class="ease-rating-half"&gt;
+    &lt;!-- 10 inputs for 0.5 increments --&gt;
+&lt;/div&gt;</pre>
+        </div>
+
+        <div class="info">
+            <h3>⭐ Star Rating Features</h3>
+            <ul>
+                <li>🎯 CSS-only with radio inputs</li>
+                <li>⭐ Hover and selected states</li>
+                <li>½ Half-star variant support</li>
+                <li>📏 Size variations (small, normal, large)</li>
+                <li>🎨 Color variations (gold, blue, green)</li>
+                <li>🔄 Reverse sibling selectors for highlighting</li>
+                <li>📊 Read-only display option</li>
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        // Interactive rating feedback
+        const ratingInputs = document.querySelectorAll('#interactiveRating input');
+        const feedback = document.getElementById('ratingFeedback');
+        
+        ratingInputs.forEach(input => {
+            input.addEventListener('change', () => {
+                const value = input.value;
+                const messages = {
+                    1: 'Poor - Needs improvement',
+                    2: 'Fair - Could be better',
+                    3: 'Good - Satisfactory',
+                    4: 'Very Good - Impressive',
+                    5: 'Excellent - Outstanding!'
+                };
+                feedback.textContent = messages[value] || 'Select a rating';
+            });
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/rating-I/style.css
+++ b/submissions/examples/rating-I/style.css
@@ -1,0 +1,314 @@
+ 
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    padding: 2rem;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    background: #fff;
+    border-radius: 1rem;
+    padding: 3rem;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+h1 {
+    text-align: center;
+    color: #1e293b;
+    margin-bottom: 0.5rem;
+}
+
+.container > p {
+    text-align: center;
+    color: #64748b;
+    margin-bottom: 2rem;
+}
+
+.demo-section {
+    margin-bottom: 2rem;
+}
+
+.demo-section h2 {
+    font-size: 1.3rem;
+    color: #1e293b;
+    margin-bottom: 1rem;
+    border-left: 4px solid #667eea;
+    padding-left: 1rem;
+}
+
+.demo-section h3 {
+    font-size: 1rem;
+    margin: 1rem 0 0.5rem;
+    color: #475569;
+}
+
+.note, .feedback {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-top: 0.5rem;
+    text-align: center;
+}
+
+/* ========================================
+   STAR RATING COMPONENT
+   ======================================== */
+
+/* Basic Rating - Reverse order for CSS highlighting */
+.ease-rating {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: center;
+    gap: 0.25rem;
+}
+
+.ease-rating input {
+    display: none;
+}
+
+.ease-rating .star {
+    font-size: 2rem;
+    color: #cbd5e1;
+    cursor: pointer;
+    transition: color 0.2s;
+}
+
+/* Hover and selected states using sibling selectors */
+.ease-rating .star:hover,
+.ease-rating .star:hover ~ .star,
+.ease-rating input:checked ~ .star {
+    color: #f59e0b;
+}
+
+/* Half-Star Rating */
+.ease-rating-half {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    gap: 0.25rem;
+}
+
+.ease-rating-half input {
+    display: none;
+}
+
+.ease-rating-half .star {
+    font-size: 2rem;
+    color: #cbd5e1;
+    cursor: pointer;
+    transition: color 0.2s;
+    position: relative;
+}
+
+.ease-rating-half .half {
+    position: relative;
+}
+
+/* Half-star hover effect - complex but works */
+.ease-rating-half .star:hover,
+.ease-rating-half .star:hover ~ .star,
+.ease-rating-half input:checked ~ .star {
+    color: #f59e0b;
+}
+
+/* Size Variants */
+.ease-rating-small .star-small {
+    font-size: 1.2rem;
+    color: #cbd5e1;
+    cursor: pointer;
+}
+
+.ease-rating-small {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: center;
+    gap: 0.2rem;
+}
+
+.ease-rating-small input {
+    display: none;
+}
+
+.ease-rating-small .star-small:hover,
+.ease-rating-small .star-small:hover ~ .star-small,
+.ease-rating-small input:checked ~ .star-small {
+    color: #f59e0b;
+}
+
+.ease-rating-large .star-large {
+    font-size: 3rem;
+    color: #cbd5e1;
+    cursor: pointer;
+}
+
+.ease-rating-large {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.ease-rating-large input {
+    display: none;
+}
+
+.ease-rating-large .star-large:hover,
+.ease-rating-large .star-large:hover ~ .star-large,
+.ease-rating-large input:checked ~ .star-large {
+    color: #f59e0b;
+}
+
+/* Color Variants */
+.ease-rating-gold .star-gold {
+    font-size: 2rem;
+    color: #cbd5e1;
+    cursor: pointer;
+}
+
+.ease-rating-gold {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: center;
+    gap: 0.25rem;
+}
+
+.ease-rating-gold input {
+    display: none;
+}
+
+.ease-rating-gold .star-gold:hover,
+.ease-rating-gold .star-gold:hover ~ .star-gold,
+.ease-rating-gold input:checked ~ .star-gold {
+    color: #f59e0b;
+}
+
+.ease-rating-blue .star-blue {
+    font-size: 2rem;
+    color: #cbd5e1;
+    cursor: pointer;
+}
+
+.ease-rating-blue {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: center;
+    gap: 0.25rem;
+}
+
+.ease-rating-blue input {
+    display: none;
+}
+
+.ease-rating-blue .star-blue:hover,
+.ease-rating-blue .star-blue:hover ~ .star-blue,
+.ease-rating-blue input:checked ~ .star-blue {
+    color: #3b82f6;
+}
+
+.ease-rating-green .star-green {
+    font-size: 2rem;
+    color: #cbd5e1;
+    cursor: pointer;
+}
+
+.ease-rating-green {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: center;
+    gap: 0.25rem;
+}
+
+.ease-rating-green input {
+    display: none;
+}
+
+.ease-rating-green .star-green:hover,
+.ease-rating-green .star-green:hover ~ .star-green,
+.ease-rating-green input:checked ~ .star-green {
+    color: #10b981;
+}
+
+/* Read-only Display */
+.rating-display {
+    background: #f8fafc;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.stars-display {
+    display: inline-flex;
+    gap: 0.25rem;
+    font-size: 1.5rem;
+    color: #f59e0b;
+}
+
+.stars-display span:last-child,
+.stars-display span:nth-last-child(2) {
+    color: #cbd5e1;
+}
+
+/* Code Section */
+.code-section {
+    background: #f8fafc;
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+    margin: 2rem 0;
+}
+
+pre {
+    background: #1e293b;
+    color: #e2e8f0;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    overflow-x: auto;
+    font-family: monospace;
+    font-size: 0.7rem;
+}
+
+.info {
+    background: #e0e7ff;
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+    margin-top: 2rem;
+}
+
+.info h3 {
+    margin-bottom: 1rem;
+    color: #1e293b;
+}
+
+.info ul {
+    margin-left: 1.5rem;
+    color: #475569;
+}
+
+.info li {
+    margin-bottom: 0.5rem;
+}
+
+code {
+    background: #f1f5f9;
+    padding: 0.2rem 0.4rem;
+    border-radius: 0.25rem;
+    font-family: monospace;
+    font-size: 0.875rem;
+    color: #d946ef;
+}
+
+@media (max-width: 768px) {
+    body {
+        padding: 1rem;
+    }
+    .container {
+        padding: 1.5rem;
+    }
+}


### PR DESCRIPTION
## Summary
Adds CSS-only star rating component with radio inputs and reverse sibling selectors.

## Details
- ease-rating - Basic 5-star rating
- ease-rating-half - Half-star increments
- ease-rating-small/large - Size variants
- ease-rating-gold/blue/green - Color variants
- Hover and selected states
- Read-only display option

## Files
- demo.html - Interactive demo
- style.css - Rating styles
- README.md - Documentation

## Testing
Click stars to test rating functionality.

## Related
Issue #283