### PR TITLE
cards-text-dark-token-bug-demo (#5945)

### DIFF
--- a/submissions/examples/cards-text-dark-token-bug-demo/README.md
+++ b/submissions/examples/cards-text-dark-token-bug-demo/README.md
@@ -1,0 +1,16 @@
+# Cards: References undefined --ease-color-text-dark token
+
+**Issue:** #5945
+**File:** `components/cards.css`
+
+## Problem
+
+Line 180 references `var(--ease-color-text-dark, #f8fafc)` but `--ease-color-text-dark` is never defined in `variables.css` or elsewhere.
+
+## Expected
+
+Either define `--ease-color-text-dark` in `variables.css` or use an existing token.
+
+## Demo
+
+Open `demo.html` to see the glass card in dark mode where the text color falls back to `#f8fafc` via the hardcoded fallback instead of a proper design token.

--- a/submissions/examples/cards-text-dark-token-bug-demo/demo.html
+++ b/submissions/examples/cards-text-dark-token-bug-demo/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cards – Undefined --ease-color-text-dark</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Bug: undefined <code>--ease-color-text-dark</code></h1>
+  <p><code>--ease-color-text-dark</code> is referenced in <code>cards.css</code> line 180 but never defined in <code>variables.css</code>.</p>
+
+  <div class="ease-card ease-card-glass" style="max-width:300px;color:#fff;">
+    <h3>Glass Card (dark mode simulation)</h3>
+    <p>Color uses <code>var(--ease-color-text-dark, #f8fafc)</code> — token doesn't exist.</p>
+  </div>
+
+  <hr />
+  <h2>Source</h2>
+  <pre>
+.ease-card-glass {
+  color: var(--ease-color-text-dark, #f8fafc);  /* token doesn't exist */
+}
+  </pre>
+
+  <h2>Fix</h2>
+  <pre>
+/* Either define in variables.css: */
+--ease-color-text-dark: #f8fafc;
+/* Or use existing token: */
+color: var(--ease-color-text, #1e293b);
+  </pre>
+</body>
+</html>

--- a/submissions/examples/cards-text-dark-token-bug-demo/style.css
+++ b/submissions/examples/cards-text-dark-token-bug-demo/style.css
@@ -1,0 +1,28 @@
+/* cards.css bug demo: undefined --ease-color-text-dark */
+
+body { font-family: system-ui, sans-serif; margin: 2rem; background: #0b1121; }
+.ease-card {
+  background-color: #141e33;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.ease-card-glass {
+  color: var(--ease-color-text-dark, #f8fafc);
+  /* BUG: --ease-color-text-dark is never defined in variables.css */
+  backdrop-filter: blur(16px);
+}
+
+h3 { margin: 0 0 0.5rem 0; color: inherit; }
+p { margin: 0; color: inherit; }
+
+/* FIX */
+/*
+  Either add to variables.css:
+  --ease-color-text-dark: #f8fafc;
+
+  Or use:
+  color: var(--ease-color-text, #e2e8f0);
+*/


### PR DESCRIPTION
## Summary
Creates a submission demo documenting that cards.css references undefined --ease-color-text-dark token.

Closes #5945