### PR TITLE
feat: add radial circle-wipe card reveal (closes #6853)

### DIFF
--- a/submissions/examples/em-circle-wipe-card/README.md
+++ b/submissions/examples/em-circle-wipe-card/README.md
@@ -1,0 +1,55 @@
+# Radial Circle-Wipe Card Reveal
+
+Closes #6853
+
+## Overview
+
+A hover overlay effect for card components. The card holds two
+overlapping layers:
+
+- **`.em-card-state-base`** — the default visible layer.
+- **`.em-card-state-overlay`** — a hidden reveal layer, clipped to a
+  circle at its center using `clip-path: circle(0% at 50% 50%)`.
+
+On hover, the overlay's `clip-path` radius expands to `75%`, creating a
+"flashlight reveal" wipe that swaps the card's background, colors, and
+content. Inner elements (`.analytics-metrics`, `.cta-button`) fade and
+slide in with staggered transition delays for a layered reveal.
+
+## Files
+
+- `index.html` — markup with both card states.
+- `style.css` — all styling and the circle-wipe transition.
+- `script.js` — optional enhancement that lets the reveal origin follow
+  the cursor position (flashlight effect). The base effect works with
+  pure CSS even without this script.
+
+## Usage
+
+```html
+<div class="em-circle-wipe-card">
+  <div class="em-card-state-base">
+    <!-- default content -->
+  </div>
+  <div class="em-card-state-overlay">
+    <!-- revealed content -->
+  </div>
+</div>
+```
+
+Include `style.css` (required) and `script.js` (optional, for
+cursor-following reveal origin).
+
+## Customization
+
+- Change the reveal origin by editing the `clip-path` coordinates
+  (e.g. `circle(75% at 0% 0%)` for a top-left origin).
+- Adjust `transition-delay` values on `.analytics-metrics` and
+  `.cta-button` to change the stagger timing.
+- Swap the overlay's `background` gradient to match your theme.
+
+## Performance
+
+Uses only `clip-path` and `opacity`/`transform` transitions — all
+GPU-accelerated, avoiding layout recalculation for smooth 60fps
+animation.

--- a/submissions/examples/em-circle-wipe-card/index.html
+++ b/submissions/examples/em-circle-wipe-card/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS - Radial Circle-Wipe Card Reveal</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="em-circle-wipe-card">
+    <!-- Default State Content -->
+    <div class="em-card-state-base">
+      <div class="card-header">
+        <span class="category">Analytics</span>
+        <h3>Data Pipeline</h3>
+      </div>
+      <p class="description">Hover to reveal pipeline status</p>
+    </div>
+
+    <!-- Reveal State Content (Overlayed) -->
+    <div class="em-card-state-overlay">
+      <div class="card-header">
+        <span class="category status-online">Live</span>
+        <h3>Active Pipeline</h3>
+      </div>
+      <div class="analytics-metrics">
+        <span class="metric">2.4M req/sec</span>
+        <span class="latency">3ms avg latency</span>
+      </div>
+      <a href="#" class="cta-button">Inspect Cluster</a>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/em-circle-wipe-card/script.js
+++ b/submissions/examples/em-circle-wipe-card/script.js
@@ -1,0 +1,32 @@
+/* =========================================================
+   EaseMotion CSS — Radial Circle-Wipe Card Reveal
+   Optional JS: allows the reveal origin to follow the
+   user's cursor position for a "flashlight" feel.
+   Purely additive — the effect works via pure CSS
+   (:hover + clip-path) even if this script is removed.
+   ========================================================= */
+
+document.addEventListener("DOMContentLoaded", () => {
+  const cards = document.querySelectorAll(".em-circle-wipe-card");
+
+  cards.forEach((card) => {
+    const overlay = card.querySelector(".em-card-state-overlay");
+
+    card.addEventListener("mousemove", (e) => {
+      const rect = card.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * 100;
+      const y = ((e.clientY - rect.top) / rect.height) * 100;
+
+      overlay.style.setProperty("--reveal-x", `${x}%`);
+      overlay.style.setProperty("--reveal-y", `${y}%`);
+    });
+
+    card.addEventListener("mouseenter", () => {
+      overlay.style.clipPath = `circle(75% at var(--reveal-x, 50%) var(--reveal-y, 50%))`;
+    });
+
+    card.addEventListener("mouseleave", () => {
+      overlay.style.clipPath = `circle(0% at var(--reveal-x, 50%) var(--reveal-y, 50%))`;
+    });
+  });
+});

--- a/submissions/examples/em-circle-wipe-card/style.css
+++ b/submissions/examples/em-circle-wipe-card/style.css
@@ -1,0 +1,159 @@
+/* =========================================================
+   EaseMotion CSS — Radial Circle-Wipe Card Reveal
+   A hover overlay that radially clip-path wipes from the
+   center of the card to reveal a secondary "live" state.
+   ========================================================= */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+}
+
+/* ===== Card container ===== */
+.em-circle-wipe-card {
+  position: relative;
+  width: 320px;
+  height: 220px;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+}
+
+/* ===== Base default layer ===== */
+.em-card-state-base {
+  position: absolute;
+  inset: 0;
+  padding: 24px;
+  background: #1c1f26;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.em-card-state-base .card-header h3 {
+  margin: 8px 0 0;
+  font-size: 1.25rem;
+  color: #e6e6e6;
+}
+
+.em-card-state-base .category {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #8a8f98;
+}
+
+.em-card-state-base .description {
+  color: #9aa0a8;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+/* ===== Reveal overlay layer ===== */
+.em-card-state-overlay {
+  position: absolute;
+  inset: 0;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: linear-gradient(135deg, #6a4cff 0%, #00c6ff 100%);
+  clip-path: circle(0% at 50% 50%);
+  transition: clip-path 0.6s ease-in-out;
+}
+
+/* Expand the circular mask from the center on hover */
+.em-circle-wipe-card:hover .em-card-state-overlay {
+  clip-path: circle(75% at 50% 50%);
+}
+
+.em-card-state-overlay .category {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.em-card-state-overlay .status-online::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2ecc71;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.em-card-state-overlay h3 {
+  margin: 8px 0 0;
+  font-size: 1.25rem;
+  color: #fff;
+}
+
+/* ===== Staggered reveal of inner elements ===== */
+.analytics-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  transition-delay: 0.15s;
+}
+
+.em-circle-wipe-card:hover .analytics-metrics {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.analytics-metrics .metric {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: #fff;
+}
+
+.analytics-metrics .latency {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.cta-button {
+  align-self: flex-start;
+  padding: 8px 16px;
+  border-radius: 8px;
+  background: #fff;
+  color: #6a4cff;
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-decoration: none;
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  transition-delay: 0.3s;
+}
+
+.em-circle-wipe-card:hover .cta-button {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 400px) {
+  .em-circle-wipe-card {
+    width: 100%;
+    max-width: 320px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new EaseMotion CSS example: a Radial Circle-Wipe Card Reveal. The card uses a `clip-path: circle()` overlay that expands from the center on hover, swapping a default state for a "live" reveal state with staggered content animation.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/em-circle-wipe-card/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A circular "flashlight wipe" hover effect that radially reveals a secondary card layer with different content, colors, and metrics.

**How does a developer use it?**
```html
<div class="em-circle-wipe-card">
  <div class="em-card-state-base">
    <!-- default content -->
  </div>
  <div class="em-card-state-overlay">
    <!-- revealed content -->
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It follows a clear, human-readable naming pattern (`.em-card-state-base` / `.em-card-state-overlay`) for semantic layout separation, and relies purely on `clip-path` and `opacity`/`transform` transitions — all GPU-accelerated and animation-first, with no layout recalculation, keeping it composable and performant at 60fps.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Closes #6853. The reveal radius is set to `circle(75% at 50% 50%)` from a hidden `circle(0% at 50% 50%)` state — happy to adjust the percentage or stagger timings if you'd like a different feel.