### PR TITLE
Ease-glitch-hover added 

### DIFF
--- a/submissions/examples/ease-glitch-hover/README.md
+++ b/submissions/examples/ease-glitch-hover/README.md
@@ -1,0 +1,19 @@
+# ease-glitch-hover
+
+RGB split and digital distortion effect on hover. Red and cyan ghost copies of the element flicker with clip-path slices.
+
+## Usage
+
+Add `data-text` matching the element's text content so pseudo-elements can mirror it.
+
+```html
+<h1 class="ease-glitch" data-text="Hello">Hello</h1>
+```
+
+## How it works
+
+Two `::before`/`::after` pseudo-elements use `attr(data-text)` as content, coloured red and cyan. On hover, `clip-path: inset()` and `steps()` timing create a frame-by-frame digital slice effect.
+
+## Why it fits EaseMotion CSS
+
+One class + one data attribute. No JavaScript, no canvas. Works on any text element.

--- a/submissions/examples/ease-glitch-hover/demo.html
+++ b/submissions/examples/ease-glitch-hover/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ease-glitch-hover demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; min-height: 100vh; background: #0f0f14; }
+    h1 { font-size: 3rem; color: #fff; letter-spacing: -0.02em; cursor: default; }
+  </style>
+</head>
+<body>
+  <h1 class="ease-glitch" data-text="GLITCH">GLITCH</h1>
+</body>
+</html>

--- a/submissions/examples/ease-glitch-hover/style.css
+++ b/submissions/examples/ease-glitch-hover/style.css
@@ -1,0 +1,45 @@
+@keyframes ease-glitch-r {
+  0%, 100% { clip-path: inset(0 0 95% 0); transform: translate(3px, 0); }
+  25%       { clip-path: inset(30% 0 50% 0); transform: translate(-3px, 0); }
+  50%       { clip-path: inset(60% 0 20% 0); transform: translate(2px, 0); }
+  75%       { clip-path: inset(80% 0 5% 0);  transform: translate(-2px, 0); }
+}
+
+@keyframes ease-glitch-b {
+  0%, 100% { clip-path: inset(50% 0 30% 0); transform: translate(-3px, 0); }
+  33%       { clip-path: inset(10% 0 70% 0); transform: translate(3px, 0); }
+  66%       { clip-path: inset(75% 0 10% 0); transform: translate(-2px, 0); }
+}
+
+.ease-glitch {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-glitch::before,
+.ease-glitch::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-glitch::before { color: #ff3c3c; }
+.ease-glitch::after  { color: #3cf0ff; }
+
+.ease-glitch:hover::before {
+  opacity: 0.75;
+  animation: ease-glitch-r 0.4s steps(1) infinite;
+}
+
+.ease-glitch:hover::after {
+  opacity: 0.75;
+  animation: ease-glitch-b 0.4s steps(1) infinite;
+  animation-delay: 0.05s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-glitch::before,
+  .ease-glitch::after { animation: none !important; opacity: 0 !important; }
+}

--- a/submissions/examples/ease-wave-border/README.md
+++ b/submissions/examples/ease-wave-border/README.md
@@ -1,0 +1,17 @@
+# ease-wave-border
+
+A glowing streak travels around an element's border on hover using an animated gradient mask on a pseudo-element.
+
+## Usage
+
+```html
+<div class="ease-wave-border">Card content</div>
+```
+
+## How it works
+
+A `::before` pseudo-element with a `background-size: 200%` gradient animates its `background-position` to simulate a travelling light streak along the border edge.
+
+## Why it fits EaseMotion CSS
+
+Pure CSS, single class, works on any block or inline-block element without modifying its structure.

--- a/submissions/examples/ease-wave-border/demo.html
+++ b/submissions/examples/ease-wave-border/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ease-wave-border demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; min-height: 100vh; background: #f5f5f7; gap: 2rem; flex-wrap: wrap; }
+    .card {
+      padding: 1.5rem 2rem;
+      background: #fff;
+      border-radius: 10px;
+      font-size: 1rem;
+      cursor: default;
+    }
+  </style>
+</head>
+<body>
+  <div class="card ease-wave-border">Hover this card</div>
+  <div class="card ease-wave-border">Another element</div>
+</body>
+</html>

--- a/submissions/examples/ease-wave-border/style.css
+++ b/submissions/examples/ease-wave-border/style.css
@@ -1,0 +1,33 @@
+@keyframes ease-wave-border {
+  0%   { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
+}
+
+.ease-wave-border {
+  position: relative;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  border-radius: 10px;
+  display: inline-block;
+}
+
+.ease-wave-border::before {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: linear-gradient(90deg, transparent 0%, #6366f1 40%, #ec4899 60%, transparent 100%);
+  background-size: 200% 100%;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: -1;
+}
+
+.ease-wave-border:hover::before {
+  opacity: 1;
+  animation: ease-wave-border 1.5s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-wave-border::before { animation: none !important; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-glitch-hover` — RGB split and digital distortion effect triggered on hover using clip-path pseudo-elements.

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-glitch-hover/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
Hover any text element to trigger a red/cyan RGB split glitch with clip-path slice animation.

```html
<h1 class="ease-glitch" data-text="Hello">Hello</h1>
```

Pure CSS. Requires `data-text` to match the element's content for pseudo-element duplication.

## Demo
- [x] Demo added
https://github.com/user-attachments/assets/5a6af0dd-71ee-4471-b385-39660602f180

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

## Notes for Maintainer
`steps(1)` timing gives the hard frame-cut feel. Softening to `ease` makes it feel more like a blur — both are valid.