### PR TITLE
fix: persist theme toggle preference across page loads

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -28,6 +28,14 @@
     <!-- Link to external docs.css -->
     <link rel="stylesheet" href="docs.css" />
 
+    <!-- Apply stored theme before first paint to avoid flash -->
+    <script>
+      (function () {
+        var t = localStorage.getItem("em-theme") || "dark";
+        document.documentElement.setAttribute("data-theme", t);
+      })();
+    </script>
+
     <style>
       /* ─────────────────────────────────────────────────────────
          Any extra page-specific overrides can go here.
@@ -374,6 +382,7 @@
         const currentTheme = document.documentElement.getAttribute("data-theme");
         const newTheme = currentTheme === "light" ? "dark" : "light";
         document.documentElement.setAttribute("data-theme", newTheme);
+        localStorage.setItem("em-theme", newTheme);
       });
 
       // ── Active nav link tracking ─────────────────────────────


### PR DESCRIPTION
 Description:

  Fixed the theme toggle button in docs/index.html that wasn't switching/persisting the theme.

  Changes:
  - Added early <head> script to read localStorage and apply saved theme before first paint (prevents flash)
  - Updated click handler to save theme preference to localStorage

  Root Cause: The toggle was correctly switching data-theme on <html> within a session, but had no localStorage support 
  — so the theme reset to dark on every page reload.