### PR TITLE
fix: prefers-reduced-motion causes jarring layout jump on hover (#2852)

### DIFF
--- a/components/footer.css
+++ b/components/footer.css
@@ -169,6 +169,7 @@
   .ease-footer-links a,
   .ease-footer-social a {
     transition: none !important;
+    transform: none !important;
   }
 }
 }


### PR DESCRIPTION
## Pull Request Description
Fixes jarring instant layout jump on `.ease-footer-social a:hover` when
`prefers-reduced-motion: reduce` is enabled. The existing fix only disabled
`transition` but not `transform`, causing the `translateY(-2px)` to still
fire instantly.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html`
- [ ] Includes `style.css`
- [ ] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`** ← only 1 line fix in footer.css
- [x] One feature per PR

---

## Feature Description
**What does this fix?**
Adds `transform: none !important` inside the existing
`@media (prefers-reduced-motion: reduce)` block in `components/footer.css`.

**Change made:**
```css
@media (prefers-reduced-motion: reduce) {
  .ease-footer-links a,
  .ease-footer-social a {
    transition: none !important;
    transform: none !important; /* ← this line added */
  }
}
```

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
1 line change only. Fixes accessibility regression for users with
reduced motion preferences enabled at OS level.

Closes #2852