### PR TITLE
feat: add CSS-only accordion using :has() selector

### DIFF
--- a/submissions/examples/accordion-has-sk/README.md
+++ b/submissions/examples/accordion-has-sk/README.md
@@ -1,0 +1,33 @@
+# CSS-Only Accordion using `:has()` Selector
+
+## What does this do?
+An accordion built on native `<details>`/`<summary>` elements, styled entirely with CSS. Uses `:has(details[open])` to style the parent container when an item is open, and the CSS Grid row-height trick for smooth height animation.
+
+## How is it used?
+
+```html
+<div class="accordion">
+  <div class="accordion__item">
+    <details>
+      <summary class="accordion__header">
+        Question or title
+        <svg class="accordion__icon"><!-- chevron --></svg>
+      </summary>
+      <div class="accordion__body">
+        <div class="accordion__body-inner">
+          Answer or content here.
+        </div>
+      </div>
+    </details>
+  </div>
+</div>
+
+<!-- Flush variant -->
+<div class="accordion accordion--flush">…</div>
+
+<!-- Light variant -->
+<div class="accordion accordion--light">…</div>
+```
+
+## Why is it useful?
+Demonstrates three modern CSS techniques together: `<details>` for zero-JS toggle, `:has()` for parent-targeting based on descendant state (border highlight + sibling dimming), and the `grid-template-rows: 0fr → 1fr` trick for smooth height animation without JavaScript or `max-height` hacks. Respects `prefers-reduced-motion`.

--- a/submissions/examples/accordion-has-sk/demo.html
+++ b/submissions/examples/accordion-has-sk/demo.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Accordion using :has()</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      background: #0f172a;
+      font-family: system-ui, sans-serif;
+      padding: 3rem 2rem;
+      color: #94a3b8;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 3rem;
+    }
+    h1 {
+      color: #f1f5f9;
+      font-size: 1rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    .section { width: 100%; max-width: 560px; }
+    .section-title {
+      font-size: 0.7rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #475569;
+      margin-bottom: 1rem;
+    }
+
+    /* chevron SVG icon */
+    .icon-chevron {
+      width: 20px; height: 20px;
+      stroke: currentColor;
+      fill: none;
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>CSS-Only Accordion — :has() Selector</h1>
+
+  <!-- Dark default -->
+  <div class="section">
+    <p class="section-title">Dark variant (default)</p>
+    <div class="accordion">
+      <div class="accordion__item">
+        <details>
+          <summary class="accordion__header">
+            What is the :has() selector?
+            <svg class="accordion__icon icon-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </summary>
+          <div class="accordion__body">
+            <div class="accordion__body-inner">
+              <p>The <code>:has()</code> pseudo-class lets you select a parent element based on its children. For example, <code>.card:has(img)</code> matches any <code>.card</code> that contains an image. It's a relational selector — often called the "parent selector" CSS developers have requested for decades.</p>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <div class="accordion__item">
+        <details>
+          <summary class="accordion__header">
+            How is this accordion CSS-only?
+            <svg class="accordion__icon icon-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </summary>
+          <div class="accordion__body">
+            <div class="accordion__body-inner">
+              <p>It uses native <code>&lt;details&gt;</code> / <code>&lt;summary&gt;</code> HTML elements for the toggle behavior — no JavaScript needed. <code>:has(details[open])</code> on the parent <code>.accordion__item</code> lets us style the container when its child is open, enabling the border highlight and dimming of siblings.</p>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <div class="accordion__item">
+        <details>
+          <summary class="accordion__header">
+            Height animation technique
+            <svg class="accordion__icon icon-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </summary>
+          <div class="accordion__body">
+            <div class="accordion__body-inner">
+              <p>The smooth height transition uses the CSS Grid trick: setting <code>grid-template-rows</code> from <code>0fr</code> to <code>1fr</code>. This avoids the need to know the content's height in advance and works in pure CSS, unlike <code>max-height</code> hacks that produce uneven easing.</p>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <div class="accordion__item">
+        <details>
+          <summary class="accordion__header">
+            Browser support for :has()
+            <svg class="accordion__icon icon-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </summary>
+          <div class="accordion__body">
+            <div class="accordion__body-inner">
+              <p>Supported in Chrome 105+, Safari 15.4+, Edge 105+, and Firefox 121+. Coverage is now above 90% of global users. The accordion still works in older browsers — only the parent-styling via <code>:has()</code> degrades (the dimming effect disappears; open/close still works).</p>
+            </div>
+          </div>
+        </details>
+      </div>
+    </div>
+  </div>
+
+  <!-- Flush variant -->
+  <div class="section">
+    <p class="section-title">Flush variant</p>
+    <div class="accordion accordion--flush">
+      <div class="accordion__item">
+        <details>
+          <summary class="accordion__header">
+            Shipping & delivery
+            <svg class="accordion__icon icon-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </summary>
+          <div class="accordion__body">
+            <div class="accordion__body-inner">
+              <p>Free standard shipping on orders over $50. Express delivery available at checkout. International shipping takes 7–14 business days.</p>
+            </div>
+          </div>
+        </details>
+      </div>
+      <div class="accordion__item">
+        <details>
+          <summary class="accordion__header">
+            Returns & refunds
+            <svg class="accordion__icon icon-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </summary>
+          <div class="accordion__body">
+            <div class="accordion__body-inner">
+              <p>30-day hassle-free returns. Items must be unused and in original packaging. Refunds are processed within 5–7 business days.</p>
+            </div>
+          </div>
+        </details>
+      </div>
+      <div class="accordion__item">
+        <details>
+          <summary class="accordion__header">
+            Warranty
+            <svg class="accordion__icon icon-chevron" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </summary>
+          <div class="accordion__body">
+            <div class="accordion__body-inner">
+              <p>All products include a 1-year limited warranty covering manufacturing defects. Extended warranty plans are available for purchase.</p>
+            </div>
+          </div>
+        </details>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/accordion-has-sk/style.css
+++ b/submissions/examples/accordion-has-sk/style.css
@@ -1,0 +1,159 @@
+:root {
+  --acc-bg: #1e293b;
+  --acc-bg-open: #0f172a;
+  --acc-border: #334155;
+  --acc-border-open: #6366f1;
+  --acc-radius: 10px;
+  --acc-header-color: #f1f5f9;
+  --acc-header-color-open: #818cf8;
+  --acc-body-color: #94a3b8;
+  --acc-icon-color: #64748b;
+  --acc-icon-color-open: #6366f1;
+  --acc-gap: 0.5rem;
+  --acc-duration: 0.3s;
+  --acc-padding-h: 1.25rem;
+  --acc-padding-v: 1rem;
+}
+
+/* ── Accordion container ── */
+.accordion {
+  display: flex;
+  flex-direction: column;
+  gap: var(--acc-gap);
+}
+
+/* ── Each item uses <details> for native toggle ── */
+.accordion__item {
+  border: 1px solid var(--acc-border);
+  border-radius: var(--acc-radius);
+  background: var(--acc-bg);
+  overflow: hidden;
+  transition:
+    border-color var(--acc-duration) ease,
+    background var(--acc-duration) ease,
+    box-shadow var(--acc-duration) ease;
+}
+
+/* :has() — style parent based on open child state */
+.accordion__item:has(> details[open]) {
+  border-color: var(--acc-border-open);
+  background: var(--acc-bg-open);
+  box-shadow: 0 0 0 1px var(--acc-border-open);
+}
+
+/* ── Summary (clickable header) ── */
+.accordion__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--acc-padding-v) var(--acc-padding-h);
+  cursor: pointer;
+  list-style: none;
+  gap: 1rem;
+  color: var(--acc-header-color);
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: color var(--acc-duration) ease;
+  user-select: none;
+}
+
+/* remove default marker */
+.accordion__header::-webkit-details-marker { display: none; }
+.accordion__header::marker { display: none; }
+
+/* style header when details is open — uses :has() on the item or direct selector on details[open] > summary */
+details[open] > .accordion__header {
+  color: var(--acc-header-color-open);
+}
+
+/* ── Icon ── */
+.accordion__icon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  color: var(--acc-icon-color);
+  transition:
+    transform var(--acc-duration) cubic-bezier(0.34, 1.2, 0.64, 1),
+    color var(--acc-duration) ease;
+}
+
+details[open] > .accordion__header .accordion__icon {
+  transform: rotate(180deg);
+  color: var(--acc-icon-color-open);
+}
+
+/* ── Body / content ── */
+.accordion__body {
+  padding: 0 var(--acc-padding-h) var(--acc-padding-v);
+  color: var(--acc-body-color);
+  font-size: 0.9rem;
+  line-height: 1.65;
+
+  /* Smooth height animation using grid trick */
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--acc-duration) ease;
+}
+
+details[open] > .accordion__body {
+  grid-template-rows: 1fr;
+}
+
+.accordion__body-inner {
+  overflow: hidden;
+}
+
+/* ── :has() powered siblings ──
+   When one item is open, dim the other items (optional UX effect) */
+.accordion:has(.accordion__item:has(details[open])) .accordion__item:not(:has(details[open])) {
+  opacity: 0.65;
+  transition:
+    opacity var(--acc-duration) ease,
+    border-color var(--acc-duration) ease,
+    background var(--acc-duration) ease,
+    box-shadow var(--acc-duration) ease;
+}
+
+.accordion:has(.accordion__item:has(details[open])) .accordion__item:not(:has(details[open])):hover {
+  opacity: 1;
+}
+
+/* ── Light variant ── */
+.accordion--light {
+  --acc-bg: #f8fafc;
+  --acc-bg-open: #fff;
+  --acc-border: #e2e8f0;
+  --acc-border-open: #6366f1;
+  --acc-header-color: #1e293b;
+  --acc-body-color: #64748b;
+  --acc-icon-color: #94a3b8;
+}
+
+/* ── Flush variant (no gaps, full border) ── */
+.accordion--flush {
+  border: 1px solid var(--acc-border);
+  border-radius: var(--acc-radius);
+  gap: 0;
+  overflow: hidden;
+}
+
+.accordion--flush .accordion__item {
+  border: none;
+  border-bottom: 1px solid var(--acc-border);
+  border-radius: 0;
+  box-shadow: none !important;
+}
+
+.accordion--flush .accordion__item:last-child {
+  border-bottom: none;
+}
+
+/* reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .accordion__item,
+  .accordion__icon,
+  .accordion__body,
+  .accordion:has(.accordion__item:has(details[open])) .accordion__item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an accordion built on native `<details>`/`<summary>` with zero JS. Uses `:has(details[open])` to style the parent item when open (border color, background, sibling dimming) and the CSS Grid row-height trick for smooth content height animation.

Closes #7558

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/accordion-has-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Dark default variant, flush (borderless between items) variant, light variant. All share the same base classes.

**How does a developer use it?**

```html
<div class="accordion">
  <div class="accordion__item">
    <details>
      <summary class="accordion__header">
        Title <svg class="accordion__icon">…</svg>
      </summary>
      <div class="accordion__body"><div class="accordion__body-inner">Content</div></div>
    </details>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

Three CSS techniques in one component: `<details>` for JS-free toggle, `:has()` for parent-state styling, `grid-template-rows` height animation. No JS, no `max-height` hack. Respects `prefers-reduced-motion`.

---

## Demo

- [x] Demo opens directly — two accordion groups (default dark + flush). Open multiple items to see sibling dimming via `:has()`.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge