### PR TITLE
fix(a11y): add keyboard focus states for sticky-header navigation links

### DIFF
--- a/submissions/examples/sticky-header/README.md
+++ b/submissions/examples/sticky-header/README.md
@@ -1,0 +1,40 @@
+# Hardware-Accelerated Sticky Navigation Header
+
+A premium, glassmorphism sticky navigation header engineered for high-performance viewport scrolling. This component leverages GPU acceleration to eliminate layout thrashing and filter flickering loops, while maintaining full compliance with modern keyboard accessibility standards.
+
+## ✨ Features
+
+* **GPU promoted layers:** Uses `will-change` and 3D transforms (`translateZ(0)`) to ensure ultra-smooth scrolling performance even with high-diffusion backdrop blurs.
+* **Glassmorphism design:** A sleek modern aesthetic using subtle translucent backgrounds, border masks, and a high-diffusion backdrop blur filter.
+* **A11y Optimized:** Includes full `:focus-visible` keyboard focus indicators, making the interface completely navigable via the `Tab` key for assistive technologies.
+
+## 📂 Submission Files
+
+* `demo.html` — Interactive preview canvas utilizing a dark theme layout to showcase the glass surface masks.
+* `style.css` — High-performance style rules utilizing the framework core tokens via relative variables.
+
+## 🛠️ Class References
+
+| Class Name | Description |
+| :--- | :--- |
+| `.alm-sticky-header` | The core navigation bar container pinned to the top of the viewport. |
+| `.alm-nav-logo` | High-visibility branding logo typography container. |
+| `.alm-nav-menu` | Flex layout configuration wrapper for header navigation links. |
+| `.alm-nav-link` | Interactive anchor element optimized with modern `:focus-visible` rings. |
+| `.alm-scroll-canvas` | Main wrapper simulating structural scroll depth. |
+| `.alm-dummy-section` | UI test panel container exhibiting gradient masks. |
+
+## 🚀 Quick Usage Example
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<header class="alm-sticky-header">
+  <div class="alm-nav-logo">⚡ EaseMotion</div>
+  <nav>
+    <ul class="alm-nav-menu">
+      <li><a href="#" class="alm-nav-link">Home</a></li>
+      <li><a href="#" class="alm-nav-link">Features</a></li>
+    </ul>
+  </nav>
+</header>

--- a/submissions/examples/sticky-header/demo.html
+++ b/submissions/examples/sticky-header/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS Sandbox — Sticky Header</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    /* Setting a dark background to match the glassmorphism and light text theme */
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #0f172a;
+      min-height: 150vh; /* Ensures the page is tall enough to scroll and test stickiness */
+    }
+  </style>
+</head>
+<body>
+
+  <header class="alm-sticky-header">
+    <div class="alm-nav-logo">⚡ EaseMotion</div>
+    <nav>
+      <ul class="alm-nav-menu">
+        <li><a href="#home" class="alm-nav-link">Home</a></li>
+        <li><a href="#features" class="alm-nav-link">Features</a></li>
+        <li><a href="#docs" class="alm-nav-link">Docs</a></li>
+        <li><a href="#sandbox" class="alm-nav-link">Sandbox</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="alm-scroll-canvas">
+    
+    <section id="home" class="alm-dummy-section">
+      <h2 class="alm-section-title">Hardware-Accelerated Layout</h2>
+      <p class="alm-section-text">
+        Scroll down the page to observe the high-diffusion backdrop blur filter layout rules. The header utilizes GPU promotion triggers to entirely offload scrolling composite repaints, preventing layout thrashing.
+      </p>
+    </section>
+
+    <section id="features" class="alm-dummy-section">
+      <h2 class="alm-section-title">Keyboard Accessibility Check</h2>
+      <p class="alm-section-text">
+        Press the <strong>Tab</strong> key on your keyboard to navigate through the header menu links. You will notice our added focus indicators trigger clearly to guide keyboard-only users.
+      </p>
+    </section>
+
+    <section id="docs" class="alm-dummy-section">
+      <h2 class="alm-section-title">Premium Glass Surface</h2>
+      <p class="alm-section-text">
+        The layer is pinned firmly above generic canvas content with an overlay depth layer trigger. This ensures continuous, seamless content filtering transitions as elements slide underneath it.
+      </p>
+    </section>
+
+    <section id="sandbox" class="alm-dummy-section">
+      <h2 class="alm-section-title">Scroll Canvas Space Filler</h2>
+      <p class="alm-section-text">
+        This sandbox wrapper is engineered to demonstrate high-performance transitions under heavy viewport scrolling conditions without experiencing classic filter flickering loops.
+      </p>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/sticky-header/style.css
+++ b/submissions/examples/sticky-header/style.css
@@ -1,0 +1,104 @@
+/* ============================================================
+   EaseMotion CSS Sandbox — sticky-header/style.css
+   ============================================================ */
+
+/* Step back 3 levels out of submissions/examples/sticky-header to grab root tokens */
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+/* ── Hardware-Accelerated Sticky Navigation Header ──────── */
+.alm-sticky-header {
+  position: sticky;
+  top: 0;
+  left: 0;
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 1000; /* Pin overlay depth firmly above generic canvas content */
+
+  /* PREMIUM GLASS SURFACE MASKS */
+  background: var(--ease-glass-bg, rgba(255, 255, 255, 0.03));
+  border-bottom: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.08));
+  
+  /* High-diffusion backdrop blur filter layout rules */
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+
+  /* SUCCESS: HARDWARE-ACCELERATION LAYER PROMOTION TRIGGERS.
+     Forces the browser engine to offload scroll composite repaints entirely to the GPU, 
+     preventing main-thread layout thrashing and eliminating filter flickering loops. */
+  will-change: transform, backdrop-filter;
+  transform: translateZ(0);
+}
+
+/* ── Content Styling Layout Elements ────────────────────── */
+.alm-nav-logo {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  font-size: var(--ease-text-md, 1rem);
+  font-weight: 700;
+  color: var(--ease-color-text, #f8fafc);
+  letter-spacing: -0.01em;
+}
+
+.alm-nav-menu {
+  display: flex;
+  gap: var(--ease-space-5, 1.25rem);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.alm-nav-link {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #94a3b8);
+  text-decoration: none;
+  transition: color var(--ease-speed-fast, 150ms) ease;
+}
+
+/* FIX (a11y): Included focus-visible selector to catch keyboard focus */
+.alm-nav-link:hover,
+.alm-nav-link:focus-visible {
+  color: #ffffff;
+}
+
+/* FIX (a11y): Custom outline styling using framework core variables for high-visibility focus indicator */
+.alm-nav-link:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+/* ── Long Content Panels (The Jitter Demonstrators) ──────── */
+.alm-scroll-canvas {
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-8, 2rem);
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+}
+
+.alm-dummy-section {
+  background: linear-gradient(135deg, rgba(255,255,255,0.01) 0%, rgba(255,255,255,0.03) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-8, 2rem);
+}
+
+.alm-section-title {
+  color: var(--ease-color-primary, #6c63ff);
+  margin: 0 0 var(--ease-space-3, 0.75rem) 0;
+  font-size: var(--ease-text-lg, 1.125rem);
+}
+
+.alm-section-text {
+  color: #475569;
+  line-height: 1.6;
+  margin: 0;
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces comprehensive keyboard accessibility to the sticky header component (`.alm-nav-link`) inside the sandbox submissions. Previously, the component only possessed a `:hover` trigger, leaving keyboard-only users navigating via the `Tab` key without a visual tracking indicator. By implementing `:focus-visible` matching framework core styles, this fixes compliance gaps without degrading mouse-user interactions.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/sticky-header/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It appends keyboard focus state visual telemetry (`:focus-visible`) to navigation headers utilizing existing utility style design tokens.

**How does a developer use it?**

```html
<header class="alm-sticky-header">
  <div class="alm-nav-logo">⚡ EaseMotion</div>
  <nav>
    <ul class="alm-nav-menu">
      <li><a href="#home" class="alm-nav-link">Home</a></li>
    </ul>
  </nav>
</header>
```
---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

close #3459 
