### PR TITLE
docs : proposed file-level header for easemotion/bounce.css

### DIFF
--- a/submissions/examples/bounce-docs-tm/README.md
+++ b/submissions/examples/bounce-docs-tm/README.md
@@ -1,0 +1,30 @@
+# Bounce Animation File Header
+
+## What does this do?
+Proposes adding a file-level documentation comment block at the top
+of `easemotion/bounce.css` to match the convention used by other
+animation files in the framework. Linked to issue #5569.
+
+## How is it used?
+Documentation-only change. The maintainer will paste the proposed
+header into `easemotion/bounce.css`.
+
+## Why is it useful?
+Most files in `easemotion/` and `components/` start with a comment
+block that describes the file's purpose. `bounce.css` was the only
+holdout in `easemotion/` — it jumped straight from the file-purpose
+line into the `@layer` declaration with no header banner. Adding
+the banner improves discoverability and consistency.
+
+## Tech Stack
+- CSS (no frameworks, no JavaScript)
+- Pure documentation change
+
+## Preview
+Open `style.css` in this folder to see the proposed header, or
+compare against `easemotion/zoom.css` and `easemotion/rotate.css`
+in the framework.
+
+## Contribution Notes
+- Documentation only, no runtime changes
+- Maintainer pastes the header at the top of `easemotion/bounce.css`

--- a/submissions/examples/bounce-docs-tm/demo.html
+++ b/submissions/examples/bounce-docs-tm/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Bounce File Header - EaseMotion CSS</title>
+
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+
+    <h1>Bounce File Header</h1>
+    <p class="description">
+      Submission proposing a file-level documentation header for
+      <code>easemotion/bounce.css</code>. No runtime CSS changes —
+      the boxes below are just a side-by-side preview of the
+      proposed header.
+    </p>
+
+    <section class="demo-row">
+      <h2>Proposed header</h2>
+      <pre class="header-preview">/* ============================================================
+   EaseMotion CSS — bounce.css
+   Bounce, spring, and elastic-entrance animation utilities
+   ============================================================ */</pre>
+    </section>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/bounce-docs-tm/style.css
+++ b/submissions/examples/bounce-docs-tm/style.css
@@ -1,0 +1,33 @@
+/* ============================================================
+   Submission: bounce file header
+   No runtime CSS changes. Styles the documentation preview page.
+   ============================================================ */
+
+.demo-wrapper {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  min-height: 100vh;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.demo-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.header-preview {
+  font-family: var(--ease-font-mono, monospace);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 1rem;
+  border-radius: 6px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+}


### PR DESCRIPTION
Closes #5569.

Summary of What Has Been Done:
Added a self-contained submission folder under submissions/examples/bounce-docs-tm/ that proposes a file-level documentation header for easemotion/bounce.css.

Changes Made:
- submissions/examples/bounce-docs-tm/README.md describing the proposal
- submissions/examples/bounce-docs-tm/demo.html previewing the proposed header
- submissions/examples/bounce-docs-tm/style.css styles for the preview page

Impact it Made:
Closes a real file-level documentation gap. The maintainer can copy the proposed header into easemotion/bounce.css without touching this PR. Submission structure passes the validator.