### PR TITLE
fix: fix: loader-ping use --ease-ease-out instead of hardcoded cubic-bezier (#3957)

### DIFF
--- a/submissions/core_changes-v1/bug-3957/README.md
+++ b/submissions/core_changes-v1/bug-3957/README.md
@@ -1,0 +1,15 @@
+# Bug 3957 — fix: loader-ping use --ease-ease-out instead of hardcoded cubic-bezier
+
+Fixes #3957
+
+## Description
+fix: loader-ping use --ease-ease-out instead of hardcoded cubic-bezier
+
+## Files
+- `loader-ping-token.css` — proposed fix
+- `README.md` — this file
+
+## Permanent fix for maintainer
+Apply the changes in `loader-ping-token.css` to the appropriate file in `core/` or `components/`.
+
+This is an additions-only PR. No existing files are modified.

--- a/submissions/core_changes-v1/bug-3957/loader-ping-token.css
+++ b/submissions/core_changes-v1/bug-3957/loader-ping-token.css
@@ -1,0 +1,4 @@
+/* Fix #3957: .ease-loader-ping use --ease-ease-out token */
+.ease-loader-ping {
+  animation: ease-kf-ping 1s var(--ease-ease-out) infinite;
+}


### PR DESCRIPTION
## Description

Fixes #3957: fix: loader-ping use --ease-ease-out instead of hardcoded cubic-bezier

See `submissions/core_changes-v1/bug-3957/README.md` for details.

Additions-only PR — no `core/` or `components/` files modified.