### PR TITLE
feat(examples): add @supports feature queries demo

### DIFF
--- a/submissions/examples/feature-supports-queries/README.md
+++ b/submissions/examples/feature-supports-queries/README.md
@@ -1,0 +1,38 @@
+# @supports Feature Queries
+
+## What does it do?
+A pure-CSS demo showing how to use `@supports` for progressive enhancement — detecting browser feature support and applying styles accordingly. No JavaScript required.
+
+## Features Detected
+- **display: grid** — CSS Grid layout support
+- **animation-timeline** — scroll-driven animation support
+- **selector(:has())** — `:has()` parent selector support
+- **color: oklch()** — OKLCH color space support
+- **selector(:focus-visible)** — `:focus-visible` selector support
+
+## Usage
+```css
+@supports (display: grid) {
+  .grid { display: grid; }
+}
+
+@supports not (selector(:has(*))) {
+  .fallback { /* alternative styles */ }
+}
+```
+
+## Data Attributes
+- `data-feature="grid"` — CSS Grid detection
+- `data-feature="scroll-timeline"` — scroll-driven animation detection
+- `data-feature="has"` — `:has()` selector detection
+- `data-feature="oklch"` — OKLCH color detection
+- `data-feature="focus-visible"` — `:focus-visible` detection
+
+## Browser Support
+- `@supports` — Chrome 28+, Firefox 22+, Safari 9+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/feature-supports-queries/demo.html
+++ b/submissions/examples/feature-supports-queries/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>@supports Feature Queries — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 750px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <h1>@supports Feature Queries</h1>
+  <p class="subtitle">Progressive enhancement with CSS feature detection — no JavaScript required.</p>
+
+  <section>
+    <h2>display: grid</h2>
+    <div class="feature-card" data-feature="grid">
+      <p>This browser <strong class="supports-yes">supports</strong><strong class="supports-no">does not support</strong> CSS Grid layout.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>animation-timeline (Scroll-Driven Animations)</h2>
+    <div class="feature-card" data-feature="scroll-timeline">
+      <p>This browser <strong class="supports-yes">supports</strong><strong class="supports-no">does not support</strong> scroll-driven animations.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>selector(:has())</h2>
+    <div class="feature-card" data-feature="has">
+      <p>This browser <strong class="supports-yes">supports</strong><strong class="supports-no">does not support</strong> the <code>:has()</code> selector.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>color: oklch()</h2>
+    <div class="feature-card" data-feature="oklch">
+      <p>This browser <strong class="supports-yes">supports</strong><strong class="supports-no">does not support</strong> the OKLCH color space.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>selector(:focus-visible)</h2>
+    <div class="feature-card" data-feature="focus-visible">
+      <p>This browser <strong class="supports-yes">supports</strong><strong class="supports-no">does not support</strong> the <code>:focus-visible</code> selector.</p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/feature-supports-queries/style.css
+++ b/submissions/examples/feature-supports-queries/style.css
@@ -1,0 +1,69 @@
+/* ============================================================
+   EaseMotion CSS — @supports Feature Queries
+   Progressive enhancement with CSS feature detection
+   ============================================================ */
+
+/* ---- Feature Card ---- */
+
+.feature-card {
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.feature-card p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.supports-yes {
+  display: none;
+  color: #22c55e;
+  font-weight: 700;
+}
+
+.supports-no {
+  color: #ef4444;
+  font-weight: 700;
+}
+
+/* ---- display: grid ---- */
+
+@supports (display: grid) {
+  [data-feature="grid"] .supports-yes { display: inline; }
+  [data-feature="grid"] .supports-no { display: none; }
+  [data-feature="grid"] { border-color: #22c55e; }
+}
+
+/* ---- animation-timeline (scroll-driven animations) ---- */
+
+@supports (animation-timeline: scroll()) {
+  [data-feature="scroll-timeline"] .supports-yes { display: inline; }
+  [data-feature="scroll-timeline"] .supports-no { display: none; }
+  [data-feature="scroll-timeline"] { border-color: #22c55e; }
+}
+
+/* ---- selector(:has()) ---- */
+
+@supports selector(:has(*)) {
+  [data-feature="has"] .supports-yes { display: inline; }
+  [data-feature="has"] .supports-no { display: none; }
+  [data-feature="has"] { border-color: #22c55e; }
+}
+
+/* ---- color: oklch() ---- */
+
+@supports (color: oklch(0.5 0.2 240)) {
+  [data-feature="oklch"] .supports-yes { display: inline; }
+  [data-feature="oklch"] .supports-no { display: none; }
+  [data-feature="oklch"] { border-color: #22c55e; }
+}
+
+/* ---- selector(:focus-visible) ---- */
+
+@supports selector(:focus-visible) {
+  [data-feature="focus-visible"] .supports-yes { display: inline; }
+  [data-feature="focus-visible"] .supports-no { display: none; }
+  [data-feature="focus-visible"] { border-color: #22c55e; }
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating progressive enhancement using `@supports` feature queries — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo showing 5 feature detection cards |
| `style.css` | Pure CSS using @supports rules for progressive enhancement |
| `README.md` | Documentation with usage, browser support, and reference |

## Features Detected
1. **display: grid** — CSS Grid layout support
2. **animation-timeline** — scroll-driven animation support
3. **selector(:has())** — parent selector support
4. **color: oklch()** — OKLCH color space support
5. **selector(:focus-visible)** — focus-visible selector support

Each card shows a green border and "supports" badge when the feature is available, or a red "does not support" badge as fallback.

## Related Issue
Closes #3780
<!-- re-trigger label sync -->