### PR TITLE
fix(3d-cube-carousel): add prefers-reduced-motion guard (closes #6069)

### DIFF
--- a/submissions/examples/3d-cube-carousel/style.css
+++ b/submissions/examples/3d-cube-carousel/style.css
@@ -147,3 +147,14 @@ body {
     transform: rotateX(360deg) rotateY(360deg);
   }
 }
+
+/* Accessibility: respect OS-level reduced-motion preference (WCAG 2.3.3) */
+@media (prefers-reduced-motion: reduce) {
+  .ease-cube-carousel,
+  .ease-cube-carousel *,
+  .ease-cube-mesh,
+  .ease-cube-mesh * {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a `@media (prefers-reduced-motion: reduce)` block to `submissions/examples/3d-cube-carousel/style.css` to stop the continuous cube spin animation for users who have enabled the OS-level reduced-motion preference.

Closes #6069

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/3d-cube-carousel/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `prefers-reduced-motion: reduce` media query guard that disables the continuous 3D cube rotation for users with vestibular disorders who have requested reduced motion at the OS level.

**How does a developer use it?**

```html
<!-- No change needed — the guard activates automatically based on the OS setting -->
<div class="ease-cube-viewport">...</div>
```

**Why does it fit EaseMotion CSS?**

EaseMotion CSS should respect user accessibility preferences. WCAG 2.3.3 specifically identifies continuous spinning animations as a trigger for vestibular disorders. This fix ensures the library is inclusive without changing any behaviour for users who have not enabled reduced motion.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The fix targets both `.ease-cube-carousel` (as suggested in the issue) and `.ease-cube-mesh` (the element that actually receives the `easeCubeSpin` animation in the current implementation), plus all their descendants, to ensure full coverage. `animation: none !important` and `transition: none !important` are used to override any inline or specificity-winning rules.