### PR TITLE
feat(examples): add scroll-margin and scroll-padding demo

### DIFF
--- a/submissions/examples/scroll-margin-padding/README.md
+++ b/submissions/examples/scroll-margin-padding/README.md
@@ -1,0 +1,42 @@
+# Scroll Margin &amp; Padding
+
+## What does it do?
+A pure-CSS demo showing how to control scroll position using `scroll-margin` and `scroll-padding` properties — no JavaScript required.
+
+## Features
+- **scroll-margin** — offset when scrolling to target elements via anchor links
+- **scroll-padding** — padding on the scroll container
+- **scroll-behavior: smooth** — smooth scrolling animation
+- **Sticky navigation** — demo navigation bar with anchor links
+- **Reduced Motion** — respects `prefers-reduced-motion`
+
+## Usage
+```css
+/* Target section offset */
+section { scroll-margin: 4rem; }
+
+/* Container padding */
+.container { scroll-padding: 2rem; }
+
+/* Smooth scrolling */
+html { scroll-behavior: smooth; }
+```
+
+## Classes
+- `.sm-small` — scroll-margin: 2rem
+- `.sm-large` — scroll-margin: 6rem (for fixed headers)
+- `.sm-custom` — scroll-margin: 4rem 2rem (per-axis)
+- `.sm-none` — no scroll-margin
+- `.scroll-nav` — sticky navigation bar
+- `.scroll-container` — container with scroll-padding
+
+## Browser Support
+- `scroll-margin` — Chrome 69+, Firefox 68+, Safari 11+
+- `scroll-padding` — Chrome 69+, Firefox 68+, Safari 11+
+- `scroll-behavior` — Chrome 61+, Firefox 36+, Safari 15.4+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/scroll-margin-padding/demo.html
+++ b/submissions/examples/scroll-margin-padding/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll Margin &amp; Padding — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+  </style>
+</head>
+<body>
+  <h1>Scroll Margin &amp; Padding</h1>
+  <p class="subtitle">Controlling scroll position with <code>scroll-margin</code> and <code>scroll-padding</code> — no JavaScript required.</p>
+
+  <nav class="scroll-nav">
+    <a href="#section-a">Section A</a>
+    <a href="#section-b">Section B</a>
+    <a href="#section-c">Section C</a>
+    <a href="#section-d">Section D</a>
+  </nav>
+
+  <div class="scroll-container">
+    <section id="section-a" class="scroll-section sm-small">
+      <h2>Section A <span class="tag">scroll-margin: 2rem</span></h2>
+      <p>Uses a small scroll margin so the section appears closer to the top of the viewport when navigated to via an anchor link.</p>
+    </section>
+
+    <section id="section-b" class="scroll-section sm-large">
+      <h2>Section B <span class="tag">scroll-margin: 6rem</span></h2>
+      <p>Uses a large scroll margin — useful when a fixed header or navbar would otherwise obscure the section heading.</p>
+    </section>
+
+    <section id="section-c" class="scroll-section sm-custom">
+      <h2>Section C <span class="tag">scroll-margin: 4rem 2rem</span></h2>
+      <p>Custom per-axis scroll margin. The top offset is 4rem, horizontal is 2rem. This gives precise control over scroll position.</p>
+    </section>
+
+    <section id="section-d" class="scroll-section sm-none">
+      <h2>Section D <span class="tag">no scroll-margin</span></h2>
+      <p>No scroll margin applied. The section snaps to the very top of the viewport, which may be hidden behind a fixed header if one exists.</p>
+    </section>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/scroll-margin-padding/style.css
+++ b/submissions/examples/scroll-margin-padding/style.css
@@ -1,0 +1,115 @@
+/* ============================================================
+   EaseMotion CSS — Scroll Margin & Padding
+   Controlling scroll position with scroll-margin/scroll-padding
+   ============================================================ */
+
+/* ---- Smooth Scroll ---- */
+
+html {
+  scroll-behavior: smooth;
+}
+
+/* ---- Navigation ---- */
+
+.scroll-nav {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  position: sticky;
+  top: 1rem;
+  z-index: 10;
+}
+
+.scroll-nav a {
+  color: #a78bfa;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.4rem 0.85rem;
+  border-radius: 6px;
+  background: #252525;
+  border: 1px solid #333;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.scroll-nav a:hover {
+  background: #6366f1;
+  color: #ffffff;
+}
+
+/* ---- Scroll Container ---- */
+
+.scroll-container {
+  scroll-padding: 2rem;
+}
+
+/* ---- Sections ---- */
+
+.scroll-section {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 2rem;
+  margin-bottom: 3rem;
+  min-height: 40vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.scroll-section h2 {
+  color: #ffffff;
+  font-size: 1.3rem;
+  margin: 0 0 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.scroll-section p {
+  line-height: 1.7;
+  margin: 0;
+  color: #9ca3af;
+}
+
+.tag {
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: #252525;
+  color: #a78bfa;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #333;
+}
+
+/* ---- Scroll Margin Variants ---- */
+
+.sm-small {
+  scroll-margin: 2rem;
+}
+
+.sm-large {
+  scroll-margin: 6rem;
+}
+
+.sm-custom {
+  scroll-margin: 4rem 2rem;
+}
+
+.sm-none {
+  scroll-margin: 0;
+}
+
+/* ---- Reduced Motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating `scroll-margin` and `scroll-padding` for controlling scroll position via anchor links — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo with sticky nav and 4 scrollable sections |
| `style.css` | Pure CSS using scroll-margin, scroll-padding, scroll-behavior |
| `README.md` | Documentation with usage, browser support, and class reference |

## Sections
1. **Section A** — `scroll-margin: 2rem` (small offset)
2. **Section B** — `scroll-margin: 6rem` (large offset for fixed headers)
3. **Section C** — `scroll-margin: 4rem 2rem` (per-axis)
4. **Section D** — no scroll-margin (baseline comparison)

## Related Issue
Closes #3782