### PR TITLE
fix(animated-avatar-stack): replace pravatar.cc CDN images with inline SVG avatars

### DIFF
--- a/submissions/examples/animated-avatar-stack/demo.html
+++ b/submissions/examples/animated-avatar-stack/demo.html
@@ -20,19 +20,19 @@
 
       <div class="avatar-stack" aria-label="Team members" role="group">
         <button class="avatar" type="button" aria-label="User 1" title="User 1">
-          <img src="https://i.pravatar.cc/120?img=1" alt="" />
+          <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120' viewBox='0 0 120 120'%3E%3Ccircle cx='60' cy='60' r='60' fill='%234f46e5'/%3E%3Ctext x='60' y='76' text-anchor='middle' font-size='52' font-family='system-ui,sans-serif' font-weight='600' fill='%23fff'%3EA%3C/text%3E%3C/svg%3E" alt="" />
         </button>
 
         <button class="avatar" type="button" aria-label="User 2" title="User 2">
-          <img src="https://i.pravatar.cc/120?img=2" alt="" />
+          <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120' viewBox='0 0 120 120'%3E%3Ccircle cx='60' cy='60' r='60' fill='%230891b2'/%3E%3Ctext x='60' y='76' text-anchor='middle' font-size='52' font-family='system-ui,sans-serif' font-weight='600' fill='%23fff'%3EB%3C/text%3E%3C/svg%3E" alt="" />
         </button>
 
         <button class="avatar" type="button" aria-label="User 3" title="User 3">
-          <img src="https://i.pravatar.cc/120?img=3" alt="" />
+          <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120' viewBox='0 0 120 120'%3E%3Ccircle cx='60' cy='60' r='60' fill='%23059669'/%3E%3Ctext x='60' y='76' text-anchor='middle' font-size='52' font-family='system-ui,sans-serif' font-weight='600' fill='%23fff'%3EC%3C/text%3E%3C/svg%3E" alt="" />
         </button>
 
         <button class="avatar" type="button" aria-label="User 4" title="User 4">
-          <img src="https://i.pravatar.cc/120?img=4" alt="" />
+          <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120' viewBox='0 0 120 120'%3E%3Ccircle cx='60' cy='60' r='60' fill='%23d97706'/%3E%3Ctext x='60' y='76' text-anchor='middle' font-size='52' font-family='system-ui,sans-serif' font-weight='600' fill='%23fff'%3ED%3C/text%3E%3C/svg%3E" alt="" />
         </button>
 
         <div class="avatar more-members" aria-hidden="true" title="More members">+8</div>


### PR DESCRIPTION
## Pull Request Description

`submissions/examples/animated-avatar-stack/demo.html` loaded all 4 avatar images from `pravatar.cc` (external CDN). When opened offline all avatars showed broken image icons, making the hover/lift animation impossible to evaluate.

Replaced with self-contained `data:` URI SVG initials avatars (A, B, C, D) with distinct background colours — fully offline-capable.

Fixes #6077

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

```html
<!-- Before — requires network -->
<img src="https://i.pravatar.cc/120?img=1" alt="" />

<!-- After — fully self-contained -->
<img src="data:image/svg+xml,..." alt="" />
```

Each of the 4 avatars now uses a distinct coloured SVG circle with a letter initial (A/B/C/D), making them visually distinguishable and removing all external dependencies.

**Why does it fit EaseMotion CSS?**

CONTRIBUTING.md requires demos to work by opening directly in a browser with no server and no CDN links.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Only the `src` attributes of the 4 `<img>` tags inside avatar buttons are changed. All ARIA labels, button markup, CSS, and animation logic are untouched.