### PR TITLE
fix : proposed --ease-color-info-alpha design token

### DIFF
--- a/submissions/examples/info-alpha-token-tm/README.md
+++ b/submissions/examples/info-alpha-token-tm/README.md
@@ -1,0 +1,37 @@
+# Info Alpha Design Token
+
+## What does this do?
+Proposes adding `--ease-color-info-alpha` to the alpha-token
+block in `core/variables.css`, matching the pattern used for
+`--ease-color-primary-alpha`, `--ease-color-success-alpha`,
+`--ease-color-danger-alpha`, and `--ease-color-warning-alpha`.
+Linked to issue #5577.
+
+## How is it used?
+This is a one-line design-token addition. Once the maintainer
+copies the line into `core/variables.css`, the info color becomes
+themable through a single source of truth.
+
+## Why is this useful?
+The framework defines an `--ease-color-info` token at full opacity
+but no alpha counterpart. The warning alpha token was added
+recently (see #5511), and info is the last color in the palette
+missing its alpha sibling. Adding the token completes the set
+and unblocks a future `.ease-input-info` state contribution.
+
+## Tech Stack
+- CSS (no frameworks, no JavaScript)
+- Pure design-token change
+
+## Preview
+Open `demo.html` in this folder to see the proposed token in
+action. The boxes below use the token to demonstrate that the
+info alpha is now themable from `:root`.
+
+## Contribution Notes
+- One-line change in `core/variables.css`
+- No consumer change required in this PR
+- Backward compatible: existing components that hardcoded
+  `rgba(59, 130, 246, ...)` continue to work
+- See also #5511 (the warning alpha addition) for the prior
+  reference change

--- a/submissions/examples/info-alpha-token-tm/demo.html
+++ b/submissions/examples/info-alpha-token-tm/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Info Alpha Design Token - EaseMotion CSS</title>
+
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h1>Info Alpha Design Token</h1>
+    <p class="description">
+      Submission proposing
+      <code>--ease-color-info-alpha: rgba(59, 130, 246, 0.15);</code>
+      in <code>core/variables.css</code>. The boxes below use the
+      token to demonstrate that the info alpha is now themable
+      from <code>:root</code>. Linked to issue #5577.
+    </p>
+
+    <div class="swatch-row">
+      <div class="swatch default">
+        <code>default token</code>
+        <span>rgba(59, 130, 246, 0.15)</span>
+      </div>
+      <div class="swatch override">
+        <code>overridden</code>
+        <span>rgba(59, 130, 246, 0.35)</span>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/info-alpha-token-tm/style.css
+++ b/submissions/examples/info-alpha-token-tm/style.css
@@ -1,0 +1,65 @@
+/* ============================================================
+   Submission: info alpha design token
+   No changes to core/variables.css itself. This stylesheet
+   styles the documentation preview page.
+   ============================================================ */
+
+:root {
+  /* Proposed new token */
+  --ease-color-info-alpha: rgba(59, 130, 246, 0.15);
+}
+
+.demo-wrapper {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  min-height: 100vh;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.swatch-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.swatch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 220px;
+  height: 100px;
+  border: 2px solid var(--ease-color-info, #3b82f6);
+  border-radius: 8px;
+  color: var(--ease-color-info-dark, #1d4ed8);
+  font-weight: 600;
+}
+
+.swatch code {
+  background: rgba(255, 255, 255, 0.6);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.8rem;
+}
+
+.swatch span {
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+.swatch.default {
+  background-color: var(--ease-color-info-alpha);
+}
+
+.swatch.override {
+  --ease-color-info-alpha: rgba(59, 130, 246, 0.35);
+  background-color: var(--ease-color-info-alpha);
+}


### PR DESCRIPTION
Closes #5577.

Submission folder under submissions/examples/info-alpha-token-tm/ proposing the missing --ease-color-info-alpha design token. Self-contained, no core file changes.