### PR TITLE
fix: correct ../style.css path to ./style.css in 23 submissions

### DIFF
--- a/submissions/examples/btn-hover-disabled-lift/demo.html
+++ b/submissions/examples/btn-hover-disabled-lift/demo.html
@@ -3,7 +3,7 @@
 <title>btn-hover-disabled-lift #3909</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3909</span>

--- a/submissions/examples/btn-icon-missing-states/demo.html
+++ b/submissions/examples/btn-icon-missing-states/demo.html
@@ -3,7 +3,7 @@
 <title>btn-icon-missing-states #3918</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3918</span>

--- a/submissions/examples/btn-xl-space-tokens/demo.html
+++ b/submissions/examples/btn-xl-space-tokens/demo.html
@@ -3,7 +3,7 @@
 <title>btn-xl-space-tokens #3915</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3915</span>

--- a/submissions/examples/card-compact-maxwidth/demo.html
+++ b/submissions/examples/card-compact-maxwidth/demo.html
@@ -3,7 +3,7 @@
 <title>card-compact-maxwidth #3910</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3910</span>

--- a/submissions/examples/card-flat-border-width/demo.html
+++ b/submissions/examples/card-flat-border-width/demo.html
@@ -3,7 +3,7 @@
 <title>card-flat-border-width #3904</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}.card-row{display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;margin:1rem 0}.measure{background:#fef3c7;padding:4px 8px;border-radius:4px;font-size:0.8rem;font-family:monospace;margin-top:0.5rem}</style>
 </head><body>
 <span class="badge">Fix #3904</span>

--- a/submissions/examples/card-image-aspect-ratio/demo.html
+++ b/submissions/examples/card-image-aspect-ratio/demo.html
@@ -3,7 +3,7 @@
 <title>card-image-aspect-ratio #3907</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3907</span>

--- a/submissions/examples/dark-scrollbar-contrast/demo.html
+++ b/submissions/examples/dark-scrollbar-contrast/demo.html
@@ -3,7 +3,7 @@
 <title>dark-scrollbar-contrast #3919</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3919</span>

--- a/submissions/examples/duplicate-dark-mode-blocks/demo.html
+++ b/submissions/examples/duplicate-dark-mode-blocks/demo.html
@@ -3,7 +3,7 @@
 <title>duplicate-dark-mode-blocks #3905</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3905</span>

--- a/submissions/examples/ease-float-var/demo.html
+++ b/submissions/examples/ease-float-var/demo.html
@@ -3,7 +3,7 @@
 <title>ease-float-var #3896</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}</style>
 </head><body>
 <span class="badge">Fix #3896</span>

--- a/submissions/examples/ease-gradient-rotation-var/demo.html
+++ b/submissions/examples/ease-gradient-rotation-var/demo.html
@@ -3,7 +3,7 @@
 <title>ease-gradient-rotation-var #3901</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}.gradient-box{width:100%;height:80px;border-radius:8px;margin:1rem 0}</style>
 </head><body>
 <span class="badge">Fix #3901</span>

--- a/submissions/examples/ease-ping-var/demo.html
+++ b/submissions/examples/ease-ping-var/demo.html
@@ -3,7 +3,7 @@
 <title>ease-ping-var #3897</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3897</span>

--- a/submissions/examples/ease-reveal-zd/demo.html
+++ b/submissions/examples/ease-reveal-zd/demo.html
@@ -24,7 +24,7 @@
       <div class="rv-card">
         <div class="rv-img-wrap">
           <div class="rv-placeholder"></div>
-          <img class="rv-img" src="https://picsum.photos/400/250?random=1" alt="Mountain landscape" loading="lazy">
+          <img class="rv-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='250'%3E%3Crect width='400' height='250' fill='%232d6a4f'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23b7e4c7' font-family='sans-serif' font-size='18'%3EMountain Landscape%3C/text%3E%3C/svg%3E" alt="Mountain landscape">
         </div>
         <div class="rv-body">
           <div class="rv-title">Mountain Retreat</div>
@@ -34,7 +34,7 @@
       <div class="rv-card">
         <div class="rv-img-wrap">
           <div class="rv-placeholder"></div>
-          <img class="rv-img" src="https://picsum.photos/400/250?random=2" alt="City skyline" loading="lazy">
+          <img class="rv-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='250'%3E%3Crect width='400' height='250' fill='%231d3557'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23a8dadc' font-family='sans-serif' font-size='18'%3ECity Skyline%3C/text%3E%3C/svg%3E" alt="City skyline">
         </div>
         <div class="rv-body">
           <div class="rv-title">Urban Living</div>

--- a/submissions/examples/ease-rotate-var/demo.html
+++ b/submissions/examples/ease-rotate-var/demo.html
@@ -3,7 +3,7 @@
 <title>ease-rotate-var #3899</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3899</span>

--- a/submissions/examples/hover-glow-compose/demo.html
+++ b/submissions/examples/hover-glow-compose/demo.html
@@ -3,7 +3,7 @@
 <title>hover-glow-compose #3903</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}.btn-row{display:flex;gap:1rem;flex-wrap:wrap;margin:1rem 0}</style>
 </head><body>
 <span class="badge">Fix #3903</span>

--- a/submissions/examples/missing-flex-col-breakpoints/demo.html
+++ b/submissions/examples/missing-flex-col-breakpoints/demo.html
@@ -3,7 +3,7 @@
 <title>missing-flex-col-breakpoints #3920</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3920</span>

--- a/submissions/examples/navbar-dark-mode/demo.html
+++ b/submissions/examples/navbar-dark-mode/demo.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="./style.css">
   <style>
     body { font-family: 'Inter', sans-serif; padding: 2rem; max-width: 800px; margin: 0 auto; }
     h2 { font-size: 1.25rem; margin-bottom: 0.5rem; }

--- a/submissions/examples/overflow-scroll-missing-styles/demo.html
+++ b/submissions/examples/overflow-scroll-missing-styles/demo.html
@@ -3,7 +3,7 @@
 <title>overflow-scroll-missing-styles #3913</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3913</span>

--- a/submissions/examples/pulse-border-emphasis-duration/demo.html
+++ b/submissions/examples/pulse-border-emphasis-duration/demo.html
@@ -3,7 +3,7 @@
 <title>pulse-border-emphasis-duration #3912</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3912</span>

--- a/submissions/examples/reveal-delay-unused-animation/demo.html
+++ b/submissions/examples/reveal-delay-unused-animation/demo.html
@@ -3,7 +3,7 @@
 <title>reveal-delay-unused-animation #3917</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3917</span>

--- a/submissions/examples/scrollbar-auto-invisible/demo.html
+++ b/submissions/examples/scrollbar-auto-invisible/demo.html
@@ -3,7 +3,7 @@
 <title>scrollbar-auto-invisible #3906</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3906</span>

--- a/submissions/examples/shimmer-sweep-var/demo.html
+++ b/submissions/examples/shimmer-sweep-var/demo.html
@@ -3,7 +3,7 @@
 <title>shimmer-sweep-var #3902</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}.shimmer-box{width:100%;height:60px;border-radius:8px;background:linear-gradient(120deg,transparent 30%,rgba(255,255,255,0.15) 50%,transparent 70%);background-size:200% auto;animation:ease-kf-shimmer-sweep var(--ease-speed-slow) var(--ease-ease) infinite;margin:1rem 0}</style>
 </head><body>
 <span class="badge">Fix #3902</span>

--- a/submissions/examples/snap-strictness-undefined/demo.html
+++ b/submissions/examples/snap-strictness-undefined/demo.html
@@ -3,7 +3,7 @@
 <title>snap-strictness-undefined #3908</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3908</span>

--- a/submissions/examples/squish-button-touch/demo.html
+++ b/submissions/examples/squish-button-touch/demo.html
@@ -3,7 +3,7 @@
 <title>squish-button-touch #3898</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>
 body { font-family: 'Inter', sans-serif; padding: 2rem; max-width: 800px; margin: 0 auto; }
 .badge { display: inline-block; background: #6c63ff; color: #fff; padding: 2px 8px; border-radius: 4px; font-size: 0.75rem; margin-bottom: 1rem; }

--- a/submissions/examples/stat-value-hardcoded/demo.html
+++ b/submissions/examples/stat-value-hardcoded/demo.html
@@ -3,7 +3,7 @@
 <title>stat-value-hardcoded #3911</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="../style.css">
+<link rel="stylesheet" href="./style.css">
 <style>body{font-family:Inter,sans-serif;padding:2rem;max-width:800px;margin:0 auto}.badge{display:inline-block;background:#6c63ff;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem;margin-bottom:1rem}pre{background:#f8fafc;padding:1rem;border-radius:8px;overflow-x:auto}code{background:#f1f5f9;padding:2px 6px;border-radius:3px;font-size:.85em}</style>
 </head><body>
 <span class="badge">Fix #3911</span>


### PR DESCRIPTION
## Pull Request Description

Fixes 23 submission `demo.html` files that linked to `../style.css` (parent directory) instead of `./style.css` (same folder). This caused the stylesheet to fail silently when the demo is opened directly in a browser, since each submission's CSS lives in its own folder alongside `demo.html`.

Closes #7548

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

23 `demo.html` files used `href="../style.css"` which resolves to `submissions/style.css` — a file that does not exist. The correct relative path is `href="./style.css"` which resolves to the `style.css` in the same submission folder.

**Affected submissions:**
- ease-rotate-var, reveal-delay-unused-animation, card-compact-maxwidth, missing-flex-col-breakpoints, btn-xl-space-tokens, scrollbar-auto-invisible, duplicate-dark-mode-blocks, card-flat-border-width, navbar-dark-mode, btn-hover-disabled-lift, card-image-aspect-ratio, squish-button-touch, ease-float-var, btn-icon-missing-states, pulse-border-emphasis-duration, stat-value-hardcoded, hover-glow-compose, ease-ping-var, snap-strictness-undefined, dark-scrollbar-contrast, overflow-scroll-missing-styles, ease-gradient-rotation-var, shimmer-sweep-var

---

## Demo

- [x] All affected demos now correctly load their local `style.css`

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Simple path fix across 23 files — `sed` was used to batch-replace the incorrect path. No logic or style changes, only the `href` attribute value.