### PR TITLE
[Docs]: Framework Integration Guides — React, Vue, and Astro

### DIFF
--- a/docs/framework-integration-astro.md
+++ b/docs/framework-integration-astro.md
@@ -1,0 +1,83 @@
+# Using EaseMotion CSS with Astro
+
+## Installation
+
+```bash
+npm install easemotion-css
+```
+
+## Global Import
+
+Import the stylesheet in your layout or page frontmatter:
+
+```astro
+---
+// src/layouts/BaseLayout.astro
+import 'easemotion-css/easemotion.min.css';
+---
+<html lang="en">
+  <head>
+    <title>My Site</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+```
+
+## Component Example
+
+```astro
+---
+// src/pages/index.astro
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+<BaseLayout>
+  <section class="ease-center ease-padding-16">
+    <h1 class="ease-fade-in">Build faster.</h1>
+    <button class="ease-btn ease-btn-primary ease-hover-grow">
+      Get Started
+    </button>
+  </section>
+</BaseLayout>
+```
+
+## Card Component
+
+```astro
+---
+// src/components/Card.astro
+export interface Props {
+  title: string;
+  description: string;
+}
+const { title, description } = Astro.props;
+---
+<div class="ease-card ease-hover-lift" style="max-width: 320px">
+  <h2 class="ease-text-lg">{title}</h2>
+  <p class="ease-text-sm ease-muted">{description}</p>
+  <a href="#" class="ease-btn ease-btn-outline ease-btn-sm">
+    Learn More
+  </a>
+</div>
+```
+
+## SSR / Static Output
+
+Astro automatically extracts and inlines CSS during the build. Importing `easemotion-css/easemotion.min.css` in any layout or component ensures styles are included in the final output — no extra configuration needed.
+
+## Scoped Styles
+
+Astro scoped styles work alongside EaseMotion CSS classes without conflicts:
+
+```astro
+<div class="ease-card custom">
+  <slot />
+</div>
+
+<style>
+  .custom {
+    border: 2px solid var(--ease-color-primary);
+  }
+</style>
+```

--- a/docs/framework-integration-react.md
+++ b/docs/framework-integration-react.md
@@ -1,0 +1,96 @@
+# Using EaseMotion CSS with React
+
+## Installation
+
+```bash
+npm install easemotion-css
+```
+
+## Global Import
+
+Import the stylesheet in your entry point:
+
+```jsx
+// app.jsx or main.jsx
+import 'easemotion-css/easemotion.min.css';
+```
+
+For **Next.js App Router**, import in `app/layout.js`:
+
+```jsx
+// app/layout.js
+import 'easemotion-css/easemotion.min.css';
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+For **Next.js Pages Router**, import in `pages/_app.js`:
+
+```jsx
+// pages/_app.js
+import 'easemotion-css/easemotion.min.css';
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+export default MyApp;
+```
+
+## Component Example
+
+```jsx
+function HeroSection() {
+  return (
+    <section className="ease-center ease-padding-16">
+      <h1 className="ease-fade-in">Build faster.</h1>
+      <button className="ease-btn ease-btn-primary ease-hover-grow">
+        Get Started
+      </button>
+    </section>
+  );
+}
+```
+
+## Card Component
+
+```jsx
+function ProfileCard({ name, role }) {
+  return (
+    <div className="ease-card ease-hover-lift" style={{ maxWidth: 320 }}>
+      <h2 className="ease-text-lg">{name}</h2>
+      <p className="ease-text-sm ease-muted">{role}</p>
+      <button className="ease-btn ease-btn-outline ease-btn-sm">
+        View Profile
+      </button>
+    </div>
+  );
+}
+```
+
+## SSR / Next.js Notes
+
+- Import styles in `app/layout.js` (App Router) or `pages/_app.js` (Pages Router) to ensure styles are available server-side.
+- EaseMotion CSS uses CSS custom properties — no flash of unstyled content (FOUC) on SSR.
+- No tree-shaking configuration needed; unused classes add minimal overhead (~5 KB gzipped).
+
+## Scoped Styles / CSS Modules
+
+EaseMotion CSS classes are global by design. You can safely combine them with CSS Modules:
+
+```jsx
+import styles from './MyComponent.module.css';
+
+function MyComponent() {
+  return (
+    <div className={`ease-card ${styles.wrapper}`}>
+      {/* scoped + global classes work together */}
+    </div>
+  );
+}
+```

--- a/docs/framework-integration-vue.md
+++ b/docs/framework-integration-vue.md
@@ -1,0 +1,85 @@
+# Using EaseMotion CSS with Vue
+
+## Installation
+
+```bash
+npm install easemotion-css
+```
+
+## Global Import
+
+Import the stylesheet in your entry point:
+
+```js
+// main.js
+import { createApp } from 'vue';
+import App from './App.vue';
+import 'easemotion-css/easemotion.min.css';
+
+createApp(App).mount('#app');
+```
+
+## Component Example
+
+```vue
+<template>
+  <section class="ease-center ease-padding-16">
+    <h1 class="ease-fade-in">Build faster.</h1>
+    <button class="ease-btn ease-btn-primary ease-hover-grow">
+      Get Started
+    </button>
+  </section>
+</template>
+```
+
+## Card Component
+
+```vue
+<template>
+  <div class="ease-card ease-hover-lift" style="max-width: 320px">
+    <h2 class="ease-text-lg">{{ name }}</h2>
+    <p class="ease-text-sm ease-muted">{{ role }}</p>
+    <button class="ease-btn ease-btn-outline ease-btn-sm">
+      View Profile
+    </button>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  name: String,
+  role: String,
+});
+</script>
+```
+
+## Nuxt / SSR
+
+For **Nuxt 3**, import in `nuxt.config.js` using the `css` option:
+
+```js
+// nuxt.config.js
+export default defineNuxtConfig({
+  css: ['easemotion-css/easemotion.min.css'],
+});
+```
+
+Styles will be injected globally and available during server-side rendering.
+
+## Scoped Styles
+
+EaseMotion CSS global classes work alongside Vue's scoped styles without conflicts:
+
+```vue
+<template>
+  <div class="ease-card custom-wrapper">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.custom-wrapper {
+  background: var(--ease-color-surface);
+}
+</style>
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -211,6 +211,14 @@
           </ul>
         </div>
         <div class="sidebar-group">
+          <div class="sidebar-group-label">Framework Integration</div>
+          <ul class="sidebar-nav">
+            <li><a href="framework-integration-react.md">React / Next.js</a></li>
+            <li><a href="framework-integration-vue.md">Vue / Nuxt</a></li>
+            <li><a href="framework-integration-astro.md">Astro</a></li>
+          </ul>
+        </div>
+        <div class="sidebar-group">
           <div class="sidebar-group-label">Contributing</div>
           <ul class="sidebar-nav">
             <li><a href="#how-to-contribute">How to Contribute</a></li>


### PR DESCRIPTION
Fixes #7422

## Description
Framework-specific integration guides for using EaseMotion CSS with React/Next.js, Vue/Nuxt, and Astro. Each guide covers installation, global import, component examples, SSR handling, and scoped styles.

## Changes Made

- `docs/framework-integration-react.md` — React + Next.js (App Router & Pages Router) guide
- `docs/framework-integration-vue.md` — Vue + Nuxt 3 guide
- `docs/framework-integration-astro.md` — Astro guide
- `docs/index.html` — Added "Framework Integration" sidebar section with links

## Features
- Installation via npm
- Global import vs per-component patterns
- SSR handling (Next.js, Nuxt, Astro)
- Scoped styles / CSS Modules compatibility
- Button, Card, and Hero section examples

## Type of Change
- [x] Documentation

## Checklist
- [x] Framework integration guides for React, Vue, and Astro
- [x] Sidebar navigation links added to docs/index.html
- [x] No modifications to core files or framework code