### PR TITLE
feat: propose semantic color architecture to support global dark mode

### DIFF
--- a/submissions/examples/dark-mode-color-system-av/README.md
+++ b/submissions/examples/dark-mode-color-system-av/README.md
@@ -1,0 +1,10 @@
+# Semantic Color System (Dark Mode Fix)
+
+## What does this do?
+Proposes migrating all framework components from absolute/hardcoded colors (e.g., `#fff` or `--ease-color-neutral-200`) to a strict semantic token system (e.g., `--ease-color-surface`, `--ease-color-border`).
+
+## How is it used?
+Component authors build components using purely semantic variables from `variables.css`. For example, using `background: var(--ease-color-surface)` instead of `background: var(--ease-color-surface, #ffffff)`.
+
+## Why is it useful?
+Currently, files like `components/footer.css`, `components/buttons.css`, and `components/cards.css` hardcode HEX fallbacks or explicitly reference fixed "neutral" palette colors. Because neutral colors don't inherently invert in dark mode, these components stay light even when the user's OS switches to dark mode. By migrating entirely to semantic tokens (`--ease-color-bg`, `--ease-color-text`, etc.), the entire library gains automatic, seamless, zero-config Dark Mode support.

--- a/submissions/examples/dark-mode-color-system-av/demo.html
+++ b/submissions/examples/dark-mode-color-system-av/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dark Mode Color System</title>
+  <link rel="stylesheet" href="../../../easemotion/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 2rem; background: var(--ease-color-bg); color: var(--ease-color-text); transition: background 0.3s, color 0.3s; }
+    .card { padding: 1.5rem; border-radius: 8px; margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Semantic Color System for Dark Mode</h1>
+  <p>Test this by switching your OS/Browser to Dark Mode.</p>
+  
+  <div class="card ease-card-bad">
+    <h3>❌ Old Component (Hardcoded)</h3>
+    <p>This stays white in dark mode because of hardcoded <code>#ffffff</code> and absolute <code>neutral-200</code> colors.</p>
+  </div>
+
+  <div class="card ease-card-good">
+    <h3>✅ New Component (Semantic)</h3>
+    <p>This automatically shifts to dark mode because it uses semantic <code>--ease-color-surface</code> and <code>--ease-color-text</code> tokens.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dark-mode-color-system-av/style.css
+++ b/submissions/examples/dark-mode-color-system-av/style.css
@@ -1,0 +1,36 @@
+/* 
+  Proposed Semantic Color Architecture
+  This demonstrates how components should reference semantic variables (which flip in dark mode)
+  instead of absolute neutral variables or hardcoded hex colors.
+*/
+
+:root {
+  /* Added semantic border color to variables.css */
+  --ease-color-border: var(--ease-color-neutral-200);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-color-border: var(--ease-color-neutral-700);
+  }
+}
+
+/* ❌ BAD: Hardcoded hex and absolute neutral fallback */
+.ease-card-bad {
+  background-color: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+/* ✅ GOOD: Pure semantic variables without hex fallbacks */
+.ease-card-good {
+  background-color: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  color: var(--ease-color-text);
+}
+
+/* ✅ GOOD: Buttons using surface color instead of hardcoded white */
+.ease-btn-good {
+  background-color: var(--ease-color-primary);
+  color: var(--ease-color-bg); /* properly maps text color on dark backgrounds */
+}


### PR DESCRIPTION
This PR addresses the hardcoded HEX and RGB fallbacks currently preventing native dark mode support across the framework. Following the strict contribution guidelines, this structural refactor is submitted as an architectural proposal inside submissions/examples/dark-mode-color-system-av/. The submission provides a complete working demonstration of how migrating component code from absolute neutral/hex fallbacks to semantic variables (like --ease-color-surface and --ease-color-text) allows for automatic, native dark-mode inversion. Integrating this strict semantic mapping into the core variables.css will grant the entire library robust, zero-config dark mode support.

Closes #3517 