### PR TITLE
feat: add expandable card grid submission

### DIFF
--- a/submissions/examples/expandable-card-grid-sb/README.md
+++ b/submissions/examples/expandable-card-grid-sb/README.md
@@ -1,0 +1,15 @@
+# Expandable Card Grid
+
+An interactive dashboard grid where selecting a card expands its column to reveal supporting content.
+
+## Features
+
+- Uses CSS grid fraction transitions for smooth horizontal expansion.
+- Radio inputs preserve selection state without JavaScript.
+- Summary copy fades in only for the selected card on desktop.
+- Mobile layout stacks cards and keeps all summaries visible.
+- Includes keyboard focus and reduced-motion handling.
+
+## Usage
+
+Open `demo.html` and select any card. The grid uses `.ease-expand-grid` plus `.ease-expand-card` labels connected to hidden radio inputs.

--- a/submissions/examples/expandable-card-grid-sb/demo.html
+++ b/submissions/examples/expandable-card-grid-sb/demo.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Expandable Card Grid</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="grid-title">
+        <p class="eyebrow">Dashboard layout</p>
+        <h1 id="grid-title">Expandable card grid</h1>
+        <p class="intro">
+          Select a dashboard tile to expand its column and reveal supporting
+          copy while nearby cards stay composed.
+        </p>
+
+        <div class="ease-expand-grid">
+          <input type="radio" name="grid-card" id="card-one" checked />
+          <input type="radio" name="grid-card" id="card-two" />
+          <input type="radio" name="grid-card" id="card-three" />
+
+          <label class="ease-expand-card card-one" for="card-one">
+            <span class="metric">92%</span>
+            <strong>Launch ready</strong>
+            <span class="summary">
+              QA coverage, docs, and release tasks are all trending green.
+            </span>
+          </label>
+
+          <label class="ease-expand-card card-two" for="card-two">
+            <span class="metric">18</span>
+            <strong>Open reviews</strong>
+            <span class="summary">
+              Pending design and API reviews need owner confirmation today.
+            </span>
+          </label>
+
+          <label class="ease-expand-card card-three" for="card-three">
+            <span class="metric">4.8</span>
+            <strong>User rating</strong>
+            <span class="summary">
+              Feedback highlights speed, clarity, and easier navigation.
+            </span>
+          </label>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/expandable-card-grid-sb/style.css
+++ b/submissions/examples/expandable-card-grid-sb/style.css
@@ -1,0 +1,177 @@
+:root {
+  --grid-bg: #f8fafc;
+  --grid-surface: #ffffff;
+  --grid-text: #111827;
+  --grid-muted: #64748b;
+  --grid-border: #dbe4f0;
+  --grid-primary: #2563eb;
+  --grid-focus: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--grid-text);
+  background:
+    radial-gradient(
+      circle at 18% 16%,
+      rgba(37, 99, 235, 0.18),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 64rem);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--grid-primary);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 42rem;
+  margin: 1rem 0 2rem;
+  color: var(--grid-muted);
+  line-height: 1.7;
+}
+
+.ease-expand-grid {
+  display: grid;
+  grid-template-columns: 1.7fr 1fr 1fr;
+  gap: 1rem;
+  transition: grid-template-columns 280ms ease;
+}
+
+.ease-expand-grid input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-expand-card {
+  display: grid;
+  min-height: 18rem;
+  align-content: end;
+  overflow: hidden;
+  padding: 1.25rem;
+  border: 1px solid var(--grid-border);
+  border-radius: 1.2rem;
+  background:
+    linear-gradient(145deg, rgba(37, 99, 235, 0.16), transparent 62%),
+    var(--grid-surface);
+  box-shadow: 0 16px 44px rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+}
+
+.ease-expand-card:focus-visible,
+.ease-expand-grid input:focus-visible + .ease-expand-card {
+  outline: 3px solid var(--grid-focus);
+  outline-offset: 4px;
+}
+
+.metric {
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+  font-weight: 900;
+  line-height: 1;
+}
+
+.ease-expand-card strong {
+  margin-top: 0.8rem;
+  font-size: 1.15rem;
+}
+
+.summary {
+  max-width: 24rem;
+  margin-top: 0.75rem;
+  color: var(--grid-muted);
+  line-height: 1.6;
+  opacity: 0;
+  transform: translateY(0.5rem);
+  transition:
+    opacity 220ms ease,
+    transform 220ms ease;
+}
+
+#card-one:checked ~ .card-one .summary,
+#card-two:checked ~ .card-two .summary,
+#card-three:checked ~ .card-three .summary {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.ease-expand-grid:has(#card-one:checked) {
+  grid-template-columns: 1.7fr 1fr 1fr;
+}
+
+.ease-expand-grid:has(#card-two:checked) {
+  grid-template-columns: 1fr 1.7fr 1fr;
+}
+
+.ease-expand-grid:has(#card-three:checked) {
+  grid-template-columns: 1fr 1fr 1.7fr;
+}
+
+@media (max-width: 760px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .ease-expand-grid,
+  .ease-expand-grid:has(#card-one:checked),
+  .ease-expand-grid:has(#card-two:checked),
+  .ease-expand-grid:has(#card-three:checked) {
+    grid-template-columns: 1fr;
+  }
+
+  .ease-expand-card {
+    min-height: 13rem;
+  }
+
+  .summary {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-expand-grid,
+  .summary {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained expandable card grid demo under submissions/examples/expandable-card-grid-sb
- use CSS grid column fraction transitions to expand the selected dashboard card
- include responsive stacking, summary reveal states, and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/expandable-card-grid-sb/demo.html submissions/examples/expandable-card-grid-sb/style.css submissions/examples/expandable-card-grid-sb/README.md
- git diff --cached --check

Closes #6762