### PR TITLE
feat(examples): add interactive Exit Animation Playground

### DIFF
--- a/submissions/examples/exit-animation-playground/README.md
+++ b/submissions/examples/exit-animation-playground/README.md
@@ -1,0 +1,76 @@
+# Exit Animation Playground
+
+An interactive, self-contained reference that previews EaseMotion's family of
+**exit** micro-interactions side by side. Existing demos each show a single
+exit effect in isolation — this playground brings them together so you can
+compare and replay every effect from one page.
+
+## Preview
+
+Open `demo.html` in any browser. Each card runs an exit animation on load;
+press **Replay all** to trigger them again without reloading.
+
+## Effects included
+
+| Effect | Motion |
+| ------ | ------ |
+| `fade`   | Opacity `1 → 0` |
+| `rotate` | Rotate + scale down + fade (mirrors `ease-rotate-image-exit`) |
+| `slide`  | Translate out horizontally + fade |
+| `scale`  | Shrink to 40% + fade |
+| `shake`  | Quick shake, then fade out |
+| `bounce` | Squash, lift, then drop away + fade |
+
+## Usage
+
+The effects are plain CSS animations driven by a `playing` state class on the
+container. Apply an effect class to any element inside a `.playing` parent:
+
+```html
+<div class="playing">
+  <span class="chip exit-fade">Goodbye</span>
+</div>
+```
+
+To replay, remove the `playing` class, force a reflow, then add it back:
+
+```js
+stage.classList.remove('playing');
+void stage.offsetWidth; // force reflow
+stage.classList.add('playing');
+```
+
+## Files
+
+```
+exit-animation-playground/
+├── demo.html   ← Interactive grid + replay button
+├── style.css   ← Self-contained styles and keyframes
+└── README.md   ← This file
+```
+
+## Accessibility
+
+The demo honours `prefers-reduced-motion: reduce`: when the user opts out of
+motion, the exit animations collapse to a near-instant duration so no movement
+plays. All controls are keyboard-focusable.
+
+## Browser Support
+
+| Browser | Supported |
+| ------- | --------- |
+| Chrome  | ✅ |
+| Firefox | ✅ |
+| Safari  | ✅ |
+| Edge    | ✅ |
+
+## Why it's useful
+
+Exit animations are the least-demoed category in the framework. A consolidated,
+replayable playground makes it easy to pick the right exit effect for a UI
+transition and see exactly how each one behaves.
+
+---
+
+**Closes:** #3026
+**Status:** Ready for review

--- a/submissions/examples/exit-animation-playground/demo.html
+++ b/submissions/examples/exit-animation-playground/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Exit Animation Playground — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="playground-header">
+    <h1>Exit Animation Playground</h1>
+    <p>
+      A single place to preview EaseMotion's family of <strong>exit</strong>
+      micro-interactions. Press <em>Replay all</em> to trigger every animation
+      again.
+    </p>
+    <button type="button" class="replay-btn" data-replay>Replay all</button>
+  </header>
+
+  <main class="grid" data-stage>
+    <figure class="card">
+      <div class="stage">
+        <span class="chip exit-fade">Fade out</span>
+      </div>
+      <figcaption><code>fade</code> — opacity 1 → 0</figcaption>
+    </figure>
+
+    <figure class="card">
+      <div class="stage">
+        <span class="chip exit-rotate">Rotate out</span>
+      </div>
+      <figcaption><code>rotate</code> — rotate + scale + fade</figcaption>
+    </figure>
+
+    <figure class="card">
+      <div class="stage">
+        <span class="chip exit-slide">Slide out</span>
+      </div>
+      <figcaption><code>slide</code> — translate + fade</figcaption>
+    </figure>
+
+    <figure class="card">
+      <div class="stage">
+        <span class="chip exit-scale">Scale out</span>
+      </div>
+      <figcaption><code>scale</code> — shrink + fade</figcaption>
+    </figure>
+
+    <figure class="card">
+      <div class="stage">
+        <span class="chip exit-shake">Shake out</span>
+      </div>
+      <figcaption><code>shake</code> — shake then fade</figcaption>
+    </figure>
+
+    <figure class="card">
+      <div class="stage">
+        <span class="chip exit-bounce">Bounce out</span>
+      </div>
+      <figcaption><code>bounce</code> — squash then drop away</figcaption>
+    </figure>
+  </main>
+
+  <script>
+    // Minimal replay helper: re-trigger CSS animations by briefly removing
+    // the `playing` state and forcing a reflow before adding it back.
+    (function () {
+      var stage = document.querySelector('[data-stage]');
+      var button = document.querySelector('[data-replay]');
+
+      function play() {
+        stage.classList.remove('playing');
+        // Force reflow so the animations restart from the beginning.
+        void stage.offsetWidth;
+        stage.classList.add('playing');
+      }
+
+      button.addEventListener('click', play);
+      play(); // Play once on load.
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/exit-animation-playground/style.css
+++ b/submissions/examples/exit-animation-playground/style.css
@@ -1,0 +1,185 @@
+/* ============================================================
+   Exit Animation Playground — EaseMotion CSS
+   Self-contained demo styles. Each exit effect mirrors the
+   behaviour of EaseMotion's *-exit utilities so the playground
+   works as a standalone reference (no framework import needed).
+   ============================================================ */
+
+:root {
+  --pg-bg: #0f1020;
+  --pg-surface: #1b1d33;
+  --pg-border: #2c2f4f;
+  --pg-text: #e7e8f5;
+  --pg-muted: #9aa0c3;
+  --pg-primary: #6c63ff;
+  --pg-speed: 0.8s;
+  --pg-ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at top, #181a30, var(--pg-bg));
+  color: var(--pg-text);
+  padding: 2.5rem 1.25rem 4rem;
+}
+
+.playground-header {
+  max-width: 720px;
+  margin: 0 auto 2.5rem;
+  text-align: center;
+}
+
+.playground-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+}
+
+.playground-header p {
+  margin: 0 auto 1.5rem;
+  max-width: 52ch;
+  color: var(--pg-muted);
+  line-height: 1.6;
+}
+
+.replay-btn {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: var(--pg-primary);
+  padding: 0.7rem 1.6rem;
+  border-radius: 999px;
+  transition: transform 0.18s var(--pg-ease), box-shadow 0.18s var(--pg-ease);
+  box-shadow: 0 8px 24px rgba(108, 99, 255, 0.35);
+}
+
+.replay-btn:hover,
+.replay-btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(108, 99, 255, 0.45);
+}
+
+.grid {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.card {
+  margin: 0;
+  background: var(--pg-surface);
+  border: 1px solid var(--pg-border);
+  border-radius: 16px;
+  padding: 1.25rem;
+  text-align: center;
+}
+
+.stage {
+  display: grid;
+  place-items: center;
+  min-height: 96px;
+  margin-bottom: 0.85rem;
+}
+
+.chip {
+  display: inline-block;
+  padding: 0.55rem 1.1rem;
+  border-radius: 10px;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(135deg, var(--pg-primary), #9b8cff);
+  white-space: nowrap;
+}
+
+.card figcaption {
+  color: var(--pg-muted);
+  font-size: 0.85rem;
+}
+
+.card code {
+  color: var(--pg-text);
+  background: rgba(108, 99, 255, 0.18);
+  padding: 0.1rem 0.4rem;
+  border-radius: 6px;
+}
+
+/* ── Exit animations (only run while the stage is "playing") ──── */
+.playing .exit-fade {
+  animation: pg-fade var(--pg-speed) var(--pg-ease) both;
+}
+.playing .exit-rotate {
+  animation: pg-rotate var(--pg-speed) var(--pg-ease) both;
+}
+.playing .exit-slide {
+  animation: pg-slide var(--pg-speed) var(--pg-ease) both;
+}
+.playing .exit-scale {
+  animation: pg-scale var(--pg-speed) var(--pg-ease) both;
+}
+.playing .exit-shake {
+  animation: pg-shake var(--pg-speed) var(--pg-ease) both;
+}
+.playing .exit-bounce {
+  animation: pg-bounce var(--pg-speed) var(--pg-ease) both;
+}
+
+@keyframes pg-fade {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+@keyframes pg-rotate {
+  from { transform: rotate(0deg) scale(1); opacity: 1; }
+  to   { transform: rotate(90deg) scale(0.75); opacity: 0; }
+}
+
+@keyframes pg-slide {
+  from { transform: translateX(0); opacity: 1; }
+  to   { transform: translateX(120%); opacity: 0; }
+}
+
+@keyframes pg-scale {
+  from { transform: scale(1); opacity: 1; }
+  to   { transform: scale(0.4); opacity: 0; }
+}
+
+@keyframes pg-shake {
+  0%       { transform: translateX(0); opacity: 1; }
+  20%      { transform: translateX(-8px); }
+  40%      { transform: translateX(8px); }
+  60%      { transform: translateX(-5px); }
+  80%      { transform: translateX(5px); opacity: 1; }
+  100%     { transform: translateX(0); opacity: 0; }
+}
+
+@keyframes pg-bounce {
+  0%   { transform: translateY(0) scale(1); opacity: 1; }
+  30%  { transform: translateY(6px) scaleY(0.85); }
+  60%  { transform: translateY(-18px) scaleY(1.05); opacity: 1; }
+  100% { transform: translateY(60px) scale(0.9); opacity: 0; }
+}
+
+/* ── Accessibility: respect reduced-motion preferences ───────── */
+@media (prefers-reduced-motion: reduce) {
+  .replay-btn {
+    transition: none;
+  }
+  .playing .exit-fade,
+  .playing .exit-rotate,
+  .playing .exit-slide,
+  .playing .exit-scale,
+  .playing .exit-shake,
+  .playing .exit-bounce {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new self-contained example, `submissions/examples/exit-animation-playground/`, that previews EaseMotion's family of **exit** micro-interactions (fade, rotate, slide, scale, shake, bounce) side by side in one replayable grid.

The existing example folders each demonstrate a single exit effect in isolation; this consolidates them into one reference page with a **"Replay all"** button so the animations can be re-triggered without reloading.

## Files

```
submissions/examples/exit-animation-playground/
├── demo.html   ← Interactive grid + replay button
├── style.css   ← Self-contained styles and keyframes
└── README.md   ← Documentation
```

## Notes
- Pure CSS animations; a tiny inline replay helper re-triggers them on demand. No dependencies, no framework import.
- Honours `prefers-reduced-motion: reduce` — animations collapse to near-instant for users who opt out.
- Touches only `submissions/`, per the contribution guidelines.

Closes #3026
<!-- re-trigger label sync -->