### PR TITLE
fix : added badge info warning and neutral color variants

### DIFF
--- a/components/badges.css
+++ b/components/badges.css
@@ -25,21 +25,6 @@
     background-color: var(--ease-color-success);
   }
 
-  .em-badge-info,
-  .ease-badge-info {
-    background-color: var(--ease-color-info);
-  }
-
-  .em-badge-warning,
-  .ease-badge-warning {
-    background-color: var(--ease-color-warning);
-  }
-
-  .em-badge-neutral,
-  .ease-badge-neutral {
-    background-color: var(--ease-color-neutral-600);
-  }
-
   /* Pulsing glow variant */
   .em-badge-pulse,
   .ease-badge-pulse {

--- a/components/badges.css
+++ b/components/badges.css
@@ -25,6 +25,21 @@
     background-color: var(--ease-color-success);
   }
 
+  .em-badge-info,
+  .ease-badge-info {
+    background-color: var(--ease-color-info);
+  }
+
+  .em-badge-warning,
+  .ease-badge-warning {
+    background-color: var(--ease-color-warning);
+  }
+
+  .em-badge-neutral,
+  .ease-badge-neutral {
+    background-color: var(--ease-color-neutral-600);
+  }
+
   /* Pulsing glow variant */
   .em-badge-pulse,
   .ease-badge-pulse {

--- a/submissions/examples/badge-color-variants-tm/README.md
+++ b/submissions/examples/badge-color-variants-tm/README.md
@@ -1,0 +1,40 @@
+# Badge Color Variants
+
+## What does this do?
+Adds info, warning, and neutral color variants to the existing badge
+component, alongside the existing primary, danger, and success variants.
+
+## How is it used?
+Add the new variant class to a `.ease-badge` element:
+
+    <span class="ease-badge ease-badge-info">3</span>
+    <span class="ease-badge ease-badge-warning">!</span>
+    <span class="ease-badge ease-badge-neutral">12</span>
+
+## Why is it useful?
+The framework defines `--ease-color-info`, `--ease-color-warning`, and
+`--ease-color-neutral-600` design tokens but the badge component did not
+expose them as named classes. This submission adds the missing variants
+so badges can communicate status without inline color overrides.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open demo.html directly in your browser to see the six badge color
+variants side by side.
+
+## Contribution Notes
+- Class naming was handled by the contributor
+- Maintainer will rename to ease-* convention before merging
+- The .em-badge-* alias convention from the existing danger/success
+  variants is mirrored here
+
+## Variants
+- .ease-badge (default, primary)
+- .ease-badge-info
+- .ease-badge-warning
+- .ease-badge-neutral
+- .ease-badge-danger (already in framework)
+- .ease-badge-success (already in framework)

--- a/submissions/examples/badge-color-variants-tm/demo.html
+++ b/submissions/examples/badge-color-variants-tm/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Badge Color Variants - EaseMotion CSS</title>
+
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+
+    <h1>Badge Color Variants</h1>
+    <p class="description">
+      Self-contained demo of the proposed info, warning, and neutral
+      badge color variants. The danger and success variants are already
+      part of the framework and are shown for comparison.
+    </p>
+
+    <section class="demo-row">
+      <span class="ease-badge">12</span>
+      <code>.ease-badge</code>
+    </section>
+
+    <section class="demo-row">
+      <span class="ease-badge ease-badge-info">i</span>
+      <code>.ease-badge.ease-badge-info</code>
+    </section>
+
+    <section class="demo-row">
+      <span class="ease-badge ease-badge-warning">!</span>
+      <code>.ease-badge.ease-badge-warning</code>
+    </section>
+
+    <section class="demo-row">
+      <span class="ease-badge ease-badge-neutral">.</span>
+      <code>.ease-badge.ease-badge-neutral</code>
+    </section>
+
+    <section class="demo-row">
+      <span class="ease-badge ease-badge-danger">3</span>
+      <code>.ease-badge.ease-badge-danger</code>
+    </section>
+
+    <section class="demo-row">
+      <span class="ease-badge ease-badge-success">5</span>
+      <code>.ease-badge.ease-badge-success</code>
+    </section>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/badge-color-variants-tm/style.css
+++ b/submissions/examples/badge-color-variants-tm/style.css
@@ -1,0 +1,46 @@
+/* ============================================================
+   EaseMotion CSS — Submission: badge color variants
+   Self-contained snippet. The maintainer will merge the
+   .ease-badge-info, .ease-badge-warning, and .ease-badge-neutral
+   rules into components/badges.css.
+   ============================================================ */
+
+.demo-wrapper {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  min-height: 100vh;
+}
+
+.demo-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.9rem;
+}
+
+.demo-row code {
+  font-family: var(--ease-font-mono, monospace);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}
+
+/* --- Proposed new badge color variants --- */
+
+.ease-badge-info {
+  background-color: var(--ease-color-info, #3b82f6);
+}
+
+.ease-badge-warning {
+  background-color: var(--ease-color-warning, #f59e0b);
+}
+
+.ease-badge-neutral {
+  background-color: var(--ease-color-neutral-600, #475569);
+}


### PR DESCRIPTION
Closes #5515.

Summary of What Has Been Done:
Added the missing badge color variants for info, warning, and neutral in components/badges.css, following the pattern used by the existing danger and success variants.

Changes Made:
- New .ease-badge-info rule using --ease-color-info
- New .ease-badge-warning rule using --ease-color-warning
- New .ease-badge-neutral rule using --ease-color-neutral-600
- Mirrored the .em-badge-* aliases that already exist.

Impact it Made:
Completes the badge color surface area and aligns it with the design tokens. npm run lint and npm test both pass.