### PR TITLE
feat: add ease-btn-icon button layout (issue #364)

### DIFF
--- a/submissions/examples/ease-btn-icon-gn/README.md
+++ b/submissions/examples/ease-btn-icon-gn/README.md
@@ -1,0 +1,25 @@
+# ease-btn-icon Button Layout
+
+1. **What does this do?** Adds `ease-btn-icon` button modifiers for buttons containing an icon and text, with proper gap and alignment between them. Includes icon-left, icon-right, outline, and icon-only variants.
+2. **How is it used?**
+```html
+<button class="ease-btn-icon">
+  <svg class="icon">...</svg>
+  Continue
+</button>
+
+<button class="ease-btn-icon-right">
+  Next
+  <svg class="icon">...</svg>
+</button>
+
+<button class="ease-btn-icon-outline">
+  <svg class="icon">...</svg>
+  Comment
+</button>
+
+<button class="ease-btn-icon-only" aria-label="Settings">
+  <svg class="icon">...</svg>
+</button>
+```
+3. **Why is it useful?** Uses `display: inline-flex` with `align-items: center` and `gap` for consistent icon-text alignment across browsers — zero JavaScript, composable variants, aligned with EaseMotion CSS's utility-first philosophy.

--- a/submissions/examples/ease-btn-icon-gn/demo.html
+++ b/submissions/examples/ease-btn-icon-gn/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-btn-icon – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      gap: 2rem;
+      background: #f5f5f5;
+      padding: 2rem;
+    }
+    h1 { color: #333; font-size: 1.3rem; margin: 0; }
+    h3 { color: #888; font-size: 0.8rem; margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.5px; }
+    .row { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+    .group { display: flex; gap: 1rem; flex-wrap: wrap; justify-content: center; }
+  </style>
+</head>
+<body>
+
+  <h1>ease-btn-icon Button Layouts</h1>
+
+  <div class="row">
+    <h3>Icon + Text</h3>
+    <div class="group">
+      <button class="ease-btn-icon">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+        Continue
+      </button>
+      <button class="ease-btn-icon">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+        Add Item
+      </button>
+    </div>
+  </div>
+
+  <div class="row">
+    <h3>Icon Right</h3>
+    <div class="group">
+      <button class="ease-btn-icon-right">
+        Next
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+      </button>
+    </div>
+  </div>
+
+  <div class="row">
+    <h3>Outline</h3>
+    <div class="group">
+      <button class="ease-btn-icon-outline">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+        Comment
+      </button>
+    </div>
+  </div>
+
+  <div class="row">
+    <h3>Icon Only</h3>
+    <div class="group">
+      <button class="ease-btn-icon-only" aria-label="Settings">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      </button>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-btn-icon-gn/style.css
+++ b/submissions/examples/ease-btn-icon-gn/style.css
@@ -1,0 +1,124 @@
+/* ============================================
+   EaseMotion CSS — ease-btn-icon button layout
+   Issue #364
+   ============================================ */
+
+/* Base icon button — icon + text with proper gap and alignment */
+.ease-btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.25rem;
+  border: none;
+  border-radius: 8px;
+  background: #6366f1;
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.ease-btn-icon:hover {
+  background: #4f46e5;
+  transform: translateY(-2px);
+}
+
+.ease-btn-icon svg,
+.ease-btn-icon img,
+.ease-btn-icon .icon {
+  width: 1.1em;
+  height: 1.1em;
+  flex-shrink: 0;
+}
+
+/* Icon-only variant (no text, square button) */
+.ease-btn-icon-only {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: #6366f1;
+  color: #ffffff;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.ease-btn-icon-only:hover {
+  background: #4f46e5;
+  transform: translateY(-2px);
+}
+
+.ease-btn-icon-only svg,
+.ease-btn-icon-only img,
+.ease-btn-icon-only .icon {
+  width: 1.2em;
+  height: 1.2em;
+}
+
+/* Icon-right variant — icon after text */
+.ease-btn-icon-right {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-direction: row-reverse;
+  padding: 0.6rem 1.25rem;
+  border: none;
+  border-radius: 8px;
+  background: #10b981;
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.ease-btn-icon-right:hover {
+  background: #059669;
+  transform: translateY(-2px);
+}
+
+.ease-btn-icon-right svg,
+.ease-btn-icon-right img,
+.ease-btn-icon-right .icon {
+  width: 1.1em;
+  height: 1.1em;
+  flex-shrink: 0;
+}
+
+/* Outline variant */
+.ease-btn-icon-outline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.25rem;
+  border: 2px solid #6366f1;
+  border-radius: 8px;
+  background: transparent;
+  color: #6366f1;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease, transform 0.2s ease;
+}
+
+.ease-btn-icon-outline:hover {
+  background: #6366f1;
+  color: #ffffff;
+  transform: translateY(-2px);
+}
+
+.ease-btn-icon-outline svg,
+.ease-btn-icon-outline img,
+.ease-btn-icon-outline .icon {
+  width: 1.1em;
+  height: 1.1em;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-btn-icon` button modifiers for buttons containing an icon and text, with proper gap and alignment — includes icon-left, icon-right, outline, and icon-only variants. Closes #364

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-btn-icon-gn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
Four icon-button layout variants — icon+text, icon-right, outline, and icon-only — with consistent spacing and alignment.

**How does a developer use it?**
```html
<button class="ease-btn-icon">
  <svg class="icon">...</svg>
  Continue
</button>

<button class="ease-btn-icon-right">
  Next
  <svg class="icon">...</svg>
</button>

<button class="ease-btn-icon-outline">
  <svg class="icon">...</svg>
  Comment
</button>

<button class="ease-btn-icon-only" aria-label="Settings">
  <svg class="icon">...</svg>
</button>
```

**Why does it fit EaseMotion CSS?**
Uses `display: inline-flex` with `align-items: center` and `gap` for consistent icon-text alignment across browsers — zero JavaScript, composable variants, aligned with EaseMotion CSS's utility-first philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Used inline SVGs in the demo for icons (no external dependencies). The `.icon` class sets a consistent `1.1em` size — feel free to adjust to match the design token scale.