### PR TITLE
feat: add ease-appearance utility classes

### DIFF
--- a/submissions/examples/ease-appearance-za/README.md
+++ b/submissions/examples/ease-appearance-za/README.md
@@ -1,0 +1,16 @@
+## What does this do?
+
+Provides `ease-appearance` utility classes to control native element appearance — primarily `appearance: none` for resetting form control styling.
+
+## How is it used?
+
+```html
+<select class="ease-appearance-none-za">
+  Custom styled select
+</select>
+<input class="ease-appearance-none-za" type="checkbox" />
+```
+
+## Why is it useful?
+
+EaseMotion core has no appearance utilities. `appearance: none` is essential for custom-styled selects, checkboxes, radio buttons, and range inputs, allowing consistent cross-browser form design.

--- a/submissions/examples/ease-appearance-za/demo.html
+++ b/submissions/examples/ease-appearance-za/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ease-appearance-za — appearance utilities</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div data-ease-demo-za>
+      <h1>ease-appearance utilities</h1>
+      <p>Reset native form control styling for custom designs.</p>
+
+      <div class="card-za">
+        <h2>ease-appearance-none-za</h2>
+        <label>Select dropdown:</label>
+        <select class="demo-field-za ease-appearance-none-za">
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
+        </select>
+        <label>Checkbox:</label>
+        <input type="checkbox" class="ease-appearance-none-za demo-check-za" />
+        <label>Range:</label>
+        <input type="range" class="ease-appearance-none-za demo-range-za" />
+      </div>
+
+      <div class="card-za">
+        <h2>ease-appearance-auto-za (default)</h2>
+        <label>Select dropdown:</label>
+        <select class="demo-field-za ease-appearance-auto-za">
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
+        </select>
+        <label>Checkbox:</label>
+        <input type="checkbox" class="ease-appearance-auto-za demo-check-za" />
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-appearance-za/style.css
+++ b/submissions/examples/ease-appearance-za/style.css
@@ -1,0 +1,75 @@
+.ease-appearance-none-za {
+  appearance: none;
+  -webkit-appearance: none;
+}
+.ease-appearance-auto-za {
+  appearance: auto;
+  -webkit-appearance: auto;
+}
+
+[data-ease-demo-za] {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+}
+
+[data-ease-demo-za] h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+[data-ease-demo-za] > p {
+  color: #64748b;
+  margin-bottom: 1.5rem;
+}
+
+[data-ease-demo-za] .card-za {
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+[data-ease-demo-za] .card-za h2 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #6c63ff;
+  margin: 0 0 0.75rem;
+  font-family: monospace;
+}
+
+[data-ease-demo-za] .card-za label {
+  display: block;
+  font-size: 0.8rem;
+  color: #64748b;
+  margin: 0.5rem 0 0.25rem;
+}
+
+[data-ease-demo-za] .demo-field-za {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  background: #fff;
+  color: #334155;
+}
+
+[data-ease-demo-za] .demo-check-za {
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 4px;
+}
+
+[data-ease-demo-za] .demo-range-za {
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: #e2e8f0;
+}


### PR DESCRIPTION
Closes #4281

## Summary
Adds appearance utility classes: `ease-appearance-none` (reset native form styling) and `ease-appearance-auto` (restore default).

## Changes
- submissions/examples/ease-appearance-za/README.md - feature documentation
- submissions/examples/ease-appearance-za/demo.html - interactive demo
- submissions/examples/ease-appearance-za/style.css - CSS implementation