### PR TITLE
fix(ease-img-circle): remove CDN framework link and replace picsum images with inline SVG avatars

### DIFF
--- a/submissions/examples/ease-img-circle/demo.html
+++ b/submissions/examples/ease-img-circle/demo.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>ease-img-circle Demo</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-img-circle Demo — EaseMotion CSS</title>
   <link rel="stylesheet" href="style.css" />
   <style>
     body { margin: 0; font-family: sans-serif; padding: 2rem; }
@@ -18,14 +18,14 @@
   <h3>Small Avatar</h3>
   <img
     class="ease-img-circle avatar"
-    src="https://picsum.photos/100/100"
+    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='50' fill='%234f46e5'/%3E%3Ccircle cx='50' cy='38' r='18' fill='%23e0e7ff'/%3E%3Cellipse cx='50' cy='80' rx='28' ry='18' fill='%23e0e7ff'/%3E%3C/svg%3E"
     alt="Small avatar"
   />
 
   <h3>Large Avatar</h3>
   <img
     class="ease-img-circle avatar-lg"
-    src="https://picsum.photos/200/200"
+    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'%3E%3Ccircle cx='100' cy='100' r='100' fill='%230891b2'/%3E%3Ccircle cx='100' cy='76' r='36' fill='%23e0f2fe'/%3E%3Cellipse cx='100' cy='160' rx='56' ry='36' fill='%23e0f2fe'/%3E%3C/svg%3E"
     alt="Large avatar"
   />
 </body>


### PR DESCRIPTION
## Pull Request Description

`submissions/examples/ease-img-circle/demo.html` had two CONTRIBUTING.md violations:

1. Loaded `easemotion.css` from `cdn.jsdelivr.net` — an external CDN
2. Loaded both demo images from `picsum.photos` — an external image service

Both fail offline, making the circular-cropping class impossible to evaluate. This PR removes all external dependencies.

Fixes #6065

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

```html
<!-- Removed — CDN not allowed -->
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />

<!-- Replaced — picsum images with inline SVG avatars -->
<img src="data:image/svg+xml,..." alt="Small avatar" />
<img src="data:image/svg+xml,..." alt="Large avatar" />
```

Also added the missing `<meta name="viewport">` tag.

**Why does it fit EaseMotion CSS?**

CONTRIBUTING.md: *"No CDN links, no external frameworks. Must work by opening directly in a browser with no server."*

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The local `style.css` already contains all necessary styles — the CDN framework link was redundant. CSS classes and page structure are unchanged.