### PR TITLE
feat: add CSS-only ease-tooltip component with position variants

### DIFF
--- a/submissions/examples/ease-tooltip-component/README.md
+++ b/submissions/examples/ease-tooltip-component/README.md
@@ -1,0 +1,28 @@
+# ease-tooltip
+
+A CSS-only tooltip component for EaseMotion CSS.
+
+## Usage
+
+```html
+<button class="ease-tooltip ease-tooltip-top" data-tip="Hello!">
+  Hover me
+</button>
+```
+
+## Classes
+
+| Class | Description |
+|---|---|
+| `ease-tooltip` | Base tooltip wrapper |
+| `ease-tooltip-top` | Tooltip appears above |
+| `ease-tooltip-bottom` | Tooltip appears below |
+| `ease-tooltip-left` | Tooltip appears to the left |
+| `ease-tooltip-right` | Tooltip appears to the right |
+| `ease-tooltip-dark` | Dark styled variant |
+
+## Notes
+- Pure CSS, no JavaScript
+- Uses `data-tip` attribute for tooltip content
+- Respects `prefers-reduced-motion`
+- Uses EaseMotion CSS design tokens

--- a/submissions/examples/ease-tooltip-component/demo.html
+++ b/submissions/examples/ease-tooltip-component/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-tooltip Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: Inter, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+      min-height: 100vh;
+      background: #f8fafc;
+    }
+    h2 {
+      font-size: 1.5rem;
+      color: #7c3aed;
+    }
+    .row {
+      display: flex;
+      gap: 2rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+  </style>
+</head>
+<body>
+
+  <h2>ease-tooltip Component</h2>
+
+  <div class="row">
+    <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-top"
+      data-tip="Tooltip on Top">
+      Top
+    </button>
+
+    <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-bottom"
+      data-tip="Tooltip on Bottom">
+      Bottom
+    </button>
+
+    <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-left"
+      data-tip="Tooltip on Left">
+      Left
+    </button>
+
+    <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-right"
+      data-tip="Tooltip on Right">
+      Right
+    </button>
+
+    <button class="ease-btn ease-btn-outline ease-tooltip ease-tooltip-top ease-tooltip-dark"
+      data-tip="Dark Tooltip">
+      Dark
+    </button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-tooltip-component/style.css
+++ b/submissions/examples/ease-tooltip-component/style.css
@@ -1,0 +1,65 @@
+/* Tooltip Component - ease-tooltip */
+
+.ease-tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.ease-tooltip::after {
+  content: attr(data-tip);
+  position: absolute;
+  background: var(--ease-color-primary, #7c3aed);
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 100;
+}
+
+.ease-tooltip:hover::after {
+  opacity: 1;
+}
+
+/* Positions */
+.ease-tooltip-top::after {
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.ease-tooltip-bottom::after {
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.ease-tooltip-left::after {
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.ease-tooltip-right::after {
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* Dark variant */
+.ease-tooltip-dark::after {
+  background: #1e1e2e;
+  color: #f8fafc;
+  border: 1px solid #333;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a CSS-only tooltip component to submissions/examples/

## Changes
- ease-tooltip — base tooltip wrapper
- ease-tooltip-top / bottom / left / right — position variants
- ease-tooltip-dark — dark styled variant

## Features
- Pure CSS, no JavaScript
- Uses data-tip attribute for content
- Uses EaseMotion CSS design tokens
- Respects prefers-reduced-motion

## Files Added
- submissions/examples/ease-tooltip-component/style.css
- submissions/examples/ease-tooltip-component/demo.html
- submissions/examples/ease-tooltip-component/README.md

## Related Issue
Closes #6434 