### PR TITLE
fix: add dark mode overrides to components/modals.css

### DIFF
--- a/components/modals.css
+++ b/components/modals.css
@@ -212,6 +212,36 @@
     }
   }
 
+  /* ── Dark Mode ──────────────────────────────────────────────────────────── */
+  @media (prefers-color-scheme: dark) {
+    .ease-modal {
+      background: var(--ease-color-surface, #141e33);
+    }
+
+    .ease-modal-header,
+    .ease-modal-footer {
+      border-color: var(--ease-color-neutral-700, #334155);
+    }
+
+    .ease-modal-footer {
+      background: var(--ease-color-neutral-800, #1e293b);
+    }
+
+    .ease-modal-header h2,
+    .ease-modal-header h3 {
+      color: var(--ease-color-text, #e2e8f0);
+    }
+
+    .ease-modal-close {
+      color: var(--ease-color-neutral-400, #94a3b8);
+    }
+
+    .ease-modal-close:hover {
+      background: var(--ease-color-neutral-700, #334155);
+      color: var(--ease-color-neutral-100, #f1f5f9);
+    }
+  }
+
   /* ── prefers-reduced-motion ─────────────────────────────────────────────── */
   @media (prefers-reduced-motion: reduce) {
     .ease-modal-overlay,


### PR DESCRIPTION
## Pull Request Description

`components/modals.css` was the only animated component in the framework with no `@media (prefers-color-scheme: dark)` block. In dark mode, the modal footer rendered with a stark light background (`#f9fafb` via `--ease-color-neutral-50`) and both header/footer borders stayed at the light value `#e5e7eb` (`--ease-color-neutral-200`), neither of which is remapped in the dark-mode block of `variables.css`. The result was a white strip at the bottom of an otherwise dark modal.

Closes #4630

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] **No changes to `core/`**
- [x] One feature per PR (no bundled unrelated changes)

> **Note for maintainer:** Purely additive change — 30 lines inserted, zero lines modified. Block is placed before the existing `prefers-reduced-motion` block, matching the structure of `navbar.css`, `sidebar.css`, `forms.css`, and every other component with dark mode support. Every token used is declared in `core/variables.css`. All 9 smoke tests pass.

---

## Feature Description

**What does this fix?**

Added `@media (prefers-color-scheme: dark)` block to `components/modals.css` covering:

| Selector | Property | Dark value |
|---|---|---|
| `.ease-modal` | `background` | `var(--ease-color-surface, #141e33)` |
| `.ease-modal-header`, `.ease-modal-footer` | `border-color` | `var(--ease-color-neutral-700, #334155)` |
| `.ease-modal-footer` | `background` | `var(--ease-color-neutral-800, #1e293b)` |
| `.ease-modal-header h2/h3` | `color` | `var(--ease-color-text, #e2e8f0)` |
| `.ease-modal-close` | `color` | `var(--ease-color-neutral-400, #94a3b8)` |
| `.ease-modal-close:hover` | `background`, `color` | neutral-700 / neutral-100 |

All fallback hex values match the dark-mode palette established by the rest of the framework (same values used in `cards.css`, `navbar.css`, `sidebar.css`).

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

- `npm test` — all 9 tests pass.
- Zero changes to existing rules — purely additive block.
- The `--ease-color-text-muted` token bug on line 127 is addressed in a separate PR #4655 to keep changes isolated.