### PR TITLE
feat: add scroll-triggered animation submission

### DIFF
--- a/submissions/examples/scroll-triggered/README.md
+++ b/submissions/examples/scroll-triggered/README.md
@@ -1,0 +1,27 @@
+# Scroll-Triggered Animations
+
+Entrance animations that fire only when an element scrolls into the viewport.
+
+## Classes
+
+| Class | Effect |
+
+| `scroll-fade-in` | Fades in on scroll |
+| `scroll-slide-up` | Slides up on scroll |
+| `scroll-zoom-in` | Zooms in on scroll |
+| `scroll-slide-left` | Slides from left on   scroll |
+| `scroll-slide-right` | Slides from right on scroll |
+
+## Usage
+
+```html
+<div class="scroll-fade-in">Fades in</div>
+<div class="scroll-slide-up delay-100">Slides up</div>
+```
+
+Add the companion JS snippet from `demo.html` to your page.
+
+## Notes
+- Uses IntersectionObserver — no dependencies
+- Animates once per element, does not repeat
+- Composable with delay classes: `delay-100`, `delay-200`, `delay-300`

--- a/submissions/examples/scroll-triggered/demo.html
+++ b/submissions/examples/scroll-triggered/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Scroll-Triggered Animations Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <section class="hero">
+    <h1>Scroll down to see animations</h1>
+    <p>Elements animate only when they enter the viewport</p>
+  </section>
+
+  <section class="demo-section">
+    <div class="box scroll-fade-in">Fade In</div>
+    <div class="box scroll-slide-up delay-100">Slide Up</div>
+    <div class="box scroll-slide-up delay-200">Slide Up + Delay</div>
+    <div class="box scroll-zoom-in delay-300">Zoom In</div>
+    <div class="box scroll-slide-left delay-100">Slide From Left</div>
+    <div class="box scroll-slide-right delay-200">Slide From Right</div>
+  </section>
+
+  <script>
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(e => {
+        if (e.isIntersecting) {
+          e.target.classList.add('visible');
+          observer.unobserve(e.target);
+        }
+      });
+    }, { threshold: 0.15 });
+
+    document.querySelectorAll('.scroll-fade-in, .scroll-slide-up, .scroll-zoom-in, .scroll-slide-left, .scroll-slide-right')
+      .forEach(el => observer.observe(el));
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/scroll-triggered/style.css
+++ b/submissions/examples/scroll-triggered/style.css
@@ -1,0 +1,74 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: sans-serif;
+  background: #0f0f0f;
+  color: #fff;
+}
+
+.hero {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 12px;
+}
+
+.hero h1 { font-size: 2rem; }
+.hero p  { color: #aaa; }
+
+.demo-section {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 80px 20px;
+}
+
+.box {
+  width: 300px;
+  padding: 24px;
+  background: #1e1e2e;
+  border-radius: 12px;
+  text-align: center;
+  font-size: 1.1rem;
+  border: 1px solid #333;
+}
+
+/* Initial hidden states */
+.scroll-fade-in,
+.scroll-slide-up,
+.scroll-zoom-in,
+.scroll-slide-left,
+.scroll-slide-right {
+  opacity: 0;
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.scroll-slide-up    { transform: translateY(40px); }
+.scroll-zoom-in     { transform: scale(0.85); }
+.scroll-slide-left  { transform: translateX(-50px); }
+.scroll-slide-right { transform: translateX(50px); }
+
+/* Visible state */
+.scroll-fade-in.visible,
+.scroll-slide-up.visible,
+.scroll-zoom-in.visible,
+.scroll-slide-left.visible,
+.scroll-slide-right.visible {
+  opacity: 1;
+  transform: none;
+}
+
+/* Delays */
+.delay-100 { transition-delay: 100ms; }
+.delay-200 { transition-delay: 200ms; }
+.delay-300 { transition-delay: 300ms; }


### PR DESCRIPTION
## Pull Request Description

Adds scroll-triggered entrance animations that fire only when elements enter the viewport, using a lightweight IntersectionObserver utility.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/scroll-triggered//`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Scroll-triggered entrance animations using IntersectionObserver — elements animate in only when they scroll into view.
**How does a developer use it?**

```html
<div class="scroll ease-fade-in">Fades in on scroll</div>
<div class="scroll ease-slide-up delay-2">Slides up with delay</div>
<div class="scroll ease-zoom-in" data-ease-once="false">Replays on re-enter</div>

<script src="script.js"></script>

**Why does it fit EaseMotion CSS?**

Follows the human-readable, animation-first philosophy — just add class="scroll ease-fade-in" and it works. Zero config, no build step, composable with existing ease-* classes and delay utilities. Respects prefers-reduced-motion.
---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission includes a companion script.js (~600B gzipped) that auto-observes all .scroll elements. Supports data-ease-threshold and data-ease-once attributes for per-element control. Feel free to adjust timing or naming conventions during integration. I noticed a similar scroll-trigger submission already exists — leaving it to your discretion to decide which approach fits better.
---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
