### PR TITLE
fix(loaders): pause loader animations when prefers-reduced-motion is active

### DIFF
--- a/submissions/examples/loader-reduced-motion-issue-4693-sn/README.md
+++ b/submissions/examples/loader-reduced-motion-issue-4693-sn/README.md
@@ -1,0 +1,24 @@
+# Reduced Motion Override for Loaders (Issue #4693)
+
+## What does this do?
+Disables all loader and spinner animations when the user has prefers-reduced-motion active.
+
+## How is it used?
+When elements with loader classes (like `.ease-loader-spin`, `.ease-loader-pulse`, `.ease-loader-ping`, `.ease-loader-dot`) are displayed and the user has reduced motion enabled in their OS, animations will be stopped/paused.
+
+## Why is it useful?
+It prevents vestibular distress and satisfies accessibility guidelines by halting continuous, rapid, or looping animations for sensitive users.
+
+## Affected File (maintainer will copy to `components/loaders.css`)
+Add this block to the end of `components/loaders.css`:
+```css
+  /* prefers-reduced-motion override for loaders */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-loader-spin,
+    .ease-loader-pulse,
+    .ease-loader-ping,
+    .ease-loader-dot {
+      animation: none !important;
+    }
+  }
+```

--- a/submissions/examples/loader-reduced-motion-issue-4693-sn/demo.html
+++ b/submissions/examples/loader-reduced-motion-issue-4693-sn/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loader Reduced Motion Demo</title>
+  <link rel="stylesheet" href="../../../core/variables.css">
+  <link rel="stylesheet" href="../../../components/loaders.css">
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 3rem;
+      max-width: 600px;
+      margin: 0 auto;
+    }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+      gap: 2rem;
+      margin-top: 2rem;
+    }
+    .loader-card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+      padding: 1rem;
+      border: 1px solid #eaeaea;
+      border-radius: 8px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Loader Reduced Motion Demo</h1>
+  <p>To verify the fix: enable reduced motion in your operating system settings. All loaders below should stop animating and display in a static state.</p>
+
+  <div class="demo-grid">
+    <div class="loader-card">
+      <div class="ease-loader ease-loader-spin"></div>
+      <span>Spin</span>
+    </div>
+    <div class="loader-card">
+      <div class="ease-loader ease-loader-pulse"></div>
+      <span>Pulse</span>
+    </div>
+    <div class="loader-card">
+      <div class="ease-loader ease-loader-ping"></div>
+      <span>Ping</span>
+    </div>
+    <div class="loader-card">
+      <div class="ease-loader-dots">
+        <div class="ease-loader-dot"></div>
+        <div class="ease-loader-dot"></div>
+        <div class="ease-loader-dot"></div>
+      </div>
+      <span>Dots</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/loader-reduced-motion-issue-4693-sn/style.css
+++ b/submissions/examples/loader-reduced-motion-issue-4693-sn/style.css
@@ -1,0 +1,9 @@
+/* prefers-reduced-motion override for loaders */
+@media (prefers-reduced-motion: reduce) {
+  .ease-loader-spin,
+  .ease-loader-pulse,
+  .ease-loader-ping,
+  .ease-loader-dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
Fixes #4693. Adds a prefers-reduced-motion media query override inside a self-contained submission folder to disable loader and spinner animations. This ensures accessibility compliance for users with vestibular sensitivities without directly modifying core files.
