### PR TITLE
feat(examples): add pure-CSS expanding search bar example

### DIFF
--- a/submissions/examples/expanding-search-bar/README.md
+++ b/submissions/examples/expanding-search-bar/README.md
@@ -1,0 +1,86 @@
+# Expanding Search Bar
+
+A self-contained, **pure-CSS** navbar search control that starts as a circular
+icon and smoothly expands into a full text input when focused — then collapses
+back to an icon when it loses focus and is empty. A common space-saving pattern
+for headers and toolbars.
+
+> This is different from `ease-search-bar-az`, which is a static, always-visible
+> search bar. This example is the **expand-on-focus** interaction.
+
+## Preview
+
+Open `demo.html`. Click the magnifier (or press <kbd>Tab</kbd> to it) and the
+field expands. Click away while it is empty and it collapses again. Type
+something and it stays open.
+
+## How it works
+
+No JavaScript. The expand/collapse is driven entirely by CSS:
+
+- `:focus-within` on the search container expands the input while it (or the
+  icon) is focused.
+- `:not(:placeholder-shown)` keeps it expanded when there is typed text.
+
+```css
+.search:focus-within .search__input,
+.search__input:not(:placeholder-shown) {
+  width: var(--sb-input-width);
+  opacity: 1;
+}
+```
+
+## Usage
+
+```html
+<form class="search" role="search">
+  <label class="search__icon" for="navsearch" aria-label="Search">
+    <!-- magnifier SVG -->
+  </label>
+  <input id="navsearch" class="search__input" type="search"
+         name="q" placeholder="Search docs…" />
+</form>
+```
+
+Adjust the expanded width with the `--sb-input-width` custom property.
+
+## Files
+
+```
+expanding-search-bar/
+├── demo.html   ← Mock navbar with the expanding search
+├── style.css   ← Self-contained styles and transitions
+└── README.md   ← This file
+```
+
+## Accessibility
+
+- The input has a real, programmatic label via the `<label for="navsearch">`
+  icon (`aria-label="Search"`), so it is announced to screen readers.
+- Fully keyboard-operable — tabbing to the icon/input expands the field; no
+  pointer required.
+- Honours `prefers-reduced-motion: reduce`: the width animation is removed and
+  the field is shown already expanded, so it stays usable without motion.
+
+## Browser Support
+
+| Browser | Supported |
+| ------- | --------- |
+| Chrome  | ✅ |
+| Firefox | ✅ |
+| Safari  | ✅ |
+| Edge    | ✅ |
+
+> Note: the "stay open when text is present" behaviour uses `:has()`, supported
+> in all current evergreen browsers. The core focus-to-expand works everywhere
+> via `:focus-within`.
+
+## Why it's useful
+
+The expanding search is one of the most common navbar space-savers. This
+provides it as a lightweight, accessible, zero-JavaScript drop-in.
+
+---
+
+**Closes:** #3117
+**Status:** Ready for review

--- a/submissions/examples/expanding-search-bar/demo.html
+++ b/submissions/examples/expanding-search-bar/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Expanding Search Bar — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="navbar">
+    <span class="navbar__brand">EaseMotion</span>
+
+    <nav class="navbar__nav">
+      <a href="#" class="navbar__link">Docs</a>
+      <a href="#" class="navbar__link">Examples</a>
+
+      <!-- Pure-CSS expanding search: focus the input (via label/icon or Tab)
+           and :focus-within expands the field. No JavaScript. -->
+      <form class="search" role="search" action="#" method="get">
+        <label class="search__icon" for="navsearch" aria-label="Search">
+          <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+            <circle cx="11" cy="11" r="7" fill="none" stroke="currentColor" stroke-width="2" />
+            <line x1="16.5" y1="16.5" x2="21" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+          </svg>
+        </label>
+        <input
+          id="navsearch"
+          class="search__input"
+          type="search"
+          name="q"
+          placeholder="Search docs…"
+        />
+      </form>
+    </nav>
+  </header>
+
+  <main class="hint">
+    <p>Click the magnifier (or press <kbd>Tab</kbd> to it) — the field expands.</p>
+    <p>Click away while it's empty and it collapses back to an icon.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/expanding-search-bar/style.css
+++ b/submissions/examples/expanding-search-bar/style.css
@@ -1,0 +1,167 @@
+/* ============================================================
+   Expanding Search Bar — EaseMotion CSS
+   A self-contained navbar search that starts as a circular icon
+   and expands into a full input on focus. Pure CSS — the
+   expand/collapse is driven by :focus-within and
+   :not(:placeholder-shown). No JavaScript.
+   ============================================================ */
+
+:root {
+  --sb-bg: #0f1124;
+  --sb-surface: #1b1e3a;
+  --sb-border: #2e3263;
+  --sb-text: #eaecff;
+  --sb-muted: #a3a9d6;
+  --sb-accent: #6c63ff;
+  --sb-input-width: 220px;
+  --sb-speed: 0.32s;
+  --sb-ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at top, #181b35, var(--sb-bg));
+  color: var(--sb-text);
+}
+
+/* ── Navbar ───────────────────────────────────────────────── */
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: rgba(20, 23, 48, 0.85);
+  border-bottom: 1px solid var(--sb-border);
+}
+
+.navbar__brand {
+  font-weight: 700;
+  font-size: 1.15rem;
+}
+
+.navbar__nav {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.navbar__link {
+  color: var(--sb-muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: color 0.2s var(--sb-ease);
+}
+
+.navbar__link:hover,
+.navbar__link:focus-visible {
+  color: var(--sb-text);
+}
+
+/* ── Search control ───────────────────────────────────────── */
+.search {
+  display: flex;
+  align-items: center;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid transparent;
+  transition: background-color var(--sb-speed) var(--sb-ease),
+              border-color var(--sb-speed) var(--sb-ease);
+}
+
+.search__icon {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  flex: none;
+  border-radius: 50%;
+  color: var(--sb-text);
+  cursor: pointer;
+  transition: background-color 0.2s var(--sb-ease), color 0.2s var(--sb-ease);
+}
+
+.search__icon:hover {
+  background: rgba(108, 99, 255, 0.18);
+}
+
+.search__input {
+  width: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--sb-text);
+  font: inherit;
+  font-size: 0.95rem;
+  opacity: 0;
+  transition: width var(--sb-speed) var(--sb-ease),
+              padding var(--sb-speed) var(--sb-ease),
+              opacity var(--sb-speed) var(--sb-ease);
+}
+
+.search__input::placeholder {
+  color: var(--sb-muted);
+}
+
+/* Expanded state: focused, OR has text typed in it (so it stays open). */
+.search:focus-within,
+.search:has(.search__input:not(:placeholder-shown)) {
+  background: var(--sb-surface);
+  border-color: var(--sb-border);
+}
+
+.search:focus-within .search__input,
+.search__input:not(:placeholder-shown) {
+  width: var(--sb-input-width);
+  padding: 0 0.75rem 0 0.25rem;
+  opacity: 1;
+}
+
+.search:focus-within .search__icon {
+  color: var(--sb-accent);
+}
+
+/* ── Hint text ────────────────────────────────────────────── */
+.hint {
+  max-width: 460px;
+  margin: 4rem auto;
+  text-align: center;
+  color: var(--sb-muted);
+  line-height: 1.7;
+}
+
+.hint kbd {
+  background: var(--sb-surface);
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.85em;
+  color: var(--sb-text);
+}
+
+/* ── Accessibility: respect reduced-motion preferences ────── */
+@media (prefers-reduced-motion: reduce) {
+  .search,
+  .search__input,
+  .search__icon,
+  .navbar__link {
+    transition: none;
+  }
+  /* Keep the field usable without animating: show it expanded. */
+  .search__input {
+    width: var(--sb-input-width);
+    padding: 0 0.75rem 0 0.25rem;
+    opacity: 1;
+  }
+  .search {
+    background: var(--sb-surface);
+    border-color: var(--sb-border);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a fully functional expanding search bar example under `submissions/examples/expanding-search-bar/`.

When the user clicks or focuses on the search input, it smoothly expands from a compact icon to a full search bar using pure CSS transitions — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo HTML with a sample navbar layout |
| `style.css` | Pure CSS expanding search bar using `:focus-within`, `:not(:placeholder-shown)`, and `:has()` selectors |
| `README.md` | Documentation with usage instructions, accessibility notes, and comparison to related examples |

## Related Issue
Closes #3117
<!-- re-trigger label sync -->