### PR TITLE
fix : added min-height to .ease-card-footer to prevent collapse

### DIFF
--- a/components/cards.css
+++ b/components/cards.css
@@ -37,6 +37,7 @@
   display: flex;
   align-items: center;
   gap: var(--ease-space-3, 0.75rem);
+  min-height: var(--ease-space-12, 3rem);
 }
 
 /* Card title & subtitle helpers */


### PR DESCRIPTION
Closes #5519.

Summary of What Has Been Done:
Added a sensible min-height to .ease-card-footer so the footer does not collapse to a single border line when it has no children.

Changes Made:
- .ease-card-footer now has min-height: var(--ease-space-12, 3rem); in components/cards.css.

Impact it Made:
Prevents an empty footer from collapsing in common card compositions such as loading skeletons. npm run lint and npm test both pass.