### PR TITLE
feat: add empty state submission

### DIFF
--- a/submissions/examples/empty-state-sb/README.md
+++ b/submissions/examples/empty-state-sb/README.md
@@ -1,0 +1,23 @@
+# Empty State Component
+
+## What does this do?
+
+Adds a self-contained empty state demo for zero results, blank dashboards, and filtered lists with an icon, heading, description, and action buttons.
+
+## How is it used?
+
+```html
+<div class="empty-state">
+  <div class="empty-icon" aria-hidden="true">✦</div>
+  <h2>No projects yet</h2>
+  <p>Create your first workspace to start tracking work.</p>
+  <div class="empty-actions">
+    <a class="primary-action" href="#create">Create project</a>
+    <a class="secondary-action" href="#templates">Browse templates</a>
+  </div>
+</div>
+```
+
+## Why is it useful?
+
+Empty states prevent blank screens from feeling broken and help users recover quickly with clear guidance and a next action.

--- a/submissions/examples/empty-state-sb/demo.html
+++ b/submissions/examples/empty-state-sb/demo.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Empty State Component</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="empty-title">
+        <p class="eyebrow">Blank slate component</p>
+        <h1 id="empty-title">Empty states that guide the next step</h1>
+        <p class="intro">
+          Give lists, dashboards, and search results a useful fallback with a
+          visual cue, short copy, and clear calls to action.
+        </p>
+
+        <div class="empty-state">
+          <div class="empty-icon" aria-hidden="true">
+            <span>✦</span>
+          </div>
+          <h2>No projects yet</h2>
+          <p>
+            Create your first workspace to start tracking tasks, teammates, and
+            delivery milestones in one place.
+          </p>
+          <div class="empty-actions">
+            <a class="primary-action" href="#create">Create project</a>
+            <a class="secondary-action" href="#templates">Browse templates</a>
+          </div>
+        </div>
+
+        <div class="empty-state compact">
+          <div class="empty-icon" aria-hidden="true">
+            <span>⌕</span>
+          </div>
+          <div>
+            <h2>No matching results</h2>
+            <p>Clear filters or try a broader search phrase.</p>
+          </div>
+          <button class="secondary-action" type="button">Clear filters</button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/empty-state-sb/style.css
+++ b/submissions/examples/empty-state-sb/style.css
@@ -1,0 +1,219 @@
+:root {
+  --empty-bg: #ffffff;
+  --empty-border: #dbe4f0;
+  --empty-text: #0f172a;
+  --empty-muted: #64748b;
+  --empty-accent: #2563eb;
+  --empty-accent-soft: #dbeafe;
+  --empty-shadow: rgba(15, 23, 42, 0.1);
+  --empty-radius: 1.5rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--empty-text);
+  background:
+    radial-gradient(
+      circle at 20% 12%,
+      rgba(37, 99, 235, 0.18),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #eff6ff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 52rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--empty-accent);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 42rem;
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 38rem;
+  margin: 1rem 0 2rem;
+  color: var(--empty-muted);
+  line-height: 1.7;
+}
+
+.empty-state {
+  display: grid;
+  justify-items: center;
+  gap: 1rem;
+  padding: clamp(1.5rem, 5vw, 3rem);
+  border: 2px dashed var(--empty-border);
+  border-radius: var(--empty-radius);
+  background: var(--empty-bg);
+  box-shadow: 0 16px 44px var(--empty-shadow);
+  text-align: center;
+}
+
+.empty-icon {
+  display: grid;
+  width: 4.5rem;
+  height: 4.5rem;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--empty-accent);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.88), transparent),
+    var(--empty-accent-soft);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.16);
+  font-size: 2rem;
+}
+
+.empty-state h2 {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+}
+
+.empty-state p {
+  max-width: 34rem;
+  margin: 0;
+  color: var(--empty-muted);
+  line-height: 1.65;
+}
+
+.empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.primary-action,
+.secondary-action {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  text-decoration: none;
+  transition:
+    background-color 180ms ease,
+    border-color 180ms ease,
+    transform 180ms ease;
+}
+
+.primary-action {
+  border: 1px solid var(--empty-accent);
+  padding: 0.75rem 1.2rem;
+  color: #ffffff;
+  background: var(--empty-accent);
+}
+
+.secondary-action {
+  border: 1px solid var(--empty-border);
+  padding: 0.75rem 1.2rem;
+  color: var(--empty-text);
+  background: #ffffff;
+}
+
+.primary-action:hover,
+.primary-action:focus-visible,
+.secondary-action:hover,
+.secondary-action:focus-visible {
+  transform: translateY(-1px);
+}
+
+.primary-action:hover,
+.primary-action:focus-visible {
+  background: #1d4ed8;
+}
+
+.secondary-action:hover,
+.secondary-action:focus-visible {
+  border-color: #bfdbfe;
+  background: #eff6ff;
+}
+
+.primary-action:focus-visible,
+.secondary-action:focus-visible {
+  outline: 3px solid #93c5fd;
+  outline-offset: 3px;
+}
+
+.empty-state.compact {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  justify-items: start;
+  margin-top: 1rem;
+  padding: 1rem;
+  text-align: left;
+}
+
+.empty-state.compact .empty-icon {
+  width: 3rem;
+  height: 3rem;
+  font-size: 1.35rem;
+}
+
+.empty-state.compact h2 {
+  font-size: 1.1rem;
+}
+
+@media (max-width: 640px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .empty-state.compact {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .primary-action,
+  .secondary-action {
+    transition: none;
+  }
+
+  .primary-action:hover,
+  .primary-action:focus-visible,
+  .secondary-action:hover,
+  .secondary-action:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained empty state component demo under submissions/examples/empty-state-sb
- include icon, heading, description, primary/secondary CTAs, and a compact filtered-results variant
- add responsive layout, focus-visible states, and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/empty-state-sb/demo.html submissions/examples/empty-state-sb/style.css submissions/examples/empty-state-sb/README.md
- git diff --cached --check

Closes #6288