### PR TITLE
feat: add ease-counter animated count-up component (issue #2717)

### DIFF
--- a/submissions/examples/ease-counter-gn/README.md
+++ b/submissions/examples/ease-counter-gn/README.md
@@ -1,0 +1,16 @@
+# ease-counter — Animated Number Count-Up
+
+1. **What does this add?** A CSS-driven number count-up animation using `@property` + CSS `counter()` to animate from 0 to a target value (`--ease-count-to`) via `@keyframes`. No JavaScript required. Includes slow (3s) and fast (0.8s) duration variants, plus a suffix variant for `%`/`+` symbols.
+2. **How is it used?**
+```html
+<span class="ease-counter" style="--ease-count-to: 97">0</span>
+
+<span class="ease-counter ease-counter-slow ease-counter-suffix"
+      style="--ease-count-to: 1500; --ease-counter-suffix: '+';">0</span>
+
+<span class="ease-counter ease-counter-fast ease-counter-suffix"
+      style="--ease-count-to: 75; --ease-counter-suffix: '%';">0</span>
+```
+3. **Why is it useful?** Animated statistics ("97 projects completed", "1500+ happy users") are common in hero sections and landing pages. This uses `@property` to register `--ease-counter-val` as an animatable `<integer>`, then displays it via `counter()` on a pseudo-element — pure CSS, zero dependencies, aligned with EaseMotion CSS's animation-first, human-readable philosophy.
+
+**Note:** This complements the existing `.ease-count-up` utility in `core/animations.css` (which uses `--ease-count`) by adding named duration variants (`-slow`, `-fast`) and a suffix variant, with its own `--ease-counter-val`/`--ease-counter-suffix` properties to avoid naming collisions.

--- a/submissions/examples/ease-counter-gn/demo.html
+++ b/submissions/examples/ease-counter-gn/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-counter – EaseMotion CSS</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3rem;
+      background: #1e1e2e;
+      color: #f5f5f5;
+      padding: 4rem 2rem;
+    }
+    h1 { font-size: 1.3rem; margin: 0; }
+    .row { display: flex; gap: 3rem; flex-wrap: wrap; justify-content: center; }
+    .col { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+    h3 { font-size: 0.75rem; color: #999; text-transform: uppercase; letter-spacing: 0.5px; margin: 0; }
+    .counter-display {
+      font-size: 3rem;
+      font-weight: 800;
+      color: #a78bfa;
+    }
+    .replay-btn {
+      margin-top: 2rem;
+      padding: 0.5rem 1.25rem;
+      border-radius: 6px;
+      border: none;
+      background: #6366f1;
+      color: #fff;
+      cursor: pointer;
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>ease-counter — Animated Count-Up</h1>
+
+  <div class="row" id="counters">
+    <div class="col">
+      <h3>Default (2s)</h3>
+      <span class="counter-display ease-counter" style="--ease-count-to: 97;">0</span>
+    </div>
+
+    <div class="col">
+      <h3>Slow (3s) + Suffix</h3>
+      <span class="counter-display ease-counter ease-counter-slow ease-counter-suffix" style="--ease-count-to: 1500; --ease-counter-suffix: '+';">0</span>
+    </div>
+
+    <div class="col">
+      <h3>Fast (0.8s) + Suffix %</h3>
+      <span class="counter-display ease-counter ease-counter-fast ease-counter-suffix" style="--ease-count-to: 75; --ease-counter-suffix: '%';">0</span>
+    </div>
+  </div>
+
+  <button class="replay-btn" onclick="replay()">Replay animation</button>
+
+  <script>
+    function replay() {
+      document.querySelectorAll('.ease-counter').forEach((el) => {
+        el.style.animation = 'none';
+        void el.offsetWidth; // force reflow
+        el.style.animation = '';
+      });
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-counter-gn/style.css
+++ b/submissions/examples/ease-counter-gn/style.css
@@ -1,0 +1,57 @@
+/* ============================================
+   EaseMotion CSS — ease-counter
+   CSS-driven animated number count-up
+   Issue #2717
+   ============================================ */
+
+@property --ease-counter-val {
+  syntax: '<integer>';
+  initial-value: 0;
+  inherits: false;
+}
+
+@keyframes ease-counter-count {
+  from {
+    --ease-counter-val: 0;
+  }
+  to {
+    --ease-counter-val: var(--ease-count-to, 0);
+  }
+}
+
+/* Base — counts from 0 to --ease-count-to over 2s */
+.ease-counter {
+  font-variant-numeric: tabular-nums;
+  --ease-counter-val: 0;
+  animation: ease-counter-count 2s ease-out forwards;
+  counter-reset: ease-counter-display var(--ease-counter-val);
+}
+
+.ease-counter::before {
+  content: counter(ease-counter-display);
+}
+
+/* Hide the literal "0" text content in the element */
+.ease-counter {
+  font-size: 0;
+}
+
+.ease-counter::before {
+  font-size: 1em;
+}
+
+/* Slow variant — 3s */
+.ease-counter-slow {
+  animation-duration: 3s;
+}
+
+/* Fast variant — 0.8s */
+.ease-counter-fast {
+  animation-duration: 0.8s;
+}
+
+/* Suffix variant — appends % or + after the number */
+.ease-counter-suffix::after {
+  content: var(--ease-counter-suffix, "+");
+  font-size: 1em;
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-counter` — a pure CSS animated number count-up using `@property` and CSS `counter()`, animating from 0 to a target value defined via `--ease-count-to`. Includes slow (3s) and fast (0.8s) duration variants and a suffix variant for `%`/`+` symbols. Closes #2717

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-counter-gn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
Four classes: `.ease-counter` (base, 2s count-up), `.ease-counter-slow` (3s), `.ease-counter-fast` (0.8s), and `.ease-counter-suffix` (appends a `%`/`+` symbol via `--ease-counter-suffix`).

**How does a developer use it?**
```html
<span class="ease-counter" style="--ease-count-to: 97">0</span>

<span class="ease-counter ease-counter-slow ease-counter-suffix"
      style="--ease-count-to: 1500; --ease-counter-suffix: '+';">0</span>

<span class="ease-counter ease-counter-fast ease-counter-suffix"
      style="--ease-count-to: 75; --ease-counter-suffix: '%';">0</span>
```

**Why does it fit EaseMotion CSS?**
Uses `@property` to register an animatable custom property, then renders it via `counter()` on a pseudo-element — zero JavaScript, zero dependencies, and a natural fit for the animated-statistics pattern common in hero sections, aligned with the library's animation-first philosophy.

---
## Demo
- [x] Demo added (`demo.html` shows three variants with a "Replay animation" button)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
This complements the existing `.ease-count-up` utility in `core/animations.css` (which uses `--ease-count`/`--ease-count-target`) by adding named duration variants and a suffix variant under a separate `--ease-counter-val`/`--ease-counter-suffix` namespace to avoid naming collisions. The scroll-trigger behavior mentioned in the issue ("on scroll") is left to be combined with the existing `.ease-reveal` scroll-reveal utilities — happy to add an explicit usage example combining both if preferred.