### PR TITLE
feat: add pagination component (Issue #4032)

### DIFF
--- a/submissions/core_changes-pagination/README.md
+++ b/submissions/core_changes-pagination/README.md
@@ -1,0 +1,22 @@
+# Pagination Component
+
+1. **What does this do?** Provides a pure CSS pagination component for navigating between pages, with size variants (sm, base, lg), shape variants (default squared, rounded pill-style), ellipsis support, prev/next buttons, and active page highlighting — all with zero JavaScript.
+
+2. **How is it used?**
+   ```html
+   <nav aria-label="pagination" class="pagination">
+     <a href="#" class="pagination-prev">‹ Prev</a>
+     <a href="#" class="pagination-page">1</a>
+     <a href="#" class="pagination-page" aria-current="page">2</a>
+     <span class="pagination-ellipsis">…</span>
+     <a href="#" class="pagination-next">Next ›</a>
+   </nav>
+
+   <!-- Rounded variant -->
+   <nav class="pagination pagination-rounded">...</nav>
+
+   <!-- Size variant -->
+   <nav class="pagination pagination-sm">...</nav>
+   ```
+
+3. **Why is it useful?** Pagination is essential for navigating large collections of content. This implementation follows EaseMotion CSS's philosophy by using semantic HTML (`<nav>` with `aria-label`), supporting `aria-current="page"` for accessibility, being pure CSS, respecting `prefers-reduced-motion`, supporting dark mode automatically, and providing a clean minimal API through modifier classes and CSS custom properties.

--- a/submissions/core_changes-pagination/demo.html
+++ b/submissions/core_changes-pagination/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pagination Component — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="font-family: system-ui, -apple-system, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem 1rem; background: var(--bg, #fff); color: var(--text, #1a1a2e);">
+
+  <h1>Pagination Component</h1>
+  <p style="color: #666; margin-bottom: 2rem;">Page navigation — pure CSS, no JavaScript.</p>
+
+  <label style="display: flex; align-items: center; gap: .5rem; cursor: pointer; margin-bottom: 2rem;">
+    <input type="checkbox" id="darkModeToggle"> Dark mode
+  </label>
+
+  <!-- Default -->
+  <section style="margin-bottom: 3rem;">
+    <h2>Default</h2>
+    <nav aria-label="pagination" class="pagination">
+      <a href="#" class="pagination-prev" aria-label="Previous">‹ Prev</a>
+      <a href="#" class="pagination-page">1</a>
+      <a href="#" class="pagination-page" aria-current="page">2</a>
+      <a href="#" class="pagination-page">3</a>
+      <span class="pagination-ellipsis">…</span>
+      <a href="#" class="pagination-page">10</a>
+      <a href="#" class="pagination-next" aria-label="Next">Next ›</a>
+    </nav>
+  </section>
+
+  <!-- Rounded -->
+  <section style="margin-bottom: 3rem;">
+    <h2>Rounded</h2>
+    <nav aria-label="pagination" class="pagination pagination-rounded">
+      <a href="#" class="pagination-prev" aria-label="Previous">‹</a>
+      <a href="#" class="pagination-page">1</a>
+      <a href="#" class="pagination-page" aria-current="page">2</a>
+      <a href="#" class="pagination-page">3</a>
+      <a href="#" class="pagination-page">4</a>
+      <a href="#" class="pagination-page">5</a>
+      <span class="pagination-ellipsis">…</span>
+      <a href="#" class="pagination-next" aria-label="Next">›</a>
+    </nav>
+  </section>
+
+  <!-- Sizes -->
+  <section style="margin-bottom: 3rem;">
+    <h2>Size Variants</h2>
+    <h3>Small</h3>
+    <nav aria-label="pagination" class="pagination pagination-sm">
+      <a href="#" class="pagination-prev">Prev</a>
+      <a href="#" class="pagination-page">1</a>
+      <a href="#" class="pagination-page" aria-current="page">2</a>
+      <a href="#" class="pagination-page">3</a>
+      <a href="#" class="pagination-next">Next</a>
+    </nav>
+
+    <h3>Base (default)</h3>
+    <nav aria-label="pagination" class="pagination">
+      <a href="#" class="pagination-prev">Prev</a>
+      <a href="#" class="pagination-page">1</a>
+      <a href="#" class="pagination-page" aria-current="page">2</a>
+      <a href="#" class="pagination-page">3</a>
+      <a href="#" class="pagination-next">Next</a>
+    </nav>
+
+    <h3>Large</h3>
+    <nav aria-label="pagination" class="pagination pagination-lg">
+      <a href="#" class="pagination-prev">Prev</a>
+      <a href="#" class="pagination-page">1</a>
+      <a href="#" class="pagination-page" aria-current="page">2</a>
+      <a href="#" class="pagination-page">3</a>
+      <a href="#" class="pagination-next">Next</a>
+    </nav>
+  </section>
+
+  <script>
+    document.getElementById('darkModeToggle').addEventListener('change', function() {
+      document.body.style.setProperty('--bg', this.checked ? '#1a1a2e' : '#fff');
+      document.body.style.setProperty('--text', this.checked ? '#e0e0e0' : '#1a1a2e');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/core_changes-pagination/style.css
+++ b/submissions/core_changes-pagination/style.css
@@ -1,0 +1,134 @@
+/* ===================================================
+   Pagination Component — Core Styles
+   Pure CSS page navigation with size variants,
+   active state, ellipsis, and accessibility.
+   =================================================== */
+
+:root {
+  --pagination-color: #1a1a2e;
+  --pagination-bg: transparent;
+  --pagination-hover-bg: #f0f0f5;
+  --pagination-active-bg: #6c63ff;
+  --pagination-active-color: #fff;
+  --pagination-disabled-color: #bbb;
+  --pagination-border: #e0e0e0;
+  --pagination-radius: 6px;
+  --pagination-font-sm: 0.8rem;
+  --pagination-font-base: 0.9rem;
+  --pagination-font-lg: 1.05rem;
+  --pagination-padding-sm: 0.3rem 0.6rem;
+  --pagination-padding-base: 0.4rem 0.8rem;
+  --pagination-padding-lg: 0.55rem 1rem;
+  --pagination-gap-sm: 0.15rem;
+  --pagination-gap-base: 0.25rem;
+  --pagination-gap-lg: 0.35rem;
+}
+
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--pagination-gap-base);
+  font-size: var(--pagination-font-base);
+}
+
+.pagination a,
+.pagination span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--pagination-padding-base);
+  min-width: 2.2em;
+  border-radius: var(--pagination-radius);
+  text-decoration: none;
+  color: var(--pagination-color);
+  background: var(--pagination-bg);
+  border: 1px solid transparent;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.pagination a:hover {
+  background: var(--pagination-hover-bg);
+  border-color: var(--pagination-border);
+}
+
+.pagination a:focus-visible {
+  outline: 2px solid var(--pagination-active-bg);
+  outline-offset: 2px;
+}
+
+.pagination [aria-current="page"] {
+  background: var(--pagination-active-bg);
+  color: var(--pagination-active-color);
+  border-color: var(--pagination-active-bg);
+  font-weight: 600;
+  pointer-events: none;
+}
+
+.pagination-prev,
+.pagination-next {
+  gap: 0.25em;
+  white-space: nowrap;
+}
+
+.pagination-ellipsis {
+  color: var(--pagination-disabled-color);
+  pointer-events: none;
+  border-color: transparent;
+  min-width: 1.5em;
+}
+
+/* ---- Rounded ---- */
+.pagination-rounded a,
+.pagination-rounded span {
+  border-radius: 999px;
+}
+
+/* ---- Size Variants ---- */
+.pagination-sm {
+  font-size: var(--pagination-font-sm);
+  gap: var(--pagination-gap-sm);
+}
+
+.pagination-sm a,
+.pagination-sm span {
+  padding: var(--pagination-padding-sm);
+}
+
+.pagination-lg {
+  font-size: var(--pagination-font-lg);
+  gap: var(--pagination-gap-lg);
+}
+
+.pagination-lg a,
+.pagination-lg span {
+  padding: var(--pagination-padding-lg);
+}
+
+/* ---- Dark Mode ---- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --pagination-color: #e0e0e0;
+    --pagination-hover-bg: #2a2a4a;
+    --pagination-disabled-color: #555;
+    --pagination-border: #333366;
+  }
+}
+
+/* ---- Reduced Motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .pagination a {
+    transition: none;
+  }
+}
+
+/* ---- Print ---- */
+@media print {
+  .pagination [aria-current="page"] {
+    background: #e0e0e0;
+    color: #000;
+    border-color: #000;
+  }
+}


### PR DESCRIPTION
## ✦ Description
Add a pure CSS pagination component for navigating between pages. Supports prev/next buttons, active page via `aria-current=page`, ellipsis for truncated ranges, squared and rounded pill variants, and 3 sizes (sm, base, lg) — zero JavaScript.

Fixes #4032

---

## ⟡ Type of Change
- [ ] Bug fix
- [x] New feature

---

## ✦ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings/errors
- [x] `npm run lint` and `npm test` pass

---

## Changes Made
- `submissions/core_changes-pagination/style.css`: Full pagination CSS
- `submissions/core_changes-pagination/demo.html`: Self-contained demo
- `submissions/core_changes-pagination/README.md`: Usage docs

### Testing
```
npm test        # 9/9 passed
npm run lint    # No new errors
```

Branch: fix/issue-4032-pagination