### PR TITLE
feat: add animated image reveal component 

### DIFF
--- a/submissions/examples/ease-reveal-zd/README.md
+++ b/submissions/examples/ease-reveal-zd/README.md
@@ -1,0 +1,23 @@
+# Ease Reveal Zd
+
+## What does this do?
+An animated image reveal component with blur-up loading effect, shimmer placeholder, and staggered card entrance — pure HTML and CSS.
+
+## How is it used?
+```html
+<div class="rv-card">
+  <div class="rv-img-wrap">
+    <div class="rv-placeholder"></div>
+    <img class="rv-img" src="photo.jpg" alt="Description" loading="lazy">
+  </div>
+  <div class="rv-body">
+    <div class="rv-title">Title</div>
+    <div class="rv-desc">Description text...</div>
+  </div>
+</div>
+```
+
+Use `.rv-shimmer-text` inside `.rv-body` for skeleton text placeholders.
+
+## Why is it useful?
+Image loading states are a crucial part of modern web UX. The blur-up reveal and shimmer placeholder provide a polished loading experience that keeps the page feeling fast and responsive while images load.

--- a/submissions/examples/ease-reveal-zd/demo.html
+++ b/submissions/examples/ease-reveal-zd/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Reveal — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', -apple-system, sans-serif; background: #0b0f1a; color: #e8edf5; padding: 2.5rem 1.5rem; display: flex; flex-direction: column; align-items: center; }
+    .wrap { width: 100%; max-width: 900px; }
+    h1 { font-size: 1.35rem; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 4px; }
+    .sub { font-size: 0.82rem; color: #8892a8; margin-bottom: 28px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Image Reveal</h1>
+    <p class="sub">Blur-up loading effect with shimmer placeholders</p>
+    <div class="rv-grid">
+      <div class="rv-card">
+        <div class="rv-img-wrap">
+          <div class="rv-placeholder"></div>
+          <img class="rv-img" src="https://picsum.photos/400/250?random=1" alt="Mountain landscape" loading="lazy">
+        </div>
+        <div class="rv-body">
+          <div class="rv-title">Mountain Retreat</div>
+          <div class="rv-desc">Peaceful mountain landscapes with crisp air and stunning views.</div>
+        </div>
+      </div>
+      <div class="rv-card">
+        <div class="rv-img-wrap">
+          <div class="rv-placeholder"></div>
+          <img class="rv-img" src="https://picsum.photos/400/250?random=2" alt="City skyline" loading="lazy">
+        </div>
+        <div class="rv-body">
+          <div class="rv-title">Urban Living</div>
+          <div class="rv-desc">Modern city life with architecture and vibrant street culture.</div>
+        </div>
+      </div>
+      <div class="rv-card">
+        <div class="rv-img-wrap">
+          <div class="rv-placeholder"></div>
+          <img class="rv-img" src="https://picsum.photos/400/250?random=3" alt="Ocean sunset" loading="lazy">
+        </div>
+        <div class="rv-body">
+          <div class="rv-title">Coastal Views</div>
+          <div class="rv-desc">Serene ocean sunsets and coastal landscapes to explore.</div>
+        </div>
+      </div>
+      <div class="rv-card">
+        <div class="rv-img-wrap">
+          <div class="rv-placeholder"></div>
+        </div>
+        <div class="rv-body">
+          <div class="rv-shimmer-text"></div>
+          <div class="rv-shimmer-text"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-reveal-zd/style.css
+++ b/submissions/examples/ease-reveal-zd/style.css
@@ -1,0 +1,99 @@
+:root {
+  --rv-font: 'Inter', -apple-system, sans-serif;
+  --rv-bg: #0b0f1a;
+  --rv-surface: #141829;
+  --rv-border: rgba(255,255,255,0.08);
+  --rv-text: #e8edf5;
+  --rv-text-sec: #8892a8;
+  --rv-placeholder: #1a1f3a;
+}
+@keyframes rv-blur-out {
+  from { filter: blur(20px) brightness(0.6); transform: scale(1.08); }
+  to { filter: blur(0) brightness(1); transform: scale(1); }
+}
+@keyframes rv-fade-up {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes rv-shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+.rv-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+.rv-card {
+  border-radius: 12px;
+  overflow: hidden;
+  font-family: var(--rv-font);
+  background: var(--rv-surface);
+  border: 1px solid var(--rv-border);
+  animation: rv-fade-up 0.4s ease-out both;
+  cursor: default;
+}
+.rv-card:nth-child(1) { animation-delay: 0s; }
+.rv-card:nth-child(2) { animation-delay: 0.1s; }
+.rv-card:nth-child(3) { animation-delay: 0.2s; }
+.rv-card:nth-child(4) { animation-delay: 0.3s; }
+.rv-img-wrap {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  background: var(--rv-placeholder);
+}
+.rv-placeholder {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--rv-placeholder) 25%, #252b45 50%, var(--rv-placeholder) 75%);
+  background-size: 200% 100%;
+  animation: rv-shimmer 1.8s ease-in-out infinite;
+  z-index: 1;
+}
+.rv-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  animation: rv-blur-out 0.8s ease-out 0.3s both;
+  z-index: 2;
+}
+.rv-body {
+  padding: 16px 18px 18px;
+}
+.rv-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--rv-text);
+  margin-bottom: 4px;
+}
+.rv-desc {
+  font-size: 0.77rem;
+  color: var(--rv-text-sec);
+  line-height: 1.5;
+}
+.rv-shimmer-text {
+  height: 14px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, var(--rv-placeholder) 25%, #252b45 50%, var(--rv-placeholder) 75%);
+  background-size: 200% 100%;
+  animation: rv-shimmer 1.8s ease-in-out infinite;
+  margin-bottom: 8px;
+}
+.rv-shimmer-text:last-child {
+  width: 60%;
+  margin-bottom: 0;
+}
+@media (max-width: 640px) {
+  .rv-grid { grid-template-columns: 1fr; }
+}
+@media (prefers-reduced-motion: reduce) {
+  * { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; }
+  .rv-card { animation: none !important; }
+  .rv-img { animation: none !important; filter: none !important; transform: none !important; }
+  .rv-placeholder { animation: none !important; }
+  .rv-shimmer-text { animation: none !important; }
+}


### PR DESCRIPTION
Adds a new animated image reveal component under
submissions/examples/ease-reveal-zd/ — blur-up loading
with shimmer placeholder and card entrance.
 
Files Added:
- submissions/examples/ease-reveal-zd/demo.html
- submissions/examples/ease-reveal-zd/style.css
- submissions/examples/ease-reveal-zd/README.md
 
Features:
- Blur-out animation (blur + brightness + scale)
- Shimmer placeholder over image area
- Skeleton text shimmer placeholders
- Card fade-up with staggered delays
- Responsive grid (minmax 260px)
- loading="lazy" on images
- prefers-reduced-motion support
 
Checklist:
- [x] Added to submissions/examples/ only
- [x] All three required files included
- [x] No core files modified
- [x] prefers-reduced-motion respected
- [ ] closes #3604