### PR TITLE
feat: add command palette submission

### DIFF
--- a/submissions/examples/command-palette-sb/README.md
+++ b/submissions/examples/command-palette-sb/README.md
@@ -1,0 +1,16 @@
+# Command Palette
+
+A self-contained command palette component for dashboards, admin panels, productivity apps, and developer tools.
+
+## Features
+
+- Modal-style command surface with fade and scale entry animation.
+- Search input with a clear focus state.
+- Grouped command sections with uppercase labels.
+- Command rows include selected and hover states.
+- Keyboard shortcut hints use semantic `kbd` elements.
+- Scrollable command list and reduced-motion support.
+
+## Usage
+
+Open `demo.html` to preview the palette. Use `.ease-command-palette` as the container, `.command-search` for the input row, `.command-group` for sections, and `.command-item` for actions.

--- a/submissions/examples/command-palette-sb/demo.html
+++ b/submissions/examples/command-palette-sb/demo.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Command Palette</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="palette-title">
+        <p class="eyebrow">Productivity component</p>
+        <h1 id="palette-title">Command palette</h1>
+        <p class="intro">
+          A modal-style action launcher with search, grouped commands, shortcut
+          hints, selected states, and a smooth entry animation.
+        </p>
+
+        <div
+          class="ease-command-palette"
+          role="dialog"
+          aria-label="Command palette"
+        >
+          <label class="command-search">
+            <span class="search-icon" aria-hidden="true">/</span>
+            <input type="text" placeholder="Search commands..." />
+          </label>
+
+          <div
+            class="command-list"
+            role="listbox"
+            aria-label="Available commands"
+          >
+            <section class="command-group" aria-labelledby="nav-group">
+              <h2 id="nav-group">Navigation</h2>
+              <button class="command-item command-selected" type="button">
+                <span>Go to dashboard</span>
+                <kbd>Ctrl D</kbd>
+              </button>
+              <button class="command-item" type="button">
+                <span>Open settings</span>
+                <kbd>Ctrl S</kbd>
+              </button>
+            </section>
+
+            <section class="command-group" aria-labelledby="actions-group">
+              <h2 id="actions-group">Actions</h2>
+              <button class="command-item" type="button">
+                <span>Create new project</span>
+                <kbd>N</kbd>
+              </button>
+              <button class="command-item" type="button">
+                <span>Invite teammate</span>
+                <kbd>I</kbd>
+              </button>
+            </section>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/command-palette-sb/style.css
+++ b/submissions/examples/command-palette-sb/style.css
@@ -1,0 +1,223 @@
+:root {
+  --cmd-bg: #f8fafc;
+  --cmd-surface: #ffffff;
+  --cmd-text: #111827;
+  --cmd-muted: #64748b;
+  --cmd-border: #dbe4f0;
+  --cmd-primary: #2563eb;
+  --cmd-hover: #eff6ff;
+  --cmd-focus: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--cmd-text);
+  background:
+    radial-gradient(
+      circle at 20% 18%,
+      rgba(37, 99, 235, 0.18),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 48rem);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--cmd-primary);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 38rem;
+  margin: 1rem 0 2rem;
+  color: var(--cmd-muted);
+  line-height: 1.7;
+}
+
+.ease-command-palette {
+  width: min(100%, 40rem);
+  overflow: hidden;
+  border: 1px solid var(--cmd-border);
+  border-radius: 1.25rem;
+  background: var(--cmd-surface);
+  box-shadow: 0 26px 80px rgba(15, 23, 42, 0.18);
+  animation: palette-enter 220ms ease-out both;
+}
+
+.command-search {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid var(--cmd-border);
+}
+
+.search-icon {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border-radius: 0.65rem;
+  color: var(--cmd-primary);
+  background: var(--cmd-hover);
+  font-weight: 900;
+}
+
+.command-search input {
+  width: 100%;
+  border: 0;
+  color: var(--cmd-text);
+  background: transparent;
+  font: inherit;
+  font-size: 1rem;
+  font-weight: 800;
+  outline: 0;
+}
+
+.command-search:focus-within {
+  box-shadow: inset 0 0 0 3px var(--cmd-focus);
+}
+
+.command-list {
+  display: grid;
+  gap: 0.75rem;
+  max-height: 22rem;
+  overflow-y: auto;
+  padding: 0.9rem;
+}
+
+.command-group {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.command-group h2 {
+  margin: 0.35rem 0;
+  color: var(--cmd-muted);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.command-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  min-height: 3rem;
+  border: 0;
+  border-radius: 0.9rem;
+  padding: 0 0.8rem;
+  color: var(--cmd-text);
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 850;
+  text-align: left;
+  transition:
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+.command-item:hover,
+.command-item:focus-visible,
+.command-selected {
+  background: var(--cmd-hover);
+  outline: 0;
+  transform: translateX(2px);
+}
+
+.command-item:focus-visible {
+  box-shadow: inset 0 0 0 3px var(--cmd-focus);
+}
+
+kbd {
+  min-width: 2rem;
+  border: 1px solid var(--cmd-border);
+  border-radius: 0.55rem;
+  padding: 0.2rem 0.45rem;
+  color: var(--cmd-muted);
+  background: #f8fafc;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 900;
+  text-align: center;
+}
+
+@keyframes palette-enter {
+  from {
+    opacity: 0;
+    transform: translateY(0.75rem) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 560px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .command-item {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+    padding: 0.7rem 0.8rem;
+  }
+
+  kbd {
+    justify-self: start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-command-palette {
+    animation: none;
+  }
+
+  .command-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained command palette demo under submissions/examples/command-palette-sb
- include search, grouped commands, selected/hover states, and shortcut hints
- add a smooth entry animation with reduced-motion support

## Validation
- npx prettier --check submissions/examples/command-palette-sb/demo.html submissions/examples/command-palette-sb/style.css submissions/examples/command-palette-sb/README.md
- git diff --cached --check

Closes #6856