### PR TITLE
fix: fix: html scroll-behavior smooth respect prefers-reduced-motion (#3963)

### DIFF
--- a/submissions/core_changes-v1/bug-3963/README.md
+++ b/submissions/core_changes-v1/bug-3963/README.md
@@ -1,0 +1,15 @@
+# Bug 3963 — fix: html scroll-behavior smooth respect prefers-reduced-motion
+
+Fixes #3963
+
+## Description
+fix: html scroll-behavior smooth respect prefers-reduced-motion
+
+## Files
+- `scroll-behavior-reduced-motion.css` — proposed fix
+- `README.md` — this file
+
+## Permanent fix for maintainer
+Apply the changes in `scroll-behavior-reduced-motion.css` to the appropriate file in `core/` or `components/`.
+
+This is an additions-only PR. No existing files are modified.

--- a/submissions/core_changes-v1/bug-3963/scroll-behavior-reduced-motion.css
+++ b/submissions/core_changes-v1/bug-3963/scroll-behavior-reduced-motion.css
@@ -1,0 +1,4 @@
+/* Fix #3963: respect prefers-reduced-motion for scroll-behavior */
+@media (prefers-reduced-motion: no-preference) {
+  html { scroll-behavior: smooth; }
+}


### PR DESCRIPTION
## Description

Fixes #3963: fix: html scroll-behavior smooth respect prefers-reduced-motion

See `submissions/core_changes-v1/bug-3963/README.md` for details.

Additions-only PR — no `core/` or `components/` files modified.