### PR TITLE
feat: add details collapsible submission

### DIFF
--- a/submissions/examples/details-collapsible-sb/README.md
+++ b/submissions/examples/details-collapsible-sb/README.md
@@ -1,0 +1,18 @@
+# CSS-Only Collapsible
+
+## What does this do?
+
+Adds a self-contained collapsible section demo using native `details` and `summary` elements with a CSS-only rotating arrow indicator.
+
+## How is it used?
+
+```html
+<details class="collapsible">
+  <summary>What is EaseMotion?</summary>
+  <div class="collapsible-body">A CSS animation framework.</div>
+</details>
+```
+
+## Why is it useful?
+
+Native collapsibles provide accessible expandable content without JavaScript, making them ideal for FAQs, documentation, settings panels, and compact UI explanations.

--- a/submissions/examples/details-collapsible-sb/demo.html
+++ b/submissions/examples/details-collapsible-sb/demo.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS-Only Collapsible</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="collapsible-title">
+        <p class="eyebrow">No-JavaScript pattern</p>
+        <h1 id="collapsible-title">CSS-only collapsible sections</h1>
+        <p class="intro">
+          Use native details and summary markup for accessible expandable
+          content with a rotating arrow indicator.
+        </p>
+
+        <div class="collapsible-stack">
+          <details class="collapsible" open>
+            <summary>What is EaseMotion?</summary>
+            <div class="collapsible-body">
+              EaseMotion is a lightweight CSS framework for motion utilities,
+              reusable components, and expressive UI details.
+            </div>
+          </details>
+
+          <details class="collapsible">
+            <summary>Does this need JavaScript?</summary>
+            <div class="collapsible-body">
+              No. The browser handles expanded state natively, while CSS styles
+              the summary, body, and open-state arrow rotation.
+            </div>
+          </details>
+
+          <details class="collapsible">
+            <summary>Can it be used in FAQs?</summary>
+            <div class="collapsible-body">
+              Yes. It works well for FAQ lists, settings panels, release notes,
+              and compact documentation sections.
+            </div>
+          </details>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/details-collapsible-sb/style.css
+++ b/submissions/examples/details-collapsible-sb/style.css
@@ -1,0 +1,173 @@
+:root {
+  --collapse-bg: #ffffff;
+  --collapse-border: #dbe4f0;
+  --collapse-text: #0f172a;
+  --collapse-muted: #64748b;
+  --collapse-accent: #2563eb;
+  --collapse-accent-soft: #dbeafe;
+  --collapse-shadow: rgba(15, 23, 42, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--collapse-text);
+  background:
+    radial-gradient(
+      circle at 18% 15%,
+      rgba(37, 99, 235, 0.18),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 48rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--collapse-accent);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 40rem;
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 36rem;
+  margin: 1rem 0 2rem;
+  color: var(--collapse-muted);
+  line-height: 1.7;
+}
+
+.collapsible-stack {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.collapsible {
+  overflow: hidden;
+  border: 1px solid var(--collapse-border);
+  border-radius: 1rem;
+  background: var(--collapse-bg);
+  box-shadow: 0 12px 30px var(--collapse-shadow);
+}
+
+.collapsible summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 3.5rem;
+  padding: 1rem 1.1rem;
+  color: var(--collapse-text);
+  cursor: pointer;
+  font-weight: 900;
+  list-style: none;
+}
+
+.collapsible summary::-webkit-details-marker {
+  display: none;
+}
+
+.collapsible summary::after {
+  display: inline-grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--collapse-accent);
+  background: var(--collapse-accent-soft);
+  content: "›";
+  font-size: 1.35rem;
+  line-height: 1;
+  transform: rotate(90deg);
+  transition:
+    background-color 180ms ease,
+    transform 180ms ease;
+}
+
+.collapsible[open] summary::after {
+  background: #bfdbfe;
+  transform: rotate(270deg);
+}
+
+.collapsible summary:hover::after {
+  background: #bfdbfe;
+}
+
+.collapsible summary:focus-visible {
+  outline: 3px solid #93c5fd;
+  outline-offset: -3px;
+}
+
+.collapsible-body {
+  padding: 0 1.1rem 1.1rem;
+  color: var(--collapse-muted);
+  line-height: 1.65;
+}
+
+.collapsible[open] .collapsible-body {
+  animation: reveal-body 180ms ease both;
+}
+
+@keyframes reveal-body {
+  from {
+    opacity: 0;
+    transform: translateY(-0.35rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 540px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .collapsible summary::after {
+    transition: none;
+  }
+
+  .collapsible[open] .collapsible-body {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained native details/summary collapsible demo under submissions/examples/details-collapsible-sb
- include rotating CSS arrow indicator for open state
- add focus-visible, responsive, and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/details-collapsible-sb/demo.html submissions/examples/details-collapsible-sb/style.css submissions/examples/details-collapsible-sb/README.md
- git diff --cached --check

Closes #6284