### PR TITLE
[FIX] Add missing @keyframes ease-kf-zoom-out to core/animations.css

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -270,6 +270,16 @@
   }
 }
 
+@keyframes ease-kf-zoom-out {
+  from {
+    transform: scale(1.5);
+  }
+
+  to {
+    transform: scale(1);
+  }
+}
+
 @keyframes ease-kf-flip {
   from {
     transform: perspective(400px) rotateY(90deg);


### PR DESCRIPTION
## ✦ Description

The `.ease-zoom-out` class in `core/animations.css` referenced `@keyframes ease-kf-zoom-out` but the keyframe was only defined in `easemotion/zoom.css` which is not imported by the main entry point `easemotion.css`. This caused the zoom-out animation to silently fail.

The fix adds the missing keyframe directly into `core/animations.css` so it is always available regardless of which entry point is used.

Fixes #5710

---

## ⟡ Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [x] I have run `npm test` locally and all 9 tests pass.

---

## ⟡ Screenshots / Screen Recordings (Required for UI changes)

N/A — CSS-only fix, no UI changes.

| Before | After |
| :--- | :--- |
| `.ease-zoom-out` referenced non-existent keyframe — animation silent failure | `@keyframes ease-kf-zoom-out` is now defined, animation works |

---

## Description

### Root Cause
Previously `.ease-zoom-out` in `core/animations.css` line 678-679 used:
```css
.ease-zoom-out {
  animation: ease-kf-zoom-out var(--ease-speed-medium) var(--ease-ease) forwards;
}
```
But `@keyframes ease-kf-zoom-out` only existed in `easemotion/zoom.css`, which is an alternative modular entry point and not imported by the main `easemotion.css`.

### Changes Made
- Added `@keyframes ease-kf-zoom-out` block to `core/animations.css` right after `ease-kf-zoom-in` (lines 272-280)
- The keyframe scales from `1.5x` to `1x`, matching the definition in `easemotion/zoom.css`

### Testing Performed
```bash
cd easemotion-css
npm test
```
Result: PASS — all 9 tests passed, including the duplicate keyframe detection test.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

---

## Additional Notes
- No UI or behavior changes beyond fixing the broken animation.
- Branch pushed: Pcmhacker-piro/EaseMotion-css:fix/5710-missing-zoom-out-keyframe
- Compare URL: https://github.com/SAPTARSHI-coder/EaseMotion-css/compare/main...Pcmhacker-piro:fix/5710-missing-zoom-out-keyframe?expand=1