### PR TITLE
fix: add aria-hidden to decorative emoji in docs/index.html (issue #2…

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -217,7 +217,7 @@
             utilities, no complex configuration.
           </p>
           <div class="docs-info">
-            <span class="docs-info-icon">💡</span>
+            <span class="docs-info-icon" aria-hidden="true">💡</span>
             <div>
               EaseMotion CSS bridges the gap between raw vanilla CSS and
               utility-heavy frameworks like Tailwind.


### PR DESCRIPTION
## Pull Request Description
Adds `aria-hidden="true"` to the decorative 💡 emoji icon in `docs/index.html` so screen readers skip it, preventing confusing announcements like "Electric light bulb EaseMotion CSS bridges the gap...". Closes #2769

---
## Type of Change
- [x] 🐛 Bug fix in an existing submission

---
## Submission Checklist
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
Adds `aria-hidden="true"` to the decorative lightbulb emoji span in the documentation, so it's hidden from assistive technology.

**How does a developer use it?**
```html
<span class="docs-info-icon" aria-hidden="true">💡</span>
```

**Why does it fit EaseMotion CSS?**
Improves accessibility of the documentation by ensuring decorative icons don't clutter the screen reader experience — aligned with the project's commitment to inclusive, accessible design.

---
## Notes for Maintainer
One-line accessibility fix — added `aria-hidden="true"` to the existing `<span class="docs-info-icon">` wrapping the decorative emoji on line 220 of `docs/index.html`. No visual or layout changes.