### PR TITLE
feat(examples): add nth-child An+B selector patterns demo

### DIFF
--- a/submissions/examples/nth-child-patterns/README.md
+++ b/submissions/examples/nth-child-patterns/README.md
@@ -1,0 +1,33 @@
+# :nth-child Patterns
+
+## What does it do?
+A pure-CSS demo showing `:nth-child()` An+B selector patterns for targeting elements by position — no JavaScript required.
+
+## Features
+- **odd / even** — alternating row styling with `:nth-child(odd/even)`
+- **Every 3rd** — `:nth-child(3n)` targets every third element
+- **Offset patterns** — `:nth-child(3n+1)` starts from element 1
+- **First N elements** — `:nth-child(-n+4)` targets the first 4
+- **From end** — `:nth-last-child(-n+2)` targets last 2 elements
+
+## Usage
+```css
+/* Alternating rows */
+tr:nth-child(even) { background: #f5f5f5; }
+
+/* Every third item */
+li:nth-child(3n) { color: red; }
+
+/* First three items */
+li:nth-child(-n+3) { font-weight: bold; }
+```
+
+## Browser Support
+- `:nth-child()` — Chrome 1+, Firefox 3.5+, Safari 3.2+
+- `:nth-last-child()` — Chrome 1+, Firefox 3.5+, Safari 3.2+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/nth-child-patterns/demo.html
+++ b/submissions/examples/nth-child-patterns/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>:nth-child Patterns — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 850px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .pattern-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <h1>:nth-child Patterns</h1>
+  <p class="subtitle">An+B selector patterns for targeting elements by position — no JavaScript required.</p>
+
+  <section>
+    <h2>odd / even</h2>
+    <p class="pattern-desc">:nth-child(odd) / :nth-child(even)</p>
+    <div class="grid-demo" id="demo-odd-even">
+      <div class="cell">1</div><div class="cell">2</div><div class="cell">3</div>
+      <div class="cell">4</div><div class="cell">5</div><div class="cell">6</div>
+      <div class="cell">7</div><div class="cell">8</div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Every 3rd</h2>
+    <p class="pattern-desc">:nth-child(3n)</p>
+    <div class="grid-demo" id="demo-3n">
+      <div class="cell">1</div><div class="cell">2</div><div class="cell">3</div>
+      <div class="cell">4</div><div class="cell">5</div><div class="cell">6</div>
+      <div class="cell">7</div><div class="cell">8</div><div class="cell">9</div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Every 3rd starting from 1st</h2>
+    <p class="pattern-desc">:nth-child(3n+1)</p>
+    <div class="grid-demo" id="demo-3n+1">
+      <div class="cell">1</div><div class="cell">2</div><div class="cell">3</div>
+      <div class="cell">4</div><div class="cell">5</div><div class="cell">6</div>
+      <div class="cell">7</div><div class="cell">8</div><div class="cell">9</div>
+    </div>
+  </section>
+
+  <section>
+    <h2>First 4 elements</h2>
+    <p class="pattern-desc">:nth-child(-n+4)</p>
+    <div class="grid-demo" id="demo-neg">
+      <div class="cell">1</div><div class="cell">2</div><div class="cell">3</div>
+      <div class="cell">4</div><div class="cell">5</div><div class="cell">6</div>
+      <div class="cell">7</div><div class="cell">8</div>
+    </div>
+  </section>
+
+  <section>
+    <h2>From the end</h2>
+    <p class="pattern-desc">:nth-last-child(2) — last 2 elements highlighted</p>
+    <div class="grid-demo" id="demo-last">
+      <div class="cell">1</div><div class="cell">2</div><div class="cell">3</div>
+      <div class="cell">4</div><div class="cell">5</div><div class="cell">6</div>
+      <div class="cell">7</div><div class="cell">8</div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/nth-child-patterns/style.css
+++ b/submissions/examples/nth-child-patterns/style.css
@@ -1,0 +1,64 @@
+/* ============================================================
+   EaseMotion CSS — :nth-child Patterns
+   An+B selector patterns for positional targeting
+   ============================================================ */
+
+.grid-demo {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.cell {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2a2a2a;
+  color: #9ca3af;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  transition: background 0.2s, color 0.2s;
+}
+
+/* ---- odd / even ---- */
+
+#demo-odd-even .cell:nth-child(odd) {
+  background: #4f46e5;
+  color: #ffffff;
+}
+
+#demo-odd-even .cell:nth-child(even) {
+  background: #1e1e1e;
+  color: #6b7280;
+}
+
+/* ---- every 3rd ---- */
+
+#demo-3n .cell:nth-child(3n) {
+  background: #0891b2;
+  color: #ffffff;
+}
+
+/* ---- every 3rd starting from 1st ---- */
+
+#demo-3n\+1 .cell:nth-child(3n+1) {
+  background: #059669;
+  color: #ffffff;
+}
+
+/* ---- first 4 elements ---- */
+
+#demo-neg .cell:nth-child(-n+4) {
+  background: #d97706;
+  color: #ffffff;
+}
+
+/* ---- from the end ---- */
+
+#demo-last .cell:nth-last-child(-n+2) {
+  background: #dc2626;
+  color: #ffffff;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating `:nth-child()` An+B selector patterns for targeting elements by position — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Six pattern demos: odd/even, 3n, 3n+1, -n+4, and nth-last-child |
| `style.css` | Pure CSS with An+B selectors |
| `README.md` | Documentation with usage examples and browser support |

## Related Issue
Closes #4819

<!-- re-trigger label sync -->