### PR TITLE
Add duplicate selector audit submission

### DIFF
--- a/submissions/examples/duplicate-selector-audit-tm/README.md
+++ b/submissions/examples/duplicate-selector-audit-tm/README.md
@@ -1,0 +1,18 @@
+# Duplicate Selector Audit
+
+### What does this do?
+This adds a self-contained audit demo that highlights duplicate selector risks, stale duplicate baselines, and reduced-motion ownership checks before CSS is promoted into the main bundle.
+
+### How is it used?
+Open `demo.html` directly in a browser and review the checklist cards:
+
+```html
+<article class="audit-card audit-card-danger">
+  <span class="audit-label">Duplicate</span>
+  <strong>.ease-btn-hover</strong>
+  <p>Component hover behavior should have one owning file.</p>
+</article>
+```
+
+### Why is it useful?
+EaseMotion CSS is easiest to maintain when every public class has a single canonical owner. This submission gives maintainers a simple review artifact for duplicate selector cleanup, baseline pruning, and reduced-motion consistency without touching protected framework files directly.

--- a/submissions/examples/duplicate-selector-audit-tm/demo.html
+++ b/submissions/examples/duplicate-selector-audit-tm/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Duplicate Selector Audit</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="audit-shell">
+    <section class="audit-panel">
+      <p class="audit-kicker">Maintainability Utility</p>
+      <h1>Duplicate Selector Audit</h1>
+      <p class="audit-copy">
+        A compact review pattern for spotting repeated public classes, stale allowlists,
+        and split reduced-motion ownership before a stylesheet is promoted into the main bundle.
+      </p>
+
+      <div class="audit-grid" aria-label="Duplicate selector audit summary">
+        <article class="audit-card audit-card-danger">
+          <span class="audit-label">Duplicate</span>
+          <strong>.ease-btn-hover</strong>
+          <p>Component hover behavior should have one owning file.</p>
+        </article>
+
+        <article class="audit-card audit-card-warning">
+          <span class="audit-label">Baseline</span>
+          <strong>20 entries</strong>
+          <p>Allowed duplicates can hide real regressions when they become stale.</p>
+        </article>
+
+        <article class="audit-card audit-card-ok">
+          <span class="audit-label">Goal</span>
+          <strong>0 duplicates</strong>
+          <p>Each public class has one canonical selector rule in the shipped bundle.</p>
+        </article>
+      </div>
+
+      <section class="audit-report" aria-labelledby="report-title">
+        <h2 id="report-title">Suggested Review Checklist</h2>
+        <ol>
+          <li>Keep component-specific reduced-motion rules with the component.</li>
+          <li>Remove stale duplicate allowlist entries after each scan.</li>
+          <li>Check multi-line selector lists, not only single-line class rules.</li>
+          <li>Publish modular animation files only after they share one source of truth.</li>
+        </ol>
+      </section>
+
+      <button class="audit-button" type="button">Ready for maintainer review</button>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/duplicate-selector-audit-tm/style.css
+++ b/submissions/examples/duplicate-selector-audit-tm/style.css
@@ -1,0 +1,170 @@
+:root {
+  --audit-bg: #f8fafc;
+  --audit-ink: #172033;
+  --audit-muted: #5b6578;
+  --audit-panel: #ffffff;
+  --audit-border: #d9e1ea;
+  --audit-accent: #0f766e;
+  --audit-danger: #b42318;
+  --audit-warning: #b7791f;
+  --audit-ok: #287a42;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Arial, sans-serif;
+  color: var(--audit-ink);
+  background:
+    linear-gradient(120deg, rgba(15, 118, 110, 0.12), transparent 34%),
+    var(--audit-bg);
+}
+
+.audit-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px 16px;
+}
+
+.audit-panel {
+  width: min(960px, 100%);
+  padding: 32px;
+  border: 1px solid var(--audit-border);
+  border-radius: 8px;
+  background: var(--audit-panel);
+  box-shadow: 0 18px 45px rgba(23, 32, 51, 0.08);
+}
+
+.audit-kicker {
+  margin: 0 0 10px;
+  color: var(--audit-accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.05;
+}
+
+.audit-copy {
+  max-width: 680px;
+  margin: 16px 0 28px;
+  color: var(--audit-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.audit-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.audit-card {
+  min-height: 168px;
+  padding: 18px;
+  border: 1px solid var(--audit-border);
+  border-radius: 8px;
+  background: #fbfdff;
+}
+
+.audit-card-danger {
+  border-top: 4px solid var(--audit-danger);
+}
+
+.audit-card-warning {
+  border-top: 4px solid var(--audit-warning);
+}
+
+.audit-card-ok {
+  border-top: 4px solid var(--audit-ok);
+}
+
+.audit-label {
+  display: inline-block;
+  margin-bottom: 18px;
+  color: var(--audit-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.audit-card strong {
+  display: block;
+  font-size: 1.45rem;
+}
+
+.audit-card p,
+.audit-report li {
+  color: var(--audit-muted);
+  line-height: 1.55;
+}
+
+.audit-report {
+  margin-top: 24px;
+  padding-top: 22px;
+  border-top: 1px solid var(--audit-border);
+}
+
+.audit-report h2 {
+  margin: 0 0 12px;
+  font-size: 1.2rem;
+}
+
+.audit-report ol {
+  margin: 0;
+  padding-left: 22px;
+}
+
+.audit-report li + li {
+  margin-top: 8px;
+}
+
+.audit-button {
+  margin-top: 26px;
+  min-height: 44px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: 6px;
+  color: #ffffff;
+  background: var(--audit-accent);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.audit-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px rgba(15, 118, 110, 0.22);
+}
+
+@media (max-width: 760px) {
+  .audit-panel {
+    padding: 22px;
+  }
+
+  .audit-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .audit-button {
+    transition: none;
+  }
+
+  .audit-button:hover {
+    transform: none;
+    box-shadow: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained duplicate selector audit submission under `submissions/examples/duplicate-selector-audit-tm`
- include the required demo, stylesheet, and README files for the submission-first review flow
- document checks for stale duplicate baselines, split reduced-motion ownership, and modular CSS drift

## Validation
- `npm run lint`
- `npm test`
- `npm run lint:duplicates`

Fixes #4546