### PR TITLE
fix: change ease-rotate timing from linear to ease matching framework defaults (#5781)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -905,7 +905,7 @@
 }
 
 .ease-rotate {
-  animation: ease-kf-rotate 1.2s linear var(--ease-animation-iterations, infinite);
+  animation: ease-kf-rotate 1.2s var(--ease-ease) var(--ease-animation-iterations, infinite);
 }
 
 .ease-pulse {


### PR DESCRIPTION
Fixes #5781

Changes .ease-rotate default timing function from \linear\ to \ar(--ease-ease)\ to match the default easing of other looping animations (ease-pulse, ease-bounce, ease-wave, etc.).