### PR TITLE
feat : added modal confirm and alert presets

### DIFF
--- a/submissions/examples/modal-confirm-alert-tm/README.md
+++ b/submissions/examples/modal-confirm-alert-tm/README.md
@@ -1,0 +1,45 @@
+# Modal — Confirm and Alert Presets
+
+## What does this do?
+Adds two preset modal variants — `.ease-modal-confirm` (warning
+icon, danger confirm button) and `.ease-modal-alert` (info icon,
+single dismiss button) — to the modal component.
+
+## How is it used?
+Apply the variant alongside `.ease-modal`:
+
+    <div class="ease-modal-overlay is-active" id="confirm">
+      <div class="ease-modal ease-modal-confirm">
+        <div class="ease-modal-header">
+          <h2>Delete file?</h2>
+        </div>
+        <div class="ease-modal-body">
+          <p>This action cannot be undone.</p>
+        </div>
+        <div class="ease-modal-footer">
+          <a href="#" class="ease-btn ease-btn-ghost">Cancel</a>
+          <a href="#" class="ease-btn ease-btn-danger">Delete</a>
+        </div>
+      </div>
+    </div>
+
+## Why is it useful?
+The modal component supports three animation variants (`.ease-modal`,
+`.ease-modal-slide`, `.ease-modal-zoom`) but no preset content
+templates. Designers typically want consistent confirm/alert
+layouts (icon, title, body, footer with a primary action). This
+submission adds the two most common presets so consumers don't
+have to handcraft the icon and footer arrangement.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open `demo.html` in your browser and click the trigger buttons to
+see the two preset modals.
+
+## Contribution Notes
+- Pure CSS addition
+- No JavaScript required (works with the existing `:target` and
+  `.is-active` activation pattern)

--- a/submissions/examples/modal-confirm-alert-tm/demo.html
+++ b/submissions/examples/modal-confirm-alert-tm/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Modal Confirm and Alert - EaseMotion CSS</title>
+
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+
+    <h1>Modal — Confirm and Alert</h1>
+    <p class="description">
+      Self-contained demo of the proposed
+      <code>.ease-modal-confirm</code> and
+      <code>.ease-modal-alert</code> preset variants. The demo
+      uses the existing <code>:target</code> activation pattern.
+    </p>
+
+    <div class="trigger-row">
+      <a href="#confirm-modal" class="ease-btn ease-btn-danger">Show confirm</a>
+      <a href="#alert-modal" class="ease-btn ease-btn-primary">Show alert</a>
+    </div>
+
+    <div class="ease-modal-overlay" id="confirm-modal">
+      <div class="ease-modal ease-modal-confirm">
+        <div class="ease-modal-header">
+          <h2>Delete file?</h2>
+        </div>
+        <div class="ease-modal-body">
+          <p>This action cannot be undone. The file will be permanently removed.</p>
+        </div>
+        <div class="ease-modal-footer">
+          <a href="#" class="ease-btn ease-btn-ghost">Cancel</a>
+          <a href="#" class="ease-btn ease-btn-danger">Delete</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-modal-overlay" id="alert-modal">
+      <div class="ease-modal ease-modal-alert">
+        <div class="ease-modal-header">
+          <h2>Update available</h2>
+        </div>
+        <div class="ease-modal-body">
+          <p>A new version of the app is ready to install.</p>
+        </div>
+        <div class="ease-modal-footer">
+          <a href="#" class="ease-btn ease-btn-primary ease-modal-close">Got it</a>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/modal-confirm-alert-tm/style.css
+++ b/submissions/examples/modal-confirm-alert-tm/style.css
@@ -1,0 +1,83 @@
+/* ============================================================
+   Submission: modal confirm and alert presets
+   ============================================================ */
+
+.demo-wrapper {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  min-height: 100vh;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.trigger-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.ease-modal-confirm {
+  border-top: 4px solid var(--ease-color-danger, #ef4444);
+}
+
+.ease-modal-alert {
+  border-top: 4px solid var(--ease-color-info, #3b82f6);
+}
+
+.ease-modal-confirm .ease-modal-header::before {
+  content: "!";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-right: 0.75rem;
+  border-radius: 50%;
+  background: var(--ease-color-danger, #ef4444);
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.ease-modal-alert .ease-modal-header::before {
+  content: "i";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-right: 0.75rem;
+  border-radius: 50%;
+  background: var(--ease-color-info, #3b82f6);
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1.1rem;
+  font-style: italic;
+  flex-shrink: 0;
+}
+
+.ease-modal-confirm .ease-modal-header,
+.ease-modal-alert .ease-modal-header {
+  display: flex;
+  align-items: center;
+}
+
+.ease-modal-confirm .ease-modal-header h2,
+.ease-modal-alert .ease-modal-header h2 {
+  margin: 0;
+  flex: 1;
+}
+
+.ease-modal-confirm .ease-modal-footer {
+  background: var(--ease-color-danger-alpha, rgba(239, 68, 68, 0.05));
+}
+
+.ease-modal-alert .ease-modal-footer {
+  background: var(--ease-color-info-alpha, rgba(59, 130, 246, 0.05));
+}


### PR DESCRIPTION
Closes #6174.

Self-contained submission under submissions/examples/modal-confirm-alert-tm/ with demo.html, style.css, and README.md. Adds .ease-modal-confirm and .ease-modal-alert presets. No core file changes.