### PR TITLE
BUG: docs/docs.css references undefined CSS variables causing invalid transition

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -779,7 +779,7 @@ a.sidebar-group-label:hover {
   height: 36px;
   width: auto;
   display: block;
-  transition: filter var(--ease-duration-3) var(--ease-ease-in-out);
+  transition: filter var(--ease-speed-medium) var(--ease-ease);
 }
 
 /* In light theme, invert colors of the transparent SVG to maintain visibility */


### PR DESCRIPTION
## Pull Request Description

Fixes an issue in the documentation stylesheet where undefined CSS custom properties are referenced in a transition declaration.

`docs/docs.css` uses `--ease-duration-3` and `--ease-ease-in-out`, but neither variable exists in the shipped framework bundle (`core/variables.css`, `easemotion.css`, or `easemotion.min.css`). This causes the transition declaration to become invalid and be ignored by browsers.

The fix replaces the undefined tokens with existing framework tokens (or defines the missing tokens) so the transition works as intended.

---
## close #5594 
## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [x] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [ ] All changes are inside `submissions/examples/your-feature-name/`
* [ ] Includes `demo.html` — self-contained, opens in browser with no server
* [ ] Includes `style.css` — raw CSS for the proposed feature
* [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes an invalid transition declaration in the documentation stylesheet by replacing undefined CSS custom properties.

**How does a developer use it?**

No API or class changes. This is an internal documentation bug fix.

**Why does it fit EaseMotion CSS?**

It improves consistency by ensuring documentation uses valid framework design tokens and behaves as intended across browsers.

---

## Demo

* [ ] Demo added (`demo.html` works by opening directly in a browser)

Not applicable for this bug fix.

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [ ] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The issue occurs in `docs/docs.css` where the following declaration references undefined variables:

```css
transition: filter var(--ease-duration-3) var(--ease-ease-in-out);
```

Neither variable is defined in:

* `core/variables.css`
* `easemotion.css`
* `easemotion.min.css`

Because no fallback values are provided, the declaration is invalid and is dropped by browsers.

Suggested replacement:

```css
transition: filter var(--ease-speed-medium) var(--ease-ease);
```

This PR only addresses the undefined token usage and does not introduce any behavioral changes outside the documentation site.
