### PR TITLE
feat: add context menu submission

### DIFF
--- a/submissions/examples/context-menu-sb/README.md
+++ b/submissions/examples/context-menu-sb/README.md
@@ -1,0 +1,15 @@
+# Context Menu Popup
+
+A self-contained custom context menu popup for file managers, tables, and editor-style interfaces.
+
+## Features
+
+- Opens from right-click or a standard actions button.
+- Uses `.ease-context-menu` and `.ease-visible` for the show/hide state.
+- Includes normal actions, a divider, and a danger action.
+- Provides keyboard focus, Escape-to-close behavior, and reduced-motion support.
+- Keeps the popup responsive with viewport-aware sizing.
+
+## Usage
+
+Open `demo.html`, then right-click the workspace tile or press the Actions button. The example positions the menu with inline `top` and `left` values, matching the requested component pattern.

--- a/submissions/examples/context-menu-sb/demo.html
+++ b/submissions/examples/context-menu-sb/demo.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Context Menu Popup</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="menu-title">
+        <p class="eyebrow">Popup component</p>
+        <h1 id="menu-title">Context menu popup</h1>
+        <p class="intro">
+          Right-click the workspace tile or use the trigger button to reveal a
+          polished action menu with dividers, danger actions, and keyboard
+          focus.
+        </p>
+
+        <div class="workspace" id="workspace" tabindex="0">
+          <span class="workspace-icon" aria-hidden="true">CM</span>
+          <div>
+            <strong>Campaign report.pdf</strong>
+            <span>Right-click or open actions</span>
+          </div>
+          <button class="menu-trigger" type="button" aria-haspopup="menu">
+            Actions
+          </button>
+        </div>
+
+        <ul
+          class="ease-context-menu"
+          id="context-menu"
+          role="menu"
+          aria-hidden="true"
+        >
+          <li class="ease-ctx-item" role="menuitem" tabindex="-1">Preview</li>
+          <li class="ease-ctx-item" role="menuitem" tabindex="-1">Rename</li>
+          <li class="ease-ctx-item" role="menuitem" tabindex="-1">Duplicate</li>
+          <li class="ease-ctx-divider" role="separator"></li>
+          <li
+            class="ease-ctx-item ease-ctx-danger"
+            role="menuitem"
+            tabindex="-1"
+          >
+            Delete
+          </li>
+        </ul>
+      </section>
+    </main>
+
+    <script>
+      const menu = document.querySelector("#context-menu");
+      const workspace = document.querySelector("#workspace");
+      const trigger = document.querySelector(".menu-trigger");
+
+      const showMenu = (x, y) => {
+        menu.style.left = `${x}px`;
+        menu.style.top = `${y}px`;
+        menu.classList.add("ease-visible");
+        menu.setAttribute("aria-hidden", "false");
+        menu.querySelector(".ease-ctx-item").focus();
+      };
+
+      const hideMenu = () => {
+        menu.classList.remove("ease-visible");
+        menu.setAttribute("aria-hidden", "true");
+      };
+
+      workspace.addEventListener("contextmenu", (event) => {
+        event.preventDefault();
+        showMenu(event.clientX, event.clientY);
+      });
+
+      trigger.addEventListener("click", () => {
+        const rect = trigger.getBoundingClientRect();
+        showMenu(rect.left, rect.bottom + 8);
+      });
+
+      document.addEventListener("click", (event) => {
+        if (!menu.contains(event.target) && event.target !== trigger) {
+          hideMenu();
+        }
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          hideMenu();
+          trigger.focus();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/context-menu-sb/style.css
+++ b/submissions/examples/context-menu-sb/style.css
@@ -1,0 +1,214 @@
+:root {
+  --ctx-bg: #f8fafc;
+  --ctx-surface: #ffffff;
+  --ctx-text: #111827;
+  --ctx-muted: #64748b;
+  --ctx-border: #dbe4f0;
+  --ctx-primary: #2563eb;
+  --ctx-hover: #eff6ff;
+  --ctx-danger: #dc2626;
+  --ctx-danger-bg: #fef2f2;
+  --ctx-focus: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ctx-text);
+  background:
+    radial-gradient(
+      circle at 70% 18%,
+      rgba(37, 99, 235, 0.18),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  position: relative;
+  width: min(100%, 44rem);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--ctx-primary);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 35rem;
+  margin: 1rem 0 2rem;
+  color: var(--ctx-muted);
+  line-height: 1.7;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+  border: 1px solid var(--ctx-border);
+  border-radius: 1rem;
+  background: var(--ctx-bg);
+}
+
+.workspace:focus-visible {
+  outline: 3px solid var(--ctx-focus);
+  outline-offset: 4px;
+}
+
+.workspace-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 0.9rem;
+  color: #ffffff;
+  background: var(--ctx-primary);
+  font-weight: 900;
+}
+
+.workspace strong,
+.workspace span {
+  display: block;
+}
+
+.workspace strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace span {
+  margin-top: 0.25rem;
+  color: var(--ctx-muted);
+}
+
+.menu-trigger {
+  min-height: 2.6rem;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 1rem;
+  color: #ffffff;
+  background: var(--ctx-primary);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+}
+
+.menu-trigger:focus-visible {
+  outline: 3px solid var(--ctx-focus);
+  outline-offset: 4px;
+}
+
+.ease-context-menu {
+  position: fixed;
+  z-index: 10;
+  width: min(14rem, calc(100vw - 2rem));
+  margin: 0;
+  padding: 0.45rem;
+  border: 1px solid var(--ctx-border);
+  border-radius: 0.95rem;
+  background: var(--ctx-surface);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+  list-style: none;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(0.5rem) scale(0.98);
+  transform-origin: top left;
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+}
+
+.ease-context-menu.ease-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+}
+
+.ease-ctx-item {
+  display: flex;
+  align-items: center;
+  min-height: 2.25rem;
+  border-radius: 0.7rem;
+  padding: 0 0.75rem;
+  color: var(--ctx-text);
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.ease-ctx-item:hover,
+.ease-ctx-item:focus-visible {
+  background: var(--ctx-hover);
+  outline: 0;
+}
+
+.ease-ctx-danger {
+  color: var(--ctx-danger);
+}
+
+.ease-ctx-danger:hover,
+.ease-ctx-danger:focus-visible {
+  background: var(--ctx-danger-bg);
+}
+
+.ease-ctx-divider {
+  height: 1px;
+  margin: 0.45rem 0.25rem;
+  background: var(--ctx-border);
+}
+
+@media (max-width: 560px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .workspace {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .menu-trigger {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-context-menu {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained context menu demo under submissions/examples/context-menu-sb
- support right-click and button-triggered popup positioning
- include dividers, danger actions, keyboard focus, Escape close, and reduced-motion support

## Validation
- npx prettier --check submissions/examples/context-menu-sb/demo.html submissions/examples/context-menu-sb/style.css submissions/examples/context-menu-sb/README.md
- git diff --cached --check

Closes #6277