### PR TITLE
feat: add one-click copy button for code snippets (closes #4223)

### DIFF
--- a/submissions/examples/copy-button/README.md
+++ b/submissions/examples/copy-button/README.md
@@ -1,0 +1,28 @@
+# 📋 Copy Button — Submission
+
+**Issue:** #4223 — Feature: One-Click Copy Button on All Documentation Code Snippets
+
+## What this adds
+
+A one-click copy-to-clipboard button that auto-injects into every `.code-block`
+wrapper on the docs page. Zero dependencies, pure vanilla JS + CSS.
+
+## Features
+- Appears on hover; always visible on touch screens
+- Checkmark icon for 2s after successful copy
+- Keyboard accessible (focus-visible ring)
+- Respects prefers-reduced-motion
+- Clipboard API with textarea fallback for older browsers
+
+## How to integrate
+
+1. Wrap every `<pre><code>` in `docs/index.html` with `<div class="code-block">`
+2. Add the CSS from style.css to the docs stylesheet
+3. Paste the `<script>` block before `</body>` in docs/index.html
+
+## Files
+- demo.html  — live demo with 5 code blocks
+- style.css  — all styles for .code-block and .copy-btn
+- README.md  — this file
+
+Submitted for GSSoC-26 · Issue #4223

--- a/submissions/examples/copy-button/demo.html
+++ b/submissions/examples/copy-button/demo.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Copy Button — EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>📋 One-Click Copy Button</h1>
+    <p>Adds a copy-to-clipboard button to every <code>&lt;pre&gt;&lt;code&gt;</code> block — zero dependencies.</p>
+  </header>
+
+  <main class="demo-main">
+
+    <section class="demo-section">
+      <h2>Layout Utilities</h2>
+      <div class="code-block">
+        <pre><code>&lt;div class="ease-center"&gt;Centered&lt;/div&gt;
+
+&lt;div class="ease-grid ease-grid-auto ease-gap-6"&gt;
+  &lt;div&gt;Card 1&lt;/div&gt;
+  &lt;div&gt;Card 2&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Animation Classes</h2>
+      <div class="code-block">
+        <pre><code>&lt;h1 class="ease-fade-in"&gt;Hello&lt;/h1&gt;
+&lt;p  class="ease-slide-up ease-delay-200"&gt;Subtitle&lt;/p&gt;
+&lt;button class="ease-hover-grow"&gt;Grows on hover&lt;/button&gt;</code></pre>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Button Classes</h2>
+      <div class="code-block">
+        <pre><code>&lt;button class="ease-btn ease-btn-primary"&gt;Primary&lt;/button&gt;
+&lt;button class="ease-btn ease-btn-success"&gt;Success&lt;/button&gt;
+&lt;button class="ease-btn ease-btn-lg ease-btn-pill"&gt;Large Pill&lt;/button&gt;</code></pre>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>CSS Variables</h2>
+      <div class="code-block">
+        <pre><code>:root {
+  --ease-color-primary: #f97316;
+  --ease-speed-medium:  500ms;
+  --ease-radius-md:     1rem;
+}</code></pre>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Quick Start</h2>
+      <div class="code-block">
+        <pre><code>&lt;link rel="stylesheet" href="easemotion.css" /&gt;</code></pre>
+      </div>
+    </section>
+
+  </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const blocks = document.querySelectorAll('.code-block');
+
+      blocks.forEach(block => {
+        const codeEl = block.querySelector('code');
+        if (!codeEl) return;
+
+        const btn = document.createElement('button');
+        btn.className = 'copy-btn';
+        btn.ariaLabel = 'Copy code to clipboard';
+        btn.title     = 'Copy';
+        btn.innerHTML = iconCopy();
+
+        block.style.position = 'relative';
+        block.appendChild(btn);
+
+        btn.addEventListener('click', async () => {
+          const text = codeEl.innerText;
+          try {
+            await navigator.clipboard.writeText(text);
+          } catch {
+            fallbackCopy(text);
+          }
+          btn.innerHTML = iconCheck();
+          btn.classList.add('copied');
+          btn.ariaLabel = 'Copied!';
+          setTimeout(() => {
+            btn.innerHTML = iconCopy();
+            btn.classList.remove('copied');
+            btn.ariaLabel = 'Copy code to clipboard';
+          }, 2000);
+        });
+      });
+    });
+
+    function iconCopy() {
+      return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                   viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                   stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+              </svg>`;
+    }
+
+    function iconCheck() {
+      return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                   viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                   stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>`;
+    }
+
+    function fallbackCopy(text) {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.cssText = 'position:fixed;top:-9999px;left:-9999px;opacity:0';
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      try { document.execCommand('copy'); } catch (_) {}
+      document.body.removeChild(ta);
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/copy-button/style.css
+++ b/submissions/examples/copy-button/style.css
@@ -1,0 +1,158 @@
+/* ═══════════════════════════════════════════════════════════════
+   EaseMotion CSS — Copy Button Submission
+   ═══════════════════════════════════════════════════════════════ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --em-bg:           #0b0f19;
+  --em-surface:      #111827;
+  --em-surface-2:    #1e293b;
+  --em-border:       #1e293b;
+  --em-text:         #e2e8f0;
+  --em-text-muted:   #94a3b8;
+  --em-accent:       #38bdf8;
+  --em-accent-dim:   rgba(56, 189, 248, 0.15);
+  --em-success:      #4ade80;
+  --em-success-dim:  rgba(74, 222, 128, 0.15);
+  --em-radius:       0.5rem;
+  --em-radius-lg:    0.75rem;
+  --em-font-mono:    'Fira Code', 'Consolas', monospace;
+  --em-font-sans:    'Inter', system-ui, sans-serif;
+  --em-transition:   0.2s ease;
+}
+
+body {
+  background: var(--em-bg);
+  color:      var(--em-text);
+  font-family: var(--em-font-sans);
+  line-height: 1.6;
+  padding:    2rem 1rem;
+  min-height: 100vh;
+}
+
+.demo-header {
+  max-width: 760px;
+  margin:    0 auto 3rem;
+  text-align: center;
+}
+
+.demo-header h1 { font-size: 2rem; font-weight: 700; margin-bottom: 0.5rem; }
+.demo-header p  { color: var(--em-text-muted); font-size: 1rem; }
+.demo-header code {
+  font-family: var(--em-font-mono);
+  background:  var(--em-surface-2);
+  padding:     0.1em 0.4em;
+  border-radius: 0.25rem;
+  font-size:   0.9em;
+}
+
+.demo-main {
+  max-width: 760px;
+  margin:    0 auto;
+  display:   flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.demo-section h2 {
+  font-size:    1.1rem;
+  font-weight:  600;
+  color:        var(--em-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  margin-bottom: 0.75rem;
+}
+
+.code-block {
+  background:    var(--em-surface);
+  border:        1px solid var(--em-border);
+  border-radius: var(--em-radius-lg);
+  overflow:      hidden;
+}
+
+.code-block pre {
+  overflow-x:   auto;
+  padding:      1.25rem 3.5rem 1.25rem 1.5rem;
+}
+
+.code-block code {
+  font-family: var(--em-font-mono);
+  font-size:   0.85rem;
+  line-height: 1.75;
+  color:       var(--em-text);
+  white-space: pre;
+  display:     block;
+}
+
+.code-block pre::-webkit-scrollbar        { height: 6px; }
+.code-block pre::-webkit-scrollbar-track  { background: transparent; }
+.code-block pre::-webkit-scrollbar-thumb  {
+  background:    var(--em-surface-2);
+  border-radius: 9999px;
+}
+
+.copy-btn {
+  position:  absolute;
+  top:       0.6rem;
+  right:     0.6rem;
+  display:        flex;
+  align-items:    center;
+  justify-content: center;
+  width:          2rem;
+  height:         2rem;
+  padding:        0;
+  border-radius:  var(--em-radius);
+  border:         1px solid transparent;
+  background: transparent;
+  color:      var(--em-text-muted);
+  cursor:     pointer;
+  transition:
+    background   var(--em-transition),
+    color        var(--em-transition),
+    border-color var(--em-transition),
+    transform    var(--em-transition),
+    opacity      var(--em-transition);
+  opacity: 0;
+}
+
+.code-block:hover .copy-btn,
+.code-block:focus-within .copy-btn { opacity: 1; }
+
+@media (hover: none) { .copy-btn { opacity: 1; } }
+
+.copy-btn:hover {
+  background:   var(--em-accent-dim);
+  color:        var(--em-accent);
+  border-color: var(--em-accent);
+  transform:    scale(1.1);
+}
+
+.copy-btn:focus-visible {
+  outline:        2px solid var(--em-accent);
+  outline-offset: 2px;
+  opacity:        1;
+}
+
+.copy-btn:active { transform: scale(0.95); }
+
+.copy-btn.copied {
+  background:   var(--em-success-dim);
+  color:        var(--em-success);
+  border-color: var(--em-success);
+  opacity:      1;
+  animation:    em-copy-pop 0.25s ease;
+}
+
+@keyframes em-copy-pop {
+  0%   { transform: scale(1);    }
+  40%  { transform: scale(1.25); }
+  100% { transform: scale(1);    }
+}
+
+.copy-btn svg { display: block; pointer-events: none; flex-shrink: 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-btn,
+  .copy-btn.copied { transition: none; animation: none; transform: none !important; }
+}


### PR DESCRIPTION
Closes #4223

## What this PR adds
One-click copy-to-clipboard button for all code snippet blocks in the docs.

## Files added
- submissions/examples/copy-button/demo.html
- submissions/examples/copy-button/style.css
- submissions/examples/copy-button/README.md

## How it works
The JS script auto-discovers every .code-block div and injects a copy
button — no per-block HTML changes needed beyond the wrapper div.

## Testing
Open demo.html directly in any browser — no build step needed.