### PR TITLE
feat(examples): add :focus-visible accessibility focus styling demo

### DIFF
--- a/submissions/examples/focus-visible-accessibility/README.md
+++ b/submissions/examples/focus-visible-accessibility/README.md
@@ -1,0 +1,42 @@
+# :focus-visible Accessibility
+
+## What does it do?
+A pure-CSS demo showing accessible focus indicators using `:focus-visible`, `:focus`, and `:focus-within` — no JavaScript required.
+
+## Features
+- **:focus vs :focus-visible** — comparison showing always-on vs keyboard-only focus rings
+- **Custom Focus Rings** — glow, double ring, inset, and underline variants
+- **Input Styles** — focus-visible styles for text inputs and selects
+- **Focus-within Cards** — entire card highlights when any child element is focused
+- **Accessible** — focus indicators only show for keyboard users, avoiding mouse-click interference
+
+## Usage
+```css
+/* Keyboard-only focus ring */
+button:focus-visible {
+  outline: 2px solid #22c55e;
+  outline-offset: 2px;
+}
+
+/* Group focus */
+.card:focus-within {
+  border-color: #6366f1;
+}
+```
+
+## Classes
+- `.focus-always` — `:focus` always visible
+- `.fv-custom` — `:focus-visible` green ring (keyboard only)
+- `.fv-glow`, `.fv-double`, `.fv-inset`, `.fv-underline` — custom focus ring variants
+- `.fv-input` — focus-visible input styling
+- `.fw-card` — focus-within card highlighting
+
+## Browser Support
+- `:focus-visible` — Chrome 86+, Firefox 85+, Safari 15.4+
+- `:focus-within` — Chrome 60+, Firefox 52+, Safari 10.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser. Use Tab key to navigate focusable elements.

--- a/submissions/examples/focus-visible-accessibility/demo.html
+++ b/submissions/examples/focus-visible-accessibility/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>:focus-visible Accessibility — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 750px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <h1>:focus-visible Accessibility</h1>
+  <p class="subtitle">Custom keyboard focus indicators with <code>:focus-visible</code> — no JavaScript required. Use Tab to navigate.</p>
+
+  <section>
+    <h2>Focus vs Focus-visible</h2>
+    <div class="demo-row">
+      <div>
+        <p class="label">:focus (always)</p>
+        <a href="#" class="demo-link focus-always">Link</a>
+        <button class="demo-btn focus-always">Button</button>
+      </div>
+      <div>
+        <p class="label">:focus-visible (keyboard only)</p>
+        <a href="#" class="demo-link fv-custom">Link</a>
+        <button class="demo-btn fv-custom">Button</button>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Custom Focus Rings</h2>
+    <div class="demo-row">
+      <button class="demo-btn fv-glow">Glow ring</button>
+      <button class="demo-btn fv-double">Double ring</button>
+      <button class="demo-btn fv-inset">Inset ring</button>
+      <button class="demo-btn fv-underline">Underline</button>
+    </div>
+  </section>
+
+  <section>
+    <h2>Input Focus Styles</h2>
+    <div style="display:flex;flex-direction:column;gap:0.75rem;">
+      <input type="text" class="demo-input fv-input" placeholder="Text input with focus-visible">
+      <input type="email" class="demo-input fv-input" placeholder="Email input">
+      <select class="demo-input fv-input">
+        <option>Option 1</option>
+        <option>Option 2</option>
+      </select>
+    </div>
+  </section>
+
+  <section>
+    <h2>Focus-within Cards</h2>
+    <div class="card-row">
+      <div class="focus-card fw-card" tabindex="0">
+        <h3>Card One</h3>
+        <p>Focus anywhere inside this card to see the outline.</p>
+      </div>
+      <div class="focus-card fw-card" tabindex="0">
+        <h3>Card Two</h3>
+        <p>The entire card highlights when any child is focused.</p>
+      </div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/focus-visible-accessibility/style.css
+++ b/submissions/examples/focus-visible-accessibility/style.css
@@ -1,0 +1,173 @@
+/* ============================================================
+   EaseMotion CSS — :focus-visible Accessibility
+   Custom keyboard focus indicators
+   ============================================================ */
+
+/* ---- Demo Row ---- */
+
+.demo-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.label {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  margin: 0 0 0.5rem;
+  font-family: monospace;
+}
+
+/* ---- Shared Button & Link Styles ---- */
+
+.demo-link,
+.demo-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  outline: none;
+}
+
+.demo-link {
+  color: #a78bfa;
+  background: transparent;
+  border: none;
+}
+
+.demo-btn {
+  color: #ffffff;
+  background: #252525;
+  border: 1px solid #333;
+  transition: background 0.2s ease;
+}
+
+.demo-btn:hover {
+  background: #2a2a2a;
+}
+
+/* ---- :focus (always shows ring) ---- */
+
+.focus-always:focus {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+/* ---- :focus-visible (keyboard only) ---- */
+
+.fv-custom:focus {
+  outline: none;
+}
+
+.fv-custom:focus-visible {
+  outline: 2px solid #22c55e;
+  outline-offset: 2px;
+}
+
+/* ---- Custom Focus Rings ---- */
+
+.fv-glow:focus {
+  outline: none;
+}
+
+.fv-glow:focus-visible {
+  outline: 2px solid #ec4899;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(236, 72, 153, 0.3);
+}
+
+.fv-double:focus {
+  outline: none;
+}
+
+.fv-double:focus-visible {
+  outline: 2px solid #f59e0b;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px #1a1a1a, 0 0 0 6px #f59e0b;
+}
+
+.fv-inset:focus {
+  outline: none;
+}
+
+.fv-inset:focus-visible {
+  outline: 2px solid #06b6d4;
+  outline-offset: -2px;
+  box-shadow: inset 0 0 0 2px #06b6d4;
+}
+
+.fv-underline:focus {
+  outline: none;
+}
+
+.fv-underline:focus-visible {
+  outline: none;
+  box-shadow: 0 2px 0 0 #22c55e;
+}
+
+/* ---- Input Focus Styles ---- */
+
+.demo-input {
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 0.6rem 0.85rem;
+  color: #e5e7eb;
+  font-size: 0.9rem;
+  outline: none;
+}
+
+.fv-input:focus {
+  border-color: #6366f1;
+  outline: none;
+}
+
+.fv-input:focus-visible {
+  border-color: #22c55e;
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.3);
+}
+
+/* ---- Focus-within Cards ---- */
+
+.card-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.focus-card {
+  flex: 1;
+  min-width: 200px;
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 1.25rem;
+  transition: border-color 0.2s ease;
+}
+
+.focus-card h3 {
+  color: #e5e7eb;
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.focus-card p {
+  margin: 0;
+  color: #9ca3af;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.fw-card:focus-within {
+  border-color: #6366f1;
+}
+
+.fw-card:focus-within h3 {
+  color: #a78bfa;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating accessible focus indicators using `:focus-visible`, `:focus`, and `:focus-within` — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo with links, buttons, inputs, and focus-within cards |
| `style.css` | Pure CSS using :focus-visible with custom focus ring variants |
| `README.md` | Documentation with usage, browser support, and class reference |

## Sections
1. **Focus vs Focus-visible** — comparison of always-on vs keyboard-only indicators
2. **Custom Focus Rings** — glow, double ring, inset, underline variants
3. **Input Focus Styles** — focus-visible for text inputs and selects
4. **Focus-within Cards** — group focus highlighting

## Related Issue
Closes #3784