### PR TITLE
feat(examples): add shape-outside text wrapping demo

### DIFF
--- a/submissions/examples/shape-outside-wrapping/README.md
+++ b/submissions/examples/shape-outside-wrapping/README.md
@@ -1,0 +1,45 @@
+# Shape Outside Wrapping
+
+## What does it do?
+A pure-CSS demo showing text wrapping around CSS shapes using `shape-outside`, `shape-margin`, and `clip-path` — no JavaScript required.
+
+## Features
+- **Circle** — text wraps around a circular gradient element
+- **Ellipse** — text wraps around an elliptical shape
+- **Polygon** — custom polygon shape with diagonal wrapping
+- **Inset (Rounded)** — rounded rectangle wrapping with `inset()`
+- **shape-margin** — spacing between shape and text
+- **clip-path** — matching the visible element to the shape boundary
+
+## Usage
+```css
+.circle {
+  float: left;
+  shape-outside: circle(50%);
+  shape-margin: 1rem;
+  clip-path: circle(50%);
+}
+
+.polygon {
+  float: left;
+  shape-outside: polygon(0 0, 100% 0, 100% 100%, 0 60%);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 60%);
+}
+```
+
+## Classes
+- `.shape-circle` — circular wrapping (float + circle)
+- `.shape-ellipse` — elliptical wrapping
+- `.shape-polygon` — custom polygon wrapping
+- `.shape-inset` — rounded rectangle wrapping
+
+## Browser Support
+- `shape-outside` — Chrome 37+, Firefox 62+, Safari 10.1+
+- `shape-margin` — Chrome 37+, Firefox 62+, Safari 10.1+
+- `clip-path` (basic shapes) — Chrome 55+, Firefox 54+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/shape-outside-wrapping/demo.html
+++ b/submissions/examples/shape-outside-wrapping/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shape Outside Wrapping — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Shape Outside Wrapping</h1>
+  <p class="subtitle">Text wrapping around CSS shapes with <code>shape-outside</code> — no JavaScript required.</p>
+
+  <section>
+    <h2>Circle</h2>
+    <div class="shape-wrap">
+      <div class="shape-circle"></div>
+      <p>Text wraps around a circular shape created with <code>shape-outside: circle()</code>. The shape-margin adds spacing between the text and the circle edge. This technique is useful for magazine-style layouts where text should flow around circular images or decorative elements without requiring JavaScript or complex HTML structures.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Ellipse</h2>
+    <div class="shape-wrap">
+      <div class="shape-ellipse"></div>
+      <p>An elliptical shape creates a wider wrapping path. The ellipse is defined by its horizontal and vertical radii using <code>shape-outside: ellipse(80px 120px at 50% 50%)</code>. This works well for portrait-oriented images or decorative oval elements where text should follow a curved path.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Polygon</h2>
+    <div class="shape-wrap">
+      <div class="shape-polygon"></div>
+      <p>A custom polygon shape allows wrapping text around any arbitrary shape. This example uses a diagonal cut created with <code>shape-outside: polygon(0 0, 100% 0, 100% 100%, 0 60%)</code>. The clipped background element matches the shape using clip-path for a seamless visual effect.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Inset (Rounded Rectangle)</h2>
+    <div class="shape-wrap">
+      <div class="shape-inset"></div>
+      <p>An inset shape creates a rounded rectangle wrapping path using <code>shape-outside: inset(0 0 0 0 round 50%)</code>. Combined with a matching clip-path, this creates a smooth pill-shaped element that text flows around naturally.</p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/shape-outside-wrapping/style.css
+++ b/submissions/examples/shape-outside-wrapping/style.css
@@ -1,0 +1,68 @@
+/* ============================================================
+   EaseMotion CSS — Shape Outside Wrapping
+   Text wrapping around CSS shapes with shape-outside
+   ============================================================ */
+
+/* ---- Shared ---- */
+
+.shape-wrap {
+  overflow: hidden;
+}
+
+.shape-wrap p {
+  line-height: 1.7;
+  margin: 0;
+  text-align: justify;
+}
+
+/* ---- Circle ---- */
+
+.shape-circle {
+  float: left;
+  width: 160px;
+  height: 160px;
+  margin: 0.5rem 1rem 0.5rem 0;
+  shape-outside: circle(50%);
+  shape-margin: 1rem;
+  clip-path: circle(50%);
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+}
+
+/* ---- Ellipse ---- */
+
+.shape-ellipse {
+  float: left;
+  width: 180px;
+  height: 240px;
+  margin: 0.5rem 1rem 0.5rem 0;
+  shape-outside: ellipse(80px 120px at 50% 50%);
+  shape-margin: 1rem;
+  clip-path: ellipse(80px 120px at 50% 50%);
+  background: linear-gradient(135deg, #ec4899, #f472b6);
+}
+
+/* ---- Polygon ---- */
+
+.shape-polygon {
+  float: left;
+  width: 200px;
+  height: 200px;
+  margin: 0.5rem 1rem 0.5rem 0;
+  shape-outside: polygon(0 0, 100% 0, 100% 100%, 0 60%);
+  shape-margin: 1rem;
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 60%);
+  background: linear-gradient(135deg, #22c55e, #4ade80);
+}
+
+/* ---- Inset (Rounded) ---- */
+
+.shape-inset {
+  float: left;
+  width: 180px;
+  height: 180px;
+  margin: 0.5rem 1rem 0.5rem 0;
+  shape-outside: inset(0 0 0 0 round 30%);
+  shape-margin: 1rem;
+  clip-path: inset(0 0 0 0 round 30%);
+  background: linear-gradient(135deg, #f59e0b, #fbbf24);
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating text wrapping around CSS shapes using `shape-outside`, `shape-margin`, and `clip-path` — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo with 4 shape wrapping examples |
| `style.css` | Pure CSS using shape-outside with circle, ellipse, polygon, and inset |
| `README.md` | Documentation with usage, browser support, and class reference |

## Sections
1. **Circle** — text wraps around a circular gradient element
2. **Ellipse** — elliptical wrapping for portrait-oriented layouts
3. **Polygon** — custom polygon shape with diagonal cut
4. **Inset (Rounded)** — rounded rectangle wrapping with shape-margin

## Related Issue
Closes #3786