### PR TITLE
feat: add pure CSS drag handle indicator submission

### DIFF
--- a/submissions/examples/drag-handle/README.md
+++ b/submissions/examples/drag-handle/README.md
@@ -1,0 +1,36 @@
+# Drag Handle Indicator
+
+## What does this do?
+A six-dot grid drag handle that shows a grab cursor, highlights on hover,
+and scales on active — pure CSS, zero JavaScript.
+
+## How is it used?
+Place the handle at the start of any list item or card:
+
+```html
+<div class="drag-list-item">
+  <div class="drag-handle">
+    <div class="drag-handle-dots">
+      <span></span><span></span>
+      <span></span><span></span>
+      <span></span><span></span>
+    </div>
+  </div>
+  Your content here
+</div>
+```
+
+Size variants: add `drag-handle-sm` or `drag-handle-lg` to the handle.
+
+## Why is it useful?
+Drag handles are a standard affordance in sortable lists, kanban boards,
+and reorderable cards. No submission currently covers this pattern.
+Pure CSS — the grab/grabbing cursor swap and hover highlight require
+no JavaScript at all.
+
+## Tech Stack
+- HTML
+- CSS only (no JavaScript, no frameworks)
+
+## Preview
+Open `demo.html` directly in your browser.

--- a/submissions/examples/drag-handle/demo.html
+++ b/submissions/examples/drag-handle/demo.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drag Handle Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2.5rem;
+      font-family: sans-serif;
+      background: #f4f5f7;
+      padding: 2rem;
+    }
+
+    h3 {
+      margin: 0 0 0.75rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #888;
+    }
+
+    section {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      width: 100%;
+      max-width: 360px;
+    }
+
+    .item-label {
+      font-size: 0.95rem;
+      color: #374151;
+      flex: 1;
+    }
+
+    .size-row {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Sortable list demo -->
+  <section>
+    <h3>Draggable List Items</h3>
+
+    <div class="drag-list-item">
+      <div class="drag-handle">
+        <div class="drag-handle-dots">
+          <span></span><span></span>
+          <span></span><span></span>
+          <span></span><span></span>
+        </div>
+      </div>
+      <span class="item-label">Design system tokens</span>
+    </div>
+
+    <div class="drag-list-item">
+      <div class="drag-handle">
+        <div class="drag-handle-dots">
+          <span></span><span></span>
+          <span></span><span></span>
+          <span></span><span></span>
+        </div>
+      </div>
+      <span class="item-label">Animation library</span>
+    </div>
+
+    <div class="drag-list-item">
+      <div class="drag-handle">
+        <div class="drag-handle-dots">
+          <span></span><span></span>
+          <span></span><span></span>
+          <span></span><span></span>
+        </div>
+      </div>
+      <span class="item-label">Component documentation</span>
+    </div>
+  </section>
+
+  <!-- Size variants -->
+  <section>
+    <h3>Size Variants</h3>
+    <div class="size-row">
+
+      <div class="drag-handle drag-handle-sm">
+        <div class="drag-handle-dots">
+          <span></span><span></span>
+          <span></span><span></span>
+          <span></span><span></span>
+        </div>
+      </div>
+
+      <div class="drag-handle">
+        <div class="drag-handle-dots">
+          <span></span><span></span>
+          <span></span><span></span>
+          <span></span><span></span>
+        </div>
+      </div>
+
+      <div class="drag-handle drag-handle-lg">
+        <div class="drag-handle-dots">
+          <span></span><span></span>
+          <span></span><span></span>
+          <span></span><span></span>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/drag-handle/style.css
+++ b/submissions/examples/drag-handle/style.css
@@ -1,0 +1,92 @@
+/* Drag Handle Indicator — pure CSS */
+
+.drag-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  cursor: grab;
+  color: #aaa;
+  border-radius: 4px;
+  transition: color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.drag-handle:hover {
+  color: #555;
+  background: #f0f0f0;
+  transform: scale(1.15);
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+  color: #333;
+  background: #e0e0e0;
+  transform: scale(0.95);
+}
+
+/* The six-dot grid pattern */
+.drag-handle-dots {
+  display: grid;
+  grid-template-columns: repeat(2, 4px);
+  grid-template-rows: repeat(3, 4px);
+  gap: 3px;
+}
+
+.drag-handle-dots span {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  display: block;
+}
+
+/* Size variants */
+.drag-handle-sm {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.drag-handle-sm .drag-handle-dots {
+  grid-template-columns: repeat(2, 3px);
+  grid-template-rows: repeat(3, 3px);
+  gap: 2px;
+}
+
+.drag-handle-sm .drag-handle-dots span {
+  width: 3px;
+  height: 3px;
+}
+
+.drag-handle-lg {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.drag-handle-lg .drag-handle-dots {
+  grid-template-columns: repeat(2, 5px);
+  grid-template-rows: repeat(3, 5px);
+  gap: 4px;
+}
+
+.drag-handle-lg .drag-handle-dots span {
+  width: 5px;
+  height: 5px;
+}
+
+/* List item with drag handle */
+.drag-list-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.drag-list-item:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
+}


### PR DESCRIPTION
closes #3284 
# Add pure CSS drag handle indicator submission

## Summary

This PR adds a new example submission: **Drag Handle Indicator**.

The component provides a reusable six-dot drag handle commonly used in sortable lists, kanban boards, tables, and reorderable cards. It is implemented entirely in CSS and includes hover and active-state feedback to communicate drag affordance.

## Features

* Pure CSS implementation (no JavaScript)
* Six-dot grid drag handle pattern
* `grab` and `grabbing` cursor states
* Hover highlight and scale animation
* Active press feedback
* Small, default, and large size variants
* Example usage within draggable list items
* Includes demo and documentation

## Files Added

```text
submissions/examples/drag-handle/
├── README.md
├── demo.html
└── style.css
```

## Why

Drag handles are a common UI pattern that helps users identify draggable and reorderable elements. They are widely used in task management apps, dashboards, kanban boards, sortable lists, and content management interfaces.

While the project contains several animation examples, there is currently no submission showcasing a drag handle affordance. This example fills that gap by demonstrating a practical UI pattern with subtle CSS interactions and no JavaScript dependency.

## Testing

* ✅ Opened `demo.html` locally and verified rendering
* ✅ Hover state correctly highlights and scales the handle
* ✅ Active state provides visual press feedback
* ✅ Cursor changes between `grab` and `grabbing`
* ✅ Size variants render correctly
* ✅ No JavaScript required
