### PR TITLE
[Feature]: Animated Modal — backdrop, slide-down entrance, 3 sizes, Escape to close

### DIFF
--- a/submissions/examples/animated-modal-pcmh/README.md
+++ b/submissions/examples/animated-modal-pcmh/README.md
@@ -1,0 +1,46 @@
+# Animated Modal — Issue #7521
+
+## Overview
+
+Modal/dialog with backdrop overlay, slide-down entrance, close button, click-outside-to-close, Escape key, scroll lock, and 3 sizes.
+
+## Sizes
+
+| Size | Class | Max Width |
+|------|-------|-----------|
+| Small | `.ease-modal-sm` | 320px |
+| Default | `.ease-modal` | 480px |
+| Large | `.ease-modal-lg` | 640px |
+
+## Features
+
+- Fade-in backdrop overlay
+- Slide-down entrance animation
+- Close button (×) in header
+- Click outside to close
+- Escape key support
+- Body scroll lock
+- Header, body, footer sections
+
+## Usage
+
+```html
+<div class="ease-modal-overlay" id="overlay"></div>
+<div class="ease-modal" id="modal">
+  <div class="ease-modal-header">
+    <span class="ease-modal-title">Title</span>
+    <button class="ease-modal-close">&times;</button>
+  </div>
+  <div class="ease-modal-body"><p>Content</p></div>
+  <div class="ease-modal-footer">
+    <button class="btn">Cancel</button>
+    <button class="btn btn-primary">Confirm</button>
+  </div>
+</div>
+```
+
+## Files
+
+- `demo.html` — Three modals (sm, md, lg) with examples
+- `style.css` — Overlay, modal, animations, header/body/footer
+- `README.md` — This documentation

--- a/submissions/examples/animated-modal-pcmh/demo.html
+++ b/submissions/examples/animated-modal-pcmh/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Modal — EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Animated Modal</h1>
+    <p class="subtitle">Backdrop, slide-down entrance, close button, click-outside, Escape key, 3 sizes</p>
+    <p>Click the buttons below to open different modal sizes.</p>
+    <button class="btn btn-primary" onclick="openModal('defaultModal')">Open Modal (md)</button>
+    <button class="btn" onclick="openModal('smallModal')">Small (sm)</button>
+    <button class="btn" onclick="openModal('largeModal')">Large (lg)</button>
+  </div>
+
+  <div class="ease-modal-overlay" id="defaultOverlay"></div>
+  <div class="ease-modal" id="defaultModal">
+    <div class="ease-modal-header">
+      <span class="ease-modal-title">Confirm Action</span>
+      <button class="ease-modal-close" onclick="closeModal('defaultModal')">&times;</button>
+    </div>
+    <div class="ease-modal-body"><p>Are you sure you want to proceed? This cannot be undone.</p></div>
+    <div class="ease-modal-footer">
+      <button class="btn" onclick="closeModal('defaultModal')">Cancel</button>
+      <button class="btn btn-primary" onclick="closeModal('defaultModal')">Confirm</button>
+    </div>
+  </div>
+
+  <div class="ease-modal-overlay" id="smallOverlay"></div>
+  <div class="ease-modal ease-modal-sm" id="smallModal">
+    <div class="ease-modal-header">
+      <span class="ease-modal-title">Delete Item</span>
+      <button class="ease-modal-close" onclick="closeModal('smallModal')">&times;</button>
+    </div>
+    <div class="ease-modal-body"><p>Delete this item permanently?</p></div>
+    <div class="ease-modal-footer">
+      <button class="btn" onclick="closeModal('smallModal')">Cancel</button>
+      <button class="btn btn-danger" onclick="closeModal('smallModal')">Delete</button>
+    </div>
+  </div>
+
+  <div class="ease-modal-overlay" id="largeOverlay"></div>
+  <div class="ease-modal ease-modal-lg" id="largeModal">
+    <div class="ease-modal-header">
+      <span class="ease-modal-title">Terms & Conditions</span>
+      <button class="ease-modal-close" onclick="closeModal('largeModal')">&times;</button>
+    </div>
+    <div class="ease-modal-body">
+      <p>By using this service you agree to the following terms. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+    </div>
+    <div class="ease-modal-footer">
+      <button class="btn" onclick="closeModal('largeModal')">Close</button>
+      <button class="btn btn-primary" onclick="closeModal('largeModal')">Accept</button>
+    </div>
+  </div>
+
+  <script>
+    function openModal(id) {
+      document.getElementById(id).classList.add('open');
+      document.getElementById(id.replace('Modal', 'Overlay')).classList.add('open');
+      document.body.classList.add('modal-open');
+    }
+    function closeModal(id) {
+      document.getElementById(id).classList.remove('open');
+      document.getElementById(id.replace('Modal', 'Overlay')).classList.remove('open');
+      document.body.classList.remove('modal-open');
+    }
+    document.querySelectorAll('.ease-modal-overlay').forEach(o => {
+      o.addEventListener('click', () => {
+        document.querySelectorAll('.ease-modal.open').forEach(m => closeModal(m.id));
+      });
+    });
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape') {
+        document.querySelectorAll('.ease-modal.open').forEach(m => closeModal(m.id));
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-modal-pcmh/style.css
+++ b/submissions/examples/animated-modal-pcmh/style.css
@@ -1,0 +1,83 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  padding: 3rem 1rem;
+  min-height: 100vh;
+}
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; text-align: center; }
+.subtitle { color: #64748b; margin-bottom: 2rem; font-size: 0.9rem; text-align: center; }
+.container { max-width: 600px; margin: 0 auto; text-align: center; }
+.container p { color: #64748b; line-height: 1.6; margin-bottom: 1.5rem; }
+
+.btn {
+  display: inline-flex; align-items: center; gap: 0.375rem;
+  padding: 0.625rem 1.25rem; border: 1px solid #e2e8f0;
+  border-radius: 0.5rem; background: #fff;
+  font-size: 0.875rem; font-weight: 500; cursor: pointer;
+  transition: all 0.15s; margin: 0.25rem;
+}
+.btn:hover { background: #f1f5f9; border-color: #cbd5e1; }
+.btn-primary { background: #6c63ff; color: #fff; border-color: #6c63ff; }
+.btn-primary:hover { background: #5b54e0; }
+.btn-danger { background: #ef4444; color: #fff; border-color: #ef4444; }
+.btn-danger:hover { background: #dc2626; }
+
+@keyframes ease-modal-in {
+  from { opacity: 0; transform: translate(-50%, -60%); }
+  to   { opacity: 1; transform: translate(-50%, -50%); }
+}
+@keyframes ease-overlay-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.ease-modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 1000;
+  display: none;
+  align-items: center; justify-content: center;
+  animation: ease-overlay-in 0.25s ease;
+}
+.ease-modal-overlay.open { display: flex; }
+
+.ease-modal {
+  position: fixed;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  background: #fff;
+  border-radius: 0.75rem;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.15);
+  z-index: 1001;
+  width: 90%;
+  max-width: 480px;
+  animation: ease-modal-in 0.3s ease;
+  display: none;
+}
+.ease-modal.open { display: block; }
+.ease-modal-sm { max-width: 320px; }
+.ease-modal-lg { max-width: 640px; }
+
+.ease-modal-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1rem 1.25rem; border-bottom: 1px solid #e2e8f0;
+}
+.ease-modal-title { font-size: 1rem; font-weight: 600; }
+.ease-modal-close {
+  background: none; border: none; font-size: 1.25rem;
+  color: #94a3b8; cursor: pointer; padding: 0.25rem;
+  border-radius: 0.25rem; transition: all 0.15s; line-height: 1;
+}
+.ease-modal-close:hover { background: #f1f5f9; color: #1e293b; }
+
+.ease-modal-body { padding: 1.25rem; }
+.ease-modal-body p { color: #475569; line-height: 1.6; font-size: 0.9rem; }
+
+.ease-modal-footer {
+  display: flex; justify-content: flex-end;
+  gap: 0.5rem; padding: 1rem 1.25rem; border-top: 1px solid #e2e8f0;
+}
+
+body.modal-open { overflow: hidden; }


### PR DESCRIPTION
Fixes #7521

## Description
Modal/dialog with backdrop overlay, slide-down entrance animation, close button, click-outside-to-close, Escape key support, body scroll lock, and sm/md/lg sizes.

## Changes Made

`submissions/examples/animated-modal-pcmh/`:
- `demo.html` — Three modals (sm confirm, default delete, lg terms)
- `style.css` — Overlay, modal positioning, entrance animation
- `README.md` — Size reference and usage

## Features
- Fade-in backdrop
- Slide-down entrance
- Close button, click-outside, Escape key
- Body scroll lock
- 3 sizes: sm (320px), default (480px), lg (640px)

## Type of Change
- [x] New feature

## Checklist
- [x] Contains `demo.html`, `style.css`, `README.md`
- [x] All files under `submissions/examples/animated-modal-pcmh/`
- [x] No modifications to core files or framework code