### PR TITLE
feat(examples): add resize property demo

### DIFF
--- a/submissions/examples/resize-property/README.md
+++ b/submissions/examples/resize-property/README.md
@@ -1,0 +1,38 @@
+# Resize Property
+
+## What does it do?
+A pure-CSS demo showing the `resize` property for making elements user-resizable — no JavaScript required.
+
+## Features
+- **resize: both** — resize in both directions
+- **resize: horizontal** — resize width only
+- **resize: vertical** — resize height only
+- **resize: none** — default, no resize handle
+- Textarea demonstration (inherently resizable)
+
+## Property Values
+| Value | Description |
+|-------|-------------|
+| `both` | Resize in both horizontal and vertical directions |
+| `horizontal` | Resize width only |
+| `vertical` | Resize height only |
+| `none` | Element is not resizable (default) |
+
+## Usage
+```css
+.resizable-panel {
+  resize: both;
+  overflow: auto;
+  min-width: 200px;
+  min-height: 100px;
+}
+```
+
+## Browser Support
+- `resize` — Chrome 1+, Firefox 4+, Safari 3+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/resize-property/demo.html
+++ b/submissions/examples/resize-property/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Resize Property — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <h1>Resize Property</h1>
+  <p class="subtitle">Making elements user-resizable with pure CSS — no JavaScript required.</p>
+
+  <section>
+    <h2>resize: both</h2>
+    <p class="sec-desc">Drag the handle to resize in both directions</p>
+    <div class="resize-box resize-both">
+      <p>I'm resizable both horizontally and vertically. Grab the bottom-right corner and drag!</p>
+      <p>The <code>resize: both</code> value allows resizing in all directions.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>resize: horizontal</h2>
+    <p class="sec-desc">Resize width only</p>
+    <div class="resize-box resize-h">
+      <p>I can only be resized horizontally. Height stays fixed.</p>
+      <p>Useful for sidebars and panels where you want width control but fixed height.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>resize: vertical</h2>
+    <p class="sec-desc">Resize height only</p>
+    <div class="resize-box resize-v">
+      <p>I can only be resized vertically. Width stays fixed.</p>
+      <p>Great for textareas, code editors, and expandable sections.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>resize: none</h2>
+    <p class="sec-desc">Default — no resize handle</p>
+    <div class="resize-box resize-none">
+      <p>I'm not resizable at all. This is the default behavior for most elements.</p>
+      <p>No resize handle appears on hover or click.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Textarea (inherently resizable)</h2>
+    <p class="sec-desc">Textareas have resize: both by default</p>
+    <textarea class="resize-ta" rows="3" placeholder="Try resizing me...">This textarea is resizable by default. The resize property lets you control whether elements can be resized and in which directions.</textarea>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/resize-property/style.css
+++ b/submissions/examples/resize-property/style.css
@@ -1,0 +1,67 @@
+/* ============================================================
+   EaseMotion CSS — Resize Property
+   User-resizable elements with pure CSS
+   ============================================================ */
+
+.resize-box {
+  overflow: auto;
+  padding: 1rem;
+  border-radius: 8px;
+  border: 1px solid #333;
+  background: #1a1a1a;
+  min-width: 200px;
+  min-height: 80px;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #9ca3af;
+}
+
+.resize-box p {
+  margin: 0 0 0.5rem;
+}
+
+.resize-box p:last-child {
+  margin-bottom: 0;
+}
+
+.resize-both {
+  resize: both;
+  width: 240px;
+  height: 100px;
+}
+
+.resize-h {
+  resize: horizontal;
+  width: 240px;
+  height: 100px;
+  overflow-x: auto;
+}
+
+.resize-v {
+  resize: vertical;
+  width: 240px;
+  height: 100px;
+}
+
+.resize-none {
+  resize: none;
+  width: 240px;
+  height: 100px;
+}
+
+.resize-ta {
+  width: 100%;
+  background: #1a1a1a;
+  color: #9ca3af;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 0.75rem;
+  font-family: inherit;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  box-sizing: border-box;
+}
+
+.resize-ta:focus {
+  outline: 1px solid #a78bfa;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating the `resize` property for making elements user-resizable — no JavaScript required.

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Five demos: both, horizontal, vertical, none, textarea |
| `style.css` | Pure CSS with resize values |
| `README.md` | Documentation with property table and usage |

## Related Issue
Closes #4830

<!-- re-trigger label sync -->