### PR TITLE
feat(examples): add selection and placeholder styling demo

### DIFF
--- a/submissions/examples/selection-placeholder-style/README.md
+++ b/submissions/examples/selection-placeholder-style/README.md
@@ -1,0 +1,41 @@
+# Selection &amp; Placeholder Styling
+
+## What does it do?
+A pure-CSS demo showing how to customize text selection highlights and input placeholder text using `::selection` and `::placeholder` pseudo-elements.
+
+## Features
+- **Global Selection** — default purple highlight for all page text
+- **Per-Section Selection** — teal, gold, and rose highlight colors in different sections
+- **Code Selection** — distinct selection style for `<code>` blocks
+- **Placeholder Colors** — purple italic and teal bold placeholders
+- **Placeholder on Focus** — placeholder fades to transparent on input focus
+
+## Usage
+```css
+/* Global selection */
+::selection { background: #8b5cf6; color: #ffffff; }
+
+/* Section-specific selection */
+.sel-teal ::selection { background: #14b8a6; color: #0f0f0f; }
+
+/* Placeholder styling */
+.pl-purple::placeholder { color: #a78bfa; font-style: italic; }
+
+/* Placeholder transition on focus */
+.pl-fade::placeholder { transition: color 0.3s ease; }
+.pl-fade:focus::placeholder { color: transparent; }
+```
+
+## Classes
+- `.sel-teal`, `.sel-gold`, `.sel-rose` — section-specific selection colors
+- `.pl-purple`, `.pl-teal`, `.pl-fade` — placeholder style variants
+
+## Browser Support
+- `::selection` — Chrome 1+, Firefox 62+, Safari 1.1+
+- `::placeholder` — Chrome 57+, Firefox 51+, Safari 10.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/selection-placeholder-style/demo.html
+++ b/submissions/examples/selection-placeholder-style/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Selection &amp; Placeholder Styling — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: sans-serif; max-width: 750px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 1rem; }
+    p { line-height: 1.7; margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>Selection &amp; Placeholder Styling</h1>
+  <p class="subtitle">Customizing text highlight color and input placeholder appearance with <code>::selection</code> and <code>::placeholder</code>.</p>
+
+  <section>
+    <h2>Default Selection (Purple)</h2>
+    <p>Try selecting this text. The background will be purple with white text. This is the default selection style for the entire page. Any text you select outside the special sections below will use this style.</p>
+  </section>
+
+  <section class="sel-teal">
+    <h2>Teal Selection</h2>
+    <p>Selecting text in this section gives you a teal highlight with dark text. Each section can have its own selection colors using scoped <code>::selection</code> rules.</p>
+  </section>
+
+  <section class="sel-gold">
+    <h2>Gold Selection</h2>
+    <p>This section uses a gold highlight with dark text. Different <code>::selection</code> colors help distinguish content zones visually when selected.</p>
+  </section>
+
+  <section class="sel-rose">
+    <h2>Rose Selection with Code</h2>
+    <p>Selecting in this section shows rose-colored highlights. Code blocks within can also have distinct selection styling.</p>
+    <pre><code>function hello() {
+  console.log("Select this code!");
+}</code></pre>
+  </section>
+
+  <section>
+    <h2>Placeholder Styling</h2>
+    <div style="display:flex;flex-direction:column;gap:0.75rem;">
+      <input type="text" class="pl-purple" placeholder="Purple italic placeholder">
+      <input type="text" class="pl-teal" placeholder="Teal bold placeholder">
+      <input type="text" class="pl-fade" placeholder="Fades on focus...">
+      <textarea class="pl-purple" rows="3" placeholder="Textarea with purple placeholder"></textarea>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/selection-placeholder-style/style.css
+++ b/submissions/examples/selection-placeholder-style/style.css
@@ -1,0 +1,74 @@
+/* ============================================================
+   EaseMotion CSS — Selection & Placeholder Styling
+   Custom text selection and input placeholder styles
+   ============================================================ */
+
+/* ---- Global Selection ---- */
+
+::selection {
+  background: #8b5cf6;
+  color: #ffffff;
+}
+
+/* ---- Per-Section Selection ---- */
+
+.sel-teal ::selection {
+  background: #14b8a6;
+  color: #0f0f0f;
+}
+
+.sel-gold ::selection {
+  background: #f59e0b;
+  color: #0f0f0f;
+}
+
+.sel-rose ::selection {
+  background: #f43f5e;
+  color: #ffffff;
+}
+
+/* Code selection within rose section */
+.sel-rose code::selection {
+  background: #881337;
+  color: #fda4af;
+}
+
+/* ---- Placeholder Styling ---- */
+
+input,
+textarea {
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 0.625rem 0.875rem;
+  color: #e5e7eb;
+  font-size: 0.9rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+input:focus,
+textarea:focus {
+  border-color: #6366f1;
+}
+
+.pl-purple::placeholder {
+  color: #a78bfa;
+  font-style: italic;
+  opacity: 0.8;
+}
+
+.pl-teal::placeholder {
+  color: #2dd4bf;
+  font-weight: 700;
+  opacity: 0.8;
+}
+
+.pl-fade::placeholder {
+  color: #6b7280;
+  transition: color 0.3s ease;
+}
+
+.pl-fade:focus::placeholder {
+  color: transparent;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating text selection highlighting with `::selection` and input placeholder styling with `::placeholder` — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo with 4 selection color zones and styled input placeholders |
| `style.css` | Pure CSS using ::selection and ::placeholder with transitions |
| `README.md` | Documentation with usage, browser support, and class reference |

## Sections
1. **Default Selection** — global purple highlight  
2. **Per-Section Selection** — teal, gold, rose highlight in different content zones  
3. **Code Selection** — distinct highlight for `<code>` blocks  
4. **Placeholder Styling** — colored, italic, bold, and fade-on-focus placeholders  

## Related Issue
Closes #3129
<!-- re-trigger label sync -->