### PR TITLE
tooltips-layer-vars-bug-demo (#5948)

### DIFF
--- a/submissions/examples/tooltips-layer-vars-bug-demo/README.md
+++ b/submissions/examples/tooltips-layer-vars-bug-demo/README.md
@@ -1,0 +1,16 @@
+# Tooltips: CSS variables defined in :root inside @layer (wrong layer)
+
+**Issue:** #5948
+**File:** `components/tooltips.css`
+
+## Problem
+
+Lines 3-12 define `--ease-tooltip-*` custom properties in `:root` inside `@layer easemotion-components`. CSS custom properties inside a `@layer` have lower cascade priority than unlayered ones. These should be in the `easemotion-base` layer (like other design tokens in `variables.css`).
+
+## Expected
+
+Move tooltip token definitions to the base layer, or remove the `:root` block from inside the component layer.
+
+## Demo
+
+Open `demo.html` to see the tooltip and its layer-related CSS issue.

--- a/submissions/examples/tooltips-layer-vars-bug-demo/demo.html
+++ b/submissions/examples/tooltips-layer-vars-bug-demo/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tooltips – :root vars inside @layer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Bug: tooltip vars in wrong layer</h1>
+  <p><code>:root</code> custom properties are defined inside <code>@layer easemotion-components</code>, giving them lower cascade priority than unlayered CSS. They should be in the base layer.</p>
+
+  <div class="ease-tooltip" data-tooltip="Tooltip text here" tabindex="0">
+    Hover or focus me
+  </div>
+
+  <hr />
+  <h2>Source</h2>
+  <pre>
+@layer easemotion-components {
+  :root {
+    --ease-tooltip-bg: var(--ease-color-neutral-900, #1f2937);
+    /* ...more vars... */
+  }
+}
+  </pre>
+
+  <h2>Fix</h2>
+  <pre>
+/* Move to variables.css (easemotion-base layer) */
+:root {
+  --ease-tooltip-bg: var(--ease-color-neutral-900, #1f2937);
+}
+  </pre>
+</body>
+</html>

--- a/submissions/examples/tooltips-layer-vars-bug-demo/style.css
+++ b/submissions/examples/tooltips-layer-vars-bug-demo/style.css
@@ -1,0 +1,57 @@
+/* tooltips.css bug demo: :root vars inside @layer */
+
+/* Simulating the tooltip vars being inside a component layer */
+@layer easemotion-components {
+  :root {
+    --ease-tooltip-bg: #1f2937;
+    --ease-tooltip-text: #ffffff;
+    --ease-tooltip-font-size: 0.75rem;
+    --ease-tooltip-padding: 0.25rem 0.5rem;
+    --ease-tooltip-radius: 0.25rem;
+    --ease-tooltip-gap: 0.5rem;
+    --ease-tooltip-animation-duration: 0.15s;
+    --ease-tooltip-z-index: 9999;
+  }
+}
+
+/* This unlayered :root should win, but due to layer ordering might not */
+:root {
+  --ease-tooltip-bg: #dc2626;  /* red — test if this overrides */
+}
+
+.ease-tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  background: #f1f5f9;
+  border-radius: 0.25rem;
+}
+
+.ease-tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  background: var(--ease-tooltip-bg);
+  color: var(--ease-tooltip-text);
+  font-size: var(--ease-tooltip-font-size);
+  padding: var(--ease-tooltip-padding);
+  border-radius: var(--ease-tooltip-radius);
+  white-space: nowrap;
+  z-index: var(--ease-tooltip-z-index);
+  bottom: calc(100% + var(--ease-tooltip-gap));
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--ease-tooltip-animation-duration) ease,
+              visibility var(--ease-tooltip-animation-duration) ease,
+              transform var(--ease-tooltip-animation-duration) ease;
+  pointer-events: none;
+}
+
+.ease-tooltip:hover::after,
+.ease-tooltip:focus-within::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}


### PR DESCRIPTION
## Summary
Creates a submission demo documenting that tooltip CSS variables are defined in :root inside @layer (wrong layer).

Closes #5948