### PR TITLE
fix(masonry): prevent nested card bottom margin collapse

### DIFF
--- a/submissions/examples/masonry-card-margin-collapse-issue-4729-sn/README.md
+++ b/submissions/examples/masonry-card-margin-collapse-issue-4729-sn/README.md
@@ -1,0 +1,21 @@
+# Masonry Card Margin Collapse (Issue #4729)
+
+## What does this do?
+Resolves a spacing collapse bug where cards inside masonry grids lose their vertical margins by inheriting a zero margin from the parent container.
+
+## How is it used?
+When `.ease-card` elements are placed inside an `.ease-masonry` container, they will correctly retain the grid's vertical spacing (`margin-bottom`).
+
+## Why is it useful?
+It ensures correct vertical layout spacings and prevents items from stacking directly on top of each other.
+
+## Affected File (maintainer will copy to `components/masonry.css`)
+Remove these lines from the end of `components/masonry.css`:
+```css
+.ease-masonry .ease-card,
+.ease-masonry-2 .ease-card,
+.ease-masonry-3 .ease-card,
+.ease-masonry-4 .ease-card {
+  margin-bottom: inherit;
+}
+```

--- a/submissions/examples/masonry-card-margin-collapse-issue-4729-sn/demo.html
+++ b/submissions/examples/masonry-card-margin-collapse-issue-4729-sn/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Masonry Card Margin Collapse Demo</title>
+  <link rel="stylesheet" href="../../../core/variables.css">
+  <link rel="stylesheet" href="../../../components/cards.css">
+  <link rel="stylesheet" href="../../../components/masonry.css">
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 3rem;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    .grid-container {
+      margin-top: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>Masonry Card Margin Collapse Demo</h1>
+  <p>This demo verifies that cards inside masonry layout maintain a 1rem spacing below them, preventing card borders from colliding or stacking directly on top of each other.</p>
+
+  <div class="grid-container">
+    <div class="ease-masonry ease-masonry-3">
+      <div class="ease-card">
+        <h3>Card 1</h3>
+        <p>This card should have a 1rem bottom margin separating it from Card 2 below.</p>
+      </div>
+      <div class="ease-card">
+        <h3>Card 2</h3>
+        <p>Content for card 2.</p>
+      </div>
+      <div class="ease-card">
+        <h3>Card 3</h3>
+        <p>Content for card 3.</p>
+      </div>
+      <div class="ease-card">
+        <h3>Card 4</h3>
+        <p>Content for card 4.</p>
+      </div>
+      <div class="ease-card">
+        <h3>Card 5</h3>
+        <p>Content for card 5.</p>
+      </div>
+      <div class="ease-card">
+        <h3>Card 6</h3>
+        <p>Content for card 6.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/masonry-card-margin-collapse-issue-4729-sn/style.css
+++ b/submissions/examples/masonry-card-margin-collapse-issue-4729-sn/style.css
@@ -1,0 +1,7 @@
+/* Fix card margin collapse inside masonry */
+.ease-masonry .ease-card,
+.ease-masonry-2 .ease-card,
+.ease-masonry-3 .ease-card,
+.ease-masonry-4 .ease-card {
+  margin-bottom: var(--ease-space-4, 1rem) !important;
+}


### PR DESCRIPTION
Fixes #4729. Resolves a card vertical margin collapse bug inside a self-contained submission folder. Overriding the inherit margin-bottom setting on cards inside masonry layouts ensures they retain the standard column row spacings without modifying core files directly.
