### PR TITLE
feat(examples): add text-shadow creative effects demo

### DIFF
--- a/submissions/examples/text-shadow-effects/README.md
+++ b/submissions/examples/text-shadow-effects/README.md
@@ -1,0 +1,34 @@
+# Text Shadow Effects
+
+## What does it do?
+A pure-CSS demo showing creative typography effects built entirely with `text-shadow` — no JavaScript or images required.
+
+## Features
+- **Neon Glow** — layered shadows for vibrant neon text (cyan, pink, green)
+- **3D & Embossed** — raised, embossed, and engraved text effects
+- **Flame Text** — fire-like glow effects
+- **Outline Stroke** — simulated text stroke using four-direction shadows
+- **Hover Transitions** — interactive effects that activate on hover
+- **Reduced Motion** — respects `prefers-reduced-motion`
+
+## Usage
+```css
+.neon { text-shadow: 0 0 7px #22d3ee, 0 0 10px #22d3ee, 0 0 21px #22d3ee; }
+.threed { text-shadow: 0 1px 0 #ccc, 0 2px 0 #bbb, 0 3px 0 #aaa; }
+```
+
+## Classes
+- `.shadow-neon-cyan`, `.shadow-neon-pink`, `.shadow-neon-green` — neon glow effects
+- `.shadow-3d`, `.shadow-emboss`, `.shadow-engrave` — depth effects
+- `.shadow-fire`, `.shadow-fire-alt` — flame effects
+- `.shadow-outline`, `.shadow-outline-white` — outline effects
+- `.shadow-hover-glow`, `.shadow-hover-3d`, `.shadow-hover-fire` — interactive hover
+
+## Browser Support
+- `text-shadow` — Chrome 2+, Firefox 3.5+, Safari 1.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/text-shadow-effects/demo.html
+++ b/submissions/examples/text-shadow-effects/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Shadow Effects — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Text Shadow Effects</h1>
+  <p class="subtitle">Creative typography with <code>text-shadow</code> — no JavaScript required.</p>
+
+  <section>
+    <h2>Neon Glow</h2>
+    <p class="shadow-neon-cyan">Cyan Neon</p>
+    <p class="shadow-neon-pink">Pink Neon</p>
+    <p class="shadow-neon-green">Green Neon</p>
+  </section>
+
+  <section>
+    <h2>3D &amp; Embossed</h2>
+    <p class="shadow-3d">3D Raised Text</p>
+    <p class="shadow-emboss">Embossed Effect</p>
+    <p class="shadow-engrave">Engraved Effect</p>
+  </section>
+
+  <section>
+    <h2>Fire &amp; Glow</h2>
+    <p class="shadow-fire">Flame Text</p>
+    <p class="shadow-fire-alt">Intense Fire</p>
+  </section>
+
+  <section>
+    <h2>Outline Stroke</h2>
+    <p class="shadow-outline">Outlined Text</p>
+    <p class="shadow-outline-white">White Outline</p>
+  </section>
+
+  <section>
+    <h2>Hover Transitions</h2>
+    <p class="shadow-hover-glow">Hover for glow</p>
+    <p class="shadow-hover-3d">Hover for 3D</p>
+    <p class="shadow-hover-fire">Hover for fire</p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/text-shadow-effects/style.css
+++ b/submissions/examples/text-shadow-effects/style.css
@@ -1,0 +1,165 @@
+/* ============================================================
+   EaseMotion CSS — Text Shadow Effects
+   Creative text-shadow techniques
+   ============================================================ */
+
+/* ---- Shared ---- */
+
+section p {
+  font-size: 1.75rem;
+  font-weight: 800;
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.02em;
+  line-height: 1.3;
+}
+
+/* ---- Neon Glow ---- */
+
+.shadow-neon-cyan {
+  color: #06b6d4;
+  text-shadow:
+    0 0 7px #22d3ee,
+    0 0 10px #22d3ee,
+    0 0 21px #22d3ee,
+    0 0 42px #06b6d4,
+    0 0 82px #06b6d4;
+}
+
+.shadow-neon-pink {
+  color: #ec4899;
+  text-shadow:
+    0 0 7px #f472b6,
+    0 0 10px #f472b6,
+    0 0 21px #f472b6,
+    0 0 42px #ec4899,
+    0 0 82px #ec4899;
+}
+
+.shadow-neon-green {
+  color: #22c55e;
+  text-shadow:
+    0 0 7px #4ade80,
+    0 0 10px #4ade80,
+    0 0 21px #4ade80,
+    0 0 42px #22c55e,
+    0 0 82px #22c55e;
+}
+
+/* ---- 3D & Embossed ---- */
+
+.shadow-3d {
+  color: #e5e7eb;
+  text-shadow:
+    0 1px 0 #ccc,
+    0 2px 0 #bbb,
+    0 3px 0 #aaa,
+    0 4px 0 #999,
+    0 5px 0 #888,
+    0 6px 4px rgba(0,0,0,0.4);
+}
+
+.shadow-emboss {
+  color: #d1d5db;
+  text-shadow:
+    -1px -1px 1px #ffffff33,
+    1px 1px 1px #00000066;
+}
+
+.shadow-engrave {
+  color: #9ca3af;
+  text-shadow:
+    -1px -1px 1px #00000066,
+    1px 1px 1px #ffffff33;
+}
+
+/* ---- Fire & Glow ---- */
+
+.shadow-fire {
+  color: #f97316;
+  text-shadow:
+    0 -1px 3px #fbbf24,
+    0 -2px 6px #f59e0b,
+    0 -4px 12px #f97316,
+    0 -6px 20px #dc2626;
+}
+
+.shadow-fire-alt {
+  color: #fbbf24;
+  text-shadow:
+    0 0 4px #fbbf24,
+    0 -3px 10px #f97316,
+    0 -6px 20px #dc2626,
+    0 -10px 30px #991b1b;
+}
+
+/* ---- Outline Stroke ---- */
+
+.shadow-outline {
+  color: #6366f1;
+  text-shadow:
+    -1px -1px 0 #1e1b4b,
+    1px -1px 0 #1e1b4b,
+    -1px 1px 0 #1e1b4b,
+    1px 1px 0 #1e1b4b;
+}
+
+.shadow-outline-white {
+  color: #a78bfa;
+  text-shadow:
+    -2px -2px 0 #ffffff,
+    2px -2px 0 #ffffff,
+    -2px 2px 0 #ffffff,
+    2px 2px 0 #ffffff;
+}
+
+/* ---- Hover Transitions ---- */
+
+.shadow-hover-glow {
+  color: #e5e7eb;
+  transition: text-shadow 0.3s ease;
+}
+
+.shadow-hover-glow:hover {
+  text-shadow:
+    0 0 7px #22d3ee,
+    0 0 10px #22d3ee,
+    0 0 21px #22d3ee,
+    0 0 42px #06b6d4;
+}
+
+.shadow-hover-3d {
+  color: #e5e7eb;
+  transition: text-shadow 0.3s ease;
+}
+
+.shadow-hover-3d:hover {
+  text-shadow:
+    0 1px 0 #ccc,
+    0 2px 0 #bbb,
+    0 3px 0 #aaa,
+    0 4px 0 #999,
+    0 5px 0 #888,
+    0 6px 4px rgba(0,0,0,0.4);
+}
+
+.shadow-hover-fire {
+  color: #e5e7eb;
+  transition: text-shadow 0.3s ease;
+}
+
+.shadow-hover-fire:hover {
+  color: #f97316;
+  text-shadow:
+    0 -1px 3px #fbbf24,
+    0 -2px 6px #f59e0b,
+    0 -4px 12px #f97316,
+    0 -6px 20px #dc2626;
+}
+
+/* ---- Reduced Motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  [class*="shadow-hover-"] {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating creative typography effects using `text-shadow` — no JavaScript or images required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo with 5 sections showing different text-shadow techniques |
| `style.css` | Pure CSS text-shadow effects with hover interactions |
| `README.md` | Documentation with usage, browser support, and class reference |

## Sections
1. **Neon Glow** — cyan, pink, green layered neon effects
2. **3D &amp; Embossed** — raised, embossed, and engraved depth effects
3. **Flame Text** — fire-like glow with warm color layers
4. **Outline Stroke** — simulated text outline using offset shadows
5. **Hover Transitions** — interactive glow/3D/fire effects on hover

## Related Issue
Closes #3778
<!-- re-trigger label sync -->