### PR TITLE
feat: add ease badge pulse notification example

### DIFF
--- a/submissions/examples/ease-badge-pulse-pr/README.md
+++ b/submissions/examples/ease-badge-pulse-pr/README.md
@@ -1,0 +1,20 @@
+# Ease Badge Pulse PR
+
+**What does this do?**  
+Adds notification, warning, and alert badges with a CSS-only pulse ring that draws attention to changing status counts.
+
+**How is it used?**
+
+```html
+<span class="badge badge--warning">Needs review</span>
+<span class="count-badge count-badge--warning" aria-label="3 warnings">3</span>
+```
+
+**Why is it useful?**  
+Badges are common in dashboards, navbars, and alert surfaces. The pulse ring communicates urgency while keeping the badge dimensions stable, so surrounding UI does not jump when the animation runs.
+
+---
+
+Submitted by: @kunal-9090  
+Issue: #5363  
+Status: **Pending review**

--- a/submissions/examples/ease-badge-pulse-pr/demo.html
+++ b/submissions/examples/ease-badge-pulse-pr/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Ease Badge Pulse PR</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro">
+      <p class="eyebrow">Status motion</p>
+      <h1>Ease Badge Pulse</h1>
+      <p>
+        Notification and warning badges use a soft pulse ring to draw attention
+        without shifting layout or relying on JavaScript.
+      </p>
+    </section>
+
+    <section class="badge-grid" aria-label="Badge pulse examples">
+      <article class="status-card">
+        <div class="status-header">
+          <span class="badge badge--warning">Needs review</span>
+          <span class="count-badge count-badge--warning" aria-label="3 warnings">3</span>
+        </div>
+        <h2>Dependency alerts</h2>
+        <p>Use a warm pulse for important but non-blocking warnings.</p>
+      </article>
+
+      <article class="status-card">
+        <div class="status-header">
+          <span class="badge badge--danger">Critical</span>
+          <span class="count-badge count-badge--danger" aria-label="1 critical alert">1</span>
+        </div>
+        <h2>Failed checks</h2>
+        <p>A stronger red pulse signals urgent items that need action.</p>
+      </article>
+
+      <article class="status-card">
+        <div class="status-header">
+          <span class="badge badge--info">New updates</span>
+          <span class="count-badge count-badge--info" aria-label="8 new updates">8</span>
+        </div>
+        <h2>Inbox activity</h2>
+        <p>Cool accent colors keep informational notifications readable.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-badge-pulse-pr/style.css
+++ b/submissions/examples/ease-badge-pulse-pr/style.css
@@ -1,0 +1,172 @@
+/* ============================================================
+   SUBMISSION - ease-badge-pulse-pr
+   Notification and warning badges with CSS pulse rings.
+   ============================================================ */
+
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #121416;
+  color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 42px 18px;
+  background:
+    radial-gradient(circle at top right, rgba(251, 191, 36, 0.18), transparent 26rem),
+    linear-gradient(140deg, #121416 0%, #20242a 52%, #15171b 100%);
+}
+
+.demo-shell {
+  width: min(980px, 100%);
+  display: grid;
+  gap: 30px;
+}
+
+.intro {
+  max-width: 680px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #facc15;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: clamp(2.35rem, 7vw, 4.7rem);
+  line-height: 1;
+}
+
+.intro p:not(.eyebrow) {
+  margin: 0;
+  color: rgba(248, 250, 252, 0.72);
+  line-height: 1.7;
+}
+
+.badge-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.status-card {
+  min-height: 220px;
+  display: grid;
+  align-content: space-between;
+  gap: 18px;
+  padding: 22px;
+  border: 1px solid rgba(248, 250, 252, 0.13);
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.075);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+}
+
+.status-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.badge,
+.count-badge {
+  --accent: #facc15;
+  --ink: #121416;
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--ink);
+  background: var(--accent);
+  font-weight: 900;
+}
+
+.badge {
+  min-height: 34px;
+  padding: 0 14px;
+  font-size: 0.82rem;
+}
+
+.count-badge {
+  inline-size: 44px;
+  block-size: 44px;
+  font-size: 1rem;
+  isolation: isolate;
+}
+
+.count-badge::before,
+.count-badge::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--accent) 72%, transparent);
+  animation: badge-pulse 1.9s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+}
+
+.count-badge::after {
+  animation-delay: 0.55s;
+}
+
+.badge--danger,
+.count-badge--danger {
+  --accent: #fb7185;
+  --ink: #2d060d;
+}
+
+.badge--info,
+.count-badge--info {
+  --accent: #38bdf8;
+  --ink: #061822;
+}
+
+.status-card h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.status-card p {
+  margin: 0;
+  color: rgba(248, 250, 252, 0.68);
+  line-height: 1.65;
+}
+
+@keyframes badge-pulse {
+  0% {
+    opacity: 0.62;
+    transform: scale(1);
+  }
+
+  70%,
+  100% {
+    opacity: 0;
+    transform: scale(1.78);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .count-badge::before,
+  .count-badge::after {
+    animation: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .badge-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only badge pulse example for warning, critical, and info states
- include accessible count labels and stable badge sizing
- support reduced-motion users

Closes #5363

## Validation
- Verified added standalone HTML/CSS/README files