### PR TITLE
feat: add animated copy button submission

### DIFF
--- a/submissions/examples/copy-button-sb/README.md
+++ b/submissions/examples/copy-button-sb/README.md
@@ -1,0 +1,15 @@
+# Animated Copy Button
+
+A self-contained copy-to-clipboard button with an animated "Copy" to "Copied!" confirmation state.
+
+## Features
+
+- Label crossfade uses stacked text so the button width does not shift.
+- `.ease-copied` toggles the success state and pulse animation.
+- Includes an `aria-live` status message for assistive technology.
+- Respects reduced-motion preferences.
+- Stacks cleanly on narrow screens.
+
+## Usage
+
+Open `demo.html` in a browser and click the button to copy the sample code. The JavaScript toggles `.ease-copied` for two seconds, matching the requested interaction pattern.

--- a/submissions/examples/copy-button-sb/demo.html
+++ b/submissions/examples/copy-button-sb/demo.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Animated Copy Button</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="copy-card" aria-labelledby="copy-title">
+        <p class="eyebrow">Micro interaction</p>
+        <h1 id="copy-title">Animated copy button</h1>
+        <p class="intro">
+          A compact clipboard action with a no-shift label swap, success pulse,
+          and accessible live feedback.
+        </p>
+
+        <div class="snippet" aria-label="Coupon code">
+          <code id="copy-value">GSSOC-READY-26</code>
+          <button
+            class="copy-button"
+            type="button"
+            aria-describedby="copy-status"
+          >
+            <span class="label label-copy">Copy</span>
+            <span class="label label-copied" aria-hidden="true">Copied!</span>
+          </button>
+        </div>
+
+        <p id="copy-status" class="status" role="status" aria-live="polite">
+          Ready to copy.
+        </p>
+      </section>
+    </main>
+
+    <script>
+      const button = document.querySelector(".copy-button");
+      const value = document.querySelector("#copy-value").textContent.trim();
+      const status = document.querySelector("#copy-status");
+
+      button.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(value);
+          button.classList.add("ease-copied");
+          status.textContent = "Code copied to clipboard.";
+
+          window.setTimeout(() => {
+            button.classList.remove("ease-copied");
+            status.textContent = "Ready to copy.";
+          }, 2000);
+        } catch {
+          status.textContent = "Copy failed. Select the code manually.";
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/copy-button-sb/style.css
+++ b/submissions/examples/copy-button-sb/style.css
@@ -1,0 +1,212 @@
+:root {
+  --copy-bg: #f8fafc;
+  --copy-surface: #ffffff;
+  --copy-text: #111827;
+  --copy-muted: #64748b;
+  --copy-border: #dbe4f0;
+  --copy-primary: #2563eb;
+  --copy-primary-dark: #1d4ed8;
+  --copy-success: #16a34a;
+  --copy-focus: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--copy-text);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.14), transparent 34%),
+    linear-gradient(160deg, #f8fafc 0%, #ecfeff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.copy-card {
+  width: min(100%, 36rem);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--copy-primary);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: var(--copy-muted);
+  line-height: 1.7;
+}
+
+.snippet {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem;
+  border: 1px solid var(--copy-border);
+  border-radius: 1rem;
+  background: var(--copy-bg);
+}
+
+.snippet code {
+  overflow: hidden;
+  color: #0f172a;
+  font-size: clamp(0.9rem, 4vw, 1.15rem);
+  font-weight: 900;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.copy-button {
+  position: relative;
+  display: inline-grid;
+  min-width: 6.5rem;
+  min-height: 2.8rem;
+  flex: 0 0 auto;
+  place-items: center;
+  overflow: hidden;
+  border: 0;
+  border-radius: 999px;
+  color: #ffffff;
+  background: var(--copy-primary);
+  box-shadow: 0 12px 26px rgba(37, 99, 235, 0.28);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  transition:
+    background-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.copy-button:hover {
+  background: var(--copy-primary-dark);
+  transform: translateY(-1px);
+}
+
+.copy-button:focus-visible {
+  outline: 3px solid var(--copy-focus);
+  outline-offset: 4px;
+}
+
+.copy-button.ease-copied {
+  background: var(--copy-success);
+  box-shadow: 0 12px 26px rgba(22, 163, 74, 0.24);
+}
+
+.copy-button.ease-copied::after {
+  position: absolute;
+  inset: -45%;
+  border-radius: inherit;
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.35),
+    transparent 58%
+  );
+  animation: copy-pulse 700ms ease-out;
+  content: "";
+}
+
+.label {
+  grid-area: 1 / 1;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+.label-copy {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.label-copied {
+  opacity: 0;
+  transform: translateY(0.75rem);
+}
+
+.copy-button.ease-copied .label-copy {
+  opacity: 0;
+  transform: translateY(-0.75rem);
+}
+
+.copy-button.ease-copied .label-copied {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.status {
+  min-height: 1.5rem;
+  margin: 1rem 0 0;
+  color: var(--copy-muted);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+@keyframes copy-pulse {
+  from {
+    opacity: 0.9;
+    transform: scale(0.35);
+  }
+
+  to {
+    opacity: 0;
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 520px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .snippet {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .copy-button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-button,
+  .label {
+    transition: none;
+  }
+
+  .copy-button.ease-copied::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained animated copy button demo under submissions/examples/copy-button-sb
- use an ease-copied class for the no-shift Copy/Copied label transition
- include clipboard handling, live status feedback, and reduced-motion support

## Validation
- npx prettier --check submissions/examples/copy-button-sb/demo.html submissions/examples/copy-button-sb/style.css submissions/examples/copy-button-sb/README.md
- git diff --cached --check

Closes #6279