### PR TITLE
Fix #5714: Proposed fix for button loading spinner double-translation offset

### DIFF
--- a/submissions/core_changes-5714/README.md
+++ b/submissions/core_changes-5714/README.md
@@ -1,0 +1,16 @@
+# Issue #5714: Button loading spinner double-translation offset
+
+## Description
+`.ease-btn-loading::after` uses both `translate: -50% -50%` (modern CSS property, line 234) AND `translate(-50%, -50%)` inside `transform` in the keyframe (lines 245, 248). These compound, placing the spinner at -100%/-100% offset — visibly off-center.
+
+## Root Cause
+The `translate` CSS property and `transform` property are independent and compound. Having `translate: -50% -50%` on the element plus `translate(-50%, -50%)` in the keyframe's `transform` creates a double offset.
+
+## Proposed Fix
+In `components/buttons.css`:
+- Keep `translate: -50% -50%` on `.ease-btn-loading::after` (independent property for centering)
+- Remove `translate(-50%, -50%)` from the `@keyframes ease-kf-btn-spin`, keeping only `rotate()`
+
+## Files
+- `style.css` — corrected CSS (centering via `translate` property, keyframe only rotates)
+- `demo.html` — interactive demo with loading buttons

--- a/submissions/core_changes-5714/demo.html
+++ b/submissions/core_changes-5714/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Demo: Button loading spinner centering fix (#5714)</title>
+  <link rel="stylesheet" href="../../easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 2rem;
+      background: var(--ease-color-bg);
+    }
+    .demo-grid {
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      justify-content: center;
+      margin-top: 2rem;
+    }
+    .note {
+      margin-top: 2rem;
+      color: var(--ease-color-muted);
+      font-size: var(--ease-text-sm);
+      max-width: 500px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <h1>Button Loading Spinner — Centering Fix</h1>
+  <div class="demo-grid">
+    <button class="ease-btn ease-btn-primary ease-btn-loading">Loading</button>
+    <button class="ease-btn ease-btn-secondary ease-btn-loading">Saving</button>
+    <button class="ease-btn ease-btn-danger ease-btn-loading">Deleting</button>
+  </div>
+  <p class="note">
+    The spinner pseudo-element uses <code>translate: -50% -50%</code> for centering (independent <code>translate</code> property).
+    The keyframe only applies <code>rotate()</code> — no double-translation. The spinner is perfectly centered.
+  </p>
+</body>
+</html>

--- a/submissions/core_changes-5714/style.css
+++ b/submissions/core_changes-5714/style.css
@@ -1,0 +1,14 @@
+@layer easemotion-components {
+  .ease-btn-loading::after {
+    translate: -50% -50%;
+  }
+
+  @keyframes ease-kf-btn-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR addresses issue #5714. The `.ease-btn-loading::after` pseudo-element uses both `translate: -50% -50%` (CSS property, line 234) AND `translate(-50%, -50%)` inside `transform` in the keyframe (lines 245/248). These compound, placing the spinner at -100%/-100% offset — visibly off-center.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows style guidelines
- [x] Self-review performed
- [x] Documentation updated
- [x] No new warnings
- [x] Fix verified with demo

## Root Cause
The `translate` CSS property and `transform` property are independent and compound together. The base element has `translate: -50% -50%` and the keyframe applies `transform: translate(-50%, -50%) rotate(...)`, resulting in a total of -100%/-100% offset.

## Changes Made
### Added: `submissions/core_changes-5714/style.css`
- Retains `translate: -50% -50%` on `.ease-btn-loading::after` for centering
- Simplified `@keyframes ease-kf-btn-spin` to only use `transform: rotate(...)` — no `translate()` inside the keyframe

### Added: `submissions/core_changes-5714/demo.html` and `README.md`

## Testing Performed
1. Verified spinner is perfectly centered in all button variants
2. Confirmed rotation animation works smoothly
3. No console errors or CSS warnings

## Additional Notes
Submission-only fix in `submissions/core_changes-5714/`.