### PR TITLE
maintenance(html-cheatsheet): add missing demo.html (#6058)

### DIFF
--- a/submissions/examples/html-cheatsheet/README.md
+++ b/submissions/examples/html-cheatsheet/README.md
@@ -16,10 +16,12 @@ A single-page, printable cheatsheet for the EaseMotion CSS framework.
 
 ## How to use
 
-1. Open `cheatsheet.html` in your browser (double-click or use `Invoke-Item`):
+Open `demo.html` in a browser to preview the cheatsheet.
+
+1. Open `demo.html` in your browser (double-click or use `Invoke-Item`):
 
 ```powershell
-Invoke-Item submissions\html-cheatsheet\cheatsheet.html
+Invoke-Item submissions\examples\html-cheatsheet\demo.html
 ```
 
 2. Use the search box in the side panel or press `/` to focus search.
@@ -40,7 +42,7 @@ Invoke-Item submissions\html-cheatsheet\cheatsheet.html
 
 ## Extending the cheatsheet
 
-To add more classes or sections, edit `cheatsheet.html` and add new `<article class="cheat">` blocks under the relevant section. Include:
+To add more classes or sections, edit `demo.html` and add new `<article class="cheat">` blocks under the relevant section. Include:
 
 ```html
 <article class="cheat" data-keywords="...">
@@ -53,7 +55,7 @@ To add more classes or sections, edit `cheatsheet.html` and add new `<article cl
 
 ## Files
 
-- `cheatsheet.html` — Single-page cheatsheet
+- `demo.html` — Single-page cheatsheet preview
 - `style.css` — Styles and print rules
 - `README.md` — This file
 

--- a/submissions/examples/html-cheatsheet/demo.html
+++ b/submissions/examples/html-cheatsheet/demo.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>HTML Cheatsheet Demo — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <header class="site-header">
+    <div class="container">
+      <h1>HTML Cheatsheet</h1>
+      <p class="lead">A printable, offline-friendly reference for commonly used EaseMotion CSS classes with live examples.</p>
+    </div>
+  </header>
+
+  <aside class="toc" aria-label="Table of contents">
+    <div class="toc-inner">
+      <h2>Contents</h2>
+      <input type="search" id="search" placeholder="Filter classes…" aria-label="Search cheatsheet">
+      <ul>
+        <li><a href="#layout">Layout</a></li>
+        <li><a href="#animation">Animation</a></li>
+        <li><a href="#buttons">Buttons</a></li>
+        <li><a href="#cards">Cards</a></li>
+        <li><a href="#utilities">Utilities</a></li>
+      </ul>
+      <p style="margin-top:1rem;">
+        <button type="button" class="btn small" onclick="window.print()">Print / Save PDF</button>
+      </p>
+    </div>
+  </aside>
+
+  <main class="container">
+    <p class="muted">Browse class names, copy snippets, and preview examples. Press <kbd>/</kbd> to focus search.</p>
+
+    <section id="layout">
+      <h2>Layout</h2>
+      <p class="muted">Centering, flex stacks, and grid helpers for page structure.</p>
+      <div class="grid">
+        <article class="cheat" data-keywords="layout center flex grid">
+          <h3 class="class-name">.ease-center</h3>
+          <p class="desc">Centers content horizontally and vertically with flexbox.</p>
+          <pre class="code">&lt;div class="ease-center"&gt;Centered&lt;/div&gt;</pre>
+          <div class="example">
+            <span class="example-box ease-center" style="display:flex;align-items:center;justify-content:center;min-height:3rem;">Centered</span>
+          </div>
+        </article>
+        <article class="cheat" data-keywords="layout flex stack gap">
+          <h3 class="class-name">.ease-stack</h3>
+          <p class="desc">Vertical flex column with consistent spacing between children.</p>
+          <pre class="code">&lt;div class="ease-stack"&gt;...&lt;/div&gt;</pre>
+          <div class="example">
+            <div class="example-card ease-stack" style="display:flex;flex-direction:column;gap:0.5rem;">
+              <span>Item one</span>
+              <span>Item two</span>
+            </div>
+          </div>
+        </article>
+        <article class="cheat" data-keywords="layout grid auto">
+          <h3 class="class-name">.ease-grid-auto</h3>
+          <p class="desc">Responsive auto-fit grid for card layouts.</p>
+          <pre class="code">&lt;div class="ease-grid ease-grid-auto"&gt;...&lt;/div&gt;</pre>
+          <div class="example">
+            <div class="example-box">Auto-fit grid preview</div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="animation">
+      <h2>Animation</h2>
+      <p class="muted">Entrance and hover motion classes.</p>
+      <div class="grid">
+        <article class="cheat" data-keywords="animation fade entrance">
+          <h3 class="class-name">.ease-fade-in</h3>
+          <p class="desc">Fades content in on load.</p>
+          <pre class="code">&lt;h1 class="ease-fade-in"&gt;Hello&lt;/h1&gt;</pre>
+          <div class="example">
+            <span class="example-inline" style="background:#ede9fe;">Fade in</span>
+          </div>
+        </article>
+        <article class="cheat" data-keywords="animation slide up">
+          <h3 class="class-name">.ease-slide-up</h3>
+          <p class="desc">Slides content upward while fading in.</p>
+          <pre class="code">&lt;p class="ease-slide-up"&gt;Subtitle&lt;/p&gt;</pre>
+          <div class="example">
+            <span class="example-box">Slide up</span>
+          </div>
+        </article>
+        <article class="cheat" data-keywords="animation hover grow">
+          <h3 class="class-name">.ease-hover-grow</h3>
+          <p class="desc">Scales element up slightly on hover.</p>
+          <pre class="code">&lt;button class="ease-hover-grow"&gt;Hover me&lt;/button&gt;</pre>
+          <div class="example">
+            <button type="button" class="example-btn ease-hover-grow">Hover me</button>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="buttons">
+      <h2>Buttons</h2>
+      <p class="muted">Semantic button styles and sizes.</p>
+      <div class="grid">
+        <article class="cheat" data-keywords="button primary">
+          <h3 class="class-name">.ease-btn-primary</h3>
+          <p class="desc">Primary call-to-action button style.</p>
+          <pre class="code">&lt;button class="ease-btn ease-btn-primary"&gt;Save&lt;/button&gt;</pre>
+          <div class="example">
+            <button type="button" class="example-btn btn">Primary</button>
+          </div>
+        </article>
+        <article class="cheat" data-keywords="button outline">
+          <h3 class="class-name">.ease-btn-outline</h3>
+          <p class="desc">Outlined button for secondary actions.</p>
+          <pre class="code">&lt;button class="ease-btn ease-btn-outline"&gt;Cancel&lt;/button&gt;</pre>
+          <div class="example">
+            <button type="button" class="example-btn">Outline</button>
+          </div>
+        </article>
+        <article class="cheat" data-keywords="button small pill">
+          <h3 class="class-name">.ease-btn-sm</h3>
+          <p class="desc">Compact button size for dense UIs.</p>
+          <pre class="code">&lt;button class="ease-btn ease-btn-sm"&gt;Small&lt;/button&gt;</pre>
+          <div class="example">
+            <button type="button" class="example-btn btn small">Small</button>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="cards">
+      <h2>Cards</h2>
+      <p class="muted">Composable card layout primitives.</p>
+      <div class="grid">
+        <article class="cheat" data-keywords="card shadow hover">
+          <h3 class="class-name">.ease-card</h3>
+          <p class="desc">Base card container with padding and radius.</p>
+          <pre class="code">&lt;div class="ease-card"&gt;...&lt;/div&gt;</pre>
+          <div class="example">
+            <div class="example-card">
+              <strong>Card title</strong>
+              <p class="desc" style="margin-bottom:0;">Card body text.</p>
+            </div>
+          </div>
+        </article>
+        <article class="cheat" data-keywords="card header body footer">
+          <h3 class="class-name">.ease-card-header</h3>
+          <p class="desc">Top section of a card with title spacing.</p>
+          <pre class="code">&lt;div class="ease-card-header"&gt;...&lt;/div&gt;</pre>
+          <div class="example">
+            <div class="example-card">
+              <div class="example-box">Header</div>
+            </div>
+          </div>
+        </article>
+        <article class="cheat" data-keywords="card lift hover">
+          <h3 class="class-name">.ease-card-hover</h3>
+          <p class="desc">Lifts card on hover with shadow transition.</p>
+          <pre class="code">&lt;div class="ease-card ease-card-hover"&gt;...&lt;/div&gt;</pre>
+          <div class="example">
+            <div class="example-card">Hover lift</div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="utilities">
+      <h2>Utilities</h2>
+      <p class="muted">Spacing, typography, and display helpers.</p>
+      <div class="grid">
+        <article class="cheat" data-keywords="utility padding margin gap">
+          <h3 class="class-name">.ease-padding-4</h3>
+          <p class="desc">Applies spacing token padding on all sides.</p>
+          <pre class="code">&lt;div class="ease-padding-4"&gt;...&lt;/div&gt;</pre>
+          <div class="example">
+            <span class="example-box">Padded box</span>
+          </div>
+        </article>
+        <article class="cheat" data-keywords="utility text muted">
+          <h3 class="class-name">.ease-text-muted</h3>
+          <p class="desc">Secondary text color from the neutral palette.</p>
+          <pre class="code">&lt;p class="ease-text-muted"&gt;Helper text&lt;/p&gt;</pre>
+          <div class="example">
+            <span class="muted example-inline">Muted helper text</span>
+          </div>
+        </article>
+        <article class="cheat" data-keywords="utility hidden sr-only">
+          <h3 class="class-name">.ease-hidden</h3>
+          <p class="desc">Removes element from visual layout.</p>
+          <pre class="code">&lt;span class="ease-hidden"&gt;...&lt;/span&gt;</pre>
+          <div class="example">
+            <span class="example-inline">Visible label</span>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p class="muted" style="margin:0;">EaseMotion CSS HTML Cheatsheet — offline demo submission</p>
+    </div>
+  </footer>
+
+  <script>
+    const search = document.getElementById('search');
+    const cheats = document.querySelectorAll('.cheat');
+
+    search.addEventListener('input', () => {
+      const query = search.value.trim().toLowerCase();
+      cheats.forEach((card) => {
+        const text = (card.textContent + ' ' + (card.dataset.keywords || '')).toLowerCase();
+        card.style.display = !query || text.includes(query) ? '' : 'none';
+      });
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === '/' && document.activeElement !== search) {
+        event.preventDefault();
+        search.focus();
+      }
+    });
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds the required `demo.html` to the html-cheatsheet submission so it passes three-file validation and can be previewed offline.

Closes #6058

## Changes

- `demo.html` — cheatsheet preview with TOC, search, print, and all style.css classes demonstrated
- `README.md` — updated usage instructions and file list

## Acceptance criteria

- [x] `demo.html` loads `./style.css`
- [x] Renders cheatsheet offline
- [x] README mentions `demo.html`
- [x] Three-file validation passes