### PR TITLE
fix(ease-avatar-bounce-pr): replace Unsplash CDN image with inline SVG avatar

### DIFF
--- a/submissions/examples/ease-avatar-bounce-pr/demo.html
+++ b/submissions/examples/ease-avatar-bounce-pr/demo.html
@@ -8,7 +8,7 @@
 <body>
     <div style="display:flex; justify-content:center; align-items:center; height:100vh; background:#f3f4f6;">
         <div style="text-align:center; background:white; padding:30px; border-radius:12px; box-shadow:0 4px 6px rgba(0,0,0,0.1);">
-            <img class="ease-avatar-bounce-pr" src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=150" alt="Avatar" width="150" height="150" style="border-radius:50%; border:4px solid #3b82f6;">
+            <img class="ease-avatar-bounce-pr" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='150' height='150' viewBox='0 0 150 150'%3E%3Ccircle cx='75' cy='75' r='75' fill='%234f46e5'/%3E%3Ccircle cx='75' cy='58' r='26' fill='%23e0e7ff'/%3E%3Cellipse cx='75' cy='118' rx='38' ry='26' fill='%23e0e7ff'/%3E%3C/svg%3E" alt="Avatar" width="150" height="150" style="border-radius:50%; border:4px solid #3b82f6;">
             <h3 style="margin-top:15px; font-family:sans-serif;">Hover Me!</h3>
         </div>
     </div>


### PR DESCRIPTION
## Pull Request Description

`submissions/examples/ease-avatar-bounce-pr/demo.html` loaded its avatar from Unsplash CDN. Offline, the image broke — the bounce animation was applied to a broken icon and could not be evaluated.

Replaced with a self-contained `data:` URI SVG user avatar so the demo works fully offline.

Fixes #6071

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

```html
<!-- Before — requires network -->
<img ... src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=150" ...>

<!-- After — fully self-contained -->
<img ... src="data:image/svg+xml,..." ...>
```

The inline SVG renders a simple user silhouette (head + shoulders) in indigo — same 150×150 dimensions with `border-radius:50%` applied by the original inline style.

**Why does it fit EaseMotion CSS?**

CONTRIBUTING.md requires demos to work by opening directly in a browser with no server and no CDN links.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Single attribute change — only `src` updated. All other attributes (`class`, `alt`, `width`, `height`, `style`) and the surrounding markup are unchanged.