### PR TITLE
docs: fix broken "How to Contribute" sidebar navigation and heading anchor

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -208,7 +208,7 @@
         <div class="sidebar-group">
           <div class="sidebar-group-label">Contributing</div>
           <ul class="sidebar-nav">
-            <li><a href="#contributing">How to Contribute</a></li>
+            <li><a href="#how-to-contribute">How to Contribute</a></li>
             <li><a href="#naming">Naming Rules</a></li>
           </ul>
         </div>
@@ -532,7 +532,7 @@
         <hr class="docs-divider" />
 
         <section id="contributing" class="docs-section">
-          <h2 class="docs-h2">Contributing</h2>
+        <h2 class="docs-h2" id="how-to-contribute">How to Contribute</h2> 
           <p class="docs-p">
             EaseMotion CSS is a <strong>curated</strong> framework. Contributors do not directly modify core styles. Instead, you submit self-contained demos, which are then standard-adjusted, optimized, and integrated into the core by the maintainer.
           </p>


### PR DESCRIPTION
### Description
This PR resolves an issue with the documentation site where the **How to Contribute** section navigation was broken. 

1. **Fixed Sidebar Anchor:** Updated the sidebar navigation link target to point accurately to the section's unique anchor ID (`#how-to-contribute`).
2. **Fixed Heading & Layout Consistency:** Added the missing `id="how-to-contribute"` anchor to the `<h2>` element on the main page and updated the text header from "Contributing" to "How to Contribute" to align perfectly with the sidebar label.

These changes ensure that clicking the sidebar item smoothly navigates the user to the correct section and allows the scroll-tracking/scrollspy script to properly highlight the active section during scrolling.

### Closes
Closes #6920 

### Changes Made
- Modified `docs/index.html` to align the sidebar anchor link `href` with the main page heading `id`.
- Updated visual text hierarchy for better navigation tracking.

### Verification Matrix
- [x] Clicked "How to Contribute" in the left sidebar and verified it accurately jumps to the section.
- [x] Verified that scrolling through the bottom sections properly highlights the corresponding sidebar items without skipping.