### PR TITLE
feat: add breadcrumb component (Issue #4031)

### DIFF
--- a/submissions/core_changes-breadcrumb/README.md
+++ b/submissions/core_changes-breadcrumb/README.md
@@ -1,0 +1,22 @@
+# Breadcrumb Component
+
+1. **What does this do?** Provides a pure CSS breadcrumb navigation trail using an `<ol>` list with multiple separator styles (slash, chevron, arrow, bullet), three size variants (sm, base, lg), and custom separator support via `--breadcrumb-separator` — all with zero JavaScript.
+
+2. **How is it used?**
+   ```html
+   <!-- Default (slash separator) -->
+   <nav aria-label="breadcrumb" class="breadcrumb">
+     <ol>
+       <li><a href="#">Home</a></li>
+       <li><a href="#">Library</a></li>
+       <li aria-current="page">Breadcrumb</li>
+     </ol>
+   </nav>
+
+   <!-- Chevron variant -->
+   <nav class="breadcrumb breadcrumb-chevron">
+     <ol>...</ol>
+   </nav>
+   ```
+
+3. **Why is it useful?** Breadcrumbs provide secondary navigation that helps users understand their location within a site hierarchy. This implementation follows EaseMotion CSS's philosophy by being pure CSS, using semantic ARIA attributes (`aria-label`, `aria-current="page"`), supporting dark mode automatically, respecting `prefers-reduced-motion`, and keeping the API simple with customizable separators via CSS custom properties.

--- a/submissions/core_changes-breadcrumb/demo.html
+++ b/submissions/core_changes-breadcrumb/demo.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Breadcrumb Component — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="font-family: system-ui, -apple-system, sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem 1rem; background: var(--bg, #fff); color: var(--text, #1a1a2e); transition: background .3s, color .3s;">
+
+  <h1>Breadcrumb Component</h1>
+  <p style="color: #666; margin-bottom: 2rem;">Navigation trail showing the current page location — pure CSS.</p>
+
+  <label style="display: flex; align-items: center; gap: .5rem; cursor: pointer; margin-bottom: 2rem;">
+    <input type="checkbox" id="darkModeToggle"> Dark mode
+  </label>
+
+  <!-- Default (slash) -->
+  <section style="margin-bottom: 3rem;">
+    <h2>Default (Slash)</h2>
+    <nav aria-label="breadcrumb" class="breadcrumb">
+      <ol>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Products</a></li>
+        <li><a href="#">Electronics</a></li>
+        <li aria-current="page">Headphones</li>
+      </ol>
+    </nav>
+  </section>
+
+  <!-- Chevron -->
+  <section style="margin-bottom: 3rem;">
+    <h2>Chevron Separator</h2>
+    <nav aria-label="breadcrumb" class="breadcrumb breadcrumb-chevron">
+      <ol>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Library</a></li>
+        <li><a href="#">Components</a></li>
+        <li aria-current="page">Breadcrumb</li>
+      </ol>
+    </nav>
+  </section>
+
+  <!-- Arrow -->
+  <section style="margin-bottom: 3rem;">
+    <h2>Arrow Separator</h2>
+    <nav aria-label="breadcrumb" class="breadcrumb breadcrumb-arrow">
+      <ol>
+        <li><a href="#">Dashboard</a></li>
+        <li><a href="#">Settings</a></li>
+        <li><a href="#">Account</a></li>
+        <li aria-current="page">Profile</li>
+      </ol>
+    </nav>
+  </section>
+
+  <!-- Bullet -->
+  <section style="margin-bottom: 3rem;">
+    <h2>Bullet Separator</h2>
+    <nav aria-label="breadcrumb" class="breadcrumb breadcrumb-bullet">
+      <ol>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Blog</a></li>
+        <li><a href="#">Articles</a></li>
+        <li aria-current="page">Getting Started</li>
+      </ol>
+    </nav>
+  </section>
+
+  <!-- Size variants -->
+  <section style="margin-bottom: 3rem;">
+    <h2>Size Variants</h2>
+    <h3>Small</h3>
+    <nav aria-label="breadcrumb" class="breadcrumb breadcrumb-sm">
+      <ol>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Small</a></li>
+        <li aria-current="page">Size</li>
+      </ol>
+    </nav>
+
+    <h3>Base (default)</h3>
+    <nav aria-label="breadcrumb" class="breadcrumb">
+      <ol>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Base</a></li>
+        <li aria-current="page">Size</li>
+      </ol>
+    </nav>
+
+    <h3>Large</h3>
+    <nav aria-label="breadcrumb" class="breadcrumb breadcrumb-lg">
+      <ol>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Large</a></li>
+        <li aria-current="page">Size</li>
+      </ol>
+    </nav>
+  </section>
+
+  <!-- No wrap / truncated -->
+  <section style="margin-bottom: 3rem;">
+    <h2>Custom Separator via CSS Variable</h2>
+    <nav aria-label="breadcrumb" class="breadcrumb" style="--breadcrumb-separator: '→';">
+      <ol>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Custom</a></li>
+        <li aria-current="page">Arrow emoji</li>
+      </ol>
+    </nav>
+  </section>
+
+  <script>
+    document.getElementById('darkModeToggle').addEventListener('change', function() {
+      document.body.style.setProperty('--bg', this.checked ? '#1a1a2e' : '#fff');
+      document.body.style.setProperty('--text', this.checked ? '#e0e0e0' : '#1a1a2e');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/core_changes-breadcrumb/style.css
+++ b/submissions/core_changes-breadcrumb/style.css
@@ -1,0 +1,136 @@
+/* ===================================================
+   Breadcrumb Component — Core Styles
+   Pure CSS navigation trail with multiple separator
+   styles, size variants, and accessibility support.
+   =================================================== */
+
+:root {
+  --breadcrumb-color: #666;
+  --breadcrumb-color-hover: #6c63ff;
+  --breadcrumb-color-active: #1a1a2e;
+  --breadcrumb-separator: '/';
+  --breadcrumb-separator-color: #999;
+  --breadcrumb-separator-size: 0.8em;
+  --breadcrumb-font-sm: 0.8rem;
+  --breadcrumb-font-base: 0.9rem;
+  --breadcrumb-font-lg: 1.1rem;
+  --breadcrumb-gap-sm: 0.25rem;
+  --breadcrumb-gap-base: 0.5rem;
+  --breadcrumb-gap-lg: 0.75rem;
+}
+
+.breadcrumb ol {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--breadcrumb-gap-base);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: var(--breadcrumb-font-base);
+}
+
+.breadcrumb li {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--breadcrumb-gap-base);
+  color: var(--breadcrumb-color);
+}
+
+.breadcrumb li + li::before {
+  content: var(--breadcrumb-separator);
+  color: var(--breadcrumb-separator-color);
+  font-size: var(--breadcrumb-separator-size);
+  display: inline-block;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.breadcrumb a {
+  color: var(--breadcrumb-color);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.breadcrumb a:hover {
+  color: var(--breadcrumb-color-hover);
+  text-decoration: underline;
+}
+
+.breadcrumb a:focus-visible {
+  outline: 2px solid var(--breadcrumb-color-hover);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.breadcrumb [aria-current="page"] {
+  color: var(--breadcrumb-color-active);
+  font-weight: 600;
+  pointer-events: none;
+}
+
+/* ---- Chevron ---- */
+.breadcrumb-chevron {
+  --breadcrumb-separator: '›';
+  --breadcrumb-separator-size: 1.1em;
+  --breadcrumb-separator-color: #999;
+}
+
+/* ---- Arrow ---- */
+.breadcrumb-arrow {
+  --breadcrumb-separator: '→';
+  --breadcrumb-separator-size: 1em;
+}
+
+/* ---- Bullet ---- */
+.breadcrumb-bullet {
+  --breadcrumb-separator: '•';
+  --breadcrumb-separator-size: 1em;
+}
+
+/* ---- Size Variants ---- */
+.breadcrumb-sm ol {
+  font-size: var(--breadcrumb-font-sm);
+  gap: var(--breadcrumb-gap-sm);
+}
+
+.breadcrumb-sm li {
+  gap: var(--breadcrumb-gap-sm);
+}
+
+.breadcrumb-lg ol {
+  font-size: var(--breadcrumb-font-lg);
+  gap: var(--breadcrumb-gap-lg);
+}
+
+.breadcrumb-lg li {
+  gap: var(--breadcrumb-gap-lg);
+}
+
+/* ---- Dark Mode ---- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --breadcrumb-color: #999;
+    --breadcrumb-color-hover: #8b8cff;
+    --breadcrumb-color-active: #e0e0e0;
+    --breadcrumb-separator-color: #555;
+  }
+}
+
+/* ---- Reduced Motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .breadcrumb a {
+    transition: none;
+  }
+}
+
+/* ---- Print ---- */
+@media print {
+  .breadcrumb li + li::before {
+    color: #000;
+  }
+  .breadcrumb a {
+    color: #000;
+  }
+}


### PR DESCRIPTION
## ✦ Description
Add a pure CSS breadcrumb navigation component to EaseMotion CSS. Supports 4 separator styles (slash, chevron, arrow, bullet), 3 size variants (sm, base, lg), custom separators via `--breadcrumb-separator`, and semantic ARIA attributes — all with zero JavaScript.

Fixes #4031

---

## ⟡ Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.
- [x] I have run npm run lint and npm test locally before pushing.

---

## Changes Made
- `submissions/core_changes-breadcrumb/style.css`: Full breadcrumb CSS
- `submissions/core_changes-breadcrumb/demo.html`: Self-contained demo
- `submissions/core_changes-breadcrumb/README.md`: Usage docs

### Testing
```
npm test        # 9/9 passed
npm run lint    # No new errors
```

## Additional Notes
- Zero JS, no changes to core/ or components/
- Branch: fix/issue-4031-breadcrumb