### PR TITLE
feat(submissions): add direction-aware hover caption reveal example

### DIFF
--- a/submissions/examples/direction-aware-hover-caption/README.md
+++ b/submissions/examples/direction-aware-hover-caption/README.md
@@ -1,0 +1,140 @@
+# Direction-Aware Hover Caption Reveal
+
+A CSS-only image card effect where a caption overlay smoothly slides into view from a specified direction when the user hovers over the card. No JavaScript required — open `demo.html` directly in any modern browser.
+
+---
+
+## Preview
+
+A 2×2 responsive grid of image cards, each demonstrating a different slide direction:
+
+| Card | Direction class | Behaviour |
+|------|----------------|-----------|
+| Mountain at Golden Hour | `.dah-from-bottom` | Caption rises up from below |
+| Ocean Waves | `.dah-from-top` | Caption drops down from above |
+| Forest Light | `.dah-from-left` | Caption sweeps in from the left |
+| Starry Night | `.dah-from-right` | Caption sweeps in from the right |
+
+---
+
+## Folder contents
+
+```
+direction-aware-hover-caption/
+├── demo.html   — Standalone demo (2×2 card grid)
+├── style.css   — All styles for the feature
+└── README.md   — This file
+```
+
+---
+
+## Usage
+
+### 1. Include the stylesheet
+
+```html
+<link rel="stylesheet" href="path/to/style.css" />
+```
+
+Optionally also link EaseMotion core variables for full token support:
+
+```html
+<link rel="stylesheet" href="path/to/core/variables.css" />
+<link rel="stylesheet" href="path/to/style.css" />
+```
+
+### 2. HTML structure
+
+Every card follows this pattern — swap the direction modifier class to change the reveal direction.
+
+```html
+<div class="dah-card dah-from-bottom">
+  <img
+    class="dah-card__image"
+    src="your-image.jpg"
+    alt="Descriptive alt text"
+  />
+  <div class="dah-card__caption">
+    <span class="dah-card__caption-title">Card Title</span>
+    <span class="dah-card__caption-desc">Short description here.</span>
+  </div>
+</div>
+```
+
+---
+
+## Direction classes
+
+| Class | Starting position | Slide direction |
+|-------|------------------|-----------------|
+| `.dah-from-bottom` | Caption starts **below** the card | Slides **up** into view |
+| `.dah-from-top` | Caption starts **above** the card | Slides **down** into view |
+| `.dah-from-left` | Caption starts **left** of the card | Slides **right** into view |
+| `.dah-from-right` | Caption starts **right** of the card | Slides **left** into view |
+
+Apply exactly **one** direction class alongside `.dah-card`:
+
+```html
+<!-- bottom (default) -->
+<div class="dah-card dah-from-bottom"> … </div>
+
+<!-- top -->
+<div class="dah-card dah-from-top"> … </div>
+
+<!-- left -->
+<div class="dah-card dah-from-left"> … </div>
+
+<!-- right -->
+<div class="dah-card dah-from-right"> … </div>
+```
+
+---
+
+## How it works
+
+The card container uses `overflow: hidden` to clip the caption overlay. Each direction variant positions the caption **completely outside** the card via `transform: translate(±100%)`. On `:hover`, the transform is reset to `translate(0, 0)` and opacity fades in, giving a smooth slide reveal powered by CSS transitions.
+
+EaseMotion design tokens used:
+
+| Token | Role |
+|-------|------|
+| `--ease-speed-medium` | Transition duration (defaults to `300ms`) |
+| `--ease-ease` | Transition timing function |
+| `--ease-color-primary` | Accent bar colour on caption |
+| `--ease-glass-bg` | Glassmorphism tint in overlay gradient |
+
+All tokens have hard-coded fallback values, so the component works even without `variables.css`.
+
+---
+
+## Accessibility
+
+- **`@media (prefers-reduced-motion: reduce)`** — When the user has requested reduced motion, all transitions and transforms are disabled. The caption is shown statically (fully visible, no animation) so content is never hidden from users who rely on this setting.
+- **`aria-hidden="true"`** on `.dah-card__caption` — the overlay is decorative; the image `alt` text already provides the primary content description.
+- **Keyboard / focus** — For interactive use cases, wrap the card in an `<a>` or `<button>` and remove `aria-hidden` from the caption so it reads correctly via screen readers.
+
+---
+
+## Example — full card with wrapper link
+
+```html
+<a href="/destination" class="dah-card dah-from-bottom" aria-label="Mountain at Golden Hour">
+  <img
+    class="dah-card__image"
+    src="mountain.jpg"
+    alt="Mountain landscape at golden hour"
+  />
+  <div class="dah-card__caption">
+    <span class="dah-card__caption-title">Mountain at Golden Hour</span>
+    <span class="dah-card__caption-desc">
+      Explore alpine trails and stunning vistas.
+    </span>
+  </div>
+</a>
+```
+
+---
+
+## Browser support
+
+Works in all evergreen browsers (Chrome, Firefox, Safari, Edge). Uses only `transform`, `transition`, `overflow: hidden`, and `opacity` — no experimental CSS required.

--- a/submissions/examples/direction-aware-hover-caption/demo.html
+++ b/submissions/examples/direction-aware-hover-caption/demo.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Direction-Aware Hover Caption Reveal — EaseMotion CSS</title>
+
+  <!--
+    EaseMotion CSS core variables (loads design tokens).
+    Path is relative to this file inside submissions/examples/<name>/.
+    Falls back gracefully when opened standalone — all tokens have
+    hard-coded fallbacks in style.css.
+  -->
+  <link rel="stylesheet" href="../../../core/variables.css" />
+
+  <!-- Feature stylesheet -->
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- ═══════════════════════════════════════════════════════
+       Page header
+       ═══════════════════════════════════════════════════════ -->
+  <h1 class="dah-page-title">Direction-Aware Hover Caption Reveal</h1>
+  <p class="dah-page-subtitle">
+    Hover over any card to see the caption slide in from its designated
+    direction. Four variants — bottom, top, left, right — all CSS-only.
+  </p>
+
+  <!-- ═══════════════════════════════════════════════════════
+       2×2 Demo grid
+       ═══════════════════════════════════════════════════════ -->
+  <div class="dah-grid">
+
+    <!-- ── 1. From bottom (default / most common) ─────────── -->
+    <div class="dah-card-wrapper">
+      <div class="dah-card dah-from-bottom">
+        <img
+          class="dah-card__image"
+          src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=600&auto=format&fit=crop"
+          alt="Mountain landscape at golden hour"
+          loading="lazy"
+        />
+        <div class="dah-card__caption" aria-hidden="true">
+          <span class="dah-card__caption-title">Mountain at Golden Hour</span>
+          <span class="dah-card__caption-desc">
+            Caption slides up from the bottom on hover.
+          </span>
+        </div>
+      </div>
+      <span class="dah-label">Class: <code>.dah-from-bottom</code></span>
+    </div>
+
+    <!-- ── 2. From top ────────────────────────────────────── -->
+    <div class="dah-card-wrapper">
+      <div class="dah-card dah-from-top">
+        <img
+          class="dah-card__image"
+          src="https://images.unsplash.com/photo-1519046904884-53103b34b206?w=600&auto=format&fit=crop"
+          alt="Calm ocean waves on a sandy beach"
+          loading="lazy"
+        />
+        <div class="dah-card__caption" aria-hidden="true">
+          <span class="dah-card__caption-title">Ocean Waves</span>
+          <span class="dah-card__caption-desc">
+            Caption slides down from the top on hover.
+          </span>
+        </div>
+      </div>
+      <span class="dah-label">Class: <code>.dah-from-top</code></span>
+    </div>
+
+    <!-- ── 3. From left ───────────────────────────────────── -->
+    <div class="dah-card-wrapper">
+      <div class="dah-card dah-from-left">
+        <img
+          class="dah-card__image"
+          src="https://images.unsplash.com/photo-1448375240586-882707db888b?w=600&auto=format&fit=crop"
+          alt="Dense forest with sunlight filtering through trees"
+          loading="lazy"
+        />
+        <div class="dah-card__caption" aria-hidden="true">
+          <span class="dah-card__caption-title">Forest Light</span>
+          <span class="dah-card__caption-desc">
+            Caption slides in from the left on hover.
+          </span>
+        </div>
+      </div>
+      <span class="dah-label">Class: <code>.dah-from-left</code></span>
+    </div>
+
+    <!-- ── 4. From right ──────────────────────────────────── -->
+    <div class="dah-card-wrapper">
+      <div class="dah-card dah-from-right">
+        <img
+          class="dah-card__image"
+          src="https://images.unsplash.com/photo-1475274047050-1d0c0975864c?w=600&auto=format&fit=crop"
+          alt="Starry night sky over a mountain range"
+          loading="lazy"
+        />
+        <div class="dah-card__caption" aria-hidden="true">
+          <span class="dah-card__caption-title">Starry Night</span>
+          <span class="dah-card__caption-desc">
+            Caption slides in from the right on hover.
+          </span>
+        </div>
+      </div>
+      <span class="dah-label">Class: <code>.dah-from-right</code></span>
+    </div>
+
+  </div><!-- /.dah-grid -->
+
+</body>
+</html>

--- a/submissions/examples/direction-aware-hover-caption/style.css
+++ b/submissions/examples/direction-aware-hover-caption/style.css
@@ -1,0 +1,237 @@
+/* =============================================================
+   Direction-Aware Hover Caption Reveal — style.css
+   EaseMotion CSS Submission
+   Provides four caption slide-in variants:
+     .dah-from-bottom  .dah-from-top
+     .dah-from-left    .dah-from-right
+   ============================================================= */
+
+/* ── EaseMotion variable fallbacks ───────────────────────────── */
+:root {
+  --ease-glass-bg:       rgba(255, 255, 255, 0.12);
+  --ease-speed-medium:   300ms;
+  --ease-ease:           cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-color-primary:  #6c63ff;
+
+  /* Local tokens */
+  --dah-overlay-bg:      rgba(15, 23, 42, 0.82);
+  --dah-caption-color:   #f8fafc;
+  --dah-caption-muted:   #cbd5e1;
+  --dah-radius:          0.75rem;
+  --dah-card-width:      300px;
+  --dah-card-height:     200px;
+}
+
+/* ── Page layout ─────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3rem 1.5rem;
+  gap: 2rem;
+}
+
+/* Page heading */
+.dah-page-title {
+  text-align: center;
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  font-weight: 700;
+  color: #f1f5f9;
+  letter-spacing: -0.02em;
+}
+
+.dah-page-subtitle {
+  text-align: center;
+  color: #94a3b8;
+  font-size: 1rem;
+  max-width: 520px;
+  line-height: 1.6;
+}
+
+/* ── 2×2 responsive grid ────────────────────────────────────── */
+.dah-grid {
+  display: grid;
+  grid-template-columns: repeat(2, var(--dah-card-width));
+  gap: 1.75rem;
+}
+
+@media (max-width: 680px) {
+  .dah-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Base card container ─────────────────────────────────────── */
+/*
+ * .dah-card          — the card root; apply one direction modifier
+ * .dah-card__image   — fills the card; clips overflowing content
+ * .dah-card__caption — the overlay panel that slides in
+ */
+.dah-card {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  border-radius: var(--dah-radius);
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  /* GPU hint for smooth compositing */
+  will-change: transform;
+}
+
+/* Image fills the card */
+.dah-card__image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform var(--ease-speed-medium) var(--ease-ease);
+}
+
+/* Subtle scale on hover for depth */
+.dah-card:hover .dah-card__image {
+  transform: scale(1.06);
+}
+
+/* ── Caption overlay ─────────────────────────────────────────── */
+.dah-card__caption {
+  position: absolute;
+  /* span the full card width/height so any direction works */
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 1.25rem 1.125rem;
+  background: var(--dah-overlay-bg);
+  /* Glassmorphism tint when EaseMotion variable resolves */
+  background: linear-gradient(
+    to top,
+    rgba(15, 23, 42, 0.92) 0%,
+    var(--ease-glass-bg) 100%
+  );
+  color: var(--dah-caption-color);
+
+  /* Transition applied to transform; direction variants override
+     the starting transform value only. */
+  transition:
+    transform var(--ease-speed-medium) var(--ease-ease),
+    opacity  var(--ease-speed-medium) var(--ease-ease);
+  opacity: 0;
+}
+
+/* Show caption on card hover */
+.dah-card:hover .dah-card__caption {
+  transform: translate(0, 0) !important; /* reset any directional offset */
+  opacity: 1;
+}
+
+/* Accent bar using --ease-color-primary */
+.dah-card__caption::before {
+  content: '';
+  display: block;
+  width: 2.5rem;
+  height: 3px;
+  background: var(--ease-color-primary);
+  border-radius: 999px;
+  margin-bottom: 0.5rem;
+}
+
+.dah-card__caption-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: #f1f5f9;
+  margin-bottom: 0.25rem;
+}
+
+.dah-card__caption-desc {
+  font-size: 0.825rem;
+  color: var(--dah-caption-muted);
+  line-height: 1.5;
+}
+
+/* ── Direction variants ─────────────────────────────────────── */
+
+/* Caption slides UP from bottom */
+.dah-from-bottom .dah-card__caption {
+  transform: translateY(100%);
+}
+
+/* Caption slides DOWN from top */
+.dah-from-top .dah-card__caption {
+  transform: translateY(-100%);
+}
+
+/* Caption slides RIGHT from left */
+.dah-from-left .dah-card__caption {
+  transform: translateX(-100%);
+}
+
+/* Caption slides LEFT from right */
+.dah-from-right .dah-card__caption {
+  transform: translateX(100%);
+}
+
+/* Direction labels under each card */
+.dah-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: #64748b;
+  margin-top: 0.5rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.dah-label code {
+  background: #1e293b;
+  color: var(--ease-color-primary);
+  padding: 0.1em 0.45em;
+  border-radius: 0.3rem;
+  font-size: 0.78rem;
+}
+
+/* Card wrapper (label + card) */
+.dah-card-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+/* ── Reduced-motion: accessibility ─────────────────────────── */
+/*
+ * When the user has requested reduced motion:
+ *   • Disable all transitions and transforms.
+ *   • Keep the caption permanently visible so content is never hidden.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .dah-card__image {
+    transition: none;
+  }
+  .dah-card__image {
+    transform: none !important;
+  }
+
+  .dah-card__caption {
+    transition: none;
+    transform: none !important;
+    opacity: 1;            /* always visible */
+  }
+
+  .dah-card:hover .dah-card__caption {
+    transform: none !important;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS-only Direction-Aware Hover Caption Reveal example showcasing image card overlays that slide in from different directions (top, bottom, left, and right) on hover.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/direction-aware-hover-caption/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only direction-aware hover caption reveal effect for image cards, supporting top, bottom, left, and right overlay entry animations.

**How does a developer use it?**

```html
<figure class="dah-card dah-from-bottom">
  <img src="image.jpg" alt="Example image">
  <figcaption class="dah-caption">
    <h3>Mountain Peak</h3>
    <p>Captured at dawn</p>
  </figcaption>
</figure>
```

**Why does it fit EaseMotion CSS?**

This feature follows EaseMotion CSS's animation-first and human-readable philosophy by providing a reusable, CSS-only hover effect that is easy to understand, customize, and integrate into galleries, portfolios, product cards, and other UI layouts.

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

* Implemented as a standalone submission only.
* No framework source files were modified.
* Includes support for `prefers-reduced-motion` accessibility preferences.
* Demonstrates all four directional variants in a responsive demo layout.

Closes #5140 
