### PR TITLE
feat(accessibility): add accessible copy buttons submission

### DIFF
--- a/submissions/examples/accessible-copy-buttons-vs/README.md
+++ b/submissions/examples/accessible-copy-buttons-vs/README.md
@@ -1,0 +1,36 @@
+# Accessible Copy Buttons
+
+## 1. What does this do?
+Demonstrates how adding a descriptive `aria-label` to documentation copy buttons tells screen-reader users exactly what will be copied, instead of announcing a generic "Copy" for every button on the page.
+
+## 2. How is it used?
+
+Apply the pattern to any copy button next to a code snippet:
+
+```html
+<!-- ❌ Before — every button announces identically as "Copy, button" -->
+<button data-copy="--ease-speed-fast">Copy</button>
+
+<!-- ✅ After — screen reader announces "Copy --ease-speed-fast variable, button" -->
+<button
+  aria-label="Copy --ease-speed-fast variable"
+  data-copy="--ease-speed-fast"
+>
+  Copy Variable
+</button>
+
+<button
+  aria-label="Copy ease-btn-primary class"
+  data-copy="ease-btn-primary"
+>
+  Copy Class
+</button>
+```
+
+The JavaScript in `copy.js` handles:
+- Clipboard write (Clipboard API with `execCommand` fallback)
+- Temporary `aria-label` update to "… — Copied!" during the feedback window
+- An `aria-live="polite"` region that announces "Copied [target]" to screen readers
+
+## 3. Why is it useful?
+EaseMotion CSS targets developers who copy CSS variables and utility class names from documentation. When multiple copy buttons appear on the same page without descriptive labels, keyboard and screen-reader users cannot distinguish them. Adding a precise `aria-label` is a one-attribute fix that brings the copy workflow to WCAG 2.1 SC 4.1.2 (Name, Role, Value) compliance, making the documentation genuinely usable for everyone.

--- a/submissions/examples/accessible-copy-buttons-vs/copy.js
+++ b/submissions/examples/accessible-copy-buttons-vs/copy.js
@@ -1,0 +1,118 @@
+/**
+ * copy.js — Accessible copy-to-clipboard handler
+ *
+ * Responsibilities:
+ *  1. Copy the text in `data-copy` to the clipboard.
+ *  2. Give visual feedback via a CSS class on the button.
+ *  3. Announce "Copied!" to screen readers via an aria-live region.
+ *
+ * No external dependencies. Works by opening the file directly in a browser.
+ */
+
+(function () {
+  "use strict";
+
+  /** Writes `text` to the clipboard. Returns a Promise<boolean>. */
+  async function copyText(text) {
+    // Prefer the modern Clipboard API (requires a secure context or user gesture).
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch (_) {
+        // Fall through to the legacy approach below.
+      }
+    }
+
+    // Legacy fallback: create a temporary textarea, select its content, copy.
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    // Position off-screen so it is invisible but still selectable.
+    textarea.style.cssText =
+      "position:fixed;top:-9999px;left:-9999px;opacity:0;";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+
+    let success = false;
+    try {
+      success = document.execCommand("copy");
+    } catch (_) {
+      // execCommand is deprecated in some browsers; failure is handled below.
+    }
+
+    document.body.removeChild(textarea);
+    return success;
+  }
+
+  /** Announce a message via the aria-live region for screen readers. */
+  function announce(message) {
+    const region = document.getElementById("copy-announcement");
+    if (!region) return;
+
+    // Clear first so repeated copies are re-announced even if the text is the same.
+    region.textContent = "";
+
+    // A brief timeout lets assistive technology register the cleared state
+    // before the new message is inserted.
+    setTimeout(function () {
+      region.textContent = message;
+    }, 50);
+  }
+
+  /** Attach click listeners to every button that has a [data-copy] attribute. */
+  function initCopyButtons() {
+    var buttons = document.querySelectorAll("[data-copy]");
+
+    buttons.forEach(function (button) {
+      button.addEventListener("click", async function () {
+        var textToCopy = button.getAttribute("data-copy");
+        if (!textToCopy) return;
+
+        var success = await copyText(textToCopy);
+
+        if (!success) {
+          // If copying truly failed, let the user know.
+          announce("Copy failed. Please copy manually.");
+          return;
+        }
+
+        // ── Visual feedback ──────────────────────────────────────
+        var originalLabel = button.getAttribute("aria-label");
+        var originalText  = button.textContent.trim();
+
+        button.classList.add("is-copied");
+
+        // Update the aria-label so screen readers announce the "Copied!" state.
+        if (originalLabel) {
+          button.setAttribute("aria-label", originalLabel + " — Copied!");
+        }
+        button.textContent = "✓ Copied!";
+
+        // ── Screen-reader announcement ───────────────────────────
+        // Announce what was copied so users do not have to infer it.
+        var copyTarget = originalLabel
+          ? originalLabel.replace(/^Copy\s+/i, "")   // e.g. "--ease-speed-fast variable"
+          : textToCopy;
+        announce("Copied " + copyTarget);
+
+        // ── Reset after 2 s ──────────────────────────────────────
+        setTimeout(function () {
+          button.classList.remove("is-copied");
+          button.textContent = originalText;
+
+          if (originalLabel) {
+            button.setAttribute("aria-label", originalLabel);
+          }
+        }, 2000);
+      });
+    });
+  }
+
+  // Run after the DOM is ready.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initCopyButtons);
+  } else {
+    initCopyButtons();
+  }
+})();

--- a/submissions/examples/accessible-copy-buttons-vs/demo.html
+++ b/submissions/examples/accessible-copy-buttons-vs/demo.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Accessible Copy Buttons Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="container">
+
+    <header class="page-header">
+      <h1>Accessible Copy Buttons</h1>
+      <p class="subtitle">
+        Copy buttons in documentation need descriptive
+        <code>aria-label</code> attributes so screen-reader users know
+        <em>exactly what</em> will be copied — not just "Copy".
+      </p>
+    </header>
+
+    <!-- ─── Section 1: The Problem ──────────────────────────────── -->
+    <section aria-labelledby="problem-heading">
+      <h2 id="problem-heading">The Problem</h2>
+      <p>
+        Generic labels like <em>"Copy"</em> are announced identically by
+        screen readers no matter which button is focused. A user tabbing
+        through several copy buttons hears "Copy, Copy, Copy" with no
+        context about what each button copies.
+      </p>
+
+      <div class="demo-block">
+        <p class="demo-label">❌ Inaccessible — all buttons sound the same</p>
+
+        <div class="snippet-row">
+          <code class="snippet">--ease-speed-fast</code>
+          <!-- No aria-label: screen reader announces "Copy, button" -->
+          <button class="copy-btn copy-btn--bad" data-copy="--ease-speed-fast">
+            Copy
+          </button>
+        </div>
+
+        <div class="snippet-row">
+          <code class="snippet">ease-btn-primary</code>
+          <!-- No aria-label: screen reader announces "Copy, button" -->
+          <button class="copy-btn copy-btn--bad" data-copy="ease-btn-primary">
+            Copy
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ─── Section 2: The Fix ───────────────────────────────────── -->
+    <section aria-labelledby="fix-heading">
+      <h2 id="fix-heading">The Fix</h2>
+      <p>
+        Adding a descriptive <code>aria-label</code> gives screen-reader
+        users the same context that sighted users infer from nearby text.
+      </p>
+
+      <div class="demo-block demo-block--good">
+        <p class="demo-label">✅ Accessible — each button has a unique label</p>
+
+        <div class="snippet-row">
+          <code class="snippet">--ease-speed-fast</code>
+          <!--
+            aria-label overrides the visible text for assistive technology.
+            Screen reader announces: "Copy --ease-speed-fast variable, button"
+          -->
+          <button
+            class="copy-btn copy-btn--good"
+            aria-label="Copy --ease-speed-fast variable"
+            data-copy="--ease-speed-fast"
+          >
+            Copy Variable
+          </button>
+        </div>
+
+        <div class="snippet-row">
+          <code class="snippet">--ease-speed-normal</code>
+          <button
+            class="copy-btn copy-btn--good"
+            aria-label="Copy --ease-speed-normal variable"
+            data-copy="--ease-speed-normal"
+          >
+            Copy Variable
+          </button>
+        </div>
+
+        <div class="snippet-row">
+          <code class="snippet">ease-btn-primary</code>
+          <!--
+            Screen reader announces: "Copy ease-btn-primary class, button"
+          -->
+          <button
+            class="copy-btn copy-btn--good"
+            aria-label="Copy ease-btn-primary class"
+            data-copy="ease-btn-primary"
+          >
+            Copy Class
+          </button>
+        </div>
+
+        <div class="snippet-row">
+          <code class="snippet">ease-fade-in</code>
+          <button
+            class="copy-btn copy-btn--good"
+            aria-label="Copy ease-fade-in class"
+            data-copy="ease-fade-in"
+          >
+            Copy Class
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ─── Section 3: Keyboard & Live Region ───────────────────── -->
+    <section aria-labelledby="a11y-heading">
+      <h2 id="a11y-heading">Accessibility Features Used</h2>
+      <ul class="feature-list">
+        <li>
+          <strong>Descriptive <code>aria-label</code></strong> — overrides
+          visible button text for screen readers so each button has a unique,
+          meaningful announcement.
+        </li>
+        <li>
+          <strong>Keyboard accessible</strong> — all buttons are native
+          <code>&lt;button&gt;</code> elements, reachable and activatable
+          with <kbd>Tab</kbd> and <kbd>Enter</kbd> / <kbd>Space</kbd>.
+        </li>
+        <li>
+          <strong>Visible focus ring</strong> — <code>:focus-visible</code>
+          shows a clear outline for keyboard users without affecting mouse
+          interactions.
+        </li>
+        <li>
+          <strong>Live region announcement</strong> — a visually-hidden
+          <code>aria-live="polite"</code> region announces "Copied!" to
+          screen readers after a successful copy.
+        </li>
+        <li>
+          <strong>Reduced motion</strong> — the feedback transition respects
+          <code>prefers-reduced-motion: reduce</code>.
+        </li>
+      </ul>
+    </section>
+
+    <!-- Live region: invisible to sighted users, announced by screen readers -->
+    <div
+      id="copy-announcement"
+      aria-live="polite"
+      aria-atomic="true"
+      class="sr-only"
+    ></div>
+
+  </main>
+
+  <script src="copy.js"></script>
+</body>
+</html>

--- a/submissions/examples/accessible-copy-buttons-vs/style.css
+++ b/submissions/examples/accessible-copy-buttons-vs/style.css
@@ -1,0 +1,220 @@
+/* accessible-copy-buttons-vs/style.css
+   Self-contained styles — no external dependencies.
+   -------------------------------------------------- */
+
+/* ── Reset & base ── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #1a1a2e;
+  background: #f4f4f8;
+  padding: 2rem 1rem;
+}
+
+/* ── Layout ── */
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+/* ── Page header ── */
+.page-header h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.page-header .subtitle {
+  color: #555;
+  font-size: 0.95rem;
+}
+
+/* ── Section headings ── */
+section h2 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+  color: #111;
+}
+
+section > p {
+  color: #444;
+  margin-bottom: 1rem;
+  font-size: 0.95rem;
+}
+
+/* ── Demo blocks ── */
+.demo-block {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.demo-block--good {
+  border-color: #22c55e;
+}
+
+.demo-label {
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: #f8f8f8;
+  border-bottom: 1px solid #ddd;
+  color: #555;
+}
+
+.demo-block--good .demo-label {
+  background: #f0fdf4;
+  border-bottom-color: #bbf7d0;
+  color: #166534;
+}
+
+/* ── Snippet rows ── */
+.snippet-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  gap: 1rem;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.snippet-row:last-child {
+  border-bottom: none;
+}
+
+/* ── Inline code ── */
+.snippet {
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  font-size: 0.875rem;
+  background: #f0f0f5;
+  color: #4f46e5;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  /* Prevent the code from being selected when double-clicking the button */
+  user-select: text;
+}
+
+/* ── Copy buttons — shared ── */
+.copy-btn {
+  flex-shrink: 0;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1.5px solid transparent;
+  cursor: pointer;
+  /* Transition only color/border — safe for reduced-motion users */
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+/* Keyboard focus ring — visible only for keyboard navigation */
+.copy-btn:focus-visible {
+  outline: 3px solid #6366f1;
+  outline-offset: 3px;
+}
+
+/* ── Bad variant (red tint, no aria-label) ── */
+.copy-btn--bad {
+  background: #fff0f0;
+  color: #b91c1c;
+  border-color: #fca5a5;
+}
+
+.copy-btn--bad:hover {
+  background: #fee2e2;
+  border-color: #f87171;
+}
+
+/* ── Good variant (indigo) ── */
+.copy-btn--good {
+  background: #eef2ff;
+  color: #4338ca;
+  border-color: #c7d2fe;
+}
+
+.copy-btn--good:hover {
+  background: #e0e7ff;
+  border-color: #a5b4fc;
+}
+
+/* Copied feedback state */
+.copy-btn--good.is-copied {
+  background: #f0fdf4;
+  color: #15803d;
+  border-color: #86efac;
+}
+
+/* ── Reduced motion: skip color transition delay ── */
+@media (prefers-reduced-motion: reduce) {
+  .copy-btn {
+    transition: none;
+  }
+}
+
+/* ── Feature list ── */
+.feature-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: #333;
+}
+
+.feature-list li {
+  padding-left: 1.2rem;
+  position: relative;
+}
+
+.feature-list li::before {
+  content: "→";
+  position: absolute;
+  left: 0;
+  color: #6366f1;
+}
+
+.feature-list code {
+  font-family: ui-monospace, monospace;
+  font-size: 0.85em;
+  background: #f0f0f5;
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+}
+
+kbd {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8em;
+  background: #e5e7eb;
+  border: 1px solid #d1d5db;
+  border-radius: 3px;
+  padding: 0.1em 0.4em;
+  color: #111;
+}
+
+/* ── Screen-reader-only utility ──
+   Visually hidden but announced by assistive technology */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a sandbox-style accessibility example under `submissions/examples/accessible-copy-buttons-vs/` that demonstrates how descriptive accessible names improve copy buttons used in documentation interfaces.

The example showcases accessible copy-to-clipboard interactions without modifying any core EaseMotion CSS files.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [x] Other (describe below)

**Other:** Accessibility-focused demo submission

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/examples/accessible-copy-buttons-vs/`
* [x] Includes `demo.html` — self-contained, opens directly in a browser
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, and why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An accessibility-focused copy button demo that uses descriptive `aria-label` attributes, screen-reader announcements, and keyboard-friendly interactions.

**How does a developer use it?**

```html
<button aria-label="Copy --ease-speed-fast variable">
  Copy Variable
</button>

<button aria-label="Copy ease-btn-primary class">
  Copy Class
</button>
```

**Why does it fit EaseMotion CSS?**

This example promotes accessible and developer-friendly UI patterns by demonstrating how copy buttons can provide meaningful context to assistive technologies while maintaining a clean user experience.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

* All changes are contained within `submissions/examples/accessible-copy-buttons-vs/`.
* No framework, core, or component files were modified.
* Demonstrates:

  * Descriptive `aria-label` values
  * `aria-live="polite"` feedback
  * Keyboard-visible focus states
  * Reduced-motion support
* Created as a sandbox-style accessibility example following the repository's current contribution guidelines.

Closes #1831
