### PR TITLE
feat: add pure CSS cursor follow dot indicator

### DIFF
--- a/submissions/examples/css-cursor-follow-dot/README.md
+++ b/submissions/examples/css-cursor-follow-dot/README.md
@@ -1,0 +1,30 @@
+# CSS-only Cursor Follow Dot
+
+## What does this do?
+A dot that appears on hover using `:hover` + `::after` pseudo-element on a 
+container, simulating a cursor follow effect with zero JavaScript.
+
+## How is it used?
+Wrap any content in a `.cursor-zone`:
+
+```html
+<div class="cursor-zone">
+  <span class="cursor-zone-label">Hover me</span>
+</div>
+```
+
+Variants:
+- Colour: `cursor-dot-pink`, `cursor-dot-green`, `cursor-dot-orange`
+- Style: `cursor-dot-ring` (outline), `cursor-dot-sm`, `cursor-dot-lg`
+- Position: `cursor-zone-corner` (anchors dot to top-right)
+
+## Why is it useful?
+Demonstrates the boundary of pure CSS cursor interaction — useful for
+portfolios, landing pages, and interactive cards without any JS overhead.
+
+## Tech Stack
+- HTML
+- CSS only (`:hover`, `::after`, transitions)
+
+## Preview
+Open `demo.html` directly in your browser.

--- a/submissions/examples/css-cursor-follow-dot/demo.html
+++ b/submissions/examples/css-cursor-follow-dot/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Cursor Follow Dot Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+      font-family: sans-serif;
+      background: #f4f5f7;
+      padding: 2rem;
+    }
+
+    h3 {
+      margin: 0 0 0.5rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #888;
+    }
+
+    .row {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+    }
+  </style>
+</head>
+<body>
+
+  <section>
+    <h3>Default — Centre Dot</h3>
+    <div class="cursor-zone">
+      <span class="cursor-zone-label">Hover me</span>
+    </div>
+  </section>
+
+  <section>
+    <h3>Colour Variants</h3>
+    <div class="row">
+      <div class="cursor-zone cursor-dot-pink">
+        <span class="cursor-zone-label">Pink</span>
+      </div>
+      <div class="cursor-zone cursor-dot-green">
+        <span class="cursor-zone-label">Green</span>
+      </div>
+      <div class="cursor-zone cursor-dot-orange">
+        <span class="cursor-zone-label">Orange</span>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3>Ring Variant</h3>
+    <div class="cursor-zone cursor-dot-ring">
+      <span class="cursor-zone-label">Outline dot</span>
+    </div>
+  </section>
+
+  <section>
+    <h3>Corner Anchored</h3>
+    <div class="cursor-zone cursor-zone-corner">
+      <span class="cursor-zone-label">Dot snaps to corner</span>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/css-cursor-follow-dot/style.css
+++ b/submissions/examples/css-cursor-follow-dot/style.css
@@ -1,0 +1,85 @@
+/* CSS-only Cursor Follow Dot — pure CSS */
+
+.cursor-zone {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem 2.5rem;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  cursor: none;
+  overflow: hidden;
+  transition: box-shadow 0.2s ease;
+}
+
+.cursor-zone:hover {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+/* The follow dot — hidden by default */
+.cursor-zone::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #6366f1;
+  transform: translate(-50%, -50%) scale(0);
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+              opacity 0.2s ease;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Dot appears on hover */
+.cursor-zone:hover::after {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+}
+
+/* Label inside the zone */
+.cursor-zone-label {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #374151;
+  transition: color 0.2s ease;
+  pointer-events: none;
+}
+
+.cursor-zone:hover .cursor-zone-label {
+  color: #6366f1;
+}
+
+/* Colour variants */
+.cursor-dot-pink::after   { background: #ec4899; }
+.cursor-dot-green::after  { background: #10b981; }
+.cursor-dot-orange::after { background: #f97316; }
+
+/* Size variants */
+.cursor-dot-sm::after { width: 8px;  height: 8px;  }
+.cursor-dot-lg::after { width: 20px; height: 20px; }
+
+/* Ring variant — outline dot instead of filled */
+.cursor-dot-ring::after {
+  background: transparent;
+  border: 2px solid #6366f1;
+  width: 18px;
+  height: 18px;
+}
+
+/* Corner-anchored variant — dot snaps to top-right */
+.cursor-zone-corner::after {
+  top: 12px;
+  left: unset;
+  right: 12px;
+  transform: scale(0);
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.cursor-zone-corner:hover::after {
+  transform: scale(1);
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS cursor follow dot — a styled dot that appears on 
container hover via `::after` pseudo-element and transitions. 
Simulates a cursor-following effect with zero JavaScript.

## Files Added
- `style.css` — hover dot, colour/size/ring/corner variants
- `demo.html` — live demo with all variants
- `README.md` — usage instructions and explanation

## What's included
- Default centre-anchored dot with spring transition
- Colour variants: pink, green, orange
- Style variants: filled, ring (outline), sm, lg
- Corner-anchored position variant

## Testing
- [ ] Verified in Chrome
- [ ] Verified in Firefox
- [ ] All demo variants appear and transition correctly

Closes #3336 