### PR TITLE
refactor : reset transform on card hover under reduced motion

### DIFF
--- a/components/cards.css
+++ b/components/cards.css
@@ -307,6 +307,10 @@
   .ease-card-glow {
     transition: none !important;
   }
+  .ease-card-neumorphic {
+    transition: none !important;
+    transform: none !important;
+  }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
Closes #5518.

Summary of What Has Been Done:
Extended the existing prefers-reduced-motion block in cards.css to also reset transform for .ease-card-neumorphic, which applies translateY on hover.

Changes Made:
- Added transform: none !important; to the reduced-motion block for .ease-card-neumorphic in components/cards.css.

Impact it Made:
Fixes a vestibular accessibility regression in the card neumorphic hover variant. npm run lint and npm test both pass.