### PR TITLE
fix(ease-scramble): pause interval on hidden tab and guard prefers-reduced-motion

### DIFF
--- a/submissions/examples/ease-scramble/demo.html
+++ b/submissions/examples/ease-scramble/demo.html
@@ -79,9 +79,16 @@
 
   <script>
     const chars = '!@#$%^&*()_+-=[]{}|;:,.<>?/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     function scramble(el) {
       const target = el.dataset.text;
+
+      if (prefersReducedMotion) {
+        el.textContent = target;
+        return;
+      }
+
       const len = target.length;
       let iteration = 0;
       const totalFrames = len * 6;
@@ -90,6 +97,8 @@
       el.classList.add('scrambling');
 
       el._scrambleInterval = setInterval(() => {
+        if (document.hidden) return;
+
         el.textContent = target
           .split('')
           .map((char, i) => {
@@ -108,11 +117,21 @@
       }, 40);
     }
 
-    document.querySelectorAll('.ease-scramble').forEach(el => {
-      // Trigger on page load
-      setTimeout(() => scramble(el), Math.random() * 600);
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        document.querySelectorAll('.ease-scramble').forEach(el => {
+          if (el._scrambleInterval) {
+            clearInterval(el._scrambleInterval);
+            el._scrambleInterval = null;
+            el.textContent = el.dataset.text;
+            el.classList.remove('scrambling');
+          }
+        });
+      }
+    });
 
-      // Trigger on hover
+    document.querySelectorAll('.ease-scramble').forEach(el => {
+      setTimeout(() => scramble(el), Math.random() * 600);
       el.addEventListener('mouseenter', () => scramble(el));
     });
   </script>

--- a/submissions/examples/ease-scramble/style.css
+++ b/submissions/examples/ease-scramble/style.css
@@ -217,6 +217,13 @@ body {
   white-space: pre-wrap;
 }
 
+/* ─── Reduced Motion ─────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-scramble.scrambling {
+    animation: none;
+  }
+}
+
 /* ─── Footer ─────────────────────────────────────────── */
 .footer {
   text-align: center;


### PR DESCRIPTION
## Pull Request Description

Fixes two accessibility and performance bugs in the `ease-scramble` component reported in issue #6081:

1. **Memory leak / wasted CPU** — the `setInterval` driving the scramble animation continued firing at 40ms even when the browser tab was hidden, burning CPU for invisible DOM updates.
2. **Missing `prefers-reduced-motion` guard** — the rapid character-cycling effect ran at full speed for users who have requested reduced motion via OS accessibility settings.

Closes #6081

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scramble/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — not required for a bug fix to an existing submission
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

Two bugs in `submissions/examples/ease-scramble/`:

- `setInterval` at 40ms continued running while the tab was hidden, wasting CPU on invisible DOM mutations.
- No `prefers-reduced-motion` check existed — users with reduced motion enabled still saw the full rapid scramble effect.

**Changes made:**

`demo.html`:
- Added `prefersReducedMotion` check at init time; if set, `scramble()` immediately writes the final text and returns early.
- Added `if (document.hidden) return;` inside the interval callback so no DOM updates fire while the tab is hidden.
- Added a `visibilitychange` listener that clears all active intervals and restores final text when the tab becomes hidden.

`style.css`:
- Added `@media (prefers-reduced-motion: reduce)` block that disables the `scramble-flicker` CSS animation on `.ease-scramble.scrambling`.

---

## Demo

- [x] Demo works by opening `demo.html` directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Both fixes are minimal and additive — no existing behaviour changes for users without reduced motion on a visible tab. The `visibilitychange` listener restores the final resolved text when clearing intervals so elements are never left in a half-scrambled state.