### PR TITLE
docs : added explanatory comment to scroll-progress keyframes

### DIFF
--- a/components/scroll-progress.css
+++ b/components/scroll-progress.css
@@ -3,7 +3,13 @@
    Pure CSS Scroll-Driven Progress Bar Component
    ============================================================ */
 
-/* ── Keyframes (outside @layer so they resolve globally) ───── */
+/* ── Keyframes ────────────────────────────────────────
+   This keyframe is consumed by the scroll-driven animation
+   declared later in this file via `animation-timeline: scroll()`.
+   It must live OUTSIDE the @layer block because CSS keyframes
+   are not cascade-layered: declaring them inside a layer can
+   prevent the binding from resolving in some browsers.
+   ─────────────────────────────────────────────────────── */
 @keyframes ease-kf-scroll-progress {
   from {
     transform: scaleX(0);


### PR DESCRIPTION
Closes #5525.

Summary of What Has Been Done:
Replaced the single-line comment above the @keyframes ease-kf-scroll-progress block in components/scroll-progress.css with a longer comment that explains the scroll-driven animation context.

Changes Made:
- Replaced the existing one-line comment in components/scroll-progress.css with a longer block that mentions the animation-timeline: scroll() binding and explains why the keyframes are placed outside the @layer.

Impact it Made:
Helps future contributors understand the scroll-driven animation mechanism. npm run lint and npm test both pass.