### PR TITLE
feat(examples): add vertical text layout demo using writing-mode

### DIFF
--- a/submissions/examples/vertical-text-layout/README.md
+++ b/submissions/examples/vertical-text-layout/README.md
@@ -1,0 +1,45 @@
+# Vertical Text Layout
+
+## What does it do?
+A pure-CSS demo showing how to create vertical text layouts using `writing-mode` and `text-orientation` properties — no JavaScript required.
+
+## Features
+- **Writing Mode** — `horizontal-tb`, `vertical-rl`, `vertical-lr`
+- **Text Orientation** — `mixed`, `upright`, `sideways`
+- **Table Headers** — compact vertical headers to save horizontal space
+- **Side Labels** — vertical sidebar labels for navigation or decoration
+
+## Usage
+```html
+<p class="wm-vertical-rl">Vertical text</p>
+<p class="wm-vertical-rl to-upright">Vertical upright</p>
+<table><th class="th-vertical">Header</th></table>
+<span class="side-label wm-vertical-rl">Label</span>
+```
+
+```css
+.wm-vertical-rl { writing-mode: vertical-rl; }
+.to-upright     { text-orientation: upright; }
+.th-vertical    { writing-mode: vertical-lr; }
+```
+
+## CSS Variables
+None — all styles are defined directly via classes.
+
+## Classes
+- `.wm-horizontal` — default horizontal writing mode
+- `.wm-vertical-rl` — vertical right-to-left
+- `.wm-vertical-lr` — vertical left-to-right
+- `.to-mixed`, `.to-upright`, `.to-sideways` — text orientation overrides
+- `.th-vertical` — vertical table header cell
+- `.side-label` — vertical sidebar label
+
+## Browser Support
+- `writing-mode` — Chrome 48+, Firefox 41+, Safari 10.1+
+- `text-orientation` — Chrome 48+, Firefox 41+, Safari 14+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/vertical-text-layout/demo.html
+++ b/submissions/examples/vertical-text-layout/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vertical Text Layout — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: sans-serif; max-width: 900px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Vertical Text Layout</h1>
+  <p class="subtitle">Using <code>writing-mode</code> and <code>text-orientation</code> for vertical text — no JavaScript required.</p>
+
+  <section>
+    <h2>Writing Mode Variants</h2>
+    <div class="demo-row">
+      <div class="demo-item">
+        <p class="label">horizontal-tb</p>
+        <p class="wm-horizontal">Horizontal text is the default.</p>
+      </div>
+      <div class="demo-item">
+        <p class="label">vertical-rl</p>
+        <p class="wm-vertical-rl">Vertical right to left.</p>
+      </div>
+      <div class="demo-item">
+        <p class="label">vertical-lr</p>
+        <p class="wm-vertical-lr">Vertical left to right.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Text Orientation</h2>
+    <div class="demo-row">
+      <div class="demo-item">
+        <p class="label">mixed (default)</p>
+        <p class="wm-vertical-rl to-mixed">CSS3 垂直文本 mixed</p>
+      </div>
+      <div class="demo-item">
+        <p class="label">upright</p>
+        <p class="wm-vertical-rl to-upright">CSS3 垂直文本 upright</p>
+      </div>
+      <div class="demo-item">
+        <p class="label">sideways</p>
+        <p class="wm-vertical-rl to-sideways">CSS3 垂直文本 sideways</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Table Headers — Space Saving</h2>
+    <table class="vtable">
+      <thead>
+        <tr>
+          <th class="th-vertical">Product Name</th>
+          <th class="th-vertical">Units Sold</th>
+          <th class="th-vertical">Revenue</th>
+          <th class="th-vertical">Growth</th>
+          <th class="th-vertical">Region</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Widget Pro</td><td>1,250</td><td>$62,500</td><td>+12%</td><td>NA</td></tr>
+        <tr><td>Gadget X</td><td>840</td><td>$42,000</td><td>+8%</td><td>EU</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Side Labels &amp; Decorative Text</h2>
+    <div class="side-labels">
+      <span class="side-label wm-vertical-rl">Navigation</span>
+      <span class="side-label wm-vertical-rl">Dashboard</span>
+      <span class="side-label wm-vertical-rl">Settings</span>
+      <span class="side-label wm-vertical-lr">Footer</span>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/vertical-text-layout/style.css
+++ b/submissions/examples/vertical-text-layout/style.css
@@ -1,0 +1,117 @@
+/* ============================================================
+   EaseMotion CSS — Vertical Text Layout
+   Vertical text using writing-mode and text-orientation
+   ============================================================ */
+
+/* ---- Writing Mode Variants ---- */
+
+.demo-row {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.demo-item {
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 1rem;
+  min-width: 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.label {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  margin: 0;
+  font-family: monospace;
+}
+
+.wm-horizontal {
+  writing-mode: horizontal-tb;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.wm-vertical-rl {
+  writing-mode: vertical-rl;
+  margin: 0;
+  line-height: 1.5;
+  height: 160px;
+}
+
+.wm-vertical-lr {
+  writing-mode: vertical-lr;
+  margin: 0;
+  line-height: 1.5;
+  height: 160px;
+}
+
+/* ---- Text Orientation ---- */
+
+.to-mixed {
+  text-orientation: mixed;
+}
+
+.to-upright {
+  text-orientation: upright;
+}
+
+.to-sideways {
+  text-orientation: sideways;
+}
+
+/* ---- Table Headers ---- */
+
+.vtable {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.vtable th,
+.vtable td {
+  border: 1px solid #333;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.vtable th {
+  background: #252525;
+  color: #e5e7eb;
+  font-weight: 600;
+}
+
+.vtable td {
+  background: #1f1f1f;
+  color: #d1d5db;
+}
+
+.th-vertical {
+  writing-mode: vertical-lr;
+  height: 100px;
+  white-space: nowrap;
+}
+
+/* ---- Side Labels ---- */
+
+.side-labels {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.side-label {
+  background: #6366f1;
+  color: #ffffff;
+  padding: 0.5rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating vertical text layout using `writing-mode` and `text-orientation` — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo with writing mode variants, text orientation, table headers, and side labels |
| `style.css` | Pure CSS using writing-mode, text-orientation |
| `README.md` | Documentation with usage, browser support, and class reference |

## Sections
1. **Writing Mode Variants** — `horizontal-tb`, `vertical-rl`, `vertical-lr`
2. **Text Orientation** — `mixed`, `upright`, `sideways` with mixed Latin/CJK text
3. **Table Headers** — vertical column headers to save horizontal space
4. **Side Labels** — vertical sidebar labels for navigation

## Related Issue
Closes #3127
<!-- re-trigger label sync -->