### PR TITLE
feat: add animated profile card component 

### DIFF
--- a/submissions/examples/ease-profile-zd/README.md
+++ b/submissions/examples/ease-profile-zd/README.md
@@ -1,0 +1,31 @@
+# Ease Profile Zd
+
+## What does this do?
+An animated profile/team card component with avatar, badges, stats, and social links — featuring fade-up entrance, avatar scale-in, hover lift, and social link hover effects — pure HTML and CSS.
+
+## How is it used?
+```html
+<div class="pf-grid">
+  <div class="pf-card">
+    <span class="pf-badge pf-badge-pro">Pro</span>
+    <img class="pf-avatar" src="avatar.jpg" alt="Name" width="80" height="80">
+    <div class="pf-name">Jane Doe</div>
+    <div class="pf-role">Senior Designer</div>
+    <div class="pf-bio">Short bio text here...</div>
+    <div class="pf-stats">
+      <div class="pf-stat">
+        <div class="pf-stat-value">128</div>
+        <div class="pf-stat-label">Projects</div>
+      </div>
+    </div>
+    <div class="pf-social">
+      <a class="pf-social-link" href="#" aria-label="Twitter">𝕏</a>
+    </div>
+  </div>
+</div>
+```
+
+Badge variants: pf-badge-pro, pf-badge-member, pf-badge-lead
+
+## Why is it useful?
+Profile cards are a staple of team pages, user directories, social platforms, and dashboard user panels. This component provides a polished, animated card with stats and social links that works out of the box.

--- a/submissions/examples/ease-profile-zd/demo.html
+++ b/submissions/examples/ease-profile-zd/demo.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profile Cards — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', -apple-system, sans-serif; background: #0b0f1a; color: #e8edf5; padding: 2.5rem 1.5rem; display: flex; flex-direction: column; align-items: center; }
+    .wrap { width: 100%; max-width: 900px; }
+    h1 { font-size: 1.35rem; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 4px; }
+    .sub { font-size: 0.82rem; color: #8892a8; margin-bottom: 28px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Team Profiles</h1>
+    <p class="sub">Animated profile cards with hover effects</p>
+    <div class="pf-grid">
+      <div class="pf-card">
+        <span class="pf-badge pf-badge-lead">Lead</span>
+        <img class="pf-avatar" src="https://i.pravatar.cc/80?img=1" alt="Alex Chen" width="80" height="80">
+        <div class="pf-name">Alex Chen</div>
+        <div class="pf-role">Senior Designer</div>
+        <div class="pf-bio">Crafting pixel-perfect interfaces with a focus on motion design and accessibility.</div>
+        <div class="pf-stats">
+          <div class="pf-stat">
+            <div class="pf-stat-value">128</div>
+            <div class="pf-stat-label">Projects</div>
+          </div>
+          <div class="pf-stat">
+            <div class="pf-stat-value">4.9</div>
+            <div class="pf-stat-label">Rating</div>
+          </div>
+          <div class="pf-stat">
+            <div class="pf-stat-value">2.3k</div>
+            <div class="pf-stat-label">Followers</div>
+          </div>
+        </div>
+        <div class="pf-social">
+          <a class="pf-social-link" href="#" aria-label="Twitter">𝕏</a>
+          <a class="pf-social-link" href="#" aria-label="GitHub">G</a>
+          <a class="pf-social-link" href="#" aria-label="LinkedIn">in</a>
+          <a class="pf-social-link" href="#" aria-label="Dribbble">Dr</a>
+        </div>
+      </div>
+      <div class="pf-card">
+        <span class="pf-badge pf-badge-pro">Pro</span>
+        <img class="pf-avatar" src="https://i.pravatar.cc/80?img=5" alt="Sarah Kim" width="80" height="80">
+        <div class="pf-name">Sarah Kim</div>
+        <div class="pf-role">Full-Stack Developer</div>
+        <div class="pf-bio">Building scalable web apps with React, Node.js, and a passion for clean architecture.</div>
+        <div class="pf-stats">
+          <div class="pf-stat">
+            <div class="pf-stat-value">342</div>
+            <div class="pf-stat-label">Commits</div>
+          </div>
+          <div class="pf-stat">
+            <div class="pf-stat-value">89</div>
+            <div class="pf-stat-label">PRs</div>
+          </div>
+          <div class="pf-stat">
+            <div class="pf-stat-value">5.1k</div>
+            <div class="pf-stat-label">Stars</div>
+          </div>
+        </div>
+        <div class="pf-social">
+          <a class="pf-social-link" href="#" aria-label="Twitter">𝕏</a>
+          <a class="pf-social-link" href="#" aria-label="GitHub">G</a>
+          <a class="pf-social-link" href="#" aria-label="LinkedIn">in</a>
+          <a class="pf-social-link" href="#" aria-label="Dribbble">Dr</a>
+        </div>
+      </div>
+      <div class="pf-card">
+        <span class="pf-badge pf-badge-member">Member</span>
+        <img class="pf-avatar" src="https://i.pravatar.cc/80?img=9" alt="Marcus Rivera" width="80" height="80">
+        <div class="pf-name">Marcus Rivera</div>
+        <div class="pf-role">UX Researcher</div>
+        <div class="pf-bio">Turning user insights into delightful product experiences through research-driven design.</div>
+        <div class="pf-stats">
+          <div class="pf-stat">
+            <div class="pf-stat-value">56</div>
+            <div class="pf-stat-label">Studies</div>
+          </div>
+          <div class="pf-stat">
+            <div class="pf-stat-value">98%</div>
+            <div class="pf-stat-label">Satisfaction</div>
+          </div>
+          <div class="pf-stat">
+            <div class="pf-stat-value">890</div>
+            <div class="pf-stat-label">Connections</div>
+          </div>
+        </div>
+        <div class="pf-social">
+          <a class="pf-social-link" href="#" aria-label="Twitter">𝕏</a>
+          <a class="pf-social-link" href="#" aria-label="GitHub">G</a>
+          <a class="pf-social-link" href="#" aria-label="LinkedIn">in</a>
+          <a class="pf-social-link" href="#" aria-label="Dribbble">Dr</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-profile-zd/style.css
+++ b/submissions/examples/ease-profile-zd/style.css
@@ -1,0 +1,155 @@
+:root {
+  --pf-font: 'Inter', -apple-system, sans-serif;
+  --pf-bg: #0b0f1a;
+  --pf-surface: #141829;
+  --pf-border: rgba(255,255,255,0.08);
+  --pf-text: #e8edf5;
+  --pf-text-sec: #8892a8;
+  --pf-primary: #6c5ce7;
+  --pf-primary-light: #a29bfe;
+  --pf-accent: #fd79a8;
+}
+@keyframes pf-fade-up {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes pf-scale-in {
+  from { transform: scale(0); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+.pf-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+.pf-card {
+  background: var(--pf-surface);
+  border: 1px solid var(--pf-border);
+  border-radius: 16px;
+  padding: 32px 24px 24px;
+  text-align: center;
+  font-family: var(--pf-font);
+  animation: pf-fade-up 0.5s ease-out both;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  cursor: default;
+}
+.pf-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 12px 40px rgba(108, 92, 231, 0.15);
+}
+.pf-card:nth-child(1) { animation-delay: 0s; }
+.pf-card:nth-child(2) { animation-delay: 0.1s; }
+.pf-card:nth-child(3) { animation-delay: 0.2s; }
+.pf-card:nth-child(4) { animation-delay: 0.3s; }
+.pf-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  margin: 0 auto 16px;
+  object-fit: cover;
+  display: block;
+  border: 3px solid var(--pf-primary);
+  animation: pf-scale-in 0.4s ease-out 0.2s both;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+.pf-card:hover .pf-avatar {
+  transform: scale(1.08);
+  border-color: var(--pf-accent);
+}
+.pf-name {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--pf-text);
+  margin-bottom: 2px;
+}
+.pf-role {
+  font-size: 0.78rem;
+  color: var(--pf-primary-light);
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+.pf-bio {
+  font-size: 0.75rem;
+  color: var(--pf-text-sec);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+.pf-stats {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding: 12px 0;
+  border-top: 1px solid var(--pf-border);
+  border-bottom: 1px solid var(--pf-border);
+}
+.pf-stat {
+  text-align: center;
+}
+.pf-stat-value {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--pf-text);
+}
+.pf-stat-label {
+  font-size: 0.6rem;
+  color: var(--pf-text-sec);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.pf-social {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+.pf-social-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.06);
+  color: var(--pf-text-sec);
+  font-size: 0.9rem;
+  text-decoration: none;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
+}
+.pf-social-link:hover {
+  background: var(--pf-primary);
+  color: #fff;
+  transform: translateY(-3px);
+}
+.pf-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 12px;
+  animation: pf-scale-in 0.3s ease-out 0.35s both;
+}
+.pf-badge-pro {
+  background: linear-gradient(135deg, var(--pf-primary), #8b5cf6);
+  color: #fff;
+}
+.pf-badge-member {
+  background: rgba(255,255,255,0.08);
+  color: var(--pf-text-sec);
+}
+.pf-badge-lead {
+  background: linear-gradient(135deg, var(--pf-accent), #e84393);
+  color: #fff;
+}
+@media (max-width: 640px) {
+  .pf-grid { grid-template-columns: 1fr; }
+  .pf-card { padding: 24px 16px 20px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  * { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+  .pf-card { animation: none !important; }
+  .pf-avatar { animation: none !important; }
+  .pf-badge { animation: none !important; }
+}


### PR DESCRIPTION
Adds a new animated profile card component under
submissions/examples/ease-profile-zd/ with avatar,
stats, social links, and badge variants.
 
Files Added:
- submissions/examples/ease-profile-zd/demo.html
- submissions/examples/ease-profile-zd/style.css
- submissions/examples/ease-profile-zd/README.md
 
Features:
- Fade-up entrance + avatar scale-in
- 3 badge variants: pf-badge-pro, pf-badge-lead, pf-badge-member
- Stats row with divider lines
- Social links with hover lift
- Hover lift on card + avatar scale
- Responsive grid with mobile breakpoint
- prefers-reduced-motion support
 
Checklist:
- [x] Added to submissions/examples/ only
- [x] All three required files included
- [x] No core files modified
- [x] prefers-reduced-motion respected
- [x] Accessible aria-labels on links
closes #3566