### PR TITLE
utilities-text-fallbacks-bug-demo (#5959)

### DIFF
--- a/submissions/examples/utilities-text-fallbacks-bug-demo/README.md
+++ b/submissions/examples/utilities-text-fallbacks-bug-demo/README.md
@@ -1,0 +1,20 @@
+# Utilities: Text size utilities missing var() fallback values
+
+**Issue:** #5959
+**File:** `core/utilities.css`
+
+## Problem
+
+Lines 250-257 define `.ease-text-xs` through `.ease-text-4xl` using `var(--ease-text-xs)` through `var(--ease-text-4xl)` without any fallback values.
+
+## Expected
+
+```css
+.ease-text-xs   { font-size: var(--ease-text-xs, 0.75rem) !important; }
+.ease-text-sm   { font-size: var(--ease-text-sm, 0.875rem) !important; }
+.ease-text-base { font-size: var(--ease-text-base, 1rem) !important; }
+```
+
+## Demo
+
+Open `demo.html` to see text size utilities resolve to `initial` without the base layer.

--- a/submissions/examples/utilities-text-fallbacks-bug-demo/demo.html
+++ b/submissions/examples/utilities-text-fallbacks-bug-demo/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Utilities – Text size missing var() fallbacks</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Bug: text utilities missing fallbacks</h1>
+  <p>Without the base layer, font-size resolves to <code>initial</code> (medium).</p>
+
+  <p class="ease-text-xs">ease-text-xs — no fallback</p>
+  <p class="ease-text-sm">ease-text-sm — no fallback</p>
+  <p class="ease-text-base">ease-text-base — no fallback</p>
+  <p class="ease-text-lg">ease-text-lg — no fallback</p>
+  <p class="ease-text-xl">ease-text-xl — no fallback</p>
+  <p class="ease-text-2xl">ease-text-2xl — no fallback</p>
+  <p class="ease-text-3xl">ease-text-3xl — no fallback</p>
+  <p class="ease-text-4xl">ease-text-4xl — no fallback</p>
+
+  <hr />
+  <h2>Fix</h2>
+  <pre>
+.ease-text-xs   { font-size: var(--ease-text-xs, 0.75rem) !important; }
+.ease-text-sm   { font-size: var(--ease-text-sm, 0.875rem) !important; }
+.ease-text-base { font-size: var(--ease-text-base, 1rem) !important; }
+/* ... etc */
+  </pre>
+</body>
+</html>

--- a/submissions/examples/utilities-text-fallbacks-bug-demo/style.css
+++ b/submissions/examples/utilities-text-fallbacks-bug-demo/style.css
@@ -1,0 +1,24 @@
+/* utilities.css bug demo: text utilities missing fallbacks */
+
+body { margin: 2rem; font-family: system-ui, sans-serif; }
+
+.ease-text-xs   { font-size: var(--ease-text-xs) !important; }   /* BUG */
+.ease-text-sm   { font-size: var(--ease-text-sm) !important; }   /* BUG */
+.ease-text-base { font-size: var(--ease-text-base) !important; } /* BUG */
+.ease-text-lg   { font-size: var(--ease-text-lg) !important; }   /* BUG */
+.ease-text-xl   { font-size: var(--ease-text-xl) !important; }   /* BUG */
+.ease-text-2xl  { font-size: var(--ease-text-2xl) !important; }  /* BUG */
+.ease-text-3xl  { font-size: var(--ease-text-3xl) !important; }  /* BUG */
+.ease-text-4xl  { font-size: var(--ease-text-4xl) !important; }  /* BUG */
+
+/* FIX */
+/*
+.ease-text-xs   { font-size: var(--ease-text-xs, 0.75rem) !important; }
+.ease-text-sm   { font-size: var(--ease-text-sm, 0.875rem) !important; }
+.ease-text-base { font-size: var(--ease-text-base, 1rem) !important; }
+.ease-text-lg   { font-size: var(--ease-text-lg, 1.125rem) !important; }
+.ease-text-xl   { font-size: var(--ease-text-xl, 1.25rem) !important; }
+.ease-text-2xl  { font-size: var(--ease-text-2xl, 1.5rem) !important; }
+.ease-text-3xl  { font-size: var(--ease-text-3xl, 1.875rem) !important; }
+.ease-text-4xl  { font-size: var(--ease-text-4xl, 2.25rem) !important; }
+*/


### PR DESCRIPTION
## Summary
Creates a submission demo documenting that text size utility classes are missing var() fallback values.

Closes #5959