### PR TITLE
fix: add default min-height to ease-skeleton-block (#5779)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -792,6 +792,7 @@
 .ease-skeleton-block {
   border-radius: var(--ease-radius-md);
   display: block;
+  min-height: 1em;
 }
 
 @property --ease-count {


### PR DESCRIPTION
Fixes #5779

Adds \min-height: 1em\ to \.ease-skeleton-block\ so the skeleton placeholder is visible even when no explicit width or height is set. Previously a bare skeleton-block with no content would be a zero-dimension invisible box.