### PR TITLE
fix: document patch for stylelint legacy notation config (issue #2779)

### DIFF
--- a/submissions/examples/fix-stylelint-modern-notation-gn/README.md
+++ b/submissions/examples/fix-stylelint-modern-notation-gn/README.md
@@ -1,0 +1,16 @@
+# Fix: Stylelint Enforces Legacy CSS Notation (#2779)
+
+> ⚠️ **For Maintainer:** This fix requires editing `.stylelintrc.json`, a project configuration file which contributors cannot modify directly. This submission documents the proposed patch for review.
+
+1. **What's the bug?** `.stylelintrc.json` sets `"color-function-notation": "legacy"`, forcing comma-separated color values (`rgba(0, 0, 0, 0.5)`) instead of the modern space-separated syntax (`rgb(0 0 0 / 50%)`). It also sets `"media-feature-range-notation": "prefix"`, forcing old-style `min-width`/`max-width` media queries instead of the modern range-context syntax (`@media (width >= 768px)`).
+2. **Proposed fix:** Update `.stylelintrc.json`:
+```diff
+- "color-function-notation": "legacy",
++ "color-function-notation": "modern",
+
+- "media-feature-range-notation": "prefix",
++ "media-feature-range-notation": "context",
+```
+   (Per the issue, `"color-function-notation"` could also simply be removed, since `"modern"` is the default in `stylelint-config-standard`.)
+3. **How is it tested?** `demo.html` shows two visually identical cards — one written with modern notation, one with legacy notation — to illustrate the syntax difference these rules govern. Once the config is updated, the "legacy" card's syntax would start failing lint while the "modern" card's syntax would pass.
+4. **Why is this correct?** Modern CSS color functions (`rgb()`/`hsl()` with space-separated values and `/` for alpha) and range-context media queries (`width >= 768px`) are part of the CSS Color Module Level 4 and Media Queries Level 4 specs, supported in all current major browsers. Enforcing legacy syntax in a "modern" framework's linter actively discourages contributors from using up-to-date, more readable CSS.

--- a/submissions/examples/fix-stylelint-modern-notation-gn/demo.html
+++ b/submissions/examples/fix-stylelint-modern-notation-gn/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Fix: Stylelint legacy notation – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: sans-serif; background: #1e1e2e; color: #f5f5f5; padding: 2rem; max-width: 700px; }
+    h1 { font-size: 1.2rem; }
+    p { color: #aaa; font-size: 0.9rem; }
+    pre { background: #11111b; padding: 1rem; border-radius: 8px; font-size: 0.8rem; overflow-x: auto; }
+    .diff-remove { color: #f87171; }
+    .diff-add { color: #4ade80; }
+    .row { display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 1.5rem; }
+    .row > div { flex: 1; min-width: 220px; }
+  </style>
+</head>
+<body>
+
+  <h1>Fix #2779: Stylelint legacy CSS notation</h1>
+  <p>
+    <code>.stylelintrc.json</code> currently forces legacy comma-separated
+    color functions and old-style media feature prefixes. Both cards below
+    render identically — the difference is purely in syntax modernity.
+  </p>
+
+  <div class="row">
+    <div class="demo-card demo-card-modern">
+      <strong>Modern notation</strong><br/>
+      <code>rgb(108 99 255 / 80%)</code><br/>
+      <code>@media (width &gt;= 768px)</code>
+    </div>
+    <div class="demo-card demo-card-legacy">
+      <strong>Legacy notation</strong><br/>
+      <code>rgba(108, 99, 255, 0.8)</code><br/>
+      <code>@media (min-width: 768px)</code>
+    </div>
+  </div>
+
+  <h3>Proposed .stylelintrc.json diff</h3>
+  <pre>
+<span class="diff-remove">- "color-function-notation": "legacy",</span>
+<span class="diff-add">+ "color-function-notation": "modern",</span>
+
+<span class="diff-remove">- "media-feature-range-notation": "prefix",</span>
+<span class="diff-add">+ "media-feature-range-notation": "context",</span>
+  </pre>
+
+</body>
+</html>

--- a/submissions/examples/fix-stylelint-modern-notation-gn/style.css
+++ b/submissions/examples/fix-stylelint-modern-notation-gn/style.css
@@ -1,0 +1,39 @@
+/* ============================================
+   Fix for #2779 — .stylelintrc.json enforces
+   legacy CSS notation instead of modern standards
+
+   This is a documentation/demo file only.
+   See README.md for the proposed .stylelintrc.json diff.
+   ============================================ */
+
+.demo-card {
+  font-family: sans-serif;
+  padding: 1.5rem;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+  color: #fff;
+}
+
+/* Modern color-function-notation: space-separated, no commas */
+.demo-card-modern {
+  background: rgb(108 99 255 / 80%);
+}
+
+/* Legacy color-function-notation: comma-separated */
+.demo-card-legacy {
+  background: rgba(108, 99, 255, 0.8);
+}
+
+/* Modern media-feature-range-notation: context syntax */
+@media (width >= 768px) {
+  .demo-card-modern {
+    border: 2px solid rgb(167 139 250 / 100%);
+  }
+}
+
+/* Legacy media-feature-range-notation: prefix syntax */
+@media (min-width: 768px) {
+  .demo-card-legacy {
+    border: 2px solid rgba(167, 139, 250, 1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Documents the proposed fix for #2779 — `.stylelintrc.json` sets `"color-function-notation": "legacy"` and `"media-feature-range-notation": "prefix"`, forcing comma-separated color functions and old-style media query prefixes instead of modern CSS notation. Proposes updating both to `"modern"`/`"context"`. Closes #2779

---
## Type of Change
- [x] 🐛 Bug fix in an existing submission

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/fix-stylelint-modern-notation-gn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A documented patch proposal for `.stylelintrc.json`: change `"color-function-notation": "legacy"` → `"modern"` and `"media-feature-range-notation": "prefix"` → `"context"`.

**How does a developer use it?**
```diff
- "color-function-notation": "legacy",
+ "color-function-notation": "modern",

- "media-feature-range-notation": "prefix",
+ "media-feature-range-notation": "context",
```

**Why does it fit EaseMotion CSS?**
Modern color notation (`rgb(0 0 0 / 50%)`) and range-context media queries (`@media (width >= 768px)`) are part of current CSS specs supported across all major browsers — aligning the linter with modern standards lets contributors write more readable, up-to-date CSS that matches a "modern animation framework" identity.

---
## Demo
- [x] Demo added (`demo.html` shows side-by-side modern vs. legacy notation examples plus the proposed config diff)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---
## Notes for Maintainer
This PR intentionally does not modify `.stylelintrc.json` directly, since it's a project configuration file contributors cannot edit. The README documents the exact two-line diff. Note that `"color-function-notation": "modern"` is actually the default in `stylelint-config-standard`, so per the issue this line could also simply be removed entirely if preferred.