### PR TITLE
fix: extend tabs component selector groups from 6 to 8 tabs

### DIFF
--- a/components/tabs.css
+++ b/components/tabs.css
@@ -42,7 +42,9 @@
   .ease-tab-input:nth-of-type(3):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3),
   .ease-tab-input:nth-of-type(4):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(4),
   .ease-tab-input:nth-of-type(5):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
-  .ease-tab-input:nth-of-type(6):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6) {
+  .ease-tab-input:nth-of-type(6):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6),
+  .ease-tab-input:nth-of-type(7):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(7),
+  .ease-tab-input:nth-of-type(8):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8) {
     outline: 2px solid var(--ease-color-primary);
     outline-offset: -2px;
   }
@@ -70,7 +72,9 @@
   .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3),
   .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(4),
   .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
-  .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6) {
+  .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6),
+  .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(7),
+  .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8) {
     color: var(--ease-color-primary);
   }
 
@@ -81,6 +85,8 @@
   .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(300%); }
   .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(400%); }
   .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(500%); }
+  .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(600%); }
+  .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(700%); }
 
   /* Content Panel toggling */
   .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(1),
@@ -88,7 +94,9 @@
   .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(3),
   .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(4),
   .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(5),
-  .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(6) {
+  .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(6),
+  .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(7),
+  .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(8) {
     display: block;
   }
 
@@ -107,7 +115,9 @@
   .ease-tabs-auto .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3),
   .ease-tabs-auto .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(4),
   .ease-tabs-auto .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
-  .ease-tabs-auto .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6) {
+  .ease-tabs-auto .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(7),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8) {
     border-bottom: 2px solid var(--ease-color-primary);
   }
 }


### PR DESCRIPTION
## Pull Request Description

All selector groups in `components/tabs.css` were hard-capped at `nth-of-type(6)`. Adding a 7th or 8th tab produced completely silent failures — the label was never highlighted as active, the panel content was permanently hidden (`display: none` never overridden), the keyboard focus ring never appeared, and the sliding underline never moved to the new position.

Closes #4634

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] **No changes to `core/`**
- [x] One feature per PR (no bundled unrelated changes)

> **Note for maintainer:** Purely additive — 14 lines added, 4 commas added to existing closing lines. All 5 selector groups extended consistently. Zero changes to existing selectors 1–6. All 9 smoke tests pass.

---

## Feature Description

**What does this fix?**

Extended all five `nth-of-type` selector groups from a max of 6 to a max of 8:

| Group | Change |
|---|---|
| Focus-visible label highlight | 6 → 8 |
| `:checked` label color | 6 → 8 |
| Underline `translateX` | Added `600%` (7th) and `700%` (8th) |
| Content panel `display: block` | 6 → 8 |
| `.ease-tabs-auto` active border | 6 → 8 |

The `translateX` values follow the identical arithmetic pattern already established for positions 1–6.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

- `npm test` — all 9 tests pass.
- 8 tabs covers the practical ceiling for most real-world UIs (settings pages, dashboards). If a higher limit is preferred, the same pattern extends trivially.