### PR TITLE
fix : added size variants to badge component

### DIFF
--- a/components/badges.css
+++ b/components/badges.css
@@ -25,6 +25,23 @@
     background-color: var(--ease-color-success);
   }
 
+  /* Size Variants */
+  .em-badge-sm,
+  .ease-badge-sm {
+    height: 16px;
+    min-width: 16px;
+    padding: 0 var(--ease-space-1, 0.25rem);
+    font-size: 0.625rem;
+  }
+
+  .em-badge-lg,
+  .ease-badge-lg {
+    height: 24px;
+    min-width: 24px;
+    padding: 0 var(--ease-space-3, 0.75rem);
+    font-size: var(--ease-text-sm, 0.875rem);
+  }
+
   /* Pulsing glow variant */
   .em-badge-pulse,
   .ease-badge-pulse {


### PR DESCRIPTION
Closes #5516.

Summary of What Has Been Done:
Added .ease-badge-sm and .ease-badge-lg size variants to components/badges.css for parity with buttons, chips, and forms.

Changes Made:
- New .ease-badge-sm with reduced padding and font-size
- New .ease-badge-lg with increased padding, height, and font-size
- Both use existing --ease-space-* and --ease-text-* tokens.

Impact it Made:
Makes the badge composable in dense and hero contexts without inline overrides. npm run lint and npm test both pass.