### PR TITLE
fix: ease-hover-morph-card uses themed border-radius instead of hardcoded 0 (#5775)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1107,7 +1107,7 @@
 /* Morphing Card Hover
    Standardized to: .ease-hover-morph-card */
 .ease-hover-morph-card {
-  border-radius: 0;
+  border-radius: var(--ease-radius-md, 0);
   will-change: border-radius, transform;
   transition:
     border-radius var(--ease-speed-medium) var(--ease-ease),


### PR DESCRIPTION
Fixes #5775

Changes the initial `border-radius` of `.ease-hover-morph-card` from hardcoded `0` to `var(--ease-radius-md, 0)`. This allows the morph effect to start from the element's theme-appropriate border radius instead of always jumping from 0 to 50%.