### PR TITLE
feat(examples): add image-rendering property comparison demo

### DIFF
--- a/submissions/examples/image-rendering-comparison/README.md
+++ b/submissions/examples/image-rendering-comparison/README.md
@@ -1,0 +1,31 @@
+# Image Rendering Comparison
+
+## What does it do?
+A pure-CSS demo showing the `image-rendering` property for controlling how scaled images are rendered — no JavaScript required.
+
+## Features
+- **auto (default)** — smooth bilinear interpolation (good for photos)
+- **pixelated** — nearest-neighbor scaling (essential for pixel art)
+- **crisp-edges** — contrast-preserving scaling
+- **Side-by-side comparison** — 8px checkerboard scaled 32x
+
+## Usage
+```css
+.pixel-art { image-rendering: pixelated; }
+.photo-img { image-rendering: auto; }
+```
+
+## Classes
+- `.ir-auto` — default smooth scaling
+- `.ir-pixelated` — blocky nearest-neighbor scaling
+- `.ir-crisp` — contrast-preserving scaling
+
+## Browser Support
+- `image-rendering` — Chrome 41+, Firefox 65+, Safari 13+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+- Self-contained data URI SVG images
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/image-rendering-comparison/demo.html
+++ b/submissions/examples/image-rendering-comparison/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Rendering — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Image Rendering</h1>
+  <p class="subtitle">Controlling image scaling quality with <code>image-rendering</code> — no JavaScript required.</p>
+
+  <section>
+    <h2>Checkerboard Pattern (8px → 256px, 32x scale)</h2>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <p class="ir-label">auto (default)</p>
+        <img class="ir-auto" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Crect x='0' y='0' width='4' height='4' fill='%23ef4444'/%3E%3Crect x='4' y='0' width='4' height='4' fill='%23ffffff'/%3E%3Crect x='0' y='4' width='4' height='4' fill='%23ffffff'/%3E%3Crect x='4' y='4' width='4' height='4' fill='%23ef4444'/%3E%3C/svg%3E" width="256" height="256" alt="Checkerboard auto">
+        <p class="ir-desc">Blurry interpolation — the browser smooths edges with bilinear filtering.</p>
+      </div>
+      <div class="demo-card">
+        <p class="ir-label">pixelated</p>
+        <img class="ir-pixelated" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Crect x='0' y='0' width='4' height='4' fill='%23ef4444'/%3E%3Crect x='4' y='0' width='4' height='4' fill='%23ffffff'/%3E%3Crect x='0' y='4' width='4' height='4' fill='%23ffffff'/%3E%3Crect x='4' y='4' width='4' height='4' fill='%23ef4444'/%3E%3C/svg%3E" width="256" height="256" alt="Checkerboard pixelated">
+        <p class="ir-desc">Nearest-neighbor scaling — each source pixel becomes a visible block.</p>
+      </div>
+      <div class="demo-card">
+        <p class="ir-label">crisp-edges</p>
+        <img class="ir-crisp" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Crect x='0' y='0' width='4' height='4' fill='%23ef4444'/%3E%3Crect x='4' y='0' width='4' height='4' fill='%23ffffff'/%3E%3Crect x='0' y='4' width='4' height='4' fill='%23ffffff'/%3E%3Crect x='4' y='4' width='4' height='4' fill='%23ef4444'/%3E%3C/svg%3E" width="256" height="256" alt="Checkerboard crisp-edges">
+        <p class="ir-desc">Contrast-preserving scaling — sharp edges with minimal interpolation.</p>
+      </div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/image-rendering-comparison/style.css
+++ b/submissions/examples/image-rendering-comparison/style.css
@@ -1,0 +1,48 @@
+/* ============================================================
+   EaseMotion CSS — Image Rendering
+   Controlling image scaling with image-rendering
+   ============================================================ */
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.demo-card {
+  text-align: center;
+}
+
+.ir-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #a78bfa;
+  margin: 0 0 0.75rem;
+  font-family: monospace;
+}
+
+.ir-desc {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  margin: 0.75rem 0 0;
+  line-height: 1.5;
+}
+
+img {
+  width: 256px;
+  height: 256px;
+  border-radius: 4px;
+  outline: 1px solid #333;
+}
+
+.ir-auto {
+  image-rendering: auto;
+}
+
+.ir-pixelated {
+  image-rendering: pixelated;
+}
+
+.ir-crisp {
+  image-rendering: crisp-edges;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating the `image-rendering` property for controlling image scaling quality — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Side-by-side comparison of auto, pixelated, and crisp-edges |
| `style.css` | Pure CSS using image-rendering with inline SVG data URIs |
| `README.md` | Documentation with usage and browser support |

## Related Issue
Closes #4816

<!-- re-trigger label sync -->