### PR TITLE
feat(examples): add form accent-color and caret-color styling demo

### DIFF
--- a/submissions/examples/form-accent-color/README.md
+++ b/submissions/examples/form-accent-color/README.md
@@ -1,0 +1,46 @@
+# Form Accent Colors
+
+## What does it do?
+A pure-CSS demo showing how to customize the appearance of native HTML form controls using `accent-color`, `caret-color`, `color-scheme`, and `::file-selector-button`.
+
+## Features
+- **Accent Color** — apply to checkboxes, radio buttons, range sliders, and progress bars
+- **Caret Color** — customize the text input blinking cursor color
+- **Color Scheme** — switch between `light` and `dark` native form control appearance
+- **File Selector Button** — style the file upload button with `::file-selector-button`
+
+## Usage
+```html
+<input type="checkbox" class="accent-purple">
+<input type="text" class="caret-teal" placeholder="Teal cursor">
+<div class="scheme-dark">...</div>
+<input type="file" class="custom-file">
+```
+
+```css
+.accent-purple { accent-color: #8b5cf6; }
+.caret-teal    { caret-color: #14b8a6; }
+.scheme-dark   { color-scheme: dark; }
+.custom-file::file-selector-button { background: #6366f1; }
+```
+
+## CSS Variables
+None — all styles use built-in CSS properties directly.
+
+## Classes
+- `.accent-purple`, `.accent-teal`, `.accent-pink`, `.accent-orange` — accent-color variants
+- `.caret-purple`, `.caret-teal`, `.caret-pink` — caret-color variants
+- `.scheme-light`, `.scheme-dark` — color-scheme containers
+- `.custom-file` — styled file input
+
+## Browser Support
+- `accent-color` — Chrome 93+, Firefox 92+, Safari 15.4+
+- `caret-color` — Chrome 57+, Firefox 53+, Safari 11.1+
+- `color-scheme` — Chrome 81+, Firefox 96+, Safari 13+
+- `::file-selector-button` — Chrome 89+, Firefox 82+, Safari 14.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/form-accent-color/demo.html
+++ b/submissions/examples/form-accent-color/demo.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Form Accent Colors — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 1rem; }
+    label { display: flex; align-items: center; gap: 0.5rem; cursor: pointer; }
+    label + label { margin-top: 0.5rem; }
+    .row { display: flex; gap: 2rem; flex-wrap: wrap; }
+    .col { display: flex; flex-direction: column; gap: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Form Accent Colors</h1>
+  <p class="subtitle">Customizing native form controls with <code>accent-color</code>, <code>caret-color</code>, and <code>color-scheme</code>.</p>
+
+  <section>
+    <h2>Accent Color — Checkboxes &amp; Radios</h2>
+    <div class="row">
+      <div class="col">
+        <label><input type="checkbox" class="accent-purple" checked> Purple theme</label>
+        <label><input type="checkbox" class="accent-teal" checked> Teal theme</label>
+        <label><input type="checkbox" class="accent-pink" checked> Pink theme</label>
+        <label><input type="checkbox" class="accent-orange"> Orange theme</label>
+      </div>
+      <div class="col">
+        <label><input type="radio" name="r1" class="accent-purple" checked> Option A</label>
+        <label><input type="radio" name="r1" class="accent-purple"> Option B</label>
+        <label><input type="radio" name="r2" class="accent-teal" checked> Choice X</label>
+        <label><input type="radio" name="r2" class="accent-teal"> Choice Y</label>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Accent Color — Range &amp; Progress</h2>
+    <div style="display:flex;flex-direction:column;gap:1rem;">
+      <div>
+        <label style="margin-bottom:0.25rem;">Volume <span class="accent-purple-text">(purple)</span></label>
+        <input type="range" min="0" max="100" value="60" class="accent-purple">
+      </div>
+      <div>
+        <label style="margin-bottom:0.25rem;">Brightness <span class="accent-teal-text">(teal)</span></label>
+        <input type="range" min="0" max="100" value="40" class="accent-teal">
+      </div>
+      <div>
+        <label style="margin-bottom:0.25rem;">Progress <span class="accent-pink-text">(pink)</span></label>
+        <progress max="100" value="75" class="accent-pink"></progress>
+      </div>
+      <div>
+        <label style="margin-bottom:0.25rem;">Storage <span class="accent-orange-text">(orange)</span></label>
+        <progress max="100" value="45" class="accent-orange"></progress>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Caret Color — Input Cursors</h2>
+    <div style="display:flex;flex-direction:column;gap:0.75rem;">
+      <input type="text" class="caret-purple" placeholder="Purple cursor" value="Typing here...">
+      <input type="text" class="caret-teal" placeholder="Teal cursor" value="Another field...">
+      <input type="text" class="caret-pink" placeholder="Pink cursor">
+      <textarea class="caret-purple" rows="3" placeholder="Textarea with purple cursor"></textarea>
+    </div>
+  </section>
+
+  <section>
+    <h2>Color Scheme — Light / Dark Toggle</h2>
+    <div style="display:flex;flex-direction:column;gap:1rem;">
+      <div class="scheme-light" style="background:#f5f5f5;color:#1a1a1a;padding:1rem;border-radius:8px;">
+        <p style="margin:0 0 0.75rem;font-size:0.9rem;"><strong>color-scheme: light</strong></p>
+        <input type="checkbox" checked> Checkbox
+        <input type="radio" name="scheme-l" checked> Radio
+        <input type="range" min="0" max="100" value="50">
+      </div>
+      <div class="scheme-dark" style="background:#1a1a1a;color:#d1d5db;padding:1rem;border-radius:8px;">
+        <p style="margin:0 0 0.75rem;font-size:0.9rem;"><strong>color-scheme: dark</strong></p>
+        <input type="checkbox" checked> Checkbox
+        <input type="radio" name="scheme-d" checked> Radio
+        <input type="range" min="0" max="100" value="50">
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>File Selector Button</h2>
+    <input type="file" class="custom-file">
+    <p style="margin-top:0.75rem;margin-bottom:0;color:#9ca3af;font-size:0.85rem;">The upload button is styled with <code>::file-selector-button</code>.</p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/form-accent-color/style.css
+++ b/submissions/examples/form-accent-color/style.css
@@ -1,0 +1,110 @@
+/* ============================================================
+   EaseMotion CSS — Form Accent Colors
+   Customizing form controls with accent-color, caret-color,
+   color-scheme, and ::file-selector-button
+   ============================================================ */
+
+/* ---- Accent Color Classes ---- */
+
+.accent-purple {
+  accent-color: #8b5cf6;
+}
+
+.accent-teal {
+  accent-color: #14b8a6;
+}
+
+.accent-pink {
+  accent-color: #ec4899;
+}
+
+.accent-orange {
+  accent-color: #f97316;
+}
+
+.accent-purple-text {
+  color: #a78bfa;
+}
+
+.accent-teal-text {
+  color: #2dd4bf;
+}
+
+.accent-pink-text {
+  color: #f472b6;
+}
+
+.accent-orange-text {
+  color: #fb923c;
+}
+
+/* ---- Caret Color Classes ---- */
+
+.caret-purple {
+  caret-color: #8b5cf6;
+}
+
+.caret-teal {
+  caret-color: #14b8a6;
+}
+
+.caret-pink {
+  caret-color: #ec4899;
+}
+
+/* Shared input/textrea styling */
+input[type="text"],
+textarea {
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 0.625rem 0.875rem;
+  color: #e5e7eb;
+  font-size: 0.9rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+input[type="text"]:focus,
+textarea:focus {
+  border-color: #6366f1;
+}
+
+input[type="text"]::placeholder,
+textarea::placeholder {
+  color: #6b7280;
+}
+
+/* ---- Color Scheme ---- */
+
+.scheme-light {
+  color-scheme: light;
+}
+
+.scheme-dark {
+  color-scheme: dark;
+}
+
+.scheme-light input,
+.scheme-dark input {
+  margin-right: 0.5rem;
+}
+
+/* ---- File Selector Button ---- */
+
+.custom-file::file-selector-button {
+  background: #6366f1;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-right: 0.75rem;
+  transition: background 0.2s ease;
+}
+
+.custom-file::file-selector-button:hover {
+  background: #4f46e5;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating how to customize native form controls using `accent-color`, `caret-color`, `color-scheme`, and `::file-selector-button` — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo with styled checkboxes, radios, range, progress, inputs, and file upload |
| `style.css` | Pure CSS using accent-color, caret-color, color-scheme, and ::file-selector-button |
| `README.md` | Documentation with usage, browser support, and class reference |

## Sections
1. **Accent Color** — Checkboxes &amp; Radios with purple/teal/pink/orange variants
2. **Accent Color** — Range sliders &amp; Progress bars
3. **Caret Color** — Input and textarea cursor colors
4. **Color Scheme** — Light vs dark native appearance
5. **File Selector Button** — Styled file upload button with `::file-selector-button`

## Related Issue
Closes #3125