### PR TITLE
Inline SVG Stroke Sizing Non-Scaling Isolation Patch

### DIFF
--- a/submissions/examples/svg-stroke-isolation/README.md
+++ b/submissions/examples/svg-stroke-isolation/README.md
@@ -1,0 +1,14 @@
+# Sandbox Layout Fix: Inline SVG Stroke-Width Sizing Sub-Pixel Jitter Resolution
+
+## Overview
+A graphic rendering patch for inline SVG nodes inside fluid layout tracks to prevent text line snapping, eliminate stroke-width wiggling, and stabilize vector stroke weights across Chromium viewports.
+
+## 📁 Sandbox Configuration Files
+* `demo.html` — Interactive dashboard template hosting animated vector loaders within resizable grid blocks to test scaling thresholds.
+* `style.css` — Scoped layout sheet establishing absolute vector path boundaries linked back to core global tokens.
+
+## 🐛 The Bug Resolved
+Previously, nesting inline vector icons or radial animation loaders inside percentage-based layout slots or responsive grid columns caused severe interaction artifacts on Chromium (Blink) engines. As the wrapper box scales fluidly along sub-pixel coordinates, the engine repeatedly attempts to re-evaluate the vector circumference coordinates. This results in rounding math collisions, forcing vector line segments to jitter, snap weights, and wobble during layout adjustments.
+
+## 🛠️ The Solution
+The drawing coordinate calculations are optimized. By anchoring the internal vector graphics mapping grid to a hardcoded asset tag (`viewBox="0 0 100 100"`), the browser calculations use a fixed coordinate baseline. Injecting `vector-effect: non-scaling-stroke;` instructs the hardware compositor to draw vector lines completely decoupled from outer box scaling loops. This maintains perfect stroke thickness weights across fluid layout transitions.

--- a/submissions/examples/svg-stroke-isolation/demo.html
+++ b/submissions/examples/svg-stroke-isolation/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS Sandbox — SVG Stroke Non-Scaling Isolation</title>
+  
+  <link rel="stylesheet" href="./style.css">
+  
+  <style>
+    body {
+      background-color: #0b1121;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+      padding: 1.5rem;
+    }
+
+    /* Adjustable testing wrapper to force high-speed width changes */
+    .stress-test-container {
+      width: 100%;
+      max-width: 600px;
+      transition: max-width 0.4s cubic-bezier(0.1, 1, 0.1, 1);
+    }
+  </style>
+</head>
+<body>
+
+  <header style="margin-bottom: 2.5rem; text-align: center; max-width: 480px;">
+    <h1 style="color: white; margin: 0; font-size: 1.5rem; font-weight: 700;">Vector Effect Sizing Canvas</h1>
+    <p style="color: #64748b; margin: 4px 0 0 0; font-size: 0.875rem; line-height: 1.5;">Hover to spin the loaders, then snap the container width using the toggles. <code>vector-effect: non-scaling-stroke</code> protects vector arcs from sub-pixel snapping.</p>
+  </header>
+
+  <div style="margin-bottom: 2rem; display: flex; gap: 0.5rem;">
+    <button onclick="resizeGrid('340px')" style="background: #1e293b; border: 1px solid rgba(255,255,255,0.1); color: white; padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 0.75rem; font-weight: 600;">Compact Grid (340px)</button>
+    <button onclick="resizeGrid('600px')" style="background: var(--ease-color-primary, #6c63ff); border: none; color: white; padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 0.75rem; font-weight: 600;">Expansive Grid (600px)</button>
+  </div>
+
+  <div class="stress-test-container" id="gridWrapperShell">
+    <div class="alm-grid-stage-wrapper">
+      <div class="alm-fluid-vector-grid">
+        
+        <div class="alm-vector-card">
+          <div class="alm-fluid-svg-wrapper">
+            <svg class="alm-isolated-vector-canvas" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle class="alm-stabilized-stroke-path" cx="50" cy="50" r="40" stroke-dasharray="160 60" />
+            </svg>
+          </div>
+          <h3 class="alm-vector-label">Pipeline Delta</h3>
+        </div>
+
+        <div class="alm-vector-card">
+          <div class="alm-fluid-svg-wrapper">
+            <svg class="alm-isolated-vector-canvas" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle class="alm-stabilized-stroke-path" cx="50" cy="50" r="40" stroke-dasharray="80 140" style="stroke: #ff65a3;" />
+            </svg>
+          </div>
+          <h3 class="alm-vector-label">Socket Streaming</h3>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function resizeGrid(targetSize) {
+      document.getElementById('gridWrapperShell').style.maxWidth = targetSize;
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/svg-stroke-isolation/style.css
+++ b/submissions/examples/svg-stroke-isolation/style.css
@@ -1,0 +1,91 @@
+/* ============================================================
+   EaseMotion CSS Sandbox — svg-stroke-isolation/style.css
+   ============================================================ */
+
+/* Step back 3 levels out of submissions/examples/svg-stroke-isolation to pull root tokens */
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+@layer easemotion-components {
+
+/* ── Fluid Responsive Dashboard Grid Shell ───────────────── */
+.alm-grid-stage-wrapper {
+  width: 100%;
+  max-width: 600px;
+  background: var(--ease-glass-bg, rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.06));
+  border-radius: var(--ease-radius-xl, 1.5rem);
+  padding: var(--ease-space-6, 1.5rem);
+  box-sizing: border-box;
+}
+
+/* Fluid responsive grid tracks driving container changes */
+.alm-fluid-vector-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--ease-space-4, 1rem);
+  align-items: center;
+}
+
+/* ── Isolated Vector Card Module ─────────────────────────── */
+.alm-vector-card {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-4, 1rem);
+  text-align: center;
+  box-sizing: border-box;
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+}
+
+/* ── Fluid SVG Fluid Containers ────────────────────────── */
+.alm-fluid-svg-wrapper {
+  width: 50%; /* Fluid percentage footprint inside the grid card box */
+  max-width: 80px;
+  margin: 0 auto var(--ease-space-3, 0.75rem) auto;
+}
+
+.alm-isolated-vector-canvas {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+/* ── Hardware Accelerated Isolated Vector Target ────────── */
+.alm-stabilized-stroke-path {
+  fill: none;
+  stroke: var(--ease-color-primary, #6c63ff);
+  stroke-width: 3px; /* Absolute base thickness targeted inside the 100x100 viewbox space */
+  stroke-linecap: round;
+
+  /* SUCCESS: Tells the browser engine to calculate path stroke bounds 
+     completely independent of layout conversions, blocking line wiggling. */
+  vector-effect: non-scaling-stroke;
+
+  will-change: transform;
+}
+
+/* ── High-Fidelity Rotation Loop Keyframes ──────────────── */
+.alm-vector-card:hover .alm-stabilized-stroke-path {
+  animation: almVectorSpin 1.5s linear infinite;
+  transform-origin: 50px 50px; /* Synchronized to the exact center of our 100x100 coordinates */
+}
+
+@keyframes almVectorSpin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.alm-vector-label {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  color: var(--ease-color-text, #f8fafc);
+  margin: 0;
+}
+
+}


### PR DESCRIPTION
## Pull Request Description
This PR introduces an isolated layout boundary fix for an Inline SVG Stroke-Width Sub-Pixel Jitter Bug placed strictly inside the submissions/examples/svg-stroke-isolation/ sandbox directory. It addresses an interface presentation degradation issue common across modern Chromium (Blink) layout engines where putting fluid percentage-based vector graphics inside responsive grids forces continuous path recalculations, causing vector lines to snap and wiggle during viewport scaling frames.
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An optimized vector path layer blueprint that isolates path strokes from fluid outer layout tracks, protecting icons from sub-pixel rounding distortions.

**How does a developer use it?**

```html
<!-- <div class="alm-vector-card">
  <div class="alm-fluid-svg-wrapper">
    <svg class="alm-isolated-vector-canvas" viewBox="0 0 100 100">
      <circle class="alm-stabilized-stroke-path" cx="50" cy="50" r="40" />
    </svg>
  </div>
</div> -->
```

**Why does it fit EaseMotion CSS?**

<!-- It matches the repository’s focus of resolving visible interface defects using clean, native vanilla CSS rules instead of overloading execution tracking pipelines with heavy JavaScript scaling listeners or layout resize hooks. Offloading layer width protection flags directly to the browser's hardware painter engine ensures fluid components reflow cleanly at a locked $60\text{fps}$ during responsive width changes. -->
---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
close #3986