### PR TITLE
feat(examples): add text-underline-offset and text-decoration-thickness demo

### DIFF
--- a/submissions/examples/underline-customization/README.md
+++ b/submissions/examples/underline-customization/README.md
@@ -1,0 +1,35 @@
+# Underline Customization
+
+## What does it do?
+A pure-CSS demo showing `text-underline-offset` and `text-decoration-thickness` for fine-grained underline control — no JavaScript required.
+
+## Features
+- **text-underline-offset** — moves underline from 0px to 12px away from baseline
+- **text-decoration-thickness** — controls underline weight from 1px to 5px
+- **Combined** — offset + thickness + color for complete control
+
+## Properties
+| Property | Values | Description |
+|----------|--------|-------------|
+| `text-underline-offset` | `auto`, `<length>` | Distance from underline to baseline |
+| `text-decoration-thickness` | `auto`, `<length>` | Thickness of the underline |
+
+## Usage
+```css
+.custom-underline {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 2px;
+  text-decoration-color: rebeccapurple;
+}
+```
+
+## Browser Support
+- `text-underline-offset` — Chrome 87+, Firefox 70+, Safari 12.1+
+- `text-decoration-thickness` — Chrome 87+, Firefox 70+, Safari 12.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/underline-customization/demo.html
+++ b/submissions/examples/underline-customization/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Underline Customization — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    p.inline-demo { font-size: 1.25rem; line-height: 2.2; margin: 0.75rem 0; }
+  </style>
+</head>
+<body>
+  <h1>Underline Customization</h1>
+  <p class="subtitle">Fine-grained underline control with <code>text-underline-offset</code> and <code>text-decoration-thickness</code> — no JavaScript required.</p>
+
+  <section>
+    <h2>text-underline-offset</h2>
+    <p class="sec-desc">Controls distance between text baseline and underline</p>
+    <p class="inline-demo"><span class="u-offset-0">offset: auto</span></p>
+    <p class="inline-demo"><span class="u-offset-2">offset: 2px</span></p>
+    <p class="inline-demo"><span class="u-offset-4">offset: 4px</span></p>
+    <p class="inline-demo"><span class="u-offset-8">offset: 8px</span></p>
+    <p class="inline-demo"><span class="u-offset-12">offset: 12px</span></p>
+  </section>
+
+  <section>
+    <h2>text-decoration-thickness</h2>
+    <p class="sec-desc">Controls the thickness (weight) of the underline</p>
+    <p class="inline-demo"><span class="u-thick-1">thickness: 1px</span></p>
+    <p class="inline-demo"><span class="u-thick-2">thickness: 2px</span></p>
+    <p class="inline-demo"><span class="u-thick-3">thickness: 3px</span></p>
+    <p class="inline-demo"><span class="u-thick-4">thickness: 4px</span></p>
+    <p class="inline-demo"><span class="u-thick-5">thickness: 5px</span></p>
+  </section>
+
+  <section>
+    <h2>Combined Customization</h2>
+    <p class="sec-desc">offset + thickness + color for complete control</p>
+    <p class="inline-demo"><span class="u-combined-1">offset 3px · thickness 1.5px · #22c55e</span></p>
+    <p class="inline-demo"><span class="u-combined-2">offset 6px · thickness 3px · #a78bfa</span></p>
+    <p class="inline-demo"><span class="u-combined-3">offset 10px · thickness 5px · #f59e0b</span></p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/underline-customization/style.css
+++ b/submissions/examples/underline-customization/style.css
@@ -1,0 +1,45 @@
+/* ============================================================
+   EaseMotion CSS — Underline Customization
+   text-underline-offset and text-decoration-thickness
+   ============================================================ */
+
+.inline-demo span {
+  text-decoration: underline;
+  text-decoration-color: #a78bfa;
+}
+
+/* ---- text-underline-offset ---- */
+
+.u-offset-0 { text-underline-offset: auto; }
+.u-offset-2 { text-underline-offset: 2px; }
+.u-offset-4 { text-underline-offset: 4px; }
+.u-offset-8 { text-underline-offset: 8px; }
+.u-offset-12 { text-underline-offset: 12px; }
+
+/* ---- text-decoration-thickness ---- */
+
+.u-thick-1 { text-decoration-thickness: 1px; }
+.u-thick-2 { text-decoration-thickness: 2px; }
+.u-thick-3 { text-decoration-thickness: 3px; }
+.u-thick-4 { text-decoration-thickness: 4px; }
+.u-thick-5 { text-decoration-thickness: 5px; }
+
+/* ---- Combined ---- */
+
+.u-combined-1 {
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1.5px;
+  text-decoration-color: #22c55e;
+}
+
+.u-combined-2 {
+  text-underline-offset: 6px;
+  text-decoration-thickness: 3px;
+  text-decoration-color: #a78bfa;
+}
+
+.u-combined-3 {
+  text-underline-offset: 10px;
+  text-decoration-thickness: 5px;
+  text-decoration-color: #f59e0b;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating `text-underline-offset` and `text-decoration-thickness` for fine-grained underline control — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Three demos: offset, thickness, and combined customization |
| `style.css` | Pure CSS with underline offset and thickness variants |
| `README.md` | Documentation with property table and usage |

## Related Issue
Closes #4828

<!-- re-trigger label sync -->