### PR TITLE
feat: add ease-glassmorphism card variant (issue #289)

### DIFF
--- a/submissions/examples/ease-glassmorphism-gn/README.md
+++ b/submissions/examples/ease-glassmorphism-gn/README.md
@@ -1,0 +1,10 @@
+# ease-glassmorphism Card Variant
+
+1. **What does this do?** Adds three glassmorphism-style card variants using `backdrop-filter: blur()`, semi-transparent backgrounds, and frosted glass borders — very popular in modern UI design.
+2. **How is it used?**
+```html
+<div class="ease-card-glass">Light glass card</div>
+<div class="ease-card-glass-dark">Dark glass card</div>
+<div class="ease-card-glass-primary">Primary glass card</div>
+```
+3. **Why is it useful?** Creates premium frosted-glass UI cards with zero JavaScript — smooth hover lift transitions, `-webkit-backdrop-filter` support for Safari, aligned with EaseMotion CSS's animation-first philosophy.

--- a/submissions/examples/ease-glassmorphism-gn/demo.html
+++ b/submissions/examples/ease-glassmorphism-gn/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-glassmorphism Card – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      gap: 2.5rem;
+      padding: 2rem;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%);
+    }
+    h1 { color: #fff; font-size: 1.3rem; margin: 0; }
+    .hint { font-size: 0.8rem; color: rgba(255,255,255,0.7); margin: 0; }
+    .grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      justify-content: center;
+    }
+    .card-content h3 { margin: 0 0 0.5rem; font-size: 1rem; }
+    .card-content p  { margin: 0; font-size: 0.85rem; opacity: 0.8; }
+    .label {
+      font-size: 0.7rem;
+      color: rgba(255,255,255,0.6);
+      text-align: center;
+      margin-top: 0.3rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>ease-glassmorphism Card Variants</h1>
+  <p class="hint">Hover over cards to see the lift effect</p>
+
+  <div class="grid">
+
+    <div>
+      <div class="ease-card-glass" style="width:220px;">
+        <div class="card-content">
+          <h3>Light Glass</h3>
+          <p>Frosted glass effect with blur backdrop.</p>
+        </div>
+      </div>
+      <p class="label">.ease-card-glass</p>
+    </div>
+
+    <div>
+      <div class="ease-card-glass-dark" style="width:220px;">
+        <div class="card-content">
+          <h3 style="color:#fff;">Dark Glass</h3>
+          <p style="color:rgba(255,255,255,0.7);">Dark frosted variant for dark themes.</p>
+        </div>
+      </div>
+      <p class="label">.ease-card-glass-dark</p>
+    </div>
+
+    <div>
+      <div class="ease-card-glass-primary" style="width:220px;">
+        <div class="card-content">
+          <h3>Primary Glass</h3>
+          <p>Colored glass with primary tint.</p>
+        </div>
+      </div>
+      <p class="label">.ease-card-glass-primary</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-glassmorphism-gn/style.css
+++ b/submissions/examples/ease-glassmorphism-gn/style.css
@@ -1,0 +1,56 @@
+/* ============================================
+   EaseMotion CSS — ease-glassmorphism card variant
+   Issue #289
+   ============================================ */
+
+/* Base glassmorphism card */
+.ease-card-glass {
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ease-card-glass:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.15);
+}
+
+/* Dark glassmorphism variant */
+.ease-card-glass-dark {
+  background: rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 1.5rem;
+  color: #ffffff;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ease-card-glass-dark:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
+}
+
+/* Colored glassmorphism variant */
+.ease-card-glass-primary {
+  background: rgba(99, 102, 241, 0.2);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 8px 32px rgba(99, 102, 241, 0.15);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ease-card-glass-primary:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px rgba(99, 102, 241, 0.25);
+}


### PR DESCRIPTION
## Pull Request Description
Adds three `ease-card-glass` glassmorphism card variants using `backdrop-filter: blur()`, semi-transparent backgrounds, and frosted glass borders — light, dark, and primary color variants. Closes #289

---
## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-glassmorphism-gn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
Three glassmorphism card variants — light, dark, and primary-tinted — using `backdrop-filter: blur()`, semi-transparent backgrounds, and frosted glass borders with smooth hover lift transitions.

**How does a developer use it?**
```html
<div class="ease-card-glass">Light glass card</div>
<div class="ease-card-glass-dark">Dark glass card</div>
<div class="ease-card-glass-primary">Primary glass card</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS with zero JavaScript — smooth `translateY` hover transitions and `backdrop-filter` blur create a premium frosted-glass UI effect using only class toggles, aligned with EaseMotion CSS's animation-first philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Added `-webkit-backdrop-filter` alongside `backdrop-filter` for Safari compatibility. Background gradient in `demo.html` is needed to make the glass effect visible — the cards themselves work on any colorful background.