### PR TITLE
fix: propose markdown table styles fix via submission

### DIFF
--- a/submissions/examples/markdown-table-fix-sb/README.md
+++ b/submissions/examples/markdown-table-fix-sb/README.md
@@ -1,0 +1,16 @@
+# Markdown Table Styles Fix (Base Styles)
+
+This submission provides base styling for standard HTML tables (`<table>`, `<th>`, `<td>`).
+
+## Description
+
+When markdown parsers compile markdown tables, they generate raw `<table>` elements without specific classes. Because `core/base.css` resets basic styling but does not supply base styles for tables, markdown tables visually render as plain, unformatted text without padding or borders.
+
+This proposal introduces base table styles that can be integrated into `core/base.css` to fix the display of raw markdown tables across documentation pages.
+
+## Features
+
+- Standard `border-collapse: collapse;`
+- Full-width table layout
+- Bottom borders for rows and headers using `--ease-color-neutral-200`
+- Padding using EaseMotion CSS spacing variables (`--ease-space-3` and `--ease-space-4`)

--- a/submissions/examples/markdown-table-fix-sb/demo.html
+++ b/submissions/examples/markdown-table-fix-sb/demo.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Markdown Table Base Styles Fix</title>
+    <link rel="stylesheet" href="../../../core/base.css" />
+    <link rel="stylesheet" href="../../../core/variables.css" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body
+    style="
+      padding: 2rem;
+      max-width: 800px;
+      margin: 0 auto;
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+    "
+  >
+    <h1>Raw HTML Table (Simulated Markdown Output)</h1>
+    <p>
+      This table does not use any specific classes. It relies entirely on the
+      base tag styling provided by this submission, which mimics what happens
+      when markdown is parsed to HTML.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Feature</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Fade In</td>
+          <td>Smooth fade animation</td>
+        </tr>
+        <tr>
+          <td>Slide Up</td>
+          <td>Upward entrance effect</td>
+        </tr>
+        <tr>
+          <td>Bounce</td>
+          <td>Infinite vertical bounce</td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/submissions/examples/markdown-table-fix-sb/style.css
+++ b/submissions/examples/markdown-table-fix-sb/style.css
@@ -1,0 +1,30 @@
+/* Base Table Styles (Proposed for integration into core/base.css) */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: var(--ease-space-6, 1.5rem);
+  text-align: left;
+}
+
+th,
+td {
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-4, 1rem);
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+th {
+  font-weight: 600;
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+/* Dark mode overrides (to match base.css style) */
+@media (prefers-color-scheme: dark) {
+  th,
+  td {
+    border-bottom: 1px solid var(--ease-color-neutral-800, #1e293b);
+  }
+
+  th {
+    color: var(--ease-color-neutral-50, #f8fafc);
+  }
+}


### PR DESCRIPTION
Proposes a fix for an issue where Markdown-generated HTML tables (and standard unclassed HTML tables) render as plain text due to missing base table styles.
closes #7249 
Because core/base.css resets basic styling but does not supply base structural styles for <table/>, markdown tables visually render without borders or padding on live documentation pages.

This submission provides the base table styles (with border-collapse, full-width, proper padding, and subtle bottom borders) that can be integrated directly into core/base.css by the maintainer.

Why is this useful for EaseMotion CSS?
As a developer-first CSS framework, EaseMotion CSS needs to support natively parsed markdown elements (since many developers use it for documentation sites). By integrating these minimal defaults into the core, tables generated from Markdown or headless CMS systems will be instantly readable without requiring the user to inject custom .ease-table classes into the generated HTML.

Type of change
 Bug Fix Proposal
Checklist
 I understand contributors cannot edit core/ files directly.
 This PR submits the proposed fix via a standard submission folder (submissions/examples/markdown-table-fix-sb/).
 The demo works by directly opening demo.html in a browser.
 The submission includes exactly demo.html, style.css, and README.md to pass the GitHub Actions validation.