### PR TITLE
Fix #5721: Proposed fix for non-existent CSS vars in docs.css

### DIFF
--- a/submissions/core_changes-5721/README.md
+++ b/submissions/core_changes-5721/README.md
@@ -1,0 +1,20 @@
+# Issue #5721: docs.css references non-existent CSS variables
+
+## Description
+`docs/docs.css` line 782 used `var(--ease-duration-3)` and `var(--ease-ease-in-out)`, which are not defined anywhere in `core/variables.css`. The correct variables are `--ease-speed-medium` and `--ease-ease`.
+
+## Status
+This issue has already been fixed in a prior commit. Line 782 now correctly uses:
+```css
+transition: filter var(--ease-speed-medium) var(--ease-ease);
+```
+
+## Root Cause
+The docs CSS was written using non-existent variable names that don't match the actual design tokens.
+
+## Proposed Fix (already applied)
+Replace `--ease-duration-3` with `--ease-speed-medium` and `--ease-ease-in-out` with `--ease-ease`.
+
+## Files
+- `style.css` — shows correct variable usage
+- `demo.html` — visual audit table

--- a/submissions/core_changes-5721/demo.html
+++ b/submissions/core_changes-5721/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Demo: Non-existent CSS variables in docs.css (#5721)</title>
+  <link rel="stylesheet" href="../../easemotion.min.css" />
+  <style>
+    body { font-family: 'Inter', system-ui, sans-serif; padding: 2rem; background: var(--ease-color-bg); display: flex; flex-direction: column; align-items: center; }
+    .card { padding: 2rem; border-radius: var(--ease-radius-lg); background: var(--ease-color-surface); box-shadow: var(--ease-shadow-md); max-width: 500px; }
+    code { background: var(--ease-color-neutral-200); padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+    table { width: 100%; margin: 1rem 0; border-collapse: collapse; }
+    th, td { padding: 0.5rem; text-align: left; border-bottom: 1px solid var(--ease-color-neutral-300); }
+    .invalid { color: var(--ease-color-danger); }
+    .valid { color: var(--ease-color-success); }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>CSS Variable Audit</h1>
+    <p><code>docs/docs.css</code> line 782 used <code>--ease-duration-3</code> and <code>--ease-ease-in-out</code> — neither exists.</p>
+    <table>
+      <tr><th>Variable</th><th>Status</th><th>Correct replacement</th></tr>
+      <tr class="invalid"><td>--ease-duration-3</td><td>DOES NOT EXIST</td><td>--ease-speed-medium</td></tr>
+      <tr class="invalid"><td>--ease-ease-in-out</td><td>DOES NOT EXIST</td><td>--ease-ease</td></tr>
+      <tr class="valid"><td>--ease-speed-medium</td><td>EXISTS</td><td>—</td></tr>
+      <tr class="valid"><td>--ease-ease</td><td>EXISTS</td><td>—</td></tr>
+    </table>
+    <p>Line 782 of <code>docs/docs.css</code> now correctly uses <code>var(--ease-speed-medium)</code> and <code>var(--ease-ease)</code>.</p>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-5721/style.css
+++ b/submissions/core_changes-5721/style.css
@@ -1,0 +1,5 @@
+/* Valid CSS variable names for transition properties */
+/* Use --ease-speed-* for durations and --ease-ease-* for easings */
+.example {
+  transition: filter var(--ease-speed-medium) var(--ease-ease);
+}


### PR DESCRIPTION
## Description
This PR addresses issue #5721. `docs/docs.css` line 782 referenced `--ease-duration-3` and `--ease-ease-in-out`, neither of which exist in `core/variables.css`. The correct variables are `--ease-speed-medium` and `--ease-ease`.

## Type of Change
- [x] Bug fix

## Root Cause
The docs CSS used non-existent variable names that don't match the design token naming convention.

## Changes Made
### Added: `submissions/core_changes-5721/`
- `style.css` — shows the correct variable usage
- `demo.html` — audit table comparing invalid vs valid tokens
- `README.md` — documents the issue

### Note
This issue appears to already be fixed in the current `docs/docs.css` — line 782 now correctly uses `var(--ease-speed-medium)` and `var(--ease-ease)`. This submission documents the fix for audit purposes.

## Additional Notes
Submission-only fix in `submissions/core_changes-5721/`.
