### PR TITLE
feat: add marquee-pause-hover utility class submission

### DIFF
--- a/submissions/examples/marquee-pause-hover/README.md
+++ b/submissions/examples/marquee-pause-hover/README.md
@@ -1,0 +1,30 @@
+# Marquee Pause on Hover
+
+## What does this do?
+A single utility class `.marquee-pause-hover` that pauses a scrolling
+marquee when the user hovers over it — pure CSS, zero JavaScript.
+
+## How is it used?
+Add the class alongside your existing marquee container:
+
+```html
+<div class="marquee marquee-pause-hover">
+  <div class="marquee-track">...</div>
+</div>
+```
+
+Works with any element using `animation` — the utility sets
+`animation-play-state: paused` on the element and all its descendants
+on `:hover`.
+
+## Why is it useful?
+Marquees scroll past content users may want to read or interact with.
+Pausing on hover is the expected accessibility behaviour and a common
+UX pattern. The existing `ease-marquee` component has no built-in way
+to do this — this utility fills that gap in one line of CSS.
+
+## Tech Stack
+- CSS only (no JavaScript, no frameworks)
+
+## Preview
+Open `demo.html` directly in your browser.

--- a/submissions/examples/marquee-pause-hover/demo.html
+++ b/submissions/examples/marquee-pause-hover/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Marquee Pause on Hover Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3rem;
+      font-family: sans-serif;
+      background: #f4f5f7;
+      padding: 2rem;
+    }
+
+    h3 {
+      margin: 0 0 0.75rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #888;
+    }
+
+    section {
+      width: 100%;
+      max-width: 540px;
+    }
+
+    .marquee {
+      overflow: hidden;
+      white-space: nowrap;
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      background: #fff;
+      padding: 0.75rem 0;
+    }
+
+    .marquee-track {
+      display: inline-flex;
+      gap: 2.5rem;
+      animation: marquee-scroll 10s linear infinite;
+    }
+
+    .marquee-track span {
+      font-size: 0.95rem;
+      color: #374151;
+      padding: 0 1rem;
+    }
+
+    @keyframes marquee-scroll {
+      from { transform: translateX(0); }
+      to   { transform: translateX(-50%); }
+    }
+
+    .hint {
+      margin-top: 0.5rem;
+      font-size: 0.8rem;
+      color: #9ca3af;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+
+  <section>
+    <h3>Without utility (scrolls forever)</h3>
+    <div class="marquee">
+      <div class="marquee-track">
+        <span>Design tokens</span>
+        <span>Animation library</span>
+        <span>Component docs</span>
+        <span>Accessibility guide</span>
+        <!-- duplicate set for seamless loop -->
+        <span>Design tokens</span>
+        <span>Animation library</span>
+        <span>Component docs</span>
+        <span>Accessibility guide</span>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3>With .marquee-pause-hover (hover to pause)</h3>
+    <div class="marquee marquee-pause-hover">
+      <div class="marquee-track">
+        <span>Design tokens</span>
+        <span>Animation library</span>
+        <span>Component docs</span>
+        <span>Accessibility guide</span>
+        <span>Design tokens</span>
+        <span>Animation library</span>
+        <span>Component docs</span>
+        <span>Accessibility guide</span>
+      </div>
+    </div>
+    <p class="hint">Hover the marquee above — it pauses.</p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/marquee-pause-hover/style.css
+++ b/submissions/examples/marquee-pause-hover/style.css
@@ -1,0 +1,21 @@
+/* Marquee Pause on Hover — pure CSS utility */
+
+.marquee-pause-hover:hover,
+.marquee-pause-hover:hover * {
+  animation-play-state: paused;
+}
+/* Base marquee (mirrors ease-marquee conventions) */
+.marquee {
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.marquee-track {
+  display: inline-flex;
+  animation: marquee-scroll 12s linear infinite;
+}
+
+@keyframes marquee-scroll {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}


### PR DESCRIPTION
# Add marquee-pause-hover utility class submission
closes #3292 

## Summary

This PR adds a new example submission: **Marquee Pause on Hover**.

The submission introduces a lightweight CSS utility class, `.marquee-pause-hover`, that pauses marquee animations when hovered. This provides a simple accessibility and usability enhancement for scrolling content without requiring any JavaScript.

## Features

* Pure CSS implementation (no JavaScript)
* Single utility class: `.marquee-pause-hover`
* Pauses animations on hover using `animation-play-state`
* Works with existing marquee implementations
* Can be applied to other CSS animations as well
* Includes demo and documentation

## Files Added

```text
submissions/examples/marquee-pause-hover/
├── README.md
├── demo.html
└── style.css
```

## Why

Marquees continuously move content across the screen, which can make it difficult for users to read or interact with specific items. A hover-to-pause interaction is a common UX and accessibility enhancement that gives users control over moving content.

The current marquee implementation does not provide a built-in way to pause scrolling on hover. This utility fills that gap with a minimal, reusable CSS-only solution that aligns with the project's zero-JavaScript philosophy.

## Implementation

The utility is intentionally simple:

```css
.marquee-pause-hover:hover,
.marquee-pause-hover:hover * {
  animation-play-state: paused;
}
```

When the user hovers over the marquee container, all running animations within it are paused and automatically resume when the cursor leaves.

## Testing

* ✅ Opened `demo.html` locally and verified behavior
* ✅ Marquee pauses immediately on hover
* ✅ Animation resumes correctly after hover ends
* ✅ Utility works without JavaScript
* ✅ Demo comparison confirms expected functionality
