### PR TITLE
fix: include forms.css in easemotion/all.css

### DIFF
--- a/easemotion/all.css
+++ b/easemotion/all.css
@@ -18,6 +18,7 @@
 @import "../components/loaders.css";
 @import "../components/tooltips.css";
 @import "../components/modals.css";
+@import "../components/forms.css";
 
 
 

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -86,6 +86,11 @@ const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
     expect(selectors).toContain('.ease-sidebar');
   });
 
+  it('should keep forms.css imported in the alternate entrypoint', () => {
+    const allCss = readFileSync(resolve(__dirname, '../easemotion/all.css'), 'utf8');
+    expect(allCss).toContain('../components/forms.css');
+  });
+
   it('should expose scroll-progress theme variants', () => {
     expect(css).toContain('.ease-scroll-progress-success');
     expect(css).toContain('.ease-scroll-progress-danger');


### PR DESCRIPTION
## Description

Fixes a parity issue between EaseMotion CSS entrypoints.

### Problem

`easemotion.css` imports `components/forms.css`, while `easemotion/all.css` does not.

As a result, users importing the alternate bundle do not receive form-related component styles.

### Changes

* Added missing `forms.css` import to `easemotion/all.css`
* Added a regression test to ensure the alternate entrypoint continues to include form components

### Validation

* `npm test` ✅
* `npm run lint` ✅

### Impact

Keeps both framework entrypoints synchronized and prevents future regressions.

### Related Issue

Closes #6560
