### PR TITLE
Fix incorrect cubic easing aliases in SCSS variables

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -23,11 +23,19 @@ $ease-in-out:       cubic-bezier(0, 0, 0.2, 1);
 $ease-ping:         cubic-bezier(0, 0, 0.2, 1);
 
 // Named easing aliases
+// Named easing aliases
+// $ease-in-out-cubic: general smooth ease — matches --ease-ease CSS var
 $ease-in-out-cubic: $ease-ease;
-$ease-out-cubic:    $ease-ease;
-$ease-in-cubic:     $ease-ease;
-$ease-elastic:      $ease-bounce;
 
+// $ease-out-cubic: starts fast, decelerates — matches --ease-ease-out CSS var
+// Use for: zoom-in, elements entering the screen
+$ease-out-cubic:    cubic-bezier(0, 0, 0.2, 1);
+
+// $ease-in-cubic: starts slow, accelerates — use for elements leaving the screen
+// No direct CSS var equivalent; mirrors cubic-bezier(0.8, 0, 1, 1) used in animations.css
+$ease-in-cubic:     cubic-bezier(0.8, 0, 1, 1);
+
+$ease-elastic:      $ease-bounce;
 // Delay and fill defaults
 $delay-none: 0s;
 $fill-both: both;


### PR DESCRIPTION
closes #3265 

## Summary

This PR fixes two incorrect easing alias values in `scss/_variables.scss`.

Both `$ease-out-cubic` and `$ease-in-cubic` were previously mapped to `$ease-ease` (`cubic-bezier(0.4, 0, 0.2, 1)`), causing all three cubic easing aliases (`ease-in`, `ease-out`, and `ease-in-out`) to resolve to the same curve.

## Changes

Updated the easing aliases to use the correct cubic-bezier values:

```scss id="4yg1h8"
$ease-out-cubic: cubic-bezier(0, 0, 0.2, 1);
$ease-in-cubic: cubic-bezier(0.8, 0, 1, 1);
```

### Rationale

* `$ease-out-cubic` should represent an ease-out curve that decelerates into its final state.
* `$ease-in-cubic` should represent an ease-in curve that starts slowly and accelerates toward the end.
* Mapping both aliases to `$ease-ease` removed any functional distinction between the easing variants and produced unexpected animation behavior.

This change also aligns the SCSS variables with the existing easing definitions used elsewhere in the project:

* `$ease-out-cubic` now matches the `--ease-ease-out` CSS custom property.
* `$ease-in-cubic` is consistent with the standard ease-in curve used in `animations.css`.

## Impact

The fix ensures that mixins relying on these aliases use the intended motion curves:

* `zoom-in` defaults to a proper ease-out transition.
* `zoom-out` defaults to a proper ease-in transition.

## Testing

* ✅ `npm run build:scss`
* ✅ `npm run lint`
* ✅ `npm test`

All checks pass with no regressions observed.
