### PR TITLE
feat: add animated avatar group component 

### DIFF
--- a/submissions/examples/ease-avatargroup-zd/README.md
+++ b/submissions/examples/ease-avatargroup-zd/README.md
@@ -1,0 +1,26 @@
+# Ease Avatar Group Zd
+
+## What does this do?
+An animated avatar group component with stacked image avatars and initials-based avatars, hover spread animation, count overflow badge, and descriptive labels — pure HTML and CSS.
+
+## How is it used?
+```html
+<!-- Image avatars -->
+<div class="ag-group">
+  <img class="ag-avatar" src="avatar1.jpg" alt="Name" width="40" height="40">
+  <img class="ag-avatar" src="avatar2.jpg" alt="Name" width="40" height="40">
+  <span class="ag-count">+5</span>
+</div>
+<div class="ag-label"><strong>12 members</strong> online now</div>
+
+<!-- Initials avatars -->
+<div class="ag-group">
+  <span class="ag-avatar-initials" style="background:#6c5ce7;" aria-label="Name">AC</span>
+  <span class="ag-count">+3</span>
+</div>
+```
+
+Use `.ag-avatar` for image avatars, `.ag-avatar-initials` for letter avatars, and `.ag-count` for the overflow count badge.
+
+## Why is it useful?
+Avatar groups are a standard UI pattern for showing multiple people in collaborative contexts — team projects, document sharing, chat rooms, and social features. The hover spread animation reveals the full set without taking up extra space.

--- a/submissions/examples/ease-avatargroup-zd/demo.html
+++ b/submissions/examples/ease-avatargroup-zd/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Avatar Groups — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', -apple-system, sans-serif; background: #0b0f1a; color: #e8edf5; padding: 2.5rem 1.5rem; display: flex; flex-direction: column; align-items: center; }
+    .wrap { width: 100%; max-width: 560px; }
+    h1 { font-size: 1.35rem; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 4px; }
+    .sub { font-size: 0.82rem; color: #8892a8; margin-bottom: 28px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Avatar Groups</h1>
+    <p class="sub">Stacked avatars with hover spread — hover over the group</p>
+
+    <div class="ag-cards">
+      <div class="ag-card">
+        <div class="ag-section-title">Image Avatars</div>
+        <div class="ag-group">
+          <img class="ag-avatar" src="https://i.pravatar.cc/80?img=1" alt="Alex Chen" width="40" height="40">
+          <img class="ag-avatar" src="https://i.pravatar.cc/80?img=5" alt="Sarah Kim" width="40" height="40">
+          <img class="ag-avatar" src="https://i.pravatar.cc/80?img=9" alt="Marcus Rivera" width="40" height="40">
+          <img class="ag-avatar" src="https://i.pravatar.cc/80?img=11" alt="Emily R." width="40" height="40">
+          <span class="ag-count">+5</span>
+        </div>
+        <div class="ag-label"><strong>12 members</strong> online now</div>
+      </div>
+
+      <div class="ag-card">
+        <div class="ag-section-title">Initials Avatars</div>
+        <div class="ag-group">
+          <span class="ag-avatar-initials" style="background:#6c5ce7;" aria-label="Alex Chen">AC</span>
+          <span class="ag-avatar-initials" style="background:#fd79a8;" aria-label="Sarah Kim">SK</span>
+          <span class="ag-avatar-initials" style="background:#00b894;" aria-label="Marcus Rivera">MR</span>
+          <span class="ag-avatar-initials" style="background:#fdcb6e; color:#1a1a2e;" aria-label="Emily R.">ER</span>
+          <span class="ag-count">+3</span>
+        </div>
+        <div class="ag-label"><strong>8 contributors</strong> on this project</div>
+      </div>
+
+      <div class="ag-card">
+        <div class="ag-section-title">Small Group</div>
+        <div class="ag-group">
+          <img class="ag-avatar" src="https://i.pravatar.cc/80?img=12" alt="James K." width="40" height="40">
+          <img class="ag-avatar" src="https://i.pravatar.cc/80?img=13" alt="Priya S." width="40" height="40">
+          <img class="ag-avatar" src="https://i.pravatar.cc/80?img=20" alt="David L." width="40" height="40">
+        </div>
+        <div class="ag-label">You and <strong>2 others</strong> are viewing</div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-avatargroup-zd/style.css
+++ b/submissions/examples/ease-avatargroup-zd/style.css
@@ -1,0 +1,115 @@
+:root {
+  --ag-font: 'Inter', -apple-system, sans-serif;
+  --ag-bg: #0b0f1a;
+  --ag-surface: #141829;
+  --ag-border: rgba(255,255,255,0.08);
+  --ag-text: #e8edf5;
+  --ag-text-sec: #8892a8;
+  --ag-primary: #6c5ce7;
+}
+@keyframes ag-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.ag-group {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--ag-font);
+  animation: ag-fade-in 0.4s ease-out both;
+}
+.ag-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid var(--ag-bg);
+  margin-left: -8px;
+  transition: transform 0.25s ease, margin 0.25s ease, box-shadow 0.25s ease;
+  cursor: default;
+  position: relative;
+  z-index: 1;
+}
+.ag-avatar:first-child { margin-left: 0; }
+.ag-group:hover .ag-avatar { margin-left: 2px; }
+.ag-group:hover .ag-avatar:first-child { margin-left: 0; }
+.ag-avatar:hover {
+  transform: translateY(-6px) scale(1.1);
+  box-shadow: 0 4px 16px rgba(108, 92, 231, 0.3);
+  z-index: 10;
+}
+.ag-avatar-initials {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid var(--ag-bg);
+  margin-left: -8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #fff;
+  transition: transform 0.25s ease, margin 0.25s ease;
+  cursor: default;
+  position: relative;
+  z-index: 1;
+}
+.ag-avatar-initials:first-child { margin-left: 0; }
+.ag-group:hover .ag-avatar-initials { margin-left: 2px; }
+.ag-group:hover .ag-avatar-initials:first-child { margin-left: 0; }
+.ag-avatar-initials:hover {
+  transform: translateY(-6px) scale(1.1);
+  z-index: 10;
+}
+.ag-count {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--ag-primary);
+  color: #fff;
+  margin-left: -8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border: 2px solid var(--ag-bg);
+  transition: transform 0.25s ease, margin 0.25s ease;
+  cursor: default;
+  position: relative;
+  z-index: 1;
+}
+.ag-group:hover .ag-count { margin-left: 2px; }
+.ag-count:hover {
+  transform: translateY(-6px) scale(1.1);
+  box-shadow: 0 4px 16px rgba(108, 92, 231, 0.3);
+  z-index: 10;
+}
+.ag-label {
+  margin-left: 12px;
+  font-size: 0.82rem;
+  color: var(--ag-text-sec);
+}
+.ag-label strong { color: var(--ag-text); font-weight: 600; }
+.ag-section-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ag-text-sec);
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.ag-card {
+  background: var(--ag-surface);
+  border: 1px solid var(--ag-border);
+  border-radius: 14px;
+  padding: 24px;
+  font-family: var(--ag-font);
+  margin-bottom: 20px;
+}
+.ag-cards { max-width: 500px; }
+@media (prefers-reduced-motion: reduce) {
+  * { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+  .ag-group { animation: none !important; }
+  .ag-avatar, .ag-avatar-initials, .ag-count { margin-left: -8px !important; transform: none !important; }
+}


### PR DESCRIPTION
Adds a new animated avatar group component under
submissions/examples/ease-avatargroup-zd/ — with stacked
image/initials avatars, hover spread, and count overflow.
 
Files Added:
- submissions/examples/ease-avatargroup-zd/demo.html
- submissions/examples/ease-avatargroup-zd/style.css
- submissions/examples/ease-avatargroup-zd/README.md
 
Features:
- Overlapping avatars with hover spread reveal
- Image (.ag-avatar) and initials (.ag-avatar-initials) variants
- Count overflow badge (.ag-count)
- Hover lift + scale on individual avatars
- Descriptive label with bold text
- prefers-reduced-motion support
 
Checklist:
- [x] Added to submissions/examples/ only
- [x] All three required files included
- [x] No core files modified
- [x] prefers-reduced-motion respected
- [ ] closes #3576 