### PR TITLE
fix(#7850): decouple animation-delay and transition-delay utilities

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1169,17 +1169,30 @@
 /* Use these with entrance animations to stagger children */
 
 /* 75ms stagger delay helper */
-.ease-delay-75  { animation-delay: 75ms; transition-delay: 75ms; }
-.ease-delay-100 { animation-delay: 100ms; transition-delay: 100ms; }
-.ease-delay-150 { animation-delay: 150ms; transition-delay: 150ms; }
-.ease-delay-200 { animation-delay: 200ms; transition-delay: 200ms; }
-.ease-delay-300 { animation-delay: 300ms; transition-delay: 300ms; }
-.ease-delay-400 { animation-delay: 400ms; transition-delay: 400ms; }
-.ease-delay-500 { animation-delay: 500ms; transition-delay: 500ms; }
-.ease-delay-600 { animation-delay: 600ms; transition-delay: 600ms; }
-.ease-delay-700 { animation-delay: 700ms; transition-delay: 700ms; }
-.ease-delay-800 { animation-delay: 800ms; transition-delay: 800ms; }
-.ease-delay-1000 { animation-delay: 1000ms; transition-delay: 1000ms; }
+.ease-delay-75  { animation-delay: 75ms; }
+.ease-delay-100 { animation-delay: 100ms; }
+.ease-delay-150 { animation-delay: 150ms; }
+.ease-delay-200 { animation-delay: 200ms; }
+.ease-delay-300 { animation-delay: 300ms; }
+.ease-delay-400 { animation-delay: 400ms; }
+.ease-delay-500 { animation-delay: 500ms; }
+.ease-delay-600 { animation-delay: 600ms; }
+.ease-delay-700 { animation-delay: 700ms; }
+.ease-delay-800 { animation-delay: 800ms; }
+.ease-delay-1000 { animation-delay: 1000ms; }
+
+/* Dedicated Transition Delay Helpers */
+.ease-transition-delay-75  { transition-delay: 75ms; }
+.ease-transition-delay-100 { transition-delay: 100ms; }
+.ease-transition-delay-150 { transition-delay: 150ms; }
+.ease-transition-delay-200 { transition-delay: 200ms; }
+.ease-transition-delay-300 { transition-delay: 300ms; }
+.ease-transition-delay-400 { transition-delay: 400ms; }
+.ease-transition-delay-500 { transition-delay: 500ms; }
+.ease-transition-delay-600 { transition-delay: 600ms; }
+.ease-transition-delay-700 { transition-delay: 700ms; }
+.ease-transition-delay-800 { transition-delay: 800ms; }
+.ease-transition-delay-1000 { transition-delay: 1000ms; }
 
 /* ── Duration Overrides ────────────────────────────────────── */
 .ease-duration-fast   { animation-duration: var(--ease-speed-fast); transition-duration: var(--ease-speed-fast); }

--- a/submissions/examples/hover-delay-fix-7850/README.md
+++ b/submissions/examples/hover-delay-fix-7850/README.md
@@ -1,0 +1,13 @@
+# Hover Delay Fix (#7850)
+
+This submission resolves a critical UX bug where `.ease-delay-*` stagger utilities were unintentionally adding lags to hover interactions.
+
+## The Bug
+Previously, `.ease-delay-*` applied both `animation-delay` AND `transition-delay`. Thus, when used to stagger entrance animations (`ease-fade-in`), it would permanently saddle the element with a transition delay, ruining interactive states like `.ease-hover-lift`.
+
+## The Fix
+In `core/animations.css`, we decoupled the two properties:
+1. `.ease-delay-*` now purely applies `animation-delay` for entrance staggers.
+2. A new suite of `.ease-transition-delay-*` classes was created for explicit transition delays if a developer needs them.
+
+This guarantees smooth hover effects immediately upon interaction, improving the perceived performance of the entire framework.

--- a/submissions/examples/hover-delay-fix-7850/demo.html
+++ b/submissions/examples/hover-delay-fix-7850/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion CSS - Hover Delay Fix (#7850)</title>
+    <!-- Link to the local development framework -->
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-surface ease-text-primary ease-flex ease-items-center ease-justify-center ease-h-screen">
+    
+    <div class="ease-container ease-stack-lg" style="max-width: 800px;">
+        <div class="ease-text-center">
+            <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">Hover Delay Fix Demo</h1>
+            <p class="ease-text-muted ease-fade-in ease-delay-100">
+                This demo proves that the <code>.ease-delay-*</code> utility classes no longer interfere with hover transitions.
+            </p>
+        </div>
+
+        <div class="ease-grid ease-grid-cols-2 ease-gap-8">
+            <!-- Card 1 -->
+            <div class="ease-card ease-hover-lift-shadow ease-p-6 ease-rounded-lg ease-bg-white ease-fade-in ease-delay-300">
+                <h3 class="ease-text-xl ease-font-bold ease-mb-2">Card 1</h3>
+                <p class="ease-text-sm ease-text-muted">Fades in after 300ms. Hovering now lifts immediately without a 300ms lag.</p>
+                <div class="ease-mt-4">
+                    <button class="ease-btn ease-btn-primary ease-btn-hover">Hover Me</button>
+                </div>
+            </div>
+
+            <!-- Card 2 -->
+            <div class="ease-card ease-hover-lift-shadow ease-p-6 ease-rounded-lg ease-bg-white ease-fade-in ease-delay-600">
+                <h3 class="ease-text-xl ease-font-bold ease-mb-2">Card 2</h3>
+                <p class="ease-text-sm ease-text-muted">Fades in after 600ms. Hovering now lifts immediately without a 600ms lag.</p>
+                <div class="ease-mt-4">
+                    <button class="ease-btn ease-btn-success ease-btn-hover">Hover Me</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="ease-mt-8 ease-p-6 ease-bg-neutral ease-rounded-lg ease-fade-in ease-delay-800">
+            <h3 class="ease-text-lg ease-font-bold ease-mb-2">Explicit Transition Delay</h3>
+            <p class="ease-text-sm ease-text-muted ease-mb-4">
+                If you explicitly want a transition delay, use the new dedicated <code>.ease-transition-delay-*</code> classes.
+            </p>
+            <button class="ease-btn ease-btn-danger ease-btn-hover ease-transition-delay-500">
+                Hover Me (500ms Delay)
+            </button>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/hover-delay-fix-7850/style.css
+++ b/submissions/examples/hover-delay-fix-7850/style.css
@@ -1,0 +1,5 @@
+/* This demo purely relies on the fixed core/animations.css */
+/* No custom styling is needed. */
+body {
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+}


### PR DESCRIPTION
Resolves #7850

This PR decouples `animation-delay` and `transition-delay` in `core/animations.css`. It fixes the bug where stagger entrance animations were causing permanent lag on hover states. A demo of the fix has been added to `submissions/examples/`.
