### PR TITLE
[BUG] : Fix False-Positive Substring Match in Smoke Tests

### DIFF
--- a/submissions/examples/smoke-test-false-positive-fix/README.md
+++ b/submissions/examples/smoke-test-false-positive-fix/README.md
@@ -1,0 +1,70 @@
+# Bug Fix — False-Positive Substring Match in Smoke Tests
+
+## What does this do?
+
+Identifies and resolves a false-positive assertion check in `tests/smoke.test.js` where the test case incorrectly passed by using substring matching. The smoke test asserted `expect(css).toContain('font-size: 0')` to check if text was hidden inside the loading button state `.ease-btn-loading`. However, `.ease-btn-loading` does not define `font-size: 0`, and the test only passed because the string was matched as a substring of unrelated class declarations containing decimal values (such as `font-size: 0.875rem` or `font-size: 0.75rem`).
+
+---
+
+## Technical Details & Exact Locations
+
+### The Bug Location
+
+**`tests/smoke.test.js` — lines 96–103:**
+
+```javascript
+it("should hide plain text in loading buttons and keep the spinner visible", () => {
+  expect(css).toContain(".ease-btn-loading");
+  expect(css).toContain("font-size: 0"); // ← BUG: Falsely matches 0.875rem or 0.75rem from other classes!
+  expect(css).toContain(".ease-btn-loading > *");
+  expect(css).toContain("visibility: hidden");
+  expect(css).toContain(".ease-btn-loading::after");
+  expect(css).toContain("border: 2px solid currentColor");
+});
+```
+
+**`components/buttons.css` — lines 218–222:**
+
+```css
+/* Loading spinner inside button */
+.ease-btn-loading {
+  pointer-events: none;
+  position: relative;
+  color: transparent !important; /* ← Target element uses color: transparent, NOT font-size: 0 */
+}
+```
+
+---
+
+## Solution
+
+We update the assertion in `tests/smoke.test.js` to target the actual property implemented by `.ease-btn-loading`:
+
+```diff
+// tests/smoke.test.js
+   it('should hide plain text in loading buttons and keep the spinner visible', () => {
+     expect(css).toContain('.ease-btn-loading');
+-    expect(css).toContain('font-size: 0');
++    expect(css).toContain('color: transparent');
+     expect(css).toContain('.ease-btn-loading > *');
+```
+
+---
+
+## Interactive Sandbox & Demo
+
+An interactive simulation lab is provided in `demo.html` allowing contributors to:
+
+1. Load a mockup CSS containing buttons and decimal font sizes.
+2. Select between the **Buggy Substring Check** (asserting `font-size: 0`), **Fixed Substring Check** (asserting `color: transparent`), and a **Strict Selector & Declaration Check** (verifying boundaries).
+3. Inspect how naive substring matching leads to false-positive test runs and check live status results.
+
+### Files Created
+
+- `demo.html`: Live interactive sandbox lab interface.
+- `style.css`: Clean, visually stunning dark mode layout for the lab.
+- `README.md`: This documentation.
+
+---
+
+_Submitted by: SAPTARSHI-coder · Issue: False-Positive Substring Match in Smoke Tests_

--- a/submissions/examples/smoke-test-false-positive-fix/demo.html
+++ b/submissions/examples/smoke-test-false-positive-fix/demo.html
@@ -1,0 +1,337 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Smoke Test False-Positive Lab — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Smoke Test Visualizer Lab</h1>
+        <p>
+          Interactive playground demonstrating the false-positive substring
+          matching bug in Vitest assertions and the solution.
+        </p>
+      </header>
+
+      <main class="grid-2col">
+        <!-- Left Column: Interactive CSS Workspace -->
+        <section class="glass-panel">
+          <div class="panel-header">
+            <h2 class="panel-title">
+              <span style="color: var(--color-primary)">●</span> CSS Under Test
+            </h2>
+            <span class="editor-tab">buttons.css & cards.css</span>
+          </div>
+          <p class="muted" style="margin-bottom: 1rem">
+            Edit the CSS stylesheet below. Unrelated classes define decimal font
+            sizes starting with <code>0</code> (e.g. <code>0.875rem</code>).
+          </p>
+
+          <div class="editor-wrapper">
+            <div class="editor-header">
+              <div class="window-dots">
+                <span class="dot dot-red"></span>
+                <span class="dot dot-yellow"></span>
+                <span class="dot dot-green"></span>
+              </div>
+              <span style="font-size: 0.7rem; color: var(--text-muted)"
+                >SOURCE CODE</span
+              >
+            </div>
+            <textarea id="cssInput" class="code-area" spellcheck="false">
+.ease-btn-loading {
+  pointer-events: none;
+  position: relative;
+  color: transparent !important;
+}
+
+.ease-card-subtitle {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+.ease-chip-sm {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+}</textarea
+            >
+          </div>
+        </section>
+
+        <!-- Right Column: Matcher Engine & Results -->
+        <section class="glass-panel lab-controls">
+          <div>
+            <div class="panel-header">
+              <h2 class="panel-title">
+                <span style="color: var(--color-primary)">●</span> Assertion
+                Matcher Engine
+              </h2>
+            </div>
+            <p class="muted">
+              Select an assertion style to run against the CSS above:
+            </p>
+            <div class="btn-group">
+              <button
+                id="btnBuggy"
+                class="btn btn-active"
+                onclick="setMode('buggy')"
+              >
+                Buggy Substring (font-size: 0)
+              </button>
+              <button id="btnFixed" class="btn" onclick="setMode('fixed')">
+                Fixed Substring (color: transparent)
+              </button>
+              <button id="btnStrict" class="btn" onclick="setMode('strict')">
+                Strict AST-like Matcher
+              </button>
+            </div>
+          </div>
+
+          <div class="status-card">
+            <div>
+              <div
+                style="
+                  font-size: 0.75rem;
+                  color: var(--text-muted);
+                  text-transform: uppercase;
+                  letter-spacing: 0.05em;
+                  margin-bottom: 2px;
+                "
+              >
+                Smoke Test Result
+              </div>
+              <div
+                id="testExplanation"
+                style="font-size: 0.9rem; font-weight: 500"
+              >
+                Matches false-positive substrings.
+              </div>
+            </div>
+            <span id="testStatus" class="status-badge status-badge-warn"
+              >False Positive</span
+            >
+          </div>
+
+          <div>
+            <div
+              style="
+                font-size: 0.85rem;
+                font-weight: 600;
+                margin-bottom: 0.5rem;
+                color: var(--text-main);
+              "
+            >
+              Matched Output & Highlighting:
+            </div>
+            <div id="highlightedOutput" class="highlight-box"></div>
+          </div>
+        </section>
+      </main>
+
+      <!-- Side-by-Side Code Comparison & Explanation -->
+      <section class="glass-panel">
+        <div class="panel-header">
+          <h2 class="panel-title">
+            <span style="color: var(--color-primary)">●</span> Why did the test
+            pass falsely?
+          </h2>
+        </div>
+        <p class="muted" style="margin-bottom: 1.5rem">
+          Because <code>expect(css).toContain('font-size: 0')</code> searches
+          the entire compiled CSS file as a single string. It matches
+          <code>font-size: 0</code> inside decimals like
+          <code>font-size: 0.875rem</code>.
+        </p>
+
+        <div class="comparison-container">
+          <!-- Buggy Card -->
+          <div
+            class="comparison-card"
+            style="border-color: rgba(239, 68, 68, 0.2)"
+          >
+            <div class="card-title">
+              <span
+                class="status-badge status-badge-fail"
+                style="padding: 2px 8px; font-size: 0.7rem"
+                >Buggy Code</span
+              >
+              <code>tests/smoke.test.js</code>
+            </div>
+            <p class="card-desc">
+              Asserts a rule that doesn't actually exist on the class, passing
+              by mistake.
+            </p>
+            <pre class="code-snippet"><code>it('should hide text...', () => {
+  expect(css).toContain('.ease-btn-loading');
+  expect(css).toContain('font-size: 0'); // Falsely matches 0.875rem!
+});</code></pre>
+          </div>
+
+          <!-- Corrected Card -->
+          <div
+            class="comparison-card"
+            style="border-color: rgba(34, 197, 94, 0.2)"
+          >
+            <div class="card-title">
+              <span
+                class="status-badge status-badge-pass"
+                style="padding: 2px 8px; font-size: 0.7rem"
+                >Fixed Code</span
+              >
+              <code>tests/smoke.test.js</code>
+            </div>
+            <p class="card-desc">
+              Asserts the correct styling declaration implemented by the loading
+              state.
+            </p>
+            <pre class="code-snippet"><code>it('should hide text...', () => {
+  expect(css).toContain('.ease-btn-loading');
+  expect(css).toContain('color: transparent'); // Exact & correct match!
+});</code></pre>
+          </div>
+        </div>
+      </section>
+
+      <footer>
+        <p>
+          Submitted as a test suite bug fix for
+          <a
+            href="https://github.com/SAPTARSHI-coder/EaseMotion-css"
+            target="_blank"
+            >EaseMotion CSS</a
+          >.
+        </p>
+      </footer>
+    </div>
+
+    <script>
+      const cssInput = document.getElementById("cssInput");
+      const highlightedOutput = document.getElementById("highlightedOutput");
+      const testStatus = document.getElementById("testStatus");
+      const testExplanation = document.getElementById("testExplanation");
+
+      let currentMode = "buggy";
+
+      function setMode(mode) {
+        currentMode = mode;
+        document
+          .getElementById("btnBuggy")
+          .classList.toggle("btn-active", mode === "buggy");
+        document
+          .getElementById("btnFixed")
+          .classList.toggle("btn-active", mode === "fixed");
+        document
+          .getElementById("btnStrict")
+          .classList.toggle("btn-active", mode === "strict");
+        updateVisuals();
+      }
+
+      function escapeHtml(text) {
+        return text
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+      }
+
+      function updateVisuals() {
+        const rawCss = cssInput.value;
+        let html = escapeHtml(rawCss);
+
+        if (currentMode === "buggy") {
+          const target = "font-size: 0";
+          if (rawCss.includes(target)) {
+            // Check if .ease-btn-loading class actually has font-size: 0 inside its braces
+            const loadingClassMatch = rawCss.match(
+              /\.ease-btn-loading\s*\{([^}]*)\}/
+            );
+            const hasInLoading =
+              loadingClassMatch && loadingClassMatch[1].includes(target);
+
+            if (!hasInLoading) {
+              // It matches, but NOT in .ease-btn-loading! This is a False Positive!
+              testStatus.className = "status-badge status-badge-warn";
+              testStatus.innerText = "False Positive";
+              testExplanation.innerHTML =
+                "Test passes falsely by matching <code>font-size: 0</code> inside decimals.";
+            } else {
+              // It matches inside .ease-btn-loading (user added it)
+              testStatus.className = "status-badge status-badge-pass";
+              testStatus.innerText = "Pass";
+              testExplanation.innerText =
+                "Test passes correctly because font-size: 0 is defined.";
+            }
+
+            // Highlight all matches
+            const regex = new RegExp(target, "g");
+            html = escapeHtml(rawCss).replace(
+              regex,
+              `<span class="hl-target">${target}</span>`
+            );
+          } else {
+            testStatus.className = "status-badge status-badge-fail";
+            testStatus.innerText = "Fail";
+            testExplanation.innerText =
+              'Test fails because "font-size: 0" was not found anywhere.';
+          }
+        } else if (currentMode === "fixed") {
+          const target = "color: transparent";
+          if (rawCss.includes(target)) {
+            testStatus.className = "status-badge status-badge-pass";
+            testStatus.innerText = "Pass";
+            testExplanation.innerText =
+              "Test passes correctly because color: transparent matches.";
+
+            const regex = new RegExp(target, "g");
+            html = escapeHtml(rawCss).replace(
+              regex,
+              `<span class="hl-correct">${target}</span>`
+            );
+          } else {
+            testStatus.className = "status-badge status-badge-fail";
+            testStatus.innerText = "Fail";
+            testExplanation.innerText =
+              "Test fails because color: transparent is missing.";
+          }
+        } else if (currentMode === "strict") {
+          // Parse .ease-btn-loading block
+          const match = rawCss.match(/\.ease-btn-loading\s*\{([^}]*)\}/);
+          if (match) {
+            const contents = match[1];
+            if (contents.includes("color: transparent")) {
+              testStatus.className = "status-badge status-badge-pass";
+              testStatus.innerText = "Pass";
+              testExplanation.innerText =
+                "AST check passes: color: transparent is inside .ease-btn-loading.";
+
+              // Highlight color: transparent inside the loading selector
+              const target = "color: transparent";
+              const regex = new RegExp(target, "g");
+              html = escapeHtml(rawCss).replace(
+                regex,
+                `<span class="hl-correct">${target}</span>`
+              );
+            } else {
+              testStatus.className = "status-badge status-badge-fail";
+              testStatus.innerText = "Fail";
+              testExplanation.innerText =
+                "AST check fails: color: transparent not inside .ease-btn-loading.";
+            }
+          } else {
+            testStatus.className = "status-badge status-badge-fail";
+            testStatus.innerText = "Fail";
+            testExplanation.innerText = ".ease-btn-loading class not found.";
+          }
+        }
+
+        highlightedOutput.innerHTML = html;
+      }
+
+      cssInput.addEventListener("input", updateVisuals);
+      // Initial paint
+      updateVisuals();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/smoke-test-false-positive-fix/style.css
+++ b/submissions/examples/smoke-test-false-positive-fix/style.css
@@ -1,0 +1,422 @@
+/* ============================================================
+   EaseMotion CSS — Substring Mismatch Test Visualizer Lab
+   ============================================================ */
+
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap");
+
+:root {
+  --font-sans:
+    "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "Fira Code", "Courier New", monospace;
+
+  /* HSL Color Palette - Sleek Dark Theme */
+  --bg-dark: hsl(222, 47%, 6%);
+  --bg-card: hsla(223, 40%, 12%, 0.6);
+  --bg-card-hover: hsla(223, 40%, 16%, 0.8);
+  --border-glow: hsla(224, 60%, 50%, 0.35);
+  --border-muted: hsla(223, 30%, 25%, 0.4);
+
+  --color-primary: hsl(244, 98%, 70%);
+  --color-primary-glow: hsla(244, 98%, 70%, 0.3);
+  --color-success: hsl(142, 76%, 45%);
+  --color-success-glow: hsla(142, 76%, 45%, 0.25);
+  --color-danger: hsl(346, 84%, 61%);
+  --color-danger-glow: hsla(346, 84%, 61%, 0.25);
+  --color-warning: hsl(38, 92%, 50%);
+  --color-warning-glow: hsla(38, 92%, 50%, 0.25);
+
+  --text-main: hsl(210, 38%, 95%);
+  --text-muted: hsl(215, 20%, 65%);
+  --text-inverse: hsl(222, 47%, 6%);
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+
+  --transition-smooth: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  --shadow-neon: 0 0 20px rgba(108, 99, 255, 0.15);
+}
+
+/* ── Base Styles ───────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  min-height: 100vh;
+  padding: 2rem 1rem;
+  background-image:
+    radial-gradient(at 0% 0%, hsla(244, 98%, 70%, 0.08) 0px, transparent 50%),
+    radial-gradient(at 100% 0%, hsla(346, 84%, 61%, 0.05) 0px, transparent 50%),
+    radial-gradient(at 50% 100%, hsla(142, 76%, 45%, 0.04) 0px, transparent 50%);
+  background-attachment: fixed;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+/* ── Typography & Header ───────────────────────────────────── */
+header {
+  text-align: center;
+  margin-bottom: 1rem;
+  position: relative;
+}
+
+header h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1.1;
+  margin-bottom: 0.75rem;
+  background: linear-gradient(
+    135deg,
+    #ffffff 30%,
+    var(--color-primary) 70%,
+    hsl(346, 84%, 80%) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+header p {
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+/* ── Glassmorphic Panels ───────────────────────────────────── */
+.glass-panel {
+  background: var(--bg-card);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-neon);
+  transition: var(--transition-smooth);
+}
+
+.glass-panel:hover {
+  border-color: var(--border-glow);
+  box-shadow: 0 0 30px hsla(244, 98%, 70%, 0.08);
+  transform: translateY(-2px);
+}
+
+/* ── Dashboard Grid ────────────────────────────────────────── */
+.grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 2rem;
+}
+
+@media (max-width: 900px) {
+  .grid-2col {
+    grid-template-columns: 1fr;
+  }
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-muted);
+  padding-bottom: 0.75rem;
+}
+
+.panel-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* ── Interactive Code Editor Mockup ───────────────────────── */
+.editor-wrapper {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--border-muted);
+}
+
+.editor-header {
+  background: hsla(223, 40%, 8%, 0.9);
+  padding: 0.75rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.window-dots {
+  display: flex;
+  gap: 6px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.dot-red {
+  background: var(--color-danger);
+}
+.dot-yellow {
+  background: var(--color-warning);
+}
+.dot-green {
+  background: var(--color-success);
+}
+
+.editor-tab {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: hsla(223, 40%, 14%, 0.8);
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border-muted);
+}
+
+.code-area {
+  background: hsl(224, 42%, 4%);
+  color: #c9d1d9;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 1.25rem;
+  width: 100%;
+  height: 250px;
+  border: none;
+  resize: none;
+  outline: none;
+  line-height: 1.6;
+}
+
+/* ── Match Highlights ──────────────────────────────────────── */
+.highlight-box {
+  background: hsl(224, 42%, 4%);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  height: 250px;
+  overflow-y: auto;
+  line-height: 1.6;
+  border: 1px solid var(--border-muted);
+}
+
+.hl-target {
+  background-color: var(--color-danger-glow);
+  border-bottom: 2px dashed var(--color-danger);
+  color: #fff;
+  padding: 2px 0;
+  position: relative;
+  font-weight: 500;
+}
+
+.hl-target::after {
+  content: 'Matches "font-size: 0"!';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-danger);
+  color: var(--text-inverse);
+  font-size: 0.65rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  font-family: var(--font-sans);
+  font-weight: bold;
+  z-index: 10;
+  opacity: 0;
+  transition: opacity 0.2s;
+  pointer-events: none;
+}
+
+.hl-target:hover::after {
+  opacity: 1;
+}
+
+.hl-correct {
+  background-color: var(--color-success-glow);
+  border-bottom: 2px solid var(--color-success);
+  color: #fff;
+  padding: 2px 0;
+}
+
+/* ── Simulator Lab Side Controls ──────────────────────────── */
+.lab-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.btn-group {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.btn {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-muted);
+  background: hsla(223, 40%, 14%, 0.6);
+  color: var(--text-main);
+  cursor: pointer;
+  transition: var(--transition-smooth);
+}
+
+.btn:hover {
+  background: hsla(223, 40%, 20%, 0.8);
+  border-color: var(--color-primary);
+}
+
+.btn-active {
+  background: var(--color-primary);
+  color: var(--text-inverse);
+  border-color: var(--color-primary);
+}
+
+.btn-active:hover {
+  background: hsl(244, 98%, 75%);
+  color: var(--text-inverse);
+}
+
+/* ── Result Badges ─────────────────────────────────────────── */
+.status-card {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: hsla(223, 40%, 10%, 0.5);
+  border: 1px solid var(--border-muted);
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.35rem 0.85rem;
+  border-radius: 20px;
+}
+
+.status-badge-fail {
+  background: var(--color-danger-glow);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger);
+}
+
+.status-badge-pass {
+  background: var(--color-success-glow);
+  color: var(--color-success);
+  border: 1px solid var(--color-success);
+}
+
+.status-badge-warn {
+  background: var(--color-warning-glow);
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning);
+  animation: pulse-warn 2s infinite ease-in-out;
+}
+
+@keyframes pulse-warn {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 hsla(38, 92%, 50%, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 12px 4px hsla(38, 92%, 50%, 0.2);
+  }
+}
+
+/* ── Live Comparison Block ────────────────────────────────── */
+.comparison-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 650px) {
+  .comparison-container {
+    grid-template-columns: 1fr;
+  }
+}
+
+.comparison-card {
+  background: hsla(223, 40%, 8%, 0.4);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text-main);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.card-desc {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.code-snippet {
+  background: #000;
+  padding: 0.75rem;
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  overflow-x: auto;
+  color: var(--text-muted);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+/* ── Footer ────────────────────────────────────────────────── */
+footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-muted);
+}
+
+footer a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+footer a:hover {
+  text-decoration: underline;
+}

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -95,7 +95,7 @@ const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
 
   it('should hide plain text in loading buttons and keep the spinner visible', () => {
     expect(css).toContain('.ease-btn-loading');
-    expect(css).toContain('font-size: 0');
+    expect(css).toContain('color: transparent');
     expect(css).toContain('.ease-btn-loading > *');
     expect(css).toContain('visibility: hidden');
     expect(css).toContain('.ease-btn-loading::after');


### PR DESCRIPTION
# Pull Request Description
---

This pull request resolves a false-positive assertion check in `tests/smoke.test.js` under the test case *"should hide plain text in loading buttons and keep the spinner visible"*. 

The test asserted `expect(css).toContain('font-size: 0')` to verify that `.ease-btn-loading` hides its text. However, `.ease-btn-loading` actually uses `color: transparent !important` and does not define `font-size: 0`. The test incorrectly passed because `font-size: 0` matched unrelated CSS definitions containing decimals starting with zero (such as `font-size: 0.875rem` or `font-size: 0.75rem`) via substring matching.

We fixed this by checking for `color: transparent`, ensuring that tests fail if the loading button's hiding properties are accidentally removed. We also packaged this fix with a visual, interactive demonstration lab under `submissions/examples/smoke-test-false-positive-fix/`.

fixes #5025
---
---

# Type of Change
---

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  - *Smoke test suite assertion correction*

---
---

# Submission Checklist
---

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/` *(with the permitted test fix in `tests/smoke.test.js`)*
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
---

# Feature Description
---

**What does this add?**

A fix for a false-positive assertion in the project's smoke test suite, paired with a visually premium interactive simulation lab explaining substring matching hazards in tests.

**How does a developer use it?**

```html
<!-- Developers can open the demo.html directly in a browser to use the interactive playground -->
<a href="submissions/examples/smoke-test-false-positive-fix/demo.html">Open Test Assertion Lab</a>
```

**Why does it fit EaseMotion CSS?**

It ensures the project's test suite remains a reliable regression shield for core component modifications, preventing loading-state test failures from going unnoticed.

---
---

# Demo
---

- [x] Demo added (`demo.html` works by opening directly in a browser)

---
---

# Browser Testing
---

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---
---

# Notes for Maintainer
---

- The Vitest suite was run locally via `npm test` and all 10 tests pass.
- Stylelint checked out clean via `npm run lint`.
- The branch was rebased/synced directly to `upstream/main` to guarantee zero merge conflicts.
