### PR TITLE
bug/fix: Resolve z-index stacking context isolation failure and layer bleeding 

### DIFF
--- a/submissions/examples/layer-bleeding-fix/README.md
+++ b/submissions/examples/layer-bleeding-fix/README.md
@@ -1,0 +1,34 @@
+# Stacking Context Isolation & Layer Bleeding Patch
+
+## What does this do?
+
+This utility resolves z-index stacking context isolation failures and layer bleeding bugs inside sticky or fixed scrolling headers. It prevents GPU-accelerated sibling elements from bleeding over header bars during scrolls.
+
+## How is it used?
+
+Attach the stacking context isolation class to sticky or fixed header elements to protect them from overlay bleed leaks:
+
+```html
+<header class="sticky-header ease-stack-isolation-shield">
+  <h3>Header Content</h3>
+</header>
+
+<main class="accelerated-page-content">
+  <!-- Accelerated elements slide underneath correctly -->
+</main>
+```
+
+## Why is it useful?
+
+- **Restricts accelerated bleeding**: Sibling nodes with active GPU compositor states (`will-change`, `transform: translate3d`) automatically establish new stacking contexts. This layout patch isolates these contexts.
+- **Independent Stacking Root**: Employs `isolation: isolate` combined with explicit z-indexing, forcing the header to form a clean parent stacking context that accelerated children cannot breach.
+- **Maintains Header Transparency Blurs**: Preserves backdrop-filters and transparent background values without introducing graphic overlaps on mobile WebKit and Blink layout engines.
+
+## Tech Stack
+
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+
+Open `demo.html` directly in your browser to inspect the side-by-side simulated panels and scroll behavior.

--- a/submissions/examples/layer-bleeding-fix/demo.html
+++ b/submissions/examples/layer-bleeding-fix/demo.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stacking Context Isolation Patch - EaseMotion CSS</title>
+    <!-- Link to EaseMotion CSS core -->
+    <link rel="stylesheet" href="../../../core/animations.css" />
+    <!-- Link to local CSS -->
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      /* Demo presentation layout wrapping style.css settings */
+      body {
+        flex-direction: column;
+        gap: 1.5rem;
+        padding: 3rem 1.5rem;
+        box-sizing: border-box;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+      .demo-header {
+        text-align: center;
+        max-width: 640px;
+      }
+      .demo-header h1 {
+        margin: 0 0 0.5rem 0;
+        font-size: 2.2rem;
+        font-weight: 750;
+        letter-spacing: -0.5px;
+        background: linear-gradient(135deg, #ffffff 0%, #a0aec0 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+      .demo-header p {
+        margin: 0;
+        font-size: 1rem;
+        color: #718096;
+        line-height: 1.6;
+      }
+      .lab-panel-grid {
+        display: flex;
+        gap: 2.5rem;
+        flex-wrap: wrap;
+        justify-content: center;
+        width: 100%;
+        max-width: 1200px;
+        margin-top: 1rem;
+      }
+      .lab-card {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        width: 100%;
+        max-width: 480px;
+      }
+      .card-title {
+        font-size: 1.15rem;
+        font-weight: 600;
+        margin: 0;
+      }
+      .card-title.bugged {
+        color: #ff4d4d;
+      }
+      .card-title.patched {
+        color: var(--ease-accent-neon);
+      }
+      .card-desc {
+        font-size: 0.85rem;
+        color: #718096;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .scroll-helper-text {
+        padding: 1.5rem;
+        font-size: 0.85rem;
+        color: #5a6578;
+        text-align: center;
+        border-top: 1px dashed rgba(255, 255, 255, 0.05);
+      }
+      .tech-pill {
+        font-size: 0.75rem;
+        font-family: monospace;
+        padding: 0.25rem 0.5rem;
+        border-radius: 6px;
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        color: #a0aec0;
+        align-self: flex-start;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="demo-header">
+      <h1>Stacking Context Isolation Lab</h1>
+      <p>
+        3D-accelerated elements generate their own independent stacking layers.
+        If sibling headers lack isolation roots, accelerated nodes bleed over
+        sticky structures, disregarding z-index values. Scroll the panels below
+        to view the bug and its fix.
+      </p>
+    </div>
+
+    <div class="lab-panel-grid">
+      <!-- Panel 1: Bugged bleeding layer layout -->
+      <div class="lab-card">
+        <h3 class="card-title bugged">⚠️ Stacking Context Bleeding</h3>
+        <p class="card-desc">
+          Sticky header has z-index 999. Scroll down: the accelerated card
+          overlaps and bleeds over the header due to independent stacking
+          contexts.
+        </p>
+
+        <div
+          class="ease-app-container"
+          style="height: 320px; overflow-y: scroll"
+        >
+          <div class="bugged-sticky-header">Sticky Header (Bleeds)</div>
+          <div class="ease-animated-content-node">
+            <h4>Accelerated Content</h4>
+            <p>
+              This box uses transform properties that force GPU compositing. In
+              WebKit/Blink, this causes it to overlay the sticky header during
+              scrolls.
+            </p>
+          </div>
+          <div class="scroll-helper-text" style="height: 250px">
+            Scroll down to see the bleeding overlap...
+          </div>
+        </div>
+        <span class="tech-pill">z-index: 999 (No isolation)</span>
+      </div>
+
+      <!-- Panel 2: Patched isolated layer layout -->
+      <div class="lab-card">
+        <h3 class="card-title patched">✨ Stacking Context Shielded</h3>
+        <p class="card-desc">
+          Patched using isolation: isolate. Scroll down: the accelerated card
+          slides correctly underneath the sticky header.
+        </p>
+
+        <div
+          class="ease-app-container"
+          style="height: 320px; overflow-y: scroll"
+        >
+          <div class="ease-stack-isolation-shield">
+            Sticky Header (Isolated)
+          </div>
+          <div class="ease-animated-content-node">
+            <h4>Accelerated Content</h4>
+            <p>
+              By forcing an independent stacking context root, the sticky header
+              prevents layer bleeding. Sibling boxes slide underneath.
+            </p>
+          </div>
+          <div class="scroll-helper-text" style="height: 250px">
+            Scroll down to see the correct behavior...
+          </div>
+        </div>
+        <span class="tech-pill">isolation: isolate; z-index: 999;</span>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/layer-bleeding-fix/style.css
+++ b/submissions/examples/layer-bleeding-fix/style.css
@@ -1,0 +1,73 @@
+/* ==========================================================================
+   EaseMotion Stacking Context Isolation & Layer Bleeding Patch
+   ========================================================================== */
+
+:root {
+  --ease-bleed-bg: #05070c;
+  --ease-panel-dark: #10121d;
+  --ease-header-color: rgba(18, 20, 32, 0.85);
+  --ease-accent-neon: #00f2fe;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background-color: var(--ease-bleed-bg);
+  color: #ffffff;
+  min-height: 120vh; /* Extended viewport height to demonstrate scrolling layout behavior */
+}
+
+/* Simulated Scrolling Application Window Frame */
+.ease-app-container {
+  width: 100%;
+  max-width: 600px;
+  margin: 2rem auto;
+  position: relative;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  overflow: hidden;
+  background: #090a12;
+}
+
+/* ❌ Default Position Fixed Header prone to stacking bleed leaks */
+.bugged-sticky-header {
+  position: sticky;
+  top: 0;
+  background: var(--ease-header-color);
+  backdrop-filter: blur(12px);
+  padding: 1.25rem;
+  border-bottom: 1px solid rgba(255, 74, 90, 0.3);
+  /* High Z-Index fails under standard WebKit conditions if siblings are accelerated */
+  z-index: 999;
+}
+
+/* 🚀 The Core Patched Stacking Isolation Shield Class */
+.ease-stack-isolation-shield {
+  position: sticky;
+  top: 0;
+  background: var(--ease-header-color);
+  backdrop-filter: blur(12px);
+  padding: 1.25rem;
+  border-bottom: 1px solid var(--ease-accent-neon);
+
+  /* Crucial Fix: Explicitly shields and forces an independent isolated structural layer root */
+  isolation: isolate;
+  z-index: 999;
+}
+
+/* Dynamic Interactive Animation Sibling Node */
+.ease-animated-content-node {
+  background: var(--ease-panel-dark);
+  margin: 2rem 1.5rem;
+  padding: 2rem;
+  border-radius: 12px;
+  /* 3D transform creates a new stack context that triggers the bleed bug */
+  transform: translate3d(0, 0, 0) scale(1);
+  will-change: transform;
+  position: relative;
+  z-index: 5;
+}


### PR DESCRIPTION
### Target Issue
Closes #7435

### Description
Introduced an isolated structural layer fix—the Stacking Context Isolation Shield—under the isolated examples layout structure. This patch resolves browser layout bleeding glitches where hardware-accelerated elements visually break layer priorities underneath sticky navbars.

- **Explicit Isolation Boundary:** Embeds the modern CSS `isolation: isolate` property to hard-lock the stacking root configuration cleanly.
- **Bleeding Prevention:** Prevents dynamic 3D transitions and canvas transformations from overflowing layered container depths.
- **Autonomous Subfolder Execution:** Deployed strictly within `submissions/examples/layer-bleeding-fix/` ensuring 100% core codebase safety.

### Checklist
- [x] Code strictly adheres to the isolated subfolder architecture constraints (`submissions/examples/...`)
- [x] Sandboxed workspace features independent `demo.html`, `style.css`, and `README.md` assets
- [x] Prettier codebase linting and formatting pass with zero errors