### PR TITLE
feat: add parallax gallery submission

### DIFF
--- a/submissions/examples/parallax-gallery-sb/README.md
+++ b/submissions/examples/parallax-gallery-sb/README.md
@@ -1,0 +1,16 @@
+# Cinematic Parallax Gallery
+
+A self-contained image gallery grid with layered hover motion for gallery cards.
+
+## Features
+
+- Card frame tilts on hover and keyboard focus.
+- Image layer shifts in the opposite direction for a parallax feel.
+- Title panel slides forward from behind the card.
+- Uses gradient image layers, so no external assets are required.
+- Responsive layout stacks cleanly on smaller screens.
+- Respects reduced-motion preferences.
+
+## Usage
+
+Open `demo.html` and hover or focus a gallery tile. Use `.ease-parallax-gallery` for the grid and `.ease-parallax-card` for each tile with an `.image-layer` and `.title-layer`.

--- a/submissions/examples/parallax-gallery-sb/demo.html
+++ b/submissions/examples/parallax-gallery-sb/demo.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cinematic Parallax Gallery</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="gallery-title">
+        <p class="eyebrow">Gallery component</p>
+        <h1 id="gallery-title">Cinematic parallax gallery</h1>
+        <p class="intro">
+          Hover or focus a tile to tilt the frame, shift the image layer, and
+          reveal a title panel from behind.
+        </p>
+
+        <div class="ease-parallax-gallery" aria-label="Featured gallery">
+          <a class="ease-parallax-card" href="#aurora">
+            <span class="image-layer aurora" aria-hidden="true"></span>
+            <span class="title-layer">
+              <strong>Aurora Ridge</strong>
+              <small>Motion preset</small>
+            </span>
+          </a>
+
+          <a class="ease-parallax-card" href="#harbor">
+            <span class="image-layer harbor" aria-hidden="true"></span>
+            <span class="title-layer">
+              <strong>Harbor Glass</strong>
+              <small>UI surface</small>
+            </span>
+          </a>
+
+          <a class="ease-parallax-card" href="#signal">
+            <span class="image-layer signal" aria-hidden="true"></span>
+            <span class="title-layer">
+              <strong>Signal Bloom</strong>
+              <small>Dashboard view</small>
+            </span>
+          </a>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/parallax-gallery-sb/style.css
+++ b/submissions/examples/parallax-gallery-sb/style.css
@@ -1,0 +1,217 @@
+:root {
+  --gallery-bg: #f8fafc;
+  --gallery-surface: #ffffff;
+  --gallery-text: #111827;
+  --gallery-muted: #64748b;
+  --gallery-border: #dbe4f0;
+  --gallery-primary: #2563eb;
+  --gallery-focus: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--gallery-text);
+  background:
+    radial-gradient(
+      circle at 18% 16%,
+      rgba(37, 99, 235, 0.18),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 66rem);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--gallery-primary);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 42rem;
+  margin: 1rem 0 2rem;
+  color: var(--gallery-muted);
+  line-height: 1.7;
+}
+
+.ease-parallax-gallery {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  perspective: 900px;
+}
+
+.ease-parallax-card {
+  position: relative;
+  display: block;
+  min-height: 22rem;
+  overflow: hidden;
+  border: 1px solid var(--gallery-border);
+  border-radius: 1.25rem;
+  background: #0f172a;
+  box-shadow: 0 18px 52px rgba(15, 23, 42, 0.16);
+  isolation: isolate;
+  text-decoration: none;
+  transform-style: preserve-3d;
+  transition:
+    box-shadow 220ms ease,
+    transform 220ms ease;
+}
+
+.ease-parallax-card:hover,
+.ease-parallax-card:focus-visible {
+  box-shadow: 0 28px 70px rgba(15, 23, 42, 0.24);
+  outline: 0;
+  transform: rotateX(7deg) rotateY(-8deg) translateY(-6px);
+}
+
+.ease-parallax-card:focus-visible {
+  box-shadow:
+    0 0 0 4px var(--gallery-focus),
+    0 28px 70px rgba(15, 23, 42, 0.24);
+}
+
+.image-layer {
+  position: absolute;
+  inset: -8%;
+  z-index: -1;
+  background-size: cover;
+  filter: saturate(1.15);
+  transition:
+    filter 220ms ease,
+    transform 260ms ease;
+}
+
+.ease-parallax-card:hover .image-layer,
+.ease-parallax-card:focus-visible .image-layer {
+  filter: saturate(1.28) contrast(1.06);
+  transform: translate3d(-1rem, -0.75rem, 2rem) scale(1.08);
+}
+
+.aurora {
+  background:
+    linear-gradient(140deg, rgba(15, 23, 42, 0.18), rgba(15, 23, 42, 0.5)),
+    radial-gradient(circle at 30% 20%, #bfdbfe, transparent 24%),
+    linear-gradient(135deg, #2563eb 0%, #7c3aed 48%, #111827 100%);
+}
+
+.harbor {
+  background:
+    linear-gradient(140deg, rgba(15, 23, 42, 0.14), rgba(15, 23, 42, 0.48)),
+    radial-gradient(circle at 72% 20%, #99f6e4, transparent 24%),
+    linear-gradient(135deg, #0f766e 0%, #0891b2 46%, #172554 100%);
+}
+
+.signal {
+  background:
+    linear-gradient(140deg, rgba(15, 23, 42, 0.12), rgba(15, 23, 42, 0.5)),
+    radial-gradient(circle at 64% 24%, #fed7aa, transparent 24%),
+    linear-gradient(135deg, #f97316 0%, #dc2626 44%, #111827 100%);
+}
+
+.title-layer {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+  display: grid;
+  gap: 0.25rem;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 1rem;
+  color: #ffffff;
+  background: rgba(15, 23, 42, 0.72);
+  box-shadow: 0 14px 40px rgba(15, 23, 42, 0.28);
+  opacity: 0;
+  transform: translate3d(0, 1.5rem, -2rem);
+  transition:
+    opacity 220ms ease,
+    transform 260ms ease;
+}
+
+.ease-parallax-card:hover .title-layer,
+.ease-parallax-card:focus-visible .title-layer {
+  opacity: 1;
+  transform: translate3d(0, 0, 2rem);
+}
+
+.title-layer strong {
+  font-size: 1.3rem;
+  font-weight: 900;
+}
+
+.title-layer small {
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+@media (max-width: 840px) {
+  .ease-parallax-gallery {
+    grid-template-columns: 1fr;
+  }
+
+  .ease-parallax-card {
+    min-height: 17rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .demo-shell {
+    padding: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-parallax-card,
+  .image-layer,
+  .title-layer {
+    transition: none;
+  }
+
+  .ease-parallax-card:hover,
+  .ease-parallax-card:focus-visible,
+  .ease-parallax-card:hover .image-layer,
+  .ease-parallax-card:focus-visible .image-layer,
+  .ease-parallax-card:hover .title-layer,
+  .ease-parallax-card:focus-visible .title-layer {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained cinematic parallax gallery demo under submissions/examples/parallax-gallery-sb
- tilt the card frame, shift the image layer, and reveal the title layer on hover/focus
- include responsive stacking and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/parallax-gallery-sb/demo.html submissions/examples/parallax-gallery-sb/style.css submissions/examples/parallax-gallery-sb/README.md
- git diff --cached --check

Closes #6793