### PR TITLE
base-heading-fallbacks-bug-demo (#5951)

### DIFF
--- a/submissions/examples/base-heading-fallbacks-bug-demo/README.md
+++ b/submissions/examples/base-heading-fallbacks-bug-demo/README.md
@@ -1,0 +1,19 @@
+# base.css: Headings use var() without fallback values
+
+**Issue:** #5951
+**File:** `core/base.css`
+
+## Problem
+
+Lines 38, 41-46 use `var(--ease-color-neutral-900)`, `var(--ease-text-4xl)`, etc without fallback values for heading typography tokens.
+
+## Expected
+
+```css
+h1 { font-size: var(--ease-text-4xl, 2.25rem); }
+h2 { font-size: var(--ease-text-3xl, 1.875rem); }
+```
+
+## Demo
+
+Open `demo.html` without the variables layer to see headings with zero/initial font-size.

--- a/submissions/examples/base-heading-fallbacks-bug-demo/demo.html
+++ b/submissions/examples/base-heading-fallbacks-bug-demo/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>base.css – Headings missing var() fallbacks</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Heading 1 (var(--ease-text-4xl) without fallback)</h1>
+  <h2>Heading 2 (var(--ease-text-3xl) without fallback)</h2>
+  <h3>Heading 3 (var(--ease-text-2xl) without fallback)</h3>
+
+  <hr />
+  <h2>Fix</h2>
+  <pre>
+h1 { font-size: var(--ease-text-4xl, 2.25rem); }
+h2 { font-size: var(--ease-text-3xl, 1.875rem); }
+h3 { font-size: var(--ease-text-2xl, 1.5rem); }
+h4 { font-size: var(--ease-text-xl, 1.25rem); }
+h5 { font-size: var(--ease-text-lg, 1.125rem); }
+h6 { font-size: var(--ease-text-base, 1rem); }
+  </pre>
+</body>
+</html>

--- a/submissions/examples/base-heading-fallbacks-bug-demo/style.css
+++ b/submissions/examples/base-heading-fallbacks-bug-demo/style.css
@@ -1,0 +1,27 @@
+/* base.css bug demo: heading var() without fallbacks */
+
+body { margin: 2rem; font-family: system-ui, sans-serif; }
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--ease-color-neutral-900);
+  /* BUG: no fallback */
+}
+
+h1 { font-size: var(--ease-text-4xl); } /* BUG */
+h2 { font-size: var(--ease-text-3xl); } /* BUG */
+h3 { font-size: var(--ease-text-2xl); } /* BUG */
+h4 { font-size: var(--ease-text-xl); }  /* BUG */
+h5 { font-size: var(--ease-text-lg); }  /* BUG */
+h6 { font-size: var(--ease-text-base); } /* BUG */
+
+/* FIX */
+/*
+h1 { font-size: var(--ease-text-4xl, 2.25rem); }
+h2 { font-size: var(--ease-text-3xl, 1.875rem); }
+h3 { font-size: var(--ease-text-2xl, 1.5rem); }
+h4 { font-size: var(--ease-text-xl, 1.25rem); }
+h5 { font-size: var(--ease-text-lg, 1.125rem); }
+h6 { font-size: var(--ease-text-base, 1rem); }
+*/


### PR DESCRIPTION
## Summary
Creates a submission demo documenting that base.css headings use var() without fallback values.

Closes #5951