### PR TITLE
feat(examples): add scrollbar-width and scrollbar-color demo

### DIFF
--- a/submissions/examples/scrollbar-customization/README.md
+++ b/submissions/examples/scrollbar-customization/README.md
@@ -1,0 +1,34 @@
+# Scrollbar Customization
+
+## What does it do?
+A pure-CSS demo showing the `scrollbar-width` and `scrollbar-color` properties for customizing scrollbar appearance — no JavaScript required.
+
+## Features
+- **Default (auto)** — standard scrollbar width
+- **Thin with custom colors** — `scrollbar-width: thin` + `scrollbar-color`
+- **Custom colors only** — color change without width reduction
+- Content overflow with scrollable boxes
+
+## Properties
+| Property | Values | Description |
+|----------|--------|-------------|
+| `scrollbar-width` | `auto`, `thin`, `none` | Controls scrollbar thickness |
+| `scrollbar-color` | `<color> <color>` | Thumb and track colors |
+
+## Usage
+```css
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rebeccapurple #1a1a1a;
+}
+```
+
+## Browser Support
+- `scrollbar-width` — Firefox 64+, Chrome 121+
+- `scrollbar-color` — Firefox 64+, Chrome 121+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/scrollbar-customization/demo.html
+++ b/submissions/examples/scrollbar-customization/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scrollbar Customization — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Scrollbar Customization</h1>
+  <p class="subtitle">Styling scrollbars with <code>scrollbar-width</code> and <code>scrollbar-color</code> — no JavaScript required.</p>
+
+  <section>
+    <h2>Default (auto)</h2>
+    <p class="sec-desc"><code>scrollbar-width: auto</code></p>
+    <div class="scrollbox scroll-auto">
+      <p>Scroll down to see the default scrollbar behavior.</p>
+      <p>These properties let you customize the scrollbar without browser-specific pseudo-elements like <code>::-webkit-scrollbar</code>.</p>
+      <p><code>scrollbar-width</code> accepts <code>auto</code>, <code>thin</code>, or <code>none</code>.</p>
+      <p><code>scrollbar-color</code> sets the thumb and track colors in one declaration.</p>
+      <p>Browser support is growing — Firefox and Chromium 121+ support both properties.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Thin with Custom Colors</h2>
+    <p class="sec-desc"><code>scrollbar-width: thin; scrollbar-color: #a78bfa #2a2a2a;</code></p>
+    <div class="scrollbox scroll-thin-custom">
+      <p>A thin scrollbar with custom purple thumb and dark track.</p>
+      <p>The <code>thin</code> value reduces the scrollbar width significantly.</p>
+      <p>Pairing with <code>scrollbar-color</code> gives a complete custom look.</p>
+      <p>This is much cleaner than maintaining separate webkit and Firefox styles.</p>
+      <p>Fallback: browsers without support show the default scrollbar.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Custom Colors, Auto Width</h2>
+    <p class="sec-desc"><code>scrollbar-width: auto; scrollbar-color: #f59e0b #1e1e1e;</code></p>
+    <div class="scrollbox scroll-color-only">
+      <p>Default width with amber thumb and near-black track.</p>
+      <p>Sometimes you want the full-width scrollbar with just a color change.</p>
+      <p>The <code>scrollbar-color</code> property takes two values: thumb color and track color.</p>
+      <p>You can also use system colors like <code>Scrollbar</code> and <code>ButtonFace</code>.</p>
+      <p>Scroll further to see more of this demo content.</p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/scrollbar-customization/style.css
+++ b/submissions/examples/scrollbar-customization/style.css
@@ -1,0 +1,44 @@
+/* ============================================================
+   EaseMotion CSS — Scrollbar Customization
+   scrollbar-width and scrollbar-color properties
+   ============================================================ */
+
+.scrollbox {
+  height: 180px;
+  overflow-y: auto;
+  padding: 1rem;
+  border-radius: 8px;
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  line-height: 1.8;
+}
+
+.scrollbox p {
+  margin: 0 0 1rem;
+  color: #9ca3af;
+  font-size: 0.9rem;
+}
+
+.scrollbox p:last-child {
+  margin-bottom: 0;
+}
+
+/* ---- Default (auto) ---- */
+
+.scroll-auto {
+  scrollbar-width: auto;
+}
+
+/* ---- Thin with custom colors ---- */
+
+.scroll-thin-custom {
+  scrollbar-width: thin;
+  scrollbar-color: #a78bfa #2a2a2a;
+}
+
+/* ---- Custom colors, auto width ---- */
+
+.scroll-color-only {
+  scrollbar-width: auto;
+  scrollbar-color: #f59e0b #1e1e1e;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating the `scrollbar-width` and `scrollbar-color` properties for customizing scrollbar appearance — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Three demos: default, thin+custom colors, custom colors only |
| `style.css` | Pure CSS using scrollbar-width and scrollbar-color |
| `README.md` | Documentation with property table and usage |

## Related Issue
Closes #4826

<!-- re-trigger label sync -->