### PR TITLE
fix: add prefers-reduced-motion support to loaders component

### DIFF
--- a/submissions/examples/loader-reduced-motion-fix-pr/README.md
+++ b/submissions/examples/loader-reduced-motion-fix-pr/README.md
@@ -1,0 +1,42 @@
+# Loader Reduced Motion Fix
+
+## What does this do?
+
+Adds a missing `@media (prefers-reduced-motion: reduce)` block to the loaders component, disabling all four loader animations (`.ease-loader-spin`, `.ease-loader-pulse`, `.ease-loader-ping`, `.ease-loader-dot`) when the user has requested reduced motion in their OS settings.
+
+## How is it used?
+
+No new classes are introduced. This is a **bug fix** — the `@media` block should be added inside the existing `@layer easemotion-components` in `components/loaders.css`:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-loader-spin,
+  .ease-loader-pulse,
+  .ease-loader-ping,
+  .ease-loader-dot {
+    animation: none !important;
+  }
+}
+```
+
+## Why is it useful?
+
+Every other animated component in the EaseMotion CSS framework already respects `prefers-reduced-motion`:
+
+| Component | Has `prefers-reduced-motion`? |
+|-----------|------------------------------|
+| `buttons.css` | ✅ Yes |
+| `cards.css` | ✅ Yes |
+| `modals.css` | ✅ Yes |
+| `forms.css` | ✅ Yes |
+| `sidebar.css` | ✅ Yes |
+| `tooltips.css` | ✅ Yes |
+| `scroll-progress.css` | ✅ Yes |
+| `ease-marquee.css` | ✅ Yes |
+| `chip.css` | ✅ Yes |
+| `footer.css` | ✅ Yes |
+| **`loaders.css`** | **❌ Missing** |
+
+The loaders component is the **only** animated component in the framework without this accessibility safeguard. This violates WCAG 2.1 Success Criterion 2.3.3 (Animation from Interactions) and creates an accessibility regression for users with vestibular disorders or motion sensitivity.
+
+This fix closes the gap and brings `loaders.css` into full compliance with the framework's established accessibility patterns.

--- a/submissions/examples/loader-reduced-motion-fix-pr/demo.html
+++ b/submissions/examples/loader-reduced-motion-fix-pr/demo.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loader Reduced Motion Fix — Demo</title>
+
+  <!-- Load the full EaseMotion CSS framework -->
+  <link rel="stylesheet" href="../../../easemotion.css">
+
+  <!-- Load the proposed fix -->
+  <link rel="stylesheet" href="style.css">
+
+  <style>
+    body {
+      font-family: var(--ease-font-sans, 'Inter', system-ui, sans-serif);
+      background-color: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      padding: 2rem;
+      max-width: 720px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      font-size: var(--ease-text-3xl, 1.875rem);
+      margin-bottom: 0.5rem;
+    }
+
+    .subtitle {
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .demo-section {
+      background: var(--ease-color-surface, #ffffff);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 2rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .demo-section h2 {
+      font-size: var(--ease-text-lg, 1.125rem);
+      margin-bottom: 1rem;
+    }
+
+    .loader-row {
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+      flex-wrap: wrap;
+    }
+
+    .loader-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .loader-item span {
+      font-size: var(--ease-text-xs, 0.75rem);
+      color: var(--ease-color-muted, #64748b);
+    }
+
+    .instructions {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-radius: var(--ease-radius-md, 0.5rem);
+      padding: 1rem 1.25rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.6;
+      color: var(--ease-color-neutral-700, #334155);
+    }
+
+    .instructions code {
+      background: var(--ease-color-neutral-200, #e2e8f0);
+      padding: 0.1em 0.4em;
+      border-radius: var(--ease-radius-sm, 0.25rem);
+      font-size: 0.85em;
+    }
+  </style>
+</head>
+<body>
+  <h1>🐛 Loader Reduced Motion Fix</h1>
+  <p class="subtitle">
+    Adds missing <code>prefers-reduced-motion: reduce</code> support to the loaders component.
+  </p>
+
+  <!-- All four loader variants -->
+  <div class="demo-section">
+    <h2>All Loader Variants (animated)</h2>
+    <div class="loader-row">
+      <div class="loader-item">
+        <div class="ease-loader ease-loader-spin"></div>
+        <span>.ease-loader-spin</span>
+      </div>
+      <div class="loader-item">
+        <div class="ease-loader ease-loader-pulse"></div>
+        <span>.ease-loader-pulse</span>
+      </div>
+      <div class="loader-item">
+        <div class="ease-loader ease-loader-ping"></div>
+        <span>.ease-loader-ping</span>
+      </div>
+      <div class="loader-item">
+        <div class="ease-loader-dots">
+          <div class="ease-loader-dot"></div>
+          <div class="ease-loader-dot"></div>
+          <div class="ease-loader-dot"></div>
+        </div>
+        <span>.ease-loader-dots</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Test instructions -->
+  <div class="instructions">
+    <strong>How to test:</strong><br>
+    1. Open this page — all four loaders should be animating normally.<br>
+    2. Enable <code>prefers-reduced-motion: reduce</code> in your OS:<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;• <strong>Windows:</strong> Settings → Accessibility → Visual effects → turn off "Animation effects"<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;• <strong>macOS:</strong> System Settings → Accessibility → Display → "Reduce motion"<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;• <strong>Chrome DevTools:</strong> Ctrl+Shift+P → "Emulate CSS prefers-reduced-motion: reduce"<br>
+    3. Reload the page — all four loaders should be <strong>frozen/static</strong>.<br>
+    4. Without the fix (comment out <code>style.css</code>), the loaders continue animating even with reduced motion enabled.
+  </div>
+</body>
+</html>

--- a/submissions/examples/loader-reduced-motion-fix-pr/style.css
+++ b/submissions/examples/loader-reduced-motion-fix-pr/style.css
@@ -1,0 +1,31 @@
+/* ============================================================
+   Loader Reduced Motion Fix
+   Adds prefers-reduced-motion support to loader components.
+   
+   The loaders component (components/loaders.css) defines four
+   animated loader variants but is the ONLY animated component
+   in the framework missing a @media (prefers-reduced-motion)
+   block. This patch adds that missing accessibility support.
+   ============================================================ */
+
+/* --- Proposed addition to components/loaders.css --- */
+
+/*
+  When the user has enabled "Reduce motion" in their OS settings,
+  all loader animations should be suppressed. The spinner falls
+  back to a static state, the pulse stops pulsing, the ping
+  stops expanding, and the bouncing dots freeze.
+
+  This matches the pattern used by every other EaseMotion CSS
+  component: buttons.css, cards.css, modals.css, forms.css,
+  sidebar.css, tooltips.css, scroll-progress.css, etc.
+*/
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-loader-spin,
+  .ease-loader-pulse,
+  .ease-loader-ping,
+  .ease-loader-dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
Closes #5399 
The `components/loaders.css` file defines four animated loader variants (`.ease-loader-spin`, `.ease-loader-pulse`, `.ease-loader-ping`, `.ease-loader-dots`) but is the **only animated component** in the entire framework missing a `@media (prefers-reduced-motion: reduce)` block.

This submission adds the missing accessibility safeguard to bring loaders into compliance with the framework's established pattern.

## What changed

Added a `prefers-reduced-motion: reduce` media query that disables `animation` on all four loader classes:

```css
@media (prefers-reduced-motion: reduce) {
  .ease-loader-spin,
  .ease-loader-pulse,
  .ease-loader-ping,
  .ease-loader-dot {
    animation: none !important;
  }
}
