### PR TITLE
resolve #6476: Sliding Underline Interactive Navigation Tabs

### DIFF
--- a/submissions/examples/tab-underline-slide/README.md
+++ b/submissions/examples/tab-underline-slide/README.md
@@ -1,0 +1,7 @@
+# Sliding Underline Interactive Navigation Tabs
+
+Clean hover tab bar with sliding bottom-underline active indication.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/tab-underline-slide/demo.html
+++ b/submissions/examples/tab-underline-slide/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: Sliding Underline Interactive Navigation Tabs</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-tab-group">
+  <div class="ease-tab-item active">Home</div>
+  <div class="ease-tab-item">Analytics</div>
+  <div class="ease-tab-item">Settings</div>
+  <div class="tab-indicator"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/tab-underline-slide/style.css
+++ b/submissions/examples/tab-underline-slide/style.css
@@ -1,0 +1,34 @@
+/* ==========================================================================
+   EaseMotion CSS: Sliding Underline Interactive Navigation Tabs
+   ========================================================================== */
+
+@layer components {
+.ease-tab-group {
+  display: flex;
+  position: relative;
+  background: rgba(0,0,0,0.2);
+  border-radius: 8px;
+  padding: 4px;
+  border: 1px solid rgba(255,255,255,0.05);
+}
+.ease-tab-item {
+  color: #fff;
+  padding: 10px 20px;
+  cursor: pointer;
+  transition: opacity 0.3s ease;
+  font-weight: 500;
+  opacity: 0.6;
+}
+.ease-tab-item.active, .ease-tab-item:hover {
+  opacity: 1;
+}
+.tab-indicator {
+  position: absolute;
+  bottom: 0;
+  height: 3px;
+  background: #7f00ff;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 64px;
+  left: 8px;
+}
+}


### PR DESCRIPTION
Closes #6476

## What this does
Clean hover tab bar with sliding bottom-underline active indication.

## Files
- `submissions/examples/tab-underline-slide/style.css`
- `submissions/examples/tab-underline-slide/demo.html`
- `submissions/examples/tab-underline-slide/README.md`
