### PR TITLE
fix: ease-ping uses var(--ease-ease) instead of hardcoded cubic-bezier (#3897)

### DIFF
--- a/submissions/examples/ease-ping-var/README.md
+++ b/submissions/examples/ease-ping-var/README.md
@@ -1,0 +1,13 @@
+# Ease Ping Var
+Fix #3897: `.ease-ping` hardcoded `cubic-bezier(0, 0, 0.2, 1)` instead of `var(--ease-ease)`.
+
+## Permanent Core Fix (for maintainer)
+```css
+/* core/animations.css .ease-ping */
+animation: ease-kf-ping 1s var(--ease-ease) var(--ease-animation-iterations, infinite);
+```
+
+## Files
+- `demo.html`
+- `style.css`
+- `README.md`

--- a/submissions/examples/ease-ping-var/demo.html
+++ b/submissions/examples/ease-ping-var/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>ease-ping-var #3897</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../style.css">
+<style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
+</head><body>
+<span class="badge">Fix #3897</span>
+<h1>ease-ping CSS Token Override</h1>
+<p>".ease-ping" hardcodes <code>cubic-bezier(0, 0, 0.2, 1)</code>. This example shows the correct override using <code>var(--ease-ease)</code>:</p>
+<pre><code>.ease-ping {
+  animation: ease-kf-ping 1s var(--ease-ease) var(--ease-animation-iterations, infinite);
+}</code></pre>
+<div class="ease-center" style="min-height:100px"><div class="ease-card ease-padding-6">
+<h3>✅ Override Active</h3>
+<p>See <code>style.css</code>. The permanent fix in core/animations.css:</p>
+<div class="ease-ping" style="font-size:2rem;display:inline-block;position:relative">🔔</div>
+</div></div></body></html>

--- a/submissions/examples/ease-ping-var/style.css
+++ b/submissions/examples/ease-ping-var/style.css
@@ -1,0 +1,4 @@
+/* Fix #3897: Override .ease-ping to use --ease-ease */
+.ease-ping {
+  animation: ease-kf-ping 1s var(--ease-ease) var(--ease-animation-iterations, infinite);
+}


### PR DESCRIPTION
## ✦ Description
Override `.ease-ping` to use `var(--ease-ease)` instead of hardcoded `cubic-bezier(0, 0, 0.2, 1)`. The permanent fix in `core/animations.css` is documented for maintainer review.

Fixes #3897

---

## ⟡ Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code styling/formatting

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [ ] (If applicable) I have run npm run lint and npm run format locally before pushing.

---

## ⟡ Screenshots / Screen Recordings
N/A — submission example.

| Before | After |
| :--- | :--- |
| `.ease-ping` hardcodes `cubic-bezier(0, 0, 0.2, 1)` | Override uses `var(--ease-ease)` |

---

## Description
### Root Cause
`core/animations.css` hardcodes the ping animation timing function.

### Changes Made (submissions only)
- `submissions/examples/ease-ping-var/demo.html`
- `submissions/examples/ease-ping-var/style.css`
- `submissions/examples/ease-ping-var/README.md`

### Permanent Core Fix (for maintainer)
```css
/* core/animations.css .ease-ping */
- animation: ease-kf-ping 1s cubic-bezier(0, 0, 0.2, 1) var(--ease-animation-iterations, infinite);
+ animation: ease-kf-ping 1s var(--ease-ease) var(--ease-animation-iterations, infinite);
```

### Result
PASS — submissions-only PR, no core files modified.

---

## Type of change
- [x] Bug fix

---

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
