### PR TITLE
refactor : reset transform on chip hover under reduced motion

### DIFF
--- a/components/chip.css
+++ b/components/chip.css
@@ -123,6 +123,7 @@
 @media (prefers-reduced-motion: reduce) {
   .ease-chip {
     transition: none !important;
+    transform: none !important;
   }
 }
 


### PR DESCRIPTION
Closes #5517.

Summary of What Has Been Done:
Extended the existing prefers-reduced-motion block in chip.css to also reset transform, so users with motion sensitivity no longer see the 1px chip lift on hover.

Changes Made:
- Added transform: none !important; to the reduced-motion block for .ease-chip in components/chip.css.

Impact it Made:
Closes a real vestibular accessibility gap and aligns chip behavior with how the framework already handles button, card, and hover effects. npm run lint and npm test both pass.