### PR TITLE
feat: add copy button for documentation code blocks

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -20,6 +20,7 @@
   --heading-color: #ffffff;
   --heading-sub-color: rgba(255, 255, 255, 0.9);
   --title-gradient-end: #a78bfa;
+  --copy-button-bg : rgba(255, 255, 255, 0.15);  
 
   /* Overrides for EaseMotion variables in dark mode */
   --ease-color-bg: #0f0e17;
@@ -52,6 +53,7 @@
   --heading-color: #0f172a;
   --heading-sub-color: #1e293b;
   --title-gradient-end: #4f46e5;
+  --copy-button-bg : rgba(15, 23, 42, 0.08);
 
   /* Overrides for EaseMotion variables in light mode */
   --ease-color-bg: #f8fafc;
@@ -433,6 +435,7 @@ a.sidebar-group-label:hover {
   opacity: 0.5;
   font-family: var(--ease-font-mono);
   transition: opacity var(--ease-speed-fast) var(--ease-ease);
+  padding-right: 20px;
 }
 
 .docs-content code {
@@ -554,6 +557,54 @@ a.sidebar-group-label:hover {
   background: rgba(255, 255, 255, 0.2);
   color: #fff;
 }
+
+
+
+.docs-code {
+  position: relative;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 14px;
+  right: 10px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 11px;
+  height: 11px;
+
+  border: none;
+  border-radius: 8px;
+
+  cursor: pointer;
+
+  background: var(--copy-button-bg);
+  backdrop-filter: blur(8px);
+
+  color: currentColor;
+
+  transition: all 0.2s ease;
+}
+
+.copy-btn:hover {
+  transform: translateY(-1px);
+}
+
+.copy-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.copy-btn.copied {
+  width: auto;
+  padding: 8px 10px;
+  font-size: 0.65rem;
+  font-weight: 600;
+}
+
 
 /* ── Scroll to Top ────────────────────────────────────── */
 .ease-scroll-top {

--- a/docs/index.html
+++ b/docs/index.html
@@ -838,6 +838,52 @@
           window.scrollTo({ top: 0, behavior: "smooth" })
         );
       })();
+
+      // ── Copy Code Buttons ─────────────────────────────
+      document.addEventListener("DOMContentLoaded", () => {
+      const clipboardIcon = `
+      <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+      >
+      <rect x="9" y="9" width="13" height="13" rx="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+      </svg>
+      `;
+
+      document.querySelectorAll(".docs-code").forEach((block) => {
+        const button = document.createElement("button");
+
+        button.className = "copy-btn";
+        button.innerHTML = clipboardIcon;
+        button.setAttribute("aria-label", "Copy code");
+
+        block.appendChild(button);
+
+        button.addEventListener("click", async () => {
+          const code = block.querySelector("code");
+
+          if (!code) return;
+
+          try {
+            await navigator.clipboard.writeText(code.innerText);
+
+            button.classList.add("copied");
+            button.textContent = "Copied!";
+
+            setTimeout(() => {
+              button.classList.remove("copied");
+              button.innerHTML = clipboardIcon;
+            }, 2000);
+          } catch (err) {
+            console.error("Copy failed:", err);
+          }
+        });
+      });
+    });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Pull Request Description

Adds a copy-to-clipboard button for all documentation code blocks to improve developer experience when copying examples from the docs page.

Fixes #6354

---

## Type of Change

* [x] 📝 Documentation improvement

---

## Submission Checklist

This PR addresses a documentation issue and does not add a new submission under `submissions/examples/`.

* [ ] All changes are inside `submissions/examples/your-feature-name/`
* [ ] Includes `demo.html`
* [ ] Includes `style.css`
* [ ] Includes `README.md`
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR

---

## Feature Description

**What does this add?**

Adds a copy button to every documentation code block.

**How does a developer use it?**

Users can click the clipboard icon in the top-right corner of any code snippet to copy its contents instantly.

**Why does it fit EaseMotion CSS?**

This improves the documentation experience by making code examples easier to use and reducing friction when testing components and utilities.

---

## Demo

* [x] Tested locally

### Features

* SVG clipboard icon
* Copies complete code block content
* "Copied!" feedback after successful copy
* Supports all existing and future `.docs-code` blocks automatically
* Compatible with light and dark themes

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [ ] Edge
* [ ] Safari

---

## Notes for Maintainer

The implementation is dynamic and automatically attaches copy functionality to all `.docs-code` elements without requiring manual updates to individual code blocks.