### PR TITLE
Fix #5715: Proposed fix for test assertion mismatch in loading button smoke test

### DIFF
--- a/submissions/core_changes-5715/README.md
+++ b/submissions/core_changes-5715/README.md
@@ -1,0 +1,22 @@
+# Issue #5715: Test expects 'font-size: 0' but CSS uses 'color: transparent'
+
+## Description
+`tests/smoke.test.js` line 98 asserts `expect(css).toContain('font-size: 0')`, but `components/buttons.css` line 221 uses `color: transparent !important`. The test assertion will always fail.
+
+## Root Cause
+The test was written to expect `font-size: 0` but the actual CSS implementation uses `color: transparent !important` to hide the button text while keeping the spinner visible.
+
+## Proposed Fix
+In `tests/smoke.test.js` line 98, change:
+```js
+expect(css).toContain('font-size: 0');
+```
+to:
+```js
+expect(css).toContain('color: transparent');
+```
+
+## Files
+- `style.css` — documents the mismatch
+- `demo.html` — shows the loading button with `color: transparent` applied
+- `README.md` — this file

--- a/submissions/core_changes-5715/demo.html
+++ b/submissions/core_changes-5715/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Verify: Test assertion fix (#5715)</title>
+  <link rel="stylesheet" href="../../easemotion.min.css" />
+  <style>
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 2rem;
+      background: var(--ease-color-bg);
+      text-align: center;
+    }
+    .ease-btn-loading {
+      margin: 2rem;
+    }
+    .note {
+      margin-top: 2rem;
+      color: var(--ease-color-muted);
+      font-size: var(--ease-text-sm);
+      max-width: 500px;
+    }
+    code {
+      background: var(--ease-color-neutral-200);
+      padding: 0.15em 0.4em;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Test Assertion Mismatch — #5715</h1>
+  <button class="ease-btn ease-btn-primary ease-btn-loading">Loading</button>
+  <p>The button text is hidden via <code>color: transparent !important</code> (not <code>font-size: 0</code>).</p>
+  <p class="note">
+    <code>tests/smoke.test.js</code> line 98 asserts <code>'font-size: 0'</code> but the CSS uses <code>color: transparent !important</code>.
+    The test assertion should be corrected.
+  </p>
+</body>
+</html>

--- a/submissions/core_changes-5715/style.css
+++ b/submissions/core_changes-5715/style.css
@@ -1,0 +1,6 @@
+/* Issue #5715: Test assertion mismatch
+ * tests/smoke.test.js line 98 expects 'font-size: 0'
+ * but components/buttons.css line 221 uses 'color: transparent !important'
+ * 
+ * The test assertion should be updated to match the actual CSS.
+ */


### PR DESCRIPTION
## Description
This PR addresses issue #5715. `tests/smoke.test.js` line 98 asserts `expect(css).toContain('font-size: 0')`, but `components/buttons.css` line 221 uses `color: transparent !important` to hide button text during loading. The test assertion will always fail.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows style guidelines
- [x] Self-review performed
- [x] Documentation updated
- [x] No new warnings
- [x] Fix verified with demo

## Root Cause
The test was written to expect `font-size: 0` but the CSS implementation uses `color: transparent !important`. These are different approaches to hiding text — the test assertion does not match the actual CSS.

## Changes Made
### Added: `submissions/core_changes-5715/`
- `README.md` — documents the mismatch and the required one-line fix
- `demo.html` — verifies the loading button behavior
- `style.css` — documents the mismatch

### Required maintainer action
In `tests/smoke.test.js` line 98, change:
```js
expect(css).toContain('font-size: 0');
```
to:
```js
expect(css).toContain('color: transparent');
```

## Testing Performed
1. Verified `.ease-btn-loading` uses `color: transparent !important` to hide text
2. Confirmed spinner remains visible and centered
3. Test file change needs to be applied by maintainers

## Additional Notes
Submission-only fix in `submissions/core_changes-5715/`.
