### PR TITLE
fix(docs): restore dark/light theme toggle on animation-combo and animations-preview pages

### DIFF
--- a/docs/animation-combo.html
+++ b/docs/animation-combo.html
@@ -6,6 +6,12 @@
   <title>EaseMotion CSS — Animation Combination Builder</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
   <link rel="stylesheet" href="docs.css" />
+  <script>
+  (function () {
+    var t = localStorage.getItem("em-theme") || "dark";
+    document.documentElement.setAttribute("data-theme", t);
+  })();
+</script>
   <link rel="stylesheet" href="animation-combo.css" />
 </head>
 <body>
@@ -130,6 +136,25 @@
     // Initial render
     renderList();
     updateGenerated();
+    const themeBtn = document.getElementById("theme-toggle");
+
+if (themeBtn) {
+  themeBtn.addEventListener("click", () => {
+    const currentTheme =
+      document.documentElement.getAttribute("data-theme");
+
+    const newTheme =
+      currentTheme === "light" ? "dark" : "light";
+
+    document.documentElement.setAttribute(
+      "data-theme",
+      newTheme
+    );
+
+    localStorage.setItem("em-theme", newTheme);
+  });
+}
+
   </script>
 
 </body>

--- a/docs/animations-preview.html
+++ b/docs/animations-preview.html
@@ -6,6 +6,12 @@
   <title>EaseMotion CSS — Animation Preview</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
   <link rel="stylesheet" href="docs.css" />
+  <script>
+  (function () {
+    var t = localStorage.getItem("em-theme") || "dark";
+    document.documentElement.setAttribute("data-theme", t);
+  })();
+</script>
   <link rel="stylesheet" href="animations-preview.css" />
 </head>
 <body>
@@ -116,6 +122,25 @@
     categoryFilter.addEventListener('change', renderGrid);
     // Initial render
     renderGrid();
+    const themeBtn = document.getElementById("theme-toggle");
+
+if (themeBtn) {
+  themeBtn.addEventListener("click", () => {
+    const currentTheme =
+      document.documentElement.getAttribute("data-theme");
+
+    const newTheme =
+      currentTheme === "light" ? "dark" : "light";
+
+    document.documentElement.setAttribute(
+      "data-theme",
+      newTheme
+    );
+
+    localStorage.setItem("em-theme", newTheme);
+  });
+}
+
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Pull Request Description

Fixes the theme toggle functionality on the documentation pages (animation-combo.html and animations-preview.html).

Previously, the theme toggle button was present on both pages but did not work because the required theme initialization and toggle logic were missing. This PR adds theme persistence using localStorage and enables switching between light and dark themes, matching the behavior already implemented on the main documentation page.

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds working dark/light theme switching and theme preference persistence to the Animation Combination Builder and Animation Preview documentation pages.

**How does a developer use it?**

Users can click the existing theme toggle button on either page to switch between dark and light themes. The selected theme is automatically saved and restored on future visits.

<button id="theme-toggle" class="theme-toggle-btn">
  ...
</button>

**Why does it fit EaseMotion CSS?**

It improves consistency across the documentation experience by ensuring all documentation pages support the same theme-switching behavior and user preferences.

## Demo

No new demo was added. This PR fixes existing documentation pages.

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Changes made
Added theme initialization script to restore the saved theme before page render.
Added theme toggle event handler for switching between dark and light modes.
Added localStorage persistence using the existing em-theme key.
Applied the fix consistently to:
docs/animation-combo.html
docs/animations-preview.html
Verification
Confirmed that clicking the theme toggle updates data-theme on the <html> element.
Confirmed that CSS variables update correctly when switching themes.
Confirmed that theme preference persists across page reloads.

### Validator Note

This PR is a documentation bug fix and only modifies existing files under the `docs/` directory:

- docs/animation-combo.html
- docs/animations-preview.html

The automated submission validator appears to expect feature submissions under `submissions/examples/`, which is not applicable to this documentation fix.

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
