### PR TITLE
buttons-icon-size-variants-bug-demo (#5947)

### DIFF
--- a/submissions/examples/buttons-icon-size-variants-bug-demo/README.md
+++ b/submissions/examples/buttons-icon-size-variants-bug-demo/README.md
@@ -1,0 +1,19 @@
+# Buttons: .ease-btn-icon missing size variants (sm, lg)
+
+**Issue:** #5947
+**File:** `components/buttons.css`
+
+## Problem
+
+`.ease-btn-icon` has only a single size. Other button variants (`.ease-btn-sm`, `.ease-btn-lg`) exist for text buttons but there is no `.ease-btn-icon-sm` or `.ease-btn-icon-lg`.
+
+## Expected
+
+```css
+.ease-btn-icon-sm { padding: var(--ease-space-2, 0.5rem); border-radius: var(--ease-radius-sm, 0.25rem); }
+.ease-btn-icon-lg { padding: var(--ease-space-4, 1rem); border-radius: var(--ease-radius-lg, 1rem); }
+```
+
+## Demo
+
+Open `demo.html` to see the icon button with no size variants.

--- a/submissions/examples/buttons-icon-size-variants-bug-demo/demo.html
+++ b/submissions/examples/buttons-icon-size-variants-bug-demo/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Buttons – .ease-btn-icon missing size variants</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Bug: .ease-btn-icon missing sm/lg variants</h1>
+  <p>Text buttons have <code>.ease-btn-sm</code> / <code>.ease-btn-lg</code>, but icon buttons only have one size.</p>
+
+  <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1rem">
+    <button class="ease-btn ease-btn-icon ease-btn-primary">★</button>
+    <span>Icon button (only size available)</span>
+  </div>
+
+  <p><strong>Missing (no <code>.ease-btn-icon-sm</code> or <code>.ease-btn-icon-lg</code>):</strong></p>
+  <div style="display:flex;align-items:center;gap:1rem">
+    <button class="ease-btn ease-btn-icon-sm ease-btn-primary">★</button>
+    <span>Small icon button (would use <code>.ease-btn-icon-sm</code>)</span>
+  </div>
+
+  <hr />
+  <h2>Fix</h2>
+  <pre>
+.ease-btn-icon-sm {
+  padding: var(--ease-space-2, 0.5rem);
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+.ease-btn-icon-lg {
+  padding: var(--ease-space-4, 1rem);
+  border-radius: var(--ease-radius-lg, 1rem);
+}
+  </pre>
+</body>
+</html>

--- a/submissions/examples/buttons-icon-size-variants-bug-demo/style.css
+++ b/submissions/examples/buttons-icon-size-variants-bug-demo/style.css
@@ -1,0 +1,27 @@
+/* buttons.css bug demo: .ease-btn-icon missing size variants */
+
+.ease-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: system-ui, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border: 2px solid transparent;
+  cursor: pointer;
+}
+
+.ease-btn-primary {
+  background-color: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-btn-icon {
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+}
+
+/* MISSING: .ease-btn-icon-sm, .ease-btn-icon-lg */
+
+.ease-btn-icon-sm { /* would use padding: var(--ease-space-2, 0.5rem); border-radius: var(--ease-radius-sm, 0.25rem); */ }


### PR DESCRIPTION
## Summary
Creates a submission demo documenting that .ease-btn-icon is missing sm and lg size variants.

Closes #5947