### PR TITLE
feat: add ease-info-color-utils submission for info text/bg utilities (#5476)

### DIFF
--- a/submissions/examples/ease-info-color-utils/README.md
+++ b/submissions/examples/ease-info-color-utils/README.md
@@ -1,0 +1,28 @@
+# ease-info-color-utils
+
+Submission proposing `.ease-text-info` and `.ease-bg-info` utility classes (plus light/dark variants) for the `--ease-color-info` design token, completing the semantic color utility API alongside success, warning, and danger.
+
+## Token-to-Utility Mapping
+
+| CSS Variable | Utility Class | Usage |
+| --- | --- | --- |
+| `--ease-color-info` | `.ease-text-info` | Info-colored text (links, icons, labels) |
+| `--ease-color-info` | `.ease-bg-info` | Solid info background (badges, buttons) |
+| `--ease-color-info-light` | `.ease-text-info-light` | Light info text on dark surfaces |
+| `--ease-color-info-light` | `.ease-bg-info-light` | Subtle info panel or alert background |
+| `--ease-color-info-dark` | `.ease-text-info-dark` | High-contrast info headings on light backgrounds |
+| `--ease-color-info-dark` | `.ease-bg-info-dark` | Deep info accent background |
+
+## Example
+
+```html
+<div class="ease-bg-info-light" style="border-left: 4px solid var(--ease-color-info); padding: 1rem;">
+  <span class="ease-text-info">ℹ</span>
+  <strong class="ease-text-info-dark">Information</strong>
+  <p>Your changes were saved successfully.</p>
+</div>
+```
+
+## Token requirement
+
+`--ease-color-info`, `--ease-color-info-light`, and `--ease-color-info-dark` must be defined on `:root`. They are provided by `core/variables.css` when integrated into the framework. Override them in your own `:root` block to theme the info palette.

--- a/submissions/examples/ease-info-color-utils/demo.html
+++ b/submissions/examples/ease-info-color-utils/demo.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-info-color-utils Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      padding: 2rem;
+      font-family: system-ui, -apple-system, sans-serif;
+      line-height: 1.6;
+      color: #1e293b;
+      background: #f8fafc;
+    }
+
+    h1 {
+      margin: 0 0 0.5rem;
+      font-size: 1.75rem;
+    }
+
+    .page-intro {
+      margin: 0 0 2rem;
+      color: #64748b;
+    }
+
+    section {
+      margin-bottom: 2.5rem;
+    }
+
+    section h2 {
+      margin: 0 0 1rem;
+      font-size: 1.125rem;
+      font-weight: 600;
+    }
+
+    /* Section 1 — Info Alert */
+    .info-alert {
+      display: flex;
+      gap: 0.75rem;
+      align-items: flex-start;
+      max-width: 32rem;
+      padding: 1rem 1.25rem;
+      border-left: 4px solid var(--ease-color-info);
+      border-radius: 0.5rem;
+    }
+
+    .info-alert-icon {
+      font-size: 1.25rem;
+      line-height: 1;
+      flex-shrink: 0;
+    }
+
+    .info-alert-heading {
+      margin: 0 0 0.25rem;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+
+    .info-alert-body {
+      margin: 0;
+      font-size: 0.875rem;
+      color: #334155;
+    }
+
+    /* Section 2 — Info Badges */
+    .badge-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .badge {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.5rem 1rem;
+      border-radius: 9999px;
+      font-size: 0.8125rem;
+      font-weight: 600;
+    }
+
+    .badge-label {
+      font-size: 0.6875rem;
+      font-weight: 400;
+      opacity: 0.85;
+    }
+
+    .badge-on-dark {
+      background: #1e293b;
+      padding: 1rem;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    /* Section 3 — Color Swatches */
+    .swatch-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.25rem;
+    }
+
+    .swatch {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .swatch-box {
+      width: 100px;
+      height: 100px;
+      border-radius: 0.5rem;
+      border: 1px solid rgba(0, 0, 0, 0.08);
+    }
+
+    .swatch-info {
+      background-color: var(--ease-color-info);
+    }
+
+    .swatch-info-light {
+      background-color: var(--ease-color-info-light);
+    }
+
+    .swatch-info-dark {
+      background-color: var(--ease-color-info-dark);
+    }
+
+    .swatch-label {
+      margin: 0;
+      font-size: 0.75rem;
+      color: #64748b;
+      font-family: ui-monospace, monospace;
+    }
+
+    /* Section 4 — Semantic comparison (demo scaffolding for other colors) */
+    .ease-bg-success {
+      background-color: #22c55e;
+    }
+
+    .ease-bg-warning {
+      background-color: #f59e0b;
+    }
+
+    .ease-bg-danger {
+      background-color: #ef4444;
+    }
+
+    .comparison-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .comparison-chip {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      min-width: 6rem;
+    }
+
+    .comparison-swatch {
+      width: 80px;
+      height: 80px;
+      border-radius: 0.5rem;
+      border: 1px solid rgba(0, 0, 0, 0.08);
+    }
+
+    .comparison-label {
+      margin: 0;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: capitalize;
+    }
+
+    .comparison-class {
+      margin: 0;
+      font-size: 0.6875rem;
+      color: #64748b;
+      font-family: ui-monospace, monospace;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>ease-info-color-utils</h1>
+  <p class="page-intro">Text and background utilities for the <code>--ease-color-info</code> semantic token family.</p>
+
+  <!-- Section 1 — Info Alert -->
+  <section>
+    <h2>Info Alert</h2>
+    <div class="info-alert ease-bg-info-light" role="status">
+      <span class="info-alert-icon ease-text-info" aria-hidden="true">ℹ</span>
+      <div>
+        <p class="info-alert-heading ease-text-info-dark">Information</p>
+        <p class="info-alert-body">Your session will expire in 15 minutes. Save your work to avoid losing changes.</p>
+        <p class="info-alert-body">You can extend your session from the account settings page.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2 — Info Badges -->
+  <section>
+    <h2>Info Badges</h2>
+    <div class="badge-row">
+      <span class="badge ease-bg-info" style="color: #ffffff;">
+        Info
+        <span class="badge-label">.ease-bg-info</span>
+      </span>
+      <span class="badge ease-bg-info-light ease-text-info-dark">
+        Info
+        <span class="badge-label">.ease-bg-info-light .ease-text-info-dark</span>
+      </span>
+      <span class="badge-on-dark">
+        <span class="badge ease-text-info" style="background: transparent;">
+          Info
+          <span class="badge-label">.ease-text-info on dark</span>
+        </span>
+      </span>
+      <span class="badge ease-text-info-dark" style="background: #ffffff;">
+        Info
+        <span class="badge-label">.ease-text-info-dark on light</span>
+      </span>
+    </div>
+  </section>
+
+  <!-- Section 3 — Color Swatches -->
+  <section>
+    <h2>Color Swatches</h2>
+    <div class="swatch-row">
+      <div class="swatch">
+        <div class="swatch-box swatch-info"></div>
+        <p class="swatch-label">--ease-color-info<br>#3b82f6</p>
+      </div>
+      <div class="swatch">
+        <div class="swatch-box swatch-info-light"></div>
+        <p class="swatch-label">--ease-color-info-light<br>#eff6ff</p>
+      </div>
+      <div class="swatch">
+        <div class="swatch-box swatch-info-dark"></div>
+        <p class="swatch-label">--ease-color-info-dark<br>#1d4ed8</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 4 — Comparison -->
+  <section>
+    <h2>Semantic Color Comparison</h2>
+    <div class="comparison-row">
+      <div class="comparison-chip">
+        <div class="comparison-swatch ease-bg-success"></div>
+        <p class="comparison-label">Success</p>
+        <p class="comparison-class">.ease-bg-success</p>
+      </div>
+      <div class="comparison-chip">
+        <div class="comparison-swatch ease-bg-warning"></div>
+        <p class="comparison-label">Warning</p>
+        <p class="comparison-class">.ease-bg-warning</p>
+      </div>
+      <div class="comparison-chip">
+        <div class="comparison-swatch ease-bg-danger"></div>
+        <p class="comparison-label">Danger</p>
+        <p class="comparison-class">.ease-bg-danger</p>
+      </div>
+      <div class="comparison-chip">
+        <div class="comparison-swatch ease-bg-info"></div>
+        <p class="comparison-label">Info</p>
+        <p class="comparison-class">.ease-bg-info</p>
+      </div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-info-color-utils/style.css
+++ b/submissions/examples/ease-info-color-utils/style.css
@@ -1,0 +1,29 @@
+:root {
+  --ease-color-info: #3b82f6;
+  --ease-color-info-light: #eff6ff;
+  --ease-color-info-dark: #1d4ed8;
+}
+
+.ease-text-info {
+  color: var(--ease-color-info);
+}
+
+.ease-bg-info {
+  background-color: var(--ease-color-info);
+}
+
+.ease-text-info-light {
+  color: var(--ease-color-info-light);
+}
+
+.ease-bg-info-light {
+  background-color: var(--ease-color-info-light);
+}
+
+.ease-text-info-dark {
+  color: var(--ease-color-info-dark);
+}
+
+.ease-bg-info-dark {
+  background-color: var(--ease-color-info-dark);
+}


### PR DESCRIPTION
## Summary

Adds a self-contained submission at `submissions/examples/ease-info-color-utils/` proposing `.ease-text-info`, `.ease-bg-info`, and light/dark variants to complete the semantic color utility API. Core already defines `--ease-color-info` tokens but `core/utilities.css` has no matching text/background helpers (unlike success, warning, and danger).

Closes #5476

## What's included

| File | Description |
|------|-------------|
| `style.css` | `:root` fallbacks + 6 info color utility classes |
| `demo.html` | Offline demo: info alert, badges, color swatches, semantic comparison row |
| `README.md` | Token-to-utility mapping table, usage example, token requirement note |

## Utility classes proposed

- `.ease-text-info` / `.ease-bg-info`
- `.ease-text-info-light` / `.ease-bg-info-light`
- `.ease-text-info-dark` / `.ease-bg-info-dark`

## Acceptance criteria

- [x] `.ease-text-info { color: var(--ease-color-info); }`
- [x] `.ease-bg-info { background-color: var(--ease-color-info); }`
- [x] Optional light/dark text and background variants
- [x] `demo.html` shows info alert and badge components using the new classes
- [x] `demo.html` works fully offline (no external CDN or image dependencies)
- [x] `README.md` documents token-to-utility mapping with a table

## How to test

1. Check out this branch
2. Open `submissions/examples/ease-info-color-utils/demo.html` in a browser (file:// or local server)
3. Confirm all four sections render: alert, badges, swatches, semantic comparison
4. Disable network in DevTools and reload — demo should still work

## Notes

- No `core/`, `components/`, or `docs/` files were modified (submission-only PR per contribution freeze)
- Comparison row uses demo-scoped `.ease-bg-success` / `.ease-bg-warning` / `.ease-bg-danger` in `demo.html` `<style>` so the info slot can be shown alongside existing semantic colors offline