### PR TITLE
feat: add CSS-only tooltip with arrow

### DIFF
--- a/submissions/examples/css-tooltip/README.md
+++ b/submissions/examples/css-tooltip/README.md
@@ -1,0 +1,32 @@
+# CSS-Only Tooltip with Arrow
+
+A pure CSS tooltip that appears on hover using `::before` and `::after` pseudo-elements. No JavaScript required.
+
+## Demo
+
+Open `demo.html` in your browser to see:
+- Top, bottom, left, right positions
+- Button, text, and icon triggers
+- Long content wrapping
+- Dark theme variant
+
+## Usage
+
+```html
+&lt;!-- Basic tooltip (top position, default) --&gt;
+&lt;button class="tooltip" data-tooltip="Tooltip text here"&gt;Hover Me&lt;/button&gt;
+
+&lt;!-- Bottom position --&gt;
+&lt;button class="tooltip tooltip-bottom" data-tooltip="Appears below"&gt;Hover Me&lt;/button&gt;
+
+&lt;!-- Left position --&gt;
+&lt;span class="tooltip tooltip-left" data-tooltip="Appears to left"&gt;Hover Me&lt;/span&gt;
+
+&lt;!-- Right position --&gt;
+&lt;div class="tooltip tooltip-right" data-tooltip="Appears to right"&gt;Hover Me&lt;/div&gt;
+
+&lt;!-- Color variants --&gt;
+&lt;button class="tooltip tooltip-dark" data-tooltip="Dark theme"&gt;Dark&lt;/button&gt;
+&lt;button class="tooltip tooltip-light" data-tooltip="Light theme"&gt;Light&lt;/button&gt;
+&lt;button class="tooltip tooltip-error" data-tooltip="Error!"&gt;Error&lt;/button&gt;
+&lt;button class="tooltip tooltip-success" data-tooltip="Success!"&gt;Success&lt;/button&gt;

--- a/submissions/examples/css-tooltip/demo.html
+++ b/submissions/examples/css-tooltip/demo.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Tooltip Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: 'Inter', sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      background: #f5f5f5;
+      margin: 0;
+    }
+    .container {
+      padding: 40px;
+      text-align: center;
+    }
+    h2 {
+      margin-bottom: 50px;
+      color: #333;
+      font-weight: 400;
+    }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 40px;
+      max-width: 600px;
+      margin: 0 auto;
+    }
+    .demo-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 20px;
+      padding: 30px;
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+    }
+    .demo-label {
+      font-size: 14px;
+      color: #888;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+    .demo-btn {
+      padding: 12px 24px;
+      background: #6366f1;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      font-size: 14px;
+      cursor: pointer;
+    }
+    .demo-text {
+      color: #333;
+      font-size: 16px;
+    }
+    .demo-icon {
+      width: 40px;
+      height: 40px;
+      background: #e0e7ff;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #6366f1;
+      font-weight: bold;
+      cursor: help;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h2>CSS-Only Tooltip with Arrow</h2>
+    
+    <div class="demo-grid">
+      <!-- Top Tooltip -->
+      <div class="demo-item">
+        <span class="demo-label">Top Position</span>
+        <button class="demo-btn tooltip" data-tooltip="This appears above the element">Hover Me</button>
+      </div>
+      
+      <!-- Bottom Tooltip -->
+      <div class="demo-item">
+        <span class="demo-label">Bottom Position</span>
+        <button class="demo-btn tooltip tooltip-bottom" data-tooltip="This appears below the element">Hover Me</button>
+      </div>
+      
+      <!-- Left Tooltip -->
+      <div class="demo-item">
+        <span class="demo-label">Left Position</span>
+        <span class="demo-text tooltip tooltip-left" data-tooltip="This appears to the left">Hover this text</span>
+      </div>
+      
+      <!-- Right Tooltip -->
+      <div class="demo-item">
+        <span class="demo-label">Right Position</span>
+        <div class="demo-icon tooltip tooltip-right" data-tooltip="Info tooltip here">?</div>
+      </div>
+      
+      <!-- Long Tooltip -->
+      <div class="demo-item">
+        <span class="demo-label">Long Content</span>
+        <button class="demo-btn tooltip" data-tooltip="This is a longer tooltip message that demonstrates how text wraps automatically">Long Tooltip</button>
+      </div>
+      
+      <!-- Custom Color -->
+      <div class="demo-item">
+        <span class="demo-label">Custom Color</span>
+        <button class="demo-btn tooltip tooltip-dark" data-tooltip="Dark themed tooltip variant">Dark Theme</button>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-tooltip/style.css
+++ b/submissions/examples/css-tooltip/style.css
@@ -1,0 +1,246 @@
+/* ============================================
+   CSS-Only Tooltip with Arrow
+   ============================================ */
+
+/* CSS Custom Properties for customization */
+:root {
+  --tooltip-bg: #1f2937;
+  --tooltip-color: #ffffff;
+  --tooltip-padding: 8px 12px;
+  --tooltip-border-radius: 6px;
+  --tooltip-font-size: 13px;
+  --tooltip-max-width: 200px;
+  --tooltip-arrow-size: 6px;
+  --tooltip-offset: 10px;
+  --tooltip-transition: 0.2s ease;
+  --tooltip-z-index: 1000;
+}
+
+/* Base tooltip container */
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+/* Tooltip content (hidden by default) */
+.tooltip::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  padding: var(--tooltip-padding);
+  background: var(--tooltip-bg);
+  color: var(--tooltip-color);
+  font-size: var(--tooltip-font-size);
+  border-radius: var(--tooltip-border-radius);
+  white-space: nowrap;
+  max-width: var(--tooltip-max-width);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  z-index: var(--tooltip-z-index);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--tooltip-transition), visibility var(--tooltip-transition), transform var(--tooltip-transition);
+  pointer-events: none;
+  line-height: 1.4;
+  font-weight: 400;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+/* Tooltip arrow */
+.tooltip::after {
+  content: '';
+  position: absolute;
+  width: 0;
+  height: 0;
+  border: var(--tooltip-arrow-size) solid transparent;
+  z-index: var(--tooltip-z-index);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--tooltip-transition), visibility var(--tooltip-transition);
+  pointer-events: none;
+}
+
+/* ============================================
+   Top Position (Default)
+   ============================================ */
+
+.tooltip::before {
+  bottom: calc(100% + var(--tooltip-offset));
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+}
+
+.tooltip::after {
+  bottom: calc(100% + var(--tooltip-offset) - var(--tooltip-arrow-size));
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--tooltip-bg);
+}
+
+/* Show on hover */
+.tooltip:hover::before,
+.tooltip:hover::after {
+  opacity: 1;
+  visibility: visible;
+}
+
+.tooltip:hover::before {
+  transform: translateX(-50%) translateY(0);
+}
+
+/* ============================================
+   Bottom Position
+   ============================================ */
+
+.tooltip-bottom::before {
+  bottom: auto;
+  top: calc(100% + var(--tooltip-offset));
+  left: 50%;
+  transform: translateX(-50%) translateY(-4px);
+}
+
+.tooltip-bottom::after {
+  bottom: auto;
+  top: calc(100% + var(--tooltip-offset) - var(--tooltip-arrow-size));
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: transparent;
+  border-bottom-color: var(--tooltip-bg);
+}
+
+.tooltip-bottom:hover::before {
+  transform: translateX(-50%) translateY(0);
+}
+
+/* ============================================
+   Left Position
+   ============================================ */
+
+.tooltip-left::before {
+  bottom: auto;
+  top: 50%;
+  left: auto;
+  right: calc(100% + var(--tooltip-offset));
+  transform: translateY(-50%) translateX(4px);
+  white-space: normal;
+}
+
+.tooltip-left::after {
+  bottom: auto;
+  top: 50%;
+  left: auto;
+  right: calc(100% + var(--tooltip-offset) - var(--tooltip-arrow-size));
+  transform: translateY(-50%);
+  border-top-color: transparent;
+  border-left-color: var(--tooltip-bg);
+}
+
+.tooltip-left:hover::before {
+  transform: translateY(-50%) translateX(0);
+}
+
+/* ============================================
+   Right Position
+   ============================================ */
+
+.tooltip-right::before {
+  bottom: auto;
+  top: 50%;
+  left: calc(100% + var(--tooltip-offset));
+  transform: translateY(-50%) translateX(-4px);
+  white-space: normal;
+}
+
+.tooltip-right::after {
+  bottom: auto;
+  top: 50%;
+  left: calc(100% + var(--tooltip-offset) - var(--tooltip-arrow-size));
+  transform: translateY(-50%);
+  border-top-color: transparent;
+  border-right-color: var(--tooltip-bg);
+}
+
+.tooltip-right:hover::before {
+  transform: translateY(-50%) translateX(0);
+}
+
+/* ============================================
+   Color Variants
+   ============================================ */
+
+/* Dark theme (default) */
+.tooltip-dark {
+  --tooltip-bg: #000000;
+}
+
+/* Light theme */
+.tooltip-light {
+  --tooltip-bg: #ffffff;
+  --tooltip-color: #1f2937;
+  --tooltip-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.tooltip-light::after {
+  border-top-color: var(--tooltip-bg);
+}
+
+.tooltip-light.tooltip-bottom::after {
+  border-top-color: transparent;
+  border-bottom-color: var(--tooltip-bg);
+}
+
+.tooltip-light.tooltip-left::after {
+  border-top-color: transparent;
+  border-left-color: var(--tooltip-bg);
+}
+
+.tooltip-light.tooltip-right::after {
+  border-top-color: transparent;
+  border-right-color: var(--tooltip-bg);
+}
+
+/* Error theme */
+.tooltip-error {
+  --tooltip-bg: #ef4444;
+}
+
+/* Success theme */
+.tooltip-success {
+  --tooltip-bg: #10b981;
+}
+
+/* ============================================
+   Multiline Tooltip (for long content)
+   ============================================ */
+
+.tooltip-multiline::before {
+  white-space: normal;
+  width: var(--tooltip-max-width);
+  text-align: center;
+}
+
+/* ============================================
+   Reduced Motion Support
+   ============================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip::before,
+  .tooltip::after {
+    transition: none;
+  }
+  
+  .tooltip::before {
+    transform: translateX(-50%) translateY(0);
+  }
+  
+  .tooltip-bottom::before {
+    transform: translateX(-50%) translateY(0);
+  }
+  
+  .tooltip-left::before {
+    transform: translateY(-50%) translateX(0);
+  }
+  
+  .tooltip-right::before {
+    transform: translateY(-50%) translateX(0);
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS tooltip component with arrow and 4 position options.

## Submission
- Folder: `submissions/examples/css-tooltip/`
- Files: `demo.html`, `style.css`, `README.md`

## Features
- 4 positions: top, bottom, left, right with correct arrow direction
- 4 color themes: default, dark, light, error, success
- Pure CSS using ::before and ::after pseudo-elements
- Smooth fade + slide animation on hover
- Multiline support for long content
- Respects `prefers-reduced-motion`

## Checklist
- [x] All 3 required files present
- [x] Self-contained submission (no core/ or components/ edits)
- [x] Tested locally in browser