### PR TITLE
feat(examples): add aspect-ratio property demo

### DIFF
--- a/submissions/examples/aspect-ratio/README.md
+++ b/submissions/examples/aspect-ratio/README.md
@@ -1,0 +1,30 @@
+# Aspect Ratio
+
+## What does it do?
+A pure-CSS demo showing the `aspect-ratio` property for maintaining element proportions — no JavaScript required.
+
+## Features
+- Square (1:1), classic (4:3), widescreen (16:9), cinema (2:1)
+- Responsive sizing without padding hacks
+- Side-by-side comparison grid
+
+## Usage
+```css
+.video-embed {
+  aspect-ratio: 16 / 9;
+  max-width: 100%;
+}
+
+.card {
+  aspect-ratio: 1 / 1;
+}
+```
+
+## Browser Support
+- `aspect-ratio` — Chrome 88+, Firefox 89+, Safari 15+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/aspect-ratio/demo.html
+++ b/submissions/examples/aspect-ratio/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Aspect Ratio — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.5rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <h1>Aspect Ratio</h1>
+  <p class="subtitle">Maintaining element proportions with <code>aspect-ratio</code> — no JavaScript required.</p>
+
+  <section>
+    <h2>Square — 1 / 1</h2>
+    <p class="sec-desc"><code>aspect-ratio: 1 / 1</code></p>
+    <div class="ar-box ar-square"><span>1:1</span></div>
+  </section>
+
+  <section>
+    <h2>Classic — 4 / 3</h2>
+    <p class="sec-desc"><code>aspect-ratio: 4 / 3</code></p>
+    <div class="ar-box ar-4-3"><span>4:3</span></div>
+  </section>
+
+  <section>
+    <h2>Widescreen — 16 / 9</h2>
+    <p class="sec-desc"><code>aspect-ratio: 16 / 9</code></p>
+    <div class="ar-box ar-16-9"><span>16:9</span></div>
+  </section>
+
+  <section>
+    <h2>Cinema — 2 / 1</h2>
+    <p class="sec-desc"><code>aspect-ratio: 2 / 1</code></p>
+    <div class="ar-box ar-2-1"><span>2:1</span></div>
+  </section>
+
+  <section>
+    <h2>Responsive Comparison</h2>
+    <p class="sec-desc">All ratios side-by-side, resize the viewport to see responsive behavior</p>
+    <div class="ar-grid">
+      <div class="ar-box ar-square"><span>1:1</span></div>
+      <div class="ar-box ar-4-3"><span>4:3</span></div>
+      <div class="ar-box ar-16-9"><span>16:9</span></div>
+      <div class="ar-box ar-2-1"><span>2:1</span></div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/aspect-ratio/style.css
+++ b/submissions/examples/aspect-ratio/style.css
@@ -1,0 +1,43 @@
+/* ============================================================
+   EaseMotion CSS — Aspect Ratio
+   Maintaining element proportions with aspect-ratio
+   ============================================================ */
+
+.ar-box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
+  border-radius: 8px;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 1.1rem;
+  width: 100%;
+  max-width: 360px;
+}
+
+.ar-square {
+  aspect-ratio: 1 / 1;
+}
+
+.ar-4-3 {
+  aspect-ratio: 4 / 3;
+}
+
+.ar-16-9 {
+  aspect-ratio: 16 / 9;
+}
+
+.ar-2-1 {
+  aspect-ratio: 2 / 1;
+}
+
+.ar-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.ar-grid .ar-box {
+  max-width: none;
+}


### PR DESCRIPTION
## Description

This PR adds a pure-CSS example demonstrating the `aspect-ratio` property for maintaining element proportions — no JavaScript required.

## Features
- Square (1/1), classic (4/3), widescreen (16/9), cinema (2/1)
- Responsive comparison grid
- Pure CSS, no padding hacks needed

## Files Added

| File | Description |
|------|-------------|
| `demo.html` | Five sections showing different aspect ratios and a comparison grid |
| `style.css` | Pure CSS using aspect-ratio values |
| `README.md` | Documentation with usage and browser support |

## Related Issue
Closes #6994

<!-- re-trigger label sync -->