### PR TITLE
feat: add toggle switch submission (issue #5566)

### DIFF
--- a/submissions/examples/toggle-switch-miller/README.md
+++ b/submissions/examples/toggle-switch-miller/README.md
@@ -1,0 +1,17 @@
+# Toggle Switch
+
+1. **What does this do?**
+   A fully CSS-driven toggle switch with a smooth spring-eased sliding animation on state change.
+
+2. **How is it used?**
+   ```html
+   <label class="toggle">
+     <input type="checkbox">
+     <span class="toggle-track">
+       <span class="toggle-knob"></span>
+     </span>
+   </label>
+   ```
+
+3. **Why is it useful?**
+   Zero JavaScript, pure CSS checkbox hack. The transition and micro-interaction ARE the component — animation-first by nature. Composable size variants (sm, default, lg) read like plain English.

--- a/submissions/examples/toggle-switch-miller/demo.html
+++ b/submissions/examples/toggle-switch-miller/demo.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toggle Switch — Submission Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      background: #f8fafc;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 48px;
+      padding: 40px 20px;
+    }
+
+    h2 {
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #94a3b8;
+      margin: 0 0 16px 0;
+    }
+
+    .demo-group {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .demo-row {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 12px;
+    }
+
+    span.label {
+      font-size: 14px;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Default -->
+  <div class="demo-group">
+    <h2>Default</h2>
+    <div class="demo-row">
+      <label class="toggle">
+        <input type="checkbox">
+        <span class="toggle-track">
+          <span class="toggle-knob"></span>
+        </span>
+      </label>
+      <span class="label">Off</span>
+    </div>
+    <div class="demo-row">
+      <label class="toggle">
+        <input type="checkbox" checked>
+        <span class="toggle-track">
+          <span class="toggle-knob"></span>
+        </span>
+      </label>
+      <span class="label">On</span>
+    </div>
+  </div>
+
+  <!-- Sizes -->
+  <div class="demo-group">
+    <h2>Sizes</h2>
+    <div class="demo-row">
+      <label class="toggle toggle-sm">
+        <input type="checkbox" checked>
+        <span class="toggle-track">
+          <span class="toggle-knob"></span>
+        </span>
+      </label>
+      <span class="label">Small</span>
+    </div>
+    <div class="demo-row">
+      <label class="toggle">
+        <input type="checkbox" checked>
+        <span class="toggle-track">
+          <span class="toggle-knob"></span>
+        </span>
+      </label>
+      <span class="label">Default</span>
+    </div>
+    <div class="demo-row">
+      <label class="toggle toggle-lg">
+        <input type="checkbox" checked>
+        <span class="toggle-track">
+          <span class="toggle-knob"></span>
+        </span>
+      </label>
+      <span class="label">Large</span>
+    </div>
+  </div>
+
+  <!-- Disabled -->
+  <div class="demo-group">
+    <h2>Disabled</h2>
+    <div class="demo-row">
+      <label class="toggle">
+        <input type="checkbox" disabled>
+        <span class="toggle-track">
+          <span class="toggle-knob"></span>
+        </span>
+      </label>
+      <span class="label">Disabled off</span>
+    </div>
+    <div class="demo-row">
+      <label class="toggle">
+        <input type="checkbox" checked disabled>
+        <span class="toggle-track">
+          <span class="toggle-knob"></span>
+        </span>
+      </label>
+      <span class="label">Disabled on</span>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/toggle-switch-miller/style.css
+++ b/submissions/examples/toggle-switch-miller/style.css
@@ -1,0 +1,88 @@
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  gap: 10px;
+  user-select: none;
+}
+
+.toggle input {
+  display: none;
+}
+
+.toggle-track {
+  display: inline-flex;
+  align-items: center;
+  width: 52px;
+  height: 28px;
+  background: #cbd5e1;
+  border-radius: 999px;
+  padding: 3px;
+  transition: background 0.3s ease;
+  cursor: pointer;
+}
+
+.toggle-knob {
+  width: 22px;
+  height: 22px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toggle input:checked + .toggle-track {
+  background: #7c3aed;
+}
+
+.toggle input:checked + .toggle-track .toggle-knob {
+  transform: translateX(24px);
+}
+
+/* Small variant */
+.toggle-sm .toggle-track {
+  width: 38px;
+  height: 20px;
+  padding: 2px;
+}
+
+.toggle-sm .toggle-knob {
+  width: 16px;
+  height: 16px;
+}
+
+.toggle-sm input:checked + .toggle-track .toggle-knob {
+  transform: translateX(18px);
+}
+
+/* Large variant */
+.toggle-lg .toggle-track {
+  width: 68px;
+  height: 36px;
+  padding: 4px;
+}
+
+.toggle-lg .toggle-knob {
+  width: 28px;
+  height: 28px;
+}
+
+.toggle-lg input:checked + .toggle-track .toggle-knob {
+  transform: translateX(32px);
+}
+
+/* Disabled state */
+.toggle input:disabled + .toggle-track {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+@media (prefers-color-scheme: dark) {
+  .toggle-track {
+    background: #334155;
+  }
+
+  .toggle input:checked + .toggle-track {
+    background: #7c3aed;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a fully CSS-driven toggle switch component with smooth spring-eased knob animation, three size variants (sm, default, lg), disabled state, and dark mode support. Zero JavaScript required.

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/toggle-switch-miller/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A pure CSS toggle switch with spring-eased slide animation, three size variants, disabled state, and dark mode support.

**How does a developer use it?**
```html
<label class="toggle">
  <input type="checkbox">
  <span class="toggle-track">
    <span class="toggle-knob"></span>
  </span>
</label>

<!-- Small -->
<label class="toggle toggle-sm">
  <input type="checkbox">
  <span class="toggle-track">
    <span class="toggle-knob"></span>
  </span>
</label>

<!-- Large -->
<label class="toggle toggle-lg">
  <input type="checkbox">
  <span class="toggle-track">
    <span class="toggle-knob"></span>
  </span>
</label>
```

**Why does it fit EaseMotion CSS?**
The spring-eased knob transition is the entire component — animation-first by design. Class names `toggle`, `toggle-sm`, `toggle-lg` are instantly readable. Pure CSS checkbox hack, zero JavaScript, dark mode included.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Used `cubic-bezier(0.34, 1.56, 0.64, 1)` for a spring bounce effect on the knob. Timing and easing freely adjustable. Dark mode via `prefers-color-scheme: dark`. All naming left un-prefixed for maintainer to standardize.

Closes #5566