### PR TITLE
feat: add pure CSS animated border beam indicator

### DIFF
--- a/submissions/examples/animated-border-beam/README.md
+++ b/submissions/examples/animated-border-beam/README.md
@@ -1,0 +1,32 @@
+# Animated Border Beam
+
+## What does this do?
+A glowing light beam continuously sweeps around the border of a card using
+a `conic-gradient` on a `::before` pseudo-element animated with `@keyframes`.
+Zero JavaScript.
+
+## How is it used?
+Add the class to any card element:
+
+```html
+<div class="beam-card">
+  Your content here
+</div>
+```
+
+Variants:
+- Colour: `beam-card-blue`, `beam-card-green`
+- Speed: `beam-slow`, `beam-fast`
+
+## Why is it useful?
+Border beams are widely used for featured cards, active states, and 
+scanning/loading indicators. No existing submission covers this pattern.
+Relies on the `@property` CSS Houdini API for smooth angle interpolation
+(supported in all modern browsers).
+
+## Tech Stack
+- HTML
+- CSS only (`@keyframes`, `conic-gradient`, `@property`)
+
+## Preview
+Open `demo.html` directly in your browser.

--- a/submissions/examples/animated-border-beam/demo.html
+++ b/submissions/examples/animated-border-beam/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Border Beam Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+      font-family: sans-serif;
+      background: #f4f5f7;
+      padding: 2rem;
+    }
+
+    h3 {
+      margin: 0 0 0.5rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #888;
+    }
+
+    .beam-card {
+      width: 280px;
+    }
+
+    .card-title {
+      font-size: 1rem;
+      font-weight: 600;
+      color: #111827;
+      margin: 0 0 0.25rem;
+    }
+
+    .card-sub {
+      font-size: 0.875rem;
+      color: #6b7280;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <section>
+    <h3>Default (Purple–Pink)</h3>
+    <div class="beam-card">
+      <p class="card-title">Featured Plan</p>
+      <p class="card-sub">Glowing beam loops forever around this card.</p>
+    </div>
+  </section>
+
+  <section>
+    <h3>Blue Variant</h3>
+    <div class="beam-card beam-card-blue">
+      <p class="card-title">Active Session</p>
+      <p class="card-sub">Blue–indigo beam, same animation.</p>
+    </div>
+  </section>
+
+  <section>
+    <h3>Green Variant — Slow</h3>
+    <div class="beam-card beam-card-green beam-slow">
+      <p class="card-title">Scanning…</p>
+      <p class="card-sub">Green beam at half speed, calm pulse feel.</p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/animated-border-beam/style.css
+++ b/submissions/examples/animated-border-beam/style.css
@@ -1,0 +1,75 @@
+/* Animated Border Beam — pure CSS */
+
+.beam-card {
+  position: relative;
+  border-radius: 12px;
+  padding: 1.5rem 2rem;
+  background: #fff;
+  overflow: hidden;
+  z-index: 0;
+}
+
+/* The beam lives on a pseudo-element behind the card */
+.beam-card::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: conic-gradient(
+    from var(--beam-angle, 0deg),
+    transparent 70%,
+    #6366f1 85%,
+    #a855f7 90%,
+    #ec4899 95%,
+    transparent 100%
+  );
+  z-index: -1;
+  animation: beam-spin 2.4s linear infinite;
+}
+
+/* White fill so only the beam edge shows */
+.beam-card::after {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  border-radius: calc(12px - 2px);
+  background: #fff;
+  z-index: -1;
+}
+
+@property --beam-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@keyframes beam-spin {
+  to {
+    --beam-angle: 360deg;
+  }
+}
+
+/* Colour variants */
+.beam-card-blue::before {
+  background: conic-gradient(
+    from var(--beam-angle, 0deg),
+    transparent 70%,
+    #38bdf8 88%,
+    #818cf8 94%,
+    transparent 100%
+  );
+}
+
+.beam-card-green::before {
+  background: conic-gradient(
+    from var(--beam-angle, 0deg),
+    transparent 70%,
+    #34d399 88%,
+    #a3e635 94%,
+    transparent 100%
+  );
+}
+
+/* Speed variants */
+.beam-slow::before  { animation-duration: 4s; }
+.beam-fast::before  { animation-duration: 1.2s; }


### PR DESCRIPTION
## Summary
Adds a pure CSS animated border beam component — a glowing light that 
continuously sweeps around the border of a card using `conic-gradient` 
on a `::before` pseudo-element animated with `@keyframes`. Zero JavaScript.

## Files Added
- `style.css` — beam animation, three colour variants, two speed variants
- `demo.html` — live demo with all variants
- `README.md` — usage instructions and explanation

## What's included
- Default purple–pink beam
- `beam-card-blue` and `beam-card-green` colour variants
- `beam-slow` and `beam-fast` speed modifiers
- Uses CSS `@property` for smooth angle interpolation (supported in all modern browsers)

## Testing
- [ ] Verified in Chrome
- [ ] Verified in Firefox
- [ ] All three demo variants render and animate correctly
- [ ] 
<img width="949" height="659" alt="image" src="https://github.com/user-attachments/assets/81d44fa6-be54-45d6-83db-425cd438733d" />


Closes #3332 