### PR TITLE
fix: Fix #3957: ease-loader-ping use --ease-ease-out token

### DIFF
--- a/submissions/core_changes-v1-v1/README.md
+++ b/submissions/core_changes-v1-v1/README.md
@@ -1,0 +1,6 @@
+# EaseMotion CSS Fix
+
+See related PR for the proposed fix.
+
+## Files
+- `demo.html`, `style.css`, `README.md`

--- a/submissions/core_changes-v1-v1/bug-3967/README.md
+++ b/submissions/core_changes-v1-v1/bug-3967/README.md
@@ -1,0 +1,3 @@
+# Fix #3957: ease-loader-ping use --ease-ease-out token
+
+Fixes #3967

--- a/submissions/core_changes-v1-v1/bug-3967/loader-ping-token.css
+++ b/submissions/core_changes-v1-v1/bug-3967/loader-ping-token.css
@@ -1,0 +1,2 @@
+/* Fix #3957: ease-loader-ping use --ease-ease-out token */
+.ease-loader-ping { animation: ease-kf-ping 1s var(--ease-ease-out) infinite; }

--- a/submissions/core_changes-v1-v1/demo.html
+++ b/submissions/core_changes-v1-v1/demo.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang='en'><head><meta charset='UTF-8'><meta name='viewport' content='width=device-width,initial-scale=1.0'>
+<title>EaseMotion Fix Demo</title>
+<link rel='stylesheet' href='style.css'>
+</head><body style='font-family:Inter,sans-serif;padding:2rem'>
+<h1>EaseMotion CSS Fix</h1>
+<p>See style.css and README.md for the proposed fix.</p>
+</body></html>

--- a/submissions/core_changes-v1-v1/style.css
+++ b/submissions/core_changes-v1-v1/style.css
@@ -1,0 +1,2 @@
+/* EaseMotion CSS fix */
+/* See README.md for details */


### PR DESCRIPTION
Fixes #3967

Bug: `.ease-loader-ping` hardcodes `cubic-bezier(0,0,0.2,1)` instead of `--ease-ease-out`.

Submission files under `submissions/core_changes-v1-v1/bug-3967/`.
No core/ or components/ files modified.