### PR TITLE
feat(examples): add text-wrap and hyphens typography demo

### DIFF
--- a/submissions/examples/text-wrap-typography/README.md
+++ b/submissions/examples/text-wrap-typography/README.md
@@ -1,0 +1,37 @@
+# Text Wrap &amp; Hyphenation
+
+## What does it do?
+A pure-CSS demo showing modern CSS text layout properties: `text-wrap` variants and `hyphens` — no JavaScript required.
+
+## Features
+- **text-wrap: balance** — balanced line wrapping for headings and short text blocks
+- **text-wrap: pretty** — optimized paragraph wrapping with fewer orphans
+- **text-wrap: stable** — content stability preventing layout shifts
+- **hyphens: auto** — automatic hyphenation for justified text
+
+## Usage
+```css
+h2 { text-wrap: balance; }
+p  { text-wrap: pretty;  }
+article { hyphens: auto; }
+```
+
+## Classes
+- `.tw-unset` — default wrapping
+- `.tw-balanced` — balanced wrapping
+- `.tw-pretty` — optimized paragraph wrapping
+- `.tw-stable` — stable content wrapping
+- `.hyphens` — automatic hyphenation
+- `.justify` — justified text alignment
+
+## Browser Support
+- `text-wrap: balance` — Chrome 114+, Firefox 121+, Safari 17.5+
+- `text-wrap: pretty` — Chrome 117+, Firefox 121+, Safari 17.5+
+- `text-wrap: stable` — Chrome 117+, Firefox 121+, Safari 17.5+
+- `hyphens` — Chrome 88+, Firefox 6+, Safari 5.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/text-wrap-typography/demo.html
+++ b/submissions/examples/text-wrap-typography/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Wrap Typography — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Text Wrap &amp; Hyphenation</h1>
+  <p class="subtitle">Modern text layout with <code>text-wrap</code> and <code>hyphens</code> — no JavaScript required.</p>
+
+  <section>
+    <h2>text-wrap: balance — Heading Comparison</h2>
+    <div class="comparison">
+      <div class="card unbalanced">
+        <span class="badge">Default</span>
+        <h3 class="tw-unset">The quick brown fox jumps over the lazy dog near the riverbank.</h3>
+      </div>
+      <div class="card balanced">
+        <span class="badge">text-wrap: balance</span>
+        <h3 class="tw-balanced">The quick brown fox jumps over the lazy dog near the riverbank.</h3>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>text-wrap: pretty — Paragraph Optimization</h2>
+    <div class="comparison">
+      <div class="card unbalanced">
+        <span class="badge">Default</span>
+        <p class="tw-unset">CSS text wrapping controls how inline content breaks across lines. The default algorithm wraps text greedily, breaking at the earliest opportunity. This can leave a single word dangling on the last line — an orphan. In long paragraphs, a few extra words on the last line can significantly improve readability and visual balance.</p>
+      </div>
+      <div class="card balanced">
+        <span class="badge">text-wrap: pretty</span>
+        <p class="tw-pretty">CSS text wrapping controls how inline content breaks across lines. The default algorithm wraps text greedily, breaking at the earliest opportunity. This can leave a single word dangling on the last line — an orphan. In long paragraphs, a few extra words on the last line can significantly improve readability and visual balance.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>hyphens: auto — Justified Text</h2>
+    <div class="comparison">
+      <div class="card unbalanced">
+        <span class="badge">No hyphens</span>
+        <p class="justify tw-unset">The extraordinary complexity of modern typography requires careful consideration of word spacing and line breaking algorithms to achieve professional results across various screen sizes and reading contexts.</p>
+      </div>
+      <div class="card balanced">
+        <span class="badge">hyphens: auto</span>
+        <p class="justify hyphens">The extraordinary complexity of modern typography requires careful consideration of word spacing and line breaking algorithms to achieve professional results across various screen sizes and reading contexts.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>text-wrap: stable — Content Stability</h2>
+    <p class="tw-stable">With <code>text-wrap: stable</code>, the browser avoids re-wrapping text when content changes elsewhere on the page. This prevents layout shifts when toggling visibility of elements. Try resizing the viewport — the text maintains stable line breaks.</p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/text-wrap-typography/style.css
+++ b/submissions/examples/text-wrap-typography/style.css
@@ -1,0 +1,83 @@
+/* ============================================================
+   EaseMotion CSS — Text Wrap & Hyphenation
+   Modern text layout with text-wrap and hyphens
+   ============================================================ */
+
+/* ---- Comparison Layout ---- */
+
+.comparison {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.card {
+  flex: 1;
+  min-width: 280px;
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #6366f1;
+  color: #ffffff;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+}
+
+.balanced .badge {
+  background: #22c55e;
+}
+
+/* ---- Text Wrap Values ---- */
+
+.tw-unset {
+  text-wrap: unset;
+}
+
+.tw-balanced {
+  text-wrap: balance;
+}
+
+.tw-pretty {
+  text-wrap: pretty;
+}
+
+.tw-stable {
+  text-wrap: stable;
+}
+
+/* ---- Hyphenation ---- */
+
+.justify {
+  text-align: justify;
+}
+
+.hyphens {
+  hyphens: auto;
+  -webkit-hyphens: auto;
+}
+
+/* ---- Card Typography ---- */
+
+.card h3 {
+  color: #e5e7eb;
+  font-size: 1.1rem;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.card p {
+  color: #d1d5db;
+  line-height: 1.7;
+  margin: 0;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating modern text layout properties `text-wrap` (balance, pretty, stable) and `hyphens` — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo with side-by-side comparisons of wrapping methods |
| `style.css` | Pure CSS using text-wrap and hyphens |
| `README.md` | Documentation with usage, browser support, and class reference |

## Sections
1. **text-wrap: balance** — balanced heading wrapping vs default
2. **text-wrap: pretty** — optimized paragraph wrapping
3. **hyphens: auto** — justified text with and without hyphenation
4. **text-wrap: stable** — content stability demo

## Related Issue
Closes #3776