### PR TITLE
fix: replace hard-coded timing values with speed tokens

### DIFF
--- a/components/buttons.css
+++ b/components/buttons.css
@@ -237,7 +237,7 @@
   border: 2px solid currentColor;
   border-top-color: transparent;
   border-radius: 50%;
-  animation: ease-kf-btn-spin 0.7s linear infinite;
+  animation: ease-kf-btn-spin var(--ease-speed-slow) linear infinite;
 }
 
 @keyframes ease-kf-btn-spin {

--- a/components/loaders.css
+++ b/components/loaders.css
@@ -9,7 +9,7 @@
   .ease-loader-spin {
     border: 3px solid var(--ease-color-neutral-200);
     border-top-color: var(--ease-color-primary);
-    animation: ease-kf-rotate 0.8s var(--ease-ease-linear) infinite;
+    animation: ease-kf-rotate var(--ease-speed-slow) var(--ease-ease-linear) infinite;
   }
 
   .ease-loader-pulse {

--- a/components/sidebar.css
+++ b/components/sidebar.css
@@ -31,8 +31,8 @@
   overflow-y: auto;
   padding: var(--ease-sidebar-main-padding, 2rem);
   transition:
-  transform 0.5s cubic-bezier(0.16, 1, 0.3, 1),
-  border-radius 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+  transform var(--ease-speed-medium) cubic-bezier(0.16, 1, 0.3, 1),
+  border-radius var(--ease-speed-medium) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* ── Collapsible Variant ────────────────────────────────────── */
@@ -79,8 +79,8 @@
     display: none;
     transform: translateX(-100%);
     transition:
-      transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
-      box-shadow 0.3s ease;
+      transform var(--ease-speed-slow) cubic-bezier(0.34, 1.56, 0.64, 1),
+      box-shadow var(--ease-speed-medium) ease;
   }
 
   .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {

--- a/core/animations.css
+++ b/core/animations.css
@@ -1125,7 +1125,7 @@
 }
 .ease-flip-3d-inner {
   transform-style: preserve-3d;
-  transition: transform 0.6s var(--ease-ease);
+  transition: transform var(--ease-speed-slow) var(--ease-ease);
   position: relative;
 }
 .ease-flip-3d:hover .ease-flip-3d-inner {
@@ -1154,15 +1154,15 @@
 /* Mask Reveal Utilities */
 .ease-mask-reveal {
   clip-path: inset(0 100% 0 0);
-  animation: ease-kf-mask-reveal 0.8s var(--ease-ease) forwards;
+  animation: ease-kf-mask-reveal var(--ease-speed-slow) var(--ease-ease) forwards;
 }
 .ease-mask-reveal-y {
   clip-path: inset(100% 0 0 0);
-  animation: ease-kf-mask-reveal-y 0.8s var(--ease-ease) forwards;
+  animation: ease-kf-mask-reveal-y var(--ease-speed-slow) var(--ease-ease) forwards;
 }
 .ease-mask-reveal-circle {
   clip-path: circle(0% at center);
-  animation: ease-kf-mask-reveal-circle 0.8s var(--ease-ease) forwards;
+  animation: ease-kf-mask-reveal-circle var(--ease-speed-slow) var(--ease-ease) forwards;
 }
 
 /* ── Stagger Delay Helpers ─────────────────────────────────── */
@@ -1199,8 +1199,8 @@
   opacity: 0;
   will-change: transform, opacity;
   transition:
-    opacity 0.7s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
-    transform 0.7s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+    opacity var(--ease-speed-slow) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    transform var(--ease-speed-slow) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
 }
 
 .ease-reveal.ease-reveal-active {
@@ -1226,7 +1226,8 @@
 /* Scroll-driven animation (progressive enhancement) */
 @supports (animation-timeline: view()) {
   .ease-reveal {
-    animation: ease-kf-reveal-up 0.7s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+    animation: ease-kf-reveal-up var(--ease-speed-slow)
+          var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
     animation-timeline: view();
     animation-range: entry 0% entry 100%;
     opacity: 1;


### PR DESCRIPTION
## Pull Request Description

This PR resolves Issue #5596 by replacing hard-coded transition and animation timing values with EaseMotion design speed tokens.

The update improves consistency across the framework and ensures users can globally customize animation timing through the existing token system (`--ease-speed-fast`, `--ease-speed-medium`, and `--ease-speed-slow`).

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

> Note: This issue specifically required updates to existing framework files.

---

## Feature Description

**What does this add?**

Replaces remaining hard-coded timing literals with EaseMotion speed tokens to improve global themeability and consistency.

**How does a developer use it?**

No API changes are required. Developers can customize animation speed globally by overriding the existing speed tokens:

```css
:root {
  --ease-speed-fast: 100ms;
  --ease-speed-medium: 200ms;
  --ease-speed-slow: 400ms;
}
```

**Why does it fit EaseMotion CSS?**

EaseMotion promotes a consistent and customizable design system. Using design tokens instead of hard-coded timing values ensures animation behavior remains predictable, maintainable, and globally configurable.

---

## Demo

- [x] Existing demos continue to function correctly after the timing token migration.

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- Replaced hard-coded transition durations in `components/sidebar.css`.
- Replaced hard-coded transition and animation durations in `core/animations.css`.
- Replaced remaining hard-coded animation durations with existing speed tokens.
- Left utility delay helpers (`.ease-delay-*`) unchanged because they intentionally represent fixed delay values.
- Left component-specific configuration durations (e.g. marquee speed and typewriter duration variables) unchanged because they are effect-specific settings rather than transition speed tokens.
- Verified that existing animation behavior remains functional after the migration.