### PR TITLE
fix: resolve all opposing slide direction pairs when both applied (#5782)

### DIFF
--- a/easemotion/slide.css
+++ b/easemotion/slide.css
@@ -152,9 +152,14 @@
   animation: ease-kf-slide-down var(--ease-speed-medium) var(--ease-ease) both;
 }
 
-.ease-slide-up.ease-slide-down {
+.ease-slide-up.ease-slide-down,
+.ease-slide-in-left.ease-slide-in-right,
+.ease-slide-in-from-top.ease-slide-in-from-bottom,
+.ease-slide-in-from-left.ease-slide-in-from-right,
+.ease-slide-in-from-top-left.ease-slide-in-from-bottom-right,
+.ease-slide-in-from-top-right.ease-slide-in-from-bottom-left {
   animation: none !important;
-  transform: translateY(0) !important;
+  transform: none !important;
   opacity: 1 !important;
 }
 


### PR DESCRIPTION
Fixes #5782

Adds conflict resolution rules for all opposing slide direction pairs:
- ease-slide-in-left + ease-slide-in-right
- ease-slide-in-from-top + ease-slide-in-from-bottom
- ease-slide-in-from-left + ease-slide-in-from-right
- ease-slide-in-from-top-left + ease-slide-in-from-bottom-right
- ease-slide-in-from-top-right + ease-slide-in-from-bottom-left

Previously only the ease-slide-up + ease-slide-down pair was handled.