### PR TITLE
fix: ease-gradient-rotation uses var(--ease-speed-slow) instead of hardcoded 3s (#3901)

### DIFF
--- a/submissions/examples/ease-gradient-rotation-var/README.md
+++ b/submissions/examples/ease-gradient-rotation-var/README.md
@@ -1,0 +1,20 @@
+# Ease Gradient Rotation Var
+Fix #3901: `.ease-gradient-rotation` hardcodes `3s` duration instead of `var(--ease-speed-slow)`.
+
+## Issue
+`core/animations.css` line 733:
+```css
+animation: ease-kf-gradient-rotation 3s var(--ease-ease) infinite;
+```
+
+## Permanent Core Fix (for maintainer)
+```css
+/* core/animations.css .ease-gradient-rotation */
+- animation: ease-kf-gradient-rotation 3s var(--ease-ease) infinite;
++ animation: ease-kf-gradient-rotation var(--ease-speed-slow) var(--ease-ease) infinite;
+```
+
+## Files
+- `demo.html`
+- `style.css`
+- `README.md`

--- a/submissions/examples/ease-gradient-rotation-var/demo.html
+++ b/submissions/examples/ease-gradient-rotation-var/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>ease-gradient-rotation-var #3901</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../style.css">
+<style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}.gradient-box{width:100%;height:80px;border-radius:8px;margin:1rem 0}</style>
+</head><body>
+<span class="badge">Fix #3901</span>
+<h1>ease-gradient-rotation CSS Token Override</h1>
+<p>The framework <code>.ease-gradient-rotation</code> hardcodes <code>3s</code> duration. This example shows the correct override using <code>var(--ease-speed-slow)</code>:</p>
+<pre><code>.ease-gradient-rotation {
+  background: linear-gradient(270deg, var(--ease-color-primary), var(--ease-color-secondary), var(--ease-color-primary));
+  background-size: 200% 200%;
+  animation: ease-kf-gradient-rotation var(--ease-speed-slow) var(--ease-ease) infinite;
+}</code></pre>
+<div class="gradient-box ease-gradient-rotation"></div>
+<hr style="margin:1.5rem 0;border-color:#e2e8f0">
+<div class="ease-center" style="min-height:100px"><div class="ease-card ease-padding-6">
+<h3>✅ Override Active</h3>
+<p>See <code>style.css</code>. The permanent fix in core/animations.css line 733:</p>
+<div class="ease-gradient-rotation" style="height:60px;border-radius:8px"></div>
+</div></div></body></html>

--- a/submissions/examples/ease-gradient-rotation-var/style.css
+++ b/submissions/examples/ease-gradient-rotation-var/style.css
@@ -1,0 +1,4 @@
+/* Fix #3901: Override .ease-gradient-rotation to use --ease-speed-slow */
+.ease-gradient-rotation {
+  animation: ease-kf-gradient-rotation var(--ease-speed-slow) var(--ease-ease) infinite;
+}


### PR DESCRIPTION
## ✦ Description
Override `.ease-gradient-rotation` to use `var(--ease-speed-slow)` instead of hardcoded `3s`. The permanent fix in `core/animations.css` is documented for maintainer review.

Fixes #3901

---

## ⟡ Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code styling/formatting

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [ ] (If applicable) I have run npm run lint and npm run format locally before pushing.

---

## ⟡ Screenshots / Screen Recordings
N/A — submission example.

| Before | After |
| :--- | :--- |
| `.ease-gradient-rotation` hardcodes `3s` | Override uses `var(--ease-speed-slow)` |

---

## Description
### Root Cause
`core/animations.css` line 733 hardcodes `3s` for `.ease-gradient-rotation` duration.

### Changes Made (submissions only)
- `submissions/examples/ease-gradient-rotation-var/demo.html`
- `submissions/examples/ease-gradient-rotation-var/style.css`
- `submissions/examples/ease-gradient-rotation-var/README.md`

### Permanent Core Fix (for maintainer)
```css
/* core/animations.css .ease-gradient-rotation */
- animation: ease-kf-gradient-rotation 3s var(--ease-ease) infinite;
+ animation: ease-kf-gradient-rotation var(--ease-speed-slow) var(--ease-ease) infinite;
```

### Result
PASS — submissions-only PR, no core files modified.

---

## Type of change
- [x] Bug fix

---

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
