### PR TITLE
feat: add ease-flip-card 3D card flip component #3834

### DIFF
--- a/submissions/examples/flip-card/README.md
+++ b/submissions/examples/flip-card/README.md
@@ -1,0 +1,57 @@
+# ease-flip-card
+
+3D CSS card flip on hover using `perspective` and `rotateY`. Zero JavaScript required.
+
+## Usage
+
+```html
+<div class="ease-flip-card" style="width: 200px; height: 130px;">
+  <div class="ease-flip-card__inner">
+    <div class="ease-flip-card__front">Front content</div>
+    <div class="ease-flip-card__back">Back content</div>
+  </div>
+</div>
+```
+
+## Required Structure
+
+| Element | Role |
+|---|---|
+| `ease-flip-card` | Outer container — sets `perspective` |
+| `ease-flip-card__inner` | The flipping element — `transform-style: preserve-3d` |
+| `ease-flip-card__front` | Front face — visible by default |
+| `ease-flip-card__back` | Back face — revealed on flip |
+
+Set `width` and `height` on `ease-flip-card` (or a parent). The inner faces use `position: absolute; inset: 0` to fill it.
+
+## Variants
+
+| Class on `ease-flip-card` | Description |
+|---|---|
+| (none) | Hover flip, rotateY (horizontal) |
+| `ease-flip-card--vertical` | Hover flip, rotateX (vertical) |
+| `ease-flip-card--click` | Flip on focus/click — no hover |
+| `ease-flip-card--fast` | 0.3s transition |
+| `ease-flip-card--slow` | 1s transition |
+
+## Click Variant
+
+The click variant uses CSS `:focus-within` — wrap a hidden `<input type="checkbox">` inside using `ease-flip-card__trigger`:
+
+```html
+<div class="ease-flip-card ease-flip-card--click" style="width:200px;height:130px;" tabindex="0">
+  <input class="ease-flip-card__trigger" type="checkbox" aria-label="Flip card" />
+  <div class="ease-flip-card__inner">
+    <div class="ease-flip-card__front">Front</div>
+    <div class="ease-flip-card__back">Back</div>
+  </div>
+</div>
+```
+
+Clicking the card focuses the hidden checkbox, toggling `:focus-within` on the wrapper — no JavaScript needed.
+
+## Submission
+
+- **Author:** sudha09-git
+- **Issue:** #3834
+- **Files:** `style.css`, `demo.html`

--- a/submissions/examples/flip-card/demo.html
+++ b/submissions/examples/flip-card/demo.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-flip-card — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      min-height: 100vh;
+      background: #0f172a;
+      gap: 3rem;
+      padding: 3rem 1.5rem;
+      color: #e2e8f0;
+    }
+    h1 { font-size: 1rem; color: #475569; letter-spacing: 0.1em; text-transform: uppercase; }
+    .section { display: flex; flex-direction: column; align-items: center; gap: 1rem; width: 100%; }
+    .label { font-size: 0.7rem; color: #475569; text-align: center; }
+    .row { display: flex; gap: 2rem; flex-wrap: wrap; justify-content: center; }
+
+    /* Card dimensions */
+    .card-size {
+      width: 200px;
+      height: 130px;
+    }
+
+    /* Front faces */
+    .front-default {
+      background: linear-gradient(135deg, #4f46e5, #7c3aed);
+      display: flex; align-items: center; justify-content: center;
+      flex-direction: column; gap: 0.4rem;
+    }
+    .front-green {
+      background: linear-gradient(135deg, #059669, #10b981);
+      display: flex; align-items: center; justify-content: center;
+      flex-direction: column; gap: 0.4rem;
+    }
+    .front-orange {
+      background: linear-gradient(135deg, #d97706, #f59e0b);
+      display: flex; align-items: center; justify-content: center;
+      flex-direction: column; gap: 0.4rem;
+    }
+
+    /* Back faces */
+    .back-default {
+      background: #1e293b;
+      border: 1px solid #334155;
+      display: flex; align-items: center; justify-content: center;
+      flex-direction: column; gap: 0.5rem; padding: 1rem; text-align: center;
+    }
+
+    .face-title { font-size: 0.9rem; font-weight: 700; color: #fff; }
+    .face-sub   { font-size: 0.7rem; color: rgba(255,255,255,0.6); }
+    .back-title { font-size: 0.85rem; font-weight: 600; color: #e2e8f0; }
+    .back-body  { font-size: 0.72rem; color: #64748b; line-height: 1.4; }
+  </style>
+</head>
+<body>
+
+  <h1>ease-flip-card Demo</h1>
+
+  <!-- Hover flip (default rotateY) -->
+  <div class="section">
+    <div class="label">Hover to flip — rotateY (default)</div>
+    <div class="row">
+
+      <div class="ease-flip-card card-size">
+        <div class="ease-flip-card__inner">
+          <div class="ease-flip-card__front front-default">
+            <span class="face-title">Hover Me</span>
+            <span class="face-sub">Front</span>
+          </div>
+          <div class="ease-flip-card__back back-default">
+            <span class="back-title">Back Side</span>
+            <span class="back-body">Revealed on hover via rotateY</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="ease-flip-card ease-flip-card--fast card-size">
+        <div class="ease-flip-card__inner">
+          <div class="ease-flip-card__front front-green">
+            <span class="face-title">Fast</span>
+            <span class="face-sub">0.3s</span>
+          </div>
+          <div class="ease-flip-card__back back-default">
+            <span class="back-title">Fast Flip</span>
+            <span class="back-body">300ms transition</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="ease-flip-card ease-flip-card--slow card-size">
+        <div class="ease-flip-card__inner">
+          <div class="ease-flip-card__front front-orange">
+            <span class="face-title">Slow</span>
+            <span class="face-sub">1s</span>
+          </div>
+          <div class="ease-flip-card__back back-default">
+            <span class="back-title">Slow Flip</span>
+            <span class="back-body">1000ms transition</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Vertical flip (rotateX) -->
+  <div class="section">
+    <div class="label">Hover to flip — rotateX (vertical)</div>
+    <div class="row">
+
+      <div class="ease-flip-card ease-flip-card--vertical card-size">
+        <div class="ease-flip-card__inner">
+          <div class="ease-flip-card__front front-default">
+            <span class="face-title">Vertical</span>
+            <span class="face-sub">rotateX</span>
+          </div>
+          <div class="ease-flip-card__back back-default">
+            <span class="back-title">Flipped!</span>
+            <span class="back-body">Vertical flip via rotateX</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Click / focus variant -->
+  <div class="section">
+    <div class="label">Click to flip (focus-within — no hover needed)</div>
+    <div class="row">
+
+      <div class="ease-flip-card ease-flip-card--click card-size" tabindex="0">
+        <input class="ease-flip-card__trigger" type="checkbox" aria-label="Flip card" />
+        <div class="ease-flip-card__inner">
+          <div class="ease-flip-card__front front-green">
+            <span class="face-title">Click Me</span>
+            <span class="face-sub">Tab + Space also works</span>
+          </div>
+          <div class="ease-flip-card__back back-default">
+            <span class="back-title">Flipped!</span>
+            <span class="back-body">Click anywhere to flip back</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/flip-card/style.css
+++ b/submissions/examples/flip-card/style.css
@@ -1,0 +1,103 @@
+/* ============================================================
+   EaseMotion CSS — ease-flip-card
+   Submission by: sudha09-git
+   Description: 3D CSS card flip on hover using perspective
+                and rotateY/rotateX. Zero JavaScript required.
+   ============================================================ */
+
+/* ---------- Container (provides perspective) ---------- */
+.ease-flip-card {
+  perspective: 1000px;
+  display: inline-block;
+  cursor: pointer;
+}
+
+/* ---------- Inner (the element that flips) ---------- */
+.ease-flip-card__inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform 0.6s ease;
+}
+
+/* Flip on hover (default — rotateY) */
+.ease-flip-card:hover .ease-flip-card__inner {
+  transform: rotateY(180deg);
+}
+
+/* ---------- Front & Back faces ---------- */
+.ease-flip-card__front,
+.ease-flip-card__back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.ease-flip-card__front {
+  /* sits at 0deg — visible by default */
+}
+
+.ease-flip-card__back {
+  transform: rotateY(180deg);
+}
+
+/* ---------- Vertical flip variant (rotateX) ---------- */
+.ease-flip-card--vertical:hover .ease-flip-card__inner {
+  transform: rotateX(180deg);
+}
+
+.ease-flip-card--vertical .ease-flip-card__back {
+  transform: rotateX(180deg);
+}
+
+/* ---------- Click / focus variant (no hover) ---------- */
+.ease-flip-card--click {
+  /* Remove hover trigger */
+}
+
+.ease-flip-card--click .ease-flip-card__inner {
+  /* driven by :focus-within instead */
+}
+
+.ease-flip-card--click:focus-within .ease-flip-card__inner,
+.ease-flip-card--click.is-flipped .ease-flip-card__inner {
+  transform: rotateY(180deg);
+}
+
+.ease-flip-card--click.ease-flip-card--vertical:focus-within .ease-flip-card__inner,
+.ease-flip-card--click.ease-flip-card--vertical.is-flipped .ease-flip-card__inner {
+  transform: rotateX(180deg);
+}
+
+/* Remove hover flip for click variant */
+.ease-flip-card--click:hover .ease-flip-card__inner {
+  transform: none;
+}
+
+.ease-flip-card--click:focus-within .ease-flip-card__inner {
+  transform: rotateY(180deg);
+}
+
+/* Hidden focusable trigger inside click variant */
+.ease-flip-card__trigger {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 2;
+}
+
+/* ---------- Speed variants ---------- */
+.ease-flip-card--fast .ease-flip-card__inner  { transition-duration: 0.3s; }
+.ease-flip-card--slow .ease-flip-card__inner  { transition-duration: 1s; }
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-flip-card__inner {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds `ease-flip-card` — a 3D CSS card flip component on hover using `perspective` and `rotateY`. Zero JavaScript required.

## Changes
- `submissions/examples/flip-card/style.css` — flip card component styles
- `submissions/examples/flip-card/demo.html` — live demo
- `submissions/examples/flip-card/README.md` — documentation

## Related Issue
Closes #3834

## Preview
- Smooth 3D hover flip using rotateY (horizontal)
- Vertical flip variant using rotateX
- Click/focus variant using CSS :focus-within (zero JS)
- Fast (0.3s) and slow (1s) speed variants
- Accessible: keyboard-navigable via tabindex + hidden checkbox trigger
- prefers-reduced-motion fallback