### PR TITLE
feat: add horizontal news ticker tape

### DIFF
--- a/submissions/examples/ticker-tape-sk/README.md
+++ b/submissions/examples/ticker-tape-sk/README.md
@@ -1,0 +1,39 @@
+# Horizontal News Ticker Tape
+
+## What does this do?
+A horizontally scrolling ticker/marquee that loops infinitely using a pure CSS `translateX` animation. Content is duplicated in markup so the second copy continues seamlessly when the first scrolls off. Hover pauses the tape.
+
+## How is it used?
+
+```html
+<div class="ticker">
+  <div class="ticker__label">LIVE</div>
+  <div class="ticker__track">
+    <!-- duplicate all items for seamless loop -->
+    <span class="ticker__item">First headline here</span>
+    <span class="ticker__item">Second headline</span>
+    <!-- ...then duplicate all items again... -->
+    <span class="ticker__item">First headline here</span>
+    <span class="ticker__item">Second headline</span>
+  </div>
+</div>
+
+<!-- Warning variant -->
+<div class="ticker ticker--warning ticker--fast">…</div>
+
+<!-- Light variant, slow speed -->
+<div class="ticker ticker--light ticker--slow">…</div>
+```
+
+CSS custom properties:
+```css
+--ticker-duration: 30s;   /* speed */
+--ticker-gap: 3rem;       /* space between items */
+--ticker-accent: #6366f1; /* separator + link hover color */
+--ticker-label-bg: #6366f1;
+```
+
+Speed modifiers: `.ticker--slow` (50s), `.ticker--fast` (15s).
+
+## Why is it useful?
+The seamless loop trick — `translateX(0)` to `translateX(-50%)` with duplicated content — is the CSS-native approach to infinite marquees (the deprecated `<marquee>` element's successor). `animation-play-state: paused` on hover is a single CSS rule. `prefers-reduced-motion` stops the animation for users who prefer no motion.

--- a/submissions/examples/ticker-tape-sk/demo.html
+++ b/submissions/examples/ticker-tape-sk/demo.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Horizontal News Ticker Tape</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      background: #050510;
+      font-family: system-ui, sans-serif;
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+    .label-bar {
+      background: #0f172a;
+      color: #475569;
+      font-size: 0.68rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      padding: 0.75rem 1.5rem;
+    }
+    .content {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1.5rem;
+      padding: 4rem 2rem;
+      color: #94a3b8;
+      font-size: 0.9rem;
+      text-align: center;
+    }
+    .content h1 { color: #f1f5f9; font-size: 1.5rem; font-weight: 800; }
+    .content p { max-width: 480px; line-height: 1.7; }
+    code {
+      background: #1e293b;
+      color: #818cf8;
+      padding: 0.1em 0.4em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+    .spacer { height: 2rem; }
+  </style>
+</head>
+<body>
+
+  <!-- Default ticker at top -->
+  <div class="label-bar">↓ Default ticker (hover to pause)</div>
+  <div class="ticker">
+    <div class="ticker__label">LIVE</div>
+    <div class="ticker__track" aria-live="off" aria-label="News ticker">
+      <!-- items duplicated for seamless loop -->
+      <span class="ticker__item">EaseMotion CSS v3.0 released with scroll-driven animations</span>
+      <span class="ticker__item">CSS :has() now supported in all major browsers</span>
+      <span class="ticker__item">Scroll-driven animations ship in Chrome 115+</span>
+      <span class="ticker__item">@property enables type-safe CSS custom properties</span>
+      <span class="ticker__item">Container queries land in Firefox 110+</span>
+      <span class="ticker__item">@starting-style solves animating from display:none</span>
+      <!-- duplicate for seamless loop -->
+      <span class="ticker__item">EaseMotion CSS v3.0 released with scroll-driven animations</span>
+      <span class="ticker__item">CSS :has() now supported in all major browsers</span>
+      <span class="ticker__item">Scroll-driven animations ship in Chrome 115+</span>
+      <span class="ticker__item">@property enables type-safe CSS custom properties</span>
+      <span class="ticker__item">Container queries land in Firefox 110+</span>
+      <span class="ticker__item">@starting-style solves animating from display:none</span>
+    </div>
+  </div>
+
+  <div class="content">
+    <h1>Horizontal News Ticker</h1>
+    <p>Pure CSS <code>translateX</code> animation. Items are duplicated in the markup so the second copy seamlessly continues when the first scrolls off-screen. Hover pauses the tape. No JavaScript.</p>
+  </div>
+
+  <div class="spacer"></div>
+
+  <!-- Warning variant -->
+  <div class="label-bar">↓ Warning variant (ticker--warning)</div>
+  <div class="ticker ticker--warning ticker--fast">
+    <div class="ticker__label">⚠ ALERT</div>
+    <div class="ticker__track">
+      <span class="ticker__item">Scheduled maintenance Sunday 02:00–04:00 UTC</span>
+      <span class="ticker__item">All services will be temporarily unavailable</span>
+      <span class="ticker__item">Please save your work before the maintenance window</span>
+      <span class="ticker__item">Status updates at status.example.com</span>
+      <span class="ticker__item">Scheduled maintenance Sunday 02:00–04:00 UTC</span>
+      <span class="ticker__item">All services will be temporarily unavailable</span>
+      <span class="ticker__item">Please save your work before the maintenance window</span>
+      <span class="ticker__item">Status updates at status.example.com</span>
+    </div>
+  </div>
+
+  <div class="spacer"></div>
+
+  <!-- Light variant -->
+  <div class="label-bar">↓ Light variant (ticker--light)</div>
+  <div class="ticker ticker--light ticker--slow" style="--ticker-label-bg:#334155; --ticker-accent:#334155;">
+    <div class="ticker__label" style="background:#334155">NEWS</div>
+    <div class="ticker__track">
+      <span class="ticker__item">Pure CSS marquee using translateX keyframe animation</span>
+      <span class="ticker__item">Seamless infinite loop by duplicating content</span>
+      <span class="ticker__item">Pause on hover via animation-play-state: paused</span>
+      <span class="ticker__item">Fully customizable via CSS custom properties</span>
+      <span class="ticker__item">Pure CSS marquee using translateX keyframe animation</span>
+      <span class="ticker__item">Seamless infinite loop by duplicating content</span>
+      <span class="ticker__item">Pause on hover via animation-play-state: paused</span>
+      <span class="ticker__item">Fully customizable via CSS custom properties</span>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ticker-tape-sk/style.css
+++ b/submissions/examples/ticker-tape-sk/style.css
@@ -1,0 +1,183 @@
+:root {
+  --ticker-bg: #0f172a;
+  --ticker-text: #f1f5f9;
+  --ticker-accent: #6366f1;
+  --ticker-border: #1e293b;
+  --ticker-label-bg: #6366f1;
+  --ticker-label-text: #fff;
+  --ticker-height: 44px;
+  --ticker-font-size: 0.875rem;
+  --ticker-gap: 3rem;
+  --ticker-duration: 30s;
+  --ticker-ease: linear;
+  --ticker-separator: '•';
+}
+
+/* ── Outer wrapper — clips the scrolling content ── */
+.ticker {
+  display: flex;
+  align-items: center;
+  height: var(--ticker-height);
+  background: var(--ticker-bg);
+  border-top: 1px solid var(--ticker-border);
+  border-bottom: 1px solid var(--ticker-border);
+  overflow: hidden;
+  position: relative;
+}
+
+/* ── Label badge (e.g. "LIVE", "BREAKING") ── */
+.ticker__label {
+  flex-shrink: 0;
+  background: var(--ticker-label-bg);
+  color: var(--ticker-label-text);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0 1rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  z-index: 2;
+  white-space: nowrap;
+  position: relative;
+}
+
+/* Decorative arrow after label */
+.ticker__label::after {
+  content: '';
+  position: absolute;
+  right: -10px;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-top: calc(var(--ticker-height) / 2) solid transparent;
+  border-bottom: calc(var(--ticker-height) / 2) solid transparent;
+  border-left: 10px solid var(--ticker-label-bg);
+}
+
+/* fade edges */
+.ticker::before,
+.ticker::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 80px;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.ticker::before {
+  left: 0;
+  background: linear-gradient(to right, var(--ticker-bg), transparent);
+}
+
+.ticker::after {
+  right: 0;
+  background: linear-gradient(to left, var(--ticker-bg), transparent);
+}
+
+/* when ticker has a label, the left fade starts after it */
+.ticker:has(.ticker__label)::before {
+  display: none;
+}
+
+/* ── Scroll track ── */
+.ticker__track {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  animation: ticker-scroll var(--ticker-duration) var(--ticker-ease) infinite;
+  will-change: transform;
+  padding-left: 2rem;
+}
+
+/* pause on hover */
+.ticker:hover .ticker__track {
+  animation-play-state: paused;
+}
+
+@keyframes ticker-scroll {
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+/* ── Item ── */
+.ticker__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 var(--ticker-gap);
+  font-size: var(--ticker-font-size);
+  color: var(--ticker-text);
+  text-decoration: none;
+  transition: color 0.15s ease;
+  cursor: default;
+}
+
+a.ticker__item {
+  cursor: pointer;
+}
+
+a.ticker__item:hover {
+  color: var(--ticker-accent);
+}
+
+/* Separator between items */
+.ticker__item::after {
+  content: var(--ticker-separator);
+  color: var(--ticker-accent);
+  margin-left: var(--ticker-gap);
+  opacity: 0.6;
+}
+
+.ticker__item:last-child::after {
+  display: none;
+}
+
+/* ── Variants ── */
+
+/* Dark background (default) already defined */
+
+/* Light variant */
+.ticker--light {
+  --ticker-bg: #f8fafc;
+  --ticker-text: #1e293b;
+  --ticker-border: #e2e8f0;
+}
+
+.ticker--light::before {
+  background: linear-gradient(to right, var(--ticker-bg), transparent);
+}
+
+.ticker--light::after {
+  background: linear-gradient(to left, var(--ticker-bg), transparent);
+}
+
+/* Announcement / warning variant */
+.ticker--warning {
+  --ticker-bg: #451a03;
+  --ticker-text: #fef3c7;
+  --ticker-border: #78350f;
+  --ticker-label-bg: #f59e0b;
+  --ticker-label-text: #1c1917;
+  --ticker-accent: #fbbf24;
+}
+
+/* Slow / fast speed modifiers */
+.ticker--slow  { --ticker-duration: 50s; }
+.ticker--fast  { --ticker-duration: 15s; }
+
+/* Tall variant */
+.ticker--tall {
+  --ticker-height: 56px;
+  --ticker-font-size: 1rem;
+}
+
+/* reduced motion: pause animation, show as static */
+@media (prefers-reduced-motion: reduce) {
+  .ticker__track {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a horizontally scrolling news ticker using a pure CSS `translateX` animation. The seamless infinite loop works by duplicating content and animating to `-50%` — when the animation resets to `0`, it's imperceptible. Hover pauses the tape.

Closes #7562

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ticker-tape-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Three ticker variants: dark default (LIVE badge), warning (amber, fast), and light (slow). Speed modifiers `.ticker--slow/fast`. Label badge with decorative arrow. Fade edges via gradient pseudo-elements.

**How does a developer use it?**

```html
<div class="ticker">
  <div class="ticker__label">LIVE</div>
  <div class="ticker__track">
    <span class="ticker__item">Headline one</span>
    <span class="ticker__item">Headline two</span>
    <!-- duplicate all items again for seamless loop -->
    <span class="ticker__item">Headline one</span>
    <span class="ticker__item">Headline two</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

Pure CSS `translateX` keyframe loop — the CSS-native successor to `<marquee>`. `animation-play-state: paused` on hover is a single property. Fully themeable via CSS custom properties. `prefers-reduced-motion` stops the animation.

---

## Demo

- [x] Demo opens directly — three ticker variants stacked with page content between them.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge