### PR TITLE
fix(ci): validate dist artifacts during release checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "validate:manifest": "node scripts/validate-package.mjs",
     "validate:bundle": "node scripts/validate-bundle.mjs",
     "validate:pack": "node scripts/validate-pack.mjs",
-    "release:check": "npm run validate:manifest && npm run validate:bundle && npm run build && npm run lint && npm run lint:duplicates && npm test && npm run validate:pack",
+    "release:check": "npm run validate:manifest && npm run validate:bundle && npm run build && npm run build:scss && npm run lint && npm run lint:duplicates && npm test && npm run validate:pack",
     "validate:release": "npm run release:check"
   },
   "repository": {


### PR DESCRIPTION
## Summary

Fixes #3628 by ensuring SCSS artifacts are validated during release checks.

## Root Cause

The repository defines a dedicated `build:scss` script for generating SCSS distribution artifacts, but the release validation pipeline did not execute it.

Current flow:

```text
validate:manifest
→ validate:bundle
→ build
→ lint
→ lint:duplicates
→ test
→ validate:pack
```

As a result, SCSS compilation failures could go undetected and releases could proceed without validating generated SCSS artifacts.

## Changes

Updated the `release:check` script in `package.json`:

```diff
- npm run validate:manifest && npm run validate:bundle && npm run build && npm run lint && npm run lint:duplicates && npm test && npm run validate:pack

+ npm run validate:manifest && npm run validate:bundle && npm run build && npm run build:scss && npm run lint && npm run lint:duplicates && npm test && npm run validate:pack
```

## Verification

* Verified `build:scss` now executes as part of `release:check`
* Confirmed SCSS compilation succeeds during release validation
* Confirmed release validation fails when SCSS compilation fails
* Existing test suite continues to pass
* No changes to runtime framework behavior

## Impact

* SCSS artifacts are validated before packaging
* Release integrity is improved
* SCSS build failures now block releases
* Published artifacts remain consistent with the release process

## Files Changed

* `package.json`

Closes #3628
