### PR TITLE
feat: add CSS-only Modal demo

### DIFF
--- a/submissions/examples/css-only-modal-demo/demo.html
+++ b/submissions/examples/css-only-modal-demo/demo.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>CSS-only Modal Demo Component - EaseMotion CSS</title>
+
+    <!-- Link to EaseMotion CSS core -->
+    <link rel="stylesheet" href="../../../core/animations.css" />
+    <!-- Link to your CSS file - do not change this path -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="demo-wrapper">
+      <h1>CSS-only Modal Demo Component</h1>
+
+      <div class="modal-demo">
+        <input class="modal-toggle" type="checkbox" id="css-modal" />
+
+        <label class="modal-open" for="css-modal"> Open Modal </label>
+
+        <div class="modal-overlay">
+          <div
+            class="modal-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="css-modal-title"
+          >
+            <div class="modal-header">
+              <h2 id="css-modal-title">CSS-only Modal</h2>
+
+              <label
+                class="modal-close"
+                for="css-modal"
+                aria-label="Close modal"
+              >
+                ×
+              </label>
+            </div>
+
+            <div class="modal-body">
+              <p>
+                This modal opens and closes using only HTML and CSS. It includes
+                an overlay, responsive layout, focus styling, and a smooth
+                transition.
+              </p>
+            </div>
+
+            <div class="modal-actions">
+              <label
+                class="modal-button modal-button-secondary"
+                for="css-modal"
+              >
+                Cancel
+              </label>
+
+              <label class="modal-button modal-button-primary" for="css-modal">
+                Confirm
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/css-only-modal-demo/style.css
+++ b/submissions/examples/css-only-modal-demo/style.css
@@ -1,0 +1,180 @@
+.modal-demo {
+  min-height: 18rem;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.modal-toggle {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.modal-open,
+.modal-button,
+.modal-close {
+  cursor: pointer;
+  user-select: none;
+}
+
+.modal-open,
+.modal-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.65rem;
+  font-weight: 700;
+  line-height: 1;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease;
+}
+
+.modal-open,
+.modal-button-primary {
+  color: #ffffff;
+  background: #4f46e5;
+  box-shadow: 0 12px 28px rgba(79, 70, 229, 0.24);
+}
+
+.modal-button-secondary {
+  color: #27324a;
+  background: #ffffff;
+  border: 1px solid #d9e1ef;
+}
+
+.modal-open:hover,
+.modal-button:hover {
+  transform: translateY(-2px);
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.58);
+  backdrop-filter: blur(8px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 220ms ease,
+    visibility 220ms ease;
+}
+
+.modal-dialog {
+  width: min(100%, 34rem);
+  border-radius: 1rem;
+  background: #ffffff;
+  color: #172033;
+  box-shadow: 0 28px 70px rgba(15, 23, 42, 0.32);
+  transform: translateY(1rem) scale(0.96);
+  opacity: 0;
+  overflow: hidden;
+  transition:
+    transform 240ms ease,
+    opacity 240ms ease;
+}
+
+.modal-toggle:checked ~ .modal-overlay {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.modal-toggle:checked ~ .modal-overlay .modal-dialog {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.25rem 0;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  line-height: 1.3;
+}
+
+.modal-close {
+  width: 2.25rem;
+  height: 2.25rem;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #f3f6fb;
+  color: #334155;
+  font-size: 1.5rem;
+  line-height: 1;
+  transition:
+    transform 180ms ease,
+    background-color 180ms ease;
+}
+
+.modal-close:hover {
+  transform: rotate(90deg);
+  background: #e8eef8;
+}
+
+.modal-body {
+  padding: 1rem 1.25rem;
+}
+
+.modal-body p {
+  margin: 0;
+  color: #4b5870;
+  line-height: 1.65;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 0 1.25rem 1.25rem;
+}
+
+.modal-open:focus-visible,
+.modal-button:focus-visible,
+.modal-close:focus-visible {
+  outline: 3px solid rgba(90, 130, 255, 0.45);
+  outline-offset: 3px;
+}
+
+@media (max-width: 520px) {
+  .modal-actions {
+    flex-direction: column-reverse;
+  }
+
+  .modal-button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal-open,
+  .modal-button,
+  .modal-close,
+  .modal-overlay,
+  .modal-dialog {
+    transition: none;
+  }
+
+  .modal-open:hover,
+  .modal-button:hover,
+  .modal-close:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Description
Added a CSS-only modal demo that opens and closes without JavaScript. The modal uses a hidden checkbox (:checked) to control the open/close state.
issue #6875 
The component includes:

Full-screen blurred overlay
Centered modal dialog with a responsive layout
Close button and action buttons
Smooth open/close transition animations
Focus-visible styling for keyboard accessibility and prefers-reduced-motion support
This modal is ideal for confirmations, alerts, onboarding messages, forms, previews, or short focused content blocks.

Why is this useful for EaseMotion CSS?
A modal is a common UI pattern in modern interfaces. A CSS-only modal fits perfectly with the EaseMotion CSS philosophy because it is lightweight, animation-first, human-readable, and does completely away with the need for JavaScript state management. It combines layout, layered UI, accessible markup patterns, and motion in one self-contained, advanced example.

Type of change
 New Feature (Component / Demo)
 Enhancement
Checklist
 This feature does not duplicate an existing EaseMotion CSS class
 I understand my naming will be standardized by the maintainer
 Code has been submitted inside submissions/examples/ only (specifically submissions/examples/css-only-modal-demo/)
 The code has been formatted and passes all local linting (npm run lint) and tests (npm test)