### PR TITLE
fix: include forms.css in modular bundle import chain (#5776)

### DIFF
--- a/easemotion/all.css
+++ b/easemotion/all.css
@@ -18,6 +18,6 @@
 @import "../components/loaders.css";
 @import "../components/tooltips.css";
 @import "../components/modals.css";
-
+@import "../components/forms.css";
 
 


### PR DESCRIPTION
Fixes #5776

Adds `@import "../components/forms.css"` to `easemotion/all.css`. The forms component was already imported in the main `easemotion.css` entry point but was missing from the modular `all.css` bundle.