### PR TITLE
fix: correct undefined --ease-color-text-muted token in modals.css

### DIFF
--- a/components/modals.css
+++ b/components/modals.css
@@ -124,7 +124,7 @@
   /* Modal Body */
   .ease-modal-body {
     padding: var(--ease-space-6, 1.5rem);
-    color: var(--ease-color-text-muted, #4b5563);
+    color: var(--ease-color-muted, #4b5563);
     line-height: 1.6;
     overflow-y: auto;
   }


### PR DESCRIPTION
## Pull Request Description

`.ease-modal-body` referenced `--ease-color-text-muted`, a token that does not exist in `core/variables.css`. The declared token is `--ease-color-muted`. The mismatched name caused modal body text to always fall back to the hardcoded `#4b5563`, silently ignoring any `--ease-color-muted` overrides.

Closes #4624

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] **No changes to `core/`**
- [x] One feature per PR (no bundled unrelated changes)

> **Note for maintainer:** One token name corrected in `components/modals.css`. The fallback value `#4b5563` is unchanged so there is zero visual difference for existing users. As a secondary benefit, `--ease-color-muted` is overridden to `#94a3b8` in the dark-mode block of `variables.css`, meaning modal body text will now also correctly adapt in dark mode. Same class of bug as #4228 (`--ease-color-text-dark` in cards.css). All 9 tests pass.

---

## Feature Description

**What does this fix?**

Before:
```css
.ease-modal-body {
  color: var(--ease-color-text-muted, #4b5563); /* token never declared */
}
```

After:
```css
.ease-modal-body {
  color: var(--ease-color-muted, #4b5563); /* correct token from variables.css line 64 */
}
```

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

- Zero visual regression — fallback hex is identical.
- `npm test` — all 9 tests pass.