### PR TITLE
fix(bounce-keyframes-var): correct broken CSS path in demo.html

### DIFF
--- a/submissions/examples/bounce-keyframes-var/demo.html
+++ b/submissions/examples/bounce-keyframes-var/demo.html
@@ -3,7 +3,7 @@
 <title>bounce-keyframes-var #3900</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3900</span>


### PR DESCRIPTION
## Pull Request Description

Fixes the broken `../style.css` path in `submissions/examples/bounce-keyframes-var/demo.html`. The `href` was resolving to `submissions/examples/style.css` which does not exist, causing a 404 and leaving the component's own `style.css` completely unloaded.

Closes #6074

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/bounce-keyframes-var/`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

Changed `href="../style.css"` → `href="style.css"` on line 6 of `demo.html` so the local `style.css` in the same directory is correctly loaded.

**Root cause:**  
The submission used the same template as other examples but the relative path `../style.css` points one level up to `submissions/examples/style.css`, which does not exist. The file `submissions/examples/bounce-keyframes-var/style.css` (12 lines of component-specific CSS) was silently never applied.

---

## Demo

- [x] `demo.html` works by opening directly in a browser (bounce animation now correctly uses the local `style.css`)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

Single-character path fix (`../style.css` → `style.css`). No logic changes, no new files, no impact on `core/` or `components/`. Safe to merge directly.