### PR TITLE
Fix #5720: Proposed fix for footer missing dark mode overrides

### DIFF
--- a/submissions/core_changes-5720/README.md
+++ b/submissions/core_changes-5720/README.md
@@ -1,0 +1,28 @@
+# Issue #5720: No dark mode overrides for footer component
+
+## Description
+`components/footer.css` has no `@media (prefers-color-scheme: dark)` overrides. The footer uses `background: var(--ease-color-neutral-900)` and `border-top: 1px solid var(--ease-color-neutral-200)`. In dark mode, these colors match the page background, making the footer nearly invisible.
+
+## Root Cause
+The footer component was never given dark mode styling, unlike other components (cards, navbar, sidebar, etc.).
+
+## Proposed Fix
+Add to `components/footer.css`:
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-footer {
+    background: var(--ease-color-neutral-950, #020617);
+    border-top-color: var(--ease-color-neutral-800, #1e293b);
+  }
+  .ease-footer-bottom {
+    border-top-color: var(--ease-color-neutral-800, #1e293b);
+  }
+  .ease-footer-social a {
+    background: var(--ease-color-neutral-900, #0f172a);
+  }
+}
+```
+
+## Files
+- `style.css` — dark mode overrides for footer
+- `demo.html` — full footer demo in light/dark mode

--- a/submissions/core_changes-5720/demo.html
+++ b/submissions/core_changes-5720/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Demo: Footer dark mode fix (#5720)</title>
+  <link rel="stylesheet" href="../../easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: 'Inter', system-ui, sans-serif; margin: 0; min-height: 100vh; display: flex; flex-direction: column; background: var(--ease-color-bg); }
+    main { flex: 1; padding: 2rem; display: flex; align-items: center; justify-content: center; }
+    .note { color: var(--ease-color-muted); font-size: var(--ease-text-sm); text-align: center; }
+  </style>
+</head>
+<body>
+  <main>
+    <p class="note">Toggle system dark mode to see footer contrast change. Without the fix, footer is nearly invisible in dark mode.</p>
+  </main>
+  <footer class="ease-footer">
+    <div class="ease-footer-grid">
+      <div>
+        <h4 class="ease-footer-col-title">Product</h4>
+        <ul class="ease-footer-links">
+          <li><a href="#">Features</a></li>
+          <li><a href="#">Pricing</a></li>
+          <li><a href="#">Docs</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4 class="ease-footer-col-title">Company</h4>
+        <ul class="ease-footer-links">
+          <li><a href="#">About</a></li>
+          <li><a href="#">Blog</a></li>
+          <li><a href="#">Careers</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4 class="ease-footer-col-title">Connect</h4>
+        <div class="ease-footer-social">
+          <a href="https://github.com"></a>
+          <a href="https://twitter.com"></a>
+          <a href="https://youtube.com"></a>
+        </div>
+      </div>
+    </div>
+    <div class="ease-footer-bottom">
+      <span>&copy; 2026 EaseMotion</span>
+      <span>Built with care</span>
+    </div>
+  </footer>
+</body>
+</html>

--- a/submissions/core_changes-5720/style.css
+++ b/submissions/core_changes-5720/style.css
@@ -1,0 +1,16 @@
+@layer easemotion-components {
+  @media (prefers-color-scheme: dark) {
+    .ease-footer {
+      background: var(--ease-color-neutral-950, #020617);
+      border-top-color: var(--ease-color-neutral-800, #1e293b);
+    }
+
+    .ease-footer-bottom {
+      border-top-color: var(--ease-color-neutral-800, #1e293b);
+    }
+
+    .ease-footer-social a {
+      background: var(--ease-color-neutral-900, #0f172a);
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR addresses issue #5720. The footer component has no `@media (prefers-color-scheme: dark)` overrides, making it nearly invisible against the dark page background.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows style guidelines
- [x] Self-review performed
- [x] Documentation updated
- [x] No new warnings

## Root Cause
`components/footer.css` was never given dark mode styling, unlike other components (cards, navbar, sidebar, modals).

## Changes Made
### Added: `submissions/core_changes-5720/`
- `style.css` — dark mode overrides for footer background, borders, and social icons
- `demo.html` — full footer with social links, light/dark toggle
- `README.md` — documents the issue

### Required maintainer action
Add the dark mode block to `components/footer.css`.

## Additional Notes
Submission-only fix in `submissions/core_changes-5720/`.
