### PR TITLE
fix: correct $ease-out-cubic and $ease-in-cubic easing aliases in scss/_variables.scss

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -22,10 +22,13 @@ $ease-bounce:       cubic-bezier(0.34, 1.56, 0.64, 1);
 $ease-in-out:       cubic-bezier(0, 0, 0.2, 1);
 $ease-ping:         cubic-bezier(0, 0, 0.2, 1);
 
-// Named easing aliases
+// Named easing aliases — each maps to the correct curve in core/variables.css:
+// $ease-in-out-cubic → --ease-ease      cubic-bezier(0.4, 0, 0.2, 1)
+// $ease-out-cubic    → --ease-ease-out  cubic-bezier(0, 0, 0.2, 1)
+// $ease-in-cubic     → --ease-ease-in   cubic-bezier(0.4, 0, 1, 1)
 $ease-in-out-cubic: $ease-ease;
-$ease-out-cubic:    $ease-ease;
-$ease-in-cubic:     $ease-ease;
+$ease-out-cubic:    cubic-bezier(0, 0, 0.2, 1);
+$ease-in-cubic:     cubic-bezier(0.4, 0, 1, 1);
 $ease-elastic:      $ease-bounce;
 
 // Delay and fill defaults


### PR DESCRIPTION
## Pull Request Description

In `scss/_variables.scss`, the named easing aliases `$ease-out-cubic` and `$ease-in-cubic` were both assigned `$ease-ease` (smooth ease-in-out), making all three directional aliases identical. This means SCSS consumers applying `$ease-in-cubic` (e.g. the `zoom-out` mixin) get the wrong timing curve — an exit feels the same as an entrance.

This PR aligns each alias with its matching CSS variable in `core/variables.css`.

Fixes #6039

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `scss/_variables.scss`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

| Alias | Before (wrong) | After (correct) | Matches CSS var |
|---|---|---|---|
| `$ease-in-out-cubic` | `cubic-bezier(0.4, 0, 0.2, 1)` | unchanged | `--ease-ease` |
| ``$ease-out-cubic`` | `cubic-bezier(0.4, 0, 0.2, 1)` | `cubic-bezier(0, 0, 0.2, 1)` | `--ease-ease-out` |
| `$ease-in-cubic` | `cubic-bezier(0.4, 0, 0.2, 1)` | `cubic-bezier(0.4, 0, 1, 1)` | `--ease-ease-in` |

`npm run build:scss` compiles cleanly after the fix.

---

## Browser Testing

N/A — SCSS token fix, no visual demo changed

---

## Notes for Maintainer

The values were taken directly from `core/variables.css` (`--ease-ease-out` and `--ease-ease-in`). No other files were changed. Comments in the file now document the mapping for future contributors.