### PR TITLE
fix(ease-reveal-zd): replace remaining picsum.photos image with offline-safe inline SVG

### DIFF
--- a/submissions/examples/ease-reveal-zd/demo.html
+++ b/submissions/examples/ease-reveal-zd/demo.html
@@ -44,7 +44,7 @@
       <div class="rv-card">
         <div class="rv-img-wrap">
           <div class="rv-placeholder"></div>
-          <img class="rv-img" src="https://picsum.photos/400/250?random=3" alt="Ocean sunset" loading="lazy">
+          <img class="rv-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='250'%3E%3Crect width='400' height='250' fill='%230077b6'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%2390e0ef' font-family='sans-serif' font-size='18'%3EOcean Sunset%3C/text%3E%3C/svg%3E" alt="Ocean sunset">
         </div>
         <div class="rv-body">
           <div class="rv-title">Coastal Views</div>


### PR DESCRIPTION
## Pull Request Description

The third demo image in `submissions/examples/ease-reveal-zd/demo.html` was still loaded from `picsum.photos`. This caused a broken image icon when opened offline and produced a different random image on every page load, making consistent evaluation of the scroll-reveal animation impossible.

This PR replaces that external URL with a distinct inline SVG (ocean-blue background, labelled "Ocean Sunset") — matching the approach already applied to the other two images in the same file.

Fixes #6072

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-reveal-zd/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Replaces the last remaining external image URL with a self-contained inline SVG so the demo works fully offline.

**How does a developer use it?**

```html
<!-- No change to usage — demo.html opens directly in any browser, no server needed -->
```

**Why does it fit EaseMotion CSS?**

EaseMotion CSS demos are meant to be self-contained and evaluable without a network connection. Using inline SVGs instead of third-party CDN images ensures the scroll-reveal animation can always be assessed regardless of connectivity.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

Only line 47 of `demo.html` was changed — the picsum URL for the third card was the sole remaining external dependency. The two other images were already fixed with inline SVGs prior to this PR. This is a minimal, targeted fix.