### PR TITLE
feat: add chaos engineering control center component

### DIFF
--- a/submissions/examples/chaos-engineering-center-rr/README.md
+++ b/submissions/examples/chaos-engineering-center-rr/README.md
@@ -1,0 +1,17 @@
+# Chaos Engineering Control Center Component
+
+## What does this do?
+
+Provides a centralized interface for monitoring chaos engineering experiments, resilience testing, recovery outcomes, and operational reliability metrics.
+
+## How is it used?
+
+```html
+<div class="experiment-card healthy">
+    <h3>Pod Failure Test</h3>
+</div>
+```
+
+## Why is it useful?
+
+Modern reliability engineering teams use controlled failure testing to validate system resilience. This component provides a reusable dashboard for tracking experiments, recovery performance, and resilience improvements.

--- a/submissions/examples/chaos-engineering-center-rr/demo.html
+++ b/submissions/examples/chaos-engineering-center-rr/demo.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Chaos Engineering Control Center</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+
+    <div class="header">
+        <h1>Chaos Engineering Control Center</h1>
+        <p>Validate resilience through controlled failure experiments and recovery analysis.</p>
+    </div>
+
+    <div class="metrics-grid">
+
+        <div class="metric-card">
+            <span>Active Experiments</span>
+            <h2>12</h2>
+        </div>
+
+        <div class="metric-card">
+            <span>Resilience Score</span>
+            <h2>94%</h2>
+        </div>
+
+        <div class="metric-card">
+            <span>Successful Recoveries</span>
+            <h2>187</h2>
+        </div>
+
+        <div class="metric-card">
+            <span>Mean Recovery Time</span>
+            <h2>3.8 min</h2>
+        </div>
+
+    </div>
+
+    <div class="experiment-grid">
+
+        <div class="experiment-card healthy">
+            <h3>Pod Failure Test</h3>
+            <p>Recovery Completed</p>
+            <span>Passed</span>
+        </div>
+
+        <div class="experiment-card healthy">
+            <h3>Network Latency Injection</h3>
+            <p>System Recovered</p>
+            <span>Passed</span>
+        </div>
+
+        <div class="experiment-card warning">
+            <h3>Database Failure Simulation</h3>
+            <p>Recovery Delay Detected</p>
+            <span>Review Needed</span>
+        </div>
+
+        <div class="experiment-card healthy">
+            <h3>Service Restart Test</h3>
+            <p>Recovery Verified</p>
+            <span>Passed</span>
+        </div>
+
+    </div>
+
+    <div class="activity-panel">
+
+        <h2>Experiment Activity Feed</h2>
+
+        <div class="activity-item">
+            <span>Pod failure experiment completed successfully</span>
+            <span class="success-badge">Passed</span>
+        </div>
+
+        <div class="activity-item">
+            <span>Database recovery exceeded expected threshold</span>
+            <span class="warning-badge">Review</span>
+        </div>
+
+        <div class="activity-item">
+            <span>Latency injection test executed</span>
+            <span class="info-badge">Completed</span>
+        </div>
+
+        <div class="activity-item">
+            <span>Service failover validation successful</span>
+            <span class="success-badge">Verified</span>
+        </div>
+
+    </div>
+
+    <div class="resilience-panel">
+
+        <h2>Resilience Metrics</h2>
+
+        <div class="resilience-item">
+            <span>Services Covered</span>
+            <span>84</span>
+        </div>
+
+        <div class="resilience-item">
+            <span>Failed Tests</span>
+            <span>4</span>
+        </div>
+
+        <div class="resilience-item">
+            <span>Blast Radius Reviews</span>
+            <span>26</span>
+        </div>
+
+        <div class="resilience-item">
+            <span>Recovery Success Rate</span>
+            <span>97%</span>
+        </div>
+
+    </div>
+
+    <div class="summary-panel">
+
+        <h2>Resilience Summary</h2>
+
+        <p>
+            Chaos engineering activities demonstrate strong platform resilience
+            with high recovery success rates and broad service coverage.
+            A small number of experiments identified areas for recovery optimization.
+        </p>
+
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/chaos-engineering-center-rr/style.css
+++ b/submissions/examples/chaos-engineering-center-rr/style.css
@@ -1,0 +1,134 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    background:#0f172a;
+    color:white;
+    font-family:Arial,sans-serif;
+    min-height:100vh;
+    padding:40px 20px;
+}
+
+.container{
+    max-width:1300px;
+    margin:auto;
+}
+
+.header{
+    text-align:center;
+    margin-bottom:40px;
+}
+
+.header h1{
+    font-size:3rem;
+    margin-bottom:10px;
+}
+
+.header p{
+    color:#94a3b8;
+}
+
+.metrics-grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+    gap:24px;
+    margin-bottom:40px;
+}
+
+.metric-card{
+    background:#111827;
+    padding:24px;
+    border-radius:20px;
+    transition:.3s;
+}
+
+.metric-card:hover{
+    transform:translateY(-8px);
+}
+
+.experiment-grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+    gap:24px;
+    margin-bottom:40px;
+}
+
+.experiment-card{
+    background:#111827;
+    padding:24px;
+    border-radius:20px;
+}
+
+.healthy{
+    border-left:5px solid #22c55e;
+}
+
+.warning{
+    border-left:5px solid #f59e0b;
+}
+
+.activity-panel,
+.resilience-panel{
+    background:#111827;
+    border-radius:24px;
+    padding:30px;
+    margin-bottom:40px;
+}
+
+.activity-item,
+.resilience-item{
+    display:flex;
+    justify-content:space-between;
+    padding:14px 0;
+    border-bottom:1px solid rgba(255,255,255,.08);
+}
+
+.success-badge,
+.warning-badge,
+.info-badge{
+    padding:6px 12px;
+    border-radius:14px;
+    font-size:12px;
+    font-weight:bold;
+}
+
+.success-badge{
+    background:#22c55e;
+    color:#000;
+}
+
+.warning-badge{
+    background:#f59e0b;
+    color:#000;
+}
+
+.info-badge{
+    background:#3b82f6;
+}
+
+.summary-panel{
+    background:linear-gradient(135deg,#2563eb,#7c3aed);
+    border-radius:24px;
+    padding:30px;
+}
+
+.summary-panel p{
+    line-height:1.8;
+}
+
+@media(max-width:768px){
+
+.header h1{
+    font-size:2.2rem;
+}
+
+.activity-item,
+.resilience-item{
+    flex-direction:column;
+    gap:10px;
+}
+
+}


### PR DESCRIPTION
## 📌 Description

This PR adds a Chaos Engineering Control Center Component under:

submissions/examples/chaos-engineering-center-rr/

The component provides a centralized interface for tracking chaos experiments, resilience testing outcomes, recovery performance, and operational reliability metrics.

### ✨ Features

- Chaos experiment overview
- Experiment status cards
- Recovery metrics dashboard
- Resilience score tracking
- Activity feed for experiments
- Blast radius and coverage metrics
- Responsive layout
- Hover animations
- Pure HTML and CSS

### 📂 Files Added

- demo.html
- style.css
- README.md

### 🎯 Use Cases

- Gremlin
- LitmusChaos
- Chaos Mesh
- AWS Fault Injection Simulator
- Harness Chaos Engineering
- Site Reliability Engineering Teams

### ✅ Checklist

- [x] Pure HTML and CSS
- [x] Responsive
- [x] Includes README
- [x] Added under submissions/examples
- [x] Tested locally
fixes #7570 