### PR TITLE
tooltip arrows misalign on right/left positions at mobile widths

### DIFF
--- a/submissions/examples/tooltip-mobile-arrows-sn/README.md
+++ b/submissions/examples/tooltip-mobile-arrows-sn/README.md
@@ -1,0 +1,7 @@
+# Fix: Tooltip Arrow Alignment on Mobile
+
+## Problem
+Right/left tooltip arrows misalign on viewports under 480px.
+
+## Fix
+Added responsive override to fall back to top positioning for right/left tooltips on small screens.

--- a/submissions/examples/tooltip-mobile-arrows-sn/demo.html
+++ b/submissions/examples/tooltip-mobile-arrows-sn/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tooltip arrows misalign on right/left positions at mobile widths</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    h1 { color: #a09af8; margin-bottom: 0.5rem; font-size: 1.4rem; }
+    .note { color: #64748b; margin-bottom: 2rem; line-height: 1.6; }
+    .demo-box {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 0.75rem;
+      padding: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>tooltip arrows misalign on right/left positions at mobile widths</h1>
+  <p class="note">Open in a browser to see the component in action with the linked style.css applied.</p>
+  <div class="demo-box">
+    <p style="color:#475569;margin:0">Component renders here.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tooltip-mobile-arrows-sn/style.css
+++ b/submissions/examples/tooltip-mobile-arrows-sn/style.css
@@ -1,0 +1,22 @@
+@layer easemotion-components {
+  @media (max-width: 480px) {
+    [data-tooltip][data-position='right']::before,
+    [data-tooltip][data-position='left']::before {
+      bottom: calc(100% + 8px);
+      top: auto;
+      left: 50%;
+      right: auto;
+      transform: translateX(-50%);
+    }
+
+    [data-tooltip][data-position='right']::after,
+    [data-tooltip][data-position='left']::after {
+      bottom: 100%;
+      top: auto;
+      left: 50%;
+      right: auto;
+      transform: translateX(-50%);
+      border-color: var(--ease-color-neutral-800) transparent transparent transparent;
+    }
+  }
+}


### PR DESCRIPTION
Closes #4891

## What this does

# Fix: Tooltip Arrow Alignment on Mobile

## Problem
Right/left tooltip arrows misalign on viewports under 480px.

## Fix

## Files
- `submissions/examples/tooltip-mobile-arrows-sn/style.css`
- `submissions/examples/tooltip-mobile-arrows-sn/demo.html`
- `submissions/examples/tooltip-mobile-arrows-sn/README.md`
