### PR TITLE
feat : add orbiting-elements

### DIFF
--- a/submissions/examples/orbiting-elements/README.md
+++ b/submissions/examples/orbiting-elements/README.md
@@ -1,0 +1,55 @@
+# Orbiting Elements
+
+## What it does
+
+Creates satellite elements that orbit around a central point. Perfect for loading animations, decorative UI elements, atom models, or planetary system visualizations.
+
+## How to use it
+
+<div class="ease-orbit">
+    <div class="ease-orbit-center">★</div>
+    <div class="ease-orbit-satellite">●</div>
+</div>
+
+## Variants
+
+- ease-orbit-double - Two satellites orbiting together
+- ease-orbit-fast - 2x orbital speed (2s orbit)
+- ease-orbit-slow - 0.5x orbital speed (8s orbit)
+- ease-orbit-wide - Larger orbital radius (280px container)
+- ease-orbit-reverse - Counter-clockwise rotation
+- ease-orbit-pulse-center - Center element pulses
+- ease-orbit-glow - Glow effect on center and satellite
+- ease-orbit-3d - 3D perspective orbit
+
+Combine variants:
+
+<div class="ease-orbit ease-orbit-fast ease-orbit-reverse">
+
+## Multiple Satellites
+
+<div class="ease-orbit ease-orbit-double">
+    <div class="ease-orbit-center">★</div>
+    <div class="ease-orbit-satellite">🔵</div>
+    <div class="ease-orbit-satellite-2">🔴</div>
+</div>
+
+## Custom Radius
+
+Override the transform-origin for custom distances:
+
+.ease-orbit-custom .ease-orbit-satellite {
+    transform-origin: 50% 150px;
+}
+
+## Accessibility
+
+Respects prefers-reduced-motion by freezing the orbit at the top position.
+
+## Why it fits EaseMotion CSS
+
+- Pure CSS, zero JavaScript
+- Smooth continuous animation
+- Multiple composable variants
+- Customizable orbital radius
+- Works with any emoji or icon

--- a/submissions/examples/orbiting-elements/demo.html
+++ b/submissions/examples/orbiting-elements/demo.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion CSS - Orbiting Elements</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+            background: #0d0d14;
+            color: #e4e4e7;
+        }
+        .demo-header {
+            text-align: center;
+            margin-bottom: 3rem;
+        }
+        .demo-header h1 {
+            font-size: 2.5rem;
+            background: linear-gradient(135deg, #6c63ff, #a855f7);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+        .demo-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            gap: 2rem;
+            margin-top: 2rem;
+        }
+        .orbit-demo {
+            background: #1a1a2e;
+            border-radius: 1rem;
+            padding: 2rem;
+            text-align: center;
+        }
+        .orbit-demo h3 {
+            margin-top: 0;
+            color: #c4b5fd;
+        }
+        .orbit-container {
+            display: flex;
+            justify-content: center;
+            margin: 2rem 0;
+        }
+        .note {
+            background: #1a1a2e;
+            padding: 1rem;
+            border-radius: 12px;
+            border-left: 3px solid #6c63ff;
+            margin: 2rem 0;
+            font-size: 0.875rem;
+            text-align: center;
+        }
+        code {
+            background: #1e1e2e;
+            padding: 0.2rem 0.4rem;
+            border-radius: 6px;
+            font-family: monospace;
+        }
+    </style>
+</head>
+<body>
+
+<div class="demo-header">
+    <h1>Orbiting Elements</h1>
+    <p>Satellite elements that orbit around a central point</p>
+</div>
+
+<div class="demo-grid">
+    <div class="orbit-demo">
+        <h3>Single Orbit</h3>
+        <div class="orbit-container">
+            <div class="ease-orbit">
+                <div class="ease-orbit-center">★</div>
+                <div class="ease-orbit-satellite">●</div>
+            </div>
+        </div>
+        <p>One satellite orbiting the center</p>
+    </div>
+
+    <div class="orbit-demo">
+        <h3>Double Orbit</h3>
+        <div class="orbit-container">
+            <div class="ease-orbit ease-orbit-double">
+                <div class="ease-orbit-center">★</div>
+                <div class="ease-orbit-satellite">🔵</div>
+                <div class="ease-orbit-satellite-2">🔴</div>
+            </div>
+        </div>
+        <p>Two satellites orbiting together</p>
+    </div>
+
+    <div class="orbit-demo">
+        <h3>Fast Orbit</h3>
+        <div class="orbit-container">
+            <div class="ease-orbit ease-orbit-fast">
+                <div class="ease-orbit-center">★</div>
+                <div class="ease-orbit-satellite">⚡</div>
+            </div>
+        </div>
+        <p>2x orbital speed</p>
+    </div>
+
+    <div class="orbit-demo">
+        <h3>Wide Orbit</h3>
+        <div class="orbit-container">
+            <div class="ease-orbit ease-orbit-wide">
+                <div class="ease-orbit-center">★</div>
+                <div class="ease-orbit-satellite">🌍</div>
+            </div>
+        </div>
+        <p>Larger orbital radius</p>
+    </div>
+
+    <div class="orbit-demo">
+        <h3>Reverse Orbit</h3>
+        <div class="orbit-container">
+            <div class="ease-orbit ease-orbit-reverse">
+                <div class="ease-orbit-center">★</div>
+                <div class="ease-orbit-satellite">🔄</div>
+            </div>
+        </div>
+        <p>Counter-clockwise rotation</p>
+    </div>
+
+    <div class="orbit-demo">
+        <h3>Pulse Center</h3>
+        <div class="orbit-container">
+            <div class="ease-orbit ease-orbit-pulse-center">
+                <div class="ease-orbit-center">❤️</div>
+                <div class="ease-orbit-satellite">✨</div>
+            </div>
+        </div>
+        <p>Center element pulses while orbiting</p>
+    </div>
+</div>
+
+<div class="note">
+    💡 <strong>How to use:</strong> Add <code>class="ease-orbit"</code> to a container, add <code>class="ease-orbit-center"</code> to the central element, and <code>class="ease-orbit-satellite"</code> to orbiting elements.
+</div>
+
+</body>
+</html>

--- a/submissions/examples/orbiting-elements/style.css
+++ b/submissions/examples/orbiting-elements/style.css
@@ -1,0 +1,134 @@
+.ease-orbit {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ease-orbit-center {
+    position: absolute;
+    z-index: 2;
+    font-size: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ease-orbit-satellite {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 1.5rem;
+    animation: ease-orbit-spin 4s linear infinite;
+    transform-origin: 50% 100px;
+}
+
+.ease-orbit-satellite-2 {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 1.5rem;
+    animation: ease-orbit-spin 4s linear infinite;
+    transform-origin: 50% 100px;
+    animation-delay: -2s;
+}
+
+@keyframes ease-orbit-spin {
+    0% {
+        transform: translateX(-50%) rotate(0deg);
+    }
+    100% {
+        transform: translateX(-50%) rotate(360deg);
+    }
+}
+
+.ease-orbit-double .ease-orbit-satellite {
+    animation-duration: 4s;
+}
+
+.ease-orbit-double .ease-orbit-satellite-2 {
+    animation-duration: 4s;
+    animation-delay: -2s;
+}
+
+.ease-orbit-fast .ease-orbit-satellite {
+    animation-duration: 2s;
+}
+
+.ease-orbit-slow .ease-orbit-satellite {
+    animation-duration: 8s;
+}
+
+.ease-orbit-wide {
+    width: 280px;
+    height: 280px;
+}
+
+.ease-orbit-wide .ease-orbit-satellite {
+    transform-origin: 50% 140px;
+}
+
+.ease-orbit-wide .ease-orbit-satellite-2 {
+    transform-origin: 50% 140px;
+}
+
+.ease-orbit-reverse .ease-orbit-satellite {
+    animation-direction: reverse;
+}
+
+.ease-orbit-reverse .ease-orbit-satellite-2 {
+    animation-direction: reverse;
+}
+
+.ease-orbit-pulse-center .ease-orbit-center {
+    animation: ease-orbit-pulse 2s ease-in-out infinite;
+}
+
+@keyframes ease-orbit-pulse {
+    0%, 100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    50% {
+        transform: scale(1.2);
+        opacity: 0.8;
+    }
+}
+
+.ease-orbit-glow .ease-orbit-center {
+    filter: drop-shadow(0 0 8px #6c63ff);
+}
+
+.ease-orbit-glow .ease-orbit-satellite {
+    filter: drop-shadow(0 0 4px #a855f7);
+}
+
+.ease-orbit-3d .ease-orbit-satellite {
+    animation: ease-orbit-spin-3d 4s linear infinite;
+}
+
+@keyframes ease-orbit-spin-3d {
+    0% {
+        transform: translateX(-50%) rotate(0deg) translateZ(0);
+    }
+    100% {
+        transform: translateX(-50%) rotate(360deg) translateZ(20px);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-orbit-satellite,
+    .ease-orbit-satellite-2,
+    .ease-orbit-center {
+        animation: none;
+    }
+    .ease-orbit-satellite {
+        position: absolute;
+        top: -20px;
+        left: 50%;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Adds Orbiting Elements component - satellite elements that orbit around a central point using CSS transforms. Perfect for loaders, decorative UI, or atom/planet visualizations.

Closes #7715 

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/orbiting-elements/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Satellite elements that orbit around a central point using CSS transform-origin and rotate animations.

**How does a developer use it?**

<div class="ease-orbit">
    <div class="ease-orbit-center">★</div>
    <div class="ease-orbit-satellite">●</div>
</div>

**Why does it fit EaseMotion CSS?**

Pure CSS orbital motion using transform animations. Includes 8 variants (fast/slow/wide/reverse/double/pulse/glow/3d). GPU-accelerated. Completely customizable.

---

## Demo

- [x] Demo added (demo.html works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

Uses transform-origin set to 50% of container height for circular orbit. The ease-orbit-double variant uses two satellites with staggered animation delays. All variants respect prefers-reduced-motion.