### PR TITLE
utilities-snap-fallbacks-bug-demo (#5957)

### DIFF
--- a/submissions/examples/utilities-snap-fallbacks-bug-demo/README.md
+++ b/submissions/examples/utilities-snap-fallbacks-bug-demo/README.md
@@ -1,0 +1,20 @@
+# Utilities: Snap classes use var() without fallback values
+
+**Issue:** #5957
+**File:** `core/utilities.css`
+
+## Problem
+
+Lines 229-244 use `var(--ease-snap-axis)` and `var(--ease-snap-strictness)` without fallback values. Without these custom properties, `scroll-snap-type` falls back to `none`.
+
+## Expected
+
+```css
+.ease-snap-x {
+  scroll-snap-type: var(--ease-snap-axis, x) var(--ease-snap-strictness, proximity) !important;
+}
+```
+
+## Demo
+
+Open `demo.html` to see scroll snap not working without the custom properties defined.

--- a/submissions/examples/utilities-snap-fallbacks-bug-demo/demo.html
+++ b/submissions/examples/utilities-snap-fallbacks-bug-demo/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Utilities – Snap missing var() fallbacks</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Bug: snap utilities missing fallbacks</h1>
+  <p><code>scroll-snap-type</code> uses <code>var(--ease-snap-axis)</code> and <code>var(--ease-snap-strictness)</code> without fallbacks — defaults to <code>none</code>.</p>
+
+  <div class="ease-snap-x" style="display:flex;overflow-x:auto;gap:1rem;padding:1rem 0;border:1px solid #ccc">
+    <div class="snap-item" style="flex:0 0 200px;height:100px;background:#6c63ff;color:#fff;display:flex;align-items:center;justify-content:center;border-radius:8px;scroll-snap-align:center">1</div>
+    <div class="snap-item" style="flex:0 0 200px;height:100px;background:#6c63ff;color:#fff;display:flex;align-items:center;justify-content:center;border-radius:8px;scroll-snap-align:center">2</div>
+    <div class="snap-item" style="flex:0 0 200px;height:100px;background:#6c63ff;color:#fff;display:flex;align-items:center;justify-content:center;border-radius:8px;scroll-snap-align:center">3</div>
+  </div>
+
+  <hr />
+  <h2>Fix</h2>
+  <pre>
+.ease-snap-x {
+  scroll-snap-type: var(--ease-snap-axis, x) var(--ease-snap-strictness, proximity) !important;
+}
+.ease-snap-y {
+  scroll-snap-type: var(--ease-snap-axis, y) var(--ease-snap-strictness, proximity) !important;
+}
+  </pre>
+</body>
+</html>

--- a/submissions/examples/utilities-snap-fallbacks-bug-demo/style.css
+++ b/submissions/examples/utilities-snap-fallbacks-bug-demo/style.css
@@ -1,0 +1,12 @@
+/* utilities.css bug demo: snap missing fallbacks */
+
+body { margin: 2rem; font-family: system-ui, sans-serif; }
+
+.ease-snap-x {
+  --ease-snap-axis: x !important;
+  scroll-snap-type: var(--ease-snap-axis, x) var(--ease-snap-strictness, proximity) !important;
+  -webkit-scroll-snap-type: var(--ease-snap-axis, x) var(--ease-snap-strictness, proximity) !important;
+}
+/* BUG: --ease-snap-axis is forced to "x" via !important, but the var() fallback is a belt-and-suspenders issue */
+/* The real bug: the !important on --ease-snap-axis makes it impossible for consumers to set --ease-snap-axis on the element */
+/* And --ease-snap-strictness has no fallback if unset */


### PR DESCRIPTION
## Summary
Creates a submission demo documenting that snap utility classes use var() without fallback values.

Closes #5957