### PR TITLE
bug/fix: Resolve flexbox wrapped orphan element alignment distortion and asymmetric item spacing #7281

### DIFF
--- a/submissions/examples/flex-orphan-alignment/README.md
+++ b/submissions/examples/flex-orphan-alignment/README.md
@@ -1,0 +1,53 @@
+# EaseMotion Flex Wrapped Orphans Gap & Spacing Guard
+
+This example demonstrates how to resolve flexbox wrapped orphan element alignment distortion and asymmetric item spacing on narrow mobile viewports.
+
+## 🐛 The Bug: Asymmetric Gap & Stretching
+
+When building responsive layouts (such as item grids or chip groups) using CSS Flexbox with `flex-wrap: wrap` and `justify-content: space-between`, rows that do not have enough elements to fill the line (orphans) align poorly.
+
+Instead of matching the grid composition of the previous row, the browser distributes the empty space between the remaining elements. This leads to:
+
+- Large gaps in the center of the bottom row.
+- Items pushed to the extreme left and right margins.
+- Asymmetrical layout structure on mobile screen viewports.
+
+```css
+/* ❌ Bugged flex wrapping layout */
+.bugged-flex-wrap-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+}
+```
+
+## 🛠️ The Solution: Balanced Flex Guard
+
+To maintain cohesive visual grids and consistent spacing even when wrapping happens:
+
+1. **`justify-content: flex-start`**: Anchors wrapped elements to the left, matching standard grid alignment.
+2. **Dedicated `gap` Sizing**: Enforces consistent margins between items, making sure they never touch or separate too far.
+3. **`@supports (grid-template-columns: subgrid)` Fallback**: Uses modern CSS Grid structure where available to auto-fill cells and preserve absolute column alignment across wrapped rows.
+
+```css
+/* ✅ Stabilized flex-wrap layout */
+.ease-flex-wrap-guard {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  gap: 1.25rem;
+}
+
+@supports (grid-template-columns: subgrid) {
+  .ease-flex-wrap-guard {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  }
+}
+```
+
+## 📁 Files Created
+
+- [style.css](file:///C:/Users/Fujitsu/.gemini/antigravity/scratch/EaseMotion-css/submissions/examples/flex-orphan-alignment/style.css) — Custom stylesheet containing root variables, flex layouts, and stabilization guard classes.
+- [demo.html](file:///C:/Users/Fujitsu/.gemini/antigravity/scratch/EaseMotion-css/submissions/examples/flex-orphan-alignment/demo.html) — Side-by-side comparison illustrating bugged spacing vs. guarded spacing.

--- a/submissions/examples/flex-orphan-alignment/demo.html
+++ b/submissions/examples/flex-orphan-alignment/demo.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — Flex Wrapped Orphans Alignment Demo</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <div class="ease-workbench-panel">
+      <header class="ease-header">
+        <h1>Flex Wrapped Orphans Alignment</h1>
+        <p>
+          Resize your screen or viewport to trigger flex wrapping. Observe how
+          wrapped "orphan" elements stretch/separate asymmetrical in the bugged
+          container, whereas the guarded container maintains consistent spacing.
+        </p>
+      </header>
+
+      <div class="comparison-grid">
+        <!-- ❌ Bugged Demonstration Column -->
+        <section class="comparison-col">
+          <span class="column-badge bugged">Bugged Layout</span>
+          <div class="bugged-flex-wrap-container">
+            <div class="ease-item-chip">Item 01</div>
+            <div class="ease-item-chip">Item 02</div>
+            <div class="ease-item-chip">Item 03</div>
+            <div class="ease-item-chip">Item 04</div>
+            <div class="ease-item-chip">Item 05</div>
+          </div>
+          <div class="explanation-card">
+            <strong>Issue:</strong> Using
+            <code>justify-content: space-between</code> on flex-wrapped
+            containers causes wrapped odd-numbered "orphan" items in the final
+            row to push to the extremes, leaving a massive empty space in the
+            middle.
+          </div>
+        </section>
+
+        <!-- ✅ Patched/Guarded Demonstration Column -->
+        <section class="comparison-col">
+          <span class="column-badge fixed">Guarded Layout</span>
+          <div class="ease-flex-wrap-guard">
+            <div class="ease-item-chip">Item 01</div>
+            <div class="ease-item-chip">Item 02</div>
+            <div class="ease-item-chip">Item 03</div>
+            <div class="ease-item-chip">Item 04</div>
+            <div class="ease-item-chip">Item 05</div>
+          </div>
+          <div class="explanation-card">
+            <strong>Solution:</strong> By combining
+            <code>justify-content: flex-start</code>, specific
+            <code>gap</code> properties, and an auto-fill grid fallback context,
+            items wrap with uniform spacing and perfect alignment.
+          </div>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/flex-orphan-alignment/style.css
+++ b/submissions/examples/flex-orphan-alignment/style.css
@@ -1,0 +1,173 @@
+/* ==========================================================================
+   EaseMotion Flex Wrapped Orphans Gap Distortion & Spacing Patch
+   ========================================================================== */
+
+:root {
+  --ease-wrap-bg: #040509;
+  --ease-panel-dark: #0f111a;
+  --ease-accent-alert: #ff4a5a;
+  --ease-accent-fixed: #00e676;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background-color: var(--ease-wrap-bg);
+  color: #ffffff;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+/* Base Workbench Display Lab Wrap */
+.ease-workbench-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Section Header */
+.ease-header {
+  text-align: center;
+  margin-bottom: 3rem;
+  max-width: 600px;
+}
+
+.ease-header h1 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  margin: 0 0 0.75rem 0;
+  background: linear-gradient(135deg, #ffffff 0%, #a5b4fc 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.ease-header p {
+  color: #94a3b8;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Comparison columns container */
+.comparison-grid {
+  display: flex;
+  gap: 3rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 100%;
+  max-width: 1000px;
+}
+
+/* Column Wrapper */
+.comparison-col {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  flex: 1 1 350px;
+  max-width: 450px;
+}
+
+/* Column title badges */
+.column-badge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.35rem 0.85rem;
+  border-radius: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.column-badge.bugged {
+  background-color: rgba(255, 74, 90, 0.15);
+  color: var(--ease-accent-alert);
+}
+
+.column-badge.fixed {
+  background-color: rgba(0, 230, 118, 0.15);
+  color: var(--ease-accent-fixed);
+}
+
+/* ❌ Janky Bugged Flex Box Layout (Orphans pichak jate hain space-between se) */
+.bugged-flex-wrap-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+  max-width: 420px; /* Constrained layout wrapper to force wrap testing */
+  background: rgba(255, 74, 90, 0.03);
+  padding: 1.25rem;
+  border-radius: 14px;
+  border: 1px dashed var(--ease-accent-alert);
+  box-sizing: border-box;
+}
+
+/* 🚀 The Core Patched Balanced Wrap Container Class */
+.ease-flex-wrap-guard {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start; /* Corrects baseline alignment tracking */
+  gap: 1.25rem;
+  width: 100%;
+  max-width: 420px;
+  background: rgba(0, 230, 118, 0.03);
+  padding: 1.25rem;
+  border-radius: 14px;
+  border: 1px solid var(--ease-accent-fixed);
+  box-sizing: border-box;
+}
+
+/* Progressive Layout Alignment enhancement via modern grid fallbacks */
+@supports (grid-template-columns: subgrid) {
+  .ease-flex-wrap-guard {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  }
+}
+
+/* Badge/Item Chip Nodes */
+.ease-item-chip {
+  background: var(--ease-panel-dark);
+  padding: 0.75rem 1.25rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-align: center;
+  flex: 1 1 110px; /* Fluid flex basis forcing structural columns */
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-sizing: border-box;
+  color: #e2e8f0;
+}
+
+/* Specific styling for demonstrating the bug */
+.bugged-flex-wrap-container .ease-item-chip {
+  border-color: rgba(255, 74, 90, 0.2);
+}
+
+.ease-flex-wrap-guard .ease-item-chip {
+  border-color: rgba(0, 230, 118, 0.2);
+}
+
+.explanation-card {
+  background: var(--ease-panel-dark);
+  padding: 1rem 1.25rem;
+  border-radius: 10px;
+  font-size: 0.825rem;
+  line-height: 1.5;
+  color: #94a3b8;
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.03);
+  box-sizing: border-box;
+}


### PR DESCRIPTION
### Target Issue
Closes #7802

### Description
Introduced an isolated structural presentation fix—the Flex Wrapper Alignment Guard—under the isolated examples layout registry. This fix addresses asymmetric layout distortion and orphan element misalignment errors inside wrapping flexbox rows when compressed under narrow responsive viewports.

- **Symmetric Flow Baseline:** Drops variable wrapping paths by locking components cleanly to left-anchored streams combined with uniform gap spacing values.
- **Progressive Grid Fallbacks:** Mounts `@supports (grid-template-columns: subgrid)` logic to secure column ratios across layout changes.
- **Autonomous Subfolder Execution:** Sandboxed 100% inside `submissions/examples/flex-orphan-alignment/` ensuring absolute safety for core repo styles.

### Checklist
- [x] Code strictly adheres to the isolated subfolder architecture constraints (`submissions/examples/...`)
- [x] Sandboxed workspace features independent `demo.html`, `style.css`, and `README.md` assets
- [x] Prettier codebase linting and formatting pass with zero errors