### PR TITLE
fix(sidebar): resolve mobile transition collision

### DIFF
--- a/submissions/examples/sidebar-mobile-transition-issue-4708-sn/README.md
+++ b/submissions/examples/sidebar-mobile-transition-issue-4708-sn/README.md
@@ -1,0 +1,41 @@
+# Mobile Sidebar Sliding Transition (Issue #4708)
+
+## What does this do?
+Resolves a transition collision on mobile devices where discrete display toggles (`display: none` / `display: block`) bypass the transform slide-in transition animation.
+
+## How is it used?
+When `.ease-sidebar-open` is toggled on the layout container on viewport widths < 768px, the sidebar slides smoothly in or out from the left.
+
+## Why is it useful?
+It restores the intended sliding transition animation on mobile viewports, improving the UX and visual coherence of the sidebar component.
+
+## Affected File (maintainer will copy to `components/sidebar.css`)
+Modify the mobile media query block in `components/sidebar.css`:
+```css
+  @media (max-width: 768px) {
+    .ease-sidebar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      height: 100vh;
+      z-index: 100;
+      width: var(--ease-sidebar-width, 260px);
+      visibility: hidden;
+      transform: translateX(-100%);
+      transition:
+        transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+        visibility 0.6s step-end,
+        box-shadow 0.3s ease;
+    }
+
+    .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
+      visibility: visible;
+      transform: translateX(0);
+      box-shadow: 12px 0 36px rgba(0, 0, 0, 0.15);
+      transition:
+        transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+        visibility 0s step-start,
+        box-shadow 0.3s ease;
+    }
+  }
+```

--- a/submissions/examples/sidebar-mobile-transition-issue-4708-sn/demo.html
+++ b/submissions/examples/sidebar-mobile-transition-issue-4708-sn/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobile Sidebar Transition Demo</title>
+  <link rel="stylesheet" href="../../../core/variables.css">
+  <link rel="stylesheet" href="../../../components/sidebar.css">
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      margin: 0;
+      font-family: sans-serif;
+    }
+    .toggle-btn {
+      padding: 0.5rem 1rem;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <div id="layout" class="ease-sidebar-layout">
+    <!-- Sidebar -->
+    <aside class="ease-sidebar" style="color: white; padding: 2rem; box-sizing: border-box;">
+      <h2>Sidebar Menu</h2>
+      <ul>
+        <li>Dashboard</li>
+        <li>Settings</li>
+        <li>Profile</li>
+      </ul>
+      <button class="toggle-btn" id="closeBtn">Close Sidebar</button>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="ease-sidebar-main">
+      <h1>Mobile Sidebar Transition Demo</h1>
+      <p>Resize the window to a width below 768px. Click the button below to toggle the sidebar. The sidebar should slide in and out smoothly from the left rather than popping into view instantly.</p>
+      
+      <button class="toggle-btn" id="openBtn">Toggle Sidebar</button>
+    </main>
+  </div>
+
+  <script>
+    const layout = document.getElementById('layout');
+    const openBtn = document.getElementById('openBtn');
+    const closeBtn = document.getElementById('closeBtn');
+
+    openBtn.addEventListener('click', () => {
+      layout.classList.toggle('ease-sidebar-open');
+    });
+
+    closeBtn.addEventListener('click', () => {
+      layout.classList.remove('ease-sidebar-open');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/sidebar-mobile-transition-issue-4708-sn/style.css
+++ b/submissions/examples/sidebar-mobile-transition-issue-4708-sn/style.css
@@ -1,0 +1,21 @@
+/* Sidebar transition override for mobile viewports */
+@media (max-width: 768px) {
+  .ease-sidebar {
+    visibility: hidden !important;
+    transform: translateX(-100%) !important;
+    display: block !important; /* Override the core display: none */
+    transition:
+      transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+      visibility 0.6s step-end,
+      box-shadow 0.3s ease !important;
+  }
+
+  .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
+    visibility: visible !important;
+    transform: translateX(0) !important;
+    transition:
+      transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+      visibility 0s step-start,
+      box-shadow 0.3s ease !important;
+  }
+}


### PR DESCRIPTION
Fixes #4708. Adds a visibility toggle-based transition inside a self-contained submission folder for mobile sidebar layout. This fixes the transition collision where discrete display toggles bypass the slide-in animation, without modifying core files directly.
