### PR TITLE
fix: replace innerHTML with safe DOM methods in motion-optimization-ai-advisor-v1

### DIFF
--- a/submissions/examples/motion-optimization-ai-advisor-v1/demo.html
+++ b/submissions/examples/motion-optimization-ai-advisor-v1/demo.html
@@ -217,14 +217,23 @@
     let heatmapActive = false;
 
     // Theme Switch
+    function setThemeButtonLabel(isDark) {
+      themeToggle.textContent = '';
+      const icon = document.createElement('span');
+      icon.className = 'theme-icon';
+      icon.textContent = isDark ? '🌙' : '☀️';
+      themeToggle.appendChild(icon);
+      themeToggle.appendChild(document.createTextNode(isDark ? ' Dark Mode' : ' Light Mode'));
+    }
+
     themeToggle.addEventListener('click', () => {
       const currentTheme = document.body.getAttribute('data-theme');
       if (currentTheme === 'light') {
         document.body.removeAttribute('data-theme');
-        themeToggle.innerHTML = '<span class="theme-icon">🌙</span> Dark Mode';
+        setThemeButtonLabel(true);
       } else {
         document.body.setAttribute('data-theme', 'light');
-        themeToggle.innerHTML = '<span class="theme-icon">☀️</span> Light Mode';
+        setThemeButtonLabel(false);
       }
     });
 
@@ -372,7 +381,9 @@
     }
 
     function generateAlerts(target, loops, travel, comfortScore) {
-      advisorAlerts.innerHTML = '';
+      while (advisorAlerts.firstChild) {
+        advisorAlerts.removeChild(advisorAlerts.firstChild);
+      }
 
       // Check GPU vs CPU
       if (target === 'cpu') {
@@ -400,13 +411,26 @@
     function addAlertItem(type, icon, title, desc) {
       const div = document.createElement('div');
       div.className = `alert-item alert-item-${type}`;
-      div.innerHTML = `
-        <span class="alert-item-icon">${icon}</span>
-        <div>
-          <strong style="display:block; margin-bottom:0.15rem;">${title}</strong>
-          <span>${desc}</span>
-        </div>
-      `;
+
+      const iconSpan = document.createElement('span');
+      iconSpan.className = 'alert-item-icon';
+      iconSpan.textContent = icon;
+
+      const contentDiv = document.createElement('div');
+
+      const strong = document.createElement('strong');
+      strong.style.display = 'block';
+      strong.style.marginBottom = '0.15rem';
+      strong.textContent = title;
+
+      const descSpan = document.createElement('span');
+      descSpan.textContent = desc;
+
+      contentDiv.appendChild(strong);
+      contentDiv.appendChild(descSpan);
+
+      div.appendChild(iconSpan);
+      div.appendChild(contentDiv);
       advisorAlerts.appendChild(div);
     }
 


### PR DESCRIPTION
## Pull Request Description

The `motion-optimization-ai-advisor-v1` submission used `innerHTML` in four places to dynamically build the theme toggle button label and alert card elements. This is an unsafe DOM pattern — injecting HTML strings can introduce XSS vulnerabilities and makes the code harder to audit.

This PR replaces all four `innerHTML` usages with explicit `document.createElement()` + `textContent` calls, keeping the rendered output identical while eliminating string-based HTML injection entirely.

Fixes #5816

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/motion-optimization-ai-advisor-v1/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

Four `innerHTML` usages replaced with safe DOM methods:

| Location | Before | After |
|---|---|---|
| Line 224/227 — theme label | `themeToggle.innerHTML = `...`` | `setThemeButtonLabel()` using `createElement` + `textContent` |
| Line 375 — clear alerts | `advisorAlerts.innerHTML = ''` | `while (firstChild) removeChild(firstChild)` |
| Line 403 — alert card | `div.innerHTML = `...`` | `createElement` for each element, `textContent` for all values |

All dynamic content (`icon`, `title`, `desc`, travel distance interpolation) now flows through `textContent` — no markup is ever injected as a string.

**How does a developer use it?**

No usage change — the demo UI is identical. The fix is internal to the JS logic.

---

## Demo

- [x] Demo verified — opens directly in browser, theme toggle and alert rendering both work correctly with no console errors

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

The rendered output is pixel-identical to before — only the DOM construction method changed. The `setThemeButtonLabel()` helper was extracted to avoid repeating the same DOM-building logic for both theme states.