### PR TITLE
fix(animated-online-user-card): viewport meta, offline-safe avatar, prefers-reduced-motion guard

### DIFF
--- a/submissions/examples/animated-online-user-card/demo.html
+++ b/submissions/examples/animated-online-user-card/demo.html
@@ -2,14 +2,15 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Animated Online User Card</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Online User Card — EaseMotion CSS</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
 <div class="user-card">
     <div class="avatar-wrapper">
-        <img src="https://via.placeholder.com/100" alt="User">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='50' fill='%234f46e5'/%3E%3Ccircle cx='50' cy='38' r='18' fill='%23e0e7ff'/%3E%3Cellipse cx='50' cy='85' rx='28' ry='20' fill='%23e0e7ff'/%3E%3C/svg%3E" alt="User avatar">
         <span class="status online"></span>
     </div>
 

--- a/submissions/examples/animated-online-user-card/style.css
+++ b/submissions/examples/animated-online-user-card/style.css
@@ -18,8 +18,10 @@ body{
     transition:0.3s;
 }
 
-.user-card:hover{
-    transform:translateY(-8px);
+@media (prefers-reduced-motion: no-preference) {
+    .user-card:hover{
+        transform:translateY(-8px);
+    }
 }
 
 .avatar-wrapper{


### PR DESCRIPTION
## Pull Request Description

`submissions/examples/animated-online-user-card` had three issues:

1. **Missing `<meta name="viewport">`** — demo was not mobile-responsive
2. **External image** — avatar from `via.placeholder.com` broke offline
3. **No `prefers-reduced-motion` guard** — hover `translateY` ran for all users regardless of OS accessibility settings

All three are fixed in this PR.

Fixes #6078

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

**`demo.html`:**
```html
<!-- Added viewport meta -->
<meta name="viewport" content="width=device-width, initial-scale=1.0">

<!-- Replaced external image with inline SVG avatar -->
<img src="data:image/svg+xml,..." alt="User avatar">
```

**`style.css`:**
```css
/* Wrapped hover transform in reduced-motion guard */
@media (prefers-reduced-motion: no-preference) {
    .user-card:hover {
        transform: translateY(-8px);
    }
}
```

**Why does it fit EaseMotion CSS?**

Keeps the submission compliant with CONTRIBUTING.md (offline-safe, self-contained) and accessible to users with vestibular sensitivities.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Two files changed: `demo.html` (viewport meta + SVG avatar) and `style.css` (reduced-motion guard). Card layout, animation keyframes, and all other styles are untouched.