### PR TITLE
dge pill breaks with long dynamic content

### DIFF
--- a/submissions/examples/badge-text-ellipsis-sn/README.md
+++ b/submissions/examples/badge-text-ellipsis-sn/README.md
@@ -1,0 +1,7 @@
+# Fix: Badge Text Overflow
+
+## Problem
+Long text breaks the badge pill shape.
+
+## Fix
+Added `max-width: 12rem`, `overflow: hidden`, and `text-overflow: ellipsis` to contain badge text gracefully.

--- a/submissions/examples/badge-text-ellipsis-sn/demo.html
+++ b/submissions/examples/badge-text-ellipsis-sn/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>badge pill breaks with long dynamic content</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    h1 { color: #a09af8; margin-bottom: 0.5rem; font-size: 1.4rem; }
+    .note { color: #64748b; margin-bottom: 2rem; line-height: 1.6; }
+    .demo-box {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 0.75rem;
+      padding: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>badge pill breaks with long dynamic content</h1>
+  <p class="note">Open in a browser to see the component in action with the linked style.css applied.</p>
+  <div class="demo-box">
+    <p style="color:#475569;margin:0">Component renders here.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/badge-text-ellipsis-sn/style.css
+++ b/submissions/examples/badge-text-ellipsis-sn/style.css
@@ -1,0 +1,8 @@
+@layer easemotion-components {
+  .ease-badge {
+    max-width: 12rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}


### PR DESCRIPTION
Closes #4888

## What this does

# Fix: Badge Text Overflow

## Problem
Long text breaks the badge pill shape.

## Fix

## Files
- `submissions/examples/badge-text-ellipsis-sn/style.css`
- `submissions/examples/badge-text-ellipsis-sn/demo.html`
- `submissions/examples/badge-text-ellipsis-sn/README.md`
