### PR TITLE
feat: add [data-theme="dark"] selector for programmatic dark mode toggle

### DIFF
--- a/core/variables.css
+++ b/core/variables.css
@@ -187,6 +187,31 @@
   }
 }
 
+[data-theme="dark"] {
+  --ease-color-bg:      #0b1121;
+  --ease-color-surface: #141e33;
+  --ease-color-text:    #e2e8f0;
+  --ease-color-muted:   #94a3b8;
+
+  --ease-shadow-sm:  0 1px 3px rgba(0, 0, 0, 0.30),
+                     0 1px 2px rgba(0, 0, 0, 0.20);
+  --ease-shadow-md:  0 4px 6px -1px rgba(0, 0, 0, 0.35),
+                     0 2px 4px -1px rgba(0, 0, 0, 0.25);
+  --ease-shadow-lg:  0 10px 15px -3px rgba(0, 0, 0, 0.40),
+                     0 4px 6px -2px rgba(0, 0, 0, 0.25);
+  --ease-shadow-xl:  0 20px 25px -5px rgba(0, 0, 0, 0.45),
+                     0 10px 10px -5px rgba(0, 0, 0, 0.30);
+
+   --ease-glass-bg: rgba(15, 23, 42, 0.30);
+  --ease-glass-border: rgba(255, 255, 255, 0.08);
+
+  --ease-glow-primary:   0 0 16px rgba(108, 99, 255, 0.45);
+  --ease-glow-secondary: 0 0 16px rgba(139, 92, 246, 0.45);
+  --ease-glow-success:   0 0 16px rgba(34, 197, 94, 0.45);
+  --ease-glow-danger:    0 0 16px rgba(239, 68, 68, 0.45);
+  --ease-glow-info:      0 0 16px rgba(59, 130, 246, 0.45);
+}
+
 @supports (color: color-mix(in srgb, red 50%, transparent)) {
   @media (prefers-color-scheme: dark) {
     :root {
@@ -196,6 +221,14 @@
       --ease-glass-border:
         color-mix(in srgb, var(--ease-color-surface) 8%, transparent);
     }
+  }
+
+  [data-theme="dark"] {
+    --ease-glass-bg:
+      color-mix(in srgb, var(--ease-color-surface) 30%, transparent);
+
+    --ease-glass-border:
+      color-mix(in srgb, var(--ease-color-surface) 8%, transparent);
   }
 }
 }

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -58,6 +58,16 @@ const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
     expect(css).toContain('@media (prefers-reduced-motion: reduce)');
   });
 
+  it('should have dark mode variables via prefers-color-scheme', () => {
+    expect(css).toContain('@media (prefers-color-scheme: dark)');
+    expect(css).toContain('--ease-color-surface: #141e33');
+  });
+
+  it('should have dark mode variables via [data-theme="dark"] selector', () => {
+    expect(css).toContain('[data-theme="dark"]');
+    expect(css).toContain('--ease-color-bg:      #0b1121');
+  });
+
   it('should have component classes defined', () => {
     const sheet = document.styleSheets[0];
     


### PR DESCRIPTION
## Description

### Root Cause
The dark mode system in EaseMotion CSS only supported automatic dark mode via `@media (prefers-color-scheme: dark)`. Users had no way to programmatically toggle dark mode by setting a class or attribute on `<html>`.

### Changes Made
- Added `[data-theme="dark"]` selector block in `core/variables.css` with the same dark mode values as the existing `@media (prefers-color-scheme: dark)` block
- Added corresponding `@supports (color: color-mix(...))` block for the `[data-theme="dark"]` selector
- Added 2 new smoke tests in `tests/smoke.test.js` verifying:
  - Dark mode variables exist via `@media (prefers-color-scheme: dark)`
  - Dark mode variables exist via `[data-theme="dark"]` selector

### Testing Performed

```bash
cd /tmp/easemotion && npm test
```

### Result
```
✓ tests/smoke.test.js (12 tests) 702ms
Test Files: 1 passed (1)
Tests: 12 passed (12)
```
All 12 tests passed, including the 2 new dark mode assertion tests.

---

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective

## Additional Notes
- No breaking changes — existing `@media (prefers-color-scheme: dark)` behavior is preserved
- Branch: `Pcmhacker-piro/EaseMotion-css:feat/dark-mode-data-theme`
- Compare URL: https://github.com/SAPTARSHI-coder/EaseMotion-css/compare/main...Pcmhacker-piro:feat/dark-mode-data-theme?expand=1
