### PR TITLE
fix: fix: ease-sr-only remove deprecated clip: rect() (#3964)

### DIFF
--- a/submissions/core_changes-v1/bug-3964/README.md
+++ b/submissions/core_changes-v1/bug-3964/README.md
@@ -1,0 +1,15 @@
+# Bug 3964 — fix: ease-sr-only remove deprecated clip: rect()
+
+Fixes #3964
+
+## Description
+fix: ease-sr-only remove deprecated clip: rect()
+
+## Files
+- `sr-only-deprecated-clip.css` — proposed fix
+- `README.md` — this file
+
+## Permanent fix for maintainer
+Apply the changes in `sr-only-deprecated-clip.css` to the appropriate file in `core/` or `components/`.
+
+This is an additions-only PR. No existing files are modified.

--- a/submissions/core_changes-v1/bug-3964/sr-only-deprecated-clip.css
+++ b/submissions/core_changes-v1/bug-3964/sr-only-deprecated-clip.css
@@ -1,0 +1,12 @@
+/* Fix #3964: .ease-sr-only — remove deprecated clip: rect() */
+.ease-sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}


### PR DESCRIPTION
## Description

Fixes #3964: fix: ease-sr-only remove deprecated clip: rect()

See `submissions/core_changes-v1/bug-3964/README.md` for details.

Additions-only PR — no `core/` or `components/` files modified.