### PR TITLE
feat: add team directory grid example

### DIFF
--- a/submissions/examples/team-directory-grid-zt/README.md
+++ b/submissions/examples/team-directory-grid-zt/README.md
@@ -1,0 +1,56 @@
+# Team Directory Grid
+
+## Overview
+
+A responsive team directory grid for SaaS dashboards featuring 6 sample team members, avatar circles, role and department labels, and status indicators. The design includes a visual search field and filter chips for a polished admin interface experience.
+
+## Features
+
+- Responsive 3-column grid that adapts to tablets and mobile devices
+- Six employee cards with avatar initials, name, role, and department
+- Online, away, and offline status indicators
+- Hover elevation effect with smooth transitions
+- Visual search input and filter chips for UI consistency
+- Modern SaaS dashboard styling with glassy dark surfaces
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css">
+<main class="directory-panel">
+  <header class="directory-header">
+    <p class="eyebrow">Team Directory</p>
+    <h1>Meet the team</h1>
+    <p class="header-copy">Browse employee profiles with role, department, and status in a clean SaaS-style dashboard layout.</p>
+  </header>
+
+  <div class="directory-controls">
+    <label class="search-field">
+      <span class="search-icon">🔍</span>
+      <input type="text" placeholder="Search team members" aria-label="Search team members">
+    </label>
+    <div class="filter-chips">
+      <button class="chip active">All</button>
+      <button class="chip">Design</button>
+      <button class="chip">Engineering</button>
+      <button class="chip">Product</button>
+    </div>
+  </div>
+
+  <section class="member-grid">
+    <article class="member-card online">
+      <div class="member-avatar">AR</div>
+      <div class="member-info">
+        <p class="member-name">Ava Reyes</p>
+        <p class="member-role">Lead Product Manager</p>
+      </div>
+      <span class="member-department">Product</span>
+    </article>
+    <!-- more cards -->
+  </section>
+</main>
+```
+
+## Why it fits EaseMotion CSS
+
+This component is self-contained and built with pure HTML and CSS only. It demonstrates polished dashboard patterns suitable for admin and team management interfaces, including responsive grid layout, interactive hover states, and scoped visual controls without JavaScript.

--- a/submissions/examples/team-directory-grid-zt/demo.html
+++ b/submissions/examples/team-directory-grid-zt/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Team Directory Grid</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="directory-panel">
+    <header class="directory-header">
+      <div>
+        <p class="eyebrow">Team Directory</p>
+        <h1>Meet the team</h1>
+      </div>
+      <p class="header-copy">Browse employee profiles with role, department, and status in a clean SaaS-style dashboard layout.</p>
+    </header>
+
+    <div class="directory-controls">
+      <label class="search-field">
+        <span class="search-icon">🔍</span>
+        <input type="text" placeholder="Search team members" aria-label="Search team members">
+      </label>
+      <div class="filter-chips">
+        <button class="chip active">All</button>
+        <button class="chip">Design</button>
+        <button class="chip">Engineering</button>
+        <button class="chip">Product</button>
+      </div>
+    </div>
+
+    <section class="member-grid">
+      <article class="member-card online">
+        <div class="member-avatar">AR</div>
+        <div class="member-info">
+          <p class="member-name">Ava Reyes</p>
+          <p class="member-role">Lead Product Manager</p>
+        </div>
+        <span class="member-department">Product</span>
+      </article>
+
+      <article class="member-card away">
+        <div class="member-avatar">MJ</div>
+        <div class="member-info">
+          <p class="member-name">Mia Johnson</p>
+          <p class="member-role">UX Designer</p>
+        </div>
+        <span class="member-department">Design</span>
+      </article>
+
+      <article class="member-card online">
+        <div class="member-avatar">EK</div>
+        <div class="member-info">
+          <p class="member-name">Ethan Kim</p>
+          <p class="member-role">Frontend Engineer</p>
+        </div>
+        <span class="member-department">Engineering</span>
+      </article>
+
+      <article class="member-card offline">
+        <div class="member-avatar">LN</div>
+        <div class="member-info">
+          <p class="member-name">Lina Novak</p>
+          <p class="member-role">Customer Success</p>
+        </div>
+        <span class="member-department">Operations</span>
+      </article>
+
+      <article class="member-card online">
+        <div class="member-avatar">SD</div>
+        <div class="member-info">
+          <p class="member-name">Sofia Diaz</p>
+          <p class="member-role">Marketing Lead</p>
+        </div>
+        <span class="member-department">Marketing</span>
+      </article>
+
+      <article class="member-card away">
+        <div class="member-avatar">RC</div>
+        <div class="member-info">
+          <p class="member-name">Riley Chen</p>
+          <p class="member-role">Data Analyst</p>
+        </div>
+        <span class="member-department">Analytics</span>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/team-directory-grid-zt/style.css
+++ b/submissions/examples/team-directory-grid-zt/style.css
@@ -1,0 +1,226 @@
+:root {
+  color-scheme: dark;
+  --bg: #07111f;
+  --surface: rgba(16, 28, 46, 0.96);
+  --surface-soft: rgba(24, 40, 68, 0.9);
+  --text: #e9f2ff;
+  --muted: #8fa8c3;
+  --border: rgba(255, 255, 255, 0.08);
+  --accent: #60c8ff;
+  --success: #63d6a5;
+  --warning: #f4c15f;
+  --danger: #f56c8d;
+  --shadow: 0 28px 80px rgba(0, 0, 0, 0.24);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top left, rgba(96, 200, 255, 0.12), transparent 20%),
+              radial-gradient(circle at 85% 15%, rgba(96, 200, 255, 0.08), transparent 18%),
+              linear-gradient(180deg, #0b1726 0%, #06101a 100%);
+  color: var(--text);
+}
+
+.directory-panel {
+  width: min(1080px, calc(100% - 2rem));
+  margin: 2.5rem auto;
+  padding: 2rem;
+  background: linear-gradient(180deg, rgba(11, 21, 37, 0.96), rgba(10, 18, 32, 0.94));
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  box-shadow: var(--shadow);
+}
+
+.directory-header {
+  display: grid;
+  gap: 0.9rem;
+  margin-bottom: 1.8rem;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.82rem;
+}
+
+.directory-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 2.6vw, 2.4rem);
+  line-height: 1.05;
+}
+
+.header-copy {
+  margin: 0;
+  color: var(--muted);
+  max-width: 62ch;
+  line-height: 1.7;
+}
+
+.directory-controls {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.search-field {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 1.1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.search-field input {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 1rem;
+  outline: none;
+}
+
+.search-icon {
+  font-size: 1rem;
+  color: var(--muted);
+}
+
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.chip {
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 220ms ease, background 220ms ease, border-color 220ms ease;
+}
+
+.chip:hover,
+.chip.active {
+  transform: translateY(-1px);
+  background: rgba(96, 200, 255, 0.14);
+  border-color: rgba(96, 200, 255, 0.32);
+}
+
+.member-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.member-card {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+  padding: 1.6rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease, background 220ms ease;
+}
+
+.member-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(96, 200, 255, 0.3);
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.18);
+  background: rgba(96, 200, 255, 0.06);
+}
+
+.member-avatar {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #0b1727;
+  background: linear-gradient(135deg, #9be8ff, #60c8ff);
+}
+
+.member-info {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.member-name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.member-role {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+.member-department {
+  align-self: start;
+  justify-self: start;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #c9dbf1;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.member-card::after {
+  content: "";
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--danger);
+  box-shadow: 0 0 0 4px rgba(245, 108, 141, 0.12);
+}
+
+.member-card.online::after {
+  background: var(--success);
+  box-shadow: 0 0 0 4px rgba(99, 214, 165, 0.14);
+}
+
+.member-card.away::after {
+  background: var(--warning);
+  box-shadow: 0 0 0 4px rgba(244, 193, 95, 0.14);
+}
+
+@media (max-width: 940px) {
+  .member-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .directory-panel {
+    padding: 1.5rem;
+    margin: 1.5rem auto;
+  }
+
+  .member-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .directory-controls {
+    gap: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new Team Directory Grid component example under:

`submissions/examples/team-directory-grid-zt/`

This submission demonstrates a responsive employee directory interface suitable for SaaS dashboards, admin portals, company intranets, and team management applications.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/examples/team-directory-grid-zt/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A responsive team directory grid with employee profile cards, status indicators, and dashboard-style organization.

**How does a developer use it?**

```html
<div class="team-grid">
  <div class="team-card">
    <div class="avatar"></div>
    <h3>Sarah Johnson</h3>
    <p>Product Designer</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

The component focuses on practical UI composition, subtle motion, and reusable dashboard patterns while remaining simple to customize and integrate.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The component includes status indicators, filter controls, and responsive employee cards to showcase a realistic SaaS dashboard use case while remaining fully self-contained.

Closes #7666 