### PR TITLE
feat: add crypto trading terminal submission

### DIFF
--- a/submissions/examples/crypto-trading-terminal-sb/README.md
+++ b/submissions/examples/crypto-trading-terminal-sb/README.md
@@ -1,0 +1,15 @@
+# Crypto Trading Terminal
+
+A self-contained trading dashboard inspired by modern crypto exchanges.
+
+## Features
+
+- Market watchlist with up/down indicators.
+- Stylized chart surface with layered price movement lines.
+- Order ticket with buy and sell actions.
+- Portfolio summary tiles for balance and risk context.
+- Responsive layout that collapses cleanly on smaller screens.
+
+## Usage
+
+Open `demo.html` to view the terminal layout. Use the `.panel` blocks to compose watchlists, charts, order tickets, and portfolio summaries in a trading UI.

--- a/submissions/examples/crypto-trading-terminal-sb/demo.html
+++ b/submissions/examples/crypto-trading-terminal-sb/demo.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crypto Trading Terminal</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="terminal-shell">
+      <section class="terminal-card" aria-labelledby="terminal-title">
+        <p class="eyebrow">Market desk</p>
+        <h1 id="terminal-title">Crypto trading terminal</h1>
+        <p class="intro">
+          A dashboard-style terminal with a market watchlist, price chart, order
+          ticket, and portfolio overview inspired by modern trading platforms.
+        </p>
+
+        <div class="terminal-grid">
+          <aside class="panel watchlist-panel">
+            <div class="panel-head">
+              <h2>Watchlist</h2>
+              <span>Live</span>
+            </div>
+            <div class="watchlist">
+              <div class="market-row">
+                <strong>BTC</strong>
+                <span class="price up">$68,240</span>
+                <small>+4.2%</small>
+              </div>
+              <div class="market-row">
+                <strong>ETH</strong>
+                <span class="price up">$3,842</span>
+                <small>+2.1%</small>
+              </div>
+              <div class="market-row">
+                <strong>SOL</strong>
+                <span class="price down">$179</span>
+                <small>-1.4%</small>
+              </div>
+              <div class="market-row">
+                <strong>XRP</strong>
+                <span class="price up">$0.74</span>
+                <small>+0.8%</small>
+              </div>
+            </div>
+          </aside>
+
+          <section class="panel chart-panel">
+            <div class="panel-head">
+              <h2>BTC/USDT</h2>
+              <span>1D</span>
+            </div>
+            <div class="chart-frame" aria-hidden="true">
+              <div class="chart-line"></div>
+              <div class="chart-line chart-line-alt"></div>
+              <div class="grid-glow"></div>
+            </div>
+            <div class="chart-stats">
+              <div>
+                <small>24h high</small>
+                <strong>$69,102</strong>
+              </div>
+              <div>
+                <small>24h low</small>
+                <strong>$66,880</strong>
+              </div>
+              <div>
+                <small>Volume</small>
+                <strong>42.8K BTC</strong>
+              </div>
+            </div>
+          </section>
+
+          <aside class="panel order-panel">
+            <div class="panel-head">
+              <h2>Order ticket</h2>
+              <span>Limit</span>
+            </div>
+            <div class="order-box">
+              <label>
+                <span>Amount</span>
+                <input type="text" value="0.15 BTC" readonly />
+              </label>
+              <label>
+                <span>Price</span>
+                <input type="text" value="$68,120" readonly />
+              </label>
+              <div class="buy-sell">
+                <button class="buy" type="button">Buy</button>
+                <button class="sell" type="button">Sell</button>
+              </div>
+            </div>
+          </aside>
+
+          <section class="panel portfolio-panel">
+            <div class="panel-head">
+              <h2>Portfolio</h2>
+              <span>Today +5.6%</span>
+            </div>
+            <div class="portfolio-summary">
+              <div>
+                <small>Balance</small>
+                <strong>$128,540</strong>
+              </div>
+              <div>
+                <small>Open positions</small>
+                <strong>12</strong>
+              </div>
+              <div>
+                <small>Risk score</small>
+                <strong>Low</strong>
+              </div>
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/crypto-trading-terminal-sb/style.css
+++ b/submissions/examples/crypto-trading-terminal-sb/style.css
@@ -1,0 +1,330 @@
+:root {
+  --term-bg: #08111f;
+  --term-surface: rgba(10, 18, 34, 0.86);
+  --term-panel: rgba(15, 23, 42, 0.92);
+  --term-border: rgba(148, 163, 184, 0.18);
+  --term-text: #e5eefc;
+  --term-muted: #94a3b8;
+  --term-primary: #38bdf8;
+  --term-green: #22c55e;
+  --term-red: #fb7185;
+  --term-gold: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--term-text);
+  background:
+    radial-gradient(
+      circle at 18% 16%,
+      rgba(56, 189, 248, 0.2),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 84% 18%,
+      rgba(34, 197, 94, 0.16),
+      transparent 24rem
+    ),
+    linear-gradient(160deg, #020617 0%, #0f172a 56%, #111827 100%);
+}
+
+.terminal-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.terminal-card {
+  width: min(100%, 74rem);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border: 1px solid var(--term-border);
+  border-radius: 1.5rem;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(2, 6, 23, 0.95)),
+    var(--term-bg);
+  box-shadow: 0 30px 90px rgba(2, 6, 23, 0.55);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--term-primary);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 44rem;
+  margin: 1rem 0 2rem;
+  color: var(--term-muted);
+  line-height: 1.7;
+}
+
+.terminal-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1.9fr 1fr;
+  gap: 1rem;
+}
+
+.panel {
+  padding: 1rem;
+  border: 1px solid var(--term-border);
+  border-radius: 1.1rem;
+  background: var(--term-surface);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.85rem;
+}
+
+.panel-head h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.panel-head span {
+  color: var(--term-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.watchlist {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.market-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.8rem 0.85rem;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.market-row strong {
+  font-size: 0.95rem;
+}
+
+.price {
+  justify-self: end;
+  font-weight: 900;
+}
+
+.price.up {
+  color: var(--term-green);
+}
+
+.price.down {
+  color: var(--term-red);
+}
+
+.market-row small {
+  color: var(--term-muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.chart-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.chart-frame {
+  position: relative;
+  min-height: 20rem;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 1rem;
+  background:
+    linear-gradient(180deg, rgba(14, 165, 233, 0.08), transparent 30%),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px) 0 0 /
+      3rem 3rem,
+    linear-gradient(180deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px) 0
+      0 / 3rem 3rem,
+    #08111f;
+}
+
+.grid-glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at 72% 28%,
+    rgba(56, 189, 248, 0.28),
+    transparent 24%
+  );
+}
+
+.chart-line {
+  position: absolute;
+  inset: 22% 8% 26% 6%;
+  border: 3px solid transparent;
+  border-image: linear-gradient(90deg, #38bdf8 0%, #22c55e 54%, #fbbf24 100%) 1;
+  border-radius: 2rem;
+  transform: skewY(-8deg);
+  clip-path: polygon(
+    0 74%,
+    12% 70%,
+    24% 50%,
+    35% 56%,
+    47% 32%,
+    61% 39%,
+    72% 18%,
+    83% 24%,
+    100% 6%,
+    100% 100%,
+    0 100%
+  );
+}
+
+.chart-line-alt {
+  inset: 32% 18% 36% 16%;
+  opacity: 0.45;
+  transform: skewY(7deg);
+  border-image: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.8),
+      rgba(56, 189, 248, 0.5)
+    )
+    1;
+}
+
+.chart-stats,
+.portfolio-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.chart-stats div,
+.portfolio-summary div,
+.order-box {
+  padding: 0.85rem;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.chart-stats small,
+.portfolio-summary small,
+.order-box span {
+  display: block;
+  color: var(--term-muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.chart-stats strong,
+.portfolio-summary strong {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 1rem;
+}
+
+.order-box {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.order-box label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.order-box input {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.7rem;
+  padding: 0.7rem 0.8rem;
+  color: var(--term-text);
+  background: rgba(8, 17, 31, 0.9);
+  font: inherit;
+  font-weight: 800;
+}
+
+.buy-sell {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.buy-sell button {
+  min-height: 2.75rem;
+  border: 0;
+  border-radius: 0.8rem;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+}
+
+.buy {
+  background: linear-gradient(135deg, #16a34a, #22c55e);
+}
+
+.sell {
+  background: linear-gradient(135deg, #e11d48, #fb7185);
+}
+
+@media (max-width: 980px) {
+  .terminal-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .chart-panel {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .terminal-shell {
+    padding: 1rem;
+  }
+
+  .terminal-grid,
+  .chart-stats,
+  .portfolio-summary,
+  .buy-sell {
+    grid-template-columns: 1fr;
+  }
+
+  .watchlist-panel,
+  .order-panel,
+  .portfolio-panel {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained crypto trading terminal demo under submissions/examples/crypto-trading-terminal-sb
- include watchlist, chart, order ticket, and portfolio panels
- keep the dashboard responsive with dark fintech styling and reduced-motion support

## Validation
- npx prettier --check submissions/examples/crypto-trading-terminal-sb/demo.html submissions/examples/crypto-trading-terminal-sb/style.css submissions/examples/crypto-trading-terminal-sb/README.md
- git diff --cached --check

Closes #6608