### PR TITLE
fix: add missing forms.css import to easemotion/all.css

### DIFF
--- a/easemotion/all.css
+++ b/easemotion/all.css
@@ -18,6 +18,7 @@
 @import "../components/loaders.css";
 @import "../components/tooltips.css";
 @import "../components/modals.css";
+@import "../components/forms.css";
 
 
 

--- a/submissions/examples/all-css-forms-import-sk/README.md
+++ b/submissions/examples/all-css-forms-import-sk/README.md
@@ -1,0 +1,15 @@
+# all.css Missing forms.css Import Fix
+
+Fixes #4620
+
+## Problem
+
+`easemotion/all.css` imports every component file except `components/forms.css`. Any user importing the full bundle via `all.css` gets no form styles — `.ease-input`, `.ease-field`, `.ease-textarea`, `.ease-select` are all silently missing.
+
+## Fix
+
+Added `@import "../components/forms.css";` to `easemotion/all.css` after the existing `modals.css` import.
+
+## Demo
+
+Open `demo.html` — form inputs render using the framework styles loaded from `all.css`.

--- a/submissions/examples/all-css-forms-import-sk/demo.html
+++ b/submissions/examples/all-css-forms-import-sk/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>all.css Forms Import Fix</title>
+  <link rel="stylesheet" href="../../easemotion/all.css" />
+  <style>
+    body { font-family: sans-serif; padding: 2rem; max-width: 480px; }
+  </style>
+</head>
+<body>
+  <h1>Forms via all.css</h1>
+  <p>These form classes are now available when importing <code>easemotion/all.css</code>.</p>
+
+  <div class="ease-field">
+    <label class="ease-field-label">Email</label>
+    <input class="ease-input" type="email" placeholder="you@example.com" />
+  </div>
+
+  <div class="ease-field">
+    <label class="ease-field-label">Notes</label>
+    <textarea class="ease-textarea" rows="3" placeholder="Leave a note..."></textarea>
+  </div>
+
+  <button class="ease-btn ease-btn-primary">Send</button>
+</body>
+</html>

--- a/submissions/examples/all-css-forms-import-sk/style.css
+++ b/submissions/examples/all-css-forms-import-sk/style.css
@@ -1,0 +1,1 @@
+/* forms.css import fix — see easemotion/all.css */


### PR DESCRIPTION
## Summary

Fixes #4620

- Added `@import "../components/forms.css";` to `easemotion/all.css` after the `modals.css` import
- `components/forms.css` was the only component file absent from the full bundle
- Included `submissions/examples/all-css-forms-import-sk/` with `demo.html`, `style.css`, and `README.md`

## Why

Any user importing the full EaseMotion bundle via `easemotion/all.css` received no form styles. `.ease-input`, `.ease-field`, `.ease-textarea`, and `.ease-select` were all silently absent.

## Test plan

- [ ] Open `submissions/examples/all-css-forms-import-sk/demo.html` — form inputs should be styled
- [ ] Before fix: inspect `all.css` and confirm `forms.css` is not listed — after fix it should be
- [ ] Run `npm test` — all tests pass

## Maintainer review notes

One-line additive import. Zero risk of regression.