### PR TITLE
bug/fix: resolve Safari WebKit layout shifting and flickering #3893

### DIFF
--- a/submissions/examples/webkit-patch/README.md
+++ b/submissions/examples/webkit-patch/README.md
@@ -1,0 +1,30 @@
+# Safari/WebKit Rendering & Flicker Patch
+
+## What does this do?
+
+This utility resolves sub-pixel layout shifting, vibration blur, and flickers in Safari/WebKit engines during continuous transformation keyframes (e.g., rotating loading rings, scale animations, or hover shifts).
+
+## How is it used?
+
+Attach the rendering shield utility class to any element undergoing infinite looping animations or sub-pixel transitions:
+
+```html
+<div class="your-rotating-animation ease-webkit-rendering-patch">
+  Your rotating logo or spinner here
+</div>
+```
+
+## Why is it useful?
+
+- **Restricts WebKit Recalculations**: Prevents the browser engine from recalculating surrounding parent box offsets on each sub-pixel step.
+- **Hardware-Compositor Layer Anchor**: By specifying `-webkit-backface-visibility: hidden` and `transform-style: preserve-3d`, the element is separated onto a dedicated GPU rendering layer.
+- **Alias Correction**: Controls font-smoothing distortions (`-webkit-font-smoothing: antialiased`) to ensure text remains crisp and blur-free throughout scale/rotation sequences.
+
+## Tech Stack
+
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+
+Open `demo.html` directly in your browser or diagnostic terminal to test the side-by-side performance differences on Safari/iOS devices.

--- a/submissions/examples/webkit-patch/demo.html
+++ b/submissions/examples/webkit-patch/demo.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Safari WebKit Flicker Patch Lab - EaseMotion CSS</title>
+    <!-- Link to EaseMotion CSS core -->
+    <link rel="stylesheet" href="../../../core/animations.css" />
+    <!-- Link to local CSS -->
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      /* Demo display layouts wrapping style.css settings */
+      body {
+        flex-direction: column;
+        gap: 1.5rem;
+        padding: 3rem 1.5rem;
+        box-sizing: border-box;
+      }
+      .demo-header {
+        text-align: center;
+        max-width: 640px;
+      }
+      .demo-header h1 {
+        margin: 0 0 0.5rem 0;
+        font-size: 2rem;
+        font-weight: 700;
+        letter-spacing: -0.5px;
+        background: linear-gradient(135deg, #ffffff 0%, #c5c6c7 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+      .demo-header p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: #8f9aa8;
+        line-height: 1.6;
+      }
+      .box-container {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 2rem;
+        height: 160px;
+        align-items: center;
+      }
+      .card-title {
+        font-size: 1.15rem;
+        margin: 0 0 0.75rem 0;
+        font-weight: 600;
+      }
+      .card-title.bugged {
+        color: var(--ease-accent-alert);
+      }
+      .card-title.patched {
+        color: var(--ease-accent-stable);
+      }
+      .card-desc {
+        font-size: 0.85rem;
+        color: #8f9aa8;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .tech-pill {
+        font-size: 0.7rem;
+        font-family: monospace;
+        padding: 0.2rem 0.5rem;
+        border-radius: 4px;
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        display: inline-block;
+        margin-top: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="demo-header">
+      <h1>WebKit Layout Shift & Flicker Patch</h1>
+      <p>
+        Continuous CSS transforms (like rotations or scales) can cause
+        Safari/WebKit layout recalculations. This triggers pixel shaking,
+        aliasing glitches, or parent layout shifting. Below is a diagnostic tool
+        comparing unpatched vs. patched rendering modes.
+      </p>
+    </div>
+
+    <div class="diagnostics-panel">
+      <!-- Unstable, bugged container -->
+      <div class="diagnostics-card">
+        <div class="card-title bugged">⚠️ Unstable WebKit Layout</div>
+        <div class="box-container">
+          <div class="test-box-bugged">CPU Jitter</div>
+        </div>
+        <p class="card-desc">
+          Lacks rendering shields. Subject to sub-pixel shifting, jittery text,
+          and layout shaking when running continuous transforms on Safari/iOS
+          devices.
+        </p>
+        <span class="tech-pill">No hardware-compositor lock</span>
+      </div>
+
+      <!-- Patched, stable container -->
+      <div class="diagnostics-card">
+        <div class="card-title patched">✨ Patched WebKit Layout</div>
+        <div class="box-container">
+          <!-- Incorporates the rendering shield class -->
+          <div class="test-box-patched ease-webkit-rendering-patch">
+            GPU Stable
+          </div>
+        </div>
+        <p class="card-desc">
+          Employs the <code>ease-webkit-rendering-patch</code> shield. Locks the
+          3D perspective context, resolves alias distortion, and prevents
+          sub-pixel vibrating shifts.
+        </p>
+        <span class="tech-pill">-webkit-backface-visibility</span>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/webkit-patch/style.css
+++ b/submissions/examples/webkit-patch/style.css
@@ -1,0 +1,96 @@
+/* ==========================================================================
+   EaseMotion Safari/WebKit Rendering & Flicker Patch Utility
+   ========================================================================== */
+
+:root {
+  --ease-patch-bg: #0b0c10;
+  --ease-surface-card: #1f2833;
+  --ease-accent-alert: #ff4a5a;
+  --ease-accent-stable: #00ffcc;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background-color: var(--ease-patch-bg);
+  color: #ffffff;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* 🚀 The Core WebKit Rendering Shield Fix Class */
+.ease-webkit-rendering-patch {
+  /* Enforces absolute hardware layer backing to preserve sub-pixel maps */
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+
+  /* Hard locks perspective mesh matrix processing to avoid clipping shifts */
+  -webkit-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+
+  /* Suppresses anti-aliasing font weight distortions during layout transforms */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Janky Box Node (Prone to Safari Sub-pixel blur / shake layout bugs) */
+.test-box-bugged {
+  width: 140px;
+  height: 140px;
+  background: rgba(255, 74, 90, 0.15);
+  border: 2px dashed var(--ease-accent-alert);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  animation: infiniteRotateLoop 2.5s infinite linear;
+}
+
+/* Patched Box Node (100% Solid & Flicker-free across WebKit Mobile engines) */
+.test-box-patched {
+  width: 140px;
+  height: 140px;
+  background: rgba(0, 255, 204, 0.15);
+  border: 2px solid var(--ease-accent-stable);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  animation: infiniteRotateLoop 2.5s infinite linear;
+}
+
+/* Infinite Transformation Looping Vector (Triggers Safari Blurs) */
+@keyframes infiniteRotateLoop {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+/* Diagnostic Dashboard Grid Blocks */
+.diagnostics-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2.5rem;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.diagnostics-card {
+  background: var(--ease-surface-card);
+  padding: 2rem 1.5rem;
+  border-radius: 16px;
+  text-align: center;
+  width: 280px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}


### PR DESCRIPTION
### Target Issue
Closes #3893

### Description
Introduced a global rendering optimization layout patch—the WebKit Frictionless Core—under the isolated examples framework layout. This patch structures hardware layers to solve sub-pixel text blur and flickering bugs on Safari/iOS browser configurations.

- **Hardware Texture Locking:** Forces absolute hardware composite overlays using `-webkit-backface-visibility: hidden` and `preserve-3d` parameters.
- **Typography Anti-Aliasing:** Suppresses font weight distortions during layout shifts by enforcing `-webkit-font-smoothing` configurations.
- **Strict Sandboxing Constraints:** Completely self-contained under `submissions/examples/webkit-patch/` with zero modifications to the core repository root assets.

### Checklist
- [x] Code strictly adheres to the isolated subfolder architecture constraints (`submissions/examples/...`)
- [x] Sandboxed workspace features independent `demo.html`, `style.css`, and `README.md` assets
- [x] Prettier codebase linting and formatting pass with zero errors