### PR TITLE
fix: replace <title>Document</title> placeholder with descriptive titles in 3 submissions

### DIFF
--- a/submissions/examples/animated-graph-stats/demo.html
+++ b/submissions/examples/animated-graph-stats/demo.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Document</title>
+  <title>Animated Graph Stats — EaseMotion CSS</title>
   <link rel="stylesheet" href="style.css">
   </head>
 <body>

--- a/submissions/examples/holographic-card/demo.html
+++ b/submissions/examples/holographic-card/demo.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Holographic Card — EaseMotion CSS</title>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/submissions/examples/loading-cup/demo.html
+++ b/submissions/examples/loading-cup/demo.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Loading Cup Animation — EaseMotion CSS</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
## Pull Request Description

Three submissions were merged with the VS Code default `<title>Document</title>` placeholder title never updated. Browser tabs, bookmarks, and browser history all showed the meaningless string "Document" instead of identifying the component.

Fixes #6079

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

Updates the `<title>` tag in three demo files from the VS Code default placeholder `Document` to descriptive names:

- `submissions/examples/holographic-card/demo.html` → `Holographic Card — EaseMotion CSS`
- `submissions/examples/loading-cup/demo.html` → `Loading Cup Animation — EaseMotion CSS`
- `submissions/examples/animated-graph-stats/demo.html` → `Animated Graph Stats — EaseMotion CSS`

**How does a developer use it?**

```html
<!-- Before -->
<title>Document</title>

<!-- After -->
<title>Holographic Card — EaseMotion CSS</title>
```

**Why does it fit EaseMotion CSS?**

Descriptive titles make demos self-documenting when shared, bookmarked, or opened in browser history — consistent with every other properly submitted demo in the repository.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Pure single-line `<title>` tag fixes in three files. No CSS, JS, or structural changes. Each file touches only line 6.