### PR TITLE
feat: add ease dropdown fade transition

### DIFF
--- a/submissions/examples/ease-dropdown-fade-pr/README.md
+++ b/submissions/examples/ease-dropdown-fade-pr/README.md
@@ -1,0 +1,24 @@
+# Ease Dropdown Fade PR
+
+**What does this do?**  
+Adds a CSS-only dropdown menu that fades, shifts, and scales into view when the trigger is hovered or focused.
+
+**How is it used?**
+
+```html
+<div class="dropdown">
+  <button class="dropdown-trigger" type="button" aria-haspopup="true">Resources</button>
+  <div class="dropdown-menu" role="menu">
+    <a href="#" role="menuitem">Motion recipes</a>
+  </div>
+</div>
+```
+
+**Why is it useful?**  
+Dropdowns can feel abrupt when they instantly appear. This pattern keeps the menu removed from interaction until visible, then uses opacity and transform transitions to make the reveal feel smooth and stable.
+
+---
+
+Submitted by: @kunal-9090  
+Issue: #5370  
+Status: **Pending review**

--- a/submissions/examples/ease-dropdown-fade-pr/demo.html
+++ b/submissions/examples/ease-dropdown-fade-pr/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Submission - Ease Dropdown Fade PR</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro">
+      <p class="eyebrow">Menu transition</p>
+      <h1>Ease Dropdown Fade</h1>
+      <p>
+        A CSS-only dropdown menu that fades, shifts, and scales into view on
+        hover or keyboard focus without layout jump.
+      </p>
+    </section>
+
+    <nav class="demo-nav" aria-label="Demo navigation">
+      <a href="#">Dashboard</a>
+      <div class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">
+          Resources
+          <span aria-hidden="true"></span>
+        </button>
+        <div class="dropdown-menu" role="menu">
+          <a href="#" role="menuitem">
+            <strong>Motion recipes</strong>
+            <small>Reusable CSS patterns</small>
+          </a>
+          <a href="#" role="menuitem">
+            <strong>Design notes</strong>
+            <small>Interaction guidance</small>
+          </a>
+          <a href="#" role="menuitem">
+            <strong>Starter snippets</strong>
+            <small>Copy-ready examples</small>
+          </a>
+        </div>
+      </div>
+      <a href="#">Docs</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-dropdown-fade-pr/style.css
+++ b/submissions/examples/ease-dropdown-fade-pr/style.css
@@ -1,0 +1,191 @@
+/* ============================================================
+   SUBMISSION - ease-dropdown-fade-pr
+   CSS-only dropdown menu fade and shift transition.
+   ============================================================ */
+
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #111318;
+  color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 42px 18px;
+  background:
+    radial-gradient(circle at 70% 18%, rgba(129, 140, 248, 0.2), transparent 26rem),
+    linear-gradient(135deg, #111318 0%, #202633 55%, #15171b 100%);
+}
+
+.demo-shell {
+  width: min(840px, 100%);
+  display: grid;
+  gap: 34px;
+}
+
+.intro {
+  max-width: 650px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #a5b4fc;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: clamp(2.35rem, 7vw, 4.7rem);
+  line-height: 1;
+}
+
+.intro p:not(.eyebrow) {
+  margin: 0;
+  color: rgba(248, 250, 252, 0.72);
+  line-height: 1.7;
+}
+
+.demo-nav {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: max-content;
+  max-width: 100%;
+  padding: 10px;
+  border: 1px solid rgba(248, 250, 252, 0.12);
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.075);
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.32);
+}
+
+.demo-nav > a,
+.dropdown-trigger {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  border: 0;
+  border-radius: 12px;
+  padding: 0 15px;
+  color: #f8fafc;
+  background: transparent;
+  font: inherit;
+  font-weight: 800;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.demo-nav > a:hover,
+.dropdown:hover .dropdown-trigger,
+.dropdown:focus-within .dropdown-trigger,
+.dropdown-trigger:focus-visible {
+  background: rgba(165, 180, 252, 0.16);
+}
+
+.dropdown-trigger:focus-visible,
+.dropdown-menu a:focus-visible {
+  outline: 3px solid #a5b4fc;
+  outline-offset: 3px;
+}
+
+.dropdown-trigger span {
+  inline-size: 8px;
+  block-size: 8px;
+  border-inline-end: 2px solid currentColor;
+  border-block-end: 2px solid currentColor;
+  transform: rotate(45deg) translateY(-2px);
+  transition: transform 220ms ease;
+}
+
+.dropdown:hover .dropdown-trigger span,
+.dropdown:focus-within .dropdown-trigger span {
+  transform: rotate(225deg) translateY(-1px);
+}
+
+.dropdown {
+  position: relative;
+}
+
+.dropdown-menu {
+  position: absolute;
+  inset-block-start: calc(100% + 12px);
+  inset-inline-start: 0;
+  z-index: 10;
+  width: min(300px, calc(100vw - 36px));
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid rgba(248, 250, 252, 0.13);
+  border-radius: 16px;
+  background: rgba(16, 24, 40, 0.96);
+  box-shadow: 0 22px 58px rgba(0, 0, 0, 0.38);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(10px) scale(0.97);
+  transform-origin: top left;
+  transition:
+    opacity 180ms ease,
+    visibility 180ms ease,
+    transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.dropdown:hover .dropdown-menu,
+.dropdown:focus-within .dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+}
+
+.dropdown-menu a {
+  display: grid;
+  gap: 4px;
+  border-radius: 12px;
+  padding: 13px;
+  color: #f8fafc;
+  text-decoration: none;
+}
+
+.dropdown-menu a:hover,
+.dropdown-menu a:focus-visible {
+  background: rgba(165, 180, 252, 0.14);
+}
+
+.dropdown-menu small {
+  color: rgba(248, 250, 252, 0.62);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dropdown-trigger span,
+  .dropdown-menu {
+    transition-duration: 1ms;
+  }
+}
+
+@media (max-width: 560px) {
+  .demo-nav {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .dropdown {
+    position: static;
+  }
+
+  .dropdown-menu {
+    inset-inline: 10px;
+    width: auto;
+    transform-origin: top center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only dropdown menu fade/shift example
- support hover and keyboard focus reveal states
- include responsive and reduced-motion handling

Closes #5370

## Validation
- Verified added standalone HTML/CSS/README files