### PR TITLE
fix(buttons): center loading spinner by removing keyframe translate

### DIFF
--- a/submissions/examples/loading-button-spinner-offset-issue-4725-sn/README.md
+++ b/submissions/examples/loading-button-spinner-offset-issue-4725-sn/README.md
@@ -1,0 +1,23 @@
+# Loading Button Spinner Alignment (Issue #4725)
+
+## What does this do?
+Resolves an alignment bug where the button spinner is offset off-center due to a double translate override in keyframes.
+
+## How is it used?
+When a button gets the `.ease-btn-loading` class, the spinner is centered inside the button.
+
+## Why is it useful?
+It ensures that the loading spinner is visually centered, correcting a design misalignment.
+
+## Affected File (maintainer will copy to `components/buttons.css`)
+Modify the `@keyframes ease-kf-btn-spin` keyframes in `components/buttons.css`:
+```css
+@keyframes ease-kf-btn-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+```

--- a/submissions/examples/loading-button-spinner-offset-issue-4725-sn/demo.html
+++ b/submissions/examples/loading-button-spinner-offset-issue-4725-sn/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loading Button Spinner Alignment Demo</title>
+  <link rel="stylesheet" href="../../../core/variables.css">
+  <link rel="stylesheet" href="../../../components/buttons.css">
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 3rem;
+      max-width: 600px;
+      margin: 0 auto;
+    }
+    .demo-container {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+      margin-top: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>Loading Button Spinner Alignment Demo</h1>
+  <p>This demo verifies that the loading spinner inside a loading button is perfectly centered. The button below uses the corrected keyframe animations to prevent double-translating the spinner.</p>
+
+  <div class="demo-container">
+    <button class="ease-btn ease-btn-primary ease-btn-loading">
+      Loading...
+    </button>
+
+    <button class="ease-btn ease-btn-success ease-btn-loading ease-btn-lg">
+      Loading Large...
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/loading-button-spinner-offset-issue-4725-sn/style.css
+++ b/submissions/examples/loading-button-spinner-offset-issue-4725-sn/style.css
@@ -1,0 +1,9 @@
+/* Reset keyframe to prevent double translate */
+@keyframes ease-kf-btn-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
Fixes #4725. Resolves a button spinner centering alignment bug inside a self-contained submission folder. Removing the translate offset in the spin keyframes prevents a double translation calculation mismatch, centering the spinner properly without modifying core files.
