### PR TITLE
fix: replace CDN link and picsum images with offline SVGs in ease-img-circle

### DIFF
--- a/submissions/examples/ease-img-circle/demo.html
+++ b/submissions/examples/ease-img-circle/demo.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8" />
   <title>ease-img-circle Demo</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />
   <link rel="stylesheet" href="style.css" />
   <style>
     body { margin: 0; font-family: sans-serif; padding: 2rem; }
@@ -18,14 +17,14 @@
   <h3>Small Avatar</h3>
   <img
     class="ease-img-circle avatar"
-    src="https://picsum.photos/100/100"
+    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Crect width='100' height='100' fill='%234f86c6'/%3E%3Ccircle cx='50' cy='38' r='18' fill='%23fff' opacity='.9'/%3E%3Cellipse cx='50' cy='72' rx='28' ry='18' fill='%23fff' opacity='.9'/%3E%3C/svg%3E"
     alt="Small avatar"
   />
 
   <h3>Large Avatar</h3>
   <img
     class="ease-img-circle avatar-lg"
-    src="https://picsum.photos/200/200"
+    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Crect width='200' height='200' fill='%23e07b4f'/%3E%3Ccircle cx='100' cy='76' r='36' fill='%23fff' opacity='.9'/%3E%3Cellipse cx='100' cy='144' rx='56' ry='36' fill='%23fff' opacity='.9'/%3E%3C/svg%3E"
     alt="Large avatar"
   />
 </body>


### PR DESCRIPTION
## Pull Request Description

Fixes the double offline violation in `submissions/examples/ease-img-circle/demo.html` reported in issue #6065. The demo loaded the framework from jsDelivr CDN and fetched placeholder images from picsum.photos, making it completely non-functional without internet access.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-img-circle/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**

`demo.html` had two external dependencies that violated CONTRIBUTING.md's self-containment rule:
1. `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />` — CDN load of the framework
2. Both `<img>` tags pointed to `https://picsum.photos/` for placeholder images

**Changes made:**
- Removed the CDN stylesheet link (`style.css` already defines `ease-img-circle` and is self-sufficient)
- Replaced both `picsum.photos` URLs with inline `data:image/svg+xml` avatar placeholders that render without any network request

**How does a developer use it?**

```html
<img class="ease-img-circle avatar" src="your-image.jpg" alt="Avatar" />
```

**Why does it fit EaseMotion CSS?**

No change to the component itself — this fix purely enforces the offline/self-contained requirement from CONTRIBUTING.md.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Only `demo.html` changed — 3 lines removed (CDN link + 2 picsum URLs), 2 lines added (inline SVG data URIs). `style.css` and `README.md` are untouched. No merge conflicts with current upstream main.

Closes #6065