### PR TITLE
fix(rotate): add missing opacity: 0 to ease-kf-rotate-image-exit exit animation

### DIFF
--- a/easemotion/rotate.css
+++ b/easemotion/rotate.css
@@ -19,6 +19,7 @@
   }
   to {
     transform: rotate(90deg) scale(0.75);
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the `ease-kf-rotate-image-exit` keyframe in `easemotion/rotate.css`, which was missing `opacity: 0` in its `to` block. The `from` block sets `opacity: 1`, so the intent is clearly to fade the element out on exit — but without `opacity: 0` in `to`, the element scales down and rotates yet **stays fully visible**, defeating the purpose of an exit animation.

## What changed

```diff
   to {
     transform: rotate(90deg) scale(0.75);
+    opacity: 0;
   }
```

One line added to `easemotion/rotate.css`.

## Why

- The canonical copy of this keyframe in `core/animations.css` (and the built `easemotion.min.css`) **already** includes `opacity: 0`. Only the modular `easemotion/rotate.css` was out of sync.
- The `easemotion/` directory is published to npm (`files` field in `package.json`), so consumers importing the modular file directly were getting the broken behaviour.
- This now matches the sibling `ease-kf-fade-icon-exit` keyframe in `easemotion/fade.css`, which correctly animates `opacity: 1 → 0` alongside a scale-down.

## Testing
- `npx stylelint easemotion/rotate.css` → passes
- `npm run lint:duplicates` → no new duplicates

Closes #3017