### PR TITLE
fix : extended tab focus-visible rule to support 8 tabs

### DIFF
--- a/components/tabs.css
+++ b/components/tabs.css
@@ -42,7 +42,9 @@
   .ease-tab-input:nth-of-type(3):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3),
   .ease-tab-input:nth-of-type(4):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(4),
   .ease-tab-input:nth-of-type(5):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
-  .ease-tab-input:nth-of-type(6):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6) {
+  .ease-tab-input:nth-of-type(6):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6),
+  .ease-tab-input:nth-of-type(7):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(7),
+  .ease-tab-input:nth-of-type(8):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8) {
     outline: 2px solid var(--ease-color-primary);
     outline-offset: -2px;
   }
@@ -70,7 +72,9 @@
   .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3),
   .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(4),
   .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
-  .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6) {
+  .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6),
+  .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(7),
+  .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8) {
     color: var(--ease-color-primary);
   }
 
@@ -81,6 +85,8 @@
   .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(300%); }
   .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(400%); }
   .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(500%); }
+  .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(600%); }
+  .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(700%); }
 
   /* Content Panel toggling */
   .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(1),


### PR DESCRIPTION
Closes #5520.

Summary of What Has Been Done:
Extended the tabs focus-visible, :checked sibling, and underline translation rules in components/tabs.css to cover 7 and 8 tabs in addition to the existing 1..6 range.

Changes Made:
- Added two more nth-of-type rules in the focus-visible block, the :checked block, and the underline translation block in components/tabs.css.

Impact it Made:
Removes a silent keyboard-accessibility regression for tab groups with more than 6 tabs. npm run lint and npm test both pass.