### PR TITLE
feat: add tag pills submission

### DIFF
--- a/submissions/examples/tag-pills-sb/README.md
+++ b/submissions/examples/tag-pills-sb/README.md
@@ -1,0 +1,19 @@
+# Tag Pills
+
+## What does this do?
+
+Adds a self-contained tag pill demo with display-only labels, color variants, and removable filter states with danger hover styling.
+
+## How is it used?
+
+```html
+<span class="tag">Design</span>
+<span class="tag tag-success">Published</span>
+<button class="tag tag-removable" type="button">
+  Python <span class="tag-remove" aria-hidden="true">×</span>
+</button>
+```
+
+## Why is it useful?
+
+Tag pills make filters, categories, and statuses easy to scan while keeping selection removal accessible, responsive, and JavaScript-free.

--- a/submissions/examples/tag-pills-sb/demo.html
+++ b/submissions/examples/tag-pills-sb/demo.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tag Pills</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="tag-title">
+        <p class="eyebrow">Display component</p>
+        <h1 id="tag-title">Tag pills for filters and category labels</h1>
+        <p class="intro">
+          Compact labels for content categories, publishing states, search
+          filters, and removable selections.
+        </p>
+
+        <div class="tag-group" aria-label="Content categories">
+          <span class="tag">Design</span>
+          <span class="tag tag-success">Published</span>
+          <span class="tag tag-warning">Needs review</span>
+          <span class="tag tag-danger">Blocked</span>
+          <span class="tag tag-info">AI/ML</span>
+        </div>
+
+        <div class="filter-bar" aria-label="Active search filters">
+          <span class="filter-label">Active filters</span>
+          <button class="tag tag-removable" type="button">
+            Python <span class="tag-remove" aria-hidden="true">×</span>
+          </button>
+          <button class="tag tag-removable tag-info" type="button">
+            React <span class="tag-remove" aria-hidden="true">×</span>
+          </button>
+          <button class="tag tag-removable tag-success" type="button">
+            Beginner <span class="tag-remove" aria-hidden="true">×</span>
+          </button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/tag-pills-sb/style.css
+++ b/submissions/examples/tag-pills-sb/style.css
@@ -1,0 +1,212 @@
+:root {
+  --tag-bg: #f8fafc;
+  --tag-border: #dbe4f0;
+  --tag-text: #334155;
+  --tag-hover: #eff6ff;
+  --tag-ring: #93c5fd;
+  --tag-success-bg: #dcfce7;
+  --tag-success-text: #166534;
+  --tag-warning-bg: #fef3c7;
+  --tag-warning-text: #92400e;
+  --tag-danger-bg: #fee2e2;
+  --tag-danger-text: #991b1b;
+  --tag-info-bg: #dbeafe;
+  --tag-info-text: #1d4ed8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(
+      circle at 16% 15%,
+      rgba(37, 99, 235, 0.2),
+      transparent 24rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 48rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #2563eb;
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 40rem;
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 36rem;
+  margin: 1rem 0 2rem;
+  color: #64748b;
+  line-height: 1.7;
+}
+
+.tag-group,
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.filter-bar {
+  margin-top: 1.25rem;
+  padding: 1rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 1rem;
+  background: #f8fafc;
+}
+
+.filter-label {
+  margin-right: 0.25rem;
+  color: #64748b;
+  font-size: 0.82rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tag {
+  display: inline-flex;
+  min-height: 2.25rem;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid var(--tag-border);
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+  color: var(--tag-text);
+  background: var(--tag-bg);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 850;
+  line-height: 1;
+  text-decoration: none;
+}
+
+button.tag {
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+button.tag:hover,
+button.tag:focus-visible {
+  border-color: #bfdbfe;
+  background: var(--tag-hover);
+  transform: translateY(-1px);
+}
+
+button.tag:focus-visible {
+  outline: 3px solid var(--tag-ring);
+  outline-offset: 3px;
+}
+
+.tag-success {
+  border-color: #bbf7d0;
+  color: var(--tag-success-text);
+  background: var(--tag-success-bg);
+}
+
+.tag-warning {
+  border-color: #fde68a;
+  color: var(--tag-warning-text);
+  background: var(--tag-warning-bg);
+}
+
+.tag-danger {
+  border-color: #fecaca;
+  color: var(--tag-danger-text);
+  background: var(--tag-danger-bg);
+}
+
+.tag-info {
+  border-color: #bfdbfe;
+  color: var(--tag-info-text);
+  background: var(--tag-info-bg);
+}
+
+.tag-removable:hover,
+.tag-removable:focus-visible {
+  border-color: #fca5a5;
+  color: #991b1b;
+  background: #fee2e2;
+}
+
+.tag-remove {
+  display: inline-grid;
+  width: 1.25rem;
+  height: 1.25rem;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.tag-removable:hover .tag-remove,
+.tag-removable:focus-visible .tag-remove {
+  color: #ffffff;
+  background: #dc2626;
+}
+
+@media (max-width: 540px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .filter-label {
+    flex-basis: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button.tag {
+    transition: none;
+  }
+
+  button.tag:hover,
+  button.tag:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained tag pills demo under submissions/examples/tag-pills-sb
- include neutral, success, warning, danger, and info display variants
- add removable filter states with danger hover styling and focus-visible support

## Validation
- npx prettier --check submissions/examples/tag-pills-sb/demo.html submissions/examples/tag-pills-sb/style.css submissions/examples/tag-pills-sb/README.md
- git diff --cached --check

Closes #6285