### PR TITLE
feat(examples): add animated character-count field

### DIFF
--- a/submissions/examples/char-count-field/README.md
+++ b/submissions/examples/char-count-field/README.md
@@ -1,0 +1,84 @@
+# Character Count Field
+
+A self-contained **textarea with live character-count feedback**. As the user
+types, an animated bar fills, the counter updates, the field turns **amber**
+near the limit, and **shakes + turns red** if the limit is exceeded.
+
+> The repo's other "count" examples (`animated-counter-component`,
+> `count-up-animation`, `ease-countdown-timer-ns`, …) are stat counters and
+> countdown timers. This is the **form-input** character-counter pattern, which
+> wasn't represented.
+
+## Preview
+
+Open `demo.html` in any browser and type into the textarea. The soft limit is
+120 characters (the field allows a little overflow so you can see the
+over-limit state).
+
+## States
+
+| State | Trigger | Visuals |
+| ----- | ------- | ------- |
+| Default  | Under ~85% of the limit | Accent-coloured fill bar |
+| Warning  | Within 15% of the limit | Amber fill + amber counter |
+| Over     | Past the limit | Red field, red bar, shake animation, negative count |
+
+## Usage
+
+```html
+<div class="field" data-charfield data-max="120">
+  <label class="field__label" for="bio">Short bio</label>
+  <textarea id="bio" class="field__input" rows="4"
+            maxlength="160" aria-describedby="bio-count"></textarea>
+
+  <div class="field__meter" aria-hidden="true">
+    <span class="field__meter-fill" data-fill></span>
+  </div>
+
+  <p class="field__count" id="bio-count" aria-live="polite">
+    <span data-remaining>120</span> characters remaining
+  </p>
+</div>
+```
+
+Set the soft limit with `data-max`. The included script keeps the count, the
+fill bar (`transform: scaleX(...)`), and the `is-warning` / `is-over` state
+classes in sync. All colours and motion are handled in `style.css`.
+
+## Files
+
+```
+char-count-field/
+├── demo.html   ← Textarea + counter + inline counting helper
+├── style.css   ← Self-contained styles and keyframes
+└── README.md   ← This file
+```
+
+## Accessibility
+
+- The counter is an `aria-live="polite"` region linked to the textarea via
+  `aria-describedby`, so screen readers announce the remaining count.
+- The over-limit state is conveyed by **text** (a negative number), not colour
+  alone.
+- Honours `prefers-reduced-motion: reduce`: transitions and the shake animation
+  are disabled.
+
+## Browser Support
+
+| Browser | Supported |
+| ------- | --------- |
+| Chrome  | ✅ |
+| Firefox | ✅ |
+| Safari  | ✅ |
+| Edge    | ✅ |
+
+## Why it's useful
+
+Character-limited inputs are one of the most common form patterns, and good
+limit feedback meaningfully improves form UX. This provides a lightweight,
+accessible, drop-in implementation.
+
+---
+
+**Closes:** #3034
+**Status:** Ready for review

--- a/submissions/examples/char-count-field/demo.html
+++ b/submissions/examples/char-count-field/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Character Count Field — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="wrap">
+    <h1>Character Count Field</h1>
+    <p class="intro">
+      A textarea with live limit feedback. The bar fills as you type, turns
+      amber near the limit, and the field shakes and turns red if you go over.
+    </p>
+
+    <div class="field" data-charfield data-max="120">
+      <label class="field__label" for="bio">Short bio</label>
+
+      <textarea
+        id="bio"
+        class="field__input"
+        rows="4"
+        maxlength="160"
+        placeholder="Tell us about yourself…"
+        aria-describedby="bio-count"
+      ></textarea>
+
+      <div class="field__meter" aria-hidden="true">
+        <span class="field__meter-fill" data-fill></span>
+      </div>
+
+      <p class="field__count" id="bio-count" aria-live="polite">
+        <span data-remaining>120</span> characters remaining
+      </p>
+    </div>
+  </main>
+
+  <script>
+    (function () {
+      document.querySelectorAll('[data-charfield]').forEach(function (field) {
+        var max = parseInt(field.dataset.max, 10);
+        var input = field.querySelector('.field__input');
+        var fill = field.querySelector('[data-fill]');
+        var remaining = field.querySelector('[data-remaining]');
+        var count = field.querySelector('.field__count');
+
+        function update() {
+          var used = input.value.length;
+          var left = max - used;
+          var ratio = Math.min(used / max, 1);
+
+          fill.style.transform = 'scaleX(' + ratio + ')';
+          remaining.textContent = left;
+          count.firstChild && (count.lastChild.textContent =
+            Math.abs(left) === 1 ? ' character remaining' : ' characters remaining');
+
+          field.classList.toggle('is-warning', left <= max * 0.15 && left >= 0);
+          field.classList.toggle('is-over', left < 0);
+
+          // Re-trigger the shake each time the user types while over the limit.
+          if (left < 0) {
+            field.classList.remove('shake');
+            void field.offsetWidth;
+            field.classList.add('shake');
+          }
+        }
+
+        input.addEventListener('input', update);
+        update();
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/char-count-field/style.css
+++ b/submissions/examples/char-count-field/style.css
@@ -1,0 +1,172 @@
+/* ============================================================
+   Character Count Field — EaseMotion CSS
+   A self-contained textarea with a live character counter and
+   animated limit feedback (fill bar, warning colour, and an
+   over-limit shake). Counting is done by a tiny inline script;
+   all motion and state styling lives here.
+   ============================================================ */
+
+:root {
+  --cc-bg: #0f1124;
+  --cc-surface: #1a1d38;
+  --cc-border: #2d3160;
+  --cc-text: #e9ebff;
+  --cc-muted: #a2a8d4;
+  --cc-accent: #6c63ff;
+  --cc-warning: #f0a020;
+  --cc-danger: #ff5470;
+  --cc-radius: 12px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at top, #181b35, var(--cc-bg));
+  color: var(--cc-text);
+}
+
+.wrap {
+  width: 100%;
+  max-width: 480px;
+}
+
+.wrap h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2rem);
+}
+
+.intro {
+  margin: 0 0 1.75rem;
+  color: var(--cc-muted);
+  line-height: 1.6;
+}
+
+/* ── Field ────────────────────────────────────────────────── */
+.field {
+  background: var(--cc-surface);
+  border: 1px solid var(--cc-border);
+  border-radius: var(--cc-radius);
+  padding: 1.1rem 1.1rem 0.9rem;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.field__label {
+  display: block;
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 0.55rem;
+}
+
+.field__input {
+  width: 100%;
+  resize: vertical;
+  font: inherit;
+  color: var(--cc-text);
+  background: #12152e;
+  border: 1px solid var(--cc-border);
+  border-radius: 8px;
+  padding: 0.7rem 0.8rem;
+  outline: none;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.field__input:focus-visible {
+  border-color: var(--cc-accent);
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.25);
+}
+
+/* ── Meter ────────────────────────────────────────────────── */
+.field__meter {
+  height: 4px;
+  margin: 0.7rem 0 0.5rem;
+  background: var(--cc-border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.field__meter-fill {
+  display: block;
+  height: 100%;
+  width: 100%;
+  transform: scaleX(0);
+  transform-origin: left center;
+  border-radius: 999px;
+  background: var(--cc-accent);
+  transition: transform 0.2s ease, background-color 0.25s ease;
+}
+
+/* ── Count text ───────────────────────────────────────────── */
+.field__count {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--cc-muted);
+  transition: color 0.25s ease;
+}
+
+.field__count [data-remaining] {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--cc-text);
+}
+
+/* ── Warning state (near the limit) ───────────────────────── */
+.field.is-warning .field__meter-fill {
+  background: var(--cc-warning);
+}
+
+.field.is-warning .field__count,
+.field.is-warning .field__count [data-remaining] {
+  color: var(--cc-warning);
+}
+
+/* ── Over-limit state ─────────────────────────────────────── */
+.field.is-over {
+  border-color: var(--cc-danger);
+  box-shadow: 0 0 0 3px rgba(255, 84, 112, 0.18);
+}
+
+.field.is-over .field__input {
+  border-color: var(--cc-danger);
+}
+
+.field.is-over .field__meter-fill {
+  background: var(--cc-danger);
+}
+
+.field.is-over .field__count,
+.field.is-over .field__count [data-remaining] {
+  color: var(--cc-danger);
+}
+
+.field.shake {
+  animation: cc-shake 0.4s ease;
+}
+
+@keyframes cc-shake {
+  0%, 100% { transform: translateX(0); }
+  20%      { transform: translateX(-6px); }
+  40%      { transform: translateX(6px); }
+  60%      { transform: translateX(-4px); }
+  80%      { transform: translateX(4px); }
+}
+
+/* ── Accessibility: respect reduced-motion preferences ────── */
+@media (prefers-reduced-motion: reduce) {
+  .field,
+  .field__input,
+  .field__meter-fill,
+  .field__count {
+    transition: none;
+  }
+  .field.shake {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new self-contained example, `submissions/examples/char-count-field/`: a textarea with **live character-count feedback**. As the user types, an animated bar fills, the counter updates, the field turns amber near the limit, and shakes + turns red when the limit is exceeded.

The repo's existing "count" examples are stat counters / countdown timers — this fills the missing **form-input character-counter** pattern.

## States
- **Default** — accent fill bar.
- **Warning** (within 15% of the limit) — amber bar + counter.
- **Over** — red field, red bar, shake animation, negative count.

## Files

```
submissions/examples/char-count-field/
├── demo.html   ← Textarea + counter + inline counting helper
├── style.css   ← Self-contained styles and keyframes
└── README.md   ← Documentation
```

## Notes
- All motion/colour is pure CSS driven by state classes; only a small counting helper is JS.
- Accessible: the counter is an `aria-live="polite"` region linked via `aria-describedby`; the over-limit state is conveyed by text (negative number), not colour alone; honours `prefers-reduced-motion: reduce`.
- Touches only `submissions/`, per the contribution guidelines.

Closes #3034