### PR TITLE
fix: add prefers-reduced-motion guard to ease-hover-grow and ease-hov…

### DIFF
--- a/submissions/examples/ease-hover-reduced-motion/README.md
+++ b/submissions/examples/ease-hover-reduced-motion/README.md
@@ -1,0 +1,23 @@
+# fix: ease-hover-grow and ease-hover-lift reduced motion guard
+
+## Problem
+`ease-hover-grow` and `ease-hover-lift` were animating even when
+the user had `prefers-reduced-motion` enabled in their OS settings.
+
+## Fix
+Wrapped both classes inside:
+```css
+@media (prefers-reduced-motion: no-preference) { ... }
+```
+
+This disables animations for users who prefer reduced motion,
+improving accessibility.
+
+## Affected Classes
+- `ease-hover-grow`
+- `ease-hover-lift`
+
+## How to Test
+1. Enable "Reduce Motion" in OS accessibility settings
+2. Open demo.html
+3. Hover over buttons — no animation should occur

--- a/submissions/examples/ease-hover-reduced-motion/demo.html
+++ b/submissions/examples/ease-hover-reduced-motion/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-hover Reduced Motion Fix</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: Inter, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+      min-height: 100vh;
+      background: #f8fafc;
+    }
+    h2 { color: #7c3aed; }
+    p { color: #64748b; font-size: 0.9rem; }
+    .row {
+      display: flex;
+      gap: 2rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+  </style>
+</head>
+<body>
+
+  <h2>ease-hover Reduced Motion Fix</h2>
+  <p>Hover over buttons. If prefers-reduced-motion is enabled, animations are disabled.</p>
+
+  <div class="row">
+    <button class="ease-btn ease-btn-primary ease-hover-grow">
+      ease-hover-grow
+    </button>
+
+    <button class="ease-btn ease-btn-outline ease-hover-lift">
+      ease-hover-lift
+    </button>
+  </div>
+
+  <p>To test: Enable "Reduce motion" in your OS accessibility settings.</p>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-reduced-motion/style.css
+++ b/submissions/examples/ease-hover-reduced-motion/style.css
@@ -1,0 +1,28 @@
+/* Fix: ease-hover-grow and ease-hover-lift reduced motion guard */
+
+/* Default: no animation for users who prefer reduced motion */
+.ease-hover-grow,
+.ease-hover-lift {
+  transition: none;
+  transform: none;
+}
+
+/* Only animate if user has no motion preference */
+@media (prefers-reduced-motion: no-preference) {
+  .ease-hover-grow {
+    transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  .ease-hover-grow:hover {
+    transform: scale(1.1);
+  }
+
+  .ease-hover-lift {
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+  }
+
+  .ease-hover-lift:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  }
+}


### PR DESCRIPTION
## Summary
Fixes missing prefers-reduced-motion guard on hover animation classes.

## Problem
ease-hover-grow and ease-hover-lift were animating even when
the user had prefers-reduced-motion enabled in OS settings.

## Fix
Wrapped both classes inside:
@media (prefers-reduced-motion: no-preference) { ... }

## Files Added
- submissions/examples/ease-hover-reduced-motion/style.css
- submissions/examples/ease-hover-reduced-motion/demo.html
- submissions/examples/ease-hover-reduced-motion/README.md

## Related Issue
Closes #6438