### PR TITLE
feat: add animated gradient mesh background

### DIFF
--- a/submissions/examples/gradient-mesh-bg-sk/README.md
+++ b/submissions/examples/gradient-mesh-bg-sk/README.md
@@ -1,0 +1,40 @@
+# Animated Gradient Mesh Background
+
+## What does this do?
+Creates a flowing gradient mesh background by animating four blurred radial-gradient orbs across the screen with independent drift keyframes, producing a smooth aurora/mesh effect in pure CSS.
+
+## How is it used?
+
+```html
+<section class="mesh-bg">
+  <div class="mesh-bg__layer">
+    <div class="mesh-bg__orb"></div>
+    <div class="mesh-bg__orb"></div>
+    <div class="mesh-bg__orb"></div>
+    <div class="mesh-bg__orb"></div>
+  </div>
+  <div class="mesh-bg__content">
+    <!-- your page content -->
+  </div>
+</section>
+
+<!-- subtle variant -->
+<section class="mesh-bg mesh-bg--subtle">…</section>
+
+<!-- vivid variant -->
+<section class="mesh-bg mesh-bg--vivid">…</section>
+```
+
+Theming via CSS custom properties:
+```css
+--mesh-color-1: #6366f1;
+--mesh-color-2: #ec4899;
+--mesh-color-3: #06b6d4;
+--mesh-color-4: #8b5cf6;
+--mesh-duration: 12s;
+--mesh-blur: 80px;
+--mesh-opacity: 0.75;
+```
+
+## Why is it useful?
+No canvas, no WebGL, no JS — just CSS `filter: blur()` and `@keyframes`. Each orb moves independently with different durations and easing, creating an organic non-repeating feel. Respects `prefers-reduced-motion` by stopping drift animations. The color palette is fully overridable via CSS custom properties inline.

--- a/submissions/examples/gradient-mesh-bg-sk/demo.html
+++ b/submissions/examples/gradient-mesh-bg-sk/demo.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Gradient Mesh Background</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #050510; }
+
+    section {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .card {
+      max-width: 480px;
+      text-align: center;
+      padding: 3rem 2rem;
+    }
+
+    .tag {
+      display: inline-block;
+      font-size: 0.72rem;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      color: #818cf8;
+      background: rgba(99,102,241,0.12);
+      padding: 0.3em 0.9em;
+      border-radius: 999px;
+      margin-bottom: 1.5rem;
+    }
+
+    h1 {
+      font-size: clamp(1.8rem, 4vw, 2.8rem);
+      font-weight: 800;
+      color: #f1f5f9;
+      line-height: 1.2;
+      margin-bottom: 1rem;
+    }
+
+    p {
+      color: #94a3b8;
+      font-size: 1rem;
+      line-height: 1.7;
+      margin-bottom: 2rem;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: linear-gradient(135deg, #6366f1, #ec4899);
+      color: #fff;
+      border: none;
+      border-radius: 10px;
+      padding: 0.75rem 1.75rem;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      text-decoration: none;
+      transition: opacity 0.2s, transform 0.2s;
+    }
+    .btn:hover { opacity: 0.85; transform: translateY(-2px); }
+
+    .variant-label {
+      color: #475569;
+      font-size: 0.7rem;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      text-align: center;
+      padding: 1rem;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Default mesh -->
+  <section class="mesh-bg">
+    <div class="mesh-bg__layer">
+      <div class="mesh-bg__orb"></div>
+      <div class="mesh-bg__orb"></div>
+      <div class="mesh-bg__orb"></div>
+      <div class="mesh-bg__orb"></div>
+    </div>
+    <div class="mesh-bg__content card">
+      <span class="tag">Gradient Mesh</span>
+      <h1>Pure CSS<br>Mesh Background</h1>
+      <p>Four radial gradient orbs drift slowly across the canvas using CSS keyframe animations. No JS, no canvas — just CSS and blur.</p>
+      <a class="btn" href="#">Get started →</a>
+    </div>
+  </section>
+
+  <p class="variant-label">↓ Subtle variant</p>
+
+  <!-- Subtle variant -->
+  <section class="mesh-bg mesh-bg--subtle" style="min-height: 50vh; --mesh-color-1:#10b981; --mesh-color-2:#f59e0b; --mesh-color-3:#3b82f6; --mesh-color-4:#ef4444;">
+    <div class="mesh-bg__layer">
+      <div class="mesh-bg__orb"></div>
+      <div class="mesh-bg__orb"></div>
+      <div class="mesh-bg__orb"></div>
+      <div class="mesh-bg__orb"></div>
+    </div>
+    <div class="mesh-bg__content card">
+      <span class="tag" style="color:#34d399; background:rgba(16,185,129,0.12)">Subtle</span>
+      <h1 style="font-size:1.6rem">Custom color palette</h1>
+      <p>Override CSS custom properties inline to change the color scheme.</p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/gradient-mesh-bg-sk/style.css
+++ b/submissions/examples/gradient-mesh-bg-sk/style.css
@@ -1,0 +1,145 @@
+@property --mesh-x1 { syntax: '<percentage>'; inherits: false; initial-value: 20%; }
+@property --mesh-y1 { syntax: '<percentage>'; inherits: false; initial-value: 30%; }
+@property --mesh-x2 { syntax: '<percentage>'; inherits: false; initial-value: 80%; }
+@property --mesh-y2 { syntax: '<percentage>'; inherits: false; initial-value: 70%; }
+@property --mesh-x3 { syntax: '<percentage>'; inherits: false; initial-value: 50%; }
+@property --mesh-y3 { syntax: '<percentage>'; inherits: false; initial-value: 10%; }
+@property --mesh-x4 { syntax: '<percentage>'; inherits: false; initial-value: 10%; }
+@property --mesh-y4 { syntax: '<percentage>'; inherits: false; initial-value: 80%; }
+
+:root {
+  --mesh-color-1: #6366f1;
+  --mesh-color-2: #ec4899;
+  --mesh-color-3: #06b6d4;
+  --mesh-color-4: #8b5cf6;
+  --mesh-base: #050510;
+  --mesh-size-1: 55%;
+  --mesh-size-2: 50%;
+  --mesh-size-3: 45%;
+  --mesh-size-4: 40%;
+  --mesh-opacity: 0.75;
+  --mesh-blur: 80px;
+  --mesh-duration: 12s;
+}
+
+.mesh-bg {
+  position: relative;
+  background: var(--mesh-base);
+  overflow: hidden;
+}
+
+.mesh-bg__layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* each orb is a pseudo-element or a span */
+.mesh-bg__orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(var(--mesh-blur));
+  opacity: var(--mesh-opacity);
+  will-change: transform;
+}
+
+.mesh-bg__orb:nth-child(1) {
+  width: var(--mesh-size-1);
+  aspect-ratio: 1;
+  background: radial-gradient(circle, var(--mesh-color-1), transparent 70%);
+  top: var(--mesh-y1);
+  left: var(--mesh-x1);
+  transform: translate(-50%, -50%);
+  animation: drift1 var(--mesh-duration) ease-in-out infinite alternate;
+}
+
+.mesh-bg__orb:nth-child(2) {
+  width: var(--mesh-size-2);
+  aspect-ratio: 1;
+  background: radial-gradient(circle, var(--mesh-color-2), transparent 70%);
+  top: var(--mesh-y2);
+  left: var(--mesh-x2);
+  transform: translate(-50%, -50%);
+  animation: drift2 calc(var(--mesh-duration) * 1.3) ease-in-out infinite alternate;
+}
+
+.mesh-bg__orb:nth-child(3) {
+  width: var(--mesh-size-3);
+  aspect-ratio: 1;
+  background: radial-gradient(circle, var(--mesh-color-3), transparent 70%);
+  top: var(--mesh-y3);
+  left: var(--mesh-x3);
+  transform: translate(-50%, -50%);
+  animation: drift3 calc(var(--mesh-duration) * 0.9) ease-in-out infinite alternate;
+}
+
+.mesh-bg__orb:nth-child(4) {
+  width: var(--mesh-size-4);
+  aspect-ratio: 1;
+  background: radial-gradient(circle, var(--mesh-color-4), transparent 70%);
+  top: var(--mesh-y4);
+  left: var(--mesh-x4);
+  transform: translate(-50%, -50%);
+  animation: drift4 calc(var(--mesh-duration) * 1.6) ease-in-out infinite alternate;
+}
+
+@keyframes drift1 {
+  0%   { top: 20%; left: 20%; }
+  33%  { top: 60%; left: 70%; }
+  66%  { top: 80%; left: 30%; }
+  100% { top: 30%; left: 80%; }
+}
+
+@keyframes drift2 {
+  0%   { top: 70%; left: 80%; }
+  33%  { top: 20%; left: 50%; }
+  66%  { top: 50%; left: 10%; }
+  100% { top: 80%; left: 60%; }
+}
+
+@keyframes drift3 {
+  0%   { top: 10%; left: 50%; }
+  50%  { top: 60%; left: 20%; }
+  100% { top: 30%; left: 70%; }
+}
+
+@keyframes drift4 {
+  0%   { top: 80%; left: 10%; }
+  50%  { top: 40%; left: 60%; }
+  100% { top: 70%; left: 40%; }
+}
+
+/* noise texture overlay for mesh-like feel */
+.mesh-bg::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E");
+  background-size: 200px 200px;
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.mesh-bg__content {
+  position: relative;
+  z-index: 1;
+}
+
+/* variant: subtle (lower opacity, less blur) */
+.mesh-bg--subtle {
+  --mesh-opacity: 0.45;
+  --mesh-blur: 100px;
+}
+
+/* variant: vivid */
+.mesh-bg--vivid {
+  --mesh-opacity: 0.9;
+  --mesh-blur: 60px;
+}
+
+/* reduced motion: stop drifting */
+@media (prefers-reduced-motion: reduce) {
+  .mesh-bg__orb {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a full-viewport gradient mesh background built from four blurred radial-gradient orbs that drift independently using CSS `@keyframes`. No canvas, no WebGL, no JS — produces a smooth aurora/mesh effect purely in CSS.

Closes #7553

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/gradient-mesh-bg-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A composable `.mesh-bg` wrapper with `.mesh-bg__orb` children that drift across the background. Three variants: default, subtle (lower opacity, more blur), vivid (higher opacity, less blur). Colors fully overridable via CSS custom properties.

**How does a developer use it?**

```html
<section class="mesh-bg">
  <div class="mesh-bg__layer">
    <div class="mesh-bg__orb"></div>
    <div class="mesh-bg__orb"></div>
    <div class="mesh-bg__orb"></div>
    <div class="mesh-bg__orb"></div>
  </div>
  <div class="mesh-bg__content"><!-- content --></div>
</section>
```

**Why does it fit EaseMotion CSS?**

Pure CSS animation — `filter: blur()` + `@keyframes` with independent durations per orb. Fully themeable via custom properties. `prefers-reduced-motion` stops all drift. Lightweight — no JS, no external assets.

---

## Demo

- [x] Demo opens directly in browser — two sections (default palette + custom green/amber palette via inline CSS vars).

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge