### PR TITLE
feat: add CSS filter utilities (blur, brightness, grayscale)

### DIFF
--- a/submissions/examples/ease-filter-utils/README.md
+++ b/submissions/examples/ease-filter-utils/README.md
@@ -1,0 +1,41 @@
+# ease-filter utilities
+
+Element-level CSS `filter` utilities for blur, brightness, and grayscale effects on images and other content.
+
+## Class reference
+
+| Class | CSS Value | Visual Effect |
+|-------|-----------|---------------|
+| `.ease-blur-sm` | `blur(4px)` | Light soft blur |
+| `.ease-blur` | `blur(8px)` | Medium blur |
+| `.ease-blur-lg` | `blur(16px)` | Strong blur |
+| `.ease-brightness-50` | `brightness(0.5)` | Half brightness, darker image |
+| `.ease-grayscale` | `grayscale(1)` | Full grayscale (black and white) |
+| `.ease-grayscale-0` | `grayscale(0)` | Removes grayscale, restores color |
+
+## Usage
+
+```html
+<img class="ease-grayscale grayscale-hover" src="photo.svg" alt="Hover to restore color">
+```
+
+```css
+.grayscale-hover {
+  transition: filter 0.3s ease;
+}
+.grayscale-hover:hover {
+  filter: grayscale(0); /* same as .ease-grayscale-0 */
+}
+```
+
+## Combining filters
+
+Multiple filters can be combined by stacking `filter` values in a custom inline style or a custom class:
+
+```html
+<img style="filter: blur(2px) brightness(0.7) grayscale(0.5);" src="photo.svg" alt="Combined">
+```
+
+## Element vs backdrop
+
+These utilities apply `filter` to the element itself. This is different from `backdrop-filter` (such as `.ease-backdrop-blur`), which blurs or modifies what appears **behind** the element. Use element-level filters to style photos, icons, and cards; use backdrop filters for glassmorphism overlays.

--- a/submissions/examples/ease-filter-utils/demo.html
+++ b/submissions/examples/ease-filter-utils/demo.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-filter utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+
+    h1 {
+      font-size: 1.75rem;
+      margin-bottom: 0.5rem;
+    }
+
+    h2 {
+      font-size: 1.15rem;
+      margin: 2rem 0 1rem;
+      color: #f8fafc;
+    }
+
+    .intro,
+    .section-note {
+      max-width: 52rem;
+      color: #94a3b8;
+      margin-bottom: 1rem;
+      font-size: 0.9rem;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1.25rem;
+      max-width: 960px;
+    }
+
+    .cell {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .cell img {
+      width: 200px;
+      height: 150px;
+      object-fit: cover;
+      border-radius: 8px;
+      border: 1px solid #334155;
+      background: #1e293b;
+    }
+
+    .cell-label {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #a5b4fc;
+      text-align: center;
+    }
+
+    .grayscale-hover {
+      filter: grayscale(1);
+      transition: filter 0.3s ease;
+      cursor: pointer;
+    }
+
+    .ease-grayscale.grayscale-hover:hover {
+      filter: grayscale(0); /* same as .ease-grayscale-0 */
+    }
+
+    .combined-demo img {
+      filter: blur(2px) brightness(0.7) grayscale(0.5);
+    }
+  </style>
+</head>
+<body>
+  <h1>ease-filter utilities</h1>
+  <p class="intro">
+    Element-level CSS filter utilities for blur, brightness, and grayscale effects.
+    All demo images use a shared inline SVG data URI — fully offline, no external files.
+  </p>
+
+  <h2>Section 1 — Blur variants</h2>
+  <p class="section-note">Before/after comparison: original vs blur utilities.</p>
+
+  <div class="grid">
+    <div class="cell">
+      <img data-demo-img alt="Original colorful demo image">
+      <span class="cell-label">Original (no filter)</span>
+    </div>
+    <div class="cell">
+      <img data-demo-img class="ease-blur-sm" alt="Blur small demo">
+      <span class="cell-label">.ease-blur-sm</span>
+    </div>
+    <div class="cell">
+      <img data-demo-img class="ease-blur" alt="Blur medium demo">
+      <span class="cell-label">.ease-blur</span>
+    </div>
+    <div class="cell">
+      <img data-demo-img class="ease-blur-lg" alt="Blur large demo">
+      <span class="cell-label">.ease-blur-lg</span>
+    </div>
+  </div>
+
+  <h2>Section 2 — Brightness</h2>
+  <div class="grid">
+    <div class="cell">
+      <img data-demo-img alt="Original brightness reference">
+      <span class="cell-label">Original</span>
+    </div>
+    <div class="cell">
+      <img data-demo-img class="ease-brightness-50" alt="Brightness 50 percent demo">
+      <span class="cell-label">.ease-brightness-50</span>
+    </div>
+  </div>
+
+  <h2>Section 3 — Grayscale</h2>
+  <p class="section-note">Hover the grayscale image to restore color (transition to grayscale(0)).</p>
+
+  <div class="grid">
+    <div class="cell">
+      <img data-demo-img alt="Original color reference">
+      <span class="cell-label">Original</span>
+    </div>
+    <div class="cell">
+      <img data-demo-img class="ease-grayscale grayscale-hover" alt="Grayscale with hover restore">
+      <span class="cell-label">.ease-grayscale — hover to restore</span>
+    </div>
+  </div>
+
+  <h2>Section 4 — Combined filters</h2>
+  <p class="section-note">Filters can be combined via inline style when multiple effects are needed.</p>
+
+  <div class="grid combined-demo">
+    <div class="cell">
+      <img
+        data-demo-img
+        style="filter: blur(2px) brightness(0.7) grayscale(0.5);"
+        alt="Combined filter demo"
+      >
+      <span class="cell-label">filter: blur(2px) brightness(0.7) grayscale(0.5)</span>
+    </div>
+  </div>
+
+  <script>
+  (function () {
+    var svg =
+      "<svg xmlns='http://www.w3.org/2000/svg' width='400' height='300'>" +
+      "<defs>" +
+      "<linearGradient id='bg' x1='0%' y1='0%' x2='100%' y2='100%'>" +
+      "<stop offset='0%' stop-color='%236366f1'/>" +
+      "<stop offset='50%' stop-color='%23ec4899'/>" +
+      "<stop offset='100%' stop-color='%23f59e0b'/>" +
+      "</linearGradient>" +
+      "</defs>" +
+      "<rect width='100%' height='100%' fill='url(#bg)'/>" +
+      "<circle cx='90' cy='80' r='45' fill='%2322c55e' opacity='0.9'/>" +
+      "<rect x='240' y='40' width='110' height='70' rx='12' fill='%2306b6d4' opacity='0.95'/>" +
+      "<circle cx='320' cy='210' r='55' fill='%23fbbf24' opacity='0.9'/>" +
+      "<rect x='40' y='180' width='140' height='55' rx='8' fill='%23ffffff' opacity='0.25'/>" +
+      "<text x='200' y='155' text-anchor='middle' font-family='sans-serif' font-size='28' font-weight='700' fill='%23ffffff'>Filter</text>" +
+      "<text x='200' y='190' text-anchor='middle' font-family='sans-serif' font-size='18' fill='%23f8fafc'>Demo</text>" +
+      "</svg>";
+
+    var dataUri = "data:image/svg+xml," + encodeURIComponent(svg);
+
+    document.addEventListener("DOMContentLoaded", function () {
+      var images = document.querySelectorAll("[data-demo-img]");
+      images.forEach(function (img) {
+        img.src = dataUri;
+      });
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-filter-utils/style.css
+++ b/submissions/examples/ease-filter-utils/style.css
@@ -1,0 +1,6 @@
+.ease-blur-sm { filter: blur(4px); }
+.ease-blur { filter: blur(8px); }
+.ease-blur-lg { filter: blur(16px); }
+.ease-brightness-50 { filter: brightness(0.5); }
+.ease-grayscale { filter: grayscale(1); }
+.ease-grayscale-0 { filter: grayscale(0); }


### PR DESCRIPTION
## Summary
- Adds `submissions/examples/ease-filter-utils/` with element-level CSS filter utilities.
- Fully offline demo using a shared inline SVG data URI — no external images or CDN.

## Acceptance criteria (closes #4491)
- [x] `.ease-blur-sm`, `.ease-blur`, `.ease-blur-lg`
- [x] `.ease-brightness-50`
- [x] `.ease-grayscale`, `.ease-grayscale-0`
- [x] `demo.html` uses inline SVG data URIs only
- [x] Before/after comparison grid in demo
- [x] `README.md` documents all classes
- [x] No core files modified

## Test plan
- [ ] Open `submissions/examples/ease-filter-utils/demo.html` in a browser
- [ ] Confirm blur variants show increasing blur
- [ ] Confirm brightness and grayscale sections
- [ ] Hover grayscale image — color should restore with transition
- [ ] Verify combined filter example renders correctly

Closes #4491