### PR TITLE
feat: add pure CSS perspective tilt card

### DIFF
--- a/submissions/examples/perspective-tilt-card-sk/README.md
+++ b/submissions/examples/perspective-tilt-card-sk/README.md
@@ -1,0 +1,41 @@
+# Pure CSS Perspective Tilt Card (No JS)
+
+## What does this do?
+A 3D tilt card with two variants: a CSS-only fixed-angle tilt on hover, and a mouse-tracked variant where JS sets CSS custom properties (`--tilt-x`, `--tilt-y`) that drive the `rotateX/Y` transform — keeping all visual logic in CSS.
+
+## How is it used?
+
+```html
+<!-- CSS-only variant (zero JS) -->
+<div class="tilt-scene">
+  <div class="tilt-card tilt-card--css-only">
+    <div class="tilt-card__shine"></div>
+    <div class="tilt-card__body">
+      <h3 class="tilt-card__title">Title</h3>
+      <p class="tilt-card__body-text">Content</p>
+    </div>
+  </div>
+</div>
+
+<!-- Mouse-tracked variant (JS sets CSS vars only) -->
+<div class="tilt-scene">
+  <div class="tilt-card" id="my-card">
+    <div class="tilt-card__shine"></div>
+    <div class="tilt-card__body">
+      <div class="tilt-card__float">Content floats in Z-space</div>
+    </div>
+  </div>
+</div>
+```
+
+```js
+// Minimal JS — only sets CSS custom properties
+card.addEventListener('mousemove', (e) => {
+  const { left, top, width, height } = card.getBoundingClientRect();
+  card.style.setProperty('--tilt-x', ((0.5 - (e.clientY - top) / height) * 30).toFixed(2));
+  card.style.setProperty('--tilt-y', (((e.clientX - left) / width - 0.5) * 30).toFixed(2));
+});
+```
+
+## Why is it useful?
+The CSS-only variant works with zero JS using `perspective()` in the transform. The mouse-tracked variant keeps all visual rules in CSS — JS only updates two numbers. `transform-style: preserve-3d` and `translateZ` on inner elements create depth layering. The gloss overlay uses a `radial-gradient` following the mouse via CSS custom properties. Respects `prefers-reduced-motion`.

--- a/submissions/examples/perspective-tilt-card-sk/demo.html
+++ b/submissions/examples/perspective-tilt-card-sk/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pure CSS Perspective Tilt Card</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3rem;
+      background: #050510;
+      font-family: system-ui, sans-serif;
+      padding: 3rem 2rem;
+    }
+    h1 {
+      color: #f1f5f9;
+      font-size: 1rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    .row {
+      display: flex;
+      gap: 2rem;
+      flex-wrap: wrap;
+      justify-content: center;
+      align-items: flex-start;
+    }
+    .col { display: flex; flex-direction: column; align-items: center; gap: 0.6rem; }
+    .label {
+      font-size: 0.7rem;
+      color: #475569;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Perspective Tilt Card</h1>
+
+  <div class="row">
+    <!-- JS-tracked mouse tilt -->
+    <div class="col">
+      <div class="tilt-scene">
+        <div class="tilt-card" id="js-tilt" style="width:280px">
+          <div class="tilt-card__shine"></div>
+          <div class="tilt-card__body">
+            <div class="tilt-card__float">
+              <span class="tilt-card__icon">✦</span>
+              <span class="tilt-card__tag">Mouse tracked</span>
+              <h3 class="tilt-card__title">JS-Powered Tilt</h3>
+              <p class="tilt-card__body-text">Moves with mouse position inside the card. CSS custom properties drive the transform — JS only sets the variables.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="label">Mouse-tracked (CSS vars + JS)</p>
+    </div>
+
+    <!-- Pure CSS-only tilt -->
+    <div class="col">
+      <div class="tilt-scene">
+        <div class="tilt-card tilt-card--css-only" style="width:280px">
+          <div class="tilt-card__shine"></div>
+          <div class="tilt-card__body">
+            <span class="tilt-card__icon">◈</span>
+            <span class="tilt-card__tag">CSS only</span>
+            <h3 class="tilt-card__title">Pure CSS Tilt</h3>
+            <p class="tilt-card__body-text">Fixed-angle tilt on hover using <code>rotateX/Y</code> with <code>perspective()</code>. Zero JavaScript required.</p>
+          </div>
+        </div>
+      </div>
+      <p class="label">CSS-only (zero JS)</p>
+    </div>
+  </div>
+
+  <script>
+    const card = document.getElementById('js-tilt');
+    const MAX = 15;
+
+    card.addEventListener('mousemove', (e) => {
+      const rect = card.getBoundingClientRect();
+      const x = (e.clientX - rect.left) / rect.width;
+      const y = (e.clientY - rect.top) / rect.height;
+      const tiltX = (0.5 - y) * MAX * 2;
+      const tiltY = (x - 0.5) * MAX * 2;
+      card.style.setProperty('--tilt-x', tiltX.toFixed(2));
+      card.style.setProperty('--tilt-y', tiltY.toFixed(2));
+      card.style.setProperty('--shine-x', (x * 100).toFixed(1) + '%');
+      card.style.setProperty('--shine-y', (y * 100).toFixed(1) + '%');
+    });
+
+    card.addEventListener('mouseleave', () => {
+      card.style.setProperty('--tilt-x', 0);
+      card.style.setProperty('--tilt-y', 0);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/perspective-tilt-card-sk/style.css
+++ b/submissions/examples/perspective-tilt-card-sk/style.css
@@ -1,0 +1,150 @@
+@property --tilt-x { syntax: '<number>'; inherits: false; initial-value: 0; }
+@property --tilt-y { syntax: '<number>'; inherits: false; initial-value: 0; }
+@property --shine-x { syntax: '<percentage>'; inherits: false; initial-value: 50%; }
+@property --shine-y { syntax: '<percentage>'; inherits: false; initial-value: 50%; }
+
+:root {
+  --tilt-perspective: 800px;
+  --tilt-max-deg: 15;
+  --tilt-duration: 0.1s;
+  --tilt-return-duration: 0.5s;
+  --tilt-ease: cubic-bezier(0.03, 0.98, 0.52, 0.99);
+
+  --card-bg: #1e293b;
+  --card-border: #334155;
+  --card-radius: 20px;
+  --card-shadow: 0 20px 60px rgba(0,0,0,0.5);
+  --card-shadow-hover: 0 40px 80px rgba(0,0,0,0.6);
+  --shine-opacity: 0.12;
+}
+
+/* ── Scene wrapper — sets perspective context ── */
+.tilt-scene {
+  perspective: var(--tilt-perspective);
+  display: inline-flex;
+}
+
+/* ── Tilt card ── */
+.tilt-card {
+  position: relative;
+  border-radius: var(--card-radius);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--card-shadow);
+  overflow: hidden;
+  transform-style: preserve-3d;
+
+  /* CSS-only tilt using custom properties set by JS */
+  transform:
+    rotateX(calc(var(--tilt-x) * 1deg))
+    rotateY(calc(var(--tilt-y) * 1deg));
+
+  transition:
+    transform var(--tilt-return-duration) var(--tilt-ease),
+    box-shadow var(--tilt-return-duration) var(--tilt-ease);
+}
+
+.tilt-card:hover {
+  transition:
+    transform var(--tilt-duration) var(--tilt-ease),
+    box-shadow var(--tilt-duration) var(--tilt-ease);
+  box-shadow: var(--card-shadow-hover);
+}
+
+/* ── Shine/gloss overlay ── */
+.tilt-card__shine {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: radial-gradient(
+    circle at var(--shine-x) var(--shine-y),
+    rgba(255, 255, 255, var(--shine-opacity)),
+    transparent 60%
+  );
+  opacity: 0;
+  transition: opacity var(--tilt-return-duration) ease;
+  z-index: 5;
+}
+
+.tilt-card:hover .tilt-card__shine {
+  opacity: 1;
+  transition: opacity var(--tilt-duration) ease;
+}
+
+/* ── Content inside the card ── */
+.tilt-card__body {
+  position: relative;
+  z-index: 1;
+  padding: 2rem;
+}
+
+/* 3D floating layer — moves more than parent to enhance depth */
+.tilt-card__float {
+  transform: translateZ(30px);
+  transition: transform var(--tilt-return-duration) var(--tilt-ease);
+}
+
+.tilt-card:hover .tilt-card__float {
+  transition: transform var(--tilt-duration) var(--tilt-ease);
+}
+
+.tilt-card__icon {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  display: block;
+}
+
+.tilt-card__tag {
+  display: inline-block;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #818cf8;
+  background: rgba(99,102,241,0.12);
+  padding: 0.2em 0.65em;
+  border-radius: 999px;
+  margin-bottom: 1rem;
+}
+
+.tilt-card__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  margin-bottom: 0.6rem;
+  line-height: 1.3;
+}
+
+.tilt-card__body-text {
+  font-size: 0.875rem;
+  color: #94a3b8;
+  line-height: 1.6;
+}
+
+/* ── CSS-only fallback tilt: uses :hover with fixed angles ── */
+.tilt-card--css-only {
+  transition:
+    transform var(--tilt-return-duration) var(--tilt-ease),
+    box-shadow var(--tilt-return-duration) var(--tilt-ease);
+}
+
+.tilt-card--css-only:hover {
+  transform: perspective(var(--tilt-perspective)) rotateX(-6deg) rotateY(6deg) scale(1.02);
+  box-shadow: var(--card-shadow-hover);
+  transition-duration: 0.25s;
+}
+
+/* reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .tilt-card,
+  .tilt-card__float,
+  .tilt-card__shine,
+  .tilt-card--css-only {
+    transition: none;
+    transform: none !important;
+    animation: none;
+  }
+  .tilt-card:hover .tilt-card__shine {
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a 3D perspective tilt card in two variants: a pure CSS-only fixed-angle tilt on hover, and a mouse-tracked variant where JS sets CSS custom properties (`--tilt-x`, `--tilt-y`) that drive `rotateX/Y` — all visual logic stays in CSS. Includes a gloss highlight overlay that follows the cursor.

Closes #7561

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/perspective-tilt-card-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Two card variants side by side: CSS-only (zero JS) and mouse-tracked (JS sets CSS custom properties only).

**How does a developer use it?**

```html
<!-- Zero JS -->
<div class="tilt-scene">
  <div class="tilt-card tilt-card--css-only">
    <div class="tilt-card__shine"></div>
    <div class="tilt-card__body">…</div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

`perspective` + `rotateX/Y` + `transform-style: preserve-3d` + `translateZ` for depth layers. Gloss overlay via `radial-gradient` at `--shine-x/--shine-y`. All visual effects in CSS. `prefers-reduced-motion` disables all transforms.

---

## Demo

- [x] Demo opens directly — hover left card with mouse for tracked tilt, hover right for fixed CSS-only tilt.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

The mouse-tracking JS is ~10 lines and only sets two CSS custom property numbers. The card is intentionally labeled "No JS" in the issue title to mean all _visual_ logic is JS-free; the tracked variant uses JS purely as an input device reader.