### PR TITLE
feat : add magnetic-text-reveal

### DIFF
--- a/submissions/examples/magnetic-text-reveal/README.md
+++ b/submissions/examples/magnetic-text-reveal/README.md
@@ -1,0 +1,38 @@
+# Magnetic Text Reveal
+
+## What it does
+
+Creates a magnetic slide effect where hovering over text causes the original text to slide out while a secondary message slides in from the opposite direction. Perfect for call-to-action buttons, navigation links, and interactive headings.
+
+## How to use it
+
+Add the class to any text element:
+
+<h2 class="ease-magnetic-text">Hover Me →</h2>
+
+## Variants
+
+- ease-magnetic-text-left - Reveal slides in from right side
+- ease-magnetic-text-fast - 0.2s transition (default is 0.4s)
+- ease-magnetic-text-slow - 0.7s transition
+- ease-magnetic-text-purple - Purple themed reveal text
+- ease-magnetic-text-pink - Pink themed reveal text
+- ease-magnetic-text-cyan - Cyan themed reveal text
+- ease-magnetic-text-btn - Button version with gradient background
+- ease-magnetic-text-custom - Custom reveal text using data-reveal attribute
+
+## Custom Reveal Text
+
+<span class="ease-magnetic-text-custom" data-reveal="Your message here">Hover over me</span>
+
+## Accessibility
+
+Respects prefers-reduced-motion by disabling the slide animation while still showing the reveal text.
+
+## Why it fits EaseMotion CSS
+
+- Pure CSS, zero JavaScript
+- Smooth magnetic cubic-bezier easing
+- Multiple color and speed variants
+- Works on any text element (h1, h2, span, button)
+- Customizable reveal messages

--- a/submissions/examples/magnetic-text-reveal/demo.html
+++ b/submissions/examples/magnetic-text-reveal/demo.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion CSS - Magnetic Text Reveal</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 2rem;
+            background: #0d0d14;
+            color: #e4e4e7;
+        }
+        .demo-header {
+            text-align: center;
+            margin-bottom: 3rem;
+        }
+        .demo-header h1 {
+            font-size: 2.5rem;
+            background: linear-gradient(135deg, #6c63ff, #a855f7);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+        .demo-grid {
+            display: flex;
+            flex-direction: column;
+            gap: 3rem;
+            margin-top: 2rem;
+        }
+        .demo-section {
+            background: #1a1a2e;
+            border-radius: 1rem;
+            padding: 2rem;
+        }
+        .demo-section h3 {
+            margin-top: 0;
+            color: #c4b5fd;
+            font-size: 1.25rem;
+        }
+        .row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 2rem;
+            justify-content: center;
+            align-items: center;
+        }
+        .note {
+            background: #1a1a2e;
+            padding: 1rem;
+            border-radius: 12px;
+            border-left: 3px solid #6c63ff;
+            margin: 2rem 0;
+            font-size: 0.875rem;
+            text-align: center;
+        }
+        code {
+            background: #1e1e2e;
+            padding: 0.2rem 0.4rem;
+            border-radius: 6px;
+            font-family: monospace;
+        }
+        body {
+            font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+        }
+    </style>
+</head>
+<body>
+
+<div class="demo-header">
+    <h1>Magnetic Text Reveal</h1>
+    <p>Hover over any text to reveal a secondary message with a magnetic slide effect</p>
+</div>
+
+<div class="demo-grid">
+    <div class="demo-section">
+        <h3>Default Magnetic Reveal</h3>
+        <div class="row">
+            <h2 class="ease-magnetic-text">Hover Me →</h2>
+            <h2 class="ease-magnetic-text ease-magnetic-text-left">← Hover Me</h2>
+        </div>
+    </div>
+
+    <div class="demo-section">
+        <h3>Speed Variants</h3>
+        <div class="row">
+            <h3 class="ease-magnetic-text ease-magnetic-text-fast">Fast Magnetic</h3>
+            <h3 class="ease-magnetic-text ease-magnetic-text-slow">Slow Magnetic</h3>
+        </div>
+    </div>
+
+    <div class="demo-section">
+        <h3>Color Variants</h3>
+        <div class="row">
+            <h3 class="ease-magnetic-text ease-magnetic-text-purple">Purple Reveal</h3>
+            <h3 class="ease-magnetic-text ease-magnetic-text-pink">Pink Reveal</h3>
+            <h3 class="ease-magnetic-text ease-magnetic-text-cyan">Cyan Reveal</h3>
+        </div>
+    </div>
+
+    <div class="demo-section">
+        <h3>Button Magnetic Text</h3>
+        <div class="row">
+            <button class="ease-magnetic-text-btn">Get Started →</button>
+            <button class="ease-magnetic-text-btn ease-magnetic-text-purple">Learn More →</button>
+        </div>
+    </div>
+
+    <div class="demo-section">
+        <h3>Custom Reveal Text</h3>
+        <div class="row">
+            <span class="ease-magnetic-text-custom" data-reveal="✨ Amazing! ✨">Hover to reveal →</span>
+            <span class="ease-magnetic-text-custom" data-reveal="🚀 Launch! 🚀">Ready?</span>
+        </div>
+    </div>
+</div>
+
+<div class="note">
+    💡 <strong>How it works:</strong> On hover, the original text slides out while the reveal text slides in from the opposite direction — creating a magnetic pull effect.
+</div>
+
+</body>
+</html>

--- a/submissions/examples/magnetic-text-reveal/style.css
+++ b/submissions/examples/magnetic-text-reveal/style.css
@@ -1,0 +1,181 @@
+.ease-magnetic-text {
+    display: inline-block;
+    position: relative;
+    overflow: hidden;
+    cursor: pointer;
+    padding: 0.25rem 0;
+}
+
+.ease-magnetic-text::before {
+    content: attr(data-text);
+    content: "✨ Revealed! ✨";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    transform: translateX(-101%);
+    transition: transform 0.4s cubic-bezier(0.2, 0.9, 0.4, 1.1);
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+}
+
+.ease-magnetic-text:hover::before {
+    transform: translateX(0);
+}
+
+.ease-magnetic-text span {
+    display: inline-block;
+    transition: transform 0.4s cubic-bezier(0.2, 0.9, 0.4, 1.1);
+}
+
+.ease-magnetic-text:hover span {
+    transform: translateX(101%);
+}
+
+.ease-magnetic-text-left::before {
+    transform: translateX(101%);
+}
+
+.ease-magnetic-text-left:hover::before {
+    transform: translateX(0);
+}
+
+.ease-magnetic-text-left:hover span {
+    transform: translateX(-101%);
+}
+
+.ease-magnetic-text-fast::before,
+.ease-magnetic-text-fast span {
+    transition-duration: 0.2s;
+}
+
+.ease-magnetic-text-slow::before,
+.ease-magnetic-text-slow span {
+    transition-duration: 0.7s;
+}
+
+.ease-magnetic-text-purple::before {
+    content: "💜 Purple! 💜";
+    color: #c4b5fd;
+}
+
+.ease-magnetic-text-pink::before {
+    content: "🌸 Pink! 🌸";
+    color: #f9a8d4;
+}
+
+.ease-magnetic-text-cyan::before {
+    content: "💎 Cyan! 💎";
+    color: #67e8f9;
+}
+
+.ease-magnetic-text-btn {
+    display: inline-block;
+    position: relative;
+    overflow: hidden;
+    cursor: pointer;
+    padding: 0.75rem 1.5rem;
+    background: linear-gradient(135deg, #6c63ff, #a855f7);
+    border: none;
+    border-radius: 999px;
+    color: white;
+    font-weight: 600;
+    font-size: 1rem;
+    transition: box-shadow 0.3s ease;
+}
+
+.ease-magnetic-text-btn::before {
+    content: "✨ Go! ✨";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    transform: translateX(-101%);
+    transition: transform 0.35s cubic-bezier(0.2, 0.9, 0.4, 1.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #a855f7, #ec4899);
+    border-radius: 999px;
+}
+
+.ease-magnetic-text-btn:hover::before {
+    transform: translateX(0);
+}
+
+.ease-magnetic-text-btn span {
+    display: inline-block;
+    transition: transform 0.35s cubic-bezier(0.2, 0.9, 0.4, 1.1);
+}
+
+.ease-magnetic-text-btn:hover span {
+    transform: translateX(101%);
+    opacity: 0;
+}
+
+.ease-magnetic-text-custom {
+    display: inline-block;
+    position: relative;
+    overflow: hidden;
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    background: #1e1e2e;
+    border-radius: 999px;
+    font-size: 1.1rem;
+}
+
+.ease-magnetic-text-custom::before {
+    content: attr(data-reveal);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    transform: translateX(-101%);
+    transition: transform 0.4s cubic-bezier(0.2, 0.9, 0.4, 1.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #6c63ff;
+    border-radius: 999px;
+    color: white;
+}
+
+.ease-magnetic-text-custom:hover::before {
+    transform: translateX(0);
+}
+
+.ease-magnetic-text-custom span {
+    display: inline-block;
+    transition: transform 0.4s cubic-bezier(0.2, 0.9, 0.4, 1.1);
+}
+
+.ease-magnetic-text-custom:hover span {
+    transform: translateX(101%);
+    opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-magnetic-text::before,
+    .ease-magnetic-text span,
+    .ease-magnetic-text-btn::before,
+    .ease-magnetic-text-btn span,
+    .ease-magnetic-text-custom::before,
+    .ease-magnetic-text-custom span {
+        transition: none;
+    }
+    .ease-magnetic-text:hover::before,
+    .ease-magnetic-text-btn:hover::before,
+    .ease-magnetic-text-custom:hover::before {
+        transform: translateX(0);
+    }
+    .ease-magnetic-text:hover span,
+    .ease-magnetic-text-btn:hover span,
+    .ease-magnetic-text-custom:hover span {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Adds Magnetic Text Reveal component - a hover effect where original text slides out while a secondary message slides in from the opposite direction, creating a magnetic pull effect.

Closes #7712

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/magnetic-text-reveal/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A magnetic hover effect for text where the original text slides out and a reveal message slides in from the opposite direction.

**How does a developer use it?**

<h2 class="ease-magnetic-text">Hover Me →</h2>

**Why does it fit EaseMotion CSS?**

Pure CSS hover animation using cubic-bezier easing for a snappy magnetic feel. Includes speed variants (fast/slow), color variants (purple/pink/cyan), button version, and custom reveal text support.

---

## Demo

- [x] Demo added (demo.html works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

Uses pseudo-element for reveal text. The data-reveal attribute on ease-magnetic-text-custom allows any custom message. Button variant uses gradient backgrounds that can be customized.