### PR TITLE
fix: ease-delay-* fill-mode bug and silent no-op documentation (#6936)

### DIFF
--- a/submissions/examples/ease-delay-fix/README.md
+++ b/submissions/examples/ease-delay-fix/README.md
@@ -1,0 +1,55 @@
+# ease-delay-* Fix
+
+**Fixes:** Issue #6936  
+**Type:** Bug Fix + Documentation  
+
+## What was broken
+
+### Bug 1 — Silent no-op
+`ease-delay-*` classes only set `animation-delay`. Used alone without
+a base animation class (like `ease-fade-in`, `ease-slide-up`), they
+do absolutely nothing — no error, no warning, no visual feedback.
+
+### Bug 2 — Flash before animation (fill-mode missing)
+Without `animation-fill-mode: both`, elements using `ease-fade-in ease-delay-300`
+flash fully visible for 300ms BEFORE the animation runs — the opposite
+of intended behaviour.
+
+### Bug 3 — Transition conflict (undocumented)
+`animation-delay` has no effect on CSS `transition`. If a user applies
+`ease-delay-*` alongside a transition-based hover effect, nothing happens
+and there's no documentation warning about this.
+
+## The Fix
+
+### CSS (`style.css`)
+One key rule added:
+```css
+[class*="ease-delay-"] {
+  animation-fill-mode: both;
+}
+```
+This ensures the element holds its animation's starting state (e.g. `opacity: 0`)
+during the delay period instead of flashing visible.
+
+### Docs (this demo)
+- Clearly shows `ease-delay-*` as a **modifier class** requiring a base animation
+- Demonstrates the flash bug before/after fix
+- Documents the transition vs animation conflict
+
+## Correct usage
+```html
+<!-- ✅ Correct — delay modifier paired with animation class -->
+<div class="ease-fade-in ease-delay-200">Fades in after 200ms</div>
+<div class="ease-slide-up ease-delay-400">Slides up after 400ms</div>
+
+<!-- ❌ Wrong — delay alone does nothing -->
+<div class="ease-delay-300">Nothing happens</div>
+```
+
+## Files
+| File | Purpose |
+|---|---|
+| `style.css` | Delay utility classes with fill-mode fix |
+| `demo.html` | Visual demo of all 3 bugs and their fixes |
+| `README.md` | This file |

--- a/submissions/examples/ease-delay-fix/demo.html
+++ b/submissions/examples/ease-delay-fix/demo.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-delay-* Fix — EaseMotion CSS</title>
+
+  <!-- Load EaseMotion core -->
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    * { box-sizing: border-box; }
+
+    body {
+      background: #0b0f1a;
+      color: #e2e8f0;
+      font-family: 'Segoe UI', sans-serif;
+      padding: 2rem;
+      margin: 0;
+    }
+
+    h1 { color: #38bdf8; margin-bottom: 0.25rem; }
+    h2 { color: #94a3b8; font-size: 1rem; font-weight: 400; margin-top: 0; }
+
+    section { margin: 2.5rem 0; }
+    section h3 { color: #7dd3fc; border-bottom: 1px solid #1e293b; padding-bottom: 0.5rem; }
+
+    .badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      padding: 0.2rem 0.6rem;
+      border-radius: 999px;
+      font-weight: 700;
+      margin-right: 0.5rem;
+    }
+    .badge-good { background: #166534; color: #bbf7d0; }
+    .badge-bad  { background: #7f1d1d; color: #fecaca; }
+
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 1rem 1.5rem;
+      margin-bottom: 0.75rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    code {
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 4px;
+      padding: 0.15rem 0.4rem;
+      font-size: 0.82rem;
+      color: #7dd3fc;
+    }
+
+    .note {
+      background: #1c1f2e;
+      border-left: 4px solid #f59e0b;
+      padding: 0.75rem 1rem;
+      border-radius: 0 8px 8px 0;
+      font-size: 0.87rem;
+      color: #fcd34d;
+      margin-top: 1rem;
+    }
+
+    .reload-btn {
+      background: #3b82f6;
+      color: white;
+      border: none;
+      padding: 0.5rem 1.25rem;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      margin-bottom: 1rem;
+    }
+    .reload-btn:hover { background: #2563eb; }
+  </style>
+</head>
+<body>
+
+  <h1>⚡ ease-delay-* Fix</h1>
+  <h2>Fix for Issue #6936 — EaseMotion CSS</h2>
+
+  <button class="reload-btn" onclick="location.reload()">↺ Replay Animations</button>
+
+  <!-- SECTION 1: Correct stagger usage -->
+  <section>
+    <h3><span class="badge badge-good">✅ CORRECT</span> Staggered slide-up with delay</h3>
+    <p>Each card uses <code>ease-slide-up</code> + <code>ease-delay-*</code> together.</p>
+
+    <div class="card ease-slide-up ease-delay-0">Card 1 — 0ms delay</div>
+    <div class="card ease-slide-up ease-delay-200">Card 2 — 200ms delay</div>
+    <div class="card ease-slide-up ease-delay-400">Card 3 — 400ms delay</div>
+    <div class="card ease-slide-up ease-delay-600">Card 4 — 600ms delay</div>
+
+    <div class="note">
+      ℹ️ <strong>ease-delay-* is a modifier.</strong> It needs a base animation class to have any effect.
+    </div>
+  </section>
+
+  <!-- SECTION 2: The no-op bug -->
+  <section>
+    <h3><span class="badge badge-bad">❌ BUG</span> ease-delay used alone (silent no-op)</h3>
+    <p>This element has <code>ease-delay-500</code> but <strong>no animation class</strong>. It appears instantly — delay is completely ignored with no warning.</p>
+
+    <div class="card" style="animation-delay: 500ms; border-color: #ef4444;">
+      Appears immediately — no animation means no delay effect
+    </div>
+  </section>
+
+  <!-- SECTION 3: The fill-mode flash bug -->
+  <section>
+    <h3><span class="badge badge-bad">❌ BUG</span> Flash before fade-in (missing fill-mode)</h3>
+    <p>Without <code>animation-fill-mode: both</code>, element is <strong>fully visible during the delay period</strong>, then fades in — backwards!</p>
+
+    <!-- Simulating the broken state (no fill-mode guard) -->
+    <div class="card ease-fade-in" style="animation-delay: 700ms; animation-fill-mode: none; border-color: #ef4444;">
+      ❌ Buggy: Visible immediately, then fades in at 700ms
+    </div>
+
+    <h3><span class="badge badge-good">✅ FIXED</span> Clean fade-in with delay (fill-mode: both)</h3>
+    <p>With <code>animation-fill-mode: both</code> applied via <code>[class*="ease-delay-"]</code>, element stays hidden during delay, then animates in cleanly.</p>
+
+    <div class="card ease-fade-in ease-delay-700" style="border-color: #22c55e;">
+      ✅ Fixed: Hidden during delay, clean fade-in at 700ms
+    </div>
+  </section>
+
+  <!-- SECTION 4: Transition conflict explanation -->
+  <section>
+    <h3><span class="badge badge-bad">⚠️ GOTCHA</span> ease-delay has no effect on CSS transitions</h3>
+    <p><code>animation-delay</code> only affects <code>animation</code> properties — not <code>transition</code>. If your element uses <code>transition</code> instead of <code>animation</code>, <code>ease-delay-*</code> does nothing. Use <code>transition-delay</code> instead.</p>
+
+    <div class="card" style="transition: background 0.4s ease; animation-delay: 500ms; border-color: #f59e0b;"
+         onmouseover="this.style.background='#3b82f6'"
+         onmouseout="this.style.background=''">
+      ⚠️ Hover me — delay has no effect on the transition (transition-delay needed instead)
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-delay-fix/style.css
+++ b/submissions/examples/ease-delay-fix/style.css
@@ -1,0 +1,31 @@
+/* =============================================================
+   ease-delay-* — Stagger delay modifier classes
+   FIX for Issue #6936
+   ⚠️  MODIFIER ONLY — must pair with a base animation class
+   e.g. ease-fade-in, ease-slide-up, ease-zoom-in
+   ============================================================= */
+
+/* --- Delay values --- */
+.ease-delay-0    { animation-delay: 0ms; }
+.ease-delay-100  { animation-delay: 100ms; }
+.ease-delay-200  { animation-delay: 200ms; }
+.ease-delay-300  { animation-delay: 300ms; }
+.ease-delay-400  { animation-delay: 400ms; }
+.ease-delay-500  { animation-delay: 500ms; }
+.ease-delay-700  { animation-delay: 700ms; }
+.ease-delay-1000 { animation-delay: 1000ms; }
+
+/*
+  THE CORE FIX:
+  Without animation-fill-mode: both, elements briefly flash
+  to their final visible state BEFORE the animation starts.
+  
+  Example bug: ease-fade-in ease-delay-300
+  → element appears instantly for 300ms, THEN fades in (wrong)
+  
+  With fill-mode: both:
+  → element stays hidden during delay, then fades in (correct)
+*/
+[class*="ease-delay-"] {
+  animation-fill-mode: both;
+}


### PR DESCRIPTION
Closes #6936

## 🐛 What this fixes

### Bug 1 — Silent no-op
`ease-delay-*` classes only set `animation-delay`. When used alone 
without a base animation class (ease-fade-in, ease-slide-up, etc.), 
they do absolutely nothing — no error, no warning, no visual feedback. 
Beginners are silently confused.

### Bug 2 — Flash before animation (missing fill-mode)
Without `animation-fill-mode: both`, elements using something like 
`ease-fade-in ease-delay-300` flash fully visible for 300ms BEFORE 
the animation runs. This is the opposite of intended behaviour.

### Bug 3 — Transition conflict (undocumented)
`animation-delay` has no effect on CSS `transition`. If a user applies 
`ease-delay-*` alongside a transition-based effect, nothing happens 
and there is no documentation warning about this.

## ✅ The Fix

Added `animation-fill-mode: both` to all `[class*="ease-delay-"]` elements:

```css
[class*="ease-delay-"] {
  animation-fill-mode: both;
}
```

This ensures the element holds its animation's starting state (e.g. opacity: 0) 
during the delay period instead of flashing visible.

## 📁 Files Added
- `submissions/examples/ease-delay-fix/style.css` — delay utility classes with fill-mode fix
- `submissions/examples/ease-delay-fix/demo.html` — visual demo of all bugs and fixes
- `submissions/examples/ease-delay-fix/README.md` — explanation for maintainer review

## 🧪 How to test
1. Open `submissions/examples/ease-delay-fix/demo.html` in browser
2. Click "Replay Animations" to re-trigger
3. Observe staggered cards animate in cleanly with no flash