### PR TITLE
fix: load forms.css in smoke.test.js and add form component assertions

### DIFF
--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -28,7 +28,7 @@ const badges = readFileSync(resolve(componentsDir, 'badges.css'), 'utf8');
 const loaders = readFileSync(resolve(componentsDir, 'loaders.css'), 'utf8');
 const tooltips = readFileSync(resolve(componentsDir, 'tooltips.css'), 'utf8');
 const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
-const forms = readFileSync(resolve(componentsDir, 'forms.css'), 'utf8');
+const forms  = readFileSync(resolve(componentsDir, 'forms.css'),  'utf8');
 
     css = variables + base + animations + utilities + buttons + cards + chip + footer + masonry + navbar + scrollProgress + sidebar + tabs + badges + loaders + tooltips + modals + forms;
     dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>');

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -28,8 +28,9 @@ const badges = readFileSync(resolve(componentsDir, 'badges.css'), 'utf8');
 const loaders = readFileSync(resolve(componentsDir, 'loaders.css'), 'utf8');
 const tooltips = readFileSync(resolve(componentsDir, 'tooltips.css'), 'utf8');
 const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
-    
-    css = variables + base + animations + utilities + buttons + cards + chip + footer + masonry + navbar + scrollProgress + sidebar + tabs + badges + loaders + tooltips + modals;
+const forms = readFileSync(resolve(componentsDir, 'forms.css'), 'utf8');
+
+    css = variables + base + animations + utilities + buttons + cards + chip + footer + masonry + navbar + scrollProgress + sidebar + tabs + badges + loaders + tooltips + modals + forms;
     dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>');
     document = dom.window.document;
     
@@ -128,6 +129,17 @@ const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
     expect(css).toContain('.ease-modal-header');
   });
   
+  it('should have forms component classes defined', () => {
+    expect(css).toContain('.ease-field');
+    expect(css).toContain('.ease-field-label');
+    expect(css).toContain('.ease-input');
+    expect(css).toContain('.ease-input-success');
+    expect(css).toContain('.ease-input-danger');
+    expect(css).toContain('.ease-input-warning');
+    expect(css).toContain('.ease-textarea');
+    expect(css).toContain('.ease-select');
+  });
+
   it('should not have duplicate @keyframes definitions', () => {
     const keyframeCounts = {};
     const keyframeRegex = /@keyframes\s+([^\s{]+)/g;


### PR DESCRIPTION
## Pull Request Description

`components/forms.css` is a shipped component (imported in `easemotion.css` line 44) but was never loaded inside `tests/smoke.test.js`. Any regression, syntax error, or missing class in the forms component would silently pass the entire CI test suite. This PR adds forms.css to the test loader and adds a dedicated test case covering all core form classes.

Fixes #6037

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `tests/smoke.test.js`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

`forms.css` was the only shipped component missing from the smoke test's `beforeAll` loader. The test suite gave false confidence that the full framework was covered.

**Changes made:**

1. Added `forms.css` to the `beforeAll` read block alongside all other components
2. Added a new test — `'should have forms component classes defined'` — asserting presence of:
   - `.ease-field`, `.ease-field-label`
   - `.ease-input`, `.ease-textarea`, `.ease-select`
   - `.ease-input-success`, `.ease-input-danger`, `.ease-input-warning`

**Test results:** All 11 tests pass (`npm test`)

---

## Browser Testing

N/A — test suite change only

---

## Notes for Maintainer

This is a test-only fix — no framework CSS is modified. The `forms.css` file already exists and is correct; it was simply never wired into the smoke test. Related issue #5744 covers the same gap in `validate-pack.mjs`.