### PR TITLE
feat: add internal developer portal analytics dashboard

### DIFF
--- a/submissions/examples/idp-analytics-dashboard-rr/README.md
+++ b/submissions/examples/idp-analytics-dashboard-rr/README.md
@@ -1,0 +1,17 @@
+# Internal Developer Portal Analytics Dashboard Component
+
+## What does this do?
+
+Provides a centralized interface for measuring developer portal adoption, self-service utilization, onboarding effectiveness, search success, and developer engagement.
+
+## How is it used?
+
+```html
+<div class="analytics-card healthy">
+    <h3>Service Catalog</h3>
+</div>
+```
+
+## Why is it useful?
+
+Platform Engineering teams need visibility into how developers use internal platforms. This component helps measure adoption, identify friction points, improve self-service workflows, and optimize the overall developer experience.

--- a/submissions/examples/idp-analytics-dashboard-rr/demo.html
+++ b/submissions/examples/idp-analytics-dashboard-rr/demo.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Internal Developer Portal Analytics Dashboard</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+
+    <div class="header">
+        <h1>Internal Developer Portal Analytics</h1>
+        <p>Measure portal adoption, self-service utilization, onboarding success, and developer engagement.</p>
+    </div>
+
+    <div class="metrics-grid">
+
+        <div class="metric-card">
+            <span>Active Developers</span>
+            <h2>2,486</h2>
+        </div>
+
+        <div class="metric-card">
+            <span>Portal Adoption</span>
+            <h2>91%</h2>
+        </div>
+
+        <div class="metric-card">
+            <span>Self-Service Requests</span>
+            <h2>8,214</h2>
+        </div>
+
+        <div class="metric-card">
+            <span>Search Success Rate</span>
+            <h2>96%</h2>
+        </div>
+
+    </div>
+
+    <div class="analytics-grid">
+
+        <div class="analytics-card healthy">
+            <h3>Service Catalog</h3>
+            <p>High Engagement</p>
+            <span>Healthy</span>
+        </div>
+
+        <div class="analytics-card healthy">
+            <h3>Golden Paths</h3>
+            <p>Strong Adoption</p>
+            <span>Optimized</span>
+        </div>
+
+        <div class="analytics-card warning">
+            <h3>Documentation</h3>
+            <p>Search Gaps Identified</p>
+            <span>Review Needed</span>
+        </div>
+
+        <div class="analytics-card healthy">
+            <h3>Templates</h3>
+            <p>Frequently Used</p>
+            <span>Popular</span>
+        </div>
+
+    </div>
+
+    <div class="activity-panel">
+
+        <h2>Portal Activity Feed</h2>
+
+        <div class="activity-item">
+            <span>Developer onboarding completed for 42 users</span>
+            <span class="success-badge">Completed</span>
+        </div>
+
+        <div class="activity-item">
+            <span>Documentation search failures increased</span>
+            <span class="warning-badge">Review</span>
+        </div>
+
+        <div class="activity-item">
+            <span>New service template published</span>
+            <span class="info-badge">Added</span>
+        </div>
+
+        <div class="activity-item">
+            <span>Portal satisfaction survey completed</span>
+            <span class="success-badge">Verified</span>
+        </div>
+
+    </div>
+
+    <div class="insights-panel">
+
+        <h2>Platform Insights</h2>
+
+        <div class="insight-item">
+            <span>Services Onboarded</span>
+            <span>1,184</span>
+        </div>
+
+        <div class="insight-item">
+            <span>Platform Satisfaction</span>
+            <span>93%</span>
+        </div>
+
+        <div class="insight-item">
+            <span>Template Usage</span>
+            <span>87%</span>
+        </div>
+
+        <div class="insight-item">
+            <span>Self-Service Completion Rate</span>
+            <span>95%</span>
+        </div>
+
+    </div>
+
+    <div class="summary-panel">
+
+        <h2>Portal Analytics Summary</h2>
+
+        <p>
+            Internal developer portal adoption remains strong with high engagement,
+            excellent self-service completion rates, and growing platform usage.
+            Documentation discoverability presents the primary opportunity for
+            improving developer productivity.
+        </p>
+
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/idp-analytics-dashboard-rr/style.css
+++ b/submissions/examples/idp-analytics-dashboard-rr/style.css
@@ -1,0 +1,138 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    background:#0f172a;
+    color:white;
+    font-family:Arial,sans-serif;
+    min-height:100vh;
+    padding:40px 20px;
+}
+
+.container{
+    max-width:1300px;
+    margin:auto;
+}
+
+.header{
+    text-align:center;
+    margin-bottom:40px;
+}
+
+.header h1{
+    font-size:3rem;
+    margin-bottom:10px;
+}
+
+.header p{
+    color:#94a3b8;
+}
+
+.metrics-grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+    gap:24px;
+    margin-bottom:40px;
+}
+
+.metric-card{
+    background:#111827;
+    padding:24px;
+    border-radius:20px;
+    transition:.3s;
+}
+
+.metric-card:hover{
+    transform:translateY(-8px);
+}
+
+.analytics-grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+    gap:24px;
+    margin-bottom:40px;
+}
+
+.analytics-card{
+    background:#111827;
+    padding:24px;
+    border-radius:20px;
+}
+
+.healthy{
+    border-left:5px solid #22c55e;
+}
+
+.warning{
+    border-left:5px solid #f59e0b;
+}
+
+.activity-panel,
+.insights-panel{
+    background:#111827;
+    border-radius:24px;
+    padding:30px;
+    margin-bottom:40px;
+}
+
+.activity-item,
+.insight-item{
+    display:flex;
+    justify-content:space-between;
+    padding:14px 0;
+    border-bottom:1px solid rgba(255,255,255,.08);
+}
+
+.success-badge,
+.warning-badge,
+.info-badge{
+    padding:6px 12px;
+    border-radius:14px;
+    font-size:12px;
+    font-weight:bold;
+}
+
+.success-badge{
+    background:#22c55e;
+    color:#000;
+}
+
+.warning-badge{
+    background:#f59e0b;
+    color:#000;
+}
+
+.info-badge{
+    background:#3b82f6;
+}
+
+.summary-panel{
+    background:linear-gradient(135deg,#2563eb,#7c3aed);
+    border-radius:24px;
+    padding:30px;
+}
+
+.summary-panel h2{
+    margin-bottom:15px;
+}
+
+.summary-panel p{
+    line-height:1.8;
+}
+
+@media(max-width:768px){
+
+.header h1{
+    font-size:2.2rem;
+}
+
+.activity-item,
+.insight-item{
+    flex-direction:column;
+    gap:10px;
+}
+
+}


### PR DESCRIPTION
## 📌 Description

This PR adds an Internal Developer Portal Analytics Dashboard Component under:

submissions/examples/idp-analytics-dashboard-rr/

The component provides a centralized interface for tracking portal adoption, self-service usage, onboarding effectiveness, search performance, and developer engagement metrics.

### ✨ Features

- Portal analytics overview
- Adoption scorecards
- Self-service utilization tracking
- Search performance indicators
- Developer engagement monitoring
- Portal activity feed
- Platform insights dashboard
- Responsive layout
- Hover animations
- Pure HTML and CSS

### 📂 Files Added

- demo.html
- style.css
- README.md

### 🎯 Use Cases

- Backstage
- Port
- Cortex
- OpsLevel
- Atlassian Compass
- Platform Engineering Teams

### ✅ Checklist

- [x] Pure HTML and CSS
- [x] Responsive
- [x] Includes README
- [x] Added under submissions/examples
- [x] Tested locally

fixes #7603 