### PR TITLE
fix(tabs): prevent layout shift in ease-tabs-auto active indicator

### DIFF
--- a/submissions/examples/tabs-layout-shift-issue-4783-sn/README.md
+++ b/submissions/examples/tabs-layout-shift-issue-4783-sn/README.md
@@ -1,0 +1,54 @@
+# Fix: Tabs Layout Shift in `.ease-tabs-auto` — Issue #4783
+
+## Problem
+
+In the `.ease-tabs-auto` variant, the active tab indicator works by adding a
+`border-bottom: 2px solid var(--ease-color-primary)` **only** to the currently checked label.
+
+Since unchecked labels have **no** bottom border, switching tabs causes a **2-pixel vertical layout shift** —
+the entire tab navigation row jumps in height whenever a tab is selected.
+
+## Root Cause
+
+```css
+/* Current behaviour — border added only on active label */
+.ease-tabs-auto .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1) {
+  border-bottom: 2px solid var(--ease-color-primary); /* ← causes shift */
+}
+```
+
+## Fix
+
+Pre-reserve the 2px border space on **every** label using a transparent border.
+When a tab is selected, only the `border-bottom-color` changes — no height change, no shift.
+
+```css
+/* Fix: pre-reserve border space on all auto-width labels */
+.ease-tabs-auto .ease-tab-label {
+  border-bottom: 2px solid transparent;
+}
+
+/* Active: only change the color, not the border width/presence */
+.ease-tabs-auto .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1),
+/* ... all 6 variants ... */ {
+  border-bottom-color: var(--ease-color-primary);
+}
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `style.css` | The CSS override fix (to be merged into `components/tabs.css`) |
+| `demo.html` | Interactive before/after comparison |
+
+## How to Test
+
+1. Open `demo.html` in a browser.
+2. Compare the **Before** section (shifts 2px) with the **After** section (no shift).
+3. Click between tabs rapidly — the tab nav row height remains perfectly stable.
+
+## References
+
+- Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/4783
+- Root file: `components/tabs.css` — `.ease-tabs-auto` block

--- a/submissions/examples/tabs-layout-shift-issue-4783-sn/demo.html
+++ b/submissions/examples/tabs-layout-shift-issue-4783-sn/demo.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Tabs Layout Shift in ease-tabs-auto — Issue #4783</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 860px;
+      margin: 0 auto;
+    }
+    h1 { color: #7c3aed; margin-bottom: 0.5rem; }
+    p  { color: #94a3b8; margin-bottom: 2rem; }
+    .section { margin-bottom: 3rem; }
+    .label-tag {
+      display: inline-block;
+      padding: 0.2rem 0.8rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .bad  { background: #7f1d1d; color: #fca5a5; }
+    .good { background: #14532d; color: #86efac; }
+    .demo-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Fix: Tabs Layout Shift (Issue #4783)</h1>
+  <p>
+    In <code>.ease-tabs-auto</code>, the active indicator adds a <code>border-bottom: 2px solid</code>
+    only to the checked label — causing a 2-pixel vertical layout shift. The fix pre-reserves
+    the border space on <em>all</em> labels using a transparent border, so only the color changes
+    when a tab is selected — no shift.
+  </p>
+
+  <!-- BEFORE: Broken (layout shift simulated) -->
+  <div class="section">
+    <span class="label-tag bad">❌ Before — Layout Shift</span>
+    <div class="demo-card">
+      <p style="color:#94a3b8;margin-top:0">Click tabs below and observe the row height jumps by 2px:</p>
+      <!-- Manually simulate the broken state: no transparent border pre-applied -->
+      <style>
+        .demo-broken .ease-tabs-auto .ease-tab-label { border-bottom: none !important; }
+        .demo-broken .ease-tabs-auto .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1),
+        .demo-broken .ease-tabs-auto .ease-tab-input:nth-of-type(2):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(2),
+        .demo-broken .ease-tabs-auto .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3) {
+          border-bottom: 2px solid var(--ease-color-primary, #7c3aed);
+        }
+      </style>
+      <div class="demo-broken">
+        <div class="ease-tabs ease-tabs-auto">
+          <input class="ease-tab-input" type="radio" name="tabs-broken" id="tab-b1" checked />
+          <input class="ease-tab-input" type="radio" name="tabs-broken" id="tab-b2" />
+          <input class="ease-tab-input" type="radio" name="tabs-broken" id="tab-b3" />
+          <div class="ease-tabs-nav">
+            <label class="ease-tab-label" for="tab-b1">Overview</label>
+            <label class="ease-tab-label" for="tab-b2">Details</label>
+            <label class="ease-tab-label" for="tab-b3">Settings</label>
+          </div>
+          <div class="ease-tabs-content">
+            <div class="ease-tab-panel"><p>Overview content</p></div>
+            <div class="ease-tab-panel"><p>Details content</p></div>
+            <div class="ease-tab-panel"><p>Settings content</p></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- AFTER: Fixed (no layout shift) -->
+  <div class="section">
+    <span class="label-tag good">✅ After — No Layout Shift</span>
+    <div class="demo-card">
+      <p style="color:#94a3b8;margin-top:0">Click tabs below — the row height stays perfectly stable:</p>
+      <div class="ease-tabs ease-tabs-auto">
+        <input class="ease-tab-input" type="radio" name="tabs-fixed" id="tab-f1" checked />
+        <input class="ease-tab-input" type="radio" name="tabs-fixed" id="tab-f2" />
+        <input class="ease-tab-input" type="radio" name="tabs-fixed" id="tab-f3" />
+        <div class="ease-tabs-nav">
+          <label class="ease-tab-label" for="tab-f1">Overview</label>
+          <label class="ease-tab-label" for="tab-f2">Details</label>
+          <label class="ease-tab-label" for="tab-f3">Settings</label>
+        </div>
+        <div class="ease-tabs-content">
+          <div class="ease-tab-panel"><p>Overview content — no row shift when switching tabs ✅</p></div>
+          <div class="ease-tab-panel"><p>Details content — no row shift when switching tabs ✅</p></div>
+          <div class="ease-tab-panel"><p>Settings content — no row shift when switching tabs ✅</p></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/tabs-layout-shift-issue-4783-sn/style.css
+++ b/submissions/examples/tabs-layout-shift-issue-4783-sn/style.css
@@ -1,0 +1,34 @@
+/*
+ * Fix: Tabs Layout Shift in .ease-tabs-auto
+ * Issue #4783: When the active indicator uses border-bottom on the label,
+ * adding a 2px border to the checked label causes a layout shift because
+ * the unchecked labels have no border, so their heights differ.
+ *
+ * Solution: Add a transparent 2px border-bottom to ALL labels in
+ * .ease-tabs-auto by default. This pre-reserves the space so the checked
+ * label simply changes color — no layout shift occurs.
+ */
+
+@layer easemotion-components {
+  /*
+   * Pre-reserve the 2px bottom-border space on every auto-tab label.
+   * The checked state only changes the color from transparent -> primary,
+   * so no height shift is triggered.
+   */
+  .ease-tabs-auto .ease-tab-label {
+    border-bottom: 2px solid transparent;
+  }
+
+  /*
+   * Override the original rule which adds the 2px border only to the
+   * checked label (causing a shift). We now just update the color.
+   */
+  .ease-tabs-auto .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(2):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(2),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(4),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6) {
+    border-bottom-color: var(--ease-color-primary);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #4783 — Layout shift when switching tabs in \.ease-tabs-auto\ mode.

## Problem

In \.ease-tabs-auto\, the active indicator adds a \order-bottom: 2px solid\ **only** to the checked label. Since inactive labels have no border, switching tabs causes a **2px vertical layout shift** — the tab nav row height jumps on every click.

## Root Cause

\\\css
/* Broken: adds border only to active label */
.ease-tabs-auto .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1) {
  border-bottom: 2px solid var(--ease-color-primary);
}
\\\

## Fix

Pre-reserve the 2px border space on **all** labels using a transparent border, then only change the color on the active tab:

\\\css
/* All labels get transparent border to reserve space */
.ease-tabs-auto .ease-tab-label {
  border-bottom: 2px solid transparent;
}

/* Active label changes color only — no layout shift */
.ease-tabs-auto .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1) {
  border-bottom-color: var(--ease-color-primary);
}
\\\

## Files Changed

- \submissions/examples/tabs-layout-shift-issue-4783-sn/style.css\ — CSS fix
- \submissions/examples/tabs-layout-shift-issue-4783-sn/demo.html\ — Before/After interactive demo
- \submissions/examples/tabs-layout-shift-issue-4783-sn/README.md\ — Documentation

## Testing

Open \demo.html\ to see a side-by-side Before/After comparison. The fixed version shows zero layout shift when switching tabs.