### PR TITLE
feat: Add CSS-only tooltips component for #7772

### DIFF
--- a/submissions/examples/css-only-tooltips/README.md
+++ b/submissions/examples/css-only-tooltips/README.md
@@ -1,0 +1,10 @@
+# CSS-only Tooltips Component
+
+A lightweight, highly accessible tooltip component that operates entirely through CSS pseudo-elements (`::before` and `::after`). It aligns with EaseMotion's zero-dependency philosophy, requiring no JavaScript positioning engines.
+
+## Files
+- `demo.html` - Interactive demonstration of the tooltips.
+- `style.css` - The CSS implementation utilizing EaseMotion tokens.
+
+## Details
+This addresses the "Modal & tooltip components" requirement currently listed as "Planned" in the project Roadmap. Simply add the `ease-tooltip` class and a `data-tooltip="Message"` attribute to any element to display floating, animated information bubbles on hover or focus.

--- a/submissions/examples/css-only-tooltips/demo.html
+++ b/submissions/examples/css-only-tooltips/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Tooltips Component</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  
+  <!-- Core EaseMotion CSS -->
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../core/utilities.css" />
+  
+  <!-- Component Specific CSS -->
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  
+  <!-- Custom Component Style -->
+  <link rel="stylesheet" href="style.css" />
+  
+  <style>
+    body {
+      background-color: var(--ease-color-bg);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: var(--ease-space-4);
+      font-family: var(--ease-font-sans);
+    }
+    .demo-container {
+      text-align: center;
+      max-width: 600px;
+      width: 100%;
+    }
+    h1 {
+      color: var(--ease-color-text);
+      margin-bottom: var(--ease-space-6);
+    }
+    .tooltip-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 3rem;
+      margin-top: 4rem;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-container">
+    <h1>EaseMotion Tooltips</h1>
+    <p class="ease-text-muted">Zero JavaScript. Powered by pseudo-elements and data attributes.</p>
+    
+    <div class="tooltip-grid">
+      <div>
+        <button class="ease-btn ease-btn-outline ease-tooltip" data-tooltip="Default is Top!">
+          Top Tooltip
+        </button>
+      </div>
+      <div>
+        <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-bottom" data-tooltip="Appears below">
+          Bottom Tooltip
+        </button>
+      </div>
+      <div>
+        <button class="ease-btn ease-btn-success ease-tooltip ease-tooltip-left" data-tooltip="Appears on left">
+          Left Tooltip
+        </button>
+      </div>
+      <div>
+        <button class="ease-btn ease-btn-danger ease-tooltip ease-tooltip-right" data-tooltip="Appears on right">
+          Right Tooltip
+        </button>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-only-tooltips/style.css
+++ b/submissions/examples/css-only-tooltips/style.css
@@ -1,0 +1,120 @@
+/* Base styles using EaseMotion tokens */
+
+/* Base Tooltip Container */
+.ease-tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+/* Tooltip Bubble */
+.ease-tooltip::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(5px);
+  padding: var(--ease-space-2) var(--ease-space-3);
+  background: var(--ease-color-text);
+  color: var(--ease-color-bg);
+  border-radius: var(--ease-radius-md);
+  font-size: var(--ease-text-xs);
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--ease-speed-fast) var(--ease-ease),
+              transform var(--ease-speed-fast) var(--ease-ease),
+              visibility var(--ease-speed-fast) var(--ease-ease);
+  z-index: 50;
+  box-shadow: var(--ease-shadow-sm);
+}
+
+/* Tooltip Arrow */
+.ease-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(5px);
+  border-width: 5px;
+  border-style: solid;
+  border-color: var(--ease-color-text) transparent transparent transparent;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--ease-speed-fast) var(--ease-ease),
+              transform var(--ease-speed-fast) var(--ease-ease),
+              visibility var(--ease-speed-fast) var(--ease-ease);
+  z-index: 50;
+}
+
+/* Hover/Focus Activation */
+.ease-tooltip:hover::before,
+.ease-tooltip:focus-visible::before,
+.ease-tooltip:hover::after,
+.ease-tooltip:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(-8px);
+}
+
+/* ── Positioning Variants ── */
+
+/* Bottom Tooltip */
+.ease-tooltip-bottom::before,
+.ease-tooltip-bottom::after {
+  bottom: auto;
+  top: 100%;
+  transform: translateX(-50%) translateY(-5px);
+}
+
+.ease-tooltip-bottom::after {
+  border-color: transparent transparent var(--ease-color-text) transparent;
+}
+
+.ease-tooltip-bottom:hover::before,
+.ease-tooltip-bottom:focus-visible::before,
+.ease-tooltip-bottom:hover::after,
+.ease-tooltip-bottom:focus-visible::after {
+  transform: translateX(-50%) translateY(8px);
+}
+
+/* Right Tooltip */
+.ease-tooltip-right::before,
+.ease-tooltip-right::after {
+  bottom: 50%;
+  left: 100%;
+  transform: translateX(-5px) translateY(50%);
+}
+
+.ease-tooltip-right::after {
+  border-color: transparent var(--ease-color-text) transparent transparent;
+}
+
+.ease-tooltip-right:hover::before,
+.ease-tooltip-right:focus-visible::before,
+.ease-tooltip-right:hover::after,
+.ease-tooltip-right:focus-visible::after {
+  transform: translateX(8px) translateY(50%);
+}
+
+/* Left Tooltip */
+.ease-tooltip-left::before,
+.ease-tooltip-left::after {
+  bottom: 50%;
+  left: auto;
+  right: 100%;
+  transform: translateX(5px) translateY(50%);
+}
+
+.ease-tooltip-left::after {
+  border-color: transparent transparent transparent var(--ease-color-text);
+}
+
+.ease-tooltip-left:hover::before,
+.ease-tooltip-left:focus-visible::before,
+.ease-tooltip-left:hover::after,
+.ease-tooltip-left:focus-visible::after {
+  transform: translateX(-8px) translateY(50%);
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces a brand new CSS-only tooltips component as requested and assigned in #7772. It relies entirely on CSS pseudo-elements (`::before` and `::after`) to display animated, accessible tooltip bubbles on hover and focus, utilizing a simple `data-tooltip` attribute.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fully functional, animated tooltip component that requires zero JavaScript and relies solely on CSS data-attributes.

**How does a developer use it?**

```html
<button class="ease-btn ease-tooltip" data-tooltip="This is a top tooltip!">
  Hover Me
</button>

<button class="ease-btn ease-tooltip ease-tooltip-bottom" data-tooltip="Appears below">
  Bottom Tooltip
</button>
