### PR TITLE
resolve #6526: Dual Side-by-Side Hover Split Screen Panel

### DIFF
--- a/submissions/examples/new-split-screen-preview-sn50/README.md
+++ b/submissions/examples/new-split-screen-preview-sn50/README.md
@@ -1,0 +1,7 @@
+# Dual Side-by-Side Hover Split Screen Panel
+
+Side-by-side split screen blocks morphing layouts on mouse hover.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-split-screen-preview-sn50/demo.html
+++ b/submissions/examples/new-split-screen-preview-sn50/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: Dual Side-by-Side Hover Split Screen Panel</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-split-container">
+  <div class="split-side left-side"><h3>Design</h3></div>
+  <div class="split-side right-side"><h3>Code</h3></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/new-split-screen-preview-sn50/style.css
+++ b/submissions/examples/new-split-screen-preview-sn50/style.css
@@ -1,0 +1,12 @@
+/* ==========================================================================
+   EaseMotion CSS: Dual Side-by-Side Hover Split Screen Panel
+   ========================================================================== */
+
+@layer components {
+.ease-split-container { display: flex; width: 400px; height: 180px; overflow: hidden; border-radius: 12px; }
+.split-side { flex: 1; transition: flex 0.5s ease; display: flex; align-items: center; justify-content: center; color: #fff; }
+.left-side { background: #ff007f; }
+.right-side { background: #7f00ff; }
+.left-side:hover { flex: 1.5; }
+.right-side:hover { flex: 1.5; }
+}


### PR DESCRIPTION
Closes #6526

## What this does
Side-by-side split screen blocks morphing layouts on mouse hover.

## Files
- `submissions/examples/new-split-screen-preview-sn50/style.css`
- `submissions/examples/new-split-screen-preview-sn50/demo.html`
- `submissions/examples/new-split-screen-preview-sn50/README.md`
