### PR TITLE
feat: add input group addons submission

### DIFF
--- a/submissions/examples/input-group-addons-sb/README.md
+++ b/submissions/examples/input-group-addons-sb/README.md
@@ -1,0 +1,19 @@
+# Input Group With Addons
+
+## What does this do?
+
+Adds a self-contained input group demo with attached prefix and suffix addon slots for URLs, currencies, search controls, and locked values.
+
+## How is it used?
+
+```html
+<span class="input-group">
+  <span class="input-addon">https://</span>
+  <input type="url" placeholder="yourproject" />
+  <span class="input-addon">.dev</span>
+</span>
+```
+
+## Why is it useful?
+
+Input addons keep form context close to the field, reduce placeholder overload, and fit EaseMotion CSS by offering a lightweight, accessible pattern with no JavaScript dependency.

--- a/submissions/examples/input-group-addons-sb/demo.html
+++ b/submissions/examples/input-group-addons-sb/demo.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Input Group With Addons</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-panel" aria-labelledby="input-group-title">
+        <p class="eyebrow">Form component</p>
+        <h1 id="input-group-title">
+          Input group with prefix and suffix addons
+        </h1>
+        <p class="intro">
+          Attach helpful context like protocols, currency symbols, units, and
+          icons without breaking keyboard access.
+        </p>
+
+        <form class="demo-form">
+          <label class="field">
+            <span class="field-label">Project URL</span>
+            <span class="input-group">
+              <span class="input-addon">https://</span>
+              <input type="url" placeholder="yourproject" />
+              <span class="input-addon">.dev</span>
+            </span>
+          </label>
+
+          <label class="field">
+            <span class="field-label">Monthly budget</span>
+            <span class="input-group">
+              <span class="input-addon">$</span>
+              <input type="number" min="0" placeholder="1200" />
+              <span class="input-addon">USD</span>
+            </span>
+          </label>
+
+          <label class="field">
+            <span class="field-label">Search docs</span>
+            <span class="input-group">
+              <span class="input-addon" aria-hidden="true">⌕</span>
+              <input type="search" placeholder="animation utilities" />
+              <button class="input-action" type="submit">Search</button>
+            </span>
+          </label>
+
+          <label class="field">
+            <span class="field-label">Locked workspace</span>
+            <span class="input-group is-disabled">
+              <span class="input-addon">team/</span>
+              <input type="text" value="production" disabled />
+              <span class="input-addon">read-only</span>
+            </span>
+          </label>
+        </form>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/input-group-addons-sb/style.css
+++ b/submissions/examples/input-group-addons-sb/style.css
@@ -1,0 +1,215 @@
+:root {
+  --input-bg: #ffffff;
+  --input-panel: rgba(255, 255, 255, 0.9);
+  --input-border: #dbe4f0;
+  --input-border-active: #2563eb;
+  --input-addon-bg: #f1f5f9;
+  --input-addon-text: #475569;
+  --input-text: #0f172a;
+  --input-muted: #64748b;
+  --input-ring: rgba(37, 99, 235, 0.18);
+  --input-radius: 1rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--input-text);
+  background:
+    radial-gradient(
+      circle at 20% 10%,
+      rgba(37, 99, 235, 0.18),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #e0f2fe 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-panel {
+  width: min(100%, 46rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 1.5rem;
+  background: var(--input-panel);
+  box-shadow: 0 26px 70px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(16px);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #2563eb;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 38rem;
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.25rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 36rem;
+  margin: 1rem 0 2rem;
+  color: var(--input-muted);
+  line-height: 1.7;
+}
+
+.demo-form {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.field-label {
+  color: #334155;
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.input-group {
+  display: flex;
+  align-items: stretch;
+  min-height: 3.25rem;
+  overflow: hidden;
+  border: 1px solid var(--input-border);
+  border-radius: var(--input-radius);
+  background: var(--input-bg);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.input-group:focus-within {
+  border-color: var(--input-border-active);
+  box-shadow: 0 0 0 4px var(--input-ring);
+  transform: translateY(-1px);
+}
+
+.input-addon,
+.input-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding-inline: 1rem;
+  border: 0;
+  background: var(--input-addon-bg);
+  color: var(--input-addon-text);
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.input-addon:first-child {
+  border-right: 1px solid var(--input-border);
+}
+
+.input-addon:last-child,
+.input-action {
+  border-left: 1px solid var(--input-border);
+}
+
+.input-group input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--input-text);
+  font: inherit;
+  font-weight: 700;
+  outline: 0;
+  padding: 0.85rem 1rem;
+}
+
+.input-group input::placeholder {
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.input-action {
+  cursor: pointer;
+  color: #ffffff;
+  background: #2563eb;
+  transition: background-color 180ms ease;
+}
+
+.input-action:hover,
+.input-action:focus-visible {
+  background: #1d4ed8;
+}
+
+.input-action:focus-visible {
+  outline: 3px solid #93c5fd;
+  outline-offset: -3px;
+}
+
+.input-group.is-disabled {
+  opacity: 0.68;
+}
+
+.input-group.is-disabled input,
+.input-group.is-disabled .input-addon {
+  cursor: not-allowed;
+}
+
+@media (max-width: 560px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .input-group {
+    flex-wrap: wrap;
+  }
+
+  .input-addon,
+  .input-action {
+    min-height: 2.75rem;
+    flex: 1 1 auto;
+  }
+
+  .input-group input {
+    flex-basis: 100%;
+    order: 2;
+    min-height: 3rem;
+    border-top: 1px solid var(--input-border);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .input-group,
+  .input-action {
+    transition: none;
+  }
+
+  .input-group:focus-within {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained input group demo under submissions/examples/input-group-addons-sb
- include prefix/suffix addon patterns for URLs, currency, search, and disabled values
- add focus-within styling, responsive wrapping, and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/input-group-addons-sb/demo.html submissions/examples/input-group-addons-sb/style.css submissions/examples/input-group-addons-sb/README.md
- git diff --cached --check

Closes #6298