### PR TITLE
fix(ci): validate SCSS artifacts during release checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "validate:manifest": "node scripts/validate-package.mjs",
     "validate:bundle": "node scripts/validate-bundle.mjs",
     "validate:pack": "node scripts/validate-pack.mjs",
-    "release:check": "npm run validate:manifest && npm run validate:bundle && npm run build && npm run lint && npm run lint:duplicates && npm test && npm run validate:pack",
+    "release:check": "npm run validate:manifest && npm run validate:bundle && npm run build && npm run build:scss && npm run lint && npm run lint:duplicates && npm test && npm run validate:pack",
     "validate:release": "npm run release:check"
   },
   "repository": {


### PR DESCRIPTION
## Summary

This PR fixes Issue #3628 by adding `build:scss` to the `release:check` validation pipeline.

Currently, the repository defines a dedicated SCSS build step, but it is never executed during release validation. As a result, SCSS compilation failures can go undetected before packaging and release.

This change ensures SCSS artifacts are generated and validated as part of the release verification process.

---

## Type of Change

* [x] 🐛 Bug Fix

---

## Issue Reference

Closes #3628

---

## Root Cause

The `release:check` script executes:

```bash
npm run validate:manifest
npm run validate:bundle
npm run build
npm run lint
npm run lint:duplicates
npm test
npm run validate:pack
```

However, it never executes:

```bash
npm run build:scss
```

This means SCSS compilation is excluded from release validation.

---

## Changes Made

Updated `package.json`:

```diff
- npm run build &&
+ npm run build &&
+ npm run build:scss &&
```

The release pipeline now validates SCSS artifacts before linting, testing, and packaging.

---

## Verification

### Before

* `release:check` skipped SCSS compilation.
* Broken SCSS could pass release validation.

### After

* `release:check` executes `build:scss`.
* SCSS compilation failures stop the release pipeline.
* Existing validation and test workflows continue to pass.

---

## Testing

* ✅ `npm run build:scss`
* ✅ `npm run release:check`
* ✅ `npm test`
* ✅ `npm run validate:pack`

---

## Impact

* Improves release validation coverage.
* Prevents broken SCSS artifacts from reaching releases.
* No changes to generated CSS output.
* No runtime behavior changes.

---

## Notes for Maintainer

This is a minimal, focused change that improves release safety by ensuring SCSS distributable artifacts are validated before packaging.
