### PR TITLE
fix: fix: add missing --ease-ease-linear and --ease-ease-in tokens (#3960)

### DIFF
--- a/submissions/core_changes-v1/bug-3960/README.md
+++ b/submissions/core_changes-v1/bug-3960/README.md
@@ -1,0 +1,15 @@
+# Bug 3960 — fix: add missing --ease-ease-linear and --ease-ease-in tokens
+
+Fixes #3960
+
+## Description
+fix: add missing --ease-ease-linear and --ease-ease-in tokens
+
+## Files
+- `variables-missing-tokens.css` — proposed fix
+- `README.md` — this file
+
+## Permanent fix for maintainer
+Apply the changes in `variables-missing-tokens.css` to the appropriate file in `core/` or `components/`.
+
+This is an additions-only PR. No existing files are modified.

--- a/submissions/core_changes-v1/bug-3960/variables-missing-tokens.css
+++ b/submissions/core_changes-v1/bug-3960/variables-missing-tokens.css
@@ -1,0 +1,6 @@
+/* Fix #3960: add missing timing tokens to core/variables.css */
+:root {
+  --ease-ease-linear: linear;
+  --ease-ease-in: cubic-bezier(0.4, 0, 1, 1);
+  --ease-timing-linear: linear;
+}


### PR DESCRIPTION
## Description

Fixes #3960: fix: add missing --ease-ease-linear and --ease-ease-in tokens

See `submissions/core_changes-v1/bug-3960/README.md` for details.

Additions-only PR — no `core/` or `components/` files modified.