### PR TITLE
submission: add animated breadcrumb example (#5883)

### DIFF
--- a/submissions/examples/breadcrumb-animated/README.md
+++ b/submissions/examples/breadcrumb-animated/README.md
@@ -1,0 +1,18 @@
+# Animated Breadcrumb
+
+## 1. What does this do?
+A breadcrumb navigation where links slide up and reveal an underline on hover, with `::before` slash separators between items.
+
+## 2. How is it used?
+Use an `<ol>` with the `.breadcrumb` class, each `<li>` is a `.crumb`. Use `.crumb-active` for the current page (no link, bold text).
+```html
+<nav aria-label="Breadcrumb">
+  <ol class="breadcrumb">
+    <li class="crumb"><a href="#">Home</a></li>
+    <li class="crumb crumb-active" aria-current="page">Current</li>
+  </ol>
+</nav>
+```
+
+## 3. Why is it useful?
+An accessible breadcrumb navigation with subtle hover animations. Auto-inserts slash separators between items. Uses `aria-current="page"` and `aria-label` for screen readers. Respects `prefers-reduced-motion`.

--- a/submissions/examples/breadcrumb-animated/demo.html
+++ b/submissions/examples/breadcrumb-animated/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Breadcrumb</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav aria-label="Breadcrumb">
+    <ol class="breadcrumb">
+      <li class="crumb"><a href="#">Home</a></li>
+      <li class="crumb"><a href="#">Products</a></li>
+      <li class="crumb"><a href="#">Electronics</a></li>
+      <li class="crumb crumb-active" aria-current="page">Headphones</li>
+    </ol>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-animated/style.css
+++ b/submissions/examples/breadcrumb-animated/style.css
@@ -1,0 +1,80 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0f172a;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  list-style: none;
+}
+
+.crumb {
+  position: relative;
+}
+
+.crumb + .crumb::before {
+  content: "/";
+  margin-right: 0.5rem;
+  color: #475569;
+}
+
+.crumb a,
+.crumb-active {
+  display: inline-block;
+  padding: 0.375rem 0.125rem;
+  font-size: 0.9375rem;
+  color: #94a3b8;
+  text-decoration: none;
+  transition: color 0.2s, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  will-change: transform;
+}
+
+.crumb a::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0.125rem;
+  right: 0.125rem;
+  height: 2px;
+  background: #6c63ff;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.25s ease;
+}
+
+.crumb a:hover {
+  color: #f1f5f9;
+  transform: translateY(-2px);
+}
+
+.crumb a:hover::after {
+  transform: scaleX(1);
+}
+
+.crumb-active {
+  color: #6c63ff;
+  font-weight: 600;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crumb a {
+    transition: color 0.2s;
+    transform: none !important;
+  }
+  .crumb a::after {
+    transition: none;
+    transform: scaleX(0) !important;
+  }
+}


### PR DESCRIPTION
Adds \submissions/examples/breadcrumb-animated/\ with \demo.html\, \style.css\, and \README.md\.

Breadcrumb navigation with hover underline animation and slash separators.

Fixes #5883