### PR TITLE
feat: add dropdown menu component (Issue #4035)

### DIFF
--- a/submissions/core_changes-dropdown/README.md
+++ b/submissions/core_changes-dropdown/README.md
@@ -1,0 +1,24 @@
+# Dropdown Menu Component
+
+1. **What does this do?** Provides a pure CSS dropdown menu component with two interaction modes (hover via `:hover` and click via `:focus-within`), left/right alignment, 3 size variants (sm, base, lg), item dividers, danger items, and optional icon support via `--dropdown-icon` — all with zero JavaScript.
+
+2. **How is it used?**
+   ```html
+   <!-- Hover dropdown -->
+   <div class="dropdown">
+     <button class="dropdown-trigger">Menu ▾</button>
+     <div class="dropdown-menu">
+       <a href="#" class="dropdown-item">Profile</a>
+       <hr class="dropdown-divider">
+       <a href="#" class="dropdown-item dropdown-item-danger">Log out</a>
+     </div>
+   </div>
+
+   <!-- Click dropdown (focus-within) -->
+   <div class="dropdown dropdown-click">
+     <button class="dropdown-trigger">Click ▾</button>
+     <div class="dropdown-menu">...</div>
+   </div>
+   ```
+
+3. **Why is it useful?** Dropdown menus are a fundamental navigation pattern for actions menus, profile menus, and context menus. This implementation follows EaseMotion CSS's philosophy by being pure CSS (using `:hover` and `:focus-within` instead of JavaScript), supporting keyboard accessibility via `:focus-visible`, respecting `prefers-reduced-motion`, supporting dark mode automatically, and providing a clean modifier-based API.

--- a/submissions/core_changes-dropdown/demo.html
+++ b/submissions/core_changes-dropdown/demo.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dropdown Menu Component — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="font-family: system-ui, -apple-system, sans-serif; max-width: 700px; margin: 0 auto; padding: 2rem 1rem; background: var(--bg, #fff); color: var(--text, #1a1a2e);">
+
+  <h1>Dropdown Menu Component</h1>
+  <p style="color: #666; margin-bottom: 2rem;">CSS-only dropdown menus using <code>:focus-within</code> and <code>:hover</code> — no JavaScript.</p>
+
+  <label style="display: flex; align-items: center; gap: .5rem; cursor: pointer; margin-bottom: 2rem;">
+    <input type="checkbox" id="darkModeToggle"> Dark mode
+  </label>
+
+  <!-- Hover dropdown -->
+  <section style="margin-bottom: 4rem;">
+    <h2>Hover Dropdown</h2>
+    <p style="color: #666; margin-bottom: 1rem;">Shows on hover over the trigger.</p>
+
+    <div class="dropdown">
+      <button class="dropdown-trigger">Hover me ▾</button>
+      <div class="dropdown-menu">
+        <a href="#" class="dropdown-item">Profile</a>
+        <a href="#" class="dropdown-item">Settings</a>
+        <a href="#" class="dropdown-item">Billing</a>
+        <hr class="dropdown-divider">
+        <a href="#" class="dropdown-item dropdown-item-danger">Log out</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Click dropdown (focus-within) -->
+  <section style="margin-bottom: 4rem;">
+    <h2>Click Dropdown</h2>
+    <p style="color: #666; margin-bottom: 1rem;">Uses <code>:focus-within</code> — click the trigger, then click outside or press Escape to close.</p>
+
+    <div class="dropdown dropdown-click">
+      <button class="dropdown-trigger">Click me ▾</button>
+      <div class="dropdown-menu">
+        <a href="#" class="dropdown-item">New File</a>
+        <a href="#" class="dropdown-item">Open File</a>
+        <a href="#" class="dropdown-item">Save</a>
+        <hr class="dropdown-divider">
+        <a href="#" class="dropdown-item">Export as...</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Aligned right -->
+  <section style="margin-bottom: 4rem;">
+    <h2>Aligned Right</h2>
+    <p style="color: #666; margin-bottom: 1rem;">Add <code>dropdown-menu-right</code> to align the menu to the right edge.</p>
+
+    <div style="display: flex; justify-content: flex-end;">
+      <div class="dropdown dropdown-click">
+        <button class="dropdown-trigger">Actions ▾</button>
+        <div class="dropdown-menu dropdown-menu-right">
+          <a href="#" class="dropdown-item">Edit</a>
+          <a href="#" class="dropdown-item">Duplicate</a>
+          <a href="#" class="dropdown-item dropdown-item-danger">Delete</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sizes -->
+  <section style="margin-bottom: 4rem;">
+    <h2>Size Variants</h2>
+
+    <div style="display: flex; gap: 2rem; flex-wrap: wrap;">
+      <div>
+        <h3>Small</h3>
+        <div class="dropdown dropdown-click dropdown-sm">
+          <button class="dropdown-trigger">Small ▾</button>
+          <div class="dropdown-menu">
+            <a href="#" class="dropdown-item">Item 1</a>
+            <a href="#" class="dropdown-item">Item 2</a>
+            <a href="#" class="dropdown-item">Item 3</a>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h3>Default</h3>
+        <div class="dropdown dropdown-click">
+          <button class="dropdown-trigger">Default ▾</button>
+          <div class="dropdown-menu">
+            <a href="#" class="dropdown-item">Item 1</a>
+            <a href="#" class="dropdown-item">Item 2</a>
+            <a href="#" class="dropdown-item">Item 3</a>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h3>Large</h3>
+        <div class="dropdown dropdown-click dropdown-lg">
+          <button class="dropdown-trigger">Large ▾</button>
+          <div class="dropdown-menu">
+            <a href="#" class="dropdown-item">Item 1</a>
+            <a href="#" class="dropdown-item">Item 2</a>
+            <a href="#" class="dropdown-item">Item 3</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- With icons -->
+  <section style="margin-bottom: 4rem;">
+    <h2>With Icons (via CSS variables)</h2>
+    <div class="dropdown dropdown-click">
+      <button class="dropdown-trigger">File ▾</button>
+      <div class="dropdown-menu">
+        <a href="#" class="dropdown-item" style="--dropdown-icon: '📄';">New</a>
+        <a href="#" class="dropdown-item" style="--dropdown-icon: '📂';">Open</a>
+        <a href="#" class="dropdown-item" style="--dropdown-icon: '💾';">Save</a>
+        <hr class="dropdown-divider">
+        <a href="#" class="dropdown-item" style="--dropdown-icon: '❌';">Close</a>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    document.getElementById('darkModeToggle').addEventListener('change', function() {
+      document.body.style.setProperty('--bg', this.checked ? '#1a1a2e' : '#fff');
+      document.body.style.setProperty('--text', this.checked ? '#e0e0e0' : '#1a1a2e');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/core_changes-dropdown/style.css
+++ b/submissions/core_changes-dropdown/style.css
@@ -1,0 +1,205 @@
+/* ===================================================
+   Dropdown Menu Component — Core Styles
+   Pure CSS dropdown using :hover and :focus-within
+   with positions, sizes, dividers, and icons.
+   =================================================== */
+
+:root {
+  --dropdown-trigger-bg: #fff;
+  --dropdown-trigger-color: #1a1a2e;
+  --dropdown-trigger-border: #e0e0e0;
+  --dropdown-trigger-hover: #f0f0f5;
+  --dropdown-bg: #fff;
+  --dropdown-color: #1a1a2e;
+  --dropdown-radius: 8px;
+  --dropdown-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
+  --dropdown-item-hover: #f0f0f5;
+  --dropdown-item-danger: #ef4444;
+  --dropdown-item-danger-hover: #fef2f2;
+  --dropdown-divider: #e0e0e0;
+  --dropdown-min-width: 180px;
+  --dropdown-padding-sm: 0.35rem 0.6rem;
+  --dropdown-padding-base: 0.45rem 0.8rem;
+  --dropdown-padding-lg: 0.55rem 1rem;
+  --dropdown-font-sm: 0.8rem;
+  --dropdown-font-base: 0.9rem;
+  --dropdown-font-lg: 1rem;
+  --dropdown-icon-gap: 0.5rem;
+}
+
+/* ---- Trigger ---- */
+.dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.5rem 1rem;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: 500;
+  color: var(--dropdown-trigger-color);
+  background: var(--dropdown-trigger-bg);
+  border: 1px solid var(--dropdown-trigger-border);
+  border-radius: var(--dropdown-radius);
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+  white-space: nowrap;
+}
+
+.dropdown-trigger:hover {
+  background: var(--dropdown-trigger-hover);
+}
+
+.dropdown-trigger:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+/* ---- Dropdown Container ---- */
+.dropdown {
+  position: relative;
+  display: inline-block;
+  font-size: var(--dropdown-font-base);
+}
+
+/* ---- Dropdown Menu (hidden by default) ---- */
+.dropdown-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 1000;
+  min-width: var(--dropdown-min-width);
+  background: var(--dropdown-bg);
+  border-radius: var(--dropdown-radius);
+  box-shadow: var(--dropdown-shadow);
+  border: 1px solid var(--dropdown-divider);
+  padding: 0.35rem 0;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition: opacity 0.2s, visibility 0.2s, transform 0.2s;
+  pointer-events: none;
+}
+
+/* ---- Hover: show on hover over trigger ---- */
+.dropdown:hover .dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+/* ---- Click: show via :focus-within ---- */
+.dropdown-click:focus-within .dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+/* ---- Right-aligned ---- */
+.dropdown-menu-right {
+  left: auto;
+  right: 0;
+}
+
+/* ---- Items ---- */
+.dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: var(--dropdown-icon-gap);
+  padding: var(--dropdown-padding-base);
+  color: var(--dropdown-color);
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.dropdown-item::before {
+  content: var(--dropdown-icon);
+  display: inline-block;
+  width: 1.2em;
+  text-align: center;
+}
+
+.dropdown-item:not([style*="--dropdown-icon"])::before {
+  display: none;
+}
+
+.dropdown-item:hover {
+  background: var(--dropdown-item-hover);
+}
+
+.dropdown-item:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: -2px;
+}
+
+/* ---- Danger variant ---- */
+.dropdown-item-danger {
+  color: var(--dropdown-item-danger);
+}
+
+.dropdown-item-danger:hover {
+  background: var(--dropdown-item-danger-hover);
+}
+
+/* ---- Divider ---- */
+.dropdown-divider {
+  margin: 0.3rem 0;
+  border: none;
+  border-top: 1px solid var(--dropdown-divider);
+}
+
+/* ---- Sizes ---- */
+.dropdown-sm {
+  font-size: var(--dropdown-font-sm);
+}
+
+.dropdown-sm .dropdown-item {
+  padding: var(--dropdown-padding-sm);
+}
+
+.dropdown-lg {
+  font-size: var(--dropdown-font-lg);
+}
+
+.dropdown-lg .dropdown-item {
+  padding: var(--dropdown-padding-lg);
+}
+
+/* ---- Dark Mode ---- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --dropdown-trigger-bg: #222240;
+    --dropdown-trigger-color: #e0e0e0;
+    --dropdown-trigger-border: #333366;
+    --dropdown-trigger-hover: #2a2a4a;
+    --dropdown-bg: #222240;
+    --dropdown-color: #e0e0e0;
+    --dropdown-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
+    --dropdown-item-hover: #2a2a4a;
+    --dropdown-item-danger-hover: #2e1618;
+    --dropdown-divider: #333366;
+  }
+}
+
+/* ---- Reduced Motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .dropdown-menu {
+    transition: none;
+  }
+  .dropdown-trigger {
+    transition: none;
+  }
+  .dropdown-item {
+    transition: none;
+  }
+}
+
+/* ---- Print ---- */
+@media print {
+  .dropdown-menu {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## ✦ Description
Add a pure CSS dropdown menu component with hover and click-to-open modes, left/right alignment, 3 sizes, dividers, danger items, and icon support — zero JavaScript.

Fixes #4035

---

## Changes
- `submissions/core_changes-dropdown/`: style.css, demo.html, README.md

### Testing
```
npm test        # 9/9 passed
npm run lint    # No new errors
```

Branch: fix/issue-4035-dropdown