### PR TITLE
feat: Add ease-border-gradient animated rotating gradient border utility (#2723)

### DIFF
--- a/submissions/examples/border-gradient/README.md
+++ b/submissions/examples/border-gradient/README.md
@@ -1,0 +1,147 @@
+# ease-border-gradient
+
+An animated rotating gradient border utility for [EaseMotion CSS](https://github.com/SAPTARSHI-coder/EaseMotion-css).
+
+Creates eye-catching glowing borders that rotate around any element — cards, buttons, inputs — using CSS `conic-gradient` and `@property`. Zero JavaScript.
+
+---
+
+## Preview
+
+Gradient border spins continuously around the element using a `conic-gradient` anchored to an animated `--ease-border-angle` CSS custom property.
+
+---
+
+## Usage
+
+### HTML Structure
+
+```html
+<!-- Card -->
+<div class="ease-card ease-border-gradient ease-border-gradient-purple">
+  Featured Plan
+</div>
+
+<!-- Button -->
+<button class="ease-btn ease-border-gradient ease-border-gradient-hover">
+  Get Started
+</button>
+
+<!-- Input -->
+<input class="ease-border-gradient ease-border-gradient-slow" placeholder="Email address" />
+```
+
+### Include the stylesheet
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+---
+
+## Available Classes
+
+| Class | Effect |
+|---|---|
+| `.ease-border-gradient` | Base class — rotating rainbow gradient border (required) |
+| `.ease-border-gradient-purple` | Purple → blue rotating border |
+| `.ease-border-gradient-sunset` | Orange → pink rotating border |
+| `.ease-border-gradient-slow` | 6s rotation speed |
+| `.ease-border-gradient-fast` | 1.5s rotation speed |
+| `.ease-border-gradient-hover` | Only animates on hover |
+
+---
+
+## How It Works (Technical)
+
+```css
+/* 1. Register @property so the browser can animate the angle */
+@property --ease-border-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+
+/* 2. Spin the angle via keyframes */
+@keyframes ease-border-spin {
+  to { --ease-border-angle: 360deg; }
+}
+
+/* 3. Use ::before pseudo-element with conic-gradient */
+.ease-border-gradient::before {
+  content: '';
+  position: absolute;
+  inset: -2px;               /* border thickness */
+  border-radius: inherit;
+  background: conic-gradient(
+    from var(--ease-border-angle, 0deg),
+    #7c3aed, #3b82f6, #06b6d4, #7c3aed
+  );
+  z-index: -1;
+  animation: ease-border-spin 3s linear infinite;
+}
+```
+
+The element's own background sits on top via `::after`, so only the border area shows the gradient.
+
+---
+
+## Features
+
+- ✅ Zero JavaScript — pure CSS only
+- ✅ Uses `@property` for smooth angle animation
+- ✅ 3 color variants (rainbow, purple, sunset)
+- ✅ 3 speed variants (slow, default, fast)
+- ✅ Hover-only mode for subtle interactions
+- ✅ Works on cards, buttons, and inputs
+- ✅ Reduced motion support — shows static gradient instead of spinning
+- ✅ Themeable via CSS custom properties
+
+---
+
+## CSS Custom Properties (Theming)
+
+```css
+:root {
+  --ease-border-width:       2px;
+  --ease-border-radius:      12px;
+  --ease-border-speed:       3s;
+  --ease-border-speed-slow:  6s;
+  --ease-border-speed-fast:  1.5s;
+
+  /* Rainbow colors */
+  --ease-border-c1: #7c3aed;
+  --ease-border-c2: #3b82f6;
+  --ease-border-c3: #06b6d4;
+  --ease-border-c4: #7c3aed;
+}
+```
+
+---
+
+## File Structure
+
+```
+border-gradient/
+├── style.css     # Component styles
+├── demo.html     # Interactive demo page
+└── README.md     # This file
+```
+
+---
+
+## Browser Support
+
+`@property` is supported in Chrome, Edge, and Firefox 128+. Safari support landed in Safari 17.2+. For older browsers the border still renders — it just won't animate smoothly (falls back to a static gradient).
+
+---
+
+## Closes
+
+Resolves issue [#2723](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/2723)
+
+---
+
+## Author
+
+Contributed as part of **Girl script  Summer of Code 2026**

--- a/submissions/examples/border-gradient/demo.html
+++ b/submissions/examples/border-gradient/demo.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-border-gradient — EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      min-height: 100vh;
+      background: #0f1120;
+      font-family: system-ui, -apple-system, sans-serif;
+      color: #e8ecf5;
+      padding: 3rem 1.5rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 3rem;
+    }
+
+    h1 {
+      font-size: 1.6rem;
+      font-weight: 700;
+      text-align: center;
+      letter-spacing: -0.02em;
+    }
+    h1 span { color: #7c3aed; }
+
+    h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: #5a6180;
+      margin-bottom: 1.25rem;
+      text-align: center;
+    }
+
+    .demo-section {
+      width: 100%;
+      max-width: 700px;
+    }
+
+    .demo-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      justify-content: center;
+    }
+
+    /* ── Card base (the element getting the gradient border) ── */
+    .demo-card {
+      background: #1a1d2e;
+      border-radius: 12px;
+      padding: 2rem 1.75rem;
+      width: 200px;
+      text-align: center;
+    }
+
+    .demo-card .badge {
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #8892a4;
+      margin-bottom: 0.5rem;
+    }
+    .demo-card .price {
+      font-size: 2rem;
+      font-weight: 800;
+      color: #e8ecf5;
+    }
+    .demo-card .desc {
+      font-size: 0.8rem;
+      color: #5a6180;
+      margin-top: 0.35rem;
+    }
+
+    /* ── Button base ── */
+    .demo-btn {
+      background: #1a1d2e;
+      color: #e8ecf5;
+      font-size: 0.9rem;
+      font-weight: 600;
+      padding: 0.7rem 1.75rem;
+      cursor: pointer;
+      display: inline-block;
+    }
+
+    /* ── Input base ── */
+    .demo-input {
+      background: #1a1d2e;
+      color: #e8ecf5;
+      font-size: 0.95rem;
+      font-family: inherit;
+      padding: 0.75rem 1rem;
+      width: 280px;
+      display: block;
+    }
+    .demo-input::placeholder { color: #5a6180; }
+
+    /* ── Speed label tags ── */
+    .tag {
+      display: inline-block;
+      font-size: 0.65rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      padding: 0.2rem 0.55rem;
+      border-radius: 999px;
+      background: #2e3452;
+      color: #8892a4;
+      margin-bottom: 0.6rem;
+    }
+  </style>
+</head>
+<body>
+
+  <div>
+    <h1><span>ease-border-gradient</span></h1>
+    <p style="color:#5a6180;font-size:0.85rem;text-align:center;margin-top:0.5rem;">
+      Animated rotating gradient borders — pure CSS, zero JavaScript
+    </p>
+  </div>
+
+
+  <!-- ── 1. Color variants ── -->
+  <div class="demo-section">
+    <h2>Color Variants</h2>
+    <div class="demo-grid">
+
+      <div class="demo-card ease-border-gradient">
+        <div class="badge">Rainbow</div>
+        <div class="price">$9</div>
+        <div class="desc">.ease-border-gradient</div>
+      </div>
+
+      <div class="demo-card ease-border-gradient ease-border-gradient-purple">
+        <div class="badge">Purple</div>
+        <div class="price">$19</div>
+        <div class="desc">.ease-border-gradient-purple</div>
+      </div>
+
+      <div class="demo-card ease-border-gradient ease-border-gradient-sunset">
+        <div class="badge">Sunset</div>
+        <div class="price">$29</div>
+        <div class="desc">.ease-border-gradient-sunset</div>
+      </div>
+
+    </div>
+  </div>
+
+
+  <!-- ── 2. Speed variants ── -->
+  <div class="demo-section">
+    <h2>Speed Variants</h2>
+    <div class="demo-grid">
+
+      <div style="text-align:center;">
+        <div class="tag">Slow — 6s</div>
+        <div class="demo-card ease-border-gradient ease-border-gradient-purple ease-border-gradient-slow">
+          <div class="price" style="font-size:1rem;">Slow</div>
+          <div class="desc">.ease-border-gradient-slow</div>
+        </div>
+      </div>
+
+      <div style="text-align:center;">
+        <div class="tag">Default — 3s</div>
+        <div class="demo-card ease-border-gradient ease-border-gradient-sunset">
+          <div class="price" style="font-size:1rem;">Default</div>
+          <div class="desc">(no speed class)</div>
+        </div>
+      </div>
+
+      <div style="text-align:center;">
+        <div class="tag">Fast — 1.5s</div>
+        <div class="demo-card ease-border-gradient ease-border-gradient-fast">
+          <div class="price" style="font-size:1rem;">Fast</div>
+          <div class="desc">.ease-border-gradient-fast</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+
+  <!-- ── 3. Hover-only variant ── -->
+  <div class="demo-section">
+    <h2>Hover-only Variant</h2>
+    <div class="demo-grid" style="flex-direction:column;align-items:center;gap:1rem;">
+
+      <button class="demo-btn ease-border-gradient ease-border-gradient-hover ease-border-gradient-purple">
+        Hover me — Get Started
+      </button>
+
+      <button class="demo-btn ease-border-gradient ease-border-gradient-hover ease-border-gradient-sunset">
+        Hover me — Learn More
+      </button>
+
+    </div>
+  </div>
+
+
+  <!-- ── 4. On an input field ── -->
+  <div class="demo-section">
+    <h2>On an Input Field</h2>
+    <div class="demo-grid">
+      <input
+        class="demo-input ease-border-gradient ease-border-gradient-purple ease-border-gradient-slow"
+        placeholder="Email address"
+        type="email"
+      />
+    </div>
+  </div>
+
+
+</body>
+</html>

--- a/submissions/examples/border-gradient/style.css
+++ b/submissions/examples/border-gradient/style.css
@@ -1,0 +1,180 @@
+/* ==========================================================================
+   EaseMotion CSS — Animated Gradient Border Component
+   Component: ease-border-gradient
+   Version: 1.0.0
+   Description: Rotating gradient borders using CSS conic-gradient and
+                @property for smooth angle animation. Zero JavaScript.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   @property registration — enables smooth CSS animation of the angle
+   (Without this, browsers can't interpolate/animate custom angle values)
+   -------------------------------------------------------------------------- */
+@property --ease-border-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+
+
+/* --------------------------------------------------------------------------
+   Keyframes
+   -------------------------------------------------------------------------- */
+@keyframes ease-border-spin {
+  to { --ease-border-angle: 360deg; }
+}
+
+
+/* --------------------------------------------------------------------------
+   CSS Custom Properties (Tokens)
+   Override in :root to theme globally, or on a selector to theme locally.
+   -------------------------------------------------------------------------- */
+:root {
+  --ease-border-width:       2px;
+  --ease-border-radius:      12px;
+  --ease-border-speed:       3s;           /* default rotation speed */
+  --ease-border-speed-slow:  6s;
+  --ease-border-speed-fast:  1.5s;
+
+  /* Rainbow gradient stops */
+  --ease-border-c1: #7c3aed;
+  --ease-border-c2: #3b82f6;
+  --ease-border-c3: #06b6d4;
+  --ease-border-c4: #7c3aed;
+
+  /* Purple–Blue gradient stops */
+  --ease-border-purple-c1: #7c3aed;
+  --ease-border-purple-c2: #6d28d9;
+  --ease-border-purple-c3: #3b82f6;
+  --ease-border-purple-c4: #7c3aed;
+
+  /* Sunset gradient stops */
+  --ease-border-sunset-c1: #f97316;
+  --ease-border-sunset-c2: #ec4899;
+  --ease-border-sunset-c3: #f59e0b;
+  --ease-border-sunset-c4: #f97316;
+}
+
+
+/* --------------------------------------------------------------------------
+   Base — .ease-border-gradient
+   Applies the rotating gradient border via ::before pseudo-element.
+   The element itself keeps its own background; the pseudo sits behind it.
+   -------------------------------------------------------------------------- */
+.ease-border-gradient {
+  position: relative;
+  border-radius: var(--ease-border-radius);
+  z-index: 0;
+
+  /* Remove any native border so our pseudo-element border is the only one */
+  border: none !important;
+  outline: none;
+}
+
+.ease-border-gradient::before {
+  content: '';
+  position: absolute;
+  inset: calc(-1 * var(--ease-border-width));
+  border-radius: inherit;
+  background: conic-gradient(
+    from var(--ease-border-angle, 0deg),
+    var(--ease-border-c1),
+    var(--ease-border-c2),
+    var(--ease-border-c3),
+    var(--ease-border-c4)
+  );
+  z-index: -1;
+  animation: ease-border-spin var(--ease-border-speed) linear infinite;
+}
+
+/* Clip the glow to just the border area for a clean border look */
+.ease-border-gradient::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: inherit;
+  z-index: -1;
+}
+
+
+/* --------------------------------------------------------------------------
+   Color Variants
+   -------------------------------------------------------------------------- */
+
+/* Purple → Blue */
+.ease-border-gradient-purple::before {
+  background: conic-gradient(
+    from var(--ease-border-angle, 0deg),
+    var(--ease-border-purple-c1),
+    var(--ease-border-purple-c2),
+    var(--ease-border-purple-c3),
+    var(--ease-border-purple-c4)
+  );
+}
+
+/* Orange → Pink (Sunset) */
+.ease-border-gradient-sunset::before {
+  background: conic-gradient(
+    from var(--ease-border-angle, 0deg),
+    var(--ease-border-sunset-c1),
+    var(--ease-border-sunset-c2),
+    var(--ease-border-sunset-c3),
+    var(--ease-border-sunset-c4)
+  );
+}
+
+
+/* --------------------------------------------------------------------------
+   Speed Variants
+   -------------------------------------------------------------------------- */
+.ease-border-gradient-slow::before {
+  animation-duration: var(--ease-border-speed-slow);
+}
+
+.ease-border-gradient-fast::before {
+  animation-duration: var(--ease-border-speed-fast);
+}
+
+
+/* --------------------------------------------------------------------------
+   Hover-only Variant — animates only on :hover
+   -------------------------------------------------------------------------- */
+.ease-border-gradient-hover::before {
+  animation-play-state: paused;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.ease-border-gradient-hover:hover::before {
+  animation-play-state: running;
+  opacity: 1;
+}
+
+
+/* --------------------------------------------------------------------------
+   Reduced-motion: stop all rotation for users who prefer it
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-border-gradient::before {
+    animation: none;
+    /* Show a static gradient snapshot instead of spinning */
+    background: conic-gradient(
+      from 45deg,
+      var(--ease-border-c1),
+      var(--ease-border-c2),
+      var(--ease-border-c3),
+      var(--ease-border-c4)
+    );
+  }
+}
+
+
+/* --------------------------------------------------------------------------
+   Dark mode — slightly increase border width for better visibility
+   -------------------------------------------------------------------------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-border-width: 2.5px;
+  }
+}


### PR DESCRIPTION
Pull Request Description
Adds ease-border-gradient, an animated rotating gradient border utility using CSS conic-gradient and @property. Supports 3 color variants, 3 speed variants, and a hover-only mode. Zero JavaScript. Resolves #2723.

Type of Change

 ✨ New animation / hover effect
 🧩 New component
 📝 Documentation improvement
 🐛 Bug fix in an existing submission
 Other (describe below)


Submission Checklist

 All changes are inside submissions/examples/border-gradient/
 Includes demo.html — self-contained, opens in browser with no server
 Includes style.css — raw CSS for the proposed feature
 Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
 No changes to core/
 No changes to components/
 One feature per PR (no bundled unrelated changes)


Feature Description
What does this add?

A rotating gradient border utility that wraps any element — card, button, or input — with a smoothly animated conic-gradient border using only CSS.
How does a developer use it?
html<!-- Card -->
<div class="ease-card ease-border-gradient ease-border-gradient-purple">
  Featured Plan
</div>

<!-- Button (hover only) -->
<button class="ease-btn ease-border-gradient ease-border-gradient-hover">
  Get Started
</button>

<!-- Input -->
<input class="ease-border-gradient ease-border-gradient-slow" placeholder="Email address" />
Why does it fit EaseMotion CSS?

It brings a whole new visual category — animated borders — to the framework using only CSS @property, conic-gradient, and ::before pseudo-elements. No JavaScript, fully composable classes, and reduced-motion safe.

Demo

 Demo added (demo.html works by opening directly in a browser)


Browser Testing

 Chrome
 Firefox
 Edge
 Safari (optional but appreciated)


Notes for Maintainer

Uses @property to register --ease-border-angle so the browser can smoothly interpolate the conic-gradient rotation. Without @property, the animation would jump instead of spin.
Falls back gracefully in unsupported browsers — border still renders as a static gradient.
prefers-reduced-motion is handled — animation stops and shows a static gradient snapshot.
The ::after pseudo-element covers the element's background so only the border strip shows the gradient.
All timings and colors are CSS custom properties — easy to override per-element.