### PR TITLE
fix: replace external picsum images with offline SVG placeholders in ease-carousel

### DIFF
--- a/submissions/examples/ease-carousel/demo.html
+++ b/submissions/examples/ease-carousel/demo.html
@@ -121,35 +121,35 @@
       <div class="ease-carousel ease-carousel--slide" id="carousel-slide">
         <div class="ease-carousel__track" role="region" aria-roledescription="carousel" aria-label="Slide carousel">
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="1 of 5">
-            <img src="https://picsum.photos/seed/slide1/800/400" alt="Slide 1">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%236366f1'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3ESlide 1%3C/text%3E%3C/svg%3E" alt="Slide 1">
             <div class="ease-carousel__slide-content">
               <h3>Mountain View</h3>
               <p>Beautiful mountain landscape</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="2 of 5">
-            <img src="https://picsum.photos/seed/slide2/800/400" alt="Slide 2">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%23f59e0b'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3ESlide 2%3C/text%3E%3C/svg%3E" alt="Slide 2">
             <div class="ease-carousel__slide-content">
               <h3>Ocean Sunset</h3>
               <p>Golden hour over the coast</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="3 of 5">
-            <img src="https://picsum.photos/seed/slide3/800/400" alt="Slide 3">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%2310b981'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3ESlide 3%3C/text%3E%3C/svg%3E" alt="Slide 3">
             <div class="ease-carousel__slide-content">
               <h3>Forest Trail</h3>
               <p>Lush green pathway</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="4 of 5">
-            <img src="https://picsum.photos/seed/slide4/800/400" alt="Slide 4">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%23ef4444'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3ESlide 4%3C/text%3E%3C/svg%3E" alt="Slide 4">
             <div class="ease-carousel__slide-content">
               <h3>City Lights</h3>
               <p>Urban skyline at night</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="5 of 5">
-            <img src="https://picsum.photos/seed/slide5/800/400" alt="Slide 5">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%238b5cf6'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3ESlide 5%3C/text%3E%3C/svg%3E" alt="Slide 5">
             <div class="ease-carousel__slide-content">
               <h3>Desert Dunes</h3>
               <p>Endless sand formations</p>
@@ -180,35 +180,35 @@
       <div class="ease-carousel ease-carousel--peek" id="carousel-peek">
         <div class="ease-carousel__track" role="region" aria-roledescription="carousel" aria-label="Peek carousel">
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="1 of 5">
-            <img src="https://picsum.photos/seed/peek1/800/400" alt="Peek 1">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%236366f1'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EPeek 1%3C/text%3E%3C/svg%3E" alt="Peek 1">
             <div class="ease-carousel__slide-content">
               <h3>Peek 1</h3>
               <p>See the edges of next slide</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="2 of 5">
-            <img src="https://picsum.photos/seed/peek2/800/400" alt="Peek 2">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%23f59e0b'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EPeek 2%3C/text%3E%3C/svg%3E" alt="Peek 2">
             <div class="ease-carousel__slide-content">
               <h3>Peek 2</h3>
               <p>Partial preview of neighbors</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="3 of 5">
-            <img src="https://picsum.photos/seed/peek3/800/400" alt="Peek 3">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%2310b981'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EPeek 3%3C/text%3E%3C/svg%3E" alt="Peek 3">
             <div class="ease-carousel__slide-content">
               <h3>Peek 3</h3>
               <p>Helps users discover more</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="4 of 5">
-            <img src="https://picsum.photos/seed/peek4/800/400" alt="Peek 4">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%23ef4444'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EPeek 4%3C/text%3E%3C/svg%3E" alt="Peek 4">
             <div class="ease-carousel__slide-content">
               <h3>Peek 4</h3>
               <p>Popular in streaming UIs</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="5 of 5">
-            <img src="https://picsum.photos/seed/peek5/800/400" alt="Peek 5">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%238b5cf6'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EPeek 5%3C/text%3E%3C/svg%3E" alt="Peek 5">
             <div class="ease-carousel__slide-content">
               <h3>Peek 5</h3>
               <p>Last slide</p>
@@ -239,35 +239,35 @@
       <div class="ease-carousel ease-carousel--fade" id="carousel-fade">
         <div class="ease-carousel__track" role="region" aria-roledescription="carousel" aria-label="Fade carousel">
           <div class="ease-carousel__slide ease-carousel__slide--active" role="group" aria-roledescription="slide" aria-label="1 of 5">
-            <img src="https://picsum.photos/seed/fade1/800/400" alt="Fade 1">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%236366f1'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EFade 1%3C/text%3E%3C/svg%3E" alt="Fade 1">
             <div class="ease-carousel__slide-content">
               <h3>Fade 1</h3>
               <p>Smooth cross-fade transition</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="2 of 5">
-            <img src="https://picsum.photos/seed/fade2/800/400" alt="Fade 2">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%23f59e0b'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EFade 2%3C/text%3E%3C/svg%3E" alt="Fade 2">
             <div class="ease-carousel__slide-content">
               <h3>Fade 2</h3>
               <p>No scroll — just opacity</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="3 of 5">
-            <img src="https://picsum.photos/seed/fade3/800/400" alt="Fade 3">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%2310b981'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EFade 3%3C/text%3E%3C/svg%3E" alt="Fade 3">
             <div class="ease-carousel__slide-content">
               <h3>Fade 3</h3>
               <p>Great for hero banners</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="4 of 5">
-            <img src="https://picsum.photos/seed/fade4/800/400" alt="Fade 4">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%23ef4444'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EFade 4%3C/text%3E%3C/svg%3E" alt="Fade 4">
             <div class="ease-carousel__slide-content">
               <h3>Fade 4</h3>
               <p>Slide 4</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="5 of 5">
-            <img src="https://picsum.photos/seed/fade5/800/400" alt="Fade 5">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%238b5cf6'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EFade 5%3C/text%3E%3C/svg%3E" alt="Fade 5">
             <div class="ease-carousel__slide-content">
               <h3>Fade 5</h3>
               <p>Slide 5</p>
@@ -298,35 +298,35 @@
       <div class="ease-carousel ease-carousel--slide ease-carousel--auto" data-ease-interval="3000" id="carousel-auto">
         <div class="ease-carousel__track" role="region" aria-roledescription="carousel" aria-label="Auto-play carousel">
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="1 of 5">
-            <img src="https://picsum.photos/seed/auto1/800/400" alt="Auto 1">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%236366f1'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EAuto 1%3C/text%3E%3C/svg%3E" alt="Auto 1">
             <div class="ease-carousel__slide-content">
               <h3>Auto 1</h3>
               <p>Advances every 3 seconds</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="2 of 5">
-            <img src="https://picsum.photos/seed/auto2/800/400" alt="Auto 2">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%23f59e0b'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EAuto 2%3C/text%3E%3C/svg%3E" alt="Auto 2">
             <div class="ease-carousel__slide-content">
               <h3>Auto 2</h3>
               <p>Pauses on hover</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="3 of 5">
-            <img src="https://picsum.photos/seed/auto3/800/400" alt="Auto 3">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%2310b981'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EAuto 3%3C/text%3E%3C/svg%3E" alt="Auto 3">
             <div class="ease-carousel__slide-content">
               <h3>Auto 3</h3>
               <p>Resumes on mouse leave</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="4 of 5">
-            <img src="https://picsum.photos/seed/auto4/800/400" alt="Auto 4">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%23ef4444'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EAuto 4%3C/text%3E%3C/svg%3E" alt="Auto 4">
             <div class="ease-carousel__slide-content">
               <h3>Auto 4</h3>
               <p>Configurable interval</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="5 of 5">
-            <img src="https://picsum.photos/seed/auto5/800/400" alt="Auto 5">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%238b5cf6'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EAuto 5%3C/text%3E%3C/svg%3E" alt="Auto 5">
             <div class="ease-carousel__slide-content">
               <h3>Auto 5</h3>
               <p>Full cycle then repeat</p>
@@ -357,42 +357,42 @@
       <div class="ease-carousel ease-carousel--slide" data-ease-slides-per-view="2" id="carousel-multi">
         <div class="ease-carousel__track" role="region" aria-roledescription="carousel" aria-label="Multi-column carousel">
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="1 of 6">
-            <img src="https://picsum.photos/seed/multi1/800/400" alt="Multi 1">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%236366f1'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EMulti 1%3C/text%3E%3C/svg%3E" alt="Multi 1">
             <div class="ease-carousel__slide-content">
               <h3>Two columns</h3>
               <p>Slide 1</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="2 of 6">
-            <img src="https://picsum.photos/seed/multi2/800/400" alt="Multi 2">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%23f59e0b'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EMulti 2%3C/text%3E%3C/svg%3E" alt="Multi 2">
             <div class="ease-carousel__slide-content">
               <h3>Two columns</h3>
               <p>Slide 2</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="3 of 6">
-            <img src="https://picsum.photos/seed/multi3/800/400" alt="Multi 3">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%2310b981'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EMulti 3%3C/text%3E%3C/svg%3E" alt="Multi 3">
             <div class="ease-carousel__slide-content">
               <h3>Two columns</h3>
               <p>Slide 3</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="4 of 6">
-            <img src="https://picsum.photos/seed/multi4/800/400" alt="Multi 4">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%23ef4444'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EMulti 4%3C/text%3E%3C/svg%3E" alt="Multi 4">
             <div class="ease-carousel__slide-content">
               <h3>Two columns</h3>
               <p>Slide 4</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="5 of 6">
-            <img src="https://picsum.photos/seed/multi5/800/400" alt="Multi 5">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%238b5cf6'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EMulti 5%3C/text%3E%3C/svg%3E" alt="Multi 5">
             <div class="ease-carousel__slide-content">
               <h3>Two columns</h3>
               <p>Slide 5</p>
             </div>
           </div>
           <div class="ease-carousel__slide" role="group" aria-roledescription="slide" aria-label="6 of 6">
-            <img src="https://picsum.photos/seed/multi6/800/400" alt="Multi 6">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='400'%3E%3Crect width='800' height='400' fill='%2306b6d4'/%3E%3Ctext x='400' y='200' font-family='sans-serif' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'%3EMulti 6%3C/text%3E%3C/svg%3E" alt="Multi 6">
             <div class="ease-carousel__slide-content">
               <h3>Two columns</h3>
               <p>Slide 6</p>


### PR DESCRIPTION
## 🔗 Related Issue

Closes #6066

## 📋 Description

All 26 `<img>` elements across the five carousel variants in `submissions/examples/ease-carousel/demo.html` were loading images from `picsum.photos`. When opened offline, every slide rendered as a broken image icon, making it impossible to evaluate the carousel transition animations.

**Fix:** replaced each external URL with a data URI SVG placeholder. Each slide gets a distinct background color (indigo, amber, emerald, red, violet, cyan) so slides are visually differentiable and all transition effects are clearly visible without any network dependency.

## ✅ Type of Change

- [x] Bug fix

## 🧪 Testing

- [x] Opened `demo.html` directly in browser (no server, no network)
- [x] All carousel variants render colored slide placeholders
- [x] Slide transitions (scroll-snap, fade, auto-play) all animate correctly
- [x] No `picsum.photos` or other external URLs remain (`grep -c picsum demo.html` → `0`)

## 📸 Screenshots

| Before | After |
|--------|-------|
| All slides show broken image icon offline | Each slide shows a distinct solid-color SVG with slide label |

## 📝 Checklist

- [x] My code follows the project's contribution guidelines
- [x] No external CDN links or frameworks introduced
- [x] Works by opening directly in a browser with no server
- [x] No unrelated changes included