### PR TITLE
fix(favicon): correct broken favicon path in 12 demo files

### DIFF
--- a/submissions/examples/ease-animated-counter/demo.html
+++ b/submissions/examples/ease-animated-counter/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Animated Counting Number</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-cursor-trail-v1/demo.html
+++ b/submissions/examples/ease-cursor-trail-v1/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Cursor Trail Effect</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-fade-in-safari-fix/demo.html
+++ b/submissions/examples/ease-fade-in-safari-fix/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Fade In Safari Fix</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-glass-login-form/demo.html
+++ b/submissions/examples/ease-glass-login-form/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Glassmorphism Login Form</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-glow-border/demo.html
+++ b/submissions/examples/ease-glow-border/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Glowing Card Border Animation</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-mesh-bg/demo.html
+++ b/submissions/examples/ease-mesh-bg/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Animated Gradient Mesh Background</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-morphing-blob/demo.html
+++ b/submissions/examples/ease-morphing-blob/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Morphing Blob Animation</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-neon-flicker/demo.html
+++ b/submissions/examples/ease-neon-flicker/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Neon Text Flicker Animation</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-scramble/demo.html
+++ b/submissions/examples/ease-scramble/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Text Scramble Decode Effect</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-skeleton-firefox-fix/demo.html
+++ b/submissions/examples/ease-skeleton-firefox-fix/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Skeleton Firefox Fix</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-speed-dial-menu/demo.html
+++ b/submissions/examples/ease-speed-dial-menu/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Floating Action Speed Dial Menu</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/submissions/examples/ease-tooltip-flicker-fix/demo.html
+++ b/submissions/examples/ease-tooltip-flicker-fix/demo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EaseMotion CSS — Tooltip Flicker Fix</title>
-  <link rel="icon" type="image/svg+xml" href="../ease-favicon/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="../ease-favicon-v1/favicon.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>


### PR DESCRIPTION
## Pull Request Description

Fixes the broken favicon link in 12 demo HTML files where the path pointed to `../ease-favicon/favicon.svg` — a folder that does not exist. The correct folder name is `ease-favicon-v1`, so all affected files now reference `../ease-favicon-v1/favicon.svg`.

Closes #6076

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Corrects the favicon `<link>` path from `../ease-favicon/favicon.svg` to `../ease-favicon-v1/favicon.svg` in 12 demo files.

**Why does it fit EaseMotion CSS?**

All demos should display the EaseMotion CSS branded favicon in the browser tab. The wrong folder path caused a 404 and a blank tab icon across 12 submissions.

**Affected files:**
- `submissions/examples/ease-scramble/demo.html`
- `submissions/examples/ease-cursor-trail-v1/demo.html`
- `submissions/examples/ease-glow-border/demo.html`
- `submissions/examples/ease-mesh-bg/demo.html`
- `submissions/examples/ease-neon-flicker/demo.html`
- `submissions/examples/ease-speed-dial-menu/demo.html`
- `submissions/examples/ease-glass-login-form/demo.html`
- `submissions/examples/ease-morphing-blob/demo.html`
- `submissions/examples/ease-fade-in-safari-fix/demo.html`
- `submissions/examples/ease-skeleton-firefox-fix/demo.html`
- `submissions/examples/ease-animated-counter/demo.html`
- `submissions/examples/ease-tooltip-flicker-fix/demo.html`

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The issue listed 6 affected files but on inspection 12 files had the same broken path. All 12 have been corrected in this PR. The fix is a one-line change per file — no logic or style changes.