### PR TITLE
feat: add ease-spinner component (ring, dots, bars, dual)

### DIFF
--- a/submissions/examples/spinner/README.md
+++ b/submissions/examples/spinner/README.md
@@ -1,0 +1,70 @@
+# ease-spinner
+
+Pure CSS loading spinners for EaseMotion CSS.
+Four styles · three sizes · two colour modifiers · zero JS · zero SVG.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `style.css` | All spinner styles and `@keyframes` |
+| `demo.html` | Visual showcase of every variant |
+| `README.md` | This file |
+
+## Classes
+
+| Class | Description |
+|-------|-------------|
+| `.ease-spinner` | Classic rotating ring |
+| `.ease-spinner-dots` | 3 bouncing dots (3 `<span>` children required) |
+| `.ease-spinner-bars` | 5 equalizer bars (5 `<span>` children required) |
+| `.ease-spinner-dual` | Two counter-rotating rings |
+| `.ease-spinner-sm` | 16px size |
+| `.ease-spinner-lg` | 48px size |
+| `.ease-spinner-primary` | Uses `--ease-color-primary` |
+| `.ease-spinner-white` | White — for dark backgrounds / coloured buttons |
+
+## Usage
+
+```html
+<!-- Page loader -->
+<div class="ease-spinner ease-spinner-lg ease-spinner-primary"></div>
+
+<!-- Inside a button -->
+<button class="ease-btn ease-btn-primary" disabled>
+  <span class="ease-spinner ease-spinner-sm ease-spinner-white"></span>
+  Loading…
+</button>
+
+<!-- Dots -->
+<div class="ease-spinner-dots">
+  <span></span><span></span><span></span>
+</div>
+
+<!-- Bars -->
+<div class="ease-spinner-bars">
+  <span></span><span></span><span></span><span></span><span></span>
+</div>
+```
+
+## CSS Variables
+
+```css
+:root {
+  --ease-color-primary:   #7c3aed;
+  --ease-color-white:     #ffffff;
+  --ease-spinner-size:    32px;
+  --ease-spinner-size-sm: 16px;
+  --ease-spinner-size-lg: 48px;
+  --ease-spinner-border:  3px;
+  --ease-spinner-speed:   0.7s;
+}
+```
+
+## Technical notes
+
+- All animation via CSS `@keyframes` — no JS, no SVG.
+- Dots and bars require child `<span>` elements; ring variants are self-contained.
+- All selectors use the `ease-` prefix to avoid collisions.
+
+Closes #2726

--- a/submissions/examples/spinner/demo.html
+++ b/submissions/examples/spinner/demo.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-spinner · EaseMotion CSS Demo</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #f5f3ff; color: #1e1b4b; padding: 2rem; }
+    h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: .25rem; }
+    h2 { font-size: 1.05rem; font-weight: 600; color: #6d28d9; margin-bottom: 1rem; }
+    .section { background: #fff; border: 1px solid #ede9fe; border-radius: 12px; padding: 1.5rem 2rem; margin-bottom: 1.5rem; }
+    .row { display: flex; flex-wrap: wrap; align-items: center; gap: 2rem; margin-bottom: 1rem; }
+    .item { display: flex; flex-direction: column; align-items: center; }
+    .label { font-size: .75rem; color: #9ca3af; margin-top: .4rem; text-align: center; }
+    .dark { background: #1e1b4b; border-radius: 10px; padding: 1rem 1.5rem; display: flex; gap: 2rem; flex-wrap: wrap; align-items: center; }
+    .dark .label { color: #c4b5fd; }
+    .ease-btn { display: inline-flex; align-items: center; gap: .5rem; padding: .5rem 1.25rem; border: none; border-radius: 8px; font-size: .9rem; font-weight: 600; cursor: not-allowed; }
+    .ease-btn-primary { background: #7c3aed; color: #fff; opacity: .85; }
+  </style>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <h1>⚡ ease-spinner</h1>
+  <p style="color:#6b7280;margin-bottom:2rem;">Pure CSS loading spinners — no JS, no SVG.</p>
+
+  <div class="section">
+    <h2>Variants</h2>
+    <div class="row">
+      <div class="item"><div class="ease-spinner"></div><span class="label">.ease-spinner</span></div>
+      <div class="item">
+        <div class="ease-spinner-dots"><span></span><span></span><span></span></div>
+        <span class="label">.ease-spinner-dots</span>
+      </div>
+      <div class="item">
+        <div class="ease-spinner-bars"><span></span><span></span><span></span><span></span><span></span></div>
+        <span class="label">.ease-spinner-bars</span>
+      </div>
+      <div class="item"><div class="ease-spinner-dual"></div><span class="label">.ease-spinner-dual</span></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Sizes</h2>
+    <div class="row">
+      <div class="item"><div class="ease-spinner ease-spinner-sm"></div><span class="label">sm (16px)</span></div>
+      <div class="item"><div class="ease-spinner"></div><span class="label">default (32px)</span></div>
+      <div class="item"><div class="ease-spinner ease-spinner-lg"></div><span class="label">lg (48px)</span></div>
+      <div class="item"><div class="ease-spinner-dual ease-spinner-sm"></div><span class="label">dual sm</span></div>
+      <div class="item"><div class="ease-spinner-dual ease-spinner-lg"></div><span class="label">dual lg</span></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Colours — primary</h2>
+    <div class="row">
+      <div class="item"><div class="ease-spinner ease-spinner-lg ease-spinner-primary"></div><span class="label">ring</span></div>
+      <div class="item"><div class="ease-spinner-dual ease-spinner-lg ease-spinner-primary"></div><span class="label">dual</span></div>
+      <div class="item">
+        <div class="ease-spinner-dots ease-spinner-lg ease-spinner-primary"><span></span><span></span><span></span></div>
+        <span class="label">dots</span>
+      </div>
+      <div class="item">
+        <div class="ease-spinner-bars ease-spinner-lg ease-spinner-primary"><span></span><span></span><span></span><span></span><span></span></div>
+        <span class="label">bars</span>
+      </div>
+    </div>
+    <h2>Colours — white</h2>
+    <div class="dark">
+      <div class="item"><div class="ease-spinner ease-spinner-lg ease-spinner-white"></div><span class="label">ring</span></div>
+      <div class="item"><div class="ease-spinner-dual ease-spinner-lg ease-spinner-white"></div><span class="label">dual</span></div>
+      <div class="item">
+        <div class="ease-spinner-dots ease-spinner-lg ease-spinner-white"><span></span><span></span><span></span></div>
+        <span class="label">dots</span>
+      </div>
+      <div class="item">
+        <div class="ease-spinner-bars ease-spinner-lg ease-spinner-white"><span></span><span></span><span></span><span></span><span></span></div>
+        <span class="label">bars</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Real-world usage</h2>
+    <div class="row">
+      <button class="ease-btn ease-btn-primary" disabled>
+        <span class="ease-spinner ease-spinner-sm ease-spinner-white"></span>
+        Loading…
+      </button>
+      <button class="ease-btn ease-btn-primary" disabled>
+        <span class="ease-spinner-dots ease-spinner-sm ease-spinner-white"><span></span><span></span><span></span></span>
+        Processing
+      </button>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/spinner/style.css
+++ b/submissions/examples/spinner/style.css
@@ -1,0 +1,163 @@
+/* ============================================================
+   ease-spinner — Pure CSS Loading Spinners
+   EaseMotion CSS · submissions/examples/spinner/style.css
+   ============================================================ */
+
+:root {
+  --ease-color-primary:   #7c3aed;
+  --ease-color-white:     #ffffff;
+  --ease-spinner-size:    32px;
+  --ease-spinner-size-sm: 16px;
+  --ease-spinner-size-lg: 48px;
+  --ease-spinner-border:  3px;
+  --ease-spinner-speed:   0.7s;
+}
+
+/* ── Classic rotating ring ───────────────────────────────── */
+.ease-spinner {
+  display: inline-block;
+  width: var(--ease-spinner-size);
+  height: var(--ease-spinner-size);
+  border: var(--ease-spinner-border) solid rgba(124, 58, 237, 0.2);
+  border-top-color: var(--ease-color-primary);
+  border-radius: 50%;
+  animation: ease-spin var(--ease-spinner-speed) linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes ease-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Three bouncing dots ─────────────────────────────────── */
+.ease-spinner-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ease-spinner-dots span {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--ease-color-primary);
+  animation: ease-dot-bounce 0.6s ease-in-out infinite alternate;
+}
+
+.ease-spinner-dots span:nth-child(2) { animation-delay: 0.1s; }
+.ease-spinner-dots span:nth-child(3) { animation-delay: 0.2s; }
+
+@keyframes ease-dot-bounce {
+  from { transform: translateY(0); }
+  to   { transform: translateY(-10px); }
+}
+
+/* ── Equalizer bars ──────────────────────────────────────── */
+.ease-spinner-bars {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: var(--ease-spinner-size);
+}
+
+.ease-spinner-bars span {
+  display: inline-block;
+  width: 5px;
+  border-radius: 3px;
+  background: var(--ease-color-primary);
+  animation: ease-bar-stretch 0.8s ease-in-out infinite alternate;
+}
+
+.ease-spinner-bars span:nth-child(1) { height: 60%;  animation-delay: 0s; }
+.ease-spinner-bars span:nth-child(2) { height: 100%; animation-delay: 0.15s; }
+.ease-spinner-bars span:nth-child(3) { height: 40%;  animation-delay: 0.3s; }
+.ease-spinner-bars span:nth-child(4) { height: 80%;  animation-delay: 0.45s; }
+.ease-spinner-bars span:nth-child(5) { height: 60%;  animation-delay: 0.6s; }
+
+@keyframes ease-bar-stretch {
+  from { transform: scaleY(0.4); opacity: 0.6; }
+  to   { transform: scaleY(1);   opacity: 1; }
+}
+
+/* ── Dual counter-rotating rings ─────────────────────────── */
+.ease-spinner-dual {
+  display: inline-block;
+  width: var(--ease-spinner-size);
+  height: var(--ease-spinner-size);
+  border-radius: 50%;
+  border: var(--ease-spinner-border) solid transparent;
+  border-top-color: var(--ease-color-primary);
+  border-bottom-color: var(--ease-color-primary);
+  animation: ease-spin var(--ease-spinner-speed) linear infinite;
+  position: relative;
+}
+
+.ease-spinner-dual::before {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  border: var(--ease-spinner-border) solid transparent;
+  border-left-color: rgba(124, 58, 237, 0.4);
+  border-right-color: rgba(124, 58, 237, 0.4);
+  animation: ease-spin-reverse calc(var(--ease-spinner-speed) * 1.5) linear infinite;
+}
+
+@keyframes ease-spin-reverse {
+  to { transform: rotate(-360deg); }
+}
+
+/* ── Size modifiers ──────────────────────────────────────── */
+.ease-spinner-sm.ease-spinner,
+.ease-spinner-sm.ease-spinner-dual {
+  width: var(--ease-spinner-size-sm);
+  height: var(--ease-spinner-size-sm);
+  border-width: 2px;
+}
+
+.ease-spinner-sm.ease-spinner-dots span { width: 6px; height: 6px; }
+
+.ease-spinner-sm.ease-spinner-bars { height: var(--ease-spinner-size-sm); gap: 2px; }
+.ease-spinner-sm.ease-spinner-bars span { width: 3px; }
+
+.ease-spinner-lg.ease-spinner,
+.ease-spinner-lg.ease-spinner-dual {
+  width: var(--ease-spinner-size-lg);
+  height: var(--ease-spinner-size-lg);
+  border-width: 4px;
+}
+
+.ease-spinner-lg.ease-spinner-dots span { width: 14px; height: 14px; }
+
+.ease-spinner-lg.ease-spinner-bars { height: var(--ease-spinner-size-lg); gap: 5px; }
+.ease-spinner-lg.ease-spinner-bars span { width: 7px; }
+
+/* ── Colour modifiers ────────────────────────────────────── */
+.ease-spinner-primary {
+  border-color: rgba(124, 58, 237, 0.2);
+  border-top-color: var(--ease-color-primary);
+}
+.ease-spinner-primary.ease-spinner-dual {
+  border-color: transparent;
+  border-top-color: var(--ease-color-primary);
+  border-bottom-color: var(--ease-color-primary);
+}
+.ease-spinner-primary.ease-spinner-dots span,
+.ease-spinner-primary.ease-spinner-bars span {
+  background: var(--ease-color-primary);
+}
+
+.ease-spinner-white {
+  border-color: rgba(255, 255, 255, 0.3);
+  border-top-color: var(--ease-color-white);
+}
+.ease-spinner-white.ease-spinner-dual {
+  border-color: transparent;
+  border-top-color: var(--ease-color-white);
+  border-bottom-color: var(--ease-color-white);
+}
+.ease-spinner-white.ease-spinner-dots span,
+.ease-spinner-white.ease-spinner-bars span {
+  background: var(--ease-color-white);
+}


### PR DESCRIPTION
Closes #2726

## What's added
- `submissions/examples/spinner/style.css` — 4 spinner variants (ring, dots, bars, dual), 3 sizes (sm/default/lg), 2 colour modifiers (primary/white)
- `submissions/examples/spinner/demo.html` — full visual showcase
- `submissions/examples/spinner/README.md` — usage docs and class reference

## Notes
- Zero JS, zero SVG — pure CSS `@keyframes` only
- Follows `ease-*` naming and uses existing CSS variable tokens
- Does not touch `core/` or `components/`