### PR TITLE
fix: ease-hover-glow uses theme color via color-mix instead of hardcoded rgba (#5774)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1017,6 +1017,13 @@
   box-shadow: none;
 }
 
+@supports (color: color-mix(in srgb, red 50%, transparent)) {
+  .ease-hover-glow:hover {
+    filter: drop-shadow(0 0 8px color-mix(in srgb, var(--ease-color-primary) 45%, transparent))
+            drop-shadow(0 0 20px color-mix(in srgb, var(--ease-color-primary) 30%, transparent));
+  }
+}
+
 /* Lift (shadow depth) on hover */
 .ease-hover-lift {
   transition: transform var(--ease-speed-medium) var(--ease-ease),


### PR DESCRIPTION
Fixes #5774

Replaces hardcoded primary color values in `.ease-hover-glow:hover` filter with `color-mix()` using `var(--ease-color-primary)`. A `@supports` block provides the new themable values while keeping the original hardcoded rgba as a fallback for older browsers.