### PR TITLE
[BUG] : Fix Double-Translation Layout Glitch on Spinner

### DIFF
--- a/submissions/examples/spinner-double-translation-fix/README.md
+++ b/submissions/examples/spinner-double-translation-fix/README.md
@@ -1,0 +1,59 @@
+# Spinner Double-Translation Layout Glitch Fix
+
+## What does this do?
+
+Resolves a layout glitch where the loading spinner inside `.ease-btn-loading::after` is positioned off-center and wobbles during animation. By removing the redundant `translate(-50%, -50%)` transform from the `@keyframes ease-kf-btn-spin` animation, the spinner remains perfectly aligned to the center of the button.
+
+## How is it used?
+
+The fix is applied directly to the framework's core button component stylesheets.
+
+### Before (Buggy):
+
+```css
+/* components/buttons.css */
+.ease-btn-loading::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  animation: ease-kf-btn-spin 0.7s linear infinite;
+}
+
+@keyframes ease-kf-btn-spin {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+```
+
+### After (Fixed):
+
+```css
+/* components/buttons.css */
+.ease-btn-loading::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  animation: ease-kf-btn-spin 0.7s linear infinite;
+}
+
+@keyframes ease-kf-btn-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+```
+
+## Why is it useful?
+
+In modern rendering engines (e.g. Blink in Chrome 120+, WebKit in Safari 17+), both the independent `translate: -50% -50%` property and the `transform: translate(-50%, -50%)` inside `@keyframes` are applied simultaneously. This results in the element translating by -100% horizontally and vertically, shifting the spinner out of the center.
+
+Removing the redundant `translate` inside keyframes preserves the original alignment set by `translate: -50% -50%` on the element itself, keeping the spinner perfectly centered at all times during its rotation.

--- a/submissions/examples/spinner-double-translation-fix/demo.html
+++ b/submissions/examples/spinner-double-translation-fix/demo.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bug Fix: Spinner Double-Translation Layout Glitch</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="page-header">
+        <h1>Bug Fix: Spinner Double-Translation Layout Glitch</h1>
+        <p class="subtitle">
+          Resolves a layout glitch where the loading spinner inside
+          <code>.ease-btn-loading::after</code> shifts off-center and wobbles
+          due to double-translation.
+        </p>
+      </header>
+
+      <main class="page-content">
+        <!-- Live Comparison Section -->
+        <section class="section">
+          <h2>Live Demonstration</h2>
+          <div class="demo-card">
+            <div class="btn-container">
+              <!-- Buggy Button -->
+              <div class="btn-demo-box">
+                <span class="label label-fail">Buggy (Double-Translated)</span>
+                <span class="btn-title">wobbles / offset center</span>
+                <button class="btn btn--loading btn--buggy">Saving...</button>
+              </div>
+
+              <!-- Fixed Button -->
+              <div class="btn-demo-box">
+                <span class="label label-pass">Fixed (Perfectly Centered)</span>
+                <span class="btn-title">stays dead center</span>
+                <button class="btn btn--loading btn--fixed">Saving...</button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Analysis Section -->
+        <section class="section">
+          <h2>Why the Glitch Occurs</h2>
+          <div class="bug-box">
+            <p class="section-text">
+              In modern layout engines, both the independent
+              <code>translate: -50% -50%;</code> property and the
+              transform-based
+              <code>transform: translate(-50%, -50%)</code> inside the keyframes
+              are evaluated together.
+            </p>
+            <p class="section-text" style="margin-bottom: 0">
+              This causes the element to be translated twice (-100% horizontally
+              and vertically), resulting in the spinner rendering out of bounds
+              relative to the button container.
+            </p>
+          </div>
+        </section>
+
+        <!-- Code Comparison Section -->
+        <section class="section">
+          <h2>Code Comparison</h2>
+          <div class="bug-row">
+            <!-- Buggy Code -->
+            <div class="bug-col">
+              <span class="label label-fail">Buggy CSS</span>
+              <pre
+                class="code-block code-block--fail"
+              ><code>.ease-btn-loading::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  animation: ease-kf-btn-spin 0.7s linear infinite;
+}
+
+@keyframes ease-kf-btn-spin {
+  from {
+    /* Translates by another -50% -50%! */
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}</code></pre>
+            </div>
+
+            <!-- Fixed Code -->
+            <div class="bug-col">
+              <span class="label label-pass">Fixed CSS (Proposed)</span>
+              <pre
+                class="code-block code-block--pass"
+              ><code>.ease-btn-loading::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  animation: ease-kf-btn-spin 0.7s linear infinite;
+}
+
+@keyframes ease-kf-btn-spin {
+  from {
+    /* Only rotate — preserve the translate property */
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}</code></pre>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/spinner-double-translation-fix/style.css
+++ b/submissions/examples/spinner-double-translation-fix/style.css
@@ -1,0 +1,291 @@
+/* ============================================================
+   Bug Fix: Spinner Double-Translation Layout Glitch
+   Submission by: Contributor
+   
+   THE BUG
+   ───────
+   In components/buttons.css (line 228-241), the loader pseudo-element:
+     .ease-btn-loading::after {
+       translate: -50% -50%;
+       animation: ease-kf-btn-spin 0.7s linear infinite;
+     }
+   
+   Animates using:
+     @keyframes ease-kf-btn-spin {
+       from { transform: translate(-50%, -50%) rotate(0deg); }
+       to   { transform: translate(-50%, -50%) rotate(360deg); }
+     }
+   
+   Because both the independent `translate` property and the `transform: translate()`
+   inside the animation keyframes are applied simultaneously, modern browsers translate
+   the spinner twice (by -100% -100% instead of -50% -50%), causing the spinner to render
+   completely off-center and wobble during rotation.
+   
+   THE FIX
+   ───────
+   Since the element itself already has `translate: -50% -50%;` defined, the animation keyframes
+   do NOT need to translate it again. We simply animate `transform: rotate(...)`:
+     @keyframes ease-kf-btn-spin {
+       from { transform: rotate(0deg); }
+       to   { transform: rotate(360deg); }
+     }
+   ============================================================ */
+
+/* ── Design tokens for standalone demo ──────────────────────── */
+:root {
+  --page-bg: #0b1121;
+  --surface: #141e33;
+  --surface-alt: #1a2540;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --border: rgba(255, 255, 255, 0.08);
+  --accent: #6c63ff;
+  --accent-lt: #a09af8;
+  --success: #22c55e;
+  --danger: #ef4444;
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+}
+
+/* ── Reset ──────────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── Page ───────────────────────────────────────────────────── */
+body {
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background: var(--page-bg);
+  color: var(--text);
+  min-height: 100vh;
+  padding: 3rem 1.5rem;
+  line-height: 1.6;
+}
+
+.page {
+  max-width: 860px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+.page-header h1 {
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #fff 40%, var(--accent-lt));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.6rem;
+}
+
+.subtitle {
+  font-size: 0.875rem;
+  color: var(--muted);
+  max-width: 660px;
+}
+
+/* ── Bug comparison box ─────────────────────────────────────────── */
+.bug-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+}
+
+.bug-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .bug-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.bug-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* ── Labels ──────────────────────────────────────────────────── */
+.label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 4px 10px;
+  border-radius: 6px;
+  width: fit-content;
+}
+
+.label--fail {
+  background: rgba(239, 68, 68, 0.12);
+  color: #fca5a5;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+}
+.label--pass {
+  background: rgba(34, 197, 94, 0.12);
+  color: #86efac;
+  border: 1px solid rgba(34, 197, 94, 0.25);
+}
+
+/* ── Code blocks ─────────────────────────────────────────────── */
+.code-block {
+  background: #090813;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  font-family: "JetBrains Mono", "Fira Code", "Consolas", monospace;
+  font-size: 0.73rem;
+  color: var(--accent-lt);
+  line-height: 1.8;
+  overflow-x: auto;
+  white-space: pre;
+  flex: 1;
+}
+
+.code-block--fail {
+  border-color: rgba(239, 68, 68, 0.2);
+}
+.code-block--pass {
+  border-color: rgba(34, 197, 94, 0.2);
+}
+
+/* ── Sections ────────────────────────────────────────────────── */
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+  border-left: 3px solid var(--accent);
+  padding-left: 0.75rem;
+}
+
+/* ── Live button demo ────────────────────────────────────────── */
+.demo-card {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.btn-container {
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.btn-demo-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+  min-width: 250px;
+  padding: 1.5rem;
+  background: rgba(11, 17, 33, 0.3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+
+.btn-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+/* Base button styles matching components/buttons.css */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 2rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border: 2px solid transparent;
+  border-radius: var(--radius-md);
+  background: var(--accent);
+  color: #ffffff;
+  cursor: pointer;
+  position: relative;
+  min-width: 150px;
+  height: 44px;
+}
+
+.btn--loading {
+  pointer-events: none;
+  color: transparent !important;
+}
+
+/* Loader Base */
+.btn--loading::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  font-size: 1rem;
+  translate: -50% -50%;
+  width: 0.85em;
+  height: 0.85em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+}
+
+/* ── Buggy Spinner implementation ── */
+.btn--buggy::after {
+  animation: ease-kf-btn-spin-buggy 0.7s linear infinite;
+}
+
+@keyframes ease-kf-btn-spin-buggy {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+
+/* ── Fixed Spinner implementation ── */
+.btn--fixed::after {
+  animation: ease-kf-btn-spin-fixed 0.7s linear infinite;
+}
+
+@keyframes ease-kf-btn-spin-fixed {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
# Pull Request Description
---

Resolves a layout glitch where the loading spinner inside `.ease-btn-loading::after` is positioned off-center and wobbles during animation. 

fixes #5027

---
---

# Type of Change
---

- [x] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] Other (describe below)

---
---

# Submission Checklist
---

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/spinner-double-translation-fix/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
---

# Feature Description
---

**What does this add?**

Fixes a double-translation layout glitch on `.ease-btn-loading::after` by removing the redundant translation inside `@keyframes ease-kf-btn-spin`.

**How does a developer use it?**

Simply use the standard loader class:
```html
<button class="ease-btn ease-btn-primary ease-btn-loading">Saving...</button>
```

**Why does it fit EaseMotion CSS?**

It ensures the loader spinner remains perfectly centered inside the button during rotation, keeping the framework's core utility states clean and visually stable across modern browsers.

---
---

# Demo
---

- [x] Demo added (`demo.html` works by opening directly in a browser)

---
---

# Browser Testing
---

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---
---

# Notes for Maintainer
---

In modern rendering engines (Chrome 120+, Safari 17+), both the independent `translate: -50% -50%` and the transform-based `transform: translate(-50%, -50%)` inside `@keyframes` are applied simultaneously. This translates the element by -100% instead of -50%, pushing it off-center. Animate only the `rotate(...)` inside keyframes to preserve the correct centering.
