### PR TITLE
feat: add corner ribbon submission

### DIFF
--- a/submissions/examples/corner-ribbon-sb/README.md
+++ b/submissions/examples/corner-ribbon-sb/README.md
@@ -1,0 +1,15 @@
+# Diagonal Corner Ribbon
+
+A CSS-only diagonal corner ribbon for cards, product tiles, and portfolio previews.
+
+## Features
+
+- `.ease-ribbon-wrapper` clips and positions the ribbon inside a card.
+- `.ease-ribbon` uses absolute positioning and rotation for the diagonal banner.
+- Includes two variants for "New" and "Sale" style badges.
+- Works inside responsive card grids.
+- Requires no JavaScript.
+
+## Usage
+
+Open `demo.html` to view the card ribbon examples. Add `.ease-ribbon-wrapper` to a card, then place `.ease-ribbon` inside it with the label you need.

--- a/submissions/examples/corner-ribbon-sb/demo.html
+++ b/submissions/examples/corner-ribbon-sb/demo.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Diagonal Corner Ribbon</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="ribbon-title">
+        <p class="eyebrow">Card accent</p>
+        <h1 id="ribbon-title">Diagonal corner ribbon</h1>
+        <p class="intro">
+          A CSS-only ribbon for product cards, portfolio tiles, and featured
+          content badges.
+        </p>
+
+        <div class="product-grid">
+          <article class="ease-card ease-ribbon-wrapper">
+            <div class="ease-ribbon">New</div>
+            <span class="card-icon" aria-hidden="true">01</span>
+            <h2>Starter Kit</h2>
+            <p>
+              Reusable layouts, tokens, and motion patterns for new projects.
+            </p>
+            <a href="#starter">View details</a>
+          </article>
+
+          <article class="ease-card ease-ribbon-wrapper ribbon-sale">
+            <div class="ease-ribbon">Sale</div>
+            <span class="card-icon" aria-hidden="true">02</span>
+            <h2>Pro Pack</h2>
+            <p>
+              Premium UI blocks with polished states and responsive behavior.
+            </p>
+            <a href="#pro">View details</a>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/corner-ribbon-sb/style.css
+++ b/submissions/examples/corner-ribbon-sb/style.css
@@ -1,0 +1,168 @@
+:root {
+  --ribbon-bg: #f8fafc;
+  --ribbon-surface: #ffffff;
+  --ribbon-text: #111827;
+  --ribbon-muted: #64748b;
+  --ribbon-border: #dbe4f0;
+  --ribbon-primary: #2563eb;
+  --ribbon-sale: #dc2626;
+  --ribbon-focus: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ribbon-text);
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(37, 99, 235, 0.18),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #eff6ff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 58rem);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--ribbon-primary);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 35rem;
+  margin: 1rem 0 2rem;
+  color: var(--ribbon-muted);
+  line-height: 1.7;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.ease-card {
+  min-height: 17rem;
+  padding: 1.25rem;
+  border: 1px solid var(--ribbon-border);
+  border-radius: 1.1rem;
+  background: var(--ribbon-surface);
+  box-shadow: 0 16px 44px rgba(15, 23, 42, 0.08);
+}
+
+.ease-ribbon-wrapper {
+  position: relative;
+  overflow: hidden;
+}
+
+.ease-ribbon {
+  position: absolute;
+  top: 1rem;
+  right: -2.65rem;
+  width: 9rem;
+  padding: 0.45rem 0;
+  color: #ffffff;
+  background: var(--ribbon-primary);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.26);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-align: center;
+  text-transform: uppercase;
+  transform: rotate(45deg);
+  transform-origin: center;
+}
+
+.ribbon-sale .ease-ribbon {
+  background: var(--ribbon-sale);
+  box-shadow: 0 10px 24px rgba(220, 38, 38, 0.24);
+}
+
+.card-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 0.9rem;
+  color: #ffffff;
+  background: var(--ribbon-primary);
+  font-weight: 900;
+}
+
+.ribbon-sale .card-icon {
+  background: var(--ribbon-sale);
+}
+
+h2 {
+  margin: 1.4rem 0 0.75rem;
+  font-size: 1.5rem;
+}
+
+.ease-card p {
+  margin: 0 0 1.5rem;
+  color: var(--ribbon-muted);
+  line-height: 1.65;
+}
+
+.ease-card a {
+  color: var(--ribbon-primary);
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.ease-card a:hover,
+.ease-card a:focus-visible {
+  text-decoration: underline;
+}
+
+.ease-card a:focus-visible {
+  outline: 3px solid var(--ribbon-focus);
+  outline-offset: 4px;
+}
+
+@media (max-width: 700px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .product-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained diagonal corner ribbon demo under submissions/examples/corner-ribbon-sb
- include CSS-only rotated New and Sale ribbons for card/product tiles
- keep the cards responsive with accessible focus styling

## Validation
- npx prettier --check submissions/examples/corner-ribbon-sb/demo.html submissions/examples/corner-ribbon-sb/style.css submissions/examples/corner-ribbon-sb/README.md
- git diff --cached --check

Closes #6275