### PR TITLE
feat: add responsive table submission

### DIFF
--- a/submissions/examples/responsive-table-sb/README.md
+++ b/submissions/examples/responsive-table-sb/README.md
@@ -1,0 +1,30 @@
+# Responsive Data Table
+
+## What does this do?
+
+Adds a self-contained responsive data table demo with uppercase headers, striped rows, hover highlighting, status pills, and a horizontal scroll wrapper.
+
+## How is it used?
+
+```html
+<div class="table-wrap" tabindex="0" aria-label="Project table">
+  <table class="data-table striped">
+    <thead>
+      <tr>
+        <th scope="col">Project</th>
+        <th scope="col">Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Atlas UI</td>
+        <td><span class="status success">Live</span></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
+
+## Why is it useful?
+
+Tables are common in dashboards and admin panels, and this pattern keeps dense data readable while preserving keyboard access and responsive overflow behavior.

--- a/submissions/examples/responsive-table-sb/demo.html
+++ b/submissions/examples/responsive-table-sb/demo.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Responsive Data Table</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="table-title">
+        <p class="eyebrow">Data component</p>
+        <h1 id="table-title">Responsive data table</h1>
+        <p class="intro">
+          A clean table surface for admin panels, comparison views, and data
+          grids with striped rows and horizontal scroll on small screens.
+        </p>
+
+        <div class="table-wrap" tabindex="0" aria-label="Project table">
+          <table class="data-table striped">
+            <caption>
+              Recent project deployments
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Project</th>
+                <th scope="col">Owner</th>
+                <th scope="col">Status</th>
+                <th scope="col">Region</th>
+                <th scope="col">Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><a href="#atlas">Atlas UI</a></td>
+                <td>Mira</td>
+                <td><span class="status success">Live</span></td>
+                <td>Asia South</td>
+                <td>2 min ago</td>
+              </tr>
+              <tr>
+                <td><a href="#pulse">Pulse API</a></td>
+                <td>Devon</td>
+                <td><span class="status warning">Review</span></td>
+                <td>US East</td>
+                <td>18 min ago</td>
+              </tr>
+              <tr>
+                <td><a href="#nova">Nova Docs</a></td>
+                <td>Asha</td>
+                <td><span class="status success">Live</span></td>
+                <td>EU West</td>
+                <td>1 hr ago</td>
+              </tr>
+              <tr>
+                <td><a href="#orbit">Orbit Admin</a></td>
+                <td>Ravi</td>
+                <td><span class="status danger">Blocked</span></td>
+                <td>Global</td>
+                <td>Yesterday</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/responsive-table-sb/style.css
+++ b/submissions/examples/responsive-table-sb/style.css
@@ -1,0 +1,192 @@
+:root {
+  --table-bg: #ffffff;
+  --table-border: #dbe4f0;
+  --table-header-bg: #f8fafc;
+  --table-header-text: #475569;
+  --table-text: #0f172a;
+  --table-muted: #64748b;
+  --table-hover: #eff6ff;
+  --table-stripe: #f8fafc;
+  --table-focus: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--table-text);
+  background:
+    radial-gradient(
+      circle at 18% 16%,
+      rgba(37, 99, 235, 0.18),
+      transparent 26rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #e0f2fe 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 62rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #2563eb;
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 42rem;
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 40rem;
+  margin: 1rem 0 2rem;
+  color: var(--table-muted);
+  line-height: 1.7;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--table-border);
+  border-radius: 1rem;
+  background: var(--table-bg);
+  box-shadow: 0 16px 44px rgba(15, 23, 42, 0.08);
+}
+
+.table-wrap:focus-visible {
+  outline: 3px solid var(--table-focus);
+  outline-offset: 4px;
+}
+
+.data-table {
+  width: 100%;
+  min-width: 44rem;
+  border-collapse: collapse;
+  color: var(--table-text);
+  font-size: 0.95rem;
+}
+
+.data-table caption {
+  padding: 1rem 1.25rem;
+  color: var(--table-muted);
+  font-weight: 800;
+  text-align: left;
+}
+
+.data-table th,
+.data-table td {
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--table-border);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.data-table thead th {
+  border-top: 0;
+  color: var(--table-header-text);
+  background: var(--table-header-bg);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.data-table.striped tbody tr:nth-child(even) {
+  background: var(--table-stripe);
+}
+
+.data-table tbody tr {
+  transition:
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+.data-table tbody tr:hover {
+  background: var(--table-hover);
+}
+
+.data-table a {
+  color: #1d4ed8;
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.data-table a:hover,
+.data-table a:focus-visible {
+  text-decoration: underline;
+}
+
+.data-table a:focus-visible {
+  outline: 3px solid var(--table-focus);
+  outline-offset: 3px;
+}
+
+.status {
+  display: inline-flex;
+  min-height: 1.8rem;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.status.success {
+  color: #166534;
+  background: #dcfce7;
+}
+
+.status.warning {
+  color: #92400e;
+  background: #fef3c7;
+}
+
+.status.danger {
+  color: #991b1b;
+  background: #fee2e2;
+}
+
+@media (max-width: 560px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .table-wrap {
+    border-radius: 0.85rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .data-table tbody tr {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained responsive data table demo under submissions/examples/responsive-table-sb
- include uppercase headers, striped rows, hover highlighting, and status pills
- add a keyboard-focusable horizontal scroll wrapper for small screens

## Validation
- npx prettier --check submissions/examples/responsive-table-sb/demo.html submissions/examples/responsive-table-sb/style.css submissions/examples/responsive-table-sb/README.md
- git diff --cached --check

Closes #6283