### PR TITLE
feat: add info color utility classes

### DIFF
--- a/core/utilities.css
+++ b/core/utilities.css
@@ -284,6 +284,9 @@
 .ease-text-success   { color: var(--ease-color-success) !important; }
 .ease-text-danger    { color: var(--ease-color-danger) !important; }
 .ease-text-warning   { color: var(--ease-color-warning) !important; }
+.ease-text-info      { color: var(--ease-color-info) !important; }
+.ease-text-info-light{ color: var(--ease-color-info-light) !important; }
+.ease-text-info-dark { color: var(--ease-color-info-dark) !important; }
 .ease-text-muted     { color: var(--ease-color-muted) !important; }
 .ease-text-white     { color: #ffffff !important; }
 
@@ -291,6 +294,9 @@
 .ease-bg-success     { background-color: var(--ease-color-success) !important; }
 .ease-bg-danger      { background-color: var(--ease-color-danger) !important; }
 .ease-bg-warning     { background-color: var(--ease-color-warning) !important; }
+.ease-bg-info        { background-color: var(--ease-color-info) !important; }
+.ease-bg-info-light  { background-color: var(--ease-color-info-light) !important; }
+.ease-bg-info-dark   { background-color: var(--ease-color-info-dark) !important; }
 .ease-bg-white       { background-color: #ffffff !important; }
 .ease-bg-surface     { background-color: var(--ease-color-surface) !important; }
 .ease-bg-neutral     { background-color: var(--ease-color-neutral-100) !important; }

--- a/submission/examples/ease-info-color-utils/README.md
+++ b/submission/examples/ease-info-color-utils/README.md
@@ -1,0 +1,36 @@
+# Info Color Utility Classes
+
+Demonstrates the new semantic info color utility classes.
+
+## Features
+
+* `.ease-text-info` utility class
+* `.ease-bg-info` utility class
+* Informational alert example
+* Informational badge example
+* No external dependencies
+* Fully offline demo
+
+## Token Mapping
+
+| CSS Token           | Utility Class     |
+| ------------------- | ----------------- |
+| `--ease-color-info` | `.ease-text-info` |
+| `--ease-color-info` | `.ease-bg-info`   |
+
+## Usage
+
+Open `demo.html` in a browser.
+
+The demo showcases informational text, alerts, and badges using the new utility classes.
+
+## Files
+
+* `demo.html` – Demo implementation
+* `style.css` – Styling and layout
+* `README.md` – Documentation
+
+## Notes
+
+This example demonstrates how semantic info color tokens can be exposed through utility classes for consistent UI styling.
+

--- a/submission/examples/ease-info-color-utils/demo.html
+++ b/submission/examples/ease-info-color-utils/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS Sandbox — Info Color Utilities</title>
+
+  <link rel="stylesheet" href="./style.css">
+
+  <style>
+    body {
+      background-color: #0b1121;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+      padding: 1rem;
+    }
+  </style>
+
+</head>
+<body>
+
+  <header style="margin-bottom: 2rem; text-align: center; max-width: 500px;">
+    <h1 style="color: white; margin: 0;">
+      Info Color Utility Classes
+    </h1>
+
+```
+<p style="color: #94a3b8;">
+  Demonstration of semantic info color helpers for text and background styling.
+</p>
+```
+
+  </header>
+
+  <section class="alm-info-card">
+
+```
+<div class="alm-info-alert ease-bg-info">
+  ℹ Information alert using .ease-bg-info
+</div>
+
+<div style="margin-top: 1rem;">
+  <span class="alm-info-badge ease-bg-info">
+    INFO
+  </span>
+</div>
+
+<p class="ease-text-info" style="margin-top: 1.5rem;">
+  This text is styled using .ease-text-info
+</p>
+```
+
+  </section>
+
+</body>
+</html>
+

--- a/submission/examples/ease-info-color-utils/style.css
+++ b/submission/examples/ease-info-color-utils/style.css
@@ -1,0 +1,41 @@
+/* ============================================================
+EaseMotion CSS Sandbox — ease-info-color-utils/style.css
+============================================================ */
+
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+/* ── Demo Container ───────────────────────────────────────── */
+
+.alm-info-card {
+background: rgba(255, 255, 255, 0.03);
+border: 1px solid rgba(255, 255, 255, 0.08);
+border-radius: 1rem;
+padding: 1.5rem;
+width: 100%;
+max-width: 500px;
+color: white;
+font-family: system-ui, sans-serif;
+}
+
+/* ── Info Alert Example ───────────────────────────────────── */
+
+.alm-info-alert {
+padding: 1rem;
+border-radius: 0.75rem;
+color: white;
+font-weight: 600;
+}
+
+/* ── Info Badge Example ───────────────────────────────────── */
+
+.alm-info-badge {
+display: inline-block;
+padding: 0.4rem 0.8rem;
+border-radius: 9999px;
+color: white;
+font-size: 0.75rem;
+font-weight: 700;
+letter-spacing: 0.05em;
+}
+


### PR DESCRIPTION
## Pull Request Description

Adds missing utility classes for the existing semantic info color token and provides an offline example demonstrating their usage.

---

## Type of Change

* [x] 📝 Documentation improvement
* [x] Other (core utility enhancement)

---

## Submission Checklist

* [x] Includes `demo.html`
* [x] Includes `style.css`
* [x] Includes `README.md`
* [x] One feature per PR

### Note

This issue explicitly requires updates to `core/utilities.css` to add the missing utility classes. Therefore the "No changes to core/" checklist item does not apply to this contribution.

---

## Feature Description

**What does this add?**

Adds missing semantic info color utility classes:

* `.ease-text-info`
* `.ease-bg-info`

**How does a developer use it?**

```html
<p class="ease-text-info">
  Informational text
</p>

<div class="ease-bg-info">
  Informational alert
</div>
```

**Why does it fit EaseMotion CSS?**

The framework already exposes utility helpers for semantic colors such as warning, success, and danger. This change completes the utility API by exposing the existing `--ease-color-info` token through matching text and background utility classes.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome

---

## Notes for Maintainer

This PR addresses Issue #5476 by exposing the existing `--ease-color-info` semantic token through utility classes and includes a fully offline example demonstrating alert and badge usage.

Fixes #5476
