### PR TITLE
feat: add ease-rounded-none utility class

### DIFF
--- a/submissions/examples/ease-rounded-none-utility/README.md
+++ b/submissions/examples/ease-rounded-none-utility/README.md
@@ -1,0 +1,16 @@
+# ease-rounded-none Utility
+
+Removes border-radius from any element. Useful for overriding rounded styles.
+
+## Usage
+
+```html
+<img class="ease-rounded-none" src="..." alt="..." />
+<button class="ease-rounded-none">Sharp button</button>
+```
+
+## Classes
+
+| Class               | CSS Property     |
+| ------------------- | ---------------- |
+| `ease-rounded-none` | border-radius: 0 |

--- a/submissions/examples/ease-rounded-none-utility/demo.html
+++ b/submissions/examples/ease-rounded-none-utility/demo.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ease-rounded-none Utility Demo</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: Inter, sans-serif;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 2rem;
+        min-height: 100vh;
+        background: #f8fafc;
+        padding: 2rem;
+      }
+      h2 {
+        color: #7c3aed;
+      }
+      .grid {
+        display: flex;
+        gap: 2rem;
+        flex-wrap: wrap;
+        justify-content: center;
+        align-items: flex-start;
+      }
+      .card {
+        width: 200px;
+        background: #fff;
+        border: 2px solid #e2e8f0;
+        overflow: hidden;
+        text-align: center;
+      }
+      .card.rounded {
+        border-radius: 12px;
+      }
+      .card img {
+        width: 100%;
+        height: 120px;
+        object-fit: cover;
+        display: block;
+      }
+      .card .label {
+        padding: 0.75rem;
+        font-weight: 600;
+        font-size: 0.85rem;
+        color: #334155;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>ease-rounded-none Utility</h2>
+
+    <div class="grid">
+      <div class="card rounded">
+        <img
+          src="https://placehold.co/400x200/E2E8F0/64748B?text=Rounded"
+          alt="rounded"
+        />
+        <div class="label">With border-radius</div>
+      </div>
+      <div class="card rounded">
+        <img
+          src="https://placehold.co/400x200/E2E8F0/64748B?text=Sharp"
+          alt="sharp"
+          class="ease-rounded-none"
+        />
+        <div class="label">ease-rounded-none</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-rounded-none-utility/style.css
+++ b/submissions/examples/ease-rounded-none-utility/style.css
@@ -1,0 +1,5 @@
+/* EaseMotion CSS — ease-rounded-none utility */
+
+.ease-rounded-none {
+  border-radius: 0 !important;
+}


### PR DESCRIPTION
Removes border-radius from any element. Useful for overriding rounded styles on images, buttons, cards, etc.

Closes #7048

@gssoc26