### PR TITLE
feat: add animated account settings component 

### DIFF
--- a/submissions/examples/ease-account-zd/README.md
+++ b/submissions/examples/ease-account-zd/README.md
@@ -1,0 +1,37 @@
+# Ease Account Zd
+
+## What does this do?
+An animated account settings / profile page component with avatar, form fields, toggle switches, and action buttons — pure HTML and CSS.
+
+## How is it used?
+```html
+<div class="ac-card">
+  <div class="ac-header">
+    <div class="ac-avatar-wrap">
+      <img class="ac-avatar" src="avatar.jpg" alt="Profile photo" width="64" height="64">
+    </div>
+    <div class="ac-heading">
+      <h2>Name</h2>
+      <p>email@example.com</p>
+    </div>
+  </div>
+  <div class="ac-body">
+    <div class="ac-section">
+      <div class="ac-section-title">Section Title</div>
+      <div class="ac-row">
+        <span class="ac-label">Field</span>
+        <input class="ac-input" type="text" value="Value">
+      </div>
+    </div>
+    <div class="ac-actions">
+      <button class="ac-btn ac-btn-primary">Save</button>
+    </div>
+  </div>
+</div>
+```
+
+Toggle: `.ac-toggle` (off) / `.ac-toggle-on` (on)
+Buttons: ac-btn-primary, ac-btn-secondary, ac-btn-danger
+
+## Why is it useful?
+Account settings pages are a core part of every web application. This component provides a clean, animated settings interface with form fields, toggles, and action buttons.

--- a/submissions/examples/ease-account-zd/demo.html
+++ b/submissions/examples/ease-account-zd/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Account Settings — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', -apple-system, sans-serif; background: #0b0f1a; color: #e8edf5; padding: 2.5rem 1.5rem; display: flex; flex-direction: column; align-items: center; }
+    .wrap { width: 100%; max-width: 660px; }
+    h1 { font-size: 1.35rem; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 4px; text-align: center; }
+    .sub { font-size: 0.82rem; color: #8892a8; margin-bottom: 28px; text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Account Settings</h1>
+    <p class="sub">Manage your profile, security, and preferences</p>
+    <div class="ac-card">
+      <div class="ac-header">
+        <div class="ac-avatar-wrap">
+          <img class="ac-avatar" src="https://i.pravatar.cc/80?img=11" alt="Profile photo" width="64" height="64">
+          <span class="ac-avatar-badge" aria-label="Verified">✓</span>
+        </div>
+        <div class="ac-heading">
+          <h2>Alex Chen</h2>
+          <p>alex@example.com · Joined Mar 2024</p>
+        </div>
+      </div>
+      <div class="ac-body">
+        <div class="ac-section">
+          <div class="ac-section-title">Profile</div>
+          <div class="ac-row">
+            <span class="ac-label">Full Name</span>
+            <input class="ac-input" type="text" value="Alex Chen" aria-label="Full Name">
+          </div>
+          <div class="ac-row">
+            <span class="ac-label">Email</span>
+            <input class="ac-input" type="email" value="alex@example.com" aria-label="Email address">
+          </div>
+          <div class="ac-row">
+            <span class="ac-label">Company</span>
+            <input class="ac-input" type="text" value="Design Studio" aria-label="Company">
+          </div>
+        </div>
+        <div class="ac-section">
+          <div class="ac-section-title">Security</div>
+          <div class="ac-row">
+            <span class="ac-label">Password</span>
+            <input class="ac-input ac-input-readonly" type="password" value="********" readonly aria-label="Password">
+          </div>
+          <div class="ac-row">
+            <span class="ac-label">Two-Factor</span>
+            <div class="ac-toggle ac-toggle-on" role="button" tabindex="0" aria-label="Two-factor authentication"></div>
+            <span class="ac-toggle-desc">Enabled</span>
+          </div>
+        </div>
+        <div class="ac-section">
+          <div class="ac-section-title">Notifications</div>
+          <div class="ac-row">
+            <span class="ac-toggle ac-toggle-on" role="button" tabindex="0" aria-label="Email notifications"></span>
+            <span class="ac-toggle-label">Email Notifications</span>
+          </div>
+          <div class="ac-row">
+            <span class="ac-toggle" role="button" tabindex="0" aria-label="Push notifications"></span>
+            <span class="ac-toggle-label">Push Notifications</span>
+          </div>
+          <div class="ac-row">
+            <span class="ac-toggle ac-toggle-on" role="button" tabindex="0" aria-label="Weekly digest"></span>
+            <span class="ac-toggle-label">Weekly Digest</span>
+          </div>
+        </div>
+        <div class="ac-actions">
+          <button class="ac-btn ac-btn-primary">Save Changes</button>
+          <button class="ac-btn ac-btn-secondary">Cancel</button>
+          <button class="ac-btn ac-btn-danger" style="margin-left:auto;">Delete Account</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-account-zd/style.css
+++ b/submissions/examples/ease-account-zd/style.css
@@ -1,0 +1,215 @@
+:root {
+  --ac-font: 'Inter', -apple-system, sans-serif;
+  --ac-bg: #0b0f1a;
+  --ac-surface: #141829;
+  --ac-border: rgba(255,255,255,0.08);
+  --ac-text: #e8edf5;
+  --ac-text-sec: #8892a8;
+  --ac-primary: #6c5ce7;
+  --ac-success: #2ecc71;
+  --ac-danger: #e74c3c;
+}
+@keyframes ac-fade-up {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes ac-slide-in {
+  from { opacity: 0; transform: translateX(-10px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+.ac-card {
+  max-width: 600px;
+  margin: 0 auto;
+  background: var(--ac-surface);
+  border: 1px solid var(--ac-border);
+  border-radius: 16px;
+  overflow: hidden;
+  font-family: var(--ac-font);
+  animation: ac-fade-up 0.5s ease-out both;
+}
+.ac-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 28px 28px 0;
+  animation: ac-fade-up 0.4s ease-out 0.05s both;
+}
+.ac-avatar-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+.ac-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid var(--ac-primary);
+}
+.ac-avatar-badge {
+  position: absolute;
+  bottom: 0;
+  right: -2px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--ac-success);
+  border: 3px solid var(--ac-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.5rem;
+  color: #fff;
+}
+.ac-heading {
+  flex: 1;
+}
+.ac-heading h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ac-text);
+}
+.ac-heading p {
+  font-size: 0.78rem;
+  color: var(--ac-text-sec);
+}
+.ac-body {
+  padding: 24px 28px 28px;
+}
+.ac-section {
+  animation: ac-slide-in 0.4s ease-out both;
+  margin-bottom: 24px;
+}
+.ac-section:last-child { margin-bottom: 0; }
+.ac-section:nth-of-type(1) { animation-delay: 0.1s; }
+.ac-section:nth-of-type(2) { animation-delay: 0.16s; }
+.ac-section:nth-of-type(3) { animation-delay: 0.22s; }
+.ac-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ac-text-sec);
+  margin-bottom: 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--ac-border);
+}
+.ac-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.ac-row:last-child { margin-bottom: 0; }
+.ac-label {
+  width: 100px;
+  font-size: 0.78rem;
+  color: var(--ac-text-sec);
+  flex-shrink: 0;
+}
+.ac-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1.5px solid var(--ac-border);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.04);
+  color: var(--ac-text);
+  font-size: 0.82rem;
+  font-family: var(--ac-font);
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.ac-input:focus {
+  border-color: var(--ac-primary);
+  box-shadow: 0 0 0 3px rgba(108,92,231,0.12);
+}
+.ac-input-readonly {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.ac-toggle {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background: rgba(255,255,255,0.12);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.25s ease;
+  flex-shrink: 0;
+}
+.ac-toggle-on {
+  background: var(--ac-primary);
+}
+.ac-toggle::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.25s ease;
+}
+.ac-toggle-on::after {
+  transform: translateX(18px);
+}
+.ac-toggle-label {
+  font-size: 0.82rem;
+  color: var(--ac-text);
+  flex: 1;
+}
+.ac-toggle-desc {
+  font-size: 0.7rem;
+  color: var(--ac-text-sec);
+}
+.ac-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--ac-border);
+  animation: ac-fade-up 0.4s ease-out 0.28s both;
+}
+.ac-btn {
+  padding: 9px 20px;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.25s ease, transform 0.25s ease;
+  border: none;
+}
+.ac-btn-primary {
+  background: var(--ac-primary);
+  color: #fff;
+}
+.ac-btn-primary:hover {
+  background: #5a4bd1;
+  transform: translateY(-1px);
+}
+.ac-btn-secondary {
+  background: rgba(255,255,255,0.06);
+  color: var(--ac-text);
+}
+.ac-btn-secondary:hover {
+  background: rgba(255,255,255,0.1);
+  transform: translateY(-1px);
+}
+.ac-btn-danger {
+  background: rgba(231,76,60,0.15);
+  color: var(--ac-danger);
+}
+.ac-btn-danger:hover {
+  background: rgba(231,76,60,0.25);
+  transform: translateY(-1px);
+}
+@media (max-width: 640px) {
+  .ac-header { flex-direction: column; text-align: center; padding: 20px 18px 0; }
+  .ac-body { padding: 18px; }
+  .ac-row { flex-direction: column; align-items: stretch; gap: 4px; }
+  .ac-label { width: auto; }
+}
+@media (prefers-reduced-motion: reduce) {
+  * { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+  .ac-card, .ac-header, .ac-section, .ac-actions { animation: none !important; }
+}


### PR DESCRIPTION
Adds a new animated account settings / profile page component under
submissions/examples/ease-account-zd/ — with avatar, form fields,
toggle switches, and section-based layout.
 
Files Added:
- submissions/examples/ease-account-zd/demo.html
- submissions/examples/ease-account-zd/style.css
- submissions/examples/ease-account-zd/README.md
 
Features:
- Header with avatar, verified badge, name, email
- 3 settings sections: Profile, Security, Notifications
- Form inputs with focus border + glow
- Password field (readonly demo)
- Toggle switches (.ac-toggle / .ac-toggle-on) with slide animation
- Action buttons: Save (primary), Cancel (secondary), Delete (danger)
- Staggered entrance animations (fade-up + slide-in)
- Responsive: stacked layout at 640px
- prefers-reduced-motion support
- Accessible: aria-labels on inputs, toggles, and avatar
 
Checklist:
- [x] Added to submissions/examples/ only
- [x] All three required files included
- [x] No core or components files modified
- [x] Single feature in this PR
- [x] prefers-reduced-motion respected
- [x] Accessible aria-labels on interactive elements
- [ ] closes #3620