### PR TITLE
feat: add ease-outline-none utility class

### DIFF
--- a/submissions/examples/ease-outline-none-utility/README.md
+++ b/submissions/examples/ease-outline-none-utility/README.md
@@ -1,0 +1,20 @@
+# ease-outline-none Utility
+
+Removes the outline from an element. Use this only when providing a custom focus indicator — never remove outlines without an accessible alternative.
+
+## Usage
+
+```html
+<button
+  class="ease-outline-none"
+  style="outline: 2px solid #6366f1; outline-offset: 2px;"
+>
+  Custom focus style
+</button>
+```
+
+## Classes
+
+| Class               | CSS Property  |
+| ------------------- | ------------- |
+| `ease-outline-none` | outline: none |

--- a/submissions/examples/ease-outline-none-utility/demo.html
+++ b/submissions/examples/ease-outline-none-utility/demo.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ease-outline-none Utility Demo</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: Inter, sans-serif;
+        max-width: 500px;
+        margin: 0 auto;
+        padding: 2rem;
+        background: #f8fafc;
+      }
+      h2 {
+        color: #6366f1;
+      }
+      .group {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: 1rem 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .group h3 {
+        margin: 0 0 0.75rem;
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #64748b;
+      }
+      button {
+        padding: 0.5rem 1rem;
+        margin-right: 0.5rem;
+        border: 2px solid #e2e8f0;
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 0.9rem;
+      }
+      .custom-focus:focus-visible {
+        outline: 3px solid #6366f1;
+        outline-offset: 2px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>ease-outline-none Utility</h2>
+
+    <div class="group">
+      <h3>Default outline on focus</h3>
+      <button>Button 1</button>
+      <button>Button 2</button>
+      <p style="margin-top: 0.5rem; font-size: 0.85rem; color: #64748b">
+        Tab to focus
+      </p>
+    </div>
+
+    <div class="group">
+      <h3>ease-outline-none (no custom fallback)</h3>
+      <button class="ease-outline-none">Button 1</button>
+      <button class="ease-outline-none">Button 2</button>
+      <p style="margin-top: 0.5rem; font-size: 0.85rem; color: #64748b">
+        No visible focus indicator — not accessible!
+      </p>
+    </div>
+
+    <div class="group">
+      <h3>ease-outline-none with custom focus</h3>
+      <button class="ease-outline-none custom-focus">Button 1</button>
+      <button class="ease-outline-none custom-focus">Button 2</button>
+      <p style="margin-top: 0.5rem; font-size: 0.85rem; color: #64748b">
+        Custom focus indicator replaces the default
+      </p>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-outline-none-utility/style.css
+++ b/submissions/examples/ease-outline-none-utility/style.css
@@ -1,0 +1,5 @@
+/* EaseMotion CSS — ease-outline-none utility */
+
+.ease-outline-none {
+  outline: none !important;
+}


### PR DESCRIPTION
Removes outline from an element. Use only with custom focus styles.

**Class:**
- ease-outline-none

Closes #7072

@gssoc26