### PR TITLE
fix: resolve large vacant space below navbar on mobile

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -1,637 +1,719 @@
-    /* ── Theme Definitions ────────────────────────────────── */
-    :root {
-      --docs-sidebar-w: 260px;
-      --docs-header-h: 60px;
+/* ── Theme Definitions ────────────────────────────────── */
+:root {
+  --docs-sidebar-w: 260px;
+  --docs-header-h: 60px;
 
-      /* Dark Theme (Default) */
-      --page-bg: #0f0e17;
-      --page-text: #fffffe;
-      --page-text-muted: rgba(255, 255, 255, 0.65);
-      --header-bg: rgba(15, 14, 23, 0.9);
-      --border-color: rgba(255, 255, 255, 0.07);
-      --card-bg: rgba(255, 255, 255, 0.04);
-      --sidebar-bg: rgba(255, 255, 255, 0.02);
-      --code-bg: rgba(255, 255, 255, 0.04);
-      --code-border: rgba(255, 255, 255, 0.08);
-      --table-row-hover: rgba(255, 255, 255, 0.02);
-      --nav-link-color: rgba(255, 255, 255, 0.6);
-      --nav-link-active-bg: rgba(108, 99, 255, 0.12);
-      --nav-link-active-text: #ffffff;
-      --heading-color: #ffffff;
-      --heading-sub-color: rgba(255, 255, 255, 0.9);
-      --title-gradient-end: #a78bfa;
+  /* Dark Theme (Default) */
+  --page-bg: #0f0e17;
+  --page-text: #fffffe;
+  --page-text-muted: rgba(255, 255, 255, 0.65);
+  --header-bg: rgba(15, 14, 23, 0.9);
+  --border-color: rgba(255, 255, 255, 0.07);
+  --card-bg: rgba(255, 255, 255, 0.04);
+  --sidebar-bg: rgba(255, 255, 255, 0.02);
+  --code-bg: rgba(255, 255, 255, 0.04);
+  --code-border: rgba(255, 255, 255, 0.08);
+  --table-row-hover: rgba(255, 255, 255, 0.02);
+  --nav-link-color: rgba(255, 255, 255, 0.6);
+  --nav-link-active-bg: rgba(108, 99, 255, 0.12);
+  --nav-link-active-text: #ffffff;
+  --heading-color: #ffffff;
+  --heading-sub-color: rgba(255, 255, 255, 0.9);
+  --title-gradient-end: #a78bfa;
 
-      /* Overrides for EaseMotion variables in dark mode */
-      --ease-color-bg: #0f0e17;
-      --ease-color-surface: #1e1b29;
-      --ease-color-text: #fffffe;
-      --ease-color-muted: rgba(255, 255, 255, 0.65);
-    }
+  /* Overrides for EaseMotion variables in dark mode */
+  --ease-color-bg: #0f0e17;
+  --ease-color-surface: #1e1b29;
+  --ease-color-text: #fffffe;
+  --ease-color-muted: rgba(255, 255, 255, 0.65);
+}
 
-    [data-theme="light"] {
-      /* Light Theme */
-      --page-bg: #f8fafc;
-      --page-text: #0f172a;
-      --page-text-muted: #475569;
-      --header-bg: rgba(248, 250, 252, 0.9);
-      --border-color: rgba(15, 23, 42, 0.08);
-      --card-bg: #ffffff;
-      --sidebar-bg: rgba(15, 23, 42, 0.02);
-      --code-bg: #f1f5f9;
-      --code-border: #e2e8f0;
-      --table-row-hover: rgba(15, 23, 42, 0.02);
-      --nav-link-color: #475569;
-      --nav-link-active-bg: rgba(108, 99, 255, 0.1);
-      --nav-link-active-text: #6c63ff;
-      --heading-color: #0f172a;
-      --heading-sub-color: #1e293b;
-      --title-gradient-end: #4f46e5;
+[data-theme="light"] {
+  /* Light Theme */
+  --page-bg: #f8fafc;
+  --page-text: #0f172a;
+  --page-text-muted: #475569;
+  --header-bg: rgba(248, 250, 252, 0.9);
+  --border-color: rgba(15, 23, 42, 0.08);
+  --card-bg: #ffffff;
+  --sidebar-bg: rgba(15, 23, 42, 0.02);
+  --code-bg: #f1f5f9;
+  --code-border: #e2e8f0;
+  --table-row-hover: rgba(15, 23, 42, 0.02);
+  --nav-link-color: #475569;
+  --nav-link-active-bg: rgba(108, 99, 255, 0.1);
+  --nav-link-active-text: #6c63ff;
+  --heading-color: #0f172a;
+  --heading-sub-color: #1e293b;
+  --title-gradient-end: #4f46e5;
 
-      /* Overrides for EaseMotion variables in light mode */
-      --ease-color-bg: #f8fafc;
-      --ease-color-surface: #ffffff;
-      --ease-color-text: #0f172a;
-      --ease-color-muted: #475569;
-    }
+  /* Overrides for EaseMotion variables in light mode */
+  --ease-color-bg: #f8fafc;
+  --ease-color-surface: #ffffff;
+  --ease-color-text: #0f172a;
+  --ease-color-muted: #475569;
+}
 
-    /* Smooth Transitions for Theme Changes */
-    body, 
-    .docs-header, 
-    .docs-sidebar, 
-    .docs-sidebar a, 
-    .docs-content, 
-    .docs-h1, 
-    .docs-h2, 
-    .docs-h3, 
-    .docs-p, 
-    .docs-code, 
-    .docs-code pre, 
-    .docs-table, 
-    .docs-table th, 
-    .docs-table td, 
-    .docs-info {
-      transition: background-color var(--ease-speed-medium) var(--ease-ease),
-                  background var(--ease-speed-medium) var(--ease-ease),
-                  border-color var(--ease-speed-medium) var(--ease-ease),
-                  color var(--ease-speed-medium) var(--ease-ease);
-    }
+/* Smooth Transitions for Theme Changes */
+body,
+.docs-header,
+.docs-sidebar,
+.docs-sidebar a,
+.docs-content,
+.docs-h1,
+.docs-h2,
+.docs-h3,
+.docs-p,
+.docs-code,
+.docs-code pre,
+.docs-table,
+.docs-table th,
+.docs-table td,
+.docs-info {
+  transition: background-color var(--ease-speed-medium) var(--ease-ease),
+    background var(--ease-speed-medium) var(--ease-ease),
+    border-color var(--ease-speed-medium) var(--ease-ease),
+    color var(--ease-speed-medium) var(--ease-ease);
+}
 
-    body {
-      background: var(--page-bg);
-      color: var(--page-text);
-      overflow-x: hidden;
-    }
+html {
+  scroll-behavior: smooth;
+}
 
-    /* ── Header ───────────────────────────────────────────── */
-    .docs-header {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: var(--docs-header-h);
-      z-index: var(--ease-z-overlay);
-      background: var(--header-bg);
-      -webkit-backdrop-filter: blur(12px);
-      backdrop-filter: blur(12px);
-      border-bottom: 1px solid var(--border-color);
-      display: flex;
-      align-items: center;
-      padding: 0 var(--ease-space-6);
-      justify-content: space-between;
-      gap: var(--ease-space-4);
-    }
+body {
+  background: var(--page-bg);
+  color: var(--page-text);
+  overflow-x: hidden;
+}
 
-    .docs-logo {
-      font-size: var(--ease-text-xl);
-      font-weight: 800;
-      background: linear-gradient(135deg, #6c63ff, #a78bfa);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-      letter-spacing: -0.02em;
-      text-decoration: none;
-    }
+/* ── Header ───────────────────────────────────────────── */
+.docs-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--docs-header-h);
+  z-index: 200;
+  background: var(--header-bg);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  padding: 0 var(--ease-space-6);
+  justify-content: space-between;
+  gap: var(--ease-space-4);
+}
 
-    .docs-header-links {
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--ease-space-5);
-      align-items: center;
-      justify-content: flex-end;
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
+.docs-logo {
+  font-size: var(--ease-text-xl);
+  font-weight: 800;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+}
 
-    .docs-header-links a {
-      color: var(--nav-link-color);
-      font-size: var(--ease-text-sm);
-      font-weight: 500;
-      text-decoration: none;
-      transition: color var(--ease-speed-fast) var(--ease-ease);
-    }
+.docs-header-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-5);
+  align-items: center;
+  justify-content: flex-end;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
 
-    .docs-header-links a:hover { color: var(--page-text); }
+.docs-header-links a:not(.ease-btn) {
+  color: var(--nav-link-color);
+  font-size: var(--ease-text-sm);
+  font-weight: 500;
+  text-decoration: none;
+  padding: 10px 20px;
+  border-radius: var(--ease-radius-md);
+  transition: color 0.3s ease, background-color 0.3s ease, transform 0.3s ease,
+    box-shadow 0.3s ease;
+  position: relative;
+}
 
-    /* ── Theme Toggle Button ──────────────────────────────── */
-    .theme-toggle-btn {
-      background: none;
-      border: 1px solid var(--border-color);
-      color: var(--page-text);
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 36px;
-      height: 36px;
-      border-radius: var(--ease-radius-full);
-      transition: background var(--ease-speed-fast) var(--ease-ease), 
-                  color var(--ease-speed-fast) var(--ease-ease),
-                  border-color var(--ease-speed-fast) var(--ease-ease);
-    }
+.docs-header-links a:not(.ease-btn):hover,
+.docs-header-links a:not(.ease-btn).active {
+  color: var(--nav-link-active-text);
+  background: var(--nav-link-active-bg);
+  box-shadow: 0 0 10px rgba(108, 99, 255, 0.2);
+}
 
-    .theme-toggle-btn:hover {
-      background: rgba(255, 255, 255, 0.08);
-      border-color: var(--ease-color-primary);
-    }
+.docs-header-links a:not(.ease-btn)::after {
+  content: "";
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 2px;
+  background: #6c63ff;
+  transition: width 0.3s ease;
+  border-radius: 2px;
+}
 
-    [data-theme="light"] .theme-toggle-btn:hover {
-      background: rgba(15, 23, 42, 0.08);
-    }
+.docs-header-links a:not(.ease-btn):hover::after,
+.docs-header-links a:not(.ease-btn).active::after {
+  width: 60%;
+}
 
-    /* Toggle visibility of icons */
-    [data-theme="light"] .theme-toggle-btn .sun-icon { display: none; }
-    [data-theme="light"] .theme-toggle-btn .moon-icon { display: block; }
-    :root:not([data-theme="light"]) .theme-toggle-btn .sun-icon { display: block; }
-    :root:not([data-theme="light"]) .theme-toggle-btn .moon-icon { display: none; }
+[data-theme="light"] .docs-header-links a:not(.ease-btn):hover,
+[data-theme="light"] .docs-header-links a:not(.ease-btn).active {
+  background: rgba(108, 99, 255, 0.18);
+  color: #4f46e5;
+  box-shadow: 0 0 10px rgba(108, 99, 255, 0.1);
+}
 
-    /* ── Layout Shell ─────────────────────────────────────── */
-    .docs-shell {
-      display: flex;
-      min-height: 100dvh;
-      padding-top: var(--docs-header-h);
-    }
+.docs-header-links a.ease-btn {
+  color: #ffffff;
+}
 
-    /* ── Sidebar ──────────────────────────────────────────── */
-   /* Update these styles in your docs.css */
+/* ── Theme Toggle Button ──────────────────────────────── */
+.theme-toggle-btn {
+  background: none;
+  border: 1px solid var(--border-color);
+  color: var(--page-text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--ease-radius-full);
+  transition: background var(--ease-speed-fast) var(--ease-ease),
+    color var(--ease-speed-fast) var(--ease-ease),
+    border-color var(--ease-speed-fast) var(--ease-ease);
+}
 
+.theme-toggle-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--ease-color-primary);
+}
+
+[data-theme="light"] .theme-toggle-btn:hover {
+  background: rgba(15, 23, 42, 0.08);
+}
+
+[data-theme="light"] .theme-toggle-btn .sun-icon {
+  display: none;
+}
+[data-theme="light"] .theme-toggle-btn .moon-icon {
+  display: block;
+}
+:root:not([data-theme="light"]) .theme-toggle-btn .sun-icon {
+  display: block;
+}
+:root:not([data-theme="light"]) .theme-toggle-btn .moon-icon {
+  display: none;
+}
+
+/* ── Layout Shell ─────────────────────────────────────── */
+.docs-shell {
+  display: flex;
+  min-height: 100vh;
+  min-height: 100dvh;
+  /* FIX: Always offset by the real header height */
+  padding-top: 60px;
+}
+
+/* ── Sidebar ──────────────────────────────────────────── */
 .docs-sidebar {
   width: var(--docs-sidebar-w);
-  position: fixed; 
-  top: var(--docs-header-h); /* This ensures it starts right below your header */
+  position: fixed;
+  top: 60px; /* FIX: Hard-coded so it never gets zeroed out by breakpoint vars */
   left: 0;
   bottom: 0;
   overflow-y: auto;
   padding: var(--ease-space-8) var(--ease-space-5);
   border-right: 1px solid var(--border-color);
-  background: var(--page-bg); /* Use the page background so it overlays cleanly */
-  transition: transform 0.3s ease-in-out;
-  z-index: 1000; /* Ensure it is above main content */
+  background: var(--sidebar-bg);
+  z-index: 100;
 }
 
-@media (max-width: 768px) {
+.docs-sidebar::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 4px;
+}
+
+.sidebar-group {
+  margin-bottom: var(--ease-space-6);
+}
+
+.sidebar-group-label {
+  font-size: var(--ease-text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ease-color-primary-light);
+  margin-bottom: var(--ease-space-2);
+  padding: 0 var(--ease-space-2);
+  text-decoration: none;
+}
+
+a.sidebar-group-label:hover {
+  color: var(--page-text);
+}
+
+.sidebar-nav {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar-nav a {
+  display: block;
+  padding: var(--ease-space-2) var(--ease-space-2);
+  font-size: var(--ease-text-sm);
+  color: var(--nav-link-color);
+  border-radius: var(--ease-radius-sm);
+  text-decoration: none;
+  transition: color var(--ease-speed-fast) var(--ease-ease),
+    background var(--ease-speed-fast) var(--ease-ease);
+}
+
+.sidebar-nav a.active {
+  color: var(--nav-link-active-text);
+  background: var(--nav-link-active-bg);
+  border-left: 3px solid #6c63ff;
+  box-shadow: inset 20px 0 20px -20px rgba(108, 99, 255, 0.25);
+}
+
+/* ── Mobile Toggle Button ─────────────────────────────── */
+.sidebar-toggle {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 1.4rem;
+  color: var(--page-text);
+  z-index: 200;
+}
+
+/* ── Content ──────────────────────────────────────────── */
+.docs-content {
+  margin-left: var(--docs-sidebar-w);
+  flex: 1;
+  padding: var(--ease-space-12) var(--ease-space-12);
+  max-width: 860px;
+  min-width: 0;
+}
+
+/* ── Section headings ─────────────────────────────────── */
+.docs-section {
+  margin-bottom: var(--ease-space-16);
+  scroll-margin-top: 80px;
+}
+
+.docs-eyebrow {
+  font-size: var(--ease-text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ease-color-primary-light);
+  margin-bottom: var(--ease-space-2);
+}
+
+.docs-h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  background: linear-gradient(
+    135deg,
+    var(--heading-color),
+    var(--title-gradient-end)
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: var(--ease-space-4);
+}
+
+.docs-h2 {
+  font-size: var(--ease-text-2xl);
+  font-weight: 700;
+  color: var(--heading-color);
+  margin-bottom: var(--ease-space-4);
+  padding-bottom: var(--ease-space-3);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.docs-h3 {
+  font-size: var(--ease-text-lg);
+  font-weight: 600;
+  color: var(--heading-sub-color);
+  margin-bottom: var(--ease-space-3);
+}
+
+.docs-p {
+  color: var(--page-text-muted);
+  line-height: 1.75;
+  margin-bottom: var(--ease-space-4);
+}
+
+/* ── Code Block ───────────────────────────────────────── */
+.docs-code {
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  border-radius: var(--ease-radius-md);
+  padding: var(--ease-space-5);
+  margin-bottom: var(--ease-space-6);
+  overflow-x: auto;
+  position: relative;
+}
+
+.docs-code pre {
+  background: none;
+  color: var(--page-text);
+  padding: 0;
+  margin: 0;
+  font-size: var(--ease-text-sm);
+  line-height: 1.7;
+  border-radius: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.docs-code-lang {
+  position: absolute;
+  top: var(--ease-space-3);
+  right: var(--ease-space-4);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--page-text-muted);
+  opacity: 0.5;
+  font-family: var(--ease-font-mono);
+  transition: opacity var(--ease-speed-fast) var(--ease-ease);
+}
+
+.docs-content code {
+  background: rgba(108, 99, 255, 0.12);
+  color: var(--ease-color-primary-light);
+  border: 1px solid rgba(108, 99, 255, 0.2);
+  padding: 0.1em 0.45em;
+  border-radius: var(--ease-radius-sm);
+  font-size: 0.87em;
+}
+
+.docs-code pre code {
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* ── Table ────────────────────────────────────────────── */
+.docs-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--ease-text-sm);
+  margin-bottom: var(--ease-space-8);
+}
+
+.docs-table th {
+  text-align: left;
+  padding: var(--ease-space-3) var(--ease-space-4);
+  background: var(--code-bg);
+  color: var(--page-text-muted);
+  font-weight: 600;
+  font-size: var(--ease-text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.docs-table td {
+  padding: var(--ease-space-3) var(--ease-space-4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--page-text-muted);
+}
+
+.docs-table tr:hover td {
+  background: var(--table-row-hover);
+}
+
+/* ── Info Box ─────────────────────────────────────────── */
+.docs-info {
+  background: rgba(108, 99, 255, 0.08);
+  border: 1px solid rgba(108, 99, 255, 0.25);
+  border-radius: var(--ease-radius-md);
+  padding: var(--ease-space-4) var(--ease-space-5);
+  color: var(--page-text-muted);
+  font-size: var(--ease-text-sm);
+  line-height: 1.7;
+  margin-bottom: var(--ease-space-6);
+  display: flex;
+  gap: var(--ease-space-3);
+}
+
+.docs-info-icon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+/* ── Divider ──────────────────────────────────────────── */
+.docs-divider {
+  border: none;
+  border-top: 1px solid var(--border-color);
+  margin: var(--ease-space-10) 0;
+}
+
+/* ── Pill badge ───────────────────────────────────────── */
+.docs-badge {
+  display: inline-block;
+  padding: 0.15em 0.65em;
+  border-radius: var(--ease-radius-full);
+  font-size: var(--ease-text-xs);
+  font-weight: 700;
+  background: rgba(108, 99, 255, 0.15);
+  color: var(--ease-color-primary-light);
+  border: 1px solid rgba(108, 99, 255, 0.25);
+  margin-right: var(--ease-space-1);
+}
+
+/* ── Copy Button ──────────────────────────────────────── */
+.docs-copy-btn {
+  position: absolute;
+  top: var(--ease-space-3);
+  right: var(--ease-space-4);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.7);
+  padding: 4px 8px;
+  border-radius: var(--ease-radius-sm);
+  font-size: 11px;
+  font-family: var(--ease-font-mono, monospace);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--ease-speed-fast) var(--ease-ease),
+    background var(--ease-speed-fast) var(--ease-ease),
+    color var(--ease-speed-fast) var(--ease-ease);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.docs-code:hover .docs-copy-btn {
+  opacity: 1;
+}
+.docs-code:hover .docs-code-lang {
+  opacity: 0;
+}
+.docs-copy-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+/* ── Scroll to Top ────────────────────────────────────── */
+.ease-scroll-top {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(12px);
+  transition: opacity var(--ease-speed-medium) var(--ease-ease),
+    transform var(--ease-speed-medium) var(--ease-ease-bounce),
+    box-shadow var(--ease-speed-fast) var(--ease-ease),
+    background var(--ease-speed-fast) var(--ease-ease);
+  z-index: 300;
+}
+
+.ease-scroll-top.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.ease-scroll-top--primary {
+  background: var(--ease-color-primary);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2), 0 0 10px rgba(108, 99, 255, 0.25);
+}
+.ease-scroll-top--primary:hover {
+  background: var(--ease-color-primary-dark);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25), 0 0 14px rgba(108, 99, 255, 0.35);
+  transform: translateY(-2px);
+}
+.ease-scroll-top--primary:active {
+  transform: scale(0.96);
+}
+
+.ease-scroll-top__ring {
+  position: absolute;
+  inset: 0;
+  width: 44px;
+  height: 44px;
+  pointer-events: none;
+}
+.ease-scroll-top__ring circle {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.4);
+  stroke-width: 2.5;
+  stroke-dasharray: 126;
+  stroke-dashoffset: 126;
+  stroke-linecap: round;
+  transform: rotate(-90deg);
+  transform-origin: center;
+  transition: stroke-dashoffset 0.1s linear;
+}
+
+.ease-scroll-top__icon {
+  width: 18px;
+  height: 18px;
+  transition: transform 0.22s var(--ease-ease-bounce);
+}
+.ease-scroll-top:hover .ease-scroll-top__icon {
+  transform: translateY(-3px);
+}
+
+.ease-scroll-top:focus-visible {
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.45);
+}
+
+/* ── Hover / touch overrides ──────────────────────────── */
+@media (hover: none), (pointer: coarse) {
+  .docs-table tr:hover td {
+    background: transparent;
+  }
+  .sidebar-nav a:hover:not(.active) {
+    color: rgba(255, 255, 255, 0.6);
+    background: transparent;
+  }
+}
+
+/* ── Tablet (≤ 900px) ─────────────────────────────────── */
+/* FIX: REMOVED --docs-header-h: 0px — that was the root cause of the blank space.
+   The header becomes sticky here, so padding-top on .docs-shell handles offset. */
+@media (max-width: 900px) {
+  .docs-header {
+    position: sticky;
+    top: 0;
+    height: 60px;
+    min-height: 60px;
+    flex-wrap: nowrap;
+    padding: 0 var(--ease-space-4);
+  }
+
+  /* Shell no longer needs padding-top because header is now in normal flow */
+  .docs-shell {
+    flex-direction: row;
+    padding-top: 0;
+  }
+
+  /* Sidebar stays fixed at 60px from top of viewport */
   .docs-sidebar {
-    /* Slide out by default */
+    top: 60px;
+  }
+}
+
+/* ── Mobile (≤ 768px) ─────────────────────────────────── */
+@media (max-width: 768px) {
+  .sidebar-toggle {
+    display: block;
+  }
+
+  /* FIX: Sidebar slides off-screen by default; never participates in layout flow */
+  .docs-sidebar {
+    position: fixed;
+    top: 60px;
+    left: 0;
+    bottom: 0;
+    width: 280px;
     transform: translateX(-100%);
-    width: 280px; /* Adjust width for mobile */
-    /* REMOVE any top margin that might be creating the gap */
-    top: var(--docs-header-h); 
-    box-shadow: 2px 0 15px rgba(0,0,0,0.2);
+    transition: transform 0.3s ease;
+    z-index: 100;
+    background: var(--page-bg);
+    border-right: 1px solid var(--border-color);
+    padding: var(--ease-space-6) var(--ease-space-4);
   }
 
   .docs-sidebar.open {
-    transform: translateX(0); /* Slides over the body content */
+    transform: translateX(0);
   }
 
-  /* Ensure main content doesn't push the sidebar */
+  /* FIX: No left margin on mobile — sidebar is overlaid, not beside content */
   .docs-content {
     margin-left: 0 !important;
-    padding-top: var(--ease-space-6); 
+    padding: var(--ease-space-6) var(--ease-space-4);
+    width: 100%;
+    max-width: 100%;
+  }
+
+  /* FIX: Shell uses padding-top equal to the sticky header height */
+  .docs-shell {
+    flex-direction: column;
+    padding-top: 0; /* header is sticky so it's in normal flow */
+  }
+
+  .docs-header-links {
+    display: none;
+  }
+
+  /* Overlay behind sidebar */
+  .sidebar-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    top: 60px;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 99;
+  }
+
+  .sidebar-overlay.open {
+    display: block;
   }
 }
 
-    .docs-sidebar::-webkit-scrollbar-thumb {
-      background: var(--border-color);
-      border-radius: 4px;
-    }
-
-    .sidebar-group {
-      margin-bottom: var(--ease-space-6);
-    }
-
-    .sidebar-group-label {
-      font-size: var(--ease-text-xs);
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--ease-color-primary-light);
-      margin-bottom: var(--ease-space-2);
-      padding: 0 var(--ease-space-2);
-      text-decoration: none;
-    }
-
-    a.sidebar-group-label:hover {
-      color: var(--page-text);
-    }
-
-    .sidebar-nav {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
-
-    .sidebar-nav a {
-      display: block;
-      padding: var(--ease-space-2) var(--ease-space-2);
-      font-size: var(--ease-text-sm);
-      color: var(--nav-link-color);
-      border-radius: var(--ease-radius-sm);
-      text-decoration: none;
-      transition: color var(--ease-speed-fast) var(--ease-ease),
-        background var(--ease-speed-fast) var(--ease-ease);
-    }
-
-    .sidebar-nav a.active {
-      color: var(--nav-link-active-text);
-      background: var(--nav-link-active-bg);
-      border-left: 3px solid #6c63ff;
-    }
-
-    /* ── Mobile Toggle Button ─────────────────────────────── */
-    .sidebar-toggle {
-      display: none;
-      background: none;
-      border: none;
-      cursor: pointer;
-      padding: 4px 8px;
-      font-size: 1.4rem;
-      color: #fff;
-      z-index: 200;
-    }
-
-    /* ── Mobile Responsive ────────────────────────────────── */
-    @media (max-width: 768px) {
-      .sidebar-toggle {
-        display: block;
-      }
-
-      .docs-sidebar {
-        transform: translateX(-100%);
-        transition: transform 0.3s ease;
-        z-index: 100;
-        top: var(--docs-header-h);
-        background: var(--page-bg);
-      }
-
-      .docs-sidebar.open {
-        transform: translateX(0);
-      }
-
-      .docs-content {
-        margin-left: 0 !important;
-        padding: var(--ease-space-6);
-        width: 100%;
-      }
-
-      .docs-header-links {
-        display: none;
-      }
-
-      /* Overlay when sidebar open */
-      .sidebar-overlay {
-        display: none;
-        position: fixed;
-        inset: 0;
-        background: rgba(0, 0, 0, 0.5);
-        z-index: 99;
-        top: var(--docs-header-h);
-      }
-
-      .sidebar-overlay.open {
-        display: block;
-      }
-    }
-
-    /* ── Content ──────────────────────────────────────────── */
-    .docs-content {
-      margin-left: var(--docs-sidebar-w);
-      flex: 1;
-      padding: var(--ease-space-12) var(--ease-space-12);
-      max-width: 860px;
-      min-width: 0;
-    }
-
-    /* ── Section headings ─────────────────────────────────── */
-    .docs-section {
-      margin-bottom: var(--ease-space-16);
-      scroll-margin-top: calc(var(--docs-header-h) + var(--ease-space-4));
-    }
-
-    .docs-eyebrow {
-      font-size: var(--ease-text-xs);
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      color: var(--ease-color-primary-light);
-      margin-bottom: var(--ease-space-2);
-    }
-
-    .docs-h1 {
-      font-size: clamp(2rem, 4vw, 3rem);
-      font-weight: 800;
-      letter-spacing: -0.04em;
-      background: linear-gradient(135deg, var(--heading-color), var(--title-gradient-end));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-      margin-bottom: var(--ease-space-4);
-    }
-
-    .docs-h2 {
-      font-size: var(--ease-text-2xl);
-      font-weight: 700;
-      color: var(--heading-color);
-      margin-bottom: var(--ease-space-4);
-      padding-bottom: var(--ease-space-3);
-      border-bottom: 1px solid var(--border-color);
-    }
-
-    .docs-h3 {
-      font-size: var(--ease-text-lg);
-      font-weight: 600;
-      color: var(--heading-sub-color);
-      margin-bottom: var(--ease-space-3);
-    }
-
-    .docs-p {
-      color: var(--page-text-muted);
-      line-height: 1.75;
-      margin-bottom: var(--ease-space-4);
-    }
-
-    /* ── Code Block ───────────────────────────────────────── */
-    .docs-code {
-      background: var(--code-bg);
-      border: 1px solid var(--code-border);
-      border-radius: var(--ease-radius-md);
-      padding: var(--ease-space-5);
-      margin-bottom: var(--ease-space-6);
-      overflow-x: auto;
-      position: relative;
-    }
-
-    .docs-code pre {
-      background: none;
-      color: var(--page-text);
-      padding: 0;
-      margin: 0;
-      font-size: var(--ease-text-sm);
-      line-height: 1.7;
-      border-radius: 0;
-    }
-
-    .docs-code-lang {
-      position: absolute;
-      top: var(--ease-space-3);
-      right: var(--ease-space-4);
-      font-size: 10px;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      transition: opacity var(--ease-speed-fast) var(--ease-ease);
-      color: var(--page-text-muted);
-      opacity: 0.5;
-      font-family: var(--ease-font-mono);
-    }
-
-    /* Inline code */
-    .docs-content code {
-      background: rgba(108, 99, 255, 0.12);
-      color: var(--ease-color-primary-light);
-      border: 1px solid rgba(108, 99, 255, 0.2);
-      padding: 0.1em 0.45em;
-      border-radius: var(--ease-radius-sm);
-      font-size: 0.87em;
-    }
-
-    .docs-code pre code {
-      background: none;
-      border: none;
-      color: inherit;
-      padding: 0;
-      font-size: inherit;
-    }
-
-    /* ── Table ────────────────────────────────────────────── */
-    .docs-table {
-      width: 100%;
-      border-collapse: collapse;
-      font-size: var(--ease-text-sm);
-      margin-bottom: var(--ease-space-8);
-    }
-
-    .docs-table th {
-      text-align: left;
-      padding: var(--ease-space-3) var(--ease-space-4);
-      background: var(--code-bg);
-      color: var(--page-text-muted);
-      font-weight: 600;
-      font-size: var(--ease-text-xs);
-      text-transform: uppercase;
-      letter-spacing: 0.07em;
-      border-bottom: 1px solid var(--border-color);
-    }
-
-    .docs-table td {
-      padding: var(--ease-space-3) var(--ease-space-4);
-      border-bottom: 1px solid var(--border-color);
-      color: var(--page-text-muted);
-    }
-
-    .docs-table tr:hover td {
-      background: var(--table-row-hover);
-    }
-
-    /* ── Info Box ─────────────────────────────────────────── */
-    .docs-info {
-      background: rgba(108, 99, 255, 0.08);
-      border: 1px solid rgba(108, 99, 255, 0.25);
-      border-radius: var(--ease-radius-md);
-      padding: var(--ease-space-4) var(--ease-space-5);
-      color: var(--page-text-muted);
-      font-size: var(--ease-text-sm);
-      line-height: 1.7;
-      margin-bottom: var(--ease-space-6);
-      display: flex;
-      gap: var(--ease-space-3);
-    }
-
-    .docs-info-icon {
-      font-size: 1.1rem;
-      flex-shrink: 0;
-    }
-
-    /* ── Divider ──────────────────────────────────────────── */
-    .docs-divider {
-      border: none;
-      border-top: 1px solid var(--border-color);
-      margin: var(--ease-space-10) 0;
-    }
-
-    /* ── Pill badge ───────────────────────────────────────── */
-    .docs-badge {
-      display: inline-block;
-      padding: 0.15em 0.65em;
-      border-radius: var(--ease-radius-full);
-      font-size: var(--ease-text-xs);
-      font-weight: 700;
-      background: rgba(108, 99, 255, 0.15);
-      color: var(--ease-color-primary-light);
-      border: 1px solid rgba(108, 99, 255, 0.25);
-      margin-right: var(--ease-space-1);
-    }
-
-    @media (hover: none), (pointer: coarse) {
-      .docs-table tr:hover td {
-        background: transparent;
-      }
-
-      .sidebar-nav a:hover:not(.active) {
-        color: rgba(255,255,255,0.6);
-        background: transparent;
-      }
-    }
-
-    @media (max-width: 900px) {
-      :root {
-        --docs-header-h: 0px;
-      }
-
-      .docs-header {
-        position: sticky;
-        min-height: 60px;
-        height: auto;
-        flex-wrap: wrap;
-        padding: var(--ease-space-3) var(--ease-space-4);
-      }
-
-      .docs-header-links {
-        gap: var(--ease-space-2);
-        justify-content: flex-start;
-        width: 100%;
-      }
-
-      .docs-shell {
-        flex-direction: column;
-        padding-top: 0;
-      }
-
-      .docs-sidebar {
-        position: static;
-        width: 100%;
-        padding: var(--ease-space-4);
-        border-right: 0;
-        border-bottom: 1px solid rgba(255,255,255,0.06);
-        background: rgba(255,255,255,0.03);
-      }
-
-      .sidebar-group {
-        margin-bottom: var(--ease-space-4);
-      }
-
-      .sidebar-nav {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--ease-space-1);
-      }
-
-      .sidebar-nav a {
-        padding: var(--ease-space-1) var(--ease-space-2);
-      }
-
-      .docs-content {
-        margin-left: 0;
-        max-width: none;
-        width: 100%;
-        padding: var(--ease-space-8) var(--ease-space-4);
-      }
-    }
-
-    @media (max-width: 640px) {
-      .docs-logo {
-        font-size: var(--ease-text-lg);
-      }
-
-      .docs-header-links li:last-child {
-        width: 100%;
-      }
-
-      .docs-header-links .ease-btn {
-        width: 100%;
-      }
-
-      .docs-h1 {
-        font-size: 2rem;
-      }
-
-      .docs-code {
-        padding: var(--ease-space-4);
-      }
-
-      .docs-table {
-        display: block;
-        overflow-x: auto; /* allow wide tables to scroll on mobile */
-        white-space: nowrap;
-      }
-
-      .docs-info {
-        padding: var(--ease-space-4);
-      }
-    }  
-    /* ── Copy Button ──────────────────────────────────────── */
-    .docs-copy-btn {
-      position: absolute;
-      top: var(--ease-space-3);
-      right: var(--ease-space-4);
-      background: rgba(255,255,255,0.1);
-      border: 1px solid rgba(255,255,255,0.2);
-      color: rgba(255,255,255,0.7);
-      padding: 4px 8px;
-      border-radius: var(--ease-radius-sm);
-      font-size: 11px;
-      font-family: var(--ease-font-mono, monospace);
-      cursor: pointer;
-      opacity: 0;
-      transition: opacity var(--ease-speed-fast) var(--ease-ease),
-                  background var(--ease-speed-fast) var(--ease-ease),
-                  color var(--ease-speed-fast) var(--ease-ease);
-      display: flex;
-      align-items: center;
-      gap: 4px;
-    }
-
-    .docs-code:hover .docs-copy-btn {
-      opacity: 1;
-    }
-
-    .docs-copy-btn:hover {
-      background: rgba(255,255,255,0.2);
-      color: #fff;
-    }
-
-    .docs-code:hover .docs-code-lang {
-      opacity: 0;
-    }
-    /* Mobile Sidebar Hidden by Default */
-@media (max-width: 768px) {
-  .sidebar {
-    transform: translateX(-100%);
-    transition: transform 0.3s ease-in-out;
-    /* Other positioning styles like position: fixed, top: 0, left: 0, etc. */
+/* ── Small mobile (≤ 640px) ───────────────────────────── */
+@media (max-width: 640px) {
+  .docs-logo {
+    font-size: var(--ease-text-lg);
   }
 
-  /* When JS adds the .active class, slide it into view */
-  .sidebar.active {
-    transform: translateX(0);
+  .docs-h1 {
+    font-size: 2rem;
+  }
+
+  .docs-code {
+    padding: var(--ease-space-4);
+  }
+
+  .docs-table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+
+  .docs-info {
+    padding: var(--ease-space-4);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-scroll-top {
+    transition: opacity var(--ease-speed-fast) linear;
+  }
+  .ease-scroll-top__ring circle {
+    transition: none;
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,709 +25,20 @@
       rel="stylesheet"
     />
 
+    <!-- Link to external docs.css -->
+    <link rel="stylesheet" href="docs.css" />
+
     <style>
-      /* ── Theme Definitions ────────────────────────────────── */
-      :root {
-        --docs-sidebar-w: 260px;
-        --docs-header-h: 60px;
-
-        /* Dark Theme (Default) */
-        --page-bg: #0f0e17;
-        --page-text: #fffffe;
-        --page-text-muted: rgba(255, 255, 255, 0.65);
-        --header-bg: rgba(15, 14, 23, 0.9);
-        --border-color: rgba(255, 255, 255, 0.07);
-        --card-bg: rgba(255, 255, 255, 0.04);
-        --sidebar-bg: rgba(255, 255, 255, 0.02);
-        --code-bg: rgba(255, 255, 255, 0.04);
-        --code-border: rgba(255, 255, 255, 0.08);
-        --table-row-hover: rgba(255, 255, 255, 0.02);
-        --nav-link-color: rgba(255, 255, 255, 0.6);
-        --nav-link-active-bg: rgba(108, 99, 255, 0.12);
-        --nav-link-active-text: #ffffff;
-        --heading-color: #ffffff;
-        --heading-sub-color: rgba(255, 255, 255, 0.9);
-        --title-gradient-end: #a78bfa;
-
-        /* Overrides for EaseMotion variables in dark mode */
-        --ease-color-bg: #0f0e17;
-        --ease-color-surface: #1e1b29;
-        --ease-color-text: #fffffe;
-        --ease-color-muted: rgba(255, 255, 255, 0.65);
-      }
-
-      [data-theme="light"] {
-        /* Light Theme */
-        --page-bg: #f8fafc;
-        --page-text: #0f172a;
-        --page-text-muted: #475569;
-        --header-bg: rgba(248, 250, 252, 0.9);
-        --border-color: rgba(15, 23, 42, 0.08);
-        --card-bg: #ffffff;
-        --sidebar-bg: rgba(15, 23, 42, 0.02);
-        --code-bg: #f1f5f9;
-        --code-border: #e2e8f0;
-        --table-row-hover: rgba(15, 23, 42, 0.02);
-        --nav-link-color: #475569;
-        --nav-link-active-bg: rgba(108, 99, 255, 0.1);
-        --nav-link-active-text: #6c63ff;
-        --heading-color: #0f172a;
-        --heading-sub-color: #1e293b;
-        --title-gradient-end: #4f46e5;
-
-        /* Overrides for EaseMotion variables in light mode */
-        --ease-color-bg: #f8fafc;
-        --ease-color-surface: #ffffff;
-        --ease-color-text: #0f172a;
-        --ease-color-muted: #475569;
-      }
-
-      /* Smooth Transitions for Theme Changes */
-      body,
-      .docs-header,
-      .docs-sidebar,
-      .docs-sidebar a,
-      .docs-content,
-      .docs-h1,
-      .docs-h2,
-      .docs-h3,
-      .docs-p,
-      .docs-code,
-      .docs-code pre,
-      .docs-table,
-      .docs-table th,
-      .docs-table td,
-      .docs-info {
-        transition:
-          background-color var(--ease-speed-medium) var(--ease-ease),
-          background var(--ease-speed-medium) var(--ease-ease),
-          border-color var(--ease-speed-medium) var(--ease-ease),
-          color var(--ease-speed-medium) var(--ease-ease);
-      }
-
-      html {
-        scroll-behavior: smooth;
-      }
-
-      body {
-        background: var(--page-bg);
-        color: var(--page-text);
-        overflow-x: hidden;
-      }
-
-      /* ── Header ───────────────────────────────────────────── */
-      .docs-header {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: var(--docs-header-h);
-        z-index: var(--ease-z-overlay);
-        background: var(--header-bg);
-        backdrop-filter: blur(12px);
-        border-bottom: 1px solid var(--border-color);
-        display: flex;
-        align-items: center;
-        padding: 0 var(--ease-space-6);
-        justify-content: space-between;
-        gap: var(--ease-space-4);
-      }
-
-      .docs-logo {
-        font-size: var(--ease-text-xl);
-        font-weight: 800;
-        background: linear-gradient(135deg, #6c63ff, #a78bfa);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-        letter-spacing: -0.02em;
-        text-decoration: none;
-      }
-
-      .docs-header-links {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--ease-space-5);
-        align-items: center;
-        justify-content: flex-end;
-        list-style: none;
-        padding: 0;
-        margin: 0;
-      }
-
-      .docs-header-links a:not(.ease-btn) {
-        color: var(--nav-link-color);
-        font-size: var(--ease-text-sm);
-        font-weight: 500;
-        text-decoration: none;
-        padding: 10px 20px;
-        border-radius: var(--ease-radius-md);
-        transition:
-          color 0.3s ease,
-          background-color 0.3s ease,
-          transform 0.3s ease,
-          box-shadow 0.3s ease;
-        position: relative;
-      }
-
-      .docs-header-links a:not(.ease-btn):hover,
-      .docs-header-links a:not(.ease-btn).active {
-        color: var(--nav-link-active-text);
-        background: var(--nav-link-active-bg);
-        box-shadow: 0 0 10px rgba(108, 99, 255, 0.2);
-      }
-
-      .docs-header-links a:not(.ease-btn)::after {
-        content: "";
-        position: absolute;
-        bottom: 6px;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 0;
-        height: 2px;
-        background: #6c63ff;
-        transition: width 0.3s ease;
-        border-radius: 2px;
-      }
-
-      .docs-header-links a:not(.ease-btn):hover::after,
-      .docs-header-links a:not(.ease-btn).active::after {
-        width: 60%;
-      }
-
-      [data-theme="light"] .docs-header-links a:not(.ease-btn):hover,
-      [data-theme="light"] .docs-header-links a:not(.ease-btn).active {
-        background: rgba(108, 99, 255, 0.18);
-        color: #4f46e5;
-        box-shadow: 0 0 10px rgba(108, 99, 255, 0.1);
-      }
-
-      .docs-header-links a.ease-btn {
-        color: #ffffff;
-      }
-      /* ── Theme Toggle Button ──────────────────────────────── */
-      .theme-toggle-btn {
-        background: none;
-        border: 1px solid var(--border-color);
-        color: var(--page-text);
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 36px;
-        height: 36px;
-        border-radius: var(--ease-radius-full);
-        transition:
-          background var(--ease-speed-fast) var(--ease-ease),
-          color var(--ease-speed-fast) var(--ease-ease),
-          border-color var(--ease-speed-fast) var(--ease-ease);
-      }
-
-      .theme-toggle-btn:hover {
-        background: rgba(255, 255, 255, 0.08);
-        border-color: var(--ease-color-primary);
-      }
-
-      [data-theme="light"] .theme-toggle-btn:hover {
-        background: rgba(15, 23, 42, 0.08);
-      }
-
-      [data-theme="light"] .theme-toggle-btn .sun-icon {
-        display: none;
-      }
-      [data-theme="light"] .theme-toggle-btn .moon-icon {
-        display: block;
-      }
-      :root:not([data-theme="light"]) .theme-toggle-btn .sun-icon {
-        display: block;
-      }
-      :root:not([data-theme="light"]) .theme-toggle-btn .moon-icon {
-        display: none;
-      }
-
-      /* ── Layout Shell ─────────────────────────────────────── */
-      .docs-shell {
-        display: flex;
-        min-height: 100vh;
-        min-height: 100dvh;
-        padding-top: var(--docs-header-h);
-      }
-
-      /* ── Sidebar ──────────────────────────────────────────── */
-      .docs-sidebar {
-        width: var(--docs-sidebar-w);
-        position: fixed;
-        top: var(--docs-header-h);
-        left: 0;
-        bottom: 0;
-        overflow-y: auto;
-        padding: var(--ease-space-8) var(--ease-space-5);
-        border-right: 1px solid var(--border-color);
-        background: var(--sidebar-bg);
-      }
-
-      .docs-sidebar::-webkit-scrollbar-thumb {
-        background: var(--border-color);
-        border-radius: 4px;
-      }
-
-      .sidebar-group {
-        margin-bottom: var(--ease-space-6);
-      }
-
-      .sidebar-group-label {
-        font-size: var(--ease-text-xs);
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.1em;
-        color: var(--ease-color-primary-light);
-        margin-bottom: var(--ease-space-2);
-        padding: 0 var(--ease-space-2);
-      }
-
-      .sidebar-nav {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-      }
-
-      .sidebar-nav a {
-        display: block;
-        padding: var(--ease-space-2) var(--ease-space-2);
-        font-size: var(--ease-text-sm);
-        color: var(--nav-link-color);
-        border-radius: var(--ease-radius-sm);
-        text-decoration: none;
-        transition:
-          color var(--ease-speed-fast) var(--ease-ease),
-          background var(--ease-speed-fast) var(--ease-ease);
-      }
-
-      .sidebar-nav a.active {
-        color: var(--nav-link-active-text);
-        background: var(--nav-link-active-bg);
-        border-left: 3px solid #6c63ff;
-        box-shadow: inset 20px 0 20px -20px rgba(108, 99, 255, 0.25);
-      }
-
-      /* ── Mobile Toggle Button ─────────────────────────────── */
-      .sidebar-toggle {
-        display: none;
-        background: none;
-        border: none;
-        cursor: pointer;
-        padding: 4px 8px;
-        font-size: 1.4rem;
-        color: var(--page-text);
-        z-index: 200;
-      }
-
-      /* ── Mobile Responsive ────────────────────────────────── */
-      @media (max-width: 768px) {
-        .sidebar-toggle {
-          display: block;
-        }
-
-        .docs-sidebar {
-          transform: translateX(-100%);
-          transition: transform 0.3s ease;
-          z-index: 100;
-          top: var(--docs-header-h);
-          background: var(--page-bg);
-        }
-
-        .docs-sidebar.open {
-          transform: translateX(0);
-        }
-
-        .docs-content {
-          margin-left: 0 !important;
-          padding: var(--ease-space-6);
-          width: 100%;
-        }
-
-        .docs-header-links {
-          display: none;
-        }
-
-        /* Overlay when sidebar open */
-        .sidebar-overlay {
-          display: none;
-          position: fixed;
-          inset: 0;
-          background: rgba(0, 0, 0, 0.5);
-          z-index: 99;
-          top: var(--docs-header-h);
-        }
-
-        .sidebar-overlay.open {
-          display: block;
-        }
-      }
-
-      /* ── Content ──────────────────────────────────────────── */
-      .docs-content {
-        margin-left: var(--docs-sidebar-w);
-        flex: 1;
-        padding: var(--ease-space-12) var(--ease-space-12);
-        max-width: 860px;
-        min-width: 0;
-      }
-
-      /* ── Section headings ─────────────────────────────────── */
-      .docs-section {
-        margin-bottom: var(--ease-space-16);
-        scroll-margin-top: calc(var(--docs-header-h) + var(--ease-space-4));
-      }
-
-      .docs-eyebrow {
-        font-size: var(--ease-text-xs);
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.12em;
-        color: var(--ease-color-primary-light);
-        margin-bottom: var(--ease-space-2);
-      }
-
-      .docs-h1 {
-        font-size: clamp(2rem, 4vw, 3rem);
-        font-weight: 800;
-        letter-spacing: -0.04em;
-        background: linear-gradient(
-          135deg,
-          var(--heading-color),
-          var(--title-gradient-end)
-        );
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-        margin-bottom: var(--ease-space-4);
-      }
-
-      .docs-h2 {
-        font-size: var(--ease-text-2xl);
-        font-weight: 700;
-        color: var(--heading-color);
-        margin-bottom: var(--ease-space-4);
-        padding-bottom: var(--ease-space-3);
-        border-bottom: 1px solid var(--border-color);
-      }
-
-      .docs-h3 {
-        font-size: var(--ease-text-lg);
-        font-weight: 600;
-        color: var(--heading-sub-color);
-        margin-bottom: var(--ease-space-3);
-      }
-
-      .docs-p {
-        color: var(--page-text-muted);
-        line-height: 1.75;
-        margin-bottom: var(--ease-space-4);
-      }
-
-      /* ── Code Block ───────────────────────────────────────── */
-      .docs-code {
-        background: var(--code-bg);
-        border: 1px solid var(--code-border);
-        border-radius: var(--ease-radius-md);
-        padding: var(--ease-space-5);
-        margin-bottom: var(--ease-space-6);
-        overflow-x: auto;
-        position: relative;
-      }
-
-      .docs-code pre {
-        background: none;
-        color: var(--page-text);
-        padding: 0;
-        margin: 0;
-        font-size: var(--ease-text-sm);
-        line-height: 1.7;
-        border-radius: 0;
-        max-width: 100%;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-      }
-
-      .docs-code-lang {
-        position: absolute;
-        top: var(--ease-space-3);
-        right: var(--ease-space-4);
-        font-size: 10px;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: var(--page-text-muted);
-        opacity: 0.5;
-        font-family: var(--ease-font-mono);
-        transition: opacity var(--ease-speed-fast) var(--ease-ease);
-      }
-
-      .docs-content code {
-        background: rgba(108, 99, 255, 0.12);
-        color: var(--ease-color-primary-light);
-        border: 1px solid rgba(108, 99, 255, 0.2);
-        padding: 0.1em 0.45em;
-        border-radius: var(--ease-radius-sm);
-        font-size: 0.87em;
-      }
-
-      .docs-code pre code {
-        background: none;
-        border: none;
-        color: inherit;
-        padding: 0;
-        font-size: inherit;
-      }
-
-      /* ── Table ────────────────────────────────────────────── */
-      .docs-table {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: var(--ease-text-sm);
-        margin-bottom: var(--ease-space-8);
-      }
-
-      .docs-table th {
-        text-align: left;
-        padding: var(--ease-space-3) var(--ease-space-4);
-        background: var(--code-bg);
-        color: var(--page-text-muted);
-        font-weight: 600;
-        font-size: var(--ease-text-xs);
-        text-transform: uppercase;
-        letter-spacing: 0.07em;
-        border-bottom: 1px solid var(--border-color);
-      }
-
-      .docs-table td {
-        padding: var(--ease-space-3) var(--ease-space-4);
-        border-bottom: 1px solid var(--border-color);
-        color: var(--page-text-muted);
-      }
-
-      .docs-table tr:hover td {
-        background: var(--table-row-hover);
-      }
-
-      /* ── Info Box ─────────────────────────────────────────── */
-      .docs-info {
-        background: rgba(108, 99, 255, 0.08);
-        border: 1px solid rgba(108, 99, 255, 0.25);
-        border-radius: var(--ease-radius-md);
-        padding: var(--ease-space-4) var(--ease-space-5);
-        color: var(--page-text-muted);
-        font-size: var(--ease-text-sm);
-        line-height: 1.7;
-        margin-bottom: var(--ease-space-6);
-        display: flex;
-        gap: var(--ease-space-3);
-      }
-
-      .docs-info-icon {
-        font-size: 1.1rem;
-        flex-shrink: 0;
-      }
-
-      /* ── Divider ──────────────────────────────────────────── */
-      .docs-divider {
-        border: none;
-        border-top: 1px solid var(--border-color);
-        margin: var(--ease-space-10) 0;
-      }
-
-      /* ── Copy Button ──────────────────────────────────────── */
-      .docs-copy-btn {
-        position: absolute;
-        top: var(--ease-space-3);
-        right: var(--ease-space-4);
-        background: rgba(255, 255, 255, 0.1);
-        border: 1px solid rgba(255, 255, 255, 0.2);
-        color: rgba(255, 255, 255, 0.7);
-        padding: 4px 8px;
-        border-radius: var(--ease-radius-sm);
-        font-size: 11px;
-        font-family: var(--ease-font-mono, monospace);
-        cursor: pointer;
-        opacity: 0;
-        transition:
-          opacity var(--ease-speed-fast) var(--ease-ease),
-          background var(--ease-speed-fast) var(--ease-ease),
-          color var(--ease-speed-fast) var(--ease-ease);
-        display: flex;
-        align-items: center;
-        gap: 4px;
-      }
-
-      .docs-code:hover .docs-copy-btn {
-        opacity: 1;
-      }
-      .docs-code:hover .docs-code-lang {
-        opacity: 0;
-      }
-      .docs-copy-btn:hover {
-        background: rgba(255, 255, 255, 0.2);
-        color: #fff;
-      }
-
-      @media (hover: none), (pointer: coarse) {
-        .docs-table tr:hover td {
-          background: transparent;
-        }
-        .sidebar-nav a:hover:not(.active) {
-          color: rgba(255, 255, 255, 0.6);
-          background: transparent;
-        }
-      }
-
-      @media (max-width: 900px) {
-        :root {
-          --docs-header-h: 0px;
-        }
-        .docs-header {
-          position: sticky;
-          min-height: 60px;
-          height: auto;
-          flex-wrap: wrap;
-          padding: var(--ease-space-3) var(--ease-space-4);
-        }
-        .docs-header-links {
-          gap: var(--ease-space-2);
-          justify-content: flex-start;
-          width: 100%;
-        }
-        .docs-shell {
-          flex-direction: column;
-          padding-top: 0;
-        }
-        .docs-sidebar {
-          position: static;
-          width: 100%;
-          padding: var(--ease-space-4);
-          border-right: 0;
-          border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-          background: rgba(255, 255, 255, 0.03);
-        }
-        .docs-content {
-          margin-left: 0;
-          max-width: none;
-          width: 100%;
-          padding: var(--ease-space-8) var(--ease-space-4);
-        }
-      }
-
-      .ease-scroll-top {
-        position: fixed;
-        bottom: 2rem;
-        right: 2rem;
-        width: 44px;
-        height: 44px;
-        border-radius: 50%;
-        border: none;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        opacity: 0;
-        pointer-events: none;
-        transform: translateY(12px);
-        transition:
-          opacity var(--ease-speed-medium) var(--ease-ease),
-          transform var(--ease-speed-medium) var(--ease-ease-bounce),
-          box-shadow var(--ease-speed-fast) var(--ease-ease),
-          background var(--ease-speed-fast) var(--ease-ease);
-        z-index: var(--ease-z-overlay);
-      }
-
-      .ease-scroll-top.is-visible {
-        opacity: 1;
-        pointer-events: auto;
-        transform: translateY(0);
-      }
-
-      /* Primary variant */
-      .ease-scroll-top--primary {
-        background: var(--ease-color-primary);
-        color: #fff;
-        box-shadow:
-          0 4px 12px rgba(0, 0, 0, 0.2),
-          0 0 10px rgba(108, 99, 255, 0.25);
-      }
-      .ease-scroll-top--primary:hover {
-        background: var(--ease-color-primary-dark);
-        box-shadow:
-          0 6px 18px rgba(0, 0, 0, 0.25),
-          0 0 14px rgba(108, 99, 255, 0.35);
-
-        transform: translateY(-2px);
-      }
-      .ease-scroll-top--primary:active {
-        transform: scale(0.96);
-      }
-
-      /* Ghost variant */
-      .ease-scroll-top--ghost {
-        background: transparent;
-        color: var(--ease-color-text);
-        border: 1.5px solid rgba(108, 99, 255, 0.35);
-      }
-      .ease-scroll-top--ghost:hover {
-        border-color: var(--ease-color-primary);
-        color: var(--ease-color-primary);
-        box-shadow: 0 4px 16px rgba(108, 99, 255, 0.18);
-        transform: translateY(-3px) scale(1.08);
-      }
-
-      /* Scroll-progress ring */
-      .ease-scroll-top__ring {
-        position: absolute;
-        inset: 0;
-        width: 44px;
-        height: 44px;
-        pointer-events: none;
-      }
-      .ease-scroll-top__ring circle {
-        fill: none;
-        stroke: rgba(255, 255, 255, 0.4);
-        stroke-width: 2.5;
-        stroke-dasharray: 126;
-        stroke-dashoffset: 126;
-        stroke-linecap: round;
-        transform: rotate(-90deg);
-        transform-origin: center;
-        transition: stroke-dashoffset 0.1s linear;
-      }
-
-      /* Animated arrow icon */
-      .ease-scroll-top__icon {
-        width: 18px;
-        height: 18px;
-        transition: transform 0.22s var(--ease-ease-bounce);
-      }
-      .ease-scroll-top:hover .ease-scroll-top__icon {
-        transform: translateY(-3px);
-      }
-
-      /* Focus ring */
-      .ease-scroll-top:focus-visible {
-        box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.45);
-      }
-
-      /* Reduced-motion */
-      @media (prefers-reduced-motion: reduce) {
-        .ease-scroll-top {
-          transition: opacity var(--ease-speed-fast) linear;
-        }
-        .ease-scroll-top__ring circle {
-          transition: none;
-        }
-      }
+      /* ─────────────────────────────────────────────────────────
+         Any extra page-specific overrides can go here.
+         The main layout + mobile fix lives in docs.css
+      ───────────────────────────────────────────────────────── */
     </style>
   </head>
 
   <body>
     <div class="ease-scroll-progress"></div>
+
     <!-- Scroll-to-top button -->
     <button
       class="ease-scroll-top ease-scroll-top--primary"
@@ -750,6 +61,7 @@
       </svg>
     </button>
 
+    <!-- ── Header ───────────────────────────────────────────── -->
     <header class="docs-header">
       <a href="/" class="docs-logo">EaseMotion CSS</a>
 
@@ -819,10 +131,12 @@
       </ul>
     </header>
 
+    <!-- ── Shell ────────────────────────────────────────────── -->
     <div class="docs-shell">
       <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
-      <aside class="docs-sidebar">
+      <!-- ── Sidebar ──────────────────────────────────────── -->
+      <aside class="docs-sidebar" id="docsSidebar">
         <div class="sidebar-group">
           <div class="sidebar-group-label">Introduction</div>
           <ul class="sidebar-nav">
@@ -859,6 +173,7 @@
         </div>
       </aside>
 
+      <!-- ── Main Content ──────────────────────────────────── -->
       <main class="docs-content">
         <section id="getting-started" class="docs-section ease-fade-in">
           <div class="docs-eyebrow">Introduction</div>
@@ -908,7 +223,7 @@
                 <td>Stack modifier classes freely — no specificity wars</td>
               </tr>
               <tr>
-                <td><code>Clean & minimal</code></td>
+                <td><code>Clean &amp; minimal</code></td>
                 <td>No dependencies, no build steps, no JavaScript required</td>
               </tr>
             </tbody>
@@ -1051,23 +366,21 @@
       </main>
     </div>
 
+    <!-- ── Scripts ──────────────────────────────────────────── -->
     <script>
-      // Theme Toggle Logic
+      // ── Theme Toggle ────────────────────────────────────────
       const themeBtn = document.getElementById("theme-toggle");
       themeBtn.addEventListener("click", () => {
-        const currentTheme =
-          document.documentElement.getAttribute("data-theme");
+        const currentTheme = document.documentElement.getAttribute("data-theme");
         const newTheme = currentTheme === "light" ? "dark" : "light";
         document.documentElement.setAttribute("data-theme", newTheme);
       });
 
-      // Smooth scrolling and active state logic
+      // ── Active nav link tracking ─────────────────────────────
       const navLi = document.querySelectorAll(".sidebar-nav a");
       const headerLi = document.querySelectorAll(
         ".docs-header-links a:not(.ease-btn)"
       );
-
-      // Combine all navigation links to find target sections/headings
       const allLinks = [...navLi, ...headerLi];
       const targetMap = new Map();
 
@@ -1075,13 +388,10 @@
         const href = link.getAttribute("href");
         if (href && href.startsWith("#")) {
           const el = document.getElementById(href.slice(1));
-          if (el) {
-            targetMap.set(href.slice(1), el);
-          }
+          if (el) targetMap.set(href.slice(1), el);
         }
       });
 
-      // Helper to get absolute offset top relative to body
       function getPageOffsetTop(element) {
         let top = 0;
         while (element) {
@@ -1095,58 +405,18 @@
       function cacheTargetPositions() {
         targets = [];
         targetMap.forEach((el, id) => {
-          targets.push({
-            id: id,
-            offsetTop: getPageOffsetTop(el),
-          });
+          targets.push({ id, offsetTop: getPageOffsetTop(el) });
         });
-        // Sort by offset top ascending
         targets.sort((a, b) => a.offsetTop - b.offsetTop);
       }
 
-      function updateActiveLink() {
-        const scrollPosition = window.scrollY;
-        const windowHeight = window.innerHeight;
-        const documentHeight = document.documentElement.scrollHeight;
-        const threshold = 160; // offset top threshold
-
-        // 1. Check if scrolled near the bottom of the page
-        if (scrollPosition + windowHeight >= documentHeight - 30) {
-          const lastNavLink = navLi[navLi.length - 1];
-          if (lastNavLink) {
-            const lastId = lastNavLink.getAttribute("href").slice(1);
-            activateId(lastId);
-            return;
-          }
-        }
-
-        // 2. Otherwise, find the current section based on scroll position
-        let activeId = null;
-        for (let i = 0; i < targets.length; i++) {
-          if (scrollPosition >= targets[i].offsetTop - threshold) {
-            activeId = targets[i].id;
-          } else {
-            break;
-          }
-        }
-
-        if (activeId) {
-          activateId(activeId);
-        }
-      }
-
       function activateId(activeId) {
-        // Update sidebar links
         navLi.forEach((link) => {
-          const href = link.getAttribute("href");
-          if (href === `#${activeId}`) {
-            link.classList.add("active");
-          } else {
-            link.classList.remove("active");
-          }
+          link.classList.toggle(
+            "active",
+            link.getAttribute("href") === `#${activeId}`
+          );
         });
-
-        // Update header links
         headerLi.forEach((link) => {
           const href = link.getAttribute("href");
           const isComponentSubItem = [
@@ -1155,62 +425,73 @@
             "scroll-progress",
             "components",
           ].includes(activeId);
-          if (
+          link.classList.toggle(
+            "active",
             href === `#${activeId}` ||
-            (href === "#components" && isComponentSubItem)
-          ) {
-            link.classList.add("active");
-          } else {
-            link.classList.remove("active");
-          }
+              (href === "#components" && isComponentSubItem)
+          );
         });
       }
 
-      // Cache targets and update active links
+      function updateActiveLink() {
+        const scrollPosition = window.scrollY;
+        const windowHeight = window.innerHeight;
+        const documentHeight = document.documentElement.scrollHeight;
+        const threshold = 160;
+
+        if (scrollPosition + windowHeight >= documentHeight - 30) {
+          const lastNavLink = navLi[navLi.length - 1];
+          if (lastNavLink) {
+            activateId(lastNavLink.getAttribute("href").slice(1));
+            return;
+          }
+        }
+
+        let activeId = null;
+        for (let i = 0; i < targets.length; i++) {
+          if (scrollPosition >= targets[i].offsetTop - threshold) {
+            activeId = targets[i].id;
+          } else {
+            break;
+          }
+        }
+        if (activeId) activateId(activeId);
+      }
+
       cacheTargetPositions();
       updateActiveLink();
-
       window.addEventListener("scroll", updateActiveLink, { passive: true });
       window.addEventListener("resize", () => {
         cacheTargetPositions();
         updateActiveLink();
       });
 
-      // Handle clicks for sidebar links (immediate active state transition)
       navLi.forEach((link) => {
         link.addEventListener("click", function () {
           const href = this.getAttribute("href");
-          if (href && href.startsWith("#")) {
-            activateId(href.slice(1));
-          }
+          if (href && href.startsWith("#")) activateId(href.slice(1));
         });
       });
-
-      // Handle clicks for header links
       headerLi.forEach((link) => {
         link.addEventListener("click", function () {
           const href = this.getAttribute("href");
-          if (href && href.startsWith("#")) {
-            activateId(href.slice(1));
-          }
+          if (href && href.startsWith("#")) activateId(href.slice(1));
         });
       });
 
-      // --- MOBILE SIDEBAR TOGGLE SCRIPT ---
+      // ── Mobile Sidebar Toggle ────────────────────────────────
       document.addEventListener("DOMContentLoaded", function () {
         const sidebarToggle = document.getElementById("sidebarToggle");
-        const sidebar = document.querySelector(".docs-sidebar");
+        const sidebar = document.getElementById("docsSidebar");
         const overlay = document.getElementById("sidebarOverlay");
 
         if (sidebarToggle && sidebar) {
-          // Toggle the 'open' class when the hamburger button is clicked
           sidebarToggle.addEventListener("click", function (e) {
             e.stopPropagation();
             sidebar.classList.toggle("open");
             if (overlay) overlay.classList.toggle("open");
           });
 
-          // Close the sidebar when clicking on the dark overlay background
           if (overlay) {
             overlay.addEventListener("click", function () {
               sidebar.classList.remove("open");
@@ -1218,9 +499,7 @@
             });
           }
 
-          // Close the sidebar when a link is clicked on mobile
-          const navLinks = sidebar.querySelectorAll("a");
-          navLinks.forEach((link) => {
+          sidebar.querySelectorAll("a").forEach((link) => {
             link.addEventListener("click", () => {
               if (window.innerWidth <= 768) {
                 sidebar.classList.remove("open");
@@ -1231,26 +510,18 @@
         }
       });
 
+      // ── Scroll-to-top button ─────────────────────────────────
       (() => {
         const btn = document.getElementById("scrollTopBtn");
         if (!btn) return;
-
         const ring = btn.querySelector(".ease-scroll-top__ring circle");
-        const THRESHOLD = 300; // px before button appears
-        const CIRCUMFERENCE = 126; // 2π × r20
+        const THRESHOLD = 300;
+        const CIRCUMFERENCE = 126;
 
         function updateProgress() {
           const scrolled = window.scrollY;
           const total = document.body.scrollHeight - window.innerHeight;
-
-          // Show / hide
-          if (scrolled > THRESHOLD) {
-            btn.classList.add("is-visible");
-          } else {
-            btn.classList.remove("is-visible");
-          }
-
-          // Drive ring: 0% → full circle filled
+          btn.classList.toggle("is-visible", scrolled > THRESHOLD);
           if (ring) {
             const pct = Math.min(scrolled / total, 1);
             ring.style.strokeDashoffset = CIRCUMFERENCE - pct * CIRCUMFERENCE;
@@ -1258,10 +529,9 @@
         }
 
         window.addEventListener("scroll", updateProgress, { passive: true });
-
-        btn.addEventListener("click", () => {
-          window.scrollTo({ top: 0, behavior: "smooth" });
-        });
+        btn.addEventListener("click", () =>
+          window.scrollTo({ top: 0, behavior: "smooth" })
+        );
       })();
     </script>
   </body>


### PR DESCRIPTION
Description:
Summary:
This PR fixes the layout bug where the mobile navigation menu was causing a large, empty vacant space to appear below the navbar on mobile devices.
Changes:
Updated .docs-sidebar and mobile media queries in docs/docs.css to use position: fixed and transform: translateX(-100%) for off-canvas behavior.
Added a sidebar-overlay to improve the UX when the menu is active.
Ensured the sidebar is removed from the document flow when closed to eliminate the vertical gap.
Testing:
Verified in Chrome/Safari mobile emulation at 375px and 768px widths.
Confirmed that content now sits flush below the navbar on mobile.
Related Issue:
Closes #2973 
<img width="281" height="540" alt="Screenshot 2026-06-08 at 6 41 41 PM" src="https://github.com/user-attachments/assets/f5b3ce69-9a69-4ac6-9276-fbe088b93cc8" />
