### PR TITLE
fix: document patch for btn hover+active transform conflict (issue #3…

### DIFF
--- a/submissions/examples/fix-btn-hover-active-transform-gn/README.md
+++ b/submissions/examples/fix-btn-hover-active-transform-gn/README.md
@@ -1,0 +1,20 @@
+# Fix: `.ease-btn:active` Overrides `.ease-btn-hover:hover` Lift (#3650)
+
+> ⚠️ **For Maintainer:** This fix requires a change to `components/buttons.css`, which contributors cannot modify directly. This submission documents the proposed patch for review.
+
+1. **What's the bug?** `.ease-btn:active { transform: scale(0.97); }` is a global rule. When a button has both `.ease-btn` and `.ease-btn-hover`, clicking while hovering triggers `:active`, which overrides `.ease-btn-hover:hover`'s `translateY(-3px)` — the button loses its lift and just shrinks instead of lifting *and* squishing.
+2. **Proposed fix:** Add a new rule scoped to `.ease-btn-hover:active` that combines both transforms, placed after `.ease-btn-hover:hover` inside the existing `@media (hover: hover) and (pointer: fine)` block in `components/buttons.css`:
+```css
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-hover:hover {
+    transform: translateY(-3px);
+    /* ...existing box-shadow... */
+  }
+
+  .ease-btn-hover:active {
+    transform: translateY(-3px) scale(0.97);
+  }
+}
+```
+3. **How is it tested?** `demo.html` shows two buttons — one without the fix (shrinks on click, losing lift) and one with `.ease-btn-hover:active` applied (lifts and squishes together).
+4. **Why is it safe?** The new rule only applies to elements with both `.ease-btn-hover` and `:active` — it doesn't change `.ease-btn:active`'s behavior for buttons without `.ease-btn-hover`, and the `prefers-reduced-motion` block (which sets `transform: none !important` on `.ease-btn:active, .ease-btn-hover:hover`) should also have `.ease-btn-hover:active` added to it for consistency.

--- a/submissions/examples/fix-btn-hover-active-transform-gn/demo.html
+++ b/submissions/examples/fix-btn-hover-active-transform-gn/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Fix: btn hover+active transform conflict – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { background: #1e1e2e; color: #f5f5f5; padding: 2rem; }
+    h1 { font-size: 1.2rem; }
+    p { color: #aaa; max-width: 600px; }
+    .label { font-size: 0.8rem; color: #999; margin-bottom: 0.5rem; }
+    .col { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+  </style>
+</head>
+<body>
+
+  <h1>Fix #3650: Button hover + active transform conflict</h1>
+  <p>
+    Click and hold each button while hovering. The left button (before the fix)
+    loses its lift and just shrinks. The right button (after the fix) keeps the
+    lift <em>and</em> squishes simultaneously.
+  </p>
+
+  <div class="demo-wrapper">
+    <div class="col">
+      <div class="label">Before fix (active overrides hover)</div>
+      <button class="demo-btn" onmouseover="this.classList.remove('demo-btn-hover')">
+        Press me
+      </button>
+    </div>
+
+    <div class="col">
+      <div class="label">After fix (.ease-btn-hover:active)</div>
+      <button class="demo-btn demo-btn-hover">
+        Press me
+      </button>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/fix-btn-hover-active-transform-gn/style.css
+++ b/submissions/examples/fix-btn-hover-active-transform-gn/style.css
@@ -1,0 +1,58 @@
+/* ============================================
+   Fix for #3650 — .ease-btn:active overrides
+   .ease-btn-hover:hover translateY lift
+
+   This is an OVERRIDE/PATCH demonstrating the fix.
+   The maintainer should apply the highlighted rule
+   to components/buttons.css after .ease-btn-hover:hover.
+   ============================================ */
+
+@media (hover: hover) and (pointer: fine) {
+  /* Existing rule (unchanged) */
+  .ease-btn-hover:hover {
+    transform: translateY(-3px);
+  }
+
+  /* NEW: combine active + hover transforms instead of
+     letting .ease-btn:active's scale(0.97) win alone */
+  .ease-btn-hover:active {
+    transform: translateY(-3px) scale(0.97);
+  }
+}
+
+/* Demo styling */
+.demo-wrapper {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  padding: 2rem;
+  font-family: sans-serif;
+}
+
+.demo-btn {
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  border: none;
+  font-size: 0.95rem;
+  cursor: pointer;
+  color: #fff;
+  background: #6366f1;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  transition:
+    transform 300ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 300ms ease;
+}
+
+.demo-btn:active {
+  transform: scale(0.97);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .demo-btn-hover:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.3);
+  }
+  .demo-btn-hover:active {
+    transform: translateY(-3px) scale(0.97);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Documents the proposed fix for #3650 — `.ease-btn:active { transform: scale(0.97); }` overrides `.ease-btn-hover:hover`'s `translateY(-3px)` lift when both classes are combined, causing the button to lose its lift on click instead of lifting and squishing together. Proposes a new `.ease-btn-hover:active` rule combining both transforms. Closes #3650

---
## Type of Change
- [x] 🐛 Bug fix in an existing submission

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/fix-btn-hover-active-transform-gn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A documented patch proposal: a new `.ease-btn-hover:active` rule in `components/buttons.css` that sets `transform: translateY(-3px) scale(0.97)`, so hover-lift and active-squish compose instead of one overriding the other.

**How does a developer use it?**
```html
<button class="ease-btn ease-btn-primary ease-btn-hover">
  Press me
</button>
```
No new class names — the fix is purely an additional CSS rule for the existing `.ease-btn-hover` combination.

**Why does it fit EaseMotion CSS?**
Preserves the intended "lift on hover" interaction while still giving tactile click feedback, matching the library's animation-first design intent without introducing new classes or breaking existing markup.

---
## Demo
- [x] Demo added (`demo.html` shows before/after side-by-side — press-and-hold to compare)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
This PR intentionally does not modify `components/buttons.css` directly, since it's part of the project's build-restricted core. The README documents the exact rule to add inside the existing `@media (hover: hover) and (pointer: fine)` block, right after `.ease-btn-hover:hover`. Also recommend adding `.ease-btn-hover:active` to the `prefers-reduced-motion` block (alongside `.ease-btn:active, .ease-btn-hover:hover`) for consistency.