### PR TITLE
fix(a11y): add prefers-reduced-motion override to loaders and badges

### DIFF
--- a/components/badges.css
+++ b/components/badges.css
@@ -49,4 +49,11 @@
   .ease-badge-danger.ease-badge-pulse::after {
     box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .em-badge-pulse::after,
+    .ease-badge-pulse::after {
+      animation: none;
+    }
+  }
 }

--- a/components/loaders.css
+++ b/components/loaders.css
@@ -45,4 +45,13 @@
   .ease-loader-dot:nth-child(3) {
     animation-delay: 0.4s;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-loader-spin,
+    .ease-loader-pulse,
+    .ease-loader-ping,
+    .ease-loader-dot {
+      animation: none;
+    }
+  }
 }


### PR DESCRIPTION
## Pull Request Description

Infinite-looping animations in `components/loaders.css` and `components/badges.css` were not suppressed when users enable Reduce Motion at the OS level. This PR adds `@media (prefers-reduced-motion: reduce)` blocks to both files, making loader and badge animations respect the user's accessibility preference.

Closes #4617

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html`
- [ ] Includes `style.css`
- [ ] Includes `README.md`
- [x] **No changes to `core/`**
- [x] One feature per PR (no bundled unrelated changes)

> **Note for maintainer:** This is a targeted accessibility bug fix, not a feature addition. Changes are limited to two `@media (prefers-reduced-motion: reduce)` blocks appended inside the existing `@layer` in `components/loaders.css` and `components/badges.css`. All 9 existing smoke tests pass. The pattern used is identical to the reduced-motion blocks already present in `buttons.css`, `cards.css`, `forms.css`, and other components.

---

## Feature Description

**What does this fix?**

All loader variants (`.ease-loader-spin`, `.ease-loader-pulse`, `.ease-loader-ping`, `.ease-loader-dot`) and the badge pulse glow (`.ease-badge-pulse::after`) loop infinitely with no motion preference check. Users with vestibular disorders or epilepsy who set Reduce Motion at the OS level still see perpetually spinning and pulsing elements.

**Files changed:**
- `components/loaders.css` — disables `ease-loader-spin`, `ease-loader-pulse`, `ease-loader-ping`, `ease-loader-dot` animations
- `components/badges.css` — disables `ease-badge-pulse::after` animation

**Why does it fit EaseMotion CSS?**

Every other animated component in the framework already has a `prefers-reduced-motion` block. This brings loaders and badges into alignment with the accessibility standard followed by `buttons.css`, `cards.css`, `sidebar.css`, `forms.css`, `modals.css`, `tooltips.css`, `chip.css`, `masonry.css`, and `ease-marquee.css`.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

- Pure additive change — zero risk of regression. No existing rules were modified.
- The blocks are placed as the last rule inside the `@layer` block, matching the convention in `buttons.css` and `cards.css`.
- Tests: `npm test` — all 9 tests pass after this change.