### PR TITLE
feat: add CSS-only image lightbox via :target pseudo-class

### DIFF
--- a/submissions/examples/css-lightbox-target-sk/README.md
+++ b/submissions/examples/css-lightbox-target-sk/README.md
@@ -1,0 +1,28 @@
+# CSS-Only Image Lightbox via `:target`
+
+## What does this do?
+A full-featured image lightbox gallery that opens and closes by reading the URL hash — no JavaScript required. Each thumbnail links to its lightbox's `id`, and the `:target` pseudo-class activates the matching overlay.
+
+## How is it used?
+
+```html
+<!-- Gallery thumbnails -->
+<div class="lightbox-gallery">
+  <a href="#lb-1" class="lightbox-gallery__thumb" aria-label="Open image">
+    <img src="thumb.jpg" alt="Description">
+  </a>
+</div>
+
+<!-- Lightbox overlay -->
+<div id="lb-1" class="lightbox" role="dialog" aria-modal="true">
+  <a href="#" class="lightbox__backdrop" aria-label="Close lightbox"></a>
+  <div class="lightbox__box">
+    <a href="#" class="lightbox__close" aria-label="Close">×</a>
+    <img src="full.jpg" alt="Description">
+    <div class="lightbox__caption">Caption text</div>
+  </div>
+</div>
+```
+
+## Why is it useful?
+Demonstrates the `:target` CSS pseudo-class as a pure CSS state machine — the URL hash acts as the toggle switch. No `display:none` hacks, no JS event listeners. Backdrop blur, scale-in animation, and zoom cursor are all CSS. Respects `prefers-reduced-motion`. Close by clicking the backdrop or the × button (both link to `#` to clear the hash).

--- a/submissions/examples/css-lightbox-target-sk/demo.html
+++ b/submissions/examples/css-lightbox-target-sk/demo.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Image Lightbox (:target)</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      background: #0f172a;
+      font-family: system-ui, sans-serif;
+      padding: 3rem 2rem;
+      color: #94a3b8;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: #f1f5f9;
+      margin-bottom: 0.5rem;
+    }
+    p { margin-bottom: 2rem; font-size: 0.9rem; }
+    code {
+      background: #1e293b;
+      padding: 0.1em 0.4em;
+      border-radius: 4px;
+      font-size: 0.85em;
+      color: #818cf8;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>CSS-Only Image Lightbox</h1>
+  <p>Uses the <code>:target</code> pseudo-class — clicking a thumbnail sets the URL hash, activating the matching lightbox overlay. No JavaScript.</p>
+
+  <!-- Thumbnail gallery -->
+  <div class="lightbox-gallery">
+    <a href="#lb-1" class="lightbox-gallery__thumb" aria-label="Open image 1">
+      <img src="https://picsum.photos/seed/sk1/400/400" alt="Abstract blue waves">
+    </a>
+    <a href="#lb-2" class="lightbox-gallery__thumb" aria-label="Open image 2">
+      <img src="https://picsum.photos/seed/sk2/400/400" alt="Forest path">
+    </a>
+    <a href="#lb-3" class="lightbox-gallery__thumb" aria-label="Open image 3">
+      <img src="https://picsum.photos/seed/sk3/400/400" alt="Mountain lake">
+    </a>
+    <a href="#lb-4" class="lightbox-gallery__thumb" aria-label="Open image 4">
+      <img src="https://picsum.photos/seed/sk4/400/400" alt="City skyline">
+    </a>
+    <a href="#lb-5" class="lightbox-gallery__thumb" aria-label="Open image 5">
+      <img src="https://picsum.photos/seed/sk5/400/400" alt="Desert dunes">
+    </a>
+    <a href="#lb-6" class="lightbox-gallery__thumb" aria-label="Open image 6">
+      <img src="https://picsum.photos/seed/sk6/400/400" alt="Ocean sunset">
+    </a>
+  </div>
+
+  <!-- Lightbox overlays — one per image -->
+  <div id="lb-1" class="lightbox" role="dialog" aria-modal="true" aria-label="Image 1">
+    <a href="#" class="lightbox__backdrop" aria-label="Close lightbox"></a>
+    <div class="lightbox__box">
+      <a href="#" class="lightbox__close" aria-label="Close">×</a>
+      <img src="https://picsum.photos/seed/sk1/1200/800" alt="Abstract blue waves">
+      <div class="lightbox__caption">Abstract blue waves — click outside or × to close</div>
+    </div>
+  </div>
+
+  <div id="lb-2" class="lightbox" role="dialog" aria-modal="true" aria-label="Image 2">
+    <a href="#" class="lightbox__backdrop" aria-label="Close lightbox"></a>
+    <div class="lightbox__box">
+      <a href="#" class="lightbox__close" aria-label="Close">×</a>
+      <img src="https://picsum.photos/seed/sk2/1200/800" alt="Forest path">
+      <div class="lightbox__caption">Forest path</div>
+    </div>
+  </div>
+
+  <div id="lb-3" class="lightbox" role="dialog" aria-modal="true" aria-label="Image 3">
+    <a href="#" class="lightbox__backdrop" aria-label="Close lightbox"></a>
+    <div class="lightbox__box">
+      <a href="#" class="lightbox__close" aria-label="Close">×</a>
+      <img src="https://picsum.photos/seed/sk3/1200/800" alt="Mountain lake">
+      <div class="lightbox__caption">Mountain lake</div>
+    </div>
+  </div>
+
+  <div id="lb-4" class="lightbox" role="dialog" aria-modal="true" aria-label="Image 4">
+    <a href="#" class="lightbox__backdrop" aria-label="Close lightbox"></a>
+    <div class="lightbox__box">
+      <a href="#" class="lightbox__close" aria-label="Close">×</a>
+      <img src="https://picsum.photos/seed/sk4/1200/800" alt="City skyline">
+      <div class="lightbox__caption">City skyline</div>
+    </div>
+  </div>
+
+  <div id="lb-5" class="lightbox" role="dialog" aria-modal="true" aria-label="Image 5">
+    <a href="#" class="lightbox__backdrop" aria-label="Close lightbox"></a>
+    <div class="lightbox__box">
+      <a href="#" class="lightbox__close" aria-label="Close">×</a>
+      <img src="https://picsum.photos/seed/sk5/1200/800" alt="Desert dunes">
+      <div class="lightbox__caption">Desert dunes</div>
+    </div>
+  </div>
+
+  <div id="lb-6" class="lightbox" role="dialog" aria-modal="true" aria-label="Image 6">
+    <a href="#" class="lightbox__backdrop" aria-label="Close lightbox"></a>
+    <div class="lightbox__box">
+      <a href="#" class="lightbox__close" aria-label="Close">×</a>
+      <img src="https://picsum.photos/seed/sk6/1200/800" alt="Ocean sunset">
+      <div class="lightbox__caption">Ocean sunset</div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-lightbox-target-sk/style.css
+++ b/submissions/examples/css-lightbox-target-sk/style.css
@@ -1,0 +1,161 @@
+:root {
+  --lightbox-bg: rgba(0, 0, 0, 0.88);
+  --lightbox-radius: 12px;
+  --lightbox-duration: 0.28s;
+  --lightbox-max-w: min(90vw, 860px);
+  --lightbox-max-h: 85vh;
+  --thumb-gap: 12px;
+  --thumb-radius: 8px;
+  --thumb-size: 160px;
+}
+
+/* ── Gallery grid ── */
+.lightbox-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--thumb-size), 1fr));
+  gap: var(--thumb-gap);
+}
+
+.lightbox-gallery__thumb {
+  display: block;
+  border-radius: var(--thumb-radius);
+  overflow: hidden;
+  cursor: zoom-in;
+  position: relative;
+  aspect-ratio: 1;
+  background: #1e293b;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.lightbox-gallery__thumb:hover {
+  transform: scale(1.03);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.35);
+}
+
+.lightbox-gallery__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: opacity 0.2s ease;
+}
+
+.lightbox-gallery__thumb:hover img {
+  opacity: 0.9;
+}
+
+/* zoom icon overlay */
+.lightbox-gallery__thumb::after {
+  content: '⤢';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  color: rgba(255,255,255,0);
+  transition: color 0.2s ease;
+  pointer-events: none;
+}
+
+.lightbox-gallery__thumb:hover::after {
+  color: rgba(255,255,255,0.8);
+}
+
+/* ── Lightbox overlay — hidden by default ── */
+.lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--lightbox-bg);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--lightbox-duration) ease;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+/* :target activates the overlay when its id is in the URL hash */
+.lightbox:target {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.lightbox__box {
+  position: relative;
+  max-width: var(--lightbox-max-w);
+  max-height: var(--lightbox-max-h);
+  border-radius: var(--lightbox-radius);
+  overflow: hidden;
+  transform: scale(0.9);
+  transition: transform var(--lightbox-duration) cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 24px 80px rgba(0,0,0,0.7);
+}
+
+.lightbox:target .lightbox__box {
+  transform: scale(1);
+}
+
+.lightbox__box img {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: var(--lightbox-max-h);
+  object-fit: contain;
+}
+
+/* caption */
+.lightbox__caption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem 1.25rem;
+  background: linear-gradient(transparent, rgba(0,0,0,0.75));
+  color: #f1f5f9;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+/* close button — links to # to clear the hash */
+.lightbox__close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.5);
+  color: #fff;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  line-height: 1;
+  transition: background 0.15s ease;
+  z-index: 1;
+}
+
+.lightbox__close:hover {
+  background: rgba(0,0,0,0.8);
+}
+
+/* click backdrop to close — full overlay is the link */
+.lightbox__backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+}
+
+/* reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .lightbox,
+  .lightbox__box,
+  .lightbox-gallery__thumb {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a full image lightbox gallery powered entirely by the `:target` CSS pseudo-class. Clicking a thumbnail sets the URL hash; CSS activates the matching overlay. No JavaScript needed for open/close.

Closes #7554

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-lightbox-target-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A 6-image gallery with thumbnail hover effects, scale-in overlay animation, backdrop blur, captions, and click-backdrop-to-close — all CSS, no JS.

**How does a developer use it?**

```html
<a href="#lb-1" class="lightbox-gallery__thumb">
  <img src="thumb.jpg" alt="...">
</a>

<div id="lb-1" class="lightbox" role="dialog" aria-modal="true">
  <a href="#" class="lightbox__backdrop"></a>
  <div class="lightbox__box">
    <a href="#" class="lightbox__close">×</a>
    <img src="full.jpg" alt="...">
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

`:target` is a pure CSS state selector — the URL hash is the toggle. Scale-in entrance animation, backdrop blur, and thumbnail zoom cursor are all CSS. `prefers-reduced-motion` disables transitions.

---

## Demo

- [x] Demo opens directly in browser — 6 placeholder images (picsum.photos). Click any thumbnail to open lightbox, × or backdrop to close.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge