### PR TITLE
masonry-reduced-motion-broad-bug-demo (#5949)

### DIFF
--- a/submissions/examples/masonry-reduced-motion-broad-bug-demo/README.md
+++ b/submissions/examples/masonry-reduced-motion-broad-bug-demo/README.md
@@ -1,0 +1,16 @@
+# Masonry: Reduced-motion rule kills transitions on ALL children
+
+**Issue:** #5949
+**File:** `components/masonry.css`
+
+## Problem
+
+Lines 217-222 apply `transition: none !important` to ALL `.ease-masonry > *` children under `prefers-reduced-motion`, not just animated elements. This is overly broad and prevents intentional transitions from working.
+
+## Expected
+
+Only target elements that have transitions, or use a more specific selector.
+
+## Demo
+
+Open `demo.html` and enable reduced motion to see all transitions killed on masonry children.

--- a/submissions/examples/masonry-reduced-motion-broad-bug-demo/demo.html
+++ b/submissions/examples/masonry-reduced-motion-broad-bug-demo/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Masonry – Reduced motion kills ALL child transitions</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Bug: reduced motion kills all child transitions</h1>
+  <p>Under <code>prefers-reduced-motion: reduce</code>, ALL masonry children get <code>transition: none !important</code> — even cards with hover transitions that should be preserved.</p>
+
+  <div class="ease-masonry-2">
+    <div class="ease-card ease-card-hover">Card with hover lift (transition killed)</div>
+    <div class="ease-card">Static card</div>
+    <div class="ease-card ease-card-hover">Card with hover lift (transition killed)</div>
+    <div class="ease-card">Static card</div>
+  </div>
+
+  <hr />
+  <h2>Source</h2>
+  <pre>
+@media (prefers-reduced-motion: reduce) {
+  .ease-masonry > *,
+  .ease-masonry-2 > *,
+  .ease-masonry-3 > *,
+  .ease-masonry-4 > * {
+    transition: none !important;  /* too broad */
+  }
+}
+  </pre>
+</body>
+</html>

--- a/submissions/examples/masonry-reduced-motion-broad-bug-demo/style.css
+++ b/submissions/examples/masonry-reduced-motion-broad-bug-demo/style.css
@@ -1,0 +1,38 @@
+/* masonry.css bug demo: too-broad reduced motion */
+
+.ease-masonry-2 {
+  columns: 2;
+  column-gap: 1rem;
+}
+
+.ease-masonry-2 > * {
+  break-inside: avoid;
+  margin-bottom: 1rem;
+}
+
+.ease-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-card-hover {
+  cursor: pointer;
+  transition: transform 300ms ease, box-shadow 300ms ease;
+}
+
+.ease-card-hover:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1);
+}
+
+/* BUG: kills ALL transitions on ALL children */
+@media (prefers-reduced-motion: reduce) {
+  .ease-masonry-2 > * {
+    transition: none !important;
+  }
+}
+
+/* FIX: remove this rule or scope it to animated children only */


### PR DESCRIPTION
## Summary
Creates a submission demo documenting that masonry reduced-motion rule kills transitions on ALL children.

Closes #5949