### PR TITLE
feat: add ease-tooltip CSS-only animated tooltip component (issue #2729)

### DIFF
--- a/submissions/examples/ease-tooltip-gn/README.md
+++ b/submissions/examples/ease-tooltip-gn/README.md
@@ -1,0 +1,29 @@
+# ease-tooltip — CSS-only Animated Tooltips
+
+1. **What does this add?** Pure CSS tooltips that appear on hover/focus using a `data-tip` attribute and `::before` pseudo-elements with a fade + scale entrance animation. No JavaScript, no extra HTML required.
+2. **How is it used?**
+```html
+<!-- Just add data-tip — no extra HTML needed -->
+<button class="ease-btn ease-tooltip" data-tip="Click to save">
+  Save
+</button>
+
+<span class="ease-tooltip ease-tooltip-bottom ease-tooltip-dark"
+      data-tip="This opens in a new tab">
+  Learn more ↗
+</span>
+
+<!-- Positions -->
+<div class="ease-tooltip">Top (default)</div>
+<div class="ease-tooltip ease-tooltip-bottom">Bottom</div>
+<div class="ease-tooltip ease-tooltip-left">Left</div>
+<div class="ease-tooltip ease-tooltip-right">Right</div>
+
+<!-- Color variants -->
+<div class="ease-tooltip ease-tooltip-dark">Dark</div>
+<div class="ease-tooltip ease-tooltip-light">Light</div>
+
+<!-- Delay variant -->
+<div class="ease-tooltip ease-tooltip-delay">Appears after 500ms</div>
+```
+3. **Why is it useful?** Zero JavaScript, single attribute (`data-tip`) drives the content via `content: attr(data-tip)`, smooth fade+scale transition on hover/focus — aligned with EaseMotion CSS's animation-first, human-readable, zero-dependency philosophy. `:focus-visible` support included for keyboard accessibility.

--- a/submissions/examples/ease-tooltip-gn/demo.html
+++ b/submissions/examples/ease-tooltip-gn/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-tooltip – EaseMotion CSS</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3rem;
+      background: #1e1e2e;
+      color: #f5f5f5;
+      padding: 4rem 2rem;
+    }
+    h1 { font-size: 1.3rem; margin: 0; }
+    .row { display: flex; gap: 2.5rem; align-items: center; flex-wrap: wrap; justify-content: center; }
+    h3 { font-size: 0.8rem; color: #999; text-transform: uppercase; letter-spacing: 0.5px; margin: 0 0 1rem; text-align: center; }
+  </style>
+</head>
+<body>
+
+  <h1>ease-tooltip — CSS-only Animated Tooltips</h1>
+
+  <div class="row">
+    <div>
+      <h3>Top (default)</h3>
+      <button class="ease-btn ease-btn-primary ease-tooltip" data-tip="Click to save">
+        Save
+      </button>
+    </div>
+
+    <div>
+      <h3>Bottom</h3>
+      <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-bottom" data-tip="Appears below">
+        Bottom
+      </button>
+    </div>
+
+    <div>
+      <h3>Left</h3>
+      <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-left" data-tip="Appears to the left">
+        Left
+      </button>
+    </div>
+
+    <div>
+      <h3>Right</h3>
+      <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-right" data-tip="Appears to the right">
+        Right
+      </button>
+    </div>
+  </div>
+
+  <div class="row">
+    <div>
+      <h3>Dark (default)</h3>
+      <span class="ease-tooltip ease-tooltip-bottom ease-tooltip-dark" data-tip="This opens in a new tab" tabindex="0">
+        Learn more ↗
+      </span>
+    </div>
+
+    <div>
+      <h3>Light</h3>
+      <span class="ease-tooltip ease-tooltip-bottom ease-tooltip-light" data-tip="Light themed tooltip" tabindex="0">
+        Hover me
+      </span>
+    </div>
+
+    <div>
+      <h3>Delayed (500ms)</h3>
+      <button class="ease-btn ease-btn-outline ease-tooltip ease-tooltip-delay" data-tip="I appear after a pause" style="color:#fff; border-color:rgba(255,255,255,0.3);">
+        Hover and wait
+      </button>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-tooltip-gn/style.css
+++ b/submissions/examples/ease-tooltip-gn/style.css
@@ -1,0 +1,96 @@
+/* ============================================
+   EaseMotion CSS — ease-tooltip
+   CSS-only animated tooltips via data-tip
+   Issue #2729
+   ============================================ */
+
+.ease-tooltip {
+  position: relative;
+}
+
+/* Base tooltip — appears above */
+.ease-tooltip::before {
+  content: attr(data-tip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.9);
+  background: #111;
+  color: #fff;
+  padding: 0.35rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 10;
+}
+
+.ease-tooltip:hover::before,
+.ease-tooltip:focus-visible::before {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}
+
+/* Bottom variant */
+.ease-tooltip-bottom::before {
+  bottom: auto;
+  top: calc(100% + 8px);
+  transform: translateX(-50%) scale(0.9);
+}
+
+.ease-tooltip-bottom:hover::before,
+.ease-tooltip-bottom:focus-visible::before {
+  transform: translateX(-50%) scale(1);
+}
+
+/* Left variant */
+.ease-tooltip-left::before {
+  bottom: auto;
+  top: 50%;
+  left: auto;
+  right: calc(100% + 8px);
+  transform: translateY(-50%) scale(0.9);
+}
+
+.ease-tooltip-left:hover::before,
+.ease-tooltip-left:focus-visible::before {
+  transform: translateY(-50%) scale(1);
+}
+
+/* Right variant */
+.ease-tooltip-right::before {
+  bottom: auto;
+  top: 50%;
+  left: calc(100% + 8px);
+  transform: translateY(-50%) scale(0.9);
+}
+
+.ease-tooltip-right:hover::before,
+.ease-tooltip-right:focus-visible::before {
+  transform: translateY(-50%) scale(1);
+}
+
+/* Dark variant (default colors, explicit for clarity) */
+.ease-tooltip-dark::before {
+  background: #111;
+  color: #fff;
+}
+
+/* Light variant */
+.ease-tooltip-light::before {
+  background: #f5f5f5;
+  color: #111;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+/* Delay variant — appears after 500ms hover */
+.ease-tooltip-delay::before {
+  transition-delay: 0s;
+}
+
+.ease-tooltip-delay:hover::before,
+.ease-tooltip-delay:focus-visible::before {
+  transition-delay: 0.5s;
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-tooltip` — pure CSS tooltips triggered via a `data-tip` attribute and `::before` pseudo-element, with a fade+scale entrance animation. Includes position variants (top/bottom/left/right), color variants (dark/light), and a delayed-appearance variant. Closes #2729

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-tooltip-gn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
Seven tooltip utility classes: `.ease-tooltip` (base, top), `.ease-tooltip-bottom`, `.ease-tooltip-left`, `.ease-tooltip-right`, `.ease-tooltip-dark`, `.ease-tooltip-light`, and `.ease-tooltip-delay`.

**How does a developer use it?**
```html
<button class="ease-btn ease-tooltip" data-tip="Click to save">
  Save
</button>

<span class="ease-tooltip ease-tooltip-bottom ease-tooltip-dark"
      data-tip="This opens in a new tab">
  Learn more ↗
</span>
```

**Why does it fit EaseMotion CSS?**
Zero JavaScript and zero extra markup — just `data-tip` plus a class. Content is generated via `content: attr(data-tip)` with a smooth `opacity`/`transform` transition, aligned with EaseMotion CSS's animation-first, human-readable philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Added `:focus-visible` support alongside `:hover` for keyboard accessibility. The `.ease-tooltip-delay` variant uses `transition-delay` on hover only (not on hide), so the tooltip disappears immediately but takes 500ms to appear — feel free to adjust the timing value if a different convention is preferred.