### PR TITLE
fix: repair How to Contribute sidebar navigation (#6920)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -199,7 +199,7 @@
         <div class="sidebar-group">
           <div class="sidebar-group-label">Contributing</div>
           <ul class="sidebar-nav">
-            <li><a href="#contributing">How to Contribute</a></li>
+           <li><a href="#how-to-contribute">How to Contribute</a></li>
             <li><a href="#naming">Naming Rules</a></li>
           </ul>
         </div>
@@ -475,19 +475,21 @@
 
         <hr class="docs-divider" />
 
-        <section id="contributing" class="docs-section">
-          <h2 class="docs-h2">Contributing</h2>
-          <p class="docs-p">
-            All contributions are welcome! Please follow the contribution
-            guidelines in our GitHub repository.
-          </p>
+       <section id="contributing" class="docs-section">
+  <h2 class="docs-h2">Contributing</h2>
 
-          <h3 class="docs-h3" id="naming">Naming Rules</h3>
-          <p class="docs-p">
-            All class names must follow the <code>ease-</code> prefix
-            convention.
-          </p>
-        </section>
+  <h3 class="docs-h3" id="how-to-contribute">How to Contribute</h3>
+  <p class="docs-p">
+    All contributions are welcome! Please follow the contribution
+    guidelines in our GitHub repository.
+  </p>
+
+  <h3 class="docs-h3" id="naming">Naming Rules</h3>
+  <p class="docs-p">
+    All class names must follow the <code>ease-</code> prefix
+    convention.
+  </p>
+</section>
       </main>
     </div>
 


### PR DESCRIPTION
## Summary

Fixes the "How to Contribute" documentation navigation issue.

### Changes

* Added a dedicated `How to Contribute` section heading with an ID.
* Updated the sidebar anchor to target the new section.
* Preserved the existing `Naming Rules` section structure.

### Result

* Sidebar navigation correctly scrolls to the section.
* Section labeling is consistent with other documentation sections.
* Scroll tracking can correctly identify the section.

Closes #6920
