### PR TITLE
feat: add accessible breadcrumb submission

### DIFF
--- a/submissions/examples/accessible-breadcrumb-sb/README.md
+++ b/submissions/examples/accessible-breadcrumb-sb/README.md
@@ -1,0 +1,21 @@
+# Accessible Breadcrumb Navigation
+
+## What does this do?
+
+Adds a semantic breadcrumb navigation demo with `nav`, ordered-list markup, `aria-current="page"` for the active item, and a CSS-variable driven separator.
+
+## How is it used?
+
+```html
+<nav aria-label="Breadcrumb">
+  <ol class="breadcrumb" style="--breadcrumb-separator: '›'">
+    <li><a href="/">Home</a></li>
+    <li><a href="/docs">Docs</a></li>
+    <li aria-current="page">Getting Started</li>
+  </ol>
+</nav>
+```
+
+## Why is it useful?
+
+Breadcrumbs help users understand where they are in nested documentation, dashboards, and app flows while staying lightweight, accessible, and easy to customize with plain CSS.

--- a/submissions/examples/accessible-breadcrumb-sb/demo.html
+++ b/submissions/examples/accessible-breadcrumb-sb/demo.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accessible Breadcrumb Navigation</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="breadcrumb-title">
+        <p class="eyebrow">Navigation component</p>
+        <h1 id="breadcrumb-title">Accessible breadcrumb navigation</h1>
+        <p class="demo-copy">
+          A semantic breadcrumb trail for documentation, dashboards, and nested
+          pages.
+        </p>
+
+        <nav aria-label="Breadcrumb" class="breadcrumb-frame">
+          <ol class="breadcrumb" style="--breadcrumb-separator: &quot;›&quot;">
+            <li><a href="/">Home</a></li>
+            <li><a href="/docs">Docs</a></li>
+            <li><a href="/docs/components">Components</a></li>
+            <li aria-current="page">Breadcrumb</li>
+          </ol>
+        </nav>
+
+        <nav aria-label="Project path" class="breadcrumb-frame compact">
+          <ol class="breadcrumb" style="--breadcrumb-separator: &quot;/&quot;">
+            <li><a href="/">Workspace</a></li>
+            <li><a href="/projects">Projects</a></li>
+            <li aria-current="page">Clinical Dashboard</li>
+          </ol>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/accessible-breadcrumb-sb/style.css
+++ b/submissions/examples/accessible-breadcrumb-sb/style.css
@@ -1,0 +1,176 @@
+:root {
+  --breadcrumb-bg: #ffffff;
+  --breadcrumb-border: #dbe4f0;
+  --breadcrumb-text: #475569;
+  --breadcrumb-link: #2563eb;
+  --breadcrumb-current: #0f172a;
+  --breadcrumb-hover-bg: #eff6ff;
+  --breadcrumb-focus: #38bdf8;
+  --breadcrumb-separator-color: #94a3b8;
+  --breadcrumb-separator: "›";
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(37, 99, 235, 0.18),
+      transparent 32rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 48rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(18px);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #2563eb;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 40rem;
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1;
+}
+
+.demo-copy {
+  max-width: 34rem;
+  margin: 1rem 0 2rem;
+  color: #64748b;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.breadcrumb-frame {
+  width: 100%;
+  margin-top: 1rem;
+  padding: 0.75rem;
+  overflow-x: auto;
+  border: 1px solid var(--breadcrumb-border);
+  border-radius: 1rem;
+  background: var(--breadcrumb-bg);
+}
+
+.breadcrumb-frame.compact {
+  --breadcrumb-bg: #f8fafc;
+  margin-top: 0.75rem;
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  color: var(--breadcrumb-text);
+  font-size: 0.95rem;
+  list-style: none;
+}
+
+.breadcrumb li {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  font-weight: 700;
+}
+
+.breadcrumb li + li::before {
+  content: var(--breadcrumb-separator);
+  margin-inline: 0.45rem 0.75rem;
+  color: var(--breadcrumb-separator-color);
+  font-weight: 800;
+}
+
+.breadcrumb a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  color: var(--breadcrumb-link);
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.breadcrumb a:hover {
+  background: var(--breadcrumb-hover-bg);
+  color: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.breadcrumb a:focus-visible {
+  outline: 3px solid var(--breadcrumb-focus);
+  outline-offset: 3px;
+}
+
+.breadcrumb [aria-current="page"] {
+  max-width: 16rem;
+  overflow: hidden;
+  padding: 0.35rem 0.2rem;
+  color: var(--breadcrumb-current);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 520px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .breadcrumb {
+    font-size: 0.875rem;
+  }
+
+  .breadcrumb [aria-current="page"] {
+    max-width: 12rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .breadcrumb a {
+    transition: none;
+  }
+
+  .breadcrumb a:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained accessible breadcrumb demo under submissions/examples/accessible-breadcrumb-sb
- use semantic nav/ordered-list markup with aria-current on the active item
- support customizable separators through --breadcrumb-separator and include focus/reduced-motion states

## Validation
- npx prettier --check submissions/examples/accessible-breadcrumb-sb/demo.html submissions/examples/accessible-breadcrumb-sb/style.css submissions/examples/accessible-breadcrumb-sb/README.md
- git diff --cached --check
- npx stylelint submissions/examples/accessible-breadcrumb-sb/style.css (repo stylelint ignores submissions/examples, so no lintable files were selected)

Closes #6271