### PR TITLE
fix: respect prefers-reduced-motion in reveal.js

### DIFF
--- a/core/reveal.js
+++ b/core/reveal.js
@@ -10,6 +10,10 @@
     return rect.top < vh * 0.85 && rect.bottom > 0;
   }
 
+  // Check if user prefers reduced motion
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+if (prefersReducedMotion) return;
+  
   var supportsObserver = 'IntersectionObserver' in window;
 
   if (supportsObserver) {


### PR DESCRIPTION
## Summary
Adds a check for `prefers-reduced-motion` in `core/reveal.js` to skip scroll-triggered animations when the user has reduced motion enabled in their OS settings.

## Problem
The `reveal.js` script initializes `IntersectionObserver` and adds animation classes to `.ease-reveal` elements regardless of the user's motion preference. This means users with vestibular disorders or motion sensitivity still experience animations, even though the framework's CSS already supports `prefers-reduced-motion`.

## Solution
Check `window.matchMedia('(prefers-reduced-motion: reduce)').matches` before initializing the observer. If the user prefers reduced motion, return early and do not attach any scroll animations.

## Changes
- `core/reveal.js`: Added 3 lines after `supportsObserver` check to detect and respect `prefers-reduced-motion`

## Testing
- [x] Tested with macOS Reduce Motion enabled — animations skipped
- [x] Tested with Chrome DevTools "Emulate CSS prefers-reduced-motion: reduce" — animations skipped
- [x] Tested with normal settings — animations work as expected

## Accessibility Impact
This fix aligns with [WCAG 2.1 Success Criterion 2.3.3 (Animation from Interactions)](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html) and ensures users with motion sensitivity are not exposed to unwanted scroll-triggered animations.

