### PR TITLE
fix: fix: modal.js use CSS.escape and remove blanket try-catch (#3961)

### DIFF
--- a/submissions/core_changes-v1/bug-3961/README.md
+++ b/submissions/core_changes-v1/bug-3961/README.md
@@ -1,0 +1,15 @@
+# Bug 3961 — fix: modal.js use CSS.escape and remove blanket try-catch
+
+Fixes #3961
+
+## Description
+fix: modal.js use CSS.escape and remove blanket try-catch
+
+## Files
+- `modal-js-escape.css` — proposed fix
+- `README.md` — this file
+
+## Permanent fix for maintainer
+Apply the changes in `modal-js-escape.css` to the appropriate file in `core/` or `components/`.
+
+This is an additions-only PR. No existing files are modified.

--- a/submissions/core_changes-v1/bug-3961/modal-js-escape.css
+++ b/submissions/core_changes-v1/bug-3961/modal-js-escape.css
@@ -1,0 +1,22 @@
+/* Fix #3961: core/modal.js — use CSS.escape for hash selectors */
+(function () {
+  'use strict';
+  function checkModal() {
+    var hash = window.location.hash;
+    if (!hash) return;
+    var escaped = CSS.escape(hash);
+    var overlay = document.querySelector('#' + escaped + '.ease-modal-overlay');
+    if (!overlay) { document.body.style.overflow = ''; return; }
+    document.body.style.overflow = 'hidden';
+    overlay.classList.add('is-active');
+    var modal = overlay.querySelector('.ease-modal');
+    if (modal) { modal.setAttribute('tabindex', '-1'); modal.focus(); }
+  }
+  window.addEventListener('hashchange', checkModal);
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') window.location.hash = '';
+  });
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', checkModal);
+  } else { checkModal(); }
+})();


### PR DESCRIPTION
## Description

Fixes #3961: fix: modal.js use CSS.escape and remove blanket try-catch

See `submissions/core_changes-v1/bug-3961/README.md` for details.

Additions-only PR — no `core/` or `components/` files modified.