### PR TITLE
Fix #5718: Proposed fix for non-existent duration classes in README

### DIFF
--- a/submissions/core_changes-5718/README.md
+++ b/submissions/core_changes-5718/README.md
@@ -1,0 +1,17 @@
+# Issue #5718: README documents non-existent duration classes
+
+## Description
+`README.md` lists duration classes including `ease-duration-normal` and `ease-duration-extra-slow`, but only 3 duration classes exist in `core/animations.css`:
+- `ease-duration-fast` (150ms)
+- `ease-duration-medium` (300ms)
+- `ease-duration-slow` (600ms)
+
+## Root Cause
+The README table was written to document planned duration classes that were never implemented.
+
+## Proposed Fix
+Remove `ease-duration-normal` and `ease-duration-extra-slow` from the README duration table, or implement them in `core/animations.css`.
+
+## Files
+- `style.css` — the 3 valid duration classes
+- `demo.html` — visual demo with valid vs invalid classes

--- a/submissions/core_changes-5718/demo.html
+++ b/submissions/core_changes-5718/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Demo: Valid duration classes (#5718)</title>
+  <link rel="stylesheet" href="../../easemotion.min.css" />
+  <style>
+    body { font-family: 'Inter', system-ui, sans-serif; padding: 2rem; background: var(--ease-color-bg); }
+    .demo-grid { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .box { padding: 1rem 2rem; border-radius: var(--ease-radius-md); background: var(--ease-color-primary); color: #fff; text-align: center; }
+    .note { margin-top: 2rem; color: var(--ease-color-muted); font-size: var(--ease-text-sm); }
+    table { width: 100%; max-width: 500px; border-collapse: collapse; margin-top: 1rem; }
+    th, td { padding: 0.5rem; text-align: left; border-bottom: 1px solid var(--ease-color-neutral-300); }
+    .invalid { color: var(--ease-color-danger); }
+    .valid { color: var(--ease-color-success); }
+  </style>
+</head>
+<body>
+  <h1>Duration Classes — Valid List</h1>
+  <div class="demo-grid">
+    <div class="box ease-fade-in ease-duration-fast">Fast (150ms)</div>
+    <div class="box ease-fade-in ease-duration-medium">Medium (300ms)</div>
+    <div class="box ease-fade-in ease-duration-slow">Slow (600ms)</div>
+  </div>
+  <table>
+    <tr><th>Class</th><th>Duration</th><th>Exists?</th></tr>
+    <tr class="valid"><td>ease-duration-fast</td><td>150ms</td><td>YES</td></tr>
+    <tr class="valid"><td>ease-duration-medium</td><td>300ms</td><td>YES</td></tr>
+    <tr class="valid"><td>ease-duration-slow</td><td>600ms</td><td>YES</td></tr>
+    <tr class="invalid"><td>ease-duration-normal</td><td>—</td><td>NO</td></tr>
+    <tr class="invalid"><td>ease-duration-extra-slow</td><td>—</td><td>NO</td></tr>
+  </table>
+  <p class="note">README documents non-existent classes <code>ease-duration-normal</code> and <code>ease-duration-extra-slow</code>. They should be removed from the documentation.</p>
+</body>
+</html>

--- a/submissions/core_changes-5718/style.css
+++ b/submissions/core_changes-5718/style.css
@@ -1,0 +1,4 @@
+/* Correct duration classes — the only ones that exist */
+.ease-duration-fast   { animation-duration: var(--ease-speed-fast);   transition-duration: var(--ease-speed-fast); }
+.ease-duration-medium { animation-duration: var(--ease-speed-medium); transition-duration: var(--ease-speed-medium); }
+.ease-duration-slow   { animation-duration: var(--ease-speed-slow);   transition-duration: var(--ease-speed-slow); }


### PR DESCRIPTION
## Description
This PR addresses issue #5718. The README duration table lists `ease-duration-normal` and `ease-duration-extra-slow` which do not exist in the framework. Only `ease-duration-fast` (150ms), `ease-duration-medium` (300ms), and `ease-duration-slow` (600ms) are defined in `core/animations.css`.

## Type of Change
- [x] Bug fix (documentation)

## Checklist
- [x] Code follows style guidelines
- [x] Self-review performed
- [x] Documentation updated
- [x] No new warnings

## Root Cause
The README duration table included planned classes that were never implemented in `core/animations.css`.

## Changes Made
### Added: `submissions/core_changes-5718/`
- `style.css` — the 3 valid duration classes
- `demo.html` — visual demo comparing valid vs invalid classes
- `README.md` — documents the issue

### Required maintainer action
Remove `ease-duration-normal` and `ease-duration-extra-slow` from the README duration table.

## Additional Notes
Submission-only fix in `submissions/core_changes-5718/`.
