### PR TITLE
test : added unit tests for card modifier classes

### DIFF
--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -86,6 +86,16 @@ const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
     expect(selectors).toContain('.ease-sidebar');
   });
 
+  it('should expose card modifier classes', () => {
+    expect(css).toContain('.ease-card-hover');
+    expect(css).toContain('.ease-card-glow');
+    expect(css).toContain('.ease-card-glass');
+    expect(css).toContain('.ease-card-neumorphic');
+    expect(css).toContain('.ease-card-flat');
+    expect(css).toContain('.ease-card-outlined');
+    expect(css).toContain('.ease-card-image');
+  });
+
   it('should hide plain text in loading buttons and keep the spinner visible', () => {
     expect(css).toContain('.ease-btn-loading');
     expect(css).toContain('font-size: 0');


### PR DESCRIPTION
Closes #5522.

Summary of What Has Been Done:
Added a Vitest block that asserts the card modifier classes are present in the bundle.

Changes Made:
- New it block: should expose card modifier classes
- Asserts .ease-card-hover, .ease-card-glow, .ease-card-glass, .ease-card-neumorphic, .ease-card-flat, .ease-card-outlined, and .ease-card-image are present in the bundle.

Impact it Made:
Brings the smoke test in line with the actual card surface area. Tests pass locally.