### PR TITLE
fix: replace github-script v8 with v7 in submission validator

### DIFF
--- a/.github/workflows/submission-validator.yml
+++ b/.github/workflows/submission-validator.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Validate Submissions
         id: validate
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
@@ -170,7 +170,7 @@ jobs:
 
       - name: Create/Update Failure Comment
         if: failure() && steps.validate.outputs.hasFailures == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         env:
           FAILURES_JSON: ${{ steps.validate.outputs.failures }}
         with:
@@ -255,7 +255,7 @@ jobs:
 
       - name: Create/Update Success Comment
         if: success() && steps.validate.outputs.hasFailures == 'false' && steps.validate.outputs.successes != '[]'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         env:
           SUCCESSES_JSON: ${{ steps.validate.outputs.successes }}
         with:
@@ -316,7 +316,7 @@ jobs:
 
       - name: Add Label for Missing Files
         if: failure() && steps.validate.outputs.hasFailures == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             try {
@@ -333,7 +333,7 @@ jobs:
 
       - name: Remove Labels on Success
         if: success() && steps.validate.outputs.hasFailures == 'false'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             try {


### PR DESCRIPTION
## Pull Request Description

This PR fixes the submission validator workflow by replacing the unreleased `actions/github-script@v8` dependency with the current stable version `actions/github-script@v7`.

This change resolves CI failures caused by referencing a non-existent GitHub Action version and ensures contributor PRs can be validated successfully.

---

## Type of Change

* [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One focused fix per PR

---

## Feature Description

**What does this add?**

Updates the submission validator workflow to use the stable `github-script@v7` action.

**Why does it fit EaseMotion CSS?**

This change improves repository maintenance and ensures the automated validation workflow functions correctly for all contributor submissions.

---

## Testing

* Verified that all references to `actions/github-script@v8` were replaced with `actions/github-script@v7`.
* Confirmed workflow configuration is updated to use a valid, stable GitHub Action version.