### PR TITLE
feat: add ease toast fade transition

### DIFF
--- a/submissions/examples/ease-toast-fade-pr/README.md
+++ b/submissions/examples/ease-toast-fade-pr/README.md
@@ -1,0 +1,25 @@
+# Ease Toast Fade PR
+
+**What does this do?**  
+Adds a CSS-only toast notification pattern that slides into view, stays readable, and fades out using keyframe animation.
+
+**How is it used?**
+
+```html
+<article class="toast toast--success">
+  <span class="toast-icon" aria-hidden="true">OK</span>
+  <div>
+    <h2>Changes saved</h2>
+    <p>Your draft has been synced.</p>
+  </div>
+</article>
+```
+
+**Why is it useful?**  
+Toast messages need to be noticeable without blocking the interface. This transition gives alerts a clear entrance and exit while preserving stack spacing and supporting reduced-motion users.
+
+---
+
+Submitted by: @kunal-9090  
+Issue: #5367  
+Status: **Pending review**

--- a/submissions/examples/ease-toast-fade-pr/demo.html
+++ b/submissions/examples/ease-toast-fade-pr/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Ease Toast Fade PR</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro">
+      <p class="eyebrow">Notification motion</p>
+      <h1>Ease Toast Fade</h1>
+      <p>
+        Toast notifications slide in, hold briefly, and fade out with CSS-only
+        keyframes. The stack keeps spacing stable while alerts animate.
+      </p>
+    </section>
+
+    <section class="preview-panel" aria-label="Toast notification preview">
+      <div class="mock-window">
+        <div class="window-bar" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+        <div class="window-content">
+          <span class="ghost-line ghost-line--wide"></span>
+          <span class="ghost-line"></span>
+          <span class="ghost-line ghost-line--short"></span>
+        </div>
+      </div>
+
+      <div class="toast-stack" aria-live="polite">
+        <article class="toast toast--success">
+          <span class="toast-icon" aria-hidden="true">OK</span>
+          <div>
+            <h2>Changes saved</h2>
+            <p>Your draft has been synced.</p>
+          </div>
+        </article>
+        <article class="toast toast--info">
+          <span class="toast-icon" aria-hidden="true">i</span>
+          <div>
+            <h2>Build queued</h2>
+            <p>Preview deployment is starting.</p>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-toast-fade-pr/style.css
+++ b/submissions/examples/ease-toast-fade-pr/style.css
@@ -1,0 +1,206 @@
+/* ============================================================
+   SUBMISSION - ease-toast-fade-pr
+   CSS-only toast notification slide and fade transition.
+   ============================================================ */
+
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #101214;
+  color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 42px 18px;
+  background:
+    radial-gradient(circle at 18% 16%, rgba(34, 197, 94, 0.18), transparent 26rem),
+    linear-gradient(135deg, #101214 0%, #20262d 54%, #15171b 100%);
+}
+
+.demo-shell {
+  width: min(940px, 100%);
+  display: grid;
+  gap: 30px;
+}
+
+.intro {
+  max-width: 660px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #86efac;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: clamp(2.35rem, 7vw, 4.7rem);
+  line-height: 1;
+}
+
+.intro p {
+  color: rgba(248, 250, 252, 0.72);
+  line-height: 1.7;
+}
+
+.preview-panel {
+  position: relative;
+  min-height: 420px;
+  overflow: hidden;
+  border: 1px solid rgba(248, 250, 252, 0.12);
+  border-radius: 20px;
+  background: rgba(248, 250, 252, 0.07);
+  box-shadow: 0 28px 72px rgba(0, 0, 0, 0.32);
+}
+
+.mock-window {
+  width: min(620px, calc(100% - 32px));
+  margin: 30px auto;
+  overflow: hidden;
+  border: 1px solid rgba(248, 250, 252, 0.1);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.62);
+}
+
+.window-bar {
+  display: flex;
+  gap: 8px;
+  padding: 14px;
+  border-bottom: 1px solid rgba(248, 250, 252, 0.08);
+}
+
+.window-bar span {
+  inline-size: 11px;
+  block-size: 11px;
+  border-radius: 999px;
+  background: rgba(248, 250, 252, 0.28);
+}
+
+.window-content {
+  display: grid;
+  gap: 16px;
+  padding: 28px;
+}
+
+.ghost-line {
+  display: block;
+  inline-size: 72%;
+  block-size: 16px;
+  border-radius: 999px;
+  background: rgba(248, 250, 252, 0.12);
+}
+
+.ghost-line--wide {
+  inline-size: 92%;
+}
+
+.ghost-line--short {
+  inline-size: 48%;
+}
+
+.toast-stack {
+  position: absolute;
+  inset-inline-end: 24px;
+  inset-block-end: 24px;
+  display: grid;
+  gap: 14px;
+  width: min(360px, calc(100% - 48px));
+}
+
+.toast {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 14px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid rgba(248, 250, 252, 0.14);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.92);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.34);
+  animation: toast-slide-fade 5.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+}
+
+.toast:nth-child(2) {
+  animation-delay: 1.2s;
+}
+
+.toast-icon {
+  display: grid;
+  place-items: center;
+  inline-size: 44px;
+  block-size: 44px;
+  border-radius: 14px;
+  color: #062011;
+  background: #86efac;
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.toast--info .toast-icon {
+  color: #061822;
+  background: #7dd3fc;
+}
+
+.toast h2 {
+  margin-bottom: 4px;
+  font-size: 1rem;
+}
+
+.toast p {
+  color: rgba(248, 250, 252, 0.66);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+@keyframes toast-slide-fade {
+  0% {
+    opacity: 0;
+    transform: translate(34px, 12px) scale(0.96);
+  }
+
+  12%,
+  72% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate(18px, -12px) scale(0.98);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    animation: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .preview-panel {
+    min-height: 500px;
+  }
+
+  .toast-stack {
+    inset-inline: 16px;
+    width: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only toast slide/fade notification example
- include stacked success and info toast states
- support responsive layout and reduced-motion users

Closes #5367

## Validation
- Verified added standalone HTML/CSS/README files