### PR TITLE
resolve #6719: CSS-Only Parallax Scroll Effect Panel

### DIFF
--- a/submissions/examples/new-parallax-scroll-image-sn50/README.md
+++ b/submissions/examples/new-parallax-scroll-image-sn50/README.md
@@ -1,0 +1,7 @@
+# CSS-Only Parallax Scroll Effect Panel
+
+Page layout block providing vertical image parallax shift on page scroll.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-parallax-scroll-image-sn50/demo.html
+++ b/submissions/examples/new-parallax-scroll-image-sn50/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: CSS-Only Parallax Scroll Effect Panel</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-parallax-bg"></div>
+</body>
+</html>

--- a/submissions/examples/new-parallax-scroll-image-sn50/style.css
+++ b/submissions/examples/new-parallax-scroll-image-sn50/style.css
@@ -1,0 +1,7 @@
+/* ==========================================================================
+   EaseMotion CSS: CSS-Only Parallax Scroll Effect Panel
+   ========================================================================== */
+
+@layer components {
+.ease-parallax-bg { height: 160px; background-image: url('https://picsum.photos/600/400'); background-attachment: fixed; background-position: center; background-repeat: no-repeat; background-size: cover; border-radius: 12px; }
+}


### PR DESCRIPTION
Closes #6719

## What this does
Page layout block providing vertical image parallax shift on page scroll.

## Files
- `submissions/examples/new-parallax-scroll-image-sn50/style.css`
- `submissions/examples/new-parallax-scroll-image-sn50/demo.html`
- `submissions/examples/new-parallax-scroll-image-sn50/README.md`
