### PR TITLE
feat: add CSS-only expanding search bar (:focus-within)

### DIFF
--- a/submissions/examples/expanding-search-bar-sk/README.md
+++ b/submissions/examples/expanding-search-bar-sk/README.md
@@ -1,0 +1,33 @@
+# CSS-Only Expanding Search Bar
+
+## What does this do?
+A search bar that expands from an icon-only collapsed state to a full input field when focused, using `:focus-within` — no JavaScript required for the expand/collapse behavior.
+
+## How is it used?
+
+```html
+<div class="search-bar">
+  <span class="search-bar__icon" aria-hidden="true">
+    <!-- search SVG icon -->
+  </span>
+  <input class="search-bar__input" type="search" placeholder="Search…" aria-label="Search">
+  <button class="search-bar__clear" aria-label="Clear search">×</button>
+</div>
+
+<!-- dark variant -->
+<div class="search-bar search-bar--dark">…</div>
+
+<!-- large variant -->
+<div class="search-bar search-bar--lg">…</div>
+```
+
+CSS custom properties for theming:
+```css
+--search-collapsed-width: 44px;
+--search-expanded-width: 280px;
+--search-border-focus: #6366f1;
+--search-duration: 0.3s;
+```
+
+## Why is it useful?
+Demonstrates `:focus-within` and `:has()` as pure CSS interaction primitives — the bar expands on focus, the clear button appears only when input has content (via `:has(:not(:placeholder-shown))`), all without a single line of JS controlling UI state. Fits EaseMotion CSS's philosophy of CSS-first animation and interaction.

--- a/submissions/examples/expanding-search-bar-sk/demo.html
+++ b/submissions/examples/expanding-search-bar-sk/demo.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Expanding Search Bar</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3rem;
+      background: #f8fafc;
+      font-family: system-ui, sans-serif;
+      padding: 3rem 1rem;
+    }
+    h1 {
+      font-size: 1rem;
+      color: #64748b;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      font-weight: 600;
+    }
+    .demo-row {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.6rem;
+    }
+    .demo-label {
+      font-size: 0.75rem;
+      color: #94a3b8;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .dark-bg {
+      background: #0f172a;
+      padding: 2rem;
+      border-radius: 12px;
+    }
+    .dark-bg .demo-label { color: #475569; }
+  </style>
+</head>
+<body>
+
+  <h1>CSS-Only Expanding Search Bar</h1>
+
+  <!-- Default / light -->
+  <div class="demo-row">
+    <p class="demo-label">Default (light)</p>
+    <div class="search-bar">
+      <span class="search-bar__icon" aria-hidden="true">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+        </svg>
+      </span>
+      <input class="search-bar__input" type="search" placeholder="Search…" aria-label="Search">
+      <button class="search-bar__clear" onclick="this.previousElementSibling.value='';this.previousElementSibling.focus()" aria-label="Clear search">×</button>
+    </div>
+  </div>
+
+  <!-- Dark variant -->
+  <div class="dark-bg">
+    <div class="demo-row">
+      <p class="demo-label" style="color:#475569">Dark variant</p>
+      <div class="search-bar search-bar--dark">
+        <span class="search-bar__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+          </svg>
+        </span>
+        <input class="search-bar__input" type="search" placeholder="Search…" aria-label="Search">
+        <button class="search-bar__clear" onclick="this.previousElementSibling.value='';this.previousElementSibling.focus()" aria-label="Clear search">×</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Large variant -->
+  <div class="demo-row">
+    <p class="demo-label">Large variant</p>
+    <div class="search-bar search-bar--lg">
+      <span class="search-bar__icon" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+        </svg>
+      </span>
+      <input class="search-bar__input" type="search" placeholder="Search anything…" aria-label="Search">
+      <button class="search-bar__clear" onclick="this.previousElementSibling.value='';this.previousElementSibling.focus()" aria-label="Clear search">×</button>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/expanding-search-bar-sk/style.css
+++ b/submissions/examples/expanding-search-bar-sk/style.css
@@ -1,0 +1,155 @@
+:root {
+  --search-collapsed-width: 44px;
+  --search-expanded-width: 280px;
+  --search-height: 44px;
+  --search-bg: #f1f5f9;
+  --search-bg-focus: #fff;
+  --search-border: #cbd5e1;
+  --search-border-focus: #6366f1;
+  --search-text: #1e293b;
+  --search-placeholder: #94a3b8;
+  --search-icon: #64748b;
+  --search-icon-focus: #6366f1;
+  --search-radius: 999px;
+  --search-duration: 0.3s;
+  --search-shadow-focus: 0 0 0 3px color-mix(in srgb, #6366f1 20%, transparent);
+}
+
+/* wrapper uses :focus-within to detect child focus */
+.search-bar {
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+  height: var(--search-height);
+  width: var(--search-collapsed-width);
+  background: var(--search-bg);
+  border: 1.5px solid var(--search-border);
+  border-radius: var(--search-radius);
+  transition:
+    width var(--search-duration) cubic-bezier(0.4, 0, 0.2, 1),
+    background var(--search-duration) ease,
+    border-color var(--search-duration) ease,
+    box-shadow var(--search-duration) ease;
+  overflow: hidden;
+}
+
+.search-bar:focus-within {
+  width: var(--search-expanded-width);
+  background: var(--search-bg-focus);
+  border-color: var(--search-border-focus);
+  box-shadow: var(--search-shadow-focus);
+}
+
+.search-bar__icon {
+  flex-shrink: 0;
+  width: var(--search-collapsed-width);
+  height: var(--search-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--search-icon);
+  transition: color var(--search-duration) ease;
+  pointer-events: none;
+}
+
+.search-bar:focus-within .search-bar__icon {
+  color: var(--search-icon-focus);
+}
+
+.search-bar__input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  color: var(--search-text);
+  outline: none;
+  padding: 0 0.75rem 0 0;
+  opacity: 0;
+  transition: opacity var(--search-duration) ease;
+  font-family: inherit;
+}
+
+.search-bar:focus-within .search-bar__input {
+  opacity: 1;
+}
+
+.search-bar__input::placeholder {
+  color: var(--search-placeholder);
+}
+
+/* clear button — appears only when input has content */
+.search-bar__clear {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--search-placeholder);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 6px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.search-bar__clear:hover {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+/* show clear button when input is non-empty — requires :has() */
+.search-bar:has(.search-bar__input:not(:placeholder-shown)) .search-bar__clear {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* variant: dark theme */
+.search-bar--dark {
+  --search-bg: #1e293b;
+  --search-bg-focus: #0f172a;
+  --search-border: #334155;
+  --search-border-focus: #818cf8;
+  --search-text: #f1f5f9;
+  --search-placeholder: #64748b;
+  --search-icon: #64748b;
+  --search-icon-focus: #818cf8;
+  --search-shadow-focus: 0 0 0 3px color-mix(in srgb, #818cf8 20%, transparent);
+}
+
+.search-bar--dark .search-bar__clear:hover {
+  background: #334155;
+  color: #94a3b8;
+}
+
+/* variant: large */
+.search-bar--lg {
+  --search-collapsed-width: 56px;
+  --search-expanded-width: 360px;
+  --search-height: 56px;
+}
+
+.search-bar--lg .search-bar__input {
+  font-size: 1.05rem;
+}
+
+/* reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .search-bar,
+  .search-bar__icon,
+  .search-bar__input {
+    transition: none;
+  }
+  .search-bar {
+    width: var(--search-expanded-width);
+  }
+  .search-bar__input {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a search bar that collapses to an icon and smoothly expands on focus using `:focus-within` — no JS needed for the expand/collapse behavior. The clear button uses `:has(:not(:placeholder-shown))` to appear only when the input has content.

Closes #7552

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/expanding-search-bar-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Three variants: default (light), dark, and large — all expanding on `:focus-within`.

**How does a developer use it?**

```html
<div class="search-bar">
  <span class="search-bar__icon" aria-hidden="true"><!-- SVG --></span>
  <input class="search-bar__input" type="search" placeholder="Search…" aria-label="Search">
  <button class="search-bar__clear" aria-label="Clear search">×</button>
</div>
```

**Why does it fit EaseMotion CSS?**

Pure CSS interaction — `:focus-within` controls layout state, `:has()` controls clear button visibility. No JS. Smooth cubic-bezier width transition. Falls back to always-expanded in reduced-motion environments.

---

## Demo

- [x] Demo works by opening `demo.html` directly — click/tab into any search bar to see it expand.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

The clear button uses a tiny inline `onclick` to reset the value and refocus — this is the only JS in the file (1 line per button). The expand/collapse, icon color, and clear-button visibility are 100% CSS.