### PR TITLE
Fix #5713: Proposed fix for undefined --ease-shadow-2xl token in modals component

### DIFF
--- a/submissions/core_changes-5713/README.md
+++ b/submissions/core_changes-5713/README.md
@@ -1,0 +1,14 @@
+# Issue #5713: Undefined CSS variable `--ease-shadow-2xl`
+
+## Description
+`components/modals.css` line 45 uses `var(--ease-shadow-2xl, ...)` for modal `box-shadow`, but `core/variables.css` only defines shadows up to `--ease-shadow-xl`.
+
+## Root Cause
+`--ease-shadow-2xl` was never added to the shadow tokens in `core/variables.css`.
+
+## Proposed Fix
+Add `--ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);` to `:root` and a dark mode override.
+
+## Files
+- `style.css` — declares the missing shadow token
+- `demo.html` — interactive demo

--- a/submissions/core_changes-5713/demo.html
+++ b/submissions/core_changes-5713/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Demo: --ease-shadow-2xl token fix (#5713)</title>
+  <link rel="stylesheet" href="../../easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 2rem;
+      background: var(--ease-color-bg);
+      transition: background 0.3s;
+    }
+    .modal-demo {
+      max-width: 400px;
+      padding: 2rem;
+      border-radius: var(--ease-radius-lg);
+      background: var(--ease-color-surface);
+      box-shadow: var(--ease-shadow-2xl);
+      text-align: center;
+    }
+    .note {
+      margin-top: 2rem;
+      color: var(--ease-color-muted);
+      font-size: var(--ease-text-sm);
+    }
+  </style>
+</head>
+<body>
+  <h1>Modal Shadow — 2XL Token</h1>
+  <div class="modal-demo">
+    <h2>Modal Title</h2>
+    <p>This modal uses <code>--ease-shadow-2xl</code>. Toggle system dark mode to see the shadow adapt.</p>
+  </div>
+  <p class="note">Declared in <code>style.css</code> — should be added to <code>core/variables.css</code>.</p>
+</body>
+</html>

--- a/submissions/core_changes-5713/style.css
+++ b/submissions/core_changes-5713/style.css
@@ -1,0 +1,11 @@
+@layer easemotion-base {
+  :root {
+    --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR addresses issue #5713 — the CSS variable `--ease-shadow-2xl` is referenced in `components/modals.css` (line 45) but never defined in `core/variables.css` (which only defines shadows up to `--ease-shadow-xl`).

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows style guidelines
- [x] Self-review performed
- [x] Documentation updated
- [x] No new warnings
- [x] Fix verified with demo

## Root Cause
`core/variables.css` defines shadow tokens `sm` through `xl` but never `2xl`. `components/modals.css` line 45 references the missing token.

## Changes Made
### Added: `submissions/core_changes-5713/style.css`
- `--ease-shadow-2xl: 0 25px 50px -12px rgba(0,0,0,0.25)` in `:root`
- Dark mode override: `rgba(0,0,0,0.50)`
- Wrapped in `@layer easemotion-base`

### Added: `submissions/core_changes-5713/demo.html` and `README.md`

## Testing Performed
1. Verified shadow renders correctly in light mode
2. Toggled dark mode — shadow deepens appropriately
3. No console errors or CSS warnings

## Additional Notes
Submission-only fix in `submissions/core_changes-5713/`.