### PR TITLE
feat: add copy-to-clipboard button for code blocks (issue #3047)

### DIFF
--- a/submissions/examples/code-copy-button-gn/README.md
+++ b/submissions/examples/code-copy-button-gn/README.md
@@ -1,0 +1,29 @@
+# Copy-to-Clipboard Button for Code Blocks
+
+1. **What does this add?** A "Copy" button that appears on hover over any code block, copies the snippet to the clipboard on click via the `navigator.clipboard` API, and briefly shows a "Copied!" confirmation before resetting.
+2. **How is it used?**
+```html
+<div class="code-block-wrapper">
+  <pre><code class="language-html">
+    &lt;button class="ease-btn ease-btn-primary"&gt;Primary&lt;/button&gt;
+  </code></pre>
+  <button class="copy-btn" aria-label="Copy code">Copy</button>
+</div>
+```
+```js
+document.querySelectorAll('.copy-btn').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const wrapper = btn.closest('.code-block-wrapper');
+    const code = wrapper.querySelector('code').innerText;
+    navigator.clipboard.writeText(code).then(() => {
+      btn.textContent = 'Copied!';
+      btn.classList.add('copied');
+      setTimeout(() => {
+        btn.textContent = 'Copy';
+        btn.classList.remove('copied');
+      }, 1500);
+    });
+  });
+});
+```
+3. **Why is it useful?** EaseMotion CSS is developer-facing documentation — developers frequently copy class names and snippets. A one-click copy button removes the friction of manual selection, fits the project's clean, minimal, dependency-free philosophy (pure JS, no libraries), and matches familiar UX patterns from GitHub, MDN, and Tailwind docs.

--- a/submissions/examples/code-copy-button-gn/demo.html
+++ b/submissions/examples/code-copy-button-gn/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Copy-to-Clipboard Code Blocks – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 700px;
+      margin: 0 auto;
+      padding: 3rem 1.5rem;
+      background: #1e1e2e;
+      color: #f5f5f5;
+    }
+    h1 { font-size: 1.3rem; }
+    p { color: #aaa; font-size: 0.9rem; }
+    pre {
+      background: #11111b;
+      color: #f5f5f5;
+      padding: 1rem 1rem 1rem 1rem;
+      border-radius: 8px;
+      font-size: 0.85rem;
+      line-height: 1.5;
+    }
+    code { font-family: 'Courier New', monospace; }
+  </style>
+</head>
+<body>
+
+  <h1>Copy-to-Clipboard Code Blocks</h1>
+  <p>Hover over a code block to reveal the "Copy" button. Clicking it copies the snippet and shows a "Copied!" confirmation.</p>
+
+  <div class="code-block-wrapper">
+    <pre><code class="language-html">&lt;button class="ease-btn ease-btn-primary"&gt;Primary&lt;/button&gt;</code></pre>
+    <button class="copy-btn" aria-label="Copy code">Copy</button>
+  </div>
+
+  <div class="code-block-wrapper">
+    <pre><code class="language-css">.ease-fade-in {
+  animation: ease-kf-fade-in 0.3s ease both;
+}</code></pre>
+    <button class="copy-btn" aria-label="Copy code">Copy</button>
+  </div>
+
+  <div class="code-block-wrapper">
+    <pre><code class="language-html">&lt;div class="ease-card ease-card-hover"&gt;
+  &lt;h3 class="ease-card-title"&gt;Title&lt;/h3&gt;
+&lt;/div&gt;</code></pre>
+    <button class="copy-btn" aria-label="Copy code">Copy</button>
+  </div>
+
+  <script>
+    document.querySelectorAll('.copy-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const wrapper = btn.closest('.code-block-wrapper');
+        const code = wrapper.querySelector('code').innerText;
+
+        navigator.clipboard.writeText(code).then(() => {
+          const originalText = btn.textContent;
+          btn.textContent = 'Copied!';
+          btn.classList.add('copied');
+
+          setTimeout(() => {
+            btn.textContent = originalText;
+            btn.classList.remove('copied');
+          }, 1500);
+        });
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/code-copy-button-gn/style.css
+++ b/submissions/examples/code-copy-button-gn/style.css
@@ -1,0 +1,40 @@
+/* ============================================
+   EaseMotion CSS — Copy-to-Clipboard Button
+   for code blocks (Issue #3047)
+   ============================================ */
+
+.code-block-wrapper {
+  position: relative;
+  margin: 1rem 0;
+}
+
+.code-block-wrapper pre {
+  margin: 0;
+  overflow-x: auto;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-family: inherit;
+  background: #7c3aed;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s ease, background 0.2s ease;
+}
+
+.code-block-wrapper:hover .copy-btn,
+.copy-btn:focus-visible {
+  opacity: 1;
+}
+
+.copy-btn.copied {
+  background: #16a34a;
+  opacity: 1;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a "Copy" button overlay for code blocks that copies the snippet to the clipboard via `navigator.clipboard` and shows a brief "Copied!" confirmation before resetting. Closes #3047

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/code-copy-button-gn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A `.code-block-wrapper` + `.copy-btn` pattern: a copy button that fades in on hover over a code block, copies the snippet on click, and shows a green "Copied!" state for 1.5s before resetting.

**How does a developer use it?**
```html
<div class="code-block-wrapper">
  <pre><code class="language-html">
    &lt;button class="ease-btn ease-btn-primary"&gt;Primary&lt;/button&gt;
  </code></pre>
  <button class="copy-btn" aria-label="Copy code">Copy</button>
</div>
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS is developer-facing documentation — a one-click copy button removes the friction of manually selecting snippets. Implemented in pure JS with no dependencies, matching the project's clean, minimal philosophy and familiar UX patterns from GitHub, MDN, and Tailwind docs.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser, includes 3 example code blocks)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Uses `navigator.clipboard.writeText()` (requires HTTPS or localhost — works fine on the docs site). The "Copied!" state resets after 1.5s; adjust the timeout if a different duration is preferred. `:focus-visible` is included alongside `:hover` so the button is reachable via keyboard.