### PR TITLE
resolve #6473: iOS Styled Range Slider Input Component

### DIFF
--- a/submissions/examples/ios-slider-custom/README.md
+++ b/submissions/examples/ios-slider-custom/README.md
@@ -1,0 +1,7 @@
+# iOS Styled Range Slider Input Component
+
+Custom range input component with Apple-like sliding rails and styled rounded thumb.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/ios-slider-custom/demo.html
+++ b/submissions/examples/ios-slider-custom/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: iOS Styled Range Slider Input Component</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-slider-wrapper">
+  <input type="range" class="ease-ios-range" min="0" max="100" value="70">
+</div>
+</body>
+</html>

--- a/submissions/examples/ios-slider-custom/style.css
+++ b/submissions/examples/ios-slider-custom/style.css
@@ -1,0 +1,31 @@
+/* ==========================================================================
+   EaseMotion CSS: iOS Styled Range Slider Input Component
+   ========================================================================== */
+
+@layer components {
+.ease-slider-wrapper {
+  width: 300px;
+  padding: 1rem;
+}
+.ease-ios-range {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.15);
+  outline: none;
+}
+.ease-ios-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #fff;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  transition: transform 0.1s ease;
+}
+.ease-ios-range::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+}
+}


### PR DESCRIPTION
Closes #6473

## What this does
Custom range input component with Apple-like sliding rails and styled rounded thumb.

## Files
- `submissions/examples/ios-slider-custom/style.css`
- `submissions/examples/ios-slider-custom/demo.html`
- `submissions/examples/ios-slider-custom/README.md`
