### PR TITLE
[submission] ease-appearance-none-za — form control appearance reset

### DIFF
--- a/submissions/examples/ease-appearance-none-za/README.md
+++ b/submissions/examples/ease-appearance-none-za/README.md
@@ -1,0 +1,16 @@
+## What does this do?
+
+Provides an `ease-appearance-none` utility class that resets native browser styling on form controls (select, checkbox, radio, button, input) using `appearance: none`.
+
+## How is it used?
+
+```html
+<select class="ease-appearance-none-za">
+  ...
+</select>
+<input type="checkbox" class="ease-appearance-none-za" />
+```
+
+## Why is it useful?
+
+EaseMotion is a CSS framework but lacks an appearance reset utility. Native form controls look inconsistent across browsers. `appearance: none` is the standard way to remove default OS-level styling so custom CSS can take full effect.

--- a/submissions/examples/ease-appearance-none-za/demo.html
+++ b/submissions/examples/ease-appearance-none-za/demo.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ease-appearance-none-za — form control reset</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div data-ease-demo-za>
+      <h1>ease-appearance-none</h1>
+      <p>
+        Removes native browser styling from form controls for custom styling.
+      </p>
+
+      <h2>Before (native appearance)</h2>
+      <div class="form-row-za">
+        <label>Select</label>
+        <select>
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
+        </select>
+      </div>
+      <div class="form-row-za">
+        <label>Checkbox</label>
+        <input type="checkbox" checked />
+      </div>
+      <div class="form-row-za">
+        <label>Radio</label>
+        <input type="radio" checked />
+      </div>
+
+      <div
+        class="btn-group-za"
+        style="margin: 1rem 0; display: flex; gap: 0.5rem"
+      >
+        <button class="btn-za" onclick="toggleAppearance()">
+          Toggle appearance: none
+        </button>
+      </div>
+
+      <h2>After (appearance: none applied)</h2>
+      <div class="form-row-za">
+        <label>Select</label>
+        <select id="demo-select">
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
+        </select>
+      </div>
+      <div class="form-row-za">
+        <label>Checkbox</label>
+        <input type="checkbox" id="demo-checkbox" checked />
+      </div>
+      <div class="form-row-za">
+        <label>Radio</label>
+        <input type="radio" id="demo-radio" checked name="demo" />
+        <label>Option 2</label>
+        <input type="radio" name="demo" />
+      </div>
+      <p class="note-za">
+        Click the button above to toggle <code>appearance: none</code> on the
+        bottom group. Native arrows on select and native check/radio indicators
+        will be removed.
+      </p>
+    </div>
+
+    <script>
+      let applied = false;
+      function toggleAppearance() {
+        applied = !applied;
+        const els = [
+          document.getElementById("demo-select"),
+          document.getElementById("demo-checkbox"),
+          document.getElementById("demo-radio"),
+        ];
+        els.forEach((el) => el.classList.toggle("ease-appearance-none-za"));
+      }
+    </script>
+
+    <style>
+      .btn-za {
+        padding: 0.5rem 1rem;
+        border: 1px solid #cbd5e1;
+        border-radius: 6px;
+        background: white;
+        cursor: pointer;
+        font-size: 0.875rem;
+      }
+      .btn-za:hover {
+        background: #f1f5f9;
+      }
+    </style>
+  </body>
+</html>

--- a/submissions/examples/ease-appearance-none-za/style.css
+++ b/submissions/examples/ease-appearance-none-za/style.css
@@ -1,0 +1,59 @@
+.ease-appearance-none-za {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+[data-ease-demo-za] {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+}
+
+[data-ease-demo-za] h2 {
+  margin-top: 2rem;
+  font-size: 1.25rem;
+}
+
+[data-ease-demo-za] .form-row-za {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 0.75rem 0;
+  padding: 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+}
+
+[data-ease-demo-za] .form-row-za label {
+  min-width: 100px;
+  font-weight: 500;
+}
+
+[data-ease-demo-za] .form-row-za select,
+[data-ease-demo-za] .form-row-za input[type="checkbox"],
+[data-ease-demo-za] .form-row-za input[type="radio"] {
+  margin: 0;
+}
+
+[data-ease-demo-za] .form-row-za select {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: white;
+  font-size: 0.875rem;
+}
+
+[data-ease-demo-za] .note-za {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background: #f8fafc;
+  border-radius: 6px;
+  border-left: 3px solid #6c63ff;
+}


### PR DESCRIPTION
## Summary
Adds `ease-appearance-none` utility that strips native browser styling
from form controls via `appearance: none` with vendor prefixes.
## How to Test
Open demo.html, click toggle button to see native select/checkbox/radio
styling disappear.
## Related Issues
Fixes #4198