### PR TITLE
fix(reveal): ensure reveal elements are visible when prefers-reduced-motion is active

### DIFF
--- a/submissions/examples/reveal-reduced-motion-issue-4683-sn/README.md
+++ b/submissions/examples/reveal-reduced-motion-issue-4683-sn/README.md
@@ -1,0 +1,38 @@
+# Reveal Reduced Motion Visibility (Issue #4683)
+
+## What does this do?
+Ensures scroll-reveal elements are instantly active and visible when prefers-reduced-motion is active.
+
+## How is it used?
+When elements have the `.ease-reveal` class and the user has reduced motion enabled, the class `.ease-reveal-active` is instantly added on page load so they are fully visible without animation.
+
+## Why is it useful?
+It prevents content from remaining completely invisible (`opacity: 0`) for users who prefer reduced motion, ensuring accessibility compliance.
+
+## Affected File (maintainer will copy to `core/reveal.js`)
+Inside `core/reveal.js`, replace the early return:
+```javascript
+  // Check if user prefers reduced motion
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (prefersReducedMotion) return;
+```
+With:
+```javascript
+  // Check if user prefers reduced motion
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (prefersReducedMotion) {
+    const revealAll = function () {
+      var els = document.querySelectorAll('.' + revealClass);
+      Array.prototype.forEach.call(els, function (el) {
+        el.classList.add(activeClass);
+      });
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', revealAll);
+    } else {
+      revealAll();
+    }
+    return;
+  }
+```

--- a/submissions/examples/reveal-reduced-motion-issue-4683-sn/demo.html
+++ b/submissions/examples/reveal-reduced-motion-issue-4683-sn/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll-Reveal Reduced Motion Demo</title>
+  <link rel="stylesheet" href="../../../core/variables.css">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <div class="demo-container">
+    <h1>Scroll-Reveal Reduced Motion Demo</h1>
+    <p>This demo verifies that scroll-reveal elements are instantly displayed when the user has <code>prefers-reduced-motion: reduce</code> enabled, rather than staying hidden (opacity: 0).</p>
+
+    <div style="margin: 1rem 0; padding: 1rem; background-color: #f0f0f0; border-radius: 4px;">
+      <strong>Current Status:</strong> <span id="motionStatus">Checking preferences...</span>
+    </div>
+
+    <div class="reveal-box reveal-item">
+      Reveal Box 1
+    </div>
+
+    <div class="reveal-box reveal-item">
+      Reveal Box 2
+    </div>
+  </div>
+
+  <script>
+    // JS simulation of reveal controller with prefers-reduced-motion fix
+    const revealClass = 'reveal-item';
+    const activeClass = 'active';
+    const statusSpan = document.getElementById('motionStatus');
+
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (prefersReducedMotion) {
+      statusSpan.textContent = 'Reduced Motion is ENABLED in your OS. All boxes should be visible immediately.';
+      // Instantly reveal all elements
+      const revealAll = function () {
+        var els = document.querySelectorAll('.' + revealClass);
+        Array.prototype.forEach.call(els, function (el) {
+          el.classList.add(activeClass);
+        });
+      };
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', revealAll);
+      } else {
+        revealAll();
+      }
+    } else {
+      statusSpan.textContent = 'Reduced Motion is DISABLED in your OS. Boxes will animate/reveal after 1 second.';
+      // Simulate normal scroll reveal behavior with a timeout
+      setTimeout(() => {
+        var els = document.querySelectorAll('.' + revealClass);
+        Array.prototype.forEach.call(els, function (el) {
+          el.classList.add(activeClass);
+        });
+      }, 1000);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/reveal-reduced-motion-issue-4683-sn/style.css
+++ b/submissions/examples/reveal-reduced-motion-issue-4683-sn/style.css
@@ -1,0 +1,30 @@
+/* Custom styles for reveal reduced motion demo */
+.demo-container {
+  padding: 2rem;
+  max-width: 600px;
+  margin: 0 auto;
+  font-family: sans-serif;
+}
+.reveal-box {
+  width: 100%;
+  height: 150px;
+  background-color: #0070f3;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 2rem 0;
+  border-radius: 8px;
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+/* Raw CSS for the reveal states */
+.reveal-item {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.reveal-item.active {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
Fixes #4683. Modifies core/reveal.js to instantly add the active class (.ease-reveal-active) to all reveal elements when prefers-reduced-motion is active, ensuring content is visible for users who prefer reduced motion.