### PR TITLE
base-link-motion-guard-bug-demo (#5952)

### DIFF
--- a/submissions/examples/base-link-motion-guard-bug-demo/README.md
+++ b/submissions/examples/base-link-motion-guard-bug-demo/README.md
@@ -1,0 +1,22 @@
+# base.css: Link transition missing prefers-reduced-motion guard
+
+**Issue:** #5952
+**File:** `core/base.css`
+
+## Problem
+
+Line 56 sets `transition: color var(--ease-speed-fast) var(--ease-ease)` on `a` elements but there is no `@media (prefers-reduced-motion: reduce)` guard for this transition.
+
+## Expected
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  a {
+    transition: none !important;
+  }
+}
+```
+
+## Demo
+
+Open `demo.html` and enable reduced motion to see the link color transition still animating.

--- a/submissions/examples/base-link-motion-guard-bug-demo/demo.html
+++ b/submissions/examples/base-link-motion-guard-bug-demo/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>base.css – Link transition missing reduced-motion guard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Bug: link transition not guarded</h1>
+  <p>The <code>a</code> element <code>transition</code> on color is not suppressed under <code>prefers-reduced-motion: reduce</code>.</p>
+
+  <p><a href="#">Hover this link</a> — the color transition still plays.</p>
+
+  <hr />
+  <h2>Source</h2>
+  <pre>
+a {
+  transition: color var(--ease-speed-fast) var(--ease-ease);
+  /* no reduced-motion guard */
+}
+  </pre>
+
+  <h2>Fix</h2>
+  <pre>
+@media (prefers-reduced-motion: reduce) {
+  a {
+    transition: none !important;
+  }
+}
+  </pre>
+</body>
+</html>

--- a/submissions/examples/base-link-motion-guard-bug-demo/style.css
+++ b/submissions/examples/base-link-motion-guard-bug-demo/style.css
@@ -1,0 +1,26 @@
+/* base.css bug demo: link transition missing guard */
+
+body { margin: 2rem; font-family: system-ui, sans-serif; }
+
+a {
+  color: var(--ease-color-primary, #6c63ff);
+  text-decoration: none;
+  transition: color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+  /* BUG: no reduced-motion guard */
+}
+
+@media (hover: hover) and (pointer: fine) {
+  a:hover {
+    color: var(--ease-color-primary-dark, #4b44cc);
+    text-decoration: underline;
+  }
+}
+
+/* FIX: add reduced-motion guard */
+/*
+@media (prefers-reduced-motion: reduce) {
+  a {
+    transition: none !important;
+  }
+}
+*/


### PR DESCRIPTION
## Summary
Creates a submission demo documenting that base.css link transition is missing a prefers-reduced-motion guard.

Closes #5952