### PR TITLE
fix: add missing lang attribute to demo.html files (WCAG 3.1.1)

### DIFF
--- a/submissions/examples/auto-assign-issue/demo.html
+++ b/submissions/examples/auto-assign-issue/demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <title>Auto Assign Workflow Demo</title>

--- a/submissions/examples/ease-hover-specific-transition/demo.html
+++ b/submissions/examples/ease-hover-specific-transition/demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset = "UTF-8">
         <meta name="viewport" content = "width=device-width , intial-scale =1.0">

--- a/submissions/examples/reduced-motion-support/demo.html
+++ b/submissions/examples/reduced-motion-support/demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>Reduced Motion Demo</title>
   <link rel="stylesheet" href="style.css">

--- a/submissions/examples/timeline-component/demo.html
+++ b/submissions/examples/timeline-component/demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/submissions/examples/ui-consistency-improvement/demo.html
+++ b/submissions/examples/ui-consistency-improvement/demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
## Pull Request Description

Adds the missing `lang` attribute to 5 submission `demo.html` files that had a full HTML document structure (`<!DOCTYPE html>` + `<html>`) but were missing `lang=\"en\"`. This violates WCAG Success Criterion 3.1.1, which requires the primary language of a page to be declared so screen readers and search engines can identify it correctly.

Closes #7549

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

5 `demo.html` files had `<html>` without a `lang` attribute. Changed to `<html lang="en">`.

**Affected submissions:**
- auto-assign-issue
- ease-hover-specific-transition
- reduced-motion-support
- timeline-component
- ui-consistency-improvement

Note: The remaining files flagged in the issue either have empty content, are HTML fragments (no `<html>` tag), or already had a `lang` attribute under a different tag form — they are not affected by this fix.

---

## Demo

- [x] Demos open directly in browser; no functional change, only accessibility metadata added.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

Purely an accessibility metadata fix. No visual or behavioral change. The 5 files corrected are the only ones that had a full `<html>` tag without a `lang` attribute.