### PR TITLE
feat(examples): add overscroll-behavior scroll chaining demo

### DIFF
--- a/submissions/examples/overscroll-behavior/README.md
+++ b/submissions/examples/overscroll-behavior/README.md
@@ -1,0 +1,38 @@
+# Overscroll Behavior
+
+## What does it do?
+A pure-CSS demo showing how to control scroll chaining using `overscroll-behavior` — no JavaScript required.
+
+## Features
+- **auto (default)** — scroll chaining propagates to parent elements
+- **contain** — prevents scroll chaining; keeps the overscroll effect within the element
+- **none** — prevents both scroll chaining and overscroll bounce effects
+- **Side-by-side comparison** — three panels showing each behavior
+
+## Usage
+```css
+/* Prevent scroll chaining inside a chat box or sidebar */
+.chat-box {
+  overscroll-behavior: contain;
+}
+
+/* Prevent all overscroll effects */
+.modal {
+  overscroll-behavior: none;
+}
+```
+
+## Classes
+- `.os-auto` — default scroll chaining
+- `.os-contain` — prevent chaining to parent
+- `.os-none` — prevent all overscroll effects
+- `.scroll-box` — scrollable container with styled content
+
+## Browser Support
+- `overscroll-behavior` — Chrome 63+, Firefox 59+, Safari 16+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser. Scroll past the end of each box to see the difference.

--- a/submissions/examples/overscroll-behavior/demo.html
+++ b/submissions/examples/overscroll-behavior/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Overscroll Behavior — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 900px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+  </style>
+</head>
+<body>
+  <h1>Overscroll Behavior</h1>
+  <p class="subtitle">Controlling scroll chaining with <code>overscroll-behavior</code> — no JavaScript required.</p>
+
+  <div class="demo-grid">
+    <div class="demo-panel">
+      <h2>Default <span class="tag">overscroll-behavior: auto</span></h2>
+      <p class="panel-desc">Scroll past the end of this box and the page scrolls too (scroll chaining).</p>
+      <div class="scroll-box os-auto">
+        <div class="scroll-content">
+          <p>Item 1 — keep scrolling...</p>
+          <p>Item 2</p>
+          <p>Item 3</p>
+          <p>Item 4</p>
+          <p>Item 5 — almost there</p>
+          <p>Item 6 — last item</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-panel">
+      <h2>Contain <span class="tag">overscroll-behavior: contain</span></h2>
+      <p class="panel-desc">Scroll past the end — scroll stops here, page does not move.</p>
+      <div class="scroll-box os-contain">
+        <div class="scroll-content">
+          <p>Item 1 — keep scrolling...</p>
+          <p>Item 2</p>
+          <p>Item 3</p>
+          <p>Item 4</p>
+          <p>Item 5 — almost there</p>
+          <p>Item 6 — last item</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-panel">
+      <h2>None <span class="tag">overscroll-behavior: none</span></h2>
+      <p class="panel-desc">No overscroll effect at all — no bounce, no chaining.</p>
+      <div class="scroll-box os-none">
+        <div class="scroll-content">
+          <p>Item 1 — keep scrolling...</p>
+          <p>Item 2</p>
+          <p>Item 3</p>
+          <p>Item 4</p>
+          <p>Item 5 — almost there</p>
+          <p>Item 6 — last item</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/overscroll-behavior/style.css
+++ b/submissions/examples/overscroll-behavior/style.css
@@ -1,0 +1,92 @@
+/* ============================================================
+   EaseMotion CSS — Overscroll Behavior
+   Controlling scroll chaining with overscroll-behavior
+   ============================================================ */
+
+/* ---- Demo Grid ---- */
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.demo-panel {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.demo-panel h2 {
+  color: #ffffff;
+  font-size: 1rem;
+  margin: 0 0 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  font-size: 0.65rem;
+  font-weight: 600;
+  background: #252525;
+  color: #a78bfa;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid #333;
+  font-family: monospace;
+}
+
+.panel-desc {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+/* ---- Scroll Box ---- */
+
+.scroll-box {
+  flex: 1;
+  height: 240px;
+  overflow-y: auto;
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+
+.scroll-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.scroll-content p {
+  background: #1f1f1f;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  padding: 1rem;
+  margin: 0;
+  color: #d1d5db;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* ---- Overscroll Variants ---- */
+
+.os-auto {
+  overscroll-behavior: auto;
+}
+
+.os-contain {
+  overscroll-behavior: contain;
+}
+
+.os-none {
+  overscroll-behavior: none;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating `overscroll-behavior` for controlling scroll chaining — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Interactive demo with 3 side-by-side scrollable panels |
| `style.css` | Pure CSS using overscroll-behavior (auto, contain, none) |
| `README.md` | Documentation with usage, browser support, and class reference |

## Panels
1. **Default (auto)** — scroll chaining propagates to the page
2. **Contain** — scroll stops within the element, page unaffected
3. **None** — no overscroll bounce or chaining at all

## Related Issue
Closes #3788
<!-- re-trigger label sync -->