### PR TITLE
cards-accent-variants-bug-demo (#5946)

### DIFF
--- a/submissions/examples/cards-accent-variants-bug-demo/README.md
+++ b/submissions/examples/cards-accent-variants-bug-demo/README.md
@@ -1,0 +1,19 @@
+# Cards: Missing accent-info and accent-secondary variants
+
+**Issue:** #5946
+**File:** `components/cards.css`
+
+## Problem
+
+Cards has `.ease-card-accent` (primary), `.ease-card-accent-success`, `.ease-card-accent-danger`, and `.ease-card-accent-warning` but no `.ease-card-accent-info` or `.ease-card-accent-secondary`.
+
+## Expected
+
+```css
+.ease-card-accent-info      { border-left: 4px solid var(--ease-color-info, #3b82f6); }
+.ease-card-accent-secondary { border-left: 4px solid var(--ease-color-secondary, #8b5cf6); }
+```
+
+## Demo
+
+Open `demo.html` to see which accent variants are available and which are missing.

--- a/submissions/examples/cards-accent-variants-bug-demo/demo.html
+++ b/submissions/examples/cards-accent-variants-bug-demo/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cards – Missing accent variants</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Bug: missing accent-info and accent-secondary</h1>
+
+  <p><strong>Available:</strong></p>
+  <div style="display:flex;flex-direction:column;gap:0.5rem;margin-bottom:1rem">
+    <div class="ease-card ease-card-accent">Primary accent</div>
+    <div class="ease-card ease-card-accent-success">Success accent</div>
+    <div class="ease-card ease-card-accent-danger">Danger accent</div>
+    <div class="ease-card ease-card-accent-warning">Warning accent</div>
+  </div>
+
+  <p><strong>Missing (shown without accent):</strong></p>
+  <div style="display:flex;flex-direction:column;gap:0.5rem;margin-bottom:1rem">
+    <div class="ease-card ease-card-accent-info">Info accent (missing)</div>
+    <div class="ease-card ease-card-accent-secondary">Secondary accent (missing)</div>
+  </div>
+
+  <hr />
+  <h2>Fix</h2>
+  <pre>
+.ease-card-accent-info {
+  border-left: 4px solid var(--ease-color-info, #3b82f6);
+}
+.ease-card-accent-secondary {
+  border-left: 4px solid var(--ease-color-secondary, #8b5cf6);
+}
+  </pre>
+</body>
+</html>

--- a/submissions/examples/cards-accent-variants-bug-demo/style.css
+++ b/submissions/examples/cards-accent-variants-bug-demo/style.css
@@ -1,0 +1,23 @@
+/* cards.css bug demo: missing accent variants */
+
+.ease-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-card-accent {
+  border-left: 4px solid var(--ease-color-primary, #6c63ff);
+}
+.ease-card-accent-success {
+  border-left: 4px solid var(--ease-color-success, #22c55e);
+}
+.ease-card-accent-danger {
+  border-left: 4px solid var(--ease-color-danger, #ef4444);
+}
+.ease-card-accent-warning {
+  border-left: 4px solid var(--ease-color-warning, #f59e0b);
+}
+/* MISSING: .ease-card-accent-info, .ease-card-accent-secondary */


### PR DESCRIPTION
## Summary
Creates a submission demo documenting that cards.css is missing accent-info and accent-secondary variants.

Closes #5946