### PR TITLE
fix(tooltips): fallback default top tooltips to bottom on mobile

### DIFF
--- a/submissions/examples/tooltip-mobile-position-issue-4688-sn/README.md
+++ b/submissions/examples/tooltip-mobile-position-issue-4688-sn/README.md
@@ -1,0 +1,37 @@
+# Default Tooltip Mobile Position Fallback (Issue #4688)
+
+## What does this do?
+Ensures default tooltips without explicit `data-position` attribute correctly fallback to bottom positioning on mobile devices to prevent viewport cropping.
+
+## How is it used?
+When a default tooltip is hovered or focused on a mobile viewport (width < 640px), its position automatically shifts to the bottom.
+
+## Why is it useful?
+It fixes a layout bug where default tooltips would remain at the top and get cropped on small screens, ensuring mobile design responsiveness.
+
+## Affected File (maintainer will copy to `components/tooltips.css`)
+Modify the media query block in `components/tooltips.css` to add the `:not([data-position])` variants:
+```css
+    /* Fallback to bottom positioning on narrow viewports to avoid cropping */
+    .ease-tooltip[data-position="top"]::after,
+    .ease-tooltip:not([data-position])::after {
+      bottom: auto;
+      top: calc(100% + var(--ease-tooltip-gap));
+      transform: translateX(-50%) translateY(-4px);
+    }
+
+    .ease-tooltip[data-position="top"]:hover::after,
+    .ease-tooltip:not([data-position]):hover::after,
+    .ease-tooltip[data-position="top"]:focus-within::after,
+    .ease-tooltip:not([data-position]):focus-within::after {
+      transform: translateX(-50%) translateY(0);
+    }
+
+    .ease-tooltip[data-position="top"]::before,
+    .ease-tooltip:not([data-position])::before {
+      bottom: auto;
+      top: calc(100% - 2px);
+      border-top-color: transparent;
+      border-bottom-color: var(--ease-tooltip-bg);
+    }
+```

--- a/submissions/examples/tooltip-mobile-position-issue-4688-sn/demo.html
+++ b/submissions/examples/tooltip-mobile-position-issue-4688-sn/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tooltip Mobile Position Fallback Demo</title>
+  <link rel="stylesheet" href="../../../core/variables.css">
+  <link rel="stylesheet" href="../../../components/tooltips.css">
+  <!-- Local style.css contains mobile overrides for testing -->
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 3rem;
+      max-width: 600px;
+      margin: 0 auto;
+    }
+    .demo-box {
+      margin: 4rem 0;
+      display: flex;
+      gap: 2rem;
+      flex-wrap: wrap;
+    }
+  </style>
+</head>
+<body>
+  <h1>Tooltip Mobile Position Fallback Demo</h1>
+  <p>To verify the fix: resize your browser to a mobile width (less than 640px) or open this on a mobile device. Both tooltips should fallback and display <strong>below</strong> the buttons to avoid being cropped at the top.</p>
+
+  <div class="demo-box">
+    <!-- Default position tooltip (should fallback to bottom on mobile) -->
+    <button class="ease-tooltip" data-tooltip="Default tooltip (top fallback)">
+      Default Tooltip
+    </button>
+
+    <!-- Explicit top position tooltip (correctly fallbacks to bottom on mobile) -->
+    <button class="ease-tooltip" data-position="top" data-tooltip="Explicit top tooltip">
+      Explicit Top Tooltip
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tooltip-mobile-position-issue-4688-sn/style.css
+++ b/submissions/examples/tooltip-mobile-position-issue-4688-sn/style.css
@@ -1,0 +1,25 @@
+/* Fallback to bottom positioning on narrow viewports to avoid cropping */
+/* Fixes issue #4688: applies to both [data-position="top"] and default tooltips :not([data-position]) */
+@media (max-width: 640px) {
+  .ease-tooltip[data-position="top"]::after,
+  .ease-tooltip:not([data-position])::after {
+    bottom: auto;
+    top: calc(100% + var(--ease-tooltip-gap, 0.5rem));
+    transform: translateX(-50%) translateY(-4px);
+  }
+
+  .ease-tooltip[data-position="top"]:hover::after,
+  .ease-tooltip:not([data-position]):hover::after,
+  .ease-tooltip[data-position="top"]:focus-within::after,
+  .ease-tooltip:not([data-position]):focus-within::after {
+    transform: translateX(-50%) translateY(0);
+  }
+
+  .ease-tooltip[data-position="top"]::before,
+  .ease-tooltip:not([data-position])::before {
+    bottom: auto;
+    top: calc(100% - 2px);
+    border-top-color: transparent;
+    border-bottom-color: var(--ease-tooltip-bg, #1f2937);
+  }
+}


### PR DESCRIPTION
Fixes #4688. Updates the mobile responsive bottom fallback in components/tooltips.css to target both [data-position="top"] and :not([data-position]) tooltips, ensuring default tooltips without explicit position attribute correctly fallback to bottom on mobile screen sizes.
