### PR TITLE
fix: fix: add responsive flex-col/flex-row breakpoint variants (#3965)

### DIFF
--- a/submissions/core_changes-v1/bug-3965/README.md
+++ b/submissions/core_changes-v1/bug-3965/README.md
@@ -1,0 +1,15 @@
+# Bug 3965 — fix: add responsive flex-col/flex-row breakpoint variants
+
+Fixes #3965
+
+## Description
+fix: add responsive flex-col/flex-row breakpoint variants
+
+## Files
+- `responsive-flex-col.css` — proposed fix
+- `README.md` — this file
+
+## Permanent fix for maintainer
+Apply the changes in `responsive-flex-col.css` to the appropriate file in `core/` or `components/`.
+
+This is an additions-only PR. No existing files are modified.

--- a/submissions/core_changes-v1/bug-3965/responsive-flex-col.css
+++ b/submissions/core_changes-v1/bug-3965/responsive-flex-col.css
@@ -1,0 +1,17 @@
+/* Fix #3965: responsive flex-direction column/row variants */
+@media (min-width: 640px) {
+  .ease-sm-flex-col { flex-direction: column !important; }
+  .ease-sm-flex-row { flex-direction: row !important; }
+}
+@media (min-width: 768px) {
+  .ease-md-flex-col { flex-direction: column !important; }
+  .ease-md-flex-row { flex-direction: row !important; }
+}
+@media (min-width: 1024px) {
+  .ease-lg-flex-col { flex-direction: column !important; }
+  .ease-lg-flex-row { flex-direction: row !important; }
+}
+@media (min-width: 1280px) {
+  .ease-xl-flex-col { flex-direction: column !important; }
+  .ease-xl-flex-row { flex-direction: row !important; }
+}


### PR DESCRIPTION
## Description

Fixes #3965: fix: add responsive flex-col/flex-row breakpoint variants

See `submissions/core_changes-v1/bug-3965/README.md` for details.

Additions-only PR — no `core/` or `components/` files modified.