### PR TITLE
feat(examples): add animated Scroll Down cue for hero sections

### DIFF
--- a/submissions/examples/scroll-down-cue/README.md
+++ b/submissions/examples/scroll-down-cue/README.md
@@ -1,0 +1,89 @@
+# Scroll Down Cue
+
+A self-contained, animated **"scroll down"** hint for hero sections and
+full-height landing pages. It invites the user to keep scrolling with a subtle
+looping animation.
+
+> This is distinct from `ease-scroll-indicator`, which is a *reading-progress
+> bar* fixed at the top of the page. This example is the bottom-of-hero prompt
+> that nudges the user to scroll **down**.
+
+## Preview
+
+Open `demo.html` in any browser and scroll through the three sections. Each
+hero shows a different cue variant.
+
+## Variants
+
+| Variant | Class | Motion |
+| ------- | ----- | ------ |
+| Mouse   | `scroll-cue--mouse`   | A wheel-dot drifts down inside a mouse outline and fades |
+| Chevron | `scroll-cue--chevron` | A stack of three chevrons bounces downward in sequence |
+
+## Usage
+
+Place the cue at the bottom of a position-relative hero. It is an anchor, so it
+also acts as a "jump to next section" link:
+
+```html
+<section class="hero">
+  <!-- hero content -->
+
+  <a class="scroll-cue scroll-cue--mouse" href="#next-section">
+    <span class="scroll-cue__mouse" aria-hidden="true">
+      <span class="scroll-cue__wheel"></span>
+    </span>
+    <span class="scroll-cue__label">Scroll down</span>
+  </a>
+</section>
+```
+
+Chevron variant:
+
+```html
+<a class="scroll-cue scroll-cue--chevron" href="#next-section">
+  <span class="scroll-cue__chevrons" aria-hidden="true">
+    <span class="scroll-cue__chevron"></span>
+    <span class="scroll-cue__chevron"></span>
+    <span class="scroll-cue__chevron"></span>
+  </span>
+  <span class="scroll-cue__label">Keep scrolling</span>
+</a>
+```
+
+## Files
+
+```
+scroll-down-cue/
+├── demo.html   ← Hero sections showing both cue variants
+├── style.css   ← Self-contained styles and keyframes
+└── README.md   ← This file
+```
+
+## Accessibility
+
+- The decorative shapes are marked `aria-hidden="true"`, while the
+  `scroll-cue__label` provides a real text label for screen readers.
+- The cue is a focusable anchor with a visible focus ring.
+- Honours `prefers-reduced-motion: reduce`: the looping animation is disabled
+  and the cue is shown in a clean static state.
+
+## Browser Support
+
+| Browser | Supported |
+| ------- | --------- |
+| Chrome  | ✅ |
+| Firefox | ✅ |
+| Safari  | ✅ |
+| Edge    | ✅ |
+
+## Why it's useful
+
+The hero scroll-down prompt is one of the most common landing-page patterns and
+was not represented in the examples. This adds it as a lightweight, pure-CSS,
+accessible drop-in with two ready-made styles.
+
+---
+
+**Closes:** #3031
+**Status:** Ready for review

--- a/submissions/examples/scroll-down-cue/demo.html
+++ b/submissions/examples/scroll-down-cue/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Down Cue — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <section class="hero">
+    <div class="hero__content">
+      <h1>EaseMotion</h1>
+      <p>Animation-first CSS. Scroll to explore.</p>
+    </div>
+
+    <!-- Variant 1: animated mouse with a drifting wheel dot -->
+    <a class="scroll-cue scroll-cue--mouse" href="#section-two">
+      <span class="scroll-cue__mouse" aria-hidden="true">
+        <span class="scroll-cue__wheel"></span>
+      </span>
+      <span class="scroll-cue__label">Scroll down</span>
+    </a>
+  </section>
+
+  <section class="hero hero--alt" id="section-two">
+    <div class="hero__content">
+      <h2>Chevron variant</h2>
+      <p>A stack of bouncing chevrons works too.</p>
+    </div>
+
+    <!-- Variant 2: stack of bouncing chevrons -->
+    <a class="scroll-cue scroll-cue--chevron" href="#section-three">
+      <span class="scroll-cue__chevrons" aria-hidden="true">
+        <span class="scroll-cue__chevron"></span>
+        <span class="scroll-cue__chevron"></span>
+        <span class="scroll-cue__chevron"></span>
+      </span>
+      <span class="scroll-cue__label">Keep scrolling</span>
+    </a>
+  </section>
+
+  <section class="hero hero--end" id="section-three">
+    <div class="hero__content">
+      <h2>You reached the end 🎉</h2>
+      <p>That's the scroll-down cue in action.</p>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/scroll-down-cue/style.css
+++ b/submissions/examples/scroll-down-cue/style.css
@@ -1,0 +1,167 @@
+/* ============================================================
+   Scroll Down Cue — EaseMotion CSS
+   A self-contained, animated "scroll down" hint for hero
+   sections. Two variants: an animated mouse with a drifting
+   wheel dot, and a stack of bouncing chevrons.
+   ============================================================ */
+
+:root {
+  --cue-bg-1: #11132a;
+  --cue-bg-2: #1d2046;
+  --cue-text: #eef0ff;
+  --cue-muted: #aab0dd;
+  --cue-accent: #6c63ff;
+  --cue-line: rgba(238, 240, 255, 0.7);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--cue-text);
+}
+
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 2rem;
+  background: radial-gradient(circle at 50% 20%, var(--cue-bg-2), var(--cue-bg-1));
+}
+
+.hero--alt {
+  background: radial-gradient(circle at 50% 80%, #1a2c3f, #0e1622);
+}
+
+.hero--end {
+  background: radial-gradient(circle at 50% 50%, #243018, #11160c);
+}
+
+.hero__content h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2.2rem, 7vw, 4rem);
+  letter-spacing: -0.02em;
+}
+
+.hero__content h2 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.6rem, 5vw, 2.6rem);
+}
+
+.hero__content p {
+  margin: 0;
+  color: var(--cue-muted);
+  font-size: 1.05rem;
+}
+
+/* ── Shared cue layout ────────────────────────────────────── */
+.scroll-cue {
+  position: absolute;
+  bottom: 2.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+  color: var(--cue-text);
+}
+
+.scroll-cue__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--cue-muted);
+}
+
+.scroll-cue:hover .scroll-cue__label,
+.scroll-cue:focus-visible .scroll-cue__label {
+  color: var(--cue-text);
+}
+
+.scroll-cue:focus-visible {
+  outline: 2px solid var(--cue-accent);
+  outline-offset: 6px;
+  border-radius: 8px;
+}
+
+/* ── Variant 1: animated mouse ────────────────────────────── */
+.scroll-cue__mouse {
+  display: block;
+  width: 28px;
+  height: 46px;
+  border: 2px solid var(--cue-line);
+  border-radius: 16px;
+  position: relative;
+}
+
+.scroll-cue__wheel {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  width: 4px;
+  height: 8px;
+  margin-left: -2px;
+  border-radius: 2px;
+  background: var(--cue-line);
+  animation: cue-wheel 1.6s ease-in-out infinite;
+}
+
+@keyframes cue-wheel {
+  0%   { transform: translateY(0); opacity: 1; }
+  60%  { transform: translateY(14px); opacity: 0; }
+  61%  { transform: translateY(0); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+
+/* ── Variant 2: bouncing chevrons ─────────────────────────── */
+.scroll-cue__chevrons {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 34px;
+}
+
+.scroll-cue__chevron {
+  width: 16px;
+  height: 16px;
+  border-right: 2px solid var(--cue-line);
+  border-bottom: 2px solid var(--cue-line);
+  transform: rotate(45deg);
+  margin-top: -8px;
+  animation: cue-chevron 1.5s ease-in-out infinite;
+}
+
+.scroll-cue__chevron:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.scroll-cue__chevron:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes cue-chevron {
+  0%, 100% { opacity: 0.25; transform: rotate(45deg) translate(0, 0); }
+  50%      { opacity: 1;    transform: rotate(45deg) translate(3px, 3px); }
+}
+
+/* ── Accessibility: respect reduced-motion preferences ────── */
+@media (prefers-reduced-motion: reduce) {
+  .scroll-cue__wheel,
+  .scroll-cue__chevron {
+    animation: none;
+  }
+  .scroll-cue__wheel {
+    top: 12px;
+    opacity: 1;
+  }
+  .scroll-cue__chevron {
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new self-contained example, `submissions/examples/scroll-down-cue/`, providing an animated **"scroll down"** hint for hero sections — one of the most common landing-page patterns, and one that wasn't represented in the examples.

This is distinct from the existing `ease-scroll-indicator` (a top-of-page *reading-progress bar*); this is the bottom-of-hero prompt that nudges the user to scroll **down**.

## Variants
- **Mouse** (`scroll-cue--mouse`) — a wheel-dot drifts down inside a mouse outline and fades.
- **Chevron** (`scroll-cue--chevron`) — a stack of three chevrons bounces downward in sequence.

## Files

```
submissions/examples/scroll-down-cue/
├── demo.html   ← Hero sections showing both cue variants
├── style.css   ← Self-contained styles and keyframes
└── README.md   ← Documentation
```

## Notes
- Pure CSS animation, no dependencies, no framework import.
- Accessible: decorative shapes are `aria-hidden`, a real text label is provided for screen readers, the cue is a focusable anchor with a visible focus ring, and it honours `prefers-reduced-motion: reduce`.
- Touches only `submissions/`, per the contribution guidelines.

Closes #3031
<!-- re-trigger label sync -->