### PR TITLE
[submission] ease-visible-invisible-za — visibility utility classes

### DIFF
--- a/submissions/examples/ease-visible-invisible-za/README.md
+++ b/submissions/examples/ease-visible-invisible-za/README.md
@@ -1,0 +1,14 @@
+## What does this do?
+
+Provides `ease-visible` and `ease-invisible` CSS visibility utility classes — unlike `display: none`, these preserve the element's layout space while hiding it visually.
+
+## How is it used?
+
+```html
+<div class="ease-invisible-za">Hidden but space preserved</div>
+<div class="ease-visible-za">Visible</div>
+```
+
+## Why is it useful?
+
+EaseMotion already has `ease-hidden` (display: none), but there's no visibility utility. `visibility: hidden` is essential when you need to hide content without collapsing layout — for example in animated transitions, dropdown menus, or maintaining grid/flex alignment.

--- a/submissions/examples/ease-visible-invisible-za/demo.html
+++ b/submissions/examples/ease-visible-invisible-za/demo.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ease-visible-invisible-za — visibility utilities</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div data-ease-demo-za>
+      <h1>ease-visible / ease-invisible</h1>
+      <p>
+        Visibility utility classes that hide content while preserving layout
+        space.
+      </p>
+
+      <div class="btn-group-za">
+        <button class="btn-za" onclick="toggleVisibility('box1')">
+          Toggle Red (invisible)
+        </button>
+        <button class="btn-za" onclick="toggleVisibility('box2')">
+          Toggle Blue (invisible)
+        </button>
+      </div>
+
+      <h2>Layout Space Preserved</h2>
+      <p>
+        Unlike <code>display: none</code>, <code>visibility: hidden</code> keeps
+        the element's space in the layout.
+      </p>
+      <div class="layout-demo-za">
+        <div id="box1" class="demo-box-za red">Box 1</div>
+        <div id="box2" class="demo-box-za blue">Box 2</div>
+        <div class="demo-box-za green">Box 3</div>
+      </div>
+      <p class="note-za">
+        Toggle boxes above — invisible boxes still occupy their space (the
+        layout doesn't collapse).
+      </p>
+    </div>
+
+    <script>
+      function toggleVisibility(id) {
+        const el = document.getElementById(id);
+        el.classList.toggle("ease-invisible-za");
+      }
+    </script>
+  </body>
+</html>

--- a/submissions/examples/ease-visible-invisible-za/style.css
+++ b/submissions/examples/ease-visible-invisible-za/style.css
@@ -1,0 +1,88 @@
+.ease-visible-za {
+  visibility: visible;
+}
+
+.ease-invisible-za {
+  visibility: hidden;
+}
+
+[data-ease-demo-za] {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+}
+
+[data-ease-demo-za] h2 {
+  margin-top: 2rem;
+  font-size: 1.25rem;
+}
+
+[data-ease-demo-za] .demo-box-za {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100px;
+  height: 100px;
+  margin: 0.5rem;
+  border-radius: 8px;
+  color: white;
+  font-weight: 600;
+  transition:
+    visibility 0.3s,
+    opacity 0.3s;
+}
+
+[data-ease-demo-za] .demo-box-za.red {
+  background: #ef4444;
+}
+[data-ease-demo-za] .demo-box-za.blue {
+  background: #3b82f6;
+}
+[data-ease-demo-za] .demo-box-za.green {
+  background: #22c55e;
+}
+
+[data-ease-demo-za] .layout-demo-za {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 1rem;
+  border: 2px dashed #cbd5e1;
+  border-radius: 8px;
+  min-height: 120px;
+}
+
+[data-ease-demo-za] .btn-group-za {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 1rem 0;
+}
+
+[data-ease-demo-za] .btn-za {
+  padding: 0.5rem 1rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: white;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: background 0.2s;
+}
+
+[data-ease-demo-za] .btn-za:hover {
+  background: #f1f5f9;
+}
+
+[data-ease-demo-za] .note-za {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background: #f8fafc;
+  border-radius: 6px;
+  border-left: 3px solid #6c63ff;
+}


### PR DESCRIPTION
## Summary
Adds `ease-visible` / `ease-invisible` CSS visibility utility classes.
Unlike `display: none`, these preserve the element's layout space.
## How to Test
Open demo.html, click toggle buttons — invisible boxes remain in layout.
## Related Issues
Fixes #4195