### PR TITLE
fix(validation): include easemotion directory in duplicate analysis

### DIFF
--- a/scripts/check-duplicates.mjs
+++ b/scripts/check-duplicates.mjs
@@ -7,7 +7,7 @@ const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, "..");
 const baselinePath = path.join(__dirname, "duplicate-baseline.json");
 
-const dirs = ["core", "components"];
+const dirs = ["core", "components", "easemotion"];
 const classPattern = /^\s*\.([a-zA-Z0-9_-]+)(?::[a-z-]+)?(?:\s*,\s*\.[a-zA-Z0-9_-]+)*\s*\{/;
 const keyframePattern = /@keyframes\s+(\S+)/;
 


### PR DESCRIPTION
## Summary

Fixes Issue #3625 by extending duplicate-definition validation to include the `easemotion/` directory.

## Root Cause

The duplicate checker only scanned:

```js
const dirs = ["core", "components"];
```

As a result, duplicate selectors and keyframes inside `easemotion/` were never analyzed.

## Changes

```diff
- const dirs = ["core", "components"];
+ const dirs = ["core", "components", "easemotion"];
```

## Verification

* Verified bug reproduction before fix.
* Verified duplicates inside `easemotion/` are now detected.
* `npm run lint:duplicates` passes.
* `npm test` passes.
* No runtime CSS behavior changed.

Closes #3625