### PR TITLE
feat(examples): add custom list markers demo using ::marker pseudo-element

### DIFF
--- a/submissions/examples/custom-list-markers/README.md
+++ b/submissions/examples/custom-list-markers/README.md
@@ -1,0 +1,49 @@
+# Custom List Markers
+
+## What does it do?
+A pure-CSS demo showing how to style list markers using the `::marker` pseudo-element and `list-style-type` string values. No JavaScript required.
+
+## Features
+- **Color & Size Variants** — change marker color, font-weight, and font-size
+- **Custom Symbol Markers** — replace default bullets with unicode symbols using `list-style-type: "\2605"`
+- **Numbered List Styling** — style ordered list counters with `::marker`
+- **Hover Feedback** — background highlight on list items while retaining marker styling
+- **Details Disclosure Markers** — style the `::marker` on `<summary>` elements inside `<details>`
+- **Reduced Motion** — respects `prefers-reduced-motion`
+
+## Usage
+```html
+<ul>
+  <li class="marker-star">Star marker</li>
+</ul>
+```
+
+```css
+.marker-star {
+  list-style-type: "\2605";
+}
+.marker-star::marker {
+  color: #f59e0b;
+  font-size: 1.2em;
+}
+```
+
+## CSS Variables
+None — all styles are defined directly via classes.
+
+## Classes
+- `.marker-colors`, `.marker-red`, `.marker-blue`, `.marker-green`, `.marker-gold`, `.marker-large` — color/size variants
+- `.marker-symbols`, `.marker-star`, `.marker-heart`, `.marker-arrow`, `.marker-check`, `.marker-fire` — custom symbol markers
+- `.marker-numbered` — ordered list with styled numbers
+- `.marker-hover` — list with hover background effects
+- `.custom-details` — disclosure widget with styled summary marker
+
+## Browser Support
+- `::marker` — Chrome 86+, Firefox 68+, Safari 11.1+
+- `list-style-type` string values — Chrome 86+, Firefox 39+, Safari 11.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/custom-list-markers/demo.html
+++ b/submissions/examples/custom-list-markers/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Custom List Markers — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: sans-serif; max-width: 800px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Custom List Markers</h1>
+  <p>Styling HTML list markers with the <code>::marker</code> pseudo-element — no JavaScript required.</p>
+
+  <section>
+    <h2>Color &amp; Size Variants</h2>
+    <ul class="marker-colors">
+      <li class="marker-red">Red marker</li>
+      <li class="marker-blue">Blue marker</li>
+      <li class="marker-green">Green marker</li>
+      <li class="marker-gold">Gold marker</li>
+      <li class="marker-large">Large marker</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Custom Symbol Markers</h2>
+    <ul class="marker-symbols">
+      <li class="marker-star">Star marker</li>
+      <li class="marker-heart">Heart marker</li>
+      <li class="marker-arrow">Arrow marker</li>
+      <li class="marker-check">Check marker</li>
+      <li class="marker-fire">Fire marker</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Numbered List with Custom Style</h2>
+    <ol class="marker-numbered">
+      <li>First item with styled number</li>
+      <li>Second item with styled number</li>
+      <li>Third item with styled number</li>
+      <li>Fourth item with styled number</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Hover Effect with Markers</h2>
+    <ul class="marker-hover">
+      <li>Hover over this item</li>
+      <li>Background highlight with marker</li>
+      <li>Shows how markers work with hover</li>
+      <li>Pure CSS interaction feedback</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Details Disclosure Marker</h2>
+    <details class="custom-details">
+      <summary>Click to expand — summary marker styled</summary>
+      <p>The <code>::marker</code> pseudo-element also works on the <code>&lt;summary&gt;</code> element inside a <code>&lt;details&gt;</code> disclosure widget. The disclosure triangle arrow is a marker that can be styled.</p>
+    </details>
+    <details class="custom-details">
+      <summary>Another styled disclosure</summary>
+      <p>Each details element gets the same custom marker styling via the class.</p>
+    </details>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/custom-list-markers/style.css
+++ b/submissions/examples/custom-list-markers/style.css
@@ -1,0 +1,212 @@
+/* ============================================================
+   EaseMotion CSS — Custom List Markers
+   Styling list markers with the ::marker pseudo-element
+   ============================================================ */
+
+/* ---- Color & Size Variants ---- */
+
+.marker-colors {
+  padding-left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.marker-red {
+  list-style-type: disc;
+}
+
+.marker-red::marker {
+  color: #ef4444;
+  font-weight: 700;
+}
+
+.marker-blue {
+  list-style-type: disc;
+}
+
+.marker-blue::marker {
+  color: #3b82f6;
+  font-weight: 700;
+}
+
+.marker-green {
+  list-style-type: disc;
+}
+
+.marker-green::marker {
+  color: #22c55e;
+  font-weight: 700;
+}
+
+.marker-gold {
+  list-style-type: disc;
+}
+
+.marker-gold::marker {
+  color: #f59e0b;
+  font-weight: 700;
+}
+
+.marker-large::marker {
+  color: #a78bfa;
+  font-size: 1.5em;
+  font-weight: 700;
+}
+
+.marker-colors li {
+  padding: 0.375rem 0.75rem;
+  background: #252525;
+  border-radius: 6px;
+  transition: background 0.2s ease;
+}
+
+.marker-colors li:hover {
+  background: #2a2a2a;
+}
+
+/* ---- Custom Symbol Markers ---- */
+
+.marker-symbols {
+  padding-left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.marker-star {
+  list-style-type: "\2605";
+}
+
+.marker-star::marker {
+  color: #f59e0b;
+  font-size: 1.2em;
+}
+
+.marker-heart {
+  list-style-type: "\2665";
+}
+
+.marker-heart::marker {
+  color: #ef4444;
+  font-size: 1.2em;
+}
+
+.marker-arrow {
+  list-style-type: "\27A4";
+}
+
+.marker-arrow::marker {
+  color: #3b82f6;
+  font-size: 1.1em;
+}
+
+.marker-check {
+  list-style-type: "\2713";
+}
+
+.marker-check::marker {
+  color: #22c55e;
+  font-weight: 700;
+  font-size: 1.2em;
+}
+
+.marker-fire {
+  list-style-type: "\1F525";
+}
+
+.marker-fire::marker {
+  font-size: 1.1em;
+}
+
+.marker-symbols li {
+  padding: 0.375rem 0;
+}
+
+/* ---- Numbered List with Custom Style ---- */
+
+.marker-numbered {
+  padding-left: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.marker-numbered li {
+  padding: 0.375rem 0.75rem;
+  background: #252525;
+  border-radius: 6px;
+  transition: background 0.2s ease;
+}
+
+.marker-numbered li:hover {
+  background: #2a2a2a;
+}
+
+.marker-numbered li::marker {
+  color: #6366f1;
+  font-weight: 700;
+  font-size: 1.1em;
+}
+
+/* ---- Hover Animated Markers ---- */
+
+.marker-hover {
+  padding-left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.marker-hover li {
+  padding: 0.375rem 0.75rem;
+  background: #252525;
+  border-radius: 6px;
+  transition: background 0.2s ease;
+  cursor: default;
+}
+
+.marker-hover li:hover {
+  background: #2d2d2d;
+}
+
+/* ---- Details Disclosure Marker ---- */
+
+.custom-details {
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.custom-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: #e5e7eb;
+  user-select: none;
+}
+
+.custom-details summary::marker {
+  color: #6366f1;
+  font-size: 1.2em;
+  transition: color 0.2s ease;
+}
+
+.custom-details summary:hover::marker {
+  color: #8b5cf6;
+}
+
+.custom-details p {
+  margin: 0.75rem 0 0;
+  color: #9ca3af;
+  line-height: 1.6;
+}
+
+/* ---- Reduced Motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .marker-hover li {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating how to style HTML list markers using the `::marker` pseudo-element and `list-style-type` string values — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo with 5 sections showing different marker techniques |
| `style.css` | Pure CSS styling of `::marker` with color, size, custom symbols, hover effects, and details disclosure |
| `README.md` | Documentation with usage, browser support, and class reference |

## Sections in Demo
1. **Color \& Size Variants** — colored and enlarged markers
2. **Custom Symbol Markers** — unicode/emoji markers via `list-style-type` string values
3. **Numbered List with Custom Style** — styled ordered list counters
4. **Hover Effect with Markers** — background highlight interaction
5. **Details Disclosure Marker** — `::marker` on `<summary>` elements

## Related Issue
Closes #3121
<!-- re-trigger label sync -->