### PR TITLE
feat(examples): add :is() vs :where() specificity demo

### DIFF
--- a/submissions/examples/is-where-specificity/README.md
+++ b/submissions/examples/is-where-specificity/README.md
@@ -1,0 +1,34 @@
+# :is() vs :where() Specificity
+
+## What does it do?
+A pure-CSS demo showing the critical specificity difference between `:is()` and `:where()` pseudo-class functions — no JavaScript required.
+
+## Features
+- **:is() demo** — takes the highest specificity from its argument list
+- **:where() demo** — specificity is always zero, regardless of arguments
+- **Direct comparison** — side-by-side with the same selector patterns
+
+## Key Difference
+| Selector | Specificity | Behavior |
+|----------|------------|----------|
+| `:is(.special, p)` | 0,1,0 | Takes highest specificity of arguments |
+| `:where(.special, p)` | 0,0,0 | Always zero specificity |
+
+## Usage
+```css
+/* :is() — handy for grouping, but beware specificity escalation */
+:is(h1, h2, h3) .title { color: red; }  /* specificity 0,0,2 */
+
+/* :where() — safe to override because specificity is always 0 */
+:where(h1, h2, h3) .title { color: blue; }  /* specificity 0,1,1 */
+```
+
+## Browser Support
+- `:is()` — Chrome 88+, Firefox 78+, Safari 14+
+- `:where()` — Chrome 88+, Firefox 78+, Safari 14+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/is-where-specificity/demo.html
+++ b/submissions/examples/is-where-specificity/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>:is() vs :where() — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <h1>:is() vs :where()</h1>
+  <p class="subtitle">Understanding specificity differences between modern CSS pseudo-class functions — no JavaScript required.</p>
+
+  <section>
+    <h2>:is() — Takes highest specificity</h2>
+    <p class="sec-desc"><code>:is(.special, div)</code> wins over a plain element selector because it takes the highest specificity from its arguments (class = 0,1,0 beats element = 0,0,1).</p>
+    <div id="demo-is" class="spec-demo">
+      <p class="item special">I'm highlighted by <code>:is()</code></p>
+      <p class="item">I'm NOT highlighted</p>
+      <span class="item special">I'm an &lt;span&gt; with .special — also matched</span>
+    </div>
+  </section>
+
+  <section>
+    <h2>:where() — Specificity is always 0</h2>
+    <p class="sec-desc"><code>:where(.special, div)</code> never beats a plain element selector because its specificity is always zero.</p>
+    <div id="demo-where" class="spec-demo">
+      <p class="item special">I'm <em>not</em> highlighted — <code>:where()</code> can't override the element selector</p>
+      <p class="item">Neither am I</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Direct Comparison</h2>
+    <p class="sec-desc">Same structure — <code>:is()</code> overrides the base style, <code>:where()</code> does not.</p>
+    <div id="demo-compare" class="spec-demo">
+      <p class="item special is-demo"><code>:is(.special, p)</code> — overrides base (specificity 0,1,0)</p>
+      <p class="item special where-demo"><code>:where(.special, p)</code> — base overrides this (specificity 0,0,0)</p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/is-where-specificity/style.css
+++ b/submissions/examples/is-where-specificity/style.css
@@ -1,0 +1,77 @@
+/* ============================================================
+   EaseMotion CSS — :is() vs :where()
+   Specificity comparison of modern pseudo-class functions
+   ============================================================ */
+
+.spec-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.item {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: #2a2a2a;
+  color: #9ca3af;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ---- :is() demo ---- */
+
+#demo-is .item {
+  color: #9ca3af;
+}
+
+/* :is() takes highest specificity from arguments.
+   .special = 0,1,0  >  .item = 0,1,0 (same), but wins by order.
+   p = 0,0,1 — so :is(.special, p) = 0,1,0 */
+#demo-is :is(.special, p) {
+  color: #22c55e;
+  background: #052e16;
+  border-left: 3px solid #22c55e;
+}
+
+/* ---- :where() demo ---- */
+
+#demo-where .item {
+  color: #9ca3af;
+}
+
+/* This sets color on all .item elements */
+#demo-where .item.special {
+  color: #f59e0b;
+}
+
+/* :where() specificity = 0,0,0 — cannot override .item.special (0,2,0) */
+#demo-where :where(.special, p) {
+  color: #ef4444;
+}
+
+/* ---- Direct comparison ---- */
+
+#demo-compare .item {
+  color: #9ca3af;
+}
+
+/* .special = 0,1,0 overrides .item = 0,1,0 */
+#demo-compare .item.special {
+  color: #f59e0b;
+  background: #2a2a2a;
+}
+
+/* :is() inherits .special's specificity (0,1,0) — ties with .item.special, wins by order */
+#demo-compare :is(.special, .item) {
+  color: #22c55e;
+  background: #052e16;
+  border-left: 3px solid #22c55e;
+}
+
+/* :where() always has 0,0,0 specificity — .item.special (0,2,0) wins */
+#demo-compare :where(.special, .item) {
+  color: #ef4444;
+  background: #3b0a0a;
+  border-left: 3px solid #ef4444;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating the critical specificity difference between `:is()` and `:where()` pseudo-class functions — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Three demo sections showing :is(), :where(), and direct comparison |
| `style.css` | Pure CSS with specificity-based styling |
| `README.md` | Documentation with comparison table and usage |

## Related Issue
Closes #4822

<!-- re-trigger label sync -->