### PR TITLE
base-body-fallbacks-bug-demo (#5950)

### DIFF
--- a/submissions/examples/base-body-fallbacks-bug-demo/README.md
+++ b/submissions/examples/base-body-fallbacks-bug-demo/README.md
@@ -1,0 +1,24 @@
+# base.css: Body element uses var() without fallback values
+
+**Issue:** #5950
+**File:** `core/base.css`
+
+## Problem
+
+Lines 24-28 use `var(--ease-font-sans)`, `var(--ease-text-base)`, `var(--ease-leading-normal)`, `var(--ease-color-text)`, and `var(--ease-color-bg)` without fallback values. Without the base layer, the body gets invisible text.
+
+## Expected
+
+```css
+body {
+  font-family: var(--ease-font-sans, 'Inter', system-ui, sans-serif);
+  font-size: var(--ease-text-base, 1rem);
+  line-height: var(--ease-leading-normal, 1.6);
+  color: var(--ease-color-text, #1e293b);
+  background-color: var(--ease-color-bg, #f8fafc);
+}
+```
+
+## Demo
+
+Open `demo.html` without the variables layer to see the body render with `initial` values.

--- a/submissions/examples/base-body-fallbacks-bug-demo/demo.html
+++ b/submissions/examples/base-body-fallbacks-bug-demo/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>base.css – Body missing var() fallbacks</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Bug: body var() without fallbacks</h1>
+  <p>Without the EaseMotion variables layer, the body below would render with transparent background and invisible text (var() resolves to <code>initial</code>).</p>
+
+  <p style="background:#f1f5f9;padding:1rem;border-radius:0.5rem">
+    This paragraph uses the fallback values directly.
+  </p>
+
+  <hr />
+  <h2>Fix</h2>
+  <pre>
+body {
+  font-family: var(--ease-font-sans, 'Inter', system-ui, sans-serif);
+  font-size: var(--ease-text-base, 1rem);
+  line-height: var(--ease-leading-normal, 1.6);
+  color: var(--ease-color-text, #1e293b);
+  background-color: var(--ease-color-bg, #f8fafc);
+}
+  </pre>
+</body>
+</html>

--- a/submissions/examples/base-body-fallbacks-bug-demo/style.css
+++ b/submissions/examples/base-body-fallbacks-bug-demo/style.css
@@ -1,0 +1,24 @@
+/* base.css bug demo: body var() without fallbacks */
+
+body {
+  font-family: var(--ease-font-sans);
+  font-size: var(--ease-text-base);
+  line-height: var(--ease-leading-normal);
+  color: var(--ease-color-text);
+  background-color: var(--ease-color-bg);
+  /* BUG: none of these have fallback values */
+  margin: 2rem;
+}
+
+h1 { font-size: 1.5rem; color: #0f172a; }
+
+/* FIX */
+/*
+body {
+  font-family: var(--ease-font-sans, 'Inter', system-ui, sans-serif);
+  font-size: var(--ease-text-base, 1rem);
+  line-height: var(--ease-leading-normal, 1.6);
+  color: var(--ease-color-text, #1e293b);
+  background-color: var(--ease-color-bg, #f8fafc);
+}
+*/


### PR DESCRIPTION
## Summary
Creates a submission demo documenting that base.css body element uses var() without fallback values.

Closes #5950