### PR TITLE
feat: add animated keyboard shortcut sequence badge

### DIFF
--- a/submissions/examples/keyboard-badge-sk/README.md
+++ b/submissions/examples/keyboard-badge-sk/README.md
@@ -1,0 +1,34 @@
+# Animated Keyboard Shortcut Sequence Badge
+
+## What does this do?
+Renders styled keyboard key badges (`<kbd>`) with a realistic 3D press effect, and sequences of keys that animate in one-by-one on load. Includes a shortcut reference table layout and press-down simulation.
+
+## How is it used?
+
+```html
+<!-- Single key -->
+<kbd class="kbd">⌘</kbd>
+<kbd class="kbd kbd--light">Ctrl</kbd>
+
+<!-- Animated shortcut sequence -->
+<div class="kbd-seq kbd-seq--animate">
+  <kbd class="kbd">⌘</kbd>
+  <span class="kbd-seq__sep">+</span>
+  <kbd class="kbd">K</kbd>
+</div>
+
+<!-- Shortcut reference row -->
+<div class="shortcut-row">
+  <span class="shortcut-row__label">Save file</span>
+  <div class="kbd-seq">
+    <kbd class="kbd">⌘</kbd>
+    <span class="kbd-seq__sep">+</span>
+    <kbd class="kbd">S</kbd>
+  </div>
+</div>
+```
+
+Add `.kbd--pressed` via JS (or use `:active`) for the press-down animation.
+
+## Why is it useful?
+Keyboard shortcut UX is a core part of developer tools, command palettes, and help overlays. The 3D key effect uses `box-shadow` and `transform: translateY` — pure CSS. The staggered sequence entry animation uses `@keyframes` with `nth-child` delays. Fully composable: single keys, sequences, and reference tables all use the same base `.kbd` class.

--- a/submissions/examples/keyboard-badge-sk/demo.html
+++ b/submissions/examples/keyboard-badge-sk/demo.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Keyboard Shortcut Badge</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      background: #0f172a;
+      font-family: system-ui, sans-serif;
+      padding: 3rem 2rem;
+      color: #94a3b8;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 3rem;
+    }
+    h1 {
+      color: #f1f5f9;
+      font-size: 1rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    .section { width: 100%; max-width: 520px; }
+    .section-title {
+      font-size: 0.7rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #475569;
+      margin-bottom: 1rem;
+    }
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.25rem 1.5rem;
+    }
+    .inline-demo {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: center;
+    }
+    .desc { font-size: 0.85rem; color: #64748b; }
+    button.replay-btn {
+      background: #334155;
+      color: #94a3b8;
+      border: 1px solid #475569;
+      border-radius: 6px;
+      padding: 0.35rem 0.8rem;
+      font-size: 0.78rem;
+      cursor: pointer;
+      font-family: inherit;
+      margin-top: 1rem;
+      transition: background 0.15s;
+    }
+    button.replay-btn:hover { background: #475569; color: #f1f5f9; }
+  </style>
+</head>
+<body>
+
+  <h1>Keyboard Shortcut Badge</h1>
+
+  <!-- Single keys — dark + light -->
+  <div class="section">
+    <p class="section-title">Single keys</p>
+    <div class="inline-demo">
+      <kbd class="kbd">⌘</kbd>
+      <kbd class="kbd">Ctrl</kbd>
+      <kbd class="kbd">Alt</kbd>
+      <kbd class="kbd">Shift</kbd>
+      <kbd class="kbd">⇥ Tab</kbd>
+      <kbd class="kbd">↵ Enter</kbd>
+      <kbd class="kbd kbd--light">⌘</kbd>
+      <kbd class="kbd kbd--light">Ctrl</kbd>
+    </div>
+  </div>
+
+  <!-- Sequences — dark -->
+  <div class="section">
+    <p class="section-title">Shortcut sequences (animated entry)</p>
+    <div class="inline-demo">
+      <div class="kbd-seq kbd-seq--animate" id="seq1">
+        <kbd class="kbd">⌘</kbd>
+        <span class="kbd-seq__sep">+</span>
+        <kbd class="kbd">K</kbd>
+      </div>
+
+      <div class="kbd-seq kbd-seq--animate" id="seq2">
+        <kbd class="kbd">Ctrl</kbd>
+        <span class="kbd-seq__sep">+</span>
+        <kbd class="kbd">Shift</kbd>
+        <span class="kbd-seq__sep">+</span>
+        <kbd class="kbd">P</kbd>
+      </div>
+
+      <div class="kbd-seq kbd-seq--animate" id="seq3">
+        <kbd class="kbd">G</kbd>
+        <span class="kbd-seq__sep">→</span>
+        <kbd class="kbd">I</kbd>
+      </div>
+    </div>
+    <button class="replay-btn" onclick="replayAll()">↻ Replay animation</button>
+  </div>
+
+  <!-- Shortcut reference table -->
+  <div class="section">
+    <p class="section-title">Shortcut reference panel</p>
+    <div class="card">
+      <div class="shortcut-row">
+        <span class="shortcut-row__label">Command palette</span>
+        <div class="kbd-seq">
+          <kbd class="kbd">⌘</kbd>
+          <span class="kbd-seq__sep">+</span>
+          <kbd class="kbd">K</kbd>
+        </div>
+      </div>
+      <div class="shortcut-row">
+        <span class="shortcut-row__label">Save file</span>
+        <div class="kbd-seq">
+          <kbd class="kbd">⌘</kbd>
+          <span class="kbd-seq__sep">+</span>
+          <kbd class="kbd">S</kbd>
+        </div>
+      </div>
+      <div class="shortcut-row">
+        <span class="shortcut-row__label">Find & replace</span>
+        <div class="kbd-seq">
+          <kbd class="kbd">⌘</kbd>
+          <span class="kbd-seq__sep">+</span>
+          <kbd class="kbd">H</kbd>
+        </div>
+      </div>
+      <div class="shortcut-row">
+        <span class="shortcut-row__label">Quick open</span>
+        <div class="kbd-seq">
+          <kbd class="kbd">Ctrl</kbd>
+          <span class="kbd-seq__sep">+</span>
+          <kbd class="kbd">P</kbd>
+        </div>
+      </div>
+      <div class="shortcut-row">
+        <span class="shortcut-row__label">Toggle terminal</span>
+        <div class="kbd-seq">
+          <kbd class="kbd">Ctrl</kbd>
+          <span class="kbd-seq__sep">+</span>
+          <kbd class="kbd">`</kbd>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Press simulation -->
+  <div class="section">
+    <p class="section-title">Press simulation (click to press)</p>
+    <div class="inline-demo">
+      <kbd class="kbd" onclick="press(this)">⌘</kbd>
+      <kbd class="kbd" onclick="press(this)">Ctrl</kbd>
+      <kbd class="kbd" onclick="press(this)">S</kbd>
+      <kbd class="kbd" onclick="press(this)">↵</kbd>
+    </div>
+    <p class="desc" style="margin-top:0.6rem;font-size:0.78rem;">Click a key to see the press-down animation.</p>
+  </div>
+
+  <script>
+    function press(el) {
+      el.classList.add('kbd--pressed');
+      setTimeout(() => el.classList.remove('kbd--pressed'), 200);
+    }
+
+    function replayAll() {
+      ['seq1','seq2','seq3'].forEach(id => {
+        const el = document.getElementById(id);
+        el.classList.remove('kbd-seq--animate');
+        void el.offsetWidth; // force reflow
+        el.classList.add('kbd-seq--animate');
+      });
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/keyboard-badge-sk/style.css
+++ b/submissions/examples/keyboard-badge-sk/style.css
@@ -1,0 +1,151 @@
+:root {
+  --kbd-bg: #1e293b;
+  --kbd-bg-top: #334155;
+  --kbd-border: #475569;
+  --kbd-border-bottom: #1e293b;
+  --kbd-text: #e2e8f0;
+  --kbd-shadow: 0 2px 0 0 var(--kbd-border-bottom), 0 1px 3px rgba(0,0,0,0.4);
+  --kbd-radius: 6px;
+  --kbd-font: ui-monospace, 'SFMono-Regular', Menlo, monospace;
+  --kbd-font-size: 0.8rem;
+  --kbd-padding: 0.25em 0.6em;
+  --kbd-press-duration: 0.12s;
+
+  /* sequence connector */
+  --kbd-sep-color: #64748b;
+  --kbd-seq-gap: 0.4rem;
+
+  /* light variant defaults */
+  --kbd-bg-light: #f8fafc;
+  --kbd-bg-top-light: #fff;
+  --kbd-border-light: #cbd5e1;
+  --kbd-border-bottom-light: #94a3b8;
+  --kbd-text-light: #334155;
+}
+
+/* ── Single key ── */
+.kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(to bottom, var(--kbd-bg-top), var(--kbd-bg));
+  color: var(--kbd-text);
+  border: 1px solid var(--kbd-border);
+  border-radius: var(--kbd-radius);
+  box-shadow: var(--kbd-shadow);
+  font-family: var(--kbd-font);
+  font-size: var(--kbd-font-size);
+  font-weight: 500;
+  line-height: 1;
+  padding: var(--kbd-padding);
+  white-space: nowrap;
+  user-select: none;
+  transition:
+    transform var(--kbd-press-duration) ease,
+    box-shadow var(--kbd-press-duration) ease,
+    background var(--kbd-press-duration) ease;
+  cursor: default;
+}
+
+/* press-down animation triggered by class or :active */
+.kbd--pressed,
+.kbd:active {
+  transform: translateY(2px);
+  box-shadow: 0 0 0 var(--kbd-border-bottom), 0 1px 1px rgba(0,0,0,0.3);
+  background: linear-gradient(to bottom, var(--kbd-bg), var(--kbd-bg));
+}
+
+/* ── Light variant ── */
+.kbd--light {
+  --kbd-bg: var(--kbd-bg-light);
+  --kbd-bg-top: var(--kbd-bg-top-light);
+  --kbd-border: var(--kbd-border-light);
+  --kbd-border-bottom: var(--kbd-border-bottom-light);
+  --kbd-text: var(--kbd-text-light);
+  --kbd-shadow: 0 2px 0 0 var(--kbd-border-bottom-light), 0 1px 3px rgba(0,0,0,0.12);
+}
+
+/* ── Sequence: group of keys with separators ── */
+.kbd-seq {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--kbd-seq-gap);
+}
+
+/* separator between keys: + or → */
+.kbd-seq__sep {
+  color: var(--kbd-sep-color);
+  font-size: 0.75rem;
+  font-family: var(--kbd-font);
+  flex-shrink: 0;
+}
+
+/* ── Animated sequence: keys appear one by one ── */
+.kbd-seq--animate .kbd {
+  opacity: 0;
+  transform: translateY(-6px) scale(0.9);
+  animation: key-appear 0.25s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.kbd-seq--animate .kbd:nth-child(1)  { animation-delay: 0.0s; }
+.kbd-seq--animate .kbd:nth-child(2)  { animation-delay: 0.0s; } /* sep */
+.kbd-seq--animate .kbd:nth-child(3)  { animation-delay: 0.12s; }
+.kbd-seq--animate .kbd:nth-child(4)  { animation-delay: 0.12s; }
+.kbd-seq--animate .kbd:nth-child(5)  { animation-delay: 0.24s; }
+.kbd-seq--animate .kbd:nth-child(6)  { animation-delay: 0.24s; }
+.kbd-seq--animate .kbd:nth-child(7)  { animation-delay: 0.36s; }
+.kbd-seq--animate .kbd:nth-child(8)  { animation-delay: 0.36s; }
+.kbd-seq--animate .kbd:nth-child(9)  { animation-delay: 0.48s; }
+.kbd-seq--animate .kbd:nth-child(10) { animation-delay: 0.48s; }
+
+@keyframes key-appear {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* separator doesn't animate */
+.kbd-seq--animate .kbd-seq__sep {
+  opacity: 0;
+  animation: fade-in 0.15s ease forwards;
+}
+.kbd-seq--animate .kbd-seq__sep:nth-child(2) { animation-delay: 0.06s; }
+.kbd-seq--animate .kbd-seq__sep:nth-child(4) { animation-delay: 0.18s; }
+.kbd-seq--animate .kbd-seq__sep:nth-child(6) { animation-delay: 0.30s; }
+
+@keyframes fade-in {
+  to { opacity: 1; }
+}
+
+/* ── Shortcut row — label + keys ── */
+.shortcut-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid #1e293b;
+  gap: 1rem;
+}
+
+.shortcut-row:last-child { border-bottom: none; }
+
+.shortcut-row__label {
+  font-size: 0.875rem;
+  color: #94a3b8;
+}
+
+/* ── Press simulation: JS adds/removes .kbd--pressed ── */
+
+/* reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .kbd-seq--animate .kbd,
+  .kbd-seq--animate .kbd-seq__sep {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+  .kbd {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a keyboard shortcut badge system: realistic 3D `<kbd>` keys, staggered sequence entry animation, a shortcut reference table layout, and press-down simulation. Pure CSS for all visual effects.

Closes #7557

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/keyboard-badge-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

`.kbd` — single key with 3D press effect. `.kbd-seq.kbd-seq--animate` — staggered entry animation. `.shortcut-row` — label + keys reference layout. Dark and light color variants.

**How does a developer use it?**

```html
<div class="kbd-seq kbd-seq--animate">
  <kbd class="kbd">Ctrl</kbd>
  <span class="kbd-seq__sep">+</span>
  <kbd class="kbd">Shift</kbd>
  <span class="kbd-seq__sep">+</span>
  <kbd class="kbd">P</kbd>
</div>
```

**Why does it fit EaseMotion CSS?**

3D key: `box-shadow` bottom border + `translateY` on press — pure CSS. Sequence entry: `@keyframes` + `nth-child` stagger delays. Respects `prefers-reduced-motion`.

---

## Demo

- [x] Demo opens directly — single keys, animated sequences with replay button, shortcut reference table, clickable press simulation.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge