### PR TITLE
feat: add ease-word-break, overflow-wrap, and hyphens utility classes

### DIFF
--- a/submissions/examples/ease-word-break-za/README.md
+++ b/submissions/examples/ease-word-break-za/README.md
@@ -1,0 +1,17 @@
+## What does this do?
+
+Provides `ease-word-break` / `ease-overflow-wrap` / `ease-hyphens` utility classes for controlling text wrapping, breaking, and hyphenation behavior.
+
+## How is it used?
+
+```html
+<p class="ease-word-break-all-za">LongUnbrokenStringHereWillBreak</p>
+<p class="ease-overflow-wrap-anywhere-za">Overflowing content wraps anywhere</p>
+<p class="ease-hyphens-auto-za" lang="en">
+  Hyphenation is applied automatically
+</p>
+```
+
+## Why is it useful?
+
+EaseMotion core has no word-break, overflow-wrap, or hyphens utilities. These are essential for handling long content (URLs, code snippets, user-generated text) in cards, tables, and responsive layouts where text overflow needs to be controlled.

--- a/submissions/examples/ease-word-break-za/demo.html
+++ b/submissions/examples/ease-word-break-za/demo.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ease-word-break-za — word breaking utilities</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div data-ease-demo-za>
+      <h1>ease-word-break utilities</h1>
+      <p>Control how text wraps, breaks, and hyphenates.</p>
+
+      <div class="card-za">
+        <h2>ease-word-break-normal-za</h2>
+        <div class="box-za ease-word-break-normal-za">
+          https://verylongunbrokenthatexceedstheboxwidthandcausesoverflow
+        </div>
+      </div>
+
+      <div class="card-za">
+        <h2>ease-word-break-all-za</h2>
+        <div class="box-za ease-word-break-all-za">
+          https://verylongunbrokenthatexceedstheboxwidthandcausesoverflow
+        </div>
+      </div>
+
+      <div class="card-za">
+        <h2>ease-word-break-keep-all-za</h2>
+        <div class="box-za ease-word-break-keep-all-za">
+          これは非常に長い文章でボックスの幅を超えてオーバーフローを引き起こします
+        </div>
+      </div>
+
+      <div class="card-za">
+        <h2>ease-overflow-wrap-normal-za</h2>
+        <div class="box-za ease-overflow-wrap-normal-za">
+          https://verylongunbrokenthatexceedstheboxwidthandcausesoverflow
+        </div>
+      </div>
+
+      <div class="card-za">
+        <h2>ease-overflow-wrap-anywhere-za</h2>
+        <div class="box-za ease-overflow-wrap-anywhere-za">
+          https://verylongunbrokenthatexceedstheboxwidthandcausesoverflow
+        </div>
+      </div>
+
+      <div class="card-za">
+        <h2>ease-overflow-wrap-break-word-za</h2>
+        <div class="box-za ease-overflow-wrap-break-word-za">
+          https://verylongunbrokenthatexceedstheboxwidthandcausesoverflow
+        </div>
+      </div>
+
+      <div class="card-za">
+        <h2>ease-hyphens-none-za</h2>
+        <p class="ease-hyphens-none-za" lang="en">
+          An extra long word like incomprehensibilities will not be hyphenated
+          at all.
+        </p>
+      </div>
+
+      <div class="card-za">
+        <h2>ease-hyphens-auto-za</h2>
+        <p class="ease-hyphens-auto-za" lang="en">
+          An extra long word like incomprehensibilities will be automatically
+          hyphenated.
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-word-break-za/style.css
+++ b/submissions/examples/ease-word-break-za/style.css
@@ -1,0 +1,77 @@
+.ease-word-break-normal-za {
+  word-break: normal;
+}
+.ease-word-break-all-za {
+  word-break: break-all;
+}
+.ease-word-break-keep-all-za {
+  word-break: keep-all;
+}
+.ease-overflow-wrap-normal-za {
+  overflow-wrap: normal;
+}
+.ease-overflow-wrap-anywhere-za {
+  overflow-wrap: anywhere;
+}
+.ease-overflow-wrap-break-word-za {
+  overflow-wrap: break-word;
+}
+.ease-hyphens-none-za {
+  hyphens: none;
+}
+.ease-hyphens-auto-za {
+  hyphens: auto;
+}
+
+[data-ease-demo-za] {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  max-width: 650px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+}
+
+[data-ease-demo-za] h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+[data-ease-demo-za] > p {
+  color: #64748b;
+  margin-bottom: 1.5rem;
+}
+
+[data-ease-demo-za] .card-za {
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+[data-ease-demo-za] .card-za h2 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #6c63ff;
+  margin: 0 0 0.5rem;
+  font-family: monospace;
+}
+
+[data-ease-demo-za] .box-za {
+  width: 260px;
+  padding: 0.75rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  background: #fff;
+  color: #334155;
+}
+
+[data-ease-demo-za] .card-za p {
+  font-size: 0.9rem;
+  color: #334155;
+  margin: 0;
+  max-width: 320px;
+}


### PR DESCRIPTION
Closes #4263

## Summary
Adds utility classes for word-break, overflow-wrap, and hyphens. Covers normal, break-all, keep-all, anywhere, break-word, none, and auto variants.

## Changes
- submissions/examples/ease-word-break-za/README.md — feature documentation
- submissions/examples/ease-word-break-za/demo.html — interactive demo
- submissions/examples/ease-word-break-za/style.css — CSS implementation