### PR TITLE
fix(blur-image-utility): replace Unsplash CDN image with inline SVG placeholder

### DIFF
--- a/submissions/examples/blur-image-utility/demo.html
+++ b/submissions/examples/blur-image-utility/demo.html
@@ -10,8 +10,8 @@
 
   <div class="container">
     <img
-      src="https://images.unsplash.com/photo-1506744038136-46273834b3fb"
-      alt="Demo Image"
+      src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='400' viewBox='0 0 640 400'%3E%3Crect width='640' height='400' fill='%231a3a5c'/%3E%3Crect x='0' y='260' width='640' height='140' fill='%230f2a45'/%3E%3Ccircle cx='320' cy='130' r='60' fill='%23f5c842' opacity='0.9'/%3E%3Cellipse cx='80' cy='260' rx='120' ry='70' fill='%232d6a4f'/%3E%3Cellipse cx='260' cy='270' rx='100' ry='60' fill='%2340916c'/%3E%3Cellipse cx='460' cy='265' rx='130' ry='65' fill='%231b4332'/%3E%3Cellipse cx='600' cy='270' rx='80' ry='55' fill='%232d6a4f'/%3E%3Crect x='270' y='200' width='18' height='70' fill='%23a0522d'/%3E%3Crect x='248' y='170' width='62' height='38' fill='%2374c69d' rx='4'/%3E%3C/svg%3E"
+      alt="Landscape placeholder — blur effect demo"
       class="blur-image-utility"
     />
   </div>


### PR DESCRIPTION
## Pull Request Description

`submissions/examples/blur-image-utility/demo.html` loaded its only image from Unsplash CDN. When opened offline the demo displayed a blank broken image icon — the blur hover effect (the entire point of the submission) could not be seen at all.

Replaced with a self-contained inline SVG landscape image encoded as a `data:` URI. The demo is now fully offline-capable.

Fixes #6064

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

```html
<!-- Before — requires network -->
<img src="https://images.unsplash.com/photo-1506744038136-46273834b3fb" alt="Demo Image" class="blur-image-utility" />

<!-- After — fully self-contained -->
<img src="data:image/svg+xml,..." alt="Landscape placeholder — blur effect demo" class="blur-image-utility" />
```

The inline SVG renders a landscape scene (sky, sun, hills, trees) giving the blur animation a realistic visual subject to demonstrate against.

**Why does it fit EaseMotion CSS?**

CONTRIBUTING.md requires demos to work by opening directly in a browser with no server and no CDN links.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Only the `src` and `alt` attributes of the single `<img>` tag are changed. The CSS class, animation keyframes, and all other markup are untouched.