### PR TITLE
fix: add forms.css to smoke test suite

### DIFF
--- a/submissions/examples/forms-smoke-test-sk/README.md
+++ b/submissions/examples/forms-smoke-test-sk/README.md
@@ -1,0 +1,16 @@
+# Forms Smoke Test Coverage
+
+Fixes #4619
+
+## Problem
+
+`components/forms.css` existed with full form component styles (`.ease-field`, `.ease-input`, `.ease-textarea`, `.ease-select`, etc.) but was completely absent from `tests/smoke.test.js`. Any regression in form classes would silently pass CI.
+
+## Fix
+
+- Added `forms.css` to the CSS bundle loaded in `beforeAll()` in `smoke.test.js`
+- Added a dedicated `should have form classes defined` test asserting `.ease-field`, `.ease-field-label`, `.ease-input`, `.ease-textarea`, and `.ease-select` are present
+
+## Demo
+
+Open `demo.html` to see form components rendered using the framework styles.

--- a/submissions/examples/forms-smoke-test-sk/demo.html
+++ b/submissions/examples/forms-smoke-test-sk/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Forms Component Demo</title>
+  <link rel="stylesheet" href="../../easemotion/all.css" />
+  <style>
+    body { font-family: sans-serif; padding: 2rem; max-width: 480px; }
+    h1 { margin-bottom: 1.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Forms component</h1>
+
+  <div class="ease-field">
+    <label class="ease-field-label">Name</label>
+    <input class="ease-input" type="text" placeholder="Your name" />
+  </div>
+
+  <div class="ease-field">
+    <label class="ease-field-label">Message</label>
+    <textarea class="ease-textarea" rows="3" placeholder="Your message"></textarea>
+  </div>
+
+  <div class="ease-field">
+    <label class="ease-field-label">Role</label>
+    <select class="ease-select">
+      <option>Developer</option>
+      <option>Designer</option>
+      <option>Other</option>
+    </select>
+  </div>
+
+  <button class="ease-btn ease-btn-primary">Submit</button>
+</body>
+</html>

--- a/submissions/examples/forms-smoke-test-sk/style.css
+++ b/submissions/examples/forms-smoke-test-sk/style.css
@@ -1,0 +1,1 @@
+/* Forms component smoke test coverage — see tests/smoke.test.js */

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -28,8 +28,9 @@ const badges = readFileSync(resolve(componentsDir, 'badges.css'), 'utf8');
 const loaders = readFileSync(resolve(componentsDir, 'loaders.css'), 'utf8');
 const tooltips = readFileSync(resolve(componentsDir, 'tooltips.css'), 'utf8');
 const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
-    
-    css = variables + base + animations + utilities + buttons + cards + chip + footer + masonry + navbar + scrollProgress + sidebar + tabs + badges + loaders + tooltips + modals;
+const forms = readFileSync(resolve(componentsDir, 'forms.css'), 'utf8');
+
+    css = variables + base + animations + utilities + buttons + cards + chip + footer + masonry + navbar + scrollProgress + sidebar + tabs + badges + loaders + tooltips + modals + forms;
     dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>');
     document = dom.window.document;
     
@@ -119,6 +120,14 @@ const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
     expect(css).toContain('.ease-modal-overlay');
     expect(css).toContain('.ease-modal');
     expect(css).toContain('.ease-modal-header');
+  });
+
+  it('should have form classes defined', () => {
+    expect(css).toContain('.ease-field');
+    expect(css).toContain('.ease-field-label');
+    expect(css).toContain('.ease-input');
+    expect(css).toContain('.ease-textarea');
+    expect(css).toContain('.ease-select');
   });
   
   it('should not have duplicate @keyframes definitions', () => {


### PR DESCRIPTION
## Summary

Fixes #4619

- Added `forms.css` to the CSS bundle loaded in `beforeAll()` in `tests/smoke.test.js`
- Added a new `should have form classes defined` test asserting `.ease-field`, `.ease-field-label`, `.ease-input`, `.ease-textarea`, `.ease-select`
- All 10 tests pass locally (`npm test`)
- Included `submissions/examples/forms-smoke-test-sk/` with `demo.html`, `style.css`, and `README.md`

## Why

`components/forms.css` contained a full set of form component styles but was never loaded in the smoke test file. Any regression (renamed class, broken rule) would silently pass CI.

## Test plan

- [ ] Run `npm test` — all tests should pass (10/10)
- [ ] Delete `.ease-field` from `forms.css` temporarily — the new test should fail
- [ ] Open `submissions/examples/forms-smoke-test-sk/demo.html` — form fields render correctly

## Maintainer review notes

Purely additive: one `readFileSync` call, one concatenation entry, one new `it()` block. No existing tests modified.