### PR TITLE
feat: propose SCSS breakpoint mixins to replace hardcoded media queries

### DIFF
--- a/submissions/examples/breakpoint-refactor-av/README.md
+++ b/submissions/examples/breakpoint-refactor-av/README.md
@@ -1,0 +1,12 @@
+# Centralized SCSS Breakpoint Architecture
+
+## What does this do?
+Proposes a structural refactor to eliminate hardcoded media queries (like `@media (max-width: 640px)`) across all framework components by migrating to a centralized SCSS `$breakpoints` map and a `@respond-to` mixin.
+
+## How is it used?
+Component authors write their styles in `.scss` files using `@include respond-to('sm') { ... }` instead of writing raw `@media` queries. This centralizes all breakpoint configurations into `scss/_variables.scss`.
+
+## Why is it useful?
+Because native CSS variables (`var(--ease-bp-sm)`) are not supported inside `@media` queries by standard CSS yet, developers cannot globally configure responsive breakpoints dynamically. Currently, core files like `components/navbar.css`, `components/masonry.css`, `components/buttons.css`, and `components/sidebar.css` heavily hardcode `640px` or `768px` breakpoints. 
+
+If a team utilizing EaseMotion CSS wants to adjust the mobile breakpoint from `640px` to `768px`, they must run a massive search-and-replace across the entire framework. By adopting an SCSS-first approach for components, we guarantee a single source of truth for responsive design, making the library infinitely more scalable.

--- a/submissions/examples/breakpoint-refactor-av/demo.html
+++ b/submissions/examples/breakpoint-refactor-av/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Breakpoint Refactor</title>
+  <link rel="stylesheet" href="../../../easemotion/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 2rem; background: #f1f5f9; color: #0f172a; }
+    .card { background: white; border-radius: 8px; margin-bottom: 1rem; border: 2px solid #e2e8f0; transition: padding 0.3s; }
+  </style>
+</head>
+<body>
+  <h1>SCSS Breakpoint Mixin Proposal</h1>
+  <p>Resize your browser window below 640px to see the padding shrink.</p>
+  
+  <div class="card ease-card-bad">
+    <h3>❌ Old Component (Hardcoded 640px)</h3>
+    <p>Padding changes on mobile, but the <code>640px</code> breakpoint is deeply hardcoded inside the CSS file.</p>
+  </div>
+
+  <div class="card ease-card-good">
+    <h3>✅ New Component (SCSS Mixin)</h3>
+    <p>Padding changes on mobile, driven entirely by a centralized <code>$breakpoints</code> SCSS map. This keeps the codebase DRY.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/breakpoint-refactor-av/style.css
+++ b/submissions/examples/breakpoint-refactor-av/style.css
@@ -1,0 +1,18 @@
+/* Compiled output for the demo */
+.ease-card-bad {
+  padding: 2rem;
+}
+@media (max-width: 640px) {
+  .ease-card-bad {
+    padding: 1rem;
+  }
+}
+
+.ease-card-good {
+  padding: 2rem;
+}
+@media (max-width: 640px) {
+  .ease-card-good {
+    padding: 1rem;
+  }
+}

--- a/submissions/examples/breakpoint-refactor-av/style.scss
+++ b/submissions/examples/breakpoint-refactor-av/style.scss
@@ -1,0 +1,37 @@
+/* Proposed SCSS Breakpoint Architecture */
+$breakpoints: (
+  'sm': 640px,
+  'md': 768px,
+  'lg': 1024px,
+  'xl': 1280px
+);
+
+@mixin respond-to($breakpoint) {
+  $value: map-get($breakpoints, $breakpoint);
+  @if $value {
+    @media (max-width: $value) {
+      @content;
+    }
+  } @else {
+    @warn "Invalid breakpoint: #{$breakpoint}.";
+  }
+}
+
+/* ❌ BAD: Hardcoded component */
+.ease-card-bad {
+  padding: 2rem;
+}
+@media (max-width: 640px) {
+  .ease-card-bad {
+    padding: 1rem;
+  }
+}
+
+/* ✅ GOOD: Using the centralized SCSS mixin */
+.ease-card-good {
+  padding: 2rem;
+  
+  @include respond-to('sm') {
+    padding: 1rem;
+  }
+}


### PR DESCRIPTION
This PR addresses the critical scalability issue of hardcoded media queries scattered throughout the framework. Since standard CSS cannot process variables inside @media blocks, and because direct modification of core component files is restricted by the project's curated contribution guidelines, this structural refactor is submitted as an architectural proposal within submissions/examples/breakpoint-refactor-av/. The submission demonstrates a centralized SCSS $breakpoints map alongside a dynamic @respond-to mixin. By migrating component authoring to SCSS, the framework gains a single source of truth for responsive design, empowering developers to instantly redefine global breakpoints without relying on search-and-replace hacks.

Closes #3525 