### PR TITLE
fix(sidebar): replace display:none with visibility+pointer-events to …

### DIFF
--- a/submissions/examples/sidebar-mobile-fix/README.md
+++ b/submissions/examples/sidebar-mobile-fix/README.md
@@ -1,0 +1,26 @@
+# ease-sidebar Mobile Slide-in Fix
+
+**Fixes:** Issue #4224
+
+## Root Cause
+
+`display: none` removes the element from the render tree.
+CSS `transition` on `transform` requires the element to exist
+in the render tree at the start of the transition — so it was
+always skipped, causing an instant snap with no animation.
+
+## Fix
+
+| Property | Before | After |
+|---|---|---|
+| Hidden state | `display: none` | `visibility: hidden` + `pointer-events: none` |
+| Open state | `display: block` | `visibility: visible` + `pointer-events: auto` |
+
+The element stays in the render tree in both states, so
+`transform: translateX()` transitions smoothly.
+
+## Acceptance Criteria
+
+- [x] Slide-in transition visible on mobile
+- [x] `display: none` removed from mobile sidebar styles
+- [x] `prefers-reduced-motion` fallback disables transition

--- a/submissions/examples/sidebar-mobile-fix/demo.html
+++ b/submissions/examples/sidebar-mobile-fix/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-sidebar Mobile Slide-in Fix</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    .ease-sidebar { padding: 2rem 1rem; color: #fff; }
+    .main-content { padding: 2rem; flex: 1; }
+    .toggle-btn {
+      display: none;
+      margin-bottom: 1rem;
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+    }
+    @media (max-width: 768px) { .toggle-btn { display: inline-block; } }
+  </style>
+</head>
+<body>
+  <div class="ease-sidebar-layout" id="layout">
+    <aside class="ease-sidebar">
+      <h2>Sidebar</h2>
+      <nav>
+        <p>Home</p><p>About</p><p>Contact</p>
+      </nav>
+    </aside>
+    <main class="main-content">
+      <button class="toggle-btn ease-btn ease-btn-primary" onclick="
+        document.getElementById('layout').classList.toggle('ease-sidebar-open')
+      ">☰ Toggle Sidebar</button>
+      <h1>Main Content</h1>
+      <p>Resize to mobile width and click the button — sidebar slides in with bounce easing.</p>
+    </main>
+  </div>
+</body>
+</html>

--- a/submissions/examples/sidebar-mobile-fix/style.css
+++ b/submissions/examples/sidebar-mobile-fix/style.css
@@ -1,0 +1,55 @@
+/* === ease-sidebar mobile slide-in fix ===
+   Replaces display: none with visibility + pointer-events
+   so transform: translateX() can actually transition.
+*/
+
+/* Layout wrapper */
+.ease-sidebar-layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* Sidebar — desktop default (always visible) */
+.ease-sidebar {
+  width: 260px;
+  flex-shrink: 0;
+  background: var(--ease-color-surface, #1e1e2e);
+  transition: transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+              visibility 0.6s;
+}
+
+/* Mobile: hide via visibility, NOT display:none */
+@media (max-width: 768px) {
+  .ease-sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 200;
+    width: 280px;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateX(-100%);
+  }
+
+  /* Open state */
+  .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(0);
+  }
+
+  /* Overlay backdrop */
+  .ease-sidebar-layout.ease-sidebar-open::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 199;
+  }
+}
+
+/* prefers-reduced-motion: kill the transition entirely */
+@media (prefers-reduced-motion: reduce) {
+  .ease-sidebar {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #4224

On mobile, `.ease-sidebar` used `display: none` / `display: block` to
toggle visibility. Because `display` is not animatable, the
`transform: translateX()` transition was always skipped — the sidebar
snapped open instantly with no animation.

## Root Cause

CSS transitions require the element to be in the render tree at the
start of the transition. `display: none` removes it entirely, so the
browser never interpolates the transform.

## Fix

Replaced `display` toggling with:
- `visibility: hidden` + `pointer-events: none` (closed)
- `visibility: visible` + `pointer-events: auto` (open)

The element stays in the render tree in both states, so the
`transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1)` bounce transition
now plays correctly.

## Acceptance Criteria (from issue)

- [x] Slide-in transition visible on mobile
- [x] `display: none` removed from mobile sidebar styles
- [x] `prefers-reduced-motion` fallback still disables transition

## Test Plan

| Scenario | Result |
|---|---|
| Mobile (≤ 768px) — toggle open | ✅ bounce slide-in plays |
| Mobile (≤ 768px) — toggle close | ✅ slides back out |
| Desktop (> 768px) | ✅ sidebar always visible, unaffected |
| `prefers-reduced-motion: reduce` | ✅ transition: none, instant toggle |

## Notes

Per contribution policy, no `core/` or `components/` files were modified.
Submission placed in `submissions/examples/sidebar-mobile-fix/`.