### PR TITLE
fix: replace Google Fonts CDN imports with system font stacks in submissions (#6075)

### DIFF
--- a/submissions/examples/Ease-Navbar-Utility/style.css
+++ b/submissions/examples/Ease-Navbar-Utility/style.css
@@ -1,5 +1,4 @@
 /* Google Font */
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap");
 
 * {
   margin: 0;
@@ -8,7 +7,7 @@
 }
 
 body {
-  font-family: "Poppins", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 
   background: linear-gradient(135deg, #2b1810, #4b2e24, #6f4e37);
 

--- a/submissions/examples/accessibility-compliance-automation-studio/style.css
+++ b/submissions/examples/accessibility-compliance-automation-studio/style.css
@@ -1,10 +1,9 @@
 /* ── Accessibility Compliance Automation Studio — DevTools Style ── */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 :root {
-  --font-sans: 'Inter', sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Theme: Dark (Default DevTools style) */
   --bg-app: #0f141c;

--- a/submissions/examples/admin-dashboard-animation/demo.html
+++ b/submissions/examples/admin-dashboard-animation/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Admin Dashboard Animation — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/animated-accordions-height-expansion/demo.html
+++ b/submissions/examples/animated-accordions-height-expansion/demo.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Animated Accordions Demo — EaseMotion CSS</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     body {

--- a/submissions/examples/animated-alerts-banner-pack/demo.html
+++ b/submissions/examples/animated-alerts-banner-pack/demo.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Animated Alerts/Banners Demo — EaseMotion CSS</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     body {

--- a/submissions/examples/animated-aurora-hero-section/style.css
+++ b/submissions/examples/animated-aurora-hero-section/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;700&display=swap');
 
 /* ================================================================
    EaseMotion CSS — Animated Aurora Hero Section
@@ -40,8 +39,8 @@
   --glow-card:         0 24px 90px rgba(0, 0, 0, 0.58), 0 0 0 1px var(--col-border);
 
   /* Typography */
-  --font-display:      "Space Grotesk", "Manrope", sans-serif;
-  --font-body:         "Manrope", sans-serif;
+  --font-display: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 
   /* Spacing scale */
   --space-xs:   4px;

--- a/submissions/examples/animated-button-page/demo.html
+++ b/submissions/examples/animated-button-page/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Buttons Enhanced — EaseMotion CSS Submission</title>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
 
   <!-- GSAP + ScrollTrigger CDN -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>

--- a/submissions/examples/animated-button-page/style.css
+++ b/submissions/examples/animated-button-page/style.css
@@ -4,7 +4,6 @@
    Maintainer will rename classes to ease-* convention
    ============================================================ */
 
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Space+Mono:wght@400;700&display=swap');
 
 /* ── TOKENS ───────────────────────────────────────────────── */
 :root {
@@ -25,8 +24,8 @@
   --text-muted:     #52526a;
   --text-tag:       #3d3d55;
 
-  --font-ui:        'Space Grotesk', sans-serif;
-  --font-mono:      'Space Mono', monospace;
+  --font-ui: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   --radius-btn:     8px;
   --radius-pill:    999px;

--- a/submissions/examples/animated-card-effect/demo.html
+++ b/submissions/examples/animated-card-effect/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Animated Stat Cards — EaseMotion CSS Submission</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/animated-card-effect/style.css
+++ b/submissions/examples/animated-card-effect/style.css
@@ -3,7 +3,6 @@
    Maintainer will rename classes to ease-* convention
    ============================================================ */
 
-@import url('https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:wght@400;500&display=swap');
 
 /* ----- Reset & base ----- */
 *, *::before, *::after {
@@ -30,8 +29,8 @@
   --text-primary:     #f0f0f8;
   --text-muted:       #5a5a72;
   --text-label:       #6c6c88;
-  --font-display:     'Syne', sans-serif;
-  --font-body:        'DM Sans', sans-serif;
+  --font-display: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   --radius-card:      18px;
   --transition-snap:  0.12s ease;
   --transition-spring:0.45s cubic-bezier(0.23, 1, 0.32, 1);

--- a/submissions/examples/animated-comic-effect/style.css
+++ b/submissions/examples/animated-comic-effect/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Bangers&display=swap');
 
 *, *::before, *::after {
   margin: 0;
@@ -60,7 +59,7 @@ html, body {
 /* ─── TEXT ───────────────────────────────────────────────── */
 .comic-word {
   position: relative;
-  font-family: 'Bangers', 'Impact', cursive;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: clamp(60px, 15vw, 160px);
   font-style: italic;
   letter-spacing: 0.04em;

--- a/submissions/examples/animated-file-upload-dropzone/demo.html
+++ b/submissions/examples/animated-file-upload-dropzone/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Animated File Upload Dropzone — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/animated-letter-effect/style.css
+++ b/submissions/examples/animated-letter-effect/style.css
@@ -3,7 +3,6 @@
    Monochrome terminal aesthetic
    ───────────────────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap');
 
 *, *::before, *::after {
   box-sizing: border-box;
@@ -16,7 +15,7 @@
   --white:      #ffffff;
   --grey:       #888888;
   --grey-light: #aaaaaa;
-  --font:       'Courier Prime', 'Courier New', Courier, monospace;
+  --font: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   --font-size:  clamp(2.8rem, 9vw, 6rem);
   --letter-gap: 0.05em;
 }

--- a/submissions/examples/animated-masonry-gallery/demo.html
+++ b/submissions/examples/animated-masonry-gallery/demo.html
@@ -7,9 +7,6 @@
   <meta name="theme-color" content="#07070f" />
   <title>Animated Masonry Gallery — EaseMotion CSS</title>
   <link rel="stylesheet" href="style.css" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Syne:wght@600;700;800&display=swap" rel="stylesheet" />
 </head>
 <body>
 

--- a/submissions/examples/animated-modals-dialog-pack/demo.html
+++ b/submissions/examples/animated-modals-dialog-pack/demo.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Animated Modals Demo — EaseMotion CSS</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     body {

--- a/submissions/examples/animated-onboarding-checklist/demo.html
+++ b/submissions/examples/animated-onboarding-checklist/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Animated Onboarding Checklist — EaseMotion CSS</title>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/submissions/examples/animated-pricing-card-toggle/demo.html
+++ b/submissions/examples/animated-pricing-card-toggle/demo.html
@@ -6,9 +6,6 @@
   <title>Animated Pricing Card Toggle - EaseMotion CSS</title>
   <meta name="description" content="A modern SaaS-style Animated Pricing Card Toggle component featuring smooth transitions, hover effects, and responsive layouts.">
   <!-- Link to Google Fonts for Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- CSS Link -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/animated-tooltips-fade-in/demo.html
+++ b/submissions/examples/animated-tooltips-fade-in/demo.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Animated Tooltips Demo — EaseMotion CSS</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     body {

--- a/submissions/examples/animation-builder-inputs-ag/style.css
+++ b/submissions/examples/animation-builder-inputs-ag/style.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 
 /* Color Variables and Theme Definition */
 :root {
@@ -54,11 +53,7 @@
 }
 
 body {
-  font-family:
-    "Inter",
-    system-ui,
-    -apple-system,
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/submissions/examples/animation-preview-copy-btn-ag/style.css
+++ b/submissions/examples/animation-preview-copy-btn-ag/style.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 
 /* Color Variables and Theme Definition */
 :root {
@@ -47,11 +46,7 @@
 }
 
 body {
-  font-family:
-    "Inter",
-    system-ui,
-    -apple-system,
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/submissions/examples/animation-preview-replay-ag/style.css
+++ b/submissions/examples/animation-preview-replay-ag/style.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 
 /* Color Variables and Design System */
 :root {
@@ -33,7 +32,7 @@
 }
 
 body {
-  font-family: "Inter", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   min-height: 100vh;
   display: flex;
   justify-content: center;

--- a/submissions/examples/animation-regression-detection-lab/style.css
+++ b/submissions/examples/animation-regression-detection-lab/style.css
@@ -1,12 +1,11 @@
 /* ── Animation Regression Detection Lab Stylesheet ── */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@500;600;700;800&display=swap');
 
 /* ── Design System Tokens ── */
 :root {
-  --font-sans: 'Inter', sans-serif;
-  --font-title: 'Outfit', sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-title: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Theme: Dark (Default) */
   --bg-app: #080c14;

--- a/submissions/examples/animation-token-automation-studio/style.css
+++ b/submissions/examples/animation-token-automation-studio/style.css
@@ -1,12 +1,11 @@
 /* ── Animation Token Automation Studio Stylesheet ── */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@500;600;700;800&display=swap');
 
 /* ── Design System Tokens ── */
 :root {
-  --font-sans: 'Inter', sans-serif;
-  --font-title: 'Outfit', sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-title: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Theme: Dark (Default) */
   --bg-app: #070a13;

--- a/submissions/examples/appear-on-scroll/style.css
+++ b/submissions/examples/appear-on-scroll/style.css
@@ -9,7 +9,6 @@
    ============================================================ */
 
 /* ─── Google Fonts ───────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&display=swap');
 
 /* ─── Design Tokens ──────────────────────────────────────── */
 :root {
@@ -22,8 +21,8 @@
   --color-text:      #e8eaf0;
   --color-heading:   #f5f7ff;
 
-  --font-display:    'DM Serif Display', Georgia, serif;
-  --font-body:       'DM Sans', system-ui, sans-serif;
+  --font-display: Georgia, 'Times New Roman', 'Palatino Linotype', serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 
   --radius-sm:  6px;
   --radius-md:  12px;
@@ -427,12 +426,12 @@ p { color: var(--color-text); font-weight: 300; }
   font-size: 0.76rem;
   color: var(--color-muted);
   margin-left: 0.5rem;
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 }
 
 .code-block {
   padding: 1.6rem 1.8rem;
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 0.82rem;
   line-height: 1.85;
   overflow-x: auto;

--- a/submissions/examples/application-progress-stepper-bb/demo.html
+++ b/submissions/examples/application-progress-stepper-bb/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Application Progress Stepper — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/audio-equalizer-visualizer/style.css
+++ b/submissions/examples/audio-equalizer-visualizer/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -18,7 +17,7 @@
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;

--- a/submissions/examples/aurora-text-gradient/style.css
+++ b/submissions/examples/aurora-text-gradient/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@800&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -8,7 +7,7 @@ body {
   align-items: center;
   justify-content: center;
   background: #030712;
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 }
 
 .hero {

--- a/submissions/examples/automated-email-notifications/demo.html
+++ b/submissions/examples/automated-email-notifications/demo.html
@@ -7,9 +7,6 @@
   <!-- Link to simulator stylesheet -->
   <link rel="stylesheet" href="style.css">
   <!-- Google Fonts Inter & JetBrains Mono -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
 </head>
 <body>
 

--- a/submissions/examples/badge-tag-avatar-progress-v1/demo.html
+++ b/submissions/examples/badge-tag-avatar-progress-v1/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Badge · Tag · Avatar · Progress Bar — Submission</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/battery-charging-indicator/style.css
+++ b/submissions/examples/battery-charging-indicator/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 
@@ -10,7 +9,7 @@
 }
 
 body{
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background:var(--bg);
   color:var(--text);
   min-height:100vh;

--- a/submissions/examples/bento-grid-effect/demo.html
+++ b/submissions/examples/bento-grid-effect/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Animated Bento Grid — EaseMotion CSS Submission</title>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/submissions/examples/bento-grid-effect/style.css
+++ b/submissions/examples/bento-grid-effect/style.css
@@ -4,7 +4,6 @@
    Maintainer will rename classes to ease-* convention
    ============================================================ */
 
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Space+Mono:wght@400;700&display=swap');
 
 /* ── TOKENS ───────────────────────────────────────────────── */
 :root {
@@ -34,8 +33,8 @@
   --text-secondary:  #8888a8;
   --text-muted:      #44445a;
 
-  --font-ui:         'Space Grotesk', sans-serif;
-  --font-mono:       'Space Mono', monospace;
+  --font-ui: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   --radius:          18px;
   --radius-sm:       10px;

--- a/submissions/examples/blockchain-transaction-flow/demo.html
+++ b/submissions/examples/blockchain-transaction-flow/demo.html
@@ -4,8 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Blockchain Transaction Flow — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/blur-button-emphasis-v1-v1/demo.html
+++ b/submissions/examples/blur-button-emphasis-v1-v1/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Blur Button Emphasis — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/book-page-turn/style.css
+++ b/submissions/examples/book-page-turn/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 
@@ -13,7 +12,7 @@
 }
 
 body{
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background:var(--bg);
   color:var(--text);
   min-height:100vh;
@@ -231,7 +230,7 @@ p{color:var(--muted);font-size:0.9rem;text-align:center;}
   border:1px solid rgba(245,158,11,0.3);
   border-radius:12px;
   padding:10px 22px;
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size:0.85rem;font-weight:600;
   color:var(--accent);
   cursor:pointer;

--- a/submissions/examples/bounce-keyframes-var/demo.html
+++ b/submissions/examples/bounce-keyframes-var/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>bounce-keyframes-var #3900</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/bounce-text-exit-preview/demo.html
+++ b/submissions/examples/bounce-text-exit-preview/demo.html
@@ -6,9 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Bounce Text & Exit Animation Preview Showcase</title>
   <link rel="stylesheet" href="./style.css" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
 </head>
 
 <body>

--- a/submissions/examples/bouncing-dots-loader/demo.html
+++ b/submissions/examples/bouncing-dots-loader/demo.html
@@ -28,9 +28,6 @@
   <title>Bouncing Dots Loader Demo — EaseMotion CSS</title>
   
   <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Outfit:wght@600;700;800&display=swap" rel="stylesheet">
   
   <!-- Core & Component Framework CSS -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/btn-hover-disabled-lift/demo.html
+++ b/submissions/examples/btn-hover-disabled-lift/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>btn-hover-disabled-lift #3909</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/btn-icon-missing-states/demo.html
+++ b/submissions/examples/btn-icon-missing-states/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>btn-icon-missing-states #3918</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/btn-xl-space-tokens/demo.html
+++ b/submissions/examples/btn-xl-space-tokens/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>btn-xl-space-tokens #3915</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/card-compact-maxwidth/demo.html
+++ b/submissions/examples/card-compact-maxwidth/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>card-compact-maxwidth #3910</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/card-flat-border-width/demo.html
+++ b/submissions/examples/card-flat-border-width/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>card-flat-border-width #3904</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}.card-row{display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;margin:1rem 0}.measure{background:#fef3c7;padding:4px 8px;border-radius:4px;font-size:0.8rem;font-family:monospace;margin-top:0.5rem}</style>
 </head><body>

--- a/submissions/examples/card-image-aspect-ratio/demo.html
+++ b/submissions/examples/card-image-aspect-ratio/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>card-image-aspect-ratio #3907</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/card-stack-swipe/style.css
+++ b/submissions/examples/card-stack-swipe/style.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: #18181b;
   color: #fafafa;
   min-height: 100vh;

--- a/submissions/examples/cinematic-parallax-poster/style.css
+++ b/submissions/examples/cinematic-parallax-poster/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap');
 
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 
@@ -9,7 +8,7 @@
 }
 
 body{
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background:var(--bg);
   color:var(--text);
   min-height:100vh;

--- a/submissions/examples/class-dark-mode-pr/demo.html
+++ b/submissions/examples/class-dark-mode-pr/demo.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Demo: Class-Based Dark Mode Toggle</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"

--- a/submissions/examples/component-showcase-loq/demo.html
+++ b/submissions/examples/component-showcase-loq/demo.html
@@ -7,8 +7,6 @@
     <!-- Load Local EaseMotion CSS -->
     <link rel="stylesheet" href="../../../easemotion.min.css" />
     <!-- Load Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"
       rel="stylesheet"

--- a/submissions/examples/components-nav-links-fix-dg/demo.html
+++ b/submissions/examples/components-nav-links-fix-dg/demo.html
@@ -23,9 +23,6 @@
   <!-- Local Demo CSS styles (contains the scroll-margin-top fix) -->
   <link rel="stylesheet" href="style.css" />
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 
   <!-- Apply stored theme before first paint to avoid flash -->
   <script>

--- a/submissions/examples/confetti-burst-button/style.css
+++ b/submissions/examples/confetti-burst-button/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -8,7 +7,7 @@
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: var(--bg);
   color: #f1f0ff;
   min-height: 100vh;
@@ -39,7 +38,7 @@ p { color: #7c7caa; font-size: 0.9rem; text-align: center; }
 .btn-confetti {
   position: relative;
   padding: 16px 42px;
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1rem;
   font-weight: 700;
   color: white;

--- a/submissions/examples/container-query-responsive-animations/style.css
+++ b/submissions/examples/container-query-responsive-animations/style.css
@@ -4,7 +4,6 @@
    ========================================================================== */
 
 /* Modern typography import */
-@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap');
 
 :root {
   /* Design system tokens */
@@ -28,7 +27,7 @@
 }
 
 body {
-  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background-color: var(--bg-dark);
   color: var(--text-primary);
   min-height: 100vh;

--- a/submissions/examples/credit-card-flip-form/style.css
+++ b/submissions/examples/credit-card-flip-form/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 
@@ -13,7 +12,7 @@
 }
 
 body{
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background:var(--bg);
   color:var(--text);
   min-height:100vh;
@@ -242,7 +241,7 @@ input{
   border:1px solid rgba(255,255,255,0.1);
   border-radius:10px;
   padding:12px 14px;
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size:0.9rem;
   color:var(--text);
   outline:none;
@@ -261,7 +260,7 @@ input:focus{
   background:linear-gradient(135deg,#6366f1,#8b5cf6,#ec4899);
   border:none;border-radius:12px;
   padding:14px;
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size:0.95rem;font-weight:700;
   color:white;cursor:pointer;
   box-shadow:0 8px 24px rgba(99,102,241,0.4);

--- a/submissions/examples/cross-device-motion-adaptation-system/style.css
+++ b/submissions/examples/cross-device-motion-adaptation-system/style.css
@@ -1,12 +1,11 @@
 /* ── Cross-Device Motion Adaptation System Stylesheet ── */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@500;600;700;800&display=swap');
 
 /* ── Design System Tokens ── */
 :root {
-  --font-sans: 'Inter', sans-serif;
-  --font-title: 'Outfit', sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-title: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Theme: Dark (Default) */
   --bg-app: #080c14;

--- a/submissions/examples/css-anchor-positioning/demo.html
+++ b/submissions/examples/css-anchor-positioning/demo.html
@@ -6,9 +6,6 @@
   <title>CSS Anchor Positioning Showcase — EaseMotion CSS</title>
   
   <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Outfit:wght@500;600;700;800&display=swap" rel="stylesheet">
   
   <!-- Core & Component Framework CSS -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/css-layer-architecture/style.css
+++ b/submissions/examples/css-layer-architecture/style.css
@@ -4,7 +4,6 @@
    ========================================================================== */
 
 /* Modern typography import */
-@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap');
 
 /* Define Cascade Layer Order (First defined = lowest priority, Last defined = highest priority) */
 @layer reset, base, utilities, animations;
@@ -25,7 +24,7 @@
    ========================================== */
 @layer base {
   body {
-    font-family: 'Plus Jakarta Sans', sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     background-color: #0b0f19;
     color: #f3f4f6;
     min-height: 100vh;

--- a/submissions/examples/css-layer-cascade-dv/demo.html
+++ b/submissions/examples/css-layer-cascade-dv/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Explicit CSS Layer Cascade Order Declaration — EaseMotion CSS</title>
   <!-- Google Fonts: Inter & JetBrains Mono -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <!-- Component Styles -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/css-only-dropdown-dv/demo.html
+++ b/submissions/examples/css-only-dropdown-dv/demo.html
@@ -4,8 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>CSS-Only Dropdown & Flyout Component — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/cursor-orb-effect/demo.html
+++ b/submissions/examples/cursor-orb-effect/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Cursor Orb Effect — EaseMotion CSS Submission</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@300;400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body class="cursor-orb">

--- a/submissions/examples/cursor-orb-effect/style.css
+++ b/submissions/examples/cursor-orb-effect/style.css
@@ -4,7 +4,6 @@
    Maintainer will rename classes to ease-* convention
    ============================================================ */
 
-@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@300;400;500&display=swap');
 
 *, *::before, *::after {
   box-sizing: border-box;
@@ -21,8 +20,8 @@
   --bg:               #0a0a0a;
   --bg-card:          #111111;
   --border:           rgba(255, 255, 255, 0.07);
-  --font-display:     'Bebas Neue', sans-serif;
-  --font-body:        'Outfit', sans-serif;
+  --font-display: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 }
 
 /* hide default cursor on orb-enabled containers */

--- a/submissions/examples/dark-scrollbar-contrast/demo.html
+++ b/submissions/examples/dark-scrollbar-contrast/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>dark-scrollbar-contrast #3919</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/day-night-theme-toggle/style.css
+++ b/submissions/examples/day-night-theme-toggle/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -11,7 +10,7 @@
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;

--- a/submissions/examples/directional-spacing-utilities/demo.html
+++ b/submissions/examples/directional-spacing-utilities/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Directional Spacing Utilities — Issue #1801</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
 
   <style>
     /* ── Design tokens (mirroring core/variables.css) ──────── */

--- a/submissions/examples/docs-search-filter-dv/demo.html
+++ b/submissions/examples/docs-search-filter-dv/demo.html
@@ -5,8 +5,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Docs Search Filter — EaseMotion CSS Submission</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 

--- a/submissions/examples/duplicate-dark-mode-blocks/demo.html
+++ b/submissions/examples/duplicate-dark-mode-blocks/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>duplicate-dark-mode-blocks #3905</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/ease-accordion-pr/demo.html
+++ b/submissions/examples/ease-accordion-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-accordion-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-account-zd/demo.html
+++ b/submissions/examples/ease-account-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Account Settings — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-alert-pr/demo.html
+++ b/submissions/examples/ease-alert-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-alert-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-aurora/demo.html
+++ b/submissions/examples/ease-aurora/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ease-aurora — EaseMotion CSS Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;600&family=JetBrains+Mono:wght@300;400&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
   <style>
     /* ── Reset & Base ── */

--- a/submissions/examples/ease-avatar-component/demo.html
+++ b/submissions/examples/ease-avatar-component/demo.html
@@ -6,9 +6,6 @@
   <title>Avatar Component - EaseMotion CSS</title>
   <meta name="description" content="A comprehensive showcase of modern, responsive, and animated Avatar components for EaseMotion CSS.">
   <!-- Google Fonts - Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- CSS Stylesheet -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/ease-avatar-pr/demo.html
+++ b/submissions/examples/ease-avatar-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-avatar-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-avatargroup-zd/demo.html
+++ b/submissions/examples/ease-avatargroup-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Avatar Groups — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-badge-component/demo.html
+++ b/submissions/examples/ease-badge-component/demo.html
@@ -6,9 +6,6 @@
   <title>Badge Component – EaseMotion CSS Docs</title>
   
   <!-- Font Imports -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   
   <!-- Framework dependencies -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/ease-badge-pr/demo.html
+++ b/submissions/examples/ease-badge-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-badge-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-blur-in-v1/demo.html
+++ b/submissions/examples/ease-blur-in-v1/demo.html
@@ -6,7 +6,6 @@
     <title>Ease Blur In Animation - EaseMotion CSS</title>
     <link rel="stylesheet" href="style.css">
     <!-- Load clean modern Google Font -->
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700;800&display=swap" rel="stylesheet">
 </head>
 <body>
     <div class="demo-wrapper">

--- a/submissions/examples/ease-breadcrumb-component-v1/demo.html
+++ b/submissions/examples/ease-breadcrumb-component-v1/demo.html
@@ -6,9 +6,6 @@
   <title>Breadcrumb Component - EaseMotion CSS</title>
   <meta name="description" content="A comprehensive pure-CSS Breadcrumb component system for EaseMotion CSS showcasing multiple shapes, separators, themed gradients, and truncation.">
   <!-- Google Fonts - Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Stylesheet -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/ease-breadcrumb-pr/demo.html
+++ b/submissions/examples/ease-breadcrumb-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-breadcrumb-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-btn-group/style.css
+++ b/submissions/examples/ease-btn-group/style.css
@@ -73,11 +73,10 @@
    (Includes framework fallbacks for local browser testing)
    ──────────────────────────────────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
   /* Framework Variables Fallbacks */
-  --ease-font-sans: 'Outfit', sans-serif;
+  --ease-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   --ease-space-2: 0.5rem;
   --ease-space-3: 0.75rem;
   --ease-space-4: 1rem;
@@ -127,7 +126,7 @@ body {
   padding: 0;
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -146,7 +145,7 @@ header {
 }
 
 h1 {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 3rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -164,7 +163,7 @@ h1 {
 }
 
 .section-title {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.6rem;
   font-weight: 600;
   margin-top: 3.5rem;
@@ -207,7 +206,7 @@ h1 {
 }
 
 .card-title {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.25rem;
   font-weight: 600;
   margin: 0 0 0.5rem 0;
@@ -313,7 +312,7 @@ h1 {
   border-radius: 10px;
   padding: 1.25rem;
   overflow-x: auto;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.95rem;
   color: #c7d2fe;
   border: 1px solid rgba(255, 255, 255, 0.03);

--- a/submissions/examples/ease-btn-loading/style.css
+++ b/submissions/examples/ease-btn-loading/style.css
@@ -38,11 +38,10 @@
    (Includes framework fallbacks for local browser testing)
    ──────────────────────────────────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
   /* Framework Variables Fallbacks */
-  --ease-font-sans: 'Outfit', sans-serif;
+  --ease-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   --ease-space-2: 0.5rem;
   --ease-space-3: 0.75rem;
   --ease-space-4: 1rem;
@@ -86,7 +85,7 @@ body {
   padding: 0;
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -105,7 +104,7 @@ header {
 }
 
 h1 {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 3rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -123,7 +122,7 @@ h1 {
 }
 
 .section-title {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.6rem;
   font-weight: 600;
   margin-top: 3.5rem;
@@ -166,7 +165,7 @@ h1 {
 }
 
 .card-title {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.25rem;
   font-weight: 600;
   margin: 0 0 0.5rem 0;
@@ -273,7 +272,7 @@ h1 {
   border-radius: 10px;
   padding: 1.25rem;
   overflow-x: auto;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.95rem;
   color: #c7d2fe;
   border: 1px solid rgba(255, 255, 255, 0.03);

--- a/submissions/examples/ease-callout-zd/demo.html
+++ b/submissions/examples/ease-callout-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Callout Boxes — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-card-dark/style.css
+++ b/submissions/examples/ease-card-dark/style.css
@@ -31,7 +31,6 @@
    (Includes framework fallbacks for local browser testing)
    ──────────────────────────────────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
   /* Framework Variables Fallbacks */
@@ -69,7 +68,7 @@ body {
   padding: 0;
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -88,7 +87,7 @@ header {
 }
 
 h1 {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 3rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -104,7 +103,7 @@ h1 {
 }
 
 .section-title {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.6rem;
   font-weight: 600;
   margin-top: 3rem;
@@ -207,7 +206,7 @@ h1 {
   border-radius: 10px;
   padding: 1.25rem;
   overflow-x: auto;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.95rem;
   color: #e2e8f0;
 }

--- a/submissions/examples/ease-card-pr-2/demo.html
+++ b/submissions/examples/ease-card-pr-2/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-card-pr-2 Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-card-pr/demo.html
+++ b/submissions/examples/ease-card-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-card-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-carousel-component/demo.html
+++ b/submissions/examples/ease-carousel-component/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ease Carousel Component Showcase — EaseMotion CSS</title>
   <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Link component styles -->
   <link rel="stylesheet" href="style.css">
   

--- a/submissions/examples/ease-center-reveal/style.css
+++ b/submissions/examples/ease-center-reveal/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Outfit:wght@300;400;500;600;700;800&display=swap');
 
 /* ==========================================================================
    EASEMOTION CSS - CENTER REVEAL UTILITY COMPONENT
@@ -221,7 +220,7 @@ body {
   align-items: center;
   padding: 40px 20px;
   box-sizing: border-box;
-  font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background-color: #f1f5f9;
   transition: background-color 0.4s ease;
 }
@@ -510,7 +509,7 @@ body:has(#theme-dark:checked) label[for="theme-dark"] {
   z-index: 2;
   text-align: center;
   color: #00f3ff;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   text-shadow: 0 0 8px rgba(0, 243, 255, 0.5);
   animation: pulse-neon 2s infinite ease-in-out;
 }
@@ -527,7 +526,7 @@ body:has(#theme-dark:checked) label[for="theme-dark"] {
   box-shadow: inset 0 0 20px rgba(0, 243, 255, 0.2), 0 0 15px rgba(0, 243, 255, 0.1);
   padding: 24px;
   color: #00f3ff;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -761,7 +760,7 @@ body:has(#theme-dark:checked) label[for="theme-dark"] {
   border-radius: 8px;
   padding: 14px;
   margin: 0 0 16px 0;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 11px;
   color: #a78bfa;
   text-align: left;

--- a/submissions/examples/ease-chip-component/demo.html
+++ b/submissions/examples/ease-chip-component/demo.html
@@ -6,9 +6,6 @@
   <title>Chip Component - EaseMotion CSS</title>
   <meta name="description" content="A modern pure-CSS Chip component showcase for EaseMotion CSS featuring color themes, avatars, dismissible animations, and selection states.">
   <!-- Google Fonts - Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Stylesheet -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/ease-chip-pr/demo.html
+++ b/submissions/examples/ease-chip-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-chip-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-code-block-component/style.css
+++ b/submissions/examples/ease-code-block-component/style.css
@@ -6,12 +6,11 @@
 /* ──────────────────────────────────────────────────────────────────────────
    1. Google Fonts & Design Tokens
    ────────────────────────────────────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap');
 
 :root {
   /* Fonts */
-  --ease-font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
-  --ease-font-mono: 'Fira Code', monospace;
+  --ease-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --ease-font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Page Canvas */
   --ease-bg:          #08070d;

--- a/submissions/examples/ease-code-block-pr/demo.html
+++ b/submissions/examples/ease-code-block-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-code-block-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-code-snippet-card/demo.html
+++ b/submissions/examples/ease-code-snippet-card/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Code Snippet Card — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-compare-table-zd/demo.html
+++ b/submissions/examples/ease-compare-table-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Feature Comparison Table — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-component-gallery/demo.html
+++ b/submissions/examples/ease-component-gallery/demo.html
@@ -6,9 +6,6 @@
   <title>EaseMotion CSS — Component Gallery</title>
   <meta name="description" content="Browse, search, filter, and copy EaseMotion CSS components with live previews." />
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/submissions/examples/ease-contact-zd/demo.html
+++ b/submissions/examples/ease-contact-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contact Form — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-count-up/style.css
+++ b/submissions/examples/ease-count-up/style.css
@@ -6,12 +6,11 @@
 /* ──────────────────────────────────────────────────────────────────────────
    1. Google Fonts & Design Tokens
    ────────────────────────────────────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap');
 
 :root {
   /* Fonts */
-  --ease-font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
-  --ease-font-mono: 'Fira Code', monospace;
+  --ease-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --ease-font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Page Canvas */
   --ease-bg:          #08070d;

--- a/submissions/examples/ease-dev-profile-1164/demo.html
+++ b/submissions/examples/ease-dev-profile-1164/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Developer Profile Card — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-developer-profile-card/style.css
+++ b/submissions/examples/ease-developer-profile-card/style.css
@@ -3,7 +3,6 @@
    ========================================================================== */
 
 /* 1. Google Fonts Import */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Outfit:wght@500;600;700;800&display=swap');
 
 /* 2. Color Tokens & Theme Configuration */
 :root {
@@ -29,8 +28,8 @@
   --header-title-color: #1e293b;
   
   /* Typography */
-  --font-heading: 'Outfit', system-ui, -apple-system, sans-serif;
-  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-heading: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 }
 
 body:has(#theme-dark:checked) {

--- a/submissions/examples/ease-divider/demo.html
+++ b/submissions/examples/ease-divider/demo.html
@@ -6,9 +6,6 @@
   <title>ease-divider — Section Divider Showcase</title>
   
   <!-- Modern Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   
   <!-- Demo Stylesheet -->
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/ease-dropcap-zd/demo.html
+++ b/submissions/examples/ease-dropcap-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Drop Caps — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-dropdown-pr/demo.html
+++ b/submissions/examples/ease-dropdown-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-dropdown-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-dropdown-v1/demo.html
+++ b/submissions/examples/ease-dropdown-v1/demo.html
@@ -6,9 +6,6 @@
   <title>ease-dropdown — EaseMotion CSS</title>
 
   <!-- Google Fonts (matches framework base.css) -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 
   <!-- EaseMotion CSS framework layers -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/ease-dropdown/demo.html
+++ b/submissions/examples/ease-dropdown/demo.html
@@ -6,9 +6,6 @@
   <title>ease-dropdown — EaseMotion CSS</title>
 
   <!-- Google Fonts (matches framework base.css) -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 
   <!-- EaseMotion CSS framework layers -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/ease-embed-zd/demo.html
+++ b/submissions/examples/ease-embed-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Media Embeds — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-empty-state-pr-E/demo.html
+++ b/submissions/examples/ease-empty-state-pr-E/demo.html
@@ -6,9 +6,6 @@
   <title>ease-empty-state — EaseMotion CSS Submission</title>
 
   <!-- EaseMotion CSS brand font -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/submissions/examples/ease-empty-state-pr/demo.html
+++ b/submissions/examples/ease-empty-state-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-empty-state-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-feature-grid-zd/demo.html
+++ b/submissions/examples/ease-feature-grid-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Feature Grid — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-file-upload-pr/demo.html
+++ b/submissions/examples/ease-file-upload-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-file-upload-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-float-var/demo.html
+++ b/submissions/examples/ease-float-var/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>ease-float-var #3896</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}</style>
 </head><body>

--- a/submissions/examples/ease-footer-pr-effect/demo.html
+++ b/submissions/examples/ease-footer-pr-effect/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Footer Component — EaseMotion CSS Submission</title>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/submissions/examples/ease-footer-pr-effect/style.css
+++ b/submissions/examples/ease-footer-pr-effect/style.css
@@ -4,7 +4,6 @@
    Maintainer will rename classes to ease-* convention
    ============================================================ */
 
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Space+Mono:wght@400;700&display=swap');
 
 /* ── TOKENS ───────────────────────────────────────────────── */
 :root {
@@ -36,8 +35,8 @@
   --text-link:       #9898c0;
   --text-link-hover: #f0f0f8;
 
-  --font-ui:         'Space Grotesk', sans-serif;
-  --font-mono:       'Space Mono', monospace;
+  --font-ui: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   --radius:          10px;
   --radius-sm:       6px;

--- a/submissions/examples/ease-glassmorphism-system/demo.html
+++ b/submissions/examples/ease-glassmorphism-system/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Glassmorphism System — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-gradient-rotation-var/demo.html
+++ b/submissions/examples/ease-gradient-rotation-var/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>ease-gradient-rotation-var #3901</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}.gradient-box{width:100%;height:80px;border-radius:8px;margin:1rem 0}</style>
 </head><body>

--- a/submissions/examples/ease-heartbeat-v1-v1/demo.html
+++ b/submissions/examples/ease-heartbeat-v1-v1/demo.html
@@ -6,7 +6,6 @@
     <title>Ease Heartbeat Animation - EaseMotion CSS</title>
     <link rel="stylesheet" href="style.css">
     <!-- Load clean modern font -->
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700;800&display=swap" rel="stylesheet">
 </head>
 <body>
     <div class="ease-heartbeat-v1-wrapper">

--- a/submissions/examples/ease-highlight-zd/demo.html
+++ b/submissions/examples/ease-highlight-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Text Highlights — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-holographic-ticket-pk/demo.html
+++ b/submissions/examples/ease-holographic-ticket-pk/demo.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Interactive Holographic Ticket - EaseMotion CSS</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/submissions/examples/ease-hover-sap/demo.html
+++ b/submissions/examples/ease-hover-sap/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-hover-sap Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-image-gallery-component/style.css
+++ b/submissions/examples/ease-image-gallery-component/style.css
@@ -6,12 +6,11 @@
 /* ──────────────────────────────────────────────────────────────────────────
    1. Google Fonts & Design Tokens
    ────────────────────────────────────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&family=Outfit:wght@300;400;500;600;700&display=swap');
 
 :root {
   /* Typography */
-  --ease-font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
-  --ease-font-mono: 'Fira Code', monospace;
+  --ease-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --ease-font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Canvas */
   --ease-bg:           #08070d;

--- a/submissions/examples/ease-image-hover-zd/demo.html
+++ b/submissions/examples/ease-image-hover-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Image Hover Effects — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-input-pr/demo.html
+++ b/submissions/examples/ease-input-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-input-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-italic/style.css
+++ b/submissions/examples/ease-italic/style.css
@@ -19,7 +19,6 @@
    DEMO SHOWCASE STYLING
    ──────────────────────────────────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,600;1,400;1,600&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
   --bg-primary: #07080b;
@@ -37,7 +36,7 @@ body {
   padding: 0;
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -56,7 +55,7 @@ header {
 }
 
 h1 {
-  font-family: 'Playfair Display', serif;
+  font-family: Georgia, 'Times New Roman', 'Palatino Linotype', serif;
   font-size: 3.5rem;
   font-weight: 600;
   margin-bottom: 1rem;
@@ -74,7 +73,7 @@ h1 {
 }
 
 .section-title {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.6rem;
   font-weight: 600;
   margin-top: 3.5rem;
@@ -109,7 +108,7 @@ h1 {
 
 /* Typography showcase box */
 .typo-preview {
-  font-family: 'Playfair Display', serif;
+  font-family: Georgia, 'Times New Roman', 'Palatino Linotype', serif;
   font-size: 1.8rem;
   line-height: 1.4;
   color: #f8fafc;
@@ -119,7 +118,7 @@ h1 {
 }
 
 .typo-label {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   color: var(--text-secondary);
   font-size: 0.9rem;
   letter-spacing: 0.05em;
@@ -132,7 +131,7 @@ h1 {
   background: rgba(251, 191, 36, 0.1);
   border: 1px solid rgba(251, 191, 36, 0.2);
   color: #fbbf24;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.85rem;
   padding: 0.25rem 0.6rem;
   border-radius: 6px;
@@ -159,7 +158,7 @@ h1 {
   border-radius: 10px;
   padding: 1.25rem;
   overflow-x: auto;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.95rem;
   color: #fde047;
   border: 1px solid rgba(255, 255, 255, 0.03);

--- a/submissions/examples/ease-kbd-component/style.css
+++ b/submissions/examples/ease-kbd-component/style.css
@@ -6,12 +6,11 @@
 /* ──────────────────────────────────────────────────────────────────────────
    1. Google Fonts & Design Tokens
    ────────────────────────────────────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap');
 
 :root {
   /* Fonts */
-  --ease-font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
-  --ease-font-mono: 'Fira Code', monospace;
+  --ease-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --ease-font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Page Canvas */
   --ease-bg:          #08070d;

--- a/submissions/examples/ease-loader-pr/demo.html
+++ b/submissions/examples/ease-loader-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-loader-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-magnetic-button-v1/demo.html
+++ b/submissions/examples/ease-magnetic-button-v1/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Magnetic Button Component – EaseMotion CSS Docs</title>
   
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   
   <link rel="stylesheet" href="../../../core/variables.css" />
   <link rel="stylesheet" href="../../../core/base.css" />

--- a/submissions/examples/ease-modal-pr/demo.html
+++ b/submissions/examples/ease-modal-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-modal-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-morph/style.css
+++ b/submissions/examples/ease-morph/style.css
@@ -6,12 +6,11 @@
 /* ──────────────────────────────────────────────────────────────────────────
    1. Design Tokens & Google Fonts Import
    ────────────────────────────────────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&family=Outfit:wght@300;400;500;600;700&display=swap');
 
 :root {
   /* Fonts */
-  --ease-font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
-  --ease-font-mono: 'Fira Code', monospace;
+  --ease-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --ease-font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Global Colors */
   --ease-color-bg: #0b0a10;

--- a/submissions/examples/ease-navbar-pr/demo.html
+++ b/submissions/examples/ease-navbar-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-navbar-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-notification-bell/demo.html
+++ b/submissions/examples/ease-notification-bell/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Notification Bell Widget — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-object-fit/style.css
+++ b/submissions/examples/ease-object-fit/style.css
@@ -48,7 +48,6 @@
    DEMO SHOWCASE STYLING
    ──────────────────────────────────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
   --bg-primary: #0a0b10;
@@ -67,7 +66,7 @@ body {
   padding: 0;
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -86,7 +85,7 @@ header {
 }
 
 h1 {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 3rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -104,7 +103,7 @@ h1 {
 }
 
 .section-title {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.75rem;
   font-weight: 600;
   margin-top: 3rem;
@@ -179,7 +178,7 @@ h1 {
   background: rgba(139, 92, 246, 0.15);
   border: 1px solid rgba(139, 92, 246, 0.3);
   color: #c084fc;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.9rem;
   padding: 0.3rem 0.75rem;
   border-radius: 8px;
@@ -213,7 +212,7 @@ h1 {
   border-radius: 12px;
   padding: 1.25rem;
   overflow-x: auto;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.95rem;
   color: #a78bfa;
   border: 1px solid rgba(255, 255, 255, 0.03);

--- a/submissions/examples/ease-pagination-pr/demo.html
+++ b/submissions/examples/ease-pagination-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-pagination-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-ping-var/demo.html
+++ b/submissions/examples/ease-ping-var/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>ease-ping-var #3897</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/ease-pricing-card-component/demo.html
+++ b/submissions/examples/ease-pricing-card-component/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ease Pricing Card Component Showcase — EaseMotion CSS</title>
   <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Link component styles -->
   <link rel="stylesheet" href="style.css">
   

--- a/submissions/examples/ease-pricing-card-pr/demo.html
+++ b/submissions/examples/ease-pricing-card-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-pricing-card-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-pricing-comparison/demo.html
+++ b/submissions/examples/ease-pricing-comparison/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pricing Comparison Table — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-profile-zd/demo.html
+++ b/submissions/examples/ease-profile-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Profile Cards — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-progress-pr/demo.html
+++ b/submissions/examples/ease-progress-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-progress-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-progress-stepper-component/demo.html
+++ b/submissions/examples/ease-progress-stepper-component/demo.html
@@ -6,9 +6,6 @@
   <title>Progress Stepper Component - EaseMotion CSS</title>
   <meta name="description" content="A modern pure-CSS Progress Stepper component showcase for EaseMotion CSS featuring horizontal/vertical flows, themes, and interactive form wizards.">
   <!-- Google Fonts - Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Stylesheet -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/ease-radial-menu/demo.html
+++ b/submissions/examples/ease-radial-menu/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Radial Menu — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-range-pr/demo.html
+++ b/submissions/examples/ease-range-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-range-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-rating-component/demo.html
+++ b/submissions/examples/ease-rating-component/demo.html
@@ -6,9 +6,6 @@
   <title>Rating Component - EaseMotion CSS</title>
   <meta name="description" content="A modern pure-CSS Rating component showcase for EaseMotion CSS featuring interactive stars, hearts, emojis, half-fill states, and review summaries.">
   <!-- Google Fonts - Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Stylesheet -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/ease-reveal-zd/demo.html
+++ b/submissions/examples/ease-reveal-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Image Reveal — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-ribbon-zd/demo.html
+++ b/submissions/examples/ease-ribbon-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ribbons — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-rotate-var/demo.html
+++ b/submissions/examples/ease-rotate-var/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>ease-rotate-var #3899</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/ease-rtl-support/style.css
+++ b/submissions/examples/ease-rtl-support/style.css
@@ -64,7 +64,6 @@
    (Includes framework fallbacks for local browser testing)
    ──────────────────────────────────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
   --ease-space-1:  0.25rem;
@@ -90,7 +89,7 @@ body {
   padding: 0;
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -109,7 +108,7 @@ header {
 }
 
 h1 {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 3rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -127,7 +126,7 @@ h1 {
 }
 
 .section-title {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.6rem;
   font-weight: 600;
   margin-top: 3.5rem;
@@ -165,7 +164,7 @@ h1 {
   background: rgba(6, 182, 212, 0.1);
   border: 1px solid rgba(6, 182, 212, 0.25);
   color: #22d3ee;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.8rem;
   font-weight: 600;
   padding: 0.2rem 0.6rem;
@@ -238,7 +237,7 @@ h1 {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.08);
   color: var(--text-secondary);
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.8rem;
   padding: 0.2rem 0.5rem;
   border-radius: 5px;
@@ -259,7 +258,7 @@ h1 {
   border-radius: 10px;
   padding: 1.25rem;
   overflow-x: auto;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.95rem;
   color: #93c5fd;
   border: 1px solid rgba(255, 255, 255, 0.03);

--- a/submissions/examples/ease-scale/style.css
+++ b/submissions/examples/ease-scale/style.css
@@ -52,7 +52,6 @@
    DEMO SHOWCASE STYLING
    ──────────────────────────────────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
   --bg-primary: #0a0b10;
@@ -71,7 +70,7 @@ body {
   padding: 0;
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -90,7 +89,7 @@ header {
 }
 
 h1 {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 3rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -108,7 +107,7 @@ h1 {
 }
 
 .section-title {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.75rem;
   font-weight: 600;
   margin-top: 3.5rem;
@@ -184,7 +183,7 @@ h1 {
   background: rgba(168, 85, 247, 0.1);
   border: 1px solid rgba(168, 85, 247, 0.2);
   color: #c084fc;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.85rem;
   padding: 0.25rem 0.6rem;
   border-radius: 6px;
@@ -217,7 +216,7 @@ h1 {
   border-radius: 12px;
   padding: 1.25rem;
   overflow-x: auto;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.95rem;
   color: #d8b4fe;
   border: 1px solid rgba(255, 255, 255, 0.03);

--- a/submissions/examples/ease-scroll-reveal/demo.html
+++ b/submissions/examples/ease-scroll-reveal/demo.html
@@ -6,9 +6,6 @@
   <title>Scroll-Driven Reveal Animation Demo — EaseMotion CSS</title>
   
   <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Outfit:wght@600;700;800&display=swap" rel="stylesheet">
   
   <!-- Core & Component Framework CSS -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/ease-search-pr/demo.html
+++ b/submissions/examples/ease-search-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-search-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-sidebar-zd/demo.html
+++ b/submissions/examples/ease-sidebar-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sidebar Nav — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-skeleton-loader-component/demo.html
+++ b/submissions/examples/ease-skeleton-loader-component/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Skeleton Loader Component - EaseMotion CSS</title>
   <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Component Stylesheet -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/ease-skeleton-loading/style.css
+++ b/submissions/examples/ease-skeleton-loading/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap');
 
 /* ==========================================================================
    EASEMOTION CSS - SKELETON LOADING COMPONENT
@@ -199,7 +198,7 @@ body {
   align-items: center;
   padding: 40px 20px;
   box-sizing: border-box;
-  font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background-color: #f1f5f9;
   transition: background-color 0.4s ease;
 }

--- a/submissions/examples/ease-skeleton-pr/demo.html
+++ b/submissions/examples/ease-skeleton-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-skeleton-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-slide-directions/style.css
+++ b/submissions/examples/ease-slide-directions/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
     --bg-color: #09090b;
@@ -12,7 +11,7 @@
 
 body {
     margin: 0;
-    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     background-color: var(--bg-color);
     color: var(--text-primary);
     display: flex;
@@ -154,7 +153,7 @@ h1 {
 }
 
 .code-block code {
-    font-family: 'Fira Code', ui-monospace, monospace;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
     font-size: 0.85rem;
     color: #ffffff;
 }

--- a/submissions/examples/ease-spinner-pr/demo.html
+++ b/submissions/examples/ease-spinner-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-spinner-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-split-zd/demo.html
+++ b/submissions/examples/ease-split-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Split Screen — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-stat-card-v1/style.css
+++ b/submissions/examples/ease-stat-card-v1/style.css
@@ -6,12 +6,11 @@
 /* ──────────────────────────────────────────────────────────────────────────
    1. Google Fonts Import & Theme Properties
    ────────────────────────────────────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&family=Outfit:wght@300;400;500;600;700&display=swap');
 
 :root {
   /* Fonts */
-  --ease-font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
-  --ease-font-mono: 'Fira Code', monospace;
+  --ease-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --ease-font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Palette */
   --ease-color-bg: #07070a;

--- a/submissions/examples/ease-stats-pr/demo.html
+++ b/submissions/examples/ease-stats-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-stats-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-status-msg-zd/demo.html
+++ b/submissions/examples/ease-status-msg-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Status Messages — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-stepper-component/style.css
+++ b/submissions/examples/ease-stepper-component/style.css
@@ -6,12 +6,11 @@
 /* ──────────────────────────────────────────────────────────────────────────
    1. Google Fonts Import & Theme Properties
    ────────────────────────────────────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&family=Outfit:wght@300;400;500;600;700&display=swap');
 
 :root {
   /* Fonts */
-  --ease-font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
-  --ease-font-mono: 'Fira Code', monospace;
+  --ease-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --ease-font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Global Colors */
   --ease-color-bg: #07060a;

--- a/submissions/examples/ease-sticky-zd/demo.html
+++ b/submissions/examples/ease-sticky-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sticky Notes — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-svg-path-draw-v1/style.css
+++ b/submissions/examples/ease-svg-path-draw-v1/style.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap");
 
 /* ==========================================================================
    EASEMOTION CSS - SVG PATH DRAW COMPONENT
@@ -503,13 +502,7 @@ body {
   align-items: center;
   padding: 40px 20px;
   box-sizing: border-box;
-  font-family:
-    "Outfit",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Roboto,
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background-color: #f1f5f9;
   transition: background-color 0.4s ease;
 }

--- a/submissions/examples/ease-table-pr/demo.html
+++ b/submissions/examples/ease-table-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-table-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-tabs-pr/demo.html
+++ b/submissions/examples/ease-tabs-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-tabs-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-tabs/demo.html
+++ b/submissions/examples/ease-tabs/demo.html
@@ -6,9 +6,6 @@
   <title>Sliding Glassmorphic Tabs - EaseMotion CSS</title>
   
   <!-- Google Fonts for modern typography -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   
   <!-- Link to the CSS demo stylesheet -->
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/ease-testimonial-pr/demo.html
+++ b/submissions/examples/ease-testimonial-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-testimonial-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-testimonial-zd/demo.html
+++ b/submissions/examples/ease-testimonial-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Testimonials — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-text-glitch-effect/style.css
+++ b/submissions/examples/ease-text-glitch-effect/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Share+Tech+Mono&display=swap');
 
 /* ==========================================================================
    EASEMOTION CSS - TEXT GLITCH EFFECT COMPONENT
@@ -67,7 +66,7 @@ body:has(#theme-dark:checked) {
 
 .ease-glitch-title {
   position: relative;
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: clamp(24px, 5.5vw, 42px);
   font-weight: 800;
   text-transform: uppercase;
@@ -110,7 +109,7 @@ body:has(#theme-dark:checked) {
 
 .ease-glitch-btn {
   position: relative;
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 14px;
   font-weight: 800;
   letter-spacing: 0.1em;
@@ -178,7 +177,7 @@ body:has(#theme-dark:checked) {
 
 .ease-glitch-terminal-text {
   position: relative;
-  font-family: 'Share Tech Mono', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: clamp(15px, 2.5vw, 20px);
   color: var(--terminal-text-color);
   letter-spacing: 0.06em;
@@ -356,7 +355,7 @@ body {
   align-items: center;
   padding: 40px 20px;
   box-sizing: border-box;
-  font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background-color: #f1f5f9;
   transition: background-color 0.4s ease;
 }
@@ -604,7 +603,7 @@ body:has(#theme-dark:checked) .badge-purple {
 }
 
 .terminal-cursor {
-  font-family: 'Share Tech Mono', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 18px;
   color: var(--terminal-text-color);
   animation: ease-glitch-cursor-blink 1s infinite step-start;

--- a/submissions/examples/ease-text-shimmer/demo.html
+++ b/submissions/examples/ease-text-shimmer/demo.html
@@ -6,9 +6,6 @@
   <title>Gradient Text Shimmer - EaseMotion CSS</title>
   
   <!-- Premium typography from Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   
   <!-- Link to the CSS demo stylesheet -->
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/ease-thanks-zd/demo.html
+++ b/submissions/examples/ease-thanks-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Order Confirmation — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-timeline-component/demo.html
+++ b/submissions/examples/ease-timeline-component/demo.html
@@ -6,9 +6,6 @@
   <title>Timeline Component - EaseMotion CSS</title>
   <meta name="description" content="A modern pure-CSS Timeline component showcase for EaseMotion CSS featuring horizontal, vertical, alternating, and card-based activity feeds.">
   <!-- Google Fonts - Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Stylesheet -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/ease-timeline-pr/demo.html
+++ b/submissions/examples/ease-timeline-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-timeline-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-timeline-showcase/demo.html
+++ b/submissions/examples/ease-timeline-showcase/demo.html
@@ -6,9 +6,6 @@
   <title>Timeline Showcase – EaseMotion CSS Docs</title>
   
   <!-- Font Imports -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   
   <!-- Framework dependencies -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/ease-toast-component/demo.html
+++ b/submissions/examples/ease-toast-component/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Toast Notification Component - EaseMotion CSS</title>
   <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Component Stylesheet -->
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-toast-pr/demo.html
+++ b/submissions/examples/ease-toast-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-toast-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-toggle-pr/demo.html
+++ b/submissions/examples/ease-toggle-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-toggle-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-tooltip-component-v1/demo.html
+++ b/submissions/examples/ease-tooltip-component-v1/demo.html
@@ -6,9 +6,6 @@
   <title>Tooltip Component - EaseMotion CSS</title>
   <meta name="description" content="A modern, pure-CSS tooltip component system for EaseMotion CSS featuring 8 placements, 10 themed variants, and focus-triggered states.">
   <!-- Google Fonts - Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Stylesheet -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/ease-tooltip-component-v2/demo.html
+++ b/submissions/examples/ease-tooltip-component-v2/demo.html
@@ -7,9 +7,6 @@
   <title>Tooltip Component - EaseMotion CSS</title>
   <meta name="description" content="A modern, pure-CSS tooltip component system for EaseMotion CSS featuring 8 placements, 10 themed variants, and focus-triggered states.">
   <!-- Google Fonts - Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <!-- Stylesheet -->
   <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/ease-tooltip-pr/demo.html
+++ b/submissions/examples/ease-tooltip-pr/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-tooltip-pr Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/submissions/examples/ease-translate/style.css
+++ b/submissions/examples/ease-translate/style.css
@@ -80,7 +80,6 @@
    DEMO SHOWCASE STYLING
    ──────────────────────────────────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
   /* Default fallbacks if not run inside framework */
@@ -111,7 +110,7 @@ body {
   padding: 0;
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -130,7 +129,7 @@ header {
 }
 
 h1 {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 3rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -148,7 +147,7 @@ h1 {
 }
 
 .section-title {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.75rem;
   font-weight: 600;
   margin-top: 3.5rem;
@@ -240,7 +239,7 @@ h1 {
   background: rgba(59, 130, 246, 0.1);
   border: 1px solid rgba(59, 130, 246, 0.2);
   color: #60a5fa;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.85rem;
   padding: 0.25rem 0.6rem;
   border-radius: 6px;
@@ -273,7 +272,7 @@ h1 {
   border-radius: 12px;
   padding: 1.25rem;
   overflow-x: auto;
-  font-family: 'Space Grotesk', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 0.95rem;
   color: #93c5fd;
   border: 1px solid rgba(255, 255, 255, 0.03);

--- a/submissions/examples/ease-typing-effect/style.css
+++ b/submissions/examples/ease-typing-effect/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Fira+Code:wght@400;500;600&display=swap');
 
 /* ==========================================================================
    EASEMOTION CSS - TYPING EFFECT ANIMATION COMPONENT
@@ -94,7 +93,7 @@ body:has(#theme-dark:checked) {
 
 /* Suffix active font style */
 .ease-typewriter-container .ease-typewriter-text {
-  font-family: 'Fira Code', 'Courier New', Courier, monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-weight: 600;
   background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
   -webkit-background-clip: text;
@@ -177,7 +176,7 @@ body:has(#theme-dark:checked) .ease-typewriter-container .ease-typewriter-text {
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
   overflow: hidden;
   width: 100%;
-  font-family: 'Fira Code', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   box-sizing: border-box;
 }
 
@@ -217,7 +216,7 @@ body:has(#theme-dark:checked) .ease-typewriter-container .ease-typewriter-text {
 }
 
 .ease-terminal-line {
-  font-family: 'Fira Code', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 14px;
   white-space: nowrap;
   overflow: hidden;
@@ -401,7 +400,7 @@ body {
   align-items: center;
   padding: 40px 20px;
   box-sizing: border-box;
-  font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background-color: #f1f5f9;
   transition: background-color 0.4s ease;
 }
@@ -647,7 +646,7 @@ body:has(#theme-dark:checked) .badge-purple {
 }
 
 .card-footer code {
-  font-family: 'Fira Code', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 12px;
   background-color: var(--control-bg);
   padding: 2px 4px;

--- a/submissions/examples/ease-video-zd-v1/demo.html
+++ b/submissions/examples/ease-video-zd-v1/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Video Player — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/ease-wavy-zd/demo.html
+++ b/submissions/examples/ease-wavy-zd/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Wavy Dividers — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/submissions/examples/elastic-range-slider/style.css
+++ b/submissions/examples/elastic-range-slider/style.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: #fafafa;
   color: #171717;
   min-height: 100vh;

--- a/submissions/examples/elastic-toggle-switch/demo.html
+++ b/submissions/examples/elastic-toggle-switch/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Elastic Toggle Switch - EaseMotion</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css">
   <style>
     /* Demo presentation layout - NOT part of the core component */

--- a/submissions/examples/expand-shadow-emphasis/demo.html
+++ b/submissions/examples/expand-shadow-emphasis/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Expand Shadow Emphasis — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/fab-menu/demo.html
+++ b/submissions/examples/fab-menu/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dynamic Island FAB - EaseMotion</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css">
   <style>
     body {

--- a/submissions/examples/fix-border-primary-utility/demo.html
+++ b/submissions/examples/fix-border-primary-utility/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>.ease-border-primary Fix — Issue #1797</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/submissions/examples/fix-csp-sri-docs/demo.html
+++ b/submissions/examples/fix-csp-sri-docs/demo.html
@@ -7,9 +7,6 @@
 
   <meta http-equiv="Content-Security-Policy" content="style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com;">
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css" />
 

--- a/submissions/examples/flex-overflow-fix/demo.html
+++ b/submissions/examples/flex-overflow-fix/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ease-min-h-0 / ease-min-w-0 — Issue #1804</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/submissions/examples/flip-button-exit/demo.html
+++ b/submissions/examples/flip-button-exit/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Flip Button Exit — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/flip-clock-countdown/style.css
+++ b/submissions/examples/flip-clock-countdown/style.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@700&family=Inter:wght@400;600&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: #1a1a2e;
   color: #eee;
   min-height: 100vh;
@@ -33,7 +32,7 @@ p { font-size: 0.9rem; opacity: 0.65; }
   width: 56px;
   height: 72px;
   perspective: 300px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 2.5rem;
   font-weight: 700;
 }
@@ -111,7 +110,7 @@ p { font-size: 0.9rem; opacity: 0.65; }
 }
 
 .colon {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 2rem;
   font-weight: 700;
   opacity: 0.8;

--- a/submissions/examples/flip-icon-utility/demo.html
+++ b/submissions/examples/flip-icon-utility/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Flip Icon Utility — EaseMotion CSS</title>
   <link rel="stylesheet" href="style.css" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
 </head>
 <body>
   <div class="demo-shell">

--- a/submissions/examples/form-components-mab/demo.html
+++ b/submissions/examples/form-components-mab/demo.html
@@ -7,9 +7,6 @@
   <title>Form Components Suite — EaseMotion CSS</title>
   <meta name="description" content="Premium animated form components for EaseMotion CSS." />
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 
   <!-- EaseMotion CSS Core -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/form-components-v1-v1/demo.html
+++ b/submissions/examples/form-components-v1-v1/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Form Components — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/frontend-rendering-stress-simulator/style.css
+++ b/submissions/examples/frontend-rendering-stress-simulator/style.css
@@ -1,12 +1,11 @@
 /* ── Frontend Rendering Stress Simulator Stylesheet ── */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@500;600;700;800&display=swap');
 
 /* ── Design System Tokens ── */
 :root {
-  --font-sans: 'Inter', sans-serif;
-  --font-title: 'Outfit', sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-title: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Theme: Dark (Default) */
   --bg-app: #060911;

--- a/submissions/examples/glass-float-v1/demo.html
+++ b/submissions/examples/glass-float-v1/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Glassmorphic Floating Emphasis — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/glassmorphic-accordion/style.css
+++ b/submissions/examples/glassmorphic-accordion/style.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #4c1d95 100%);
   min-height: 100vh;
   display: flex;

--- a/submissions/examples/glitch-animation/demo.html
+++ b/submissions/examples/glitch-animation/demo.html
@@ -10,9 +10,6 @@
     Share Tech Mono: condensed, technical.
     VT323: retro terminal warmth.
   -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=VT323&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/submissions/examples/glitch-text-hover/demo.html
+++ b/submissions/examples/glitch-text-hover/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ultimate Glitch Collection - EaseMotion</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Teko:wght@600;700&family=Share+Tech+Mono&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css">
   <style>
     body {

--- a/submissions/examples/glow-warning-token/demo.html
+++ b/submissions/examples/glow-warning-token/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>--ease-glow-warning Token — Issue #1799</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/submissions/examples/gradient-animated-border/style.css
+++ b/submissions/examples/gradient-animated-border/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 @property --angle {
   syntax: '<angle>';
@@ -9,7 +8,7 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: #0c0c0c;
   color: #fafafa;
   min-height: 100vh;

--- a/submissions/examples/gradient-button-pr/demo.html
+++ b/submissions/examples/gradient-button-pr/demo.html
@@ -4,8 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>gradient-button-pr — Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
   <link rel="stylesheet" href="style.css" />
   <style>

--- a/submissions/examples/holographic-foil-card/style.css
+++ b/submissions/examples/holographic-foil-card/style.css
@@ -3,7 +3,6 @@
    A showcase of 3D transforms, custom properties, and blending modes.
 */
 
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800&display=swap');
 
 :root {
   --bg-color: #0b0b0f;
@@ -26,7 +25,7 @@
 
 body {
   background-color: var(--bg-color);
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   min-height: 100vh;
   display: flex;
   flex-direction: column;

--- a/submissions/examples/hover-color-shift/demo.html
+++ b/submissions/examples/hover-color-shift/demo.html
@@ -5,14 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>hover-color-shift — EaseMotion CSS Demo</title>
 
-  <!-- Google Fonts: DM Serif Display + DM Sans -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&display=swap"
-    rel="stylesheet"
-  />
-
   <!-- The EaseMotion hover-color-shift stylesheet -->
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/submissions/examples/hover-color-shift/style.css
+++ b/submissions/examples/hover-color-shift/style.css
@@ -52,9 +52,9 @@
   --hcs-radius-banner: 1.25rem;
 
   /* Typography */
-  --font-display: 'DM Serif Display', 'Georgia', serif;
-  --font-body:    'DM Sans', 'Helvetica Neue', sans-serif;
-  --font-mono:    'JetBrains Mono', 'Fira Code', monospace;
+  --font-display: Georgia, 'Times New Roman', 'Palatino Linotype', serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Demo page surface */
   --page-bg:      #f7f4ef;
@@ -88,7 +88,6 @@ body {
 }
 
 /* Google Fonts import — display + body pairing */
-@import url('https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&display=swap');
 
 
 /* ============================================================

--- a/submissions/examples/hover-glow-compose/demo.html
+++ b/submissions/examples/hover-glow-compose/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>hover-glow-compose #3903</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}.btn-row{display:flex;gap:1rem;flex-wrap:wrap;margin:1rem 0}</style>
 </head><body>

--- a/submissions/examples/hover-scale-shadow-sap/demo.html
+++ b/submissions/examples/hover-scale-shadow-sap/demo.html
@@ -6,8 +6,6 @@
   <title>hover-scale-shadow-sap — Demo</title>
   
   <!-- Inter font (optional but recommended) -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   
   <!-- EaseMotion CSS (CDN) -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />

--- a/submissions/examples/hover-swing-animation/demo.html
+++ b/submissions/examples/hover-swing-animation/demo.html
@@ -6,9 +6,6 @@
   <title>Hover Swing Animation — EaseMotion</title>
 
   <!-- Google Fonts: Playfair Display + DM Sans + DM Mono -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,400;0,500;1,400&family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Playfair+Display:ital,wght@0,700;0,800;1,700&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/submissions/examples/input-focus-pr/demo.html
+++ b/submissions/examples/input-focus-pr/demo.html
@@ -4,8 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>input-focus-pr — Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
   <link rel="stylesheet" href="style.css" />
   <style>

--- a/submissions/examples/interactive-component-showcase-gallery/style.css
+++ b/submissions/examples/interactive-component-showcase-gallery/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap');
 
 /* ==========================================================================
    EASEMOTION CSS - INTERACTIVE COMPONENT SHOWCASE GALLERY
@@ -56,7 +55,7 @@
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: 'Outfit', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background-color: var(--bg-primary);
   color: var(--text-primary);
   display: flex;

--- a/submissions/examples/isometric-grid-hover/demo.html
+++ b/submissions/examples/isometric-grid-hover/demo.html
@@ -6,7 +6,6 @@
     <title>Isometric 3D Card Grid - EaseMotion CSS</title>
     <link rel="stylesheet" href="style.css">
     <!-- Load clean modern font -->
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700;800&display=swap" rel="stylesheet">
 </head>
 <body>
     <div class="demo-wrapper">

--- a/submissions/examples/layount-page/demo.html
+++ b/submissions/examples/layount-page/demo.html
@@ -6,9 +6,6 @@
   <title>3D Animation Suite — EaseMotion CSS</title>
 
   <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 
   <!-- EaseMotion CSS (CDN) -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css" />

--- a/submissions/examples/letter-spacing-utilities/demo.html
+++ b/submissions/examples/letter-spacing-utilities/demo.html
@@ -4,8 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Letter Spacing Utilities Demo</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/submissions/examples/lg-breakpoint-utilities/demo.html
+++ b/submissions/examples/lg-breakpoint-utilities/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>lg Breakpoint Utilities — Issue #1800</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/submissions/examples/liquid-gooey-fab/style.css
+++ b/submissions/examples/liquid-gooey-fab/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
 *, *::before, *::after {
   box-sizing: border-box;
@@ -24,7 +23,7 @@
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;

--- a/submissions/examples/liquid-wave-loader/demo.html
+++ b/submissions/examples/liquid-wave-loader/demo.html
@@ -6,7 +6,6 @@
     <title>Liquid Wave Loader - EaseMotion CSS</title>
     <link rel="stylesheet" href="style.css">
     <!-- Load premium Google Font -->
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700;800&display=swap" rel="stylesheet">
 </head>
 <body>
     <div class="demo-wrapper">

--- a/submissions/examples/live-class-inspector-mab/demo.html
+++ b/submissions/examples/live-class-inspector-mab/demo.html
@@ -7,9 +7,6 @@
   <meta name="description" content="Interactive demo of the Live Class Inspector Panel feature for EaseMotion CSS animation classes." />
 
   <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet" />
 
   <!-- EaseMotion Core -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/magnetic-hover-button/style.css
+++ b/submissions/examples/magnetic-hover-button/style.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: #09090b;
   color: #fafafa;
   min-height: 100vh;

--- a/submissions/examples/missing-flex-col-breakpoints/demo.html
+++ b/submissions/examples/missing-flex-col-breakpoints/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>missing-flex-col-breakpoints #3920</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/mobile-sidebar-fix-pr/demo.html
+++ b/submissions/examples/mobile-sidebar-fix-pr/demo.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Demo: Responsive Mobile Sidebar Fix</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"

--- a/submissions/examples/mobile-sidebar-slide-fix-mab/demo.html
+++ b/submissions/examples/mobile-sidebar-slide-fix-mab/demo.html
@@ -7,9 +7,6 @@
   <meta name="description" content="Premium interactive demo: Mobile sidebar slide-in animation fix using visibility and pointer-events instead of display toggling.">
 
   <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700&display=swap" rel="stylesheet">
 
   <!-- EaseMotion Core -->
   <link rel="stylesheet" href="../../../core/variables.css">

--- a/submissions/examples/modal-focus-trap/demo.html
+++ b/submissions/examples/modal-focus-trap/demo.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Modal Focus Trap — EaseMotion CSS Fix #4220</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link
     href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
     rel="stylesheet"

--- a/submissions/examples/morphing-blob-loader/style.css
+++ b/submissions/examples/morphing-blob-loader/style.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: #0f172a;
   color: #e2e8f0;
   min-height: 100vh;

--- a/submissions/examples/motion-accessibility-audit-engine/demo.html
+++ b/submissions/examples/motion-accessibility-audit-engine/demo.html
@@ -7,9 +7,6 @@
   <meta name="description" content="A professional frontend auditing dashboard for analyzing UI animation safety, compliance scores, and reduced-motion timing recommendations.">
   
   <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
   
   <!-- Stylesheets -->
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/motion-chaining-orchestration-dashboard/demo.html
+++ b/submissions/examples/motion-chaining-orchestration-dashboard/demo.html
@@ -7,9 +7,6 @@
   <meta name="description" content="An interactive motion design system orchestration dashboard. Customize delays, durations, easing curves, visually check timeline tracks, and export optimized CSS tokens.">
   
   <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
   
   <!-- Stylesheets -->
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/motion-debugging-console/demo.html
+++ b/submissions/examples/motion-debugging-console/demo.html
@@ -7,9 +7,6 @@
   <meta name="description" content="A professional developer-console-style dashboard for inspecting animation states, listening to transition events, and tracking layout reflow mutations.">
   
   <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
   
   <!-- Stylesheets -->
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/motion-easing-spring-physics-visualizer/demo.html
+++ b/submissions/examples/motion-easing-spring-physics-visualizer/demo.html
@@ -7,9 +7,6 @@
   <meta name="description" content="An interactive frontend dashboard for visualizing and comparing cubic-bezier easing curves, linear timing functions, and spring-based physical motion timing.">
   
   <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
   
   <!-- Stylesheets -->
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/motion-failure-recovery-system/style.css
+++ b/submissions/examples/motion-failure-recovery-system/style.css
@@ -1,12 +1,11 @@
 /* ── Motion Failure Recovery System Stylesheet ── */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@500;600;700;800&display=swap');
 
 /* ── Design System Tokens ── */
 :root {
-  --font-sans: 'Inter', sans-serif;
-  --font-title: 'Outfit', sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-title: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Theme: Dark (Default) */
   --bg-app: #070913;

--- a/submissions/examples/motion-optimization-ai-advisor/style.css
+++ b/submissions/examples/motion-optimization-ai-advisor/style.css
@@ -1,12 +1,11 @@
 /* ── Motion Optimization AI Advisor Stylesheet ── */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@500;600;700;800&display=swap');
 
 /* ── Design System Tokens ── */
 :root {
-  --font-sans: 'Inter', sans-serif;
-  --font-title: 'Outfit', sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-title: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Theme: Dark (Default) */
   --bg-app: #080a13;

--- a/submissions/examples/motion-performance-profiler/demo.html
+++ b/submissions/examples/motion-performance-profiler/demo.html
@@ -7,9 +7,6 @@
   <meta name="description" content="A professional rendering-performance profiling dashboard. Stress-test animation layers, analyze FPS spikes, detect layout thrashing, and inspect VRAM telemetry.">
   
   <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
   
   <!-- Stylesheets -->
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/motion-testing-automation-framework/style.css
+++ b/submissions/examples/motion-testing-automation-framework/style.css
@@ -1,12 +1,11 @@
 /* ── Motion Testing Automation Framework Stylesheet ── */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@500;600;700;800&display=swap');
 
 /* ── Design System Tokens ── */
 :root {
-  --font-sans: 'Inter', sans-serif;
-  --font-title: 'Outfit', sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-title: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Theme: Dark (Default) */
   --bg-app: #090d16;

--- a/submissions/examples/navbar-components-buttonNotRedirecting/demo.html
+++ b/submissions/examples/navbar-components-buttonNotRedirecting/demo.html
@@ -9,9 +9,6 @@
     content="Official documentation for EaseMotion CSS — the animation-first, human-readable CSS framework." />
 
   <!-- Inter font — loaded via <link> instead of CSS @import for performance -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 
   <!-- EaseMotion CSS — loaded from jsDelivr CDN -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />

--- a/submissions/examples/navbar-dark-mode/demo.html
+++ b/submissions/examples/navbar-dark-mode/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>navbar-dark-mode — Fix #3636</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../style.css">
   <style>
     body { font-family: 'Inter', sans-serif; padding: 2rem; max-width: 800px; margin: 0 auto; }

--- a/submissions/examples/neon-sign-flicker/style.css
+++ b/submissions/examples/neon-sign-flicker/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;500&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -10,7 +9,7 @@
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: var(--bg);
   color: #c8c8d8;
   min-height: 100vh;
@@ -67,7 +66,7 @@ p { font-size: 0.9rem; opacity: 0.7; }
 }
 
 .neon-text {
-  font-family: 'Bebas Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: clamp(4rem, 12vw, 7rem);
   letter-spacing: 0.15em;
   color: var(--neon-pink);
@@ -80,7 +79,7 @@ p { font-size: 0.9rem; opacity: 0.7; }
 }
 
 .neon-sub {
-  font-family: 'Bebas Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size: 1.4rem;
   letter-spacing: 0.4em;
   color: var(--neon-cyan);

--- a/submissions/examples/non-blocking-font-loading/demo.html
+++ b/submissions/examples/non-blocking-font-loading/demo.html
@@ -9,10 +9,8 @@
     ✅ CORRECT APPROACH (this demo):
     Font loaded via <link> tags — browser discovers the resource early,
     in parallel with other assets. Non-blocking.
+    (This demo uses system font stacks only — no external font requests.)
   -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
   <!--
     ❌ BROKEN APPROACH (what core/base.css currently does):
@@ -20,8 +18,7 @@
     is synchronously render-blocking. The browser cannot paint the page
     until this external stylesheet is fully downloaded and parsed.
 
-    To reproduce the problem, comment out the <link> tags above and
-    uncomment the <style> block below, then run Lighthouse.
+    To reproduce the problem, uncomment the <style> block below, then run Lighthouse.
   -->
   <!--
   <style>
@@ -33,7 +30,7 @@
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
     body {
-      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
       background: #f8fafc;
       color: #1e293b;
       padding: 2rem;
@@ -74,7 +71,7 @@
     }
 
     code {
-      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
       font-size: 0.85rem;
       background: #f1f5f9;
       color: #4b44cc;
@@ -88,7 +85,7 @@
       padding: 1.25rem;
       border-radius: 0.5rem;
       overflow-x: auto;
-      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
       font-size: 0.85rem;
       line-height: 1.7;
       margin: 0.75rem 0;

--- a/submissions/examples/non-blocking-font-loading/style.css
+++ b/submissions/examples/non-blocking-font-loading/style.css
@@ -5,7 +5,6 @@
   and replace with the <link> tags shown in demo.html and README.md.
 
   REMOVE from core/base.css:
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
   The framework already has system-ui fallbacks in --ease-font-sans so no
   functional change occurs for the core library. The demo page and docs
@@ -16,7 +15,7 @@
 
 /* Demonstration: the correct font-family declaration stays unchanged */
 :root {
-  --demo-font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --demo-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 }
 
 /* Visual comparison helpers used in demo.html only */

--- a/submissions/examples/one-click-copy-button/demo.html
+++ b/submissions/examples/one-click-copy-button/demo.html
@@ -5,8 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>One-Click Copy Button · EaseMotion CSS</title>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
     href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap"
     rel="stylesheet"

--- a/submissions/examples/organic-morphing-blob/demo.html
+++ b/submissions/examples/organic-morphing-blob/demo.html
@@ -6,7 +6,6 @@
     <title>Organic Morphing Blob - EaseMotion CSS</title>
     <link rel="stylesheet" href="style.css">
     <!-- Load clean Google Font for premium visual look -->
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800&display=swap" rel="stylesheet">
 </head>
 <body>
     <div class="demo-wrapper">

--- a/submissions/examples/origami-map-pin/style.css
+++ b/submissions/examples/origami-map-pin/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 
@@ -14,7 +13,7 @@
 }
 
 body{
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background:var(--bg);
   color:var(--text);
   min-height:100vh;
@@ -175,7 +174,7 @@ p{color:var(--muted);font-size:0.9rem;text-align:center;}
   background:linear-gradient(135deg,rgba(56,189,248,0.15),rgba(129,140,248,0.15));
   border:1px solid rgba(56,189,248,0.3);
   border-radius:10px;
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   font-size:0.75rem;font-weight:600;
   color:var(--accent);cursor:pointer;
   transition:background 0.2s ease,transform 0.2s ease;

--- a/submissions/examples/overflow-scroll-missing-styles/demo.html
+++ b/submissions/examples/overflow-scroll-missing-styles/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>overflow-scroll-missing-styles #3913</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/parallax-tilt-showcase/style.css
+++ b/submissions/examples/parallax-tilt-showcase/style.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: #0f0f23;
   color: #e2e8f0;
   min-height: 100vh;

--- a/submissions/examples/particle-orbit-loader/style.css
+++ b/submissions/examples/particle-orbit-loader/style.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: #0a0a0f;
   color: #e2e8f0;
   min-height: 100vh;

--- a/submissions/examples/password-strength-indicator/demo.html
+++ b/submissions/examples/password-strength-indicator/demo.html
@@ -6,9 +6,6 @@
   <title>Interactive Password Strength Indicator • EaseMotion</title>
   <link rel="stylesheet" href="./style.css" />
   <!-- Google Fonts: Inter and Fira Code -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 </head>
 <body>
   <main class="psi-root">

--- a/submissions/examples/prefers-reduced-motion-fix/demo.html
+++ b/submissions/examples/prefers-reduced-motion-fix/demo.html
@@ -6,9 +6,6 @@
   <title>Reduced Motion Accessibility Audit & Demo — EaseMotion CSS</title>
   
   <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   
   <!-- Core & Component Framework CSS -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/production-motion-monitoring-dashboard/style.css
+++ b/submissions/examples/production-motion-monitoring-dashboard/style.css
@@ -1,12 +1,11 @@
 /* ── Production Motion Monitoring Dashboard Stylesheet ── */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@500;600;700;800&display=swap');
 
 /* ── Design System Tokens ── */
 :root {
-  --font-sans: 'Inter', sans-serif;
-  --font-title: 'Outfit', sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-title: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
   /* Theme: Dark (Default) */
   --bg-app: #080c14;

--- a/submissions/examples/project-roadmap-timeline/demo.html
+++ b/submissions/examples/project-roadmap-timeline/demo.html
@@ -7,9 +7,6 @@
   <title>Project Roadmap Timeline | EaseMotion CSS</title>
   
   <!-- Font Integrations -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   
   <!-- Local Stylesheet -->
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/pulse-border-emphasis-duration/demo.html
+++ b/submissions/examples/pulse-border-emphasis-duration/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>pulse-border-emphasis-duration #3912</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/pulse-icon-exit/demo.html
+++ b/submissions/examples/pulse-icon-exit/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pulse Icon Exit — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/react-integration-guide/demo.html
+++ b/submissions/examples/react-integration-guide/demo.html
@@ -6,9 +6,6 @@
   <title>React Integration Guide — EaseMotion CSS</title>
   
   <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Outfit:wght@600;700&display=swap" rel="stylesheet">
   
   <!-- Core Framework CSS -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/responsive-spacing-dv/demo.html
+++ b/submissions/examples/responsive-spacing-dv/demo.html
@@ -5,8 +5,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Responsive Spacing Utilities — EaseMotion CSS Submission</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 

--- a/submissions/examples/resume-upload-animation/demo.html
+++ b/submissions/examples/resume-upload-animation/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Resume Upload Animation — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/retro-led-dot-matrix/style.css
+++ b/submissions/examples/retro-led-dot-matrix/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Inter:wght@400;500;600;700&display=swap');
 
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 
@@ -15,7 +14,7 @@
 }
 
 body{
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background:var(--bg);
   color:var(--text);
   min-height:100vh;
@@ -31,7 +30,7 @@ body::before{
 }
 
 h1{
-  font-family:'Share Tech Mono',monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size:1.6rem;
   color:var(--dot-on);
   text-shadow:0 0 20px var(--dot-glow);
@@ -39,7 +38,7 @@ h1{
   letter-spacing:0.1em;
 }
 
-p{color:var(--muted);font-size:0.85rem;text-align:center;font-family:'Share Tech Mono',monospace;}
+p{color:var(--muted);font-size:0.85rem;text-align:center;font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;}
 
 /* ---- LED PANEL ---- */
 .led-panel{
@@ -115,7 +114,7 @@ p{color:var(--muted);font-size:0.85rem;text-align:center;font-family:'Share Tech
   border:1px solid var(--panel-border);
   border-radius:8px;
   padding:8px 18px;
-  font-family:'Share Tech Mono',monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size:0.78rem;
   color:var(--text);
   cursor:pointer;
@@ -142,7 +141,7 @@ p{color:var(--muted);font-size:0.85rem;text-align:center;font-family:'Share Tech
 }
 
 .speed-wrap label{
-  font-family:'Share Tech Mono',monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size:0.75rem;color:var(--muted);
   letter-spacing:0.08em;
 }
@@ -162,7 +161,7 @@ p{color:var(--muted);font-size:0.85rem;text-align:center;font-family:'Share Tech
   border:1px solid var(--panel-border);
   border-radius:8px;
   padding:8px 14px;
-  font-family:'Share Tech Mono',monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size:0.82rem;
   color:var(--text);
   outline:none;
@@ -184,14 +183,14 @@ p{color:var(--muted);font-size:0.85rem;text-align:center;font-family:'Share Tech
 }
 
 .panel-title{
-  font-family:'Share Tech Mono',monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size:0.7rem;color:var(--muted);
   letter-spacing:0.15em;text-transform:uppercase;
 }
 
 .panel-status{
   display:flex;align-items:center;gap:6px;
-  font-family:'Share Tech Mono',monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size:0.7rem;color:var(--dot-on);
 }
 

--- a/submissions/examples/reveal-delay-unused-animation/demo.html
+++ b/submissions/examples/reveal-delay-unused-animation/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>reveal-delay-unused-animation #3917</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/rotate-icon-emphasis/demo.html
+++ b/submissions/examples/rotate-icon-emphasis/demo.html
@@ -6,8 +6,6 @@
   <title>Rotate Icon Emphasis — Demo</title>
 
   <!-- Google Fonts: DM Serif Display + DM Sans + DM Mono -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
     href="https://fonts.googleapis.com/css2?family=DM+Mono&family=DM+Sans:wght@400;500&family=DM+Serif+Display&display=swap"
     rel="stylesheet"

--- a/submissions/examples/scale-icon-emphasis/style.css
+++ b/submissions/examples/scale-icon-emphasis/style.css
@@ -46,7 +46,6 @@
 
 /* ── Demo Page Styling ────────────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
 :root {
   --bg-color: #0b0f17;
@@ -69,7 +68,7 @@
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background-color: var(--bg-color);
   background-image: 
     radial-gradient(at 0% 0%, rgba(99, 102, 241, 0.12) 0px, transparent 50%),

--- a/submissions/examples/scratch-off-reveal/style.css
+++ b/submissions/examples/scratch-off-reveal/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 
@@ -11,7 +10,7 @@
 }
 
 body{
-  font-family:'Inter',sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background:var(--bg);
   color:var(--text);
   min-height:100vh;
@@ -132,7 +131,7 @@ p{color:var(--muted);font-size:0.9rem;text-align:center;}
   background:rgba(245,158,11,0.1);
   border:1px solid rgba(245,158,11,0.3);
   border-radius:10px;padding:10px 24px;
-  font-family:'Inter',sans-serif;font-size:0.85rem;font-weight:600;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:0.85rem;font-weight:600;
   color:var(--gold);cursor:pointer;
   transition:background 0.2s ease,transform 0.2s ease;
 }

--- a/submissions/examples/scroll-behavior-reduced-motion/demo.html
+++ b/submissions/examples/scroll-behavior-reduced-motion/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>scroll-behavior Reduced Motion Fix — Issue #1798</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/submissions/examples/scroll-driven-animation-lab/demo.html
+++ b/submissions/examples/scroll-driven-animation-lab/demo.html
@@ -7,9 +7,6 @@
   <meta name="description" content="An interactive frontend laboratory showcasing modern scroll-driven animations, parallax systems, reveal-on-scroll grids, and cinematic viewport transitions.">
   
   <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
   
   <!-- Stylesheets -->
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/scroll-reveal-config-pr/demo.html
+++ b/submissions/examples/scroll-reveal-config-pr/demo.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Demo: Scroll Reveal Configurations</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"

--- a/submissions/examples/scroll-trigger-v1-v1/demo.html
+++ b/submissions/examples/scroll-trigger-v1-v1/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Scroll-Triggered Animations — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/scroll-triggered-engine-kp/style.css
+++ b/submissions/examples/scroll-triggered-engine-kp/style.css
@@ -8,7 +8,6 @@
    ========================================================================== */
 
 /* ─── Modern Typography ────────────────────────────────────────────────── */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;500;600;700;800&display=swap");
 
 /* ─── Premium Design System ────────────────────────────────────────────── */
 :root {
@@ -29,8 +28,8 @@
   --text-dimmed: #6b7280;
 
   /* Typography */
-  --font-display: "Outfit", "Inter", sans-serif;
-  --font-body: "Inter", sans-serif;
+  --font-display: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 
   /* Border Radii */
   --radius-sm: 8px;

--- a/submissions/examples/scrollbar-auto-invisible/demo.html
+++ b/submissions/examples/scrollbar-auto-invisible/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>scrollbar-auto-invisible #3906</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/scrollspy-fix-dh/demo.html
+++ b/submissions/examples/scrollspy-fix-dh/demo.html
@@ -18,8 +18,6 @@
     <!-- Local Demo CSS styles -->
     <link rel="stylesheet" href="style.css" />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"

--- a/submissions/examples/security-threat-flow-v1/demo.html
+++ b/submissions/examples/security-threat-flow-v1/demo.html
@@ -4,8 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Security Threat Flow — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/shake-animation-v1/demo.html
+++ b/submissions/examples/shake-animation-v1/demo.html
@@ -6,8 +6,6 @@
   <title>shake-error · EaseMotion CSS</title>
 
   <!-- Google Fonts: DM Serif Display + DM Sans + JetBrains Mono -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
     href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap"
     rel="stylesheet"

--- a/submissions/examples/shimmer-sweep-var/demo.html
+++ b/submissions/examples/shimmer-sweep-var/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>shimmer-sweep-var #3902</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}.shimmer-box{width:100%;height:60px;border-radius:8px;background:linear-gradient(120deg,transparent 30%,rgba(255,255,255,0.15) 50%,transparent 70%);background-size:200% auto;animation:ease-kf-shimmer-sweep var(--ease-speed-slow) var(--ease-ease) infinite;margin:1rem 0}</style>
 </head><body>

--- a/submissions/examples/skeleton-loader-pr/demo.html
+++ b/submissions/examples/skeleton-loader-pr/demo.html
@@ -4,8 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>skeleton-loader-pr — Demo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
   <link rel="stylesheet" href="style.css" />
   <style>

--- a/submissions/examples/skeleton-loading-animation/demo.html
+++ b/submissions/examples/skeleton-loading-animation/demo.html
@@ -6,9 +6,6 @@
   <title>Skeleton Loading — EaseMotion CSS</title>
 
   <!-- Only one external resource: a clean Google Font for the demo UI -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet" />
 
   <!-- The skeleton animation library -->
   <link rel="stylesheet" href="style.css" />

--- a/submissions/examples/skeleton-shimmer-loader/style.css
+++ b/submissions/examples/skeleton-shimmer-loader/style.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: #f1f5f9;
   color: #0f172a;
   min-height: 100vh;

--- a/submissions/examples/snap-strictness-undefined/demo.html
+++ b/submissions/examples/snap-strictness-undefined/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>snap-strictness-undefined #3908</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/spacing-token-space-7/demo.html
+++ b/submissions/examples/spacing-token-space-7/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>--ease-space-7 Token — Issue #1803</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/submissions/examples/spotlight-soft/demo.html
+++ b/submissions/examples/spotlight-soft/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spotlight Soft — EaseMotion CSS</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=DM+Mono:wght@300;400&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/squish-button-touch/demo.html
+++ b/submissions/examples/squish-button-touch/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>squish-button-touch #3898</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>
 body { font-family: 'Inter', sans-serif; padding: 2rem; max-width: 800px; margin: 0 auto; }

--- a/submissions/examples/stat-value-hardcoded/demo.html
+++ b/submissions/examples/stat-value-hardcoded/demo.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>stat-value-hardcoded #3911</title>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>

--- a/submissions/examples/sticky-top-variable/demo.html
+++ b/submissions/examples/sticky-top-variable/demo.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>.ease-sticky Fix — Configurable top offset — Issue #1802</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/submissions/examples/tooltip-centering-fix-pr/demo.html
+++ b/submissions/examples/tooltip-centering-fix-pr/demo.html
@@ -5,8 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Demo: Tooltip Centering Fix under Prefers Reduced Motion</title>
     <!-- Base variables and layout styles from the framework -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"

--- a/submissions/examples/transform-origin-utilities/style.css
+++ b/submissions/examples/transform-origin-utilities/style.css
@@ -7,7 +7,6 @@
 /* --------------------------------------------------------------------------
    1. Design System & Variables
    -------------------------------------------------------------------------- */
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 :root {
   --bg-darkest: #0a0b10;
@@ -26,8 +25,8 @@
   --text-secondary: #94a3b8;
   --text-muted: #64748b;
   
-  --font-sans: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 }
 
 /* --------------------------------------------------------------------------

--- a/submissions/examples/typewriter-animation/demo.html
+++ b/submissions/examples/typewriter-animation/demo.html
@@ -6,8 +6,6 @@
   <title>Typewriter Animation — CSS Demo</title>
 
   <!-- Monospace display font from Google Fonts (two weights) -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
     href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=DM+Mono:wght@300;400&display=swap"
     rel="stylesheet"

--- a/submissions/examples/typewriter-cursor-glow/style.css
+++ b/submissions/examples/typewriter-cursor-glow/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -8,7 +7,7 @@ body {
   align-items: center;
   justify-content: center;
   background: #0d1117;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   padding: 2rem;
 }
 

--- a/submissions/examples/validate-bundle-fix-mab/demo.html
+++ b/submissions/examples/validate-bundle-fix-mab/demo.html
@@ -7,9 +7,6 @@
   <title>Line Ending Normalization Visualizer — EaseMotion CSS</title>
   <meta name="description" content="Visualizer demonstrating the CRLF vs LF line ending mismatch bug on Windows environments." />
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
 
   <!-- EaseMotion CSS Core -->
   <link rel="stylesheet" href="../../../core/variables.css" />

--- a/submissions/examples/water-ripple-button/style.css
+++ b/submissions/examples/water-ripple-button/style.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;600&display=swap');
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   background: #f8fafc;
   color: #0f172a;
   min-height: 100vh;

--- a/submissions/examples/wave-text-v1/demo.html
+++ b/submissions/examples/wave-text-v1/demo.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ease-wave-text — EaseMotion CSS</title>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=DM+Mono:wght@300;400;500&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="style.css" />
 


### PR DESCRIPTION
## Summary
- Removes all `@import url('https://fonts.googleapis.com/...')` lines from 78 submission `style.css` files
- Replaces referenced Google Font families with offline-safe system font stacks (sans, serif, or monospace as appropriate)
- Strips Google Fonts `<link>` preconnect/stylesheet tags from 200 matching `demo.html` files

## Test plan
- [ ] Open several affected demos offline (e.g. `ease-object-fit`, `hover-color-shift`, `ease-italic`, `typewriter-cursor-glow`) and confirm typography renders without network requests
- [ ] Verify `grep -r fonts.googleapis.com submissions/examples --include=style.css` returns no matches
- [ ] Verify no `demo.html` contains live `<link>` tags to fonts.googleapis.com or fonts.gstatic.com
- [ ] Spot-check display-font demos (`animated-comic-effect`, `cursor-orb-effect`) for acceptable fallback appearance

Fixes #6075