### PR TITLE
fix: FOUC prevention for entrance animation classes on slow page load

### DIFF
--- a/submissions/examples/ease-fouc-fix/README.md
+++ b/submissions/examples/ease-fouc-fix/README.md
@@ -1,0 +1,72 @@
+# FOUC Prevention Fix for EaseMotion CSS
+
+**Fixes:** FOUC (Flash of Unstyled Content) bug on page load  
+**Type:** Bug Fix  
+
+## What was broken
+
+On slow connections or low-end devices, elements with EaseMotion 
+entrance animation classes (`ease-fade-in`, `ease-slide-up`, etc.) 
+flash fully visible before the CSS is parsed, then abruptly 
+disappear and re-animate — breaking the entire entrance effect.
+
+## The Fix (2 steps)
+
+### Step 1 — Critical inline CSS in `<head>`
+Hides all animated elements immediately before any stylesheet loads:
+
+```css
+body:not(.ease-ready) [class*="ease-fade"],
+body:not(.ease-ready) [class*="ease-slide"],
+body:not(.ease-ready) [class*="ease-zoom"] {
+  opacity: 0;
+  animation: none !important;
+}
+```
+
+### Step 2 — JS adds `.ease-ready` after DOM loads
+This unlocks all animations at the right moment:
+
+```html
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.body.classList.add('ease-ready');
+  });
+</script>
+```
+
+## How to use in your project
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- 1. Critical CSS first (inline) -->
+  <style>
+    body:not(.ease-ready) [class*="ease-fade"] { opacity: 0; animation: none !important; }
+    body:not(.ease-ready) [class*="ease-slide"] { opacity: 0; animation: none !important; }
+    body:not(.ease-ready) [class*="ease-zoom"]  { opacity: 0; animation: none !important; }
+  </style>
+
+  <!-- 2. Then load EaseMotion -->
+  <link rel="stylesheet" href="easemotion.css" />
+</head>
+<body>
+  <!-- 3. JS unlock -->
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.body.classList.add('ease-ready');
+    });
+  </script>
+
+  <div class="ease-fade-in">I won't flash! ✅</div>
+</body>
+</html>
+```
+
+## Files
+| File | Purpose |
+|---|---|
+| `style.css` | FOUC guard CSS using body:not(.ease-ready) selector |
+| `demo.html` | Visual demo with reload button to simulate page load |
+| `README.md` | This file |

--- a/submissions/examples/ease-fouc-fix/demo.html
+++ b/submissions/examples/ease-fouc-fix/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FOUC Fix — EaseMotion CSS</title>
+
+  <!--
+    FOUC FIX STEP 1:
+    Add this critical inline style in <head> BEFORE any stylesheet.
+    This immediately hides animated elements so they never flash.
+  -->
+  <style>
+    body:not(.ease-ready) [class*="ease-fade"],
+    body:not(.ease-ready) [class*="ease-slide"],
+    body:not(.ease-ready) [class*="ease-zoom"],
+    body:not(.ease-ready) [class*="ease-bounce"],
+    body:not(.ease-ready) [class*="ease-flip"],
+    body:not(.ease-ready) [class*="ease-rotate"] {
+      opacity: 0;
+      animation: none !important;
+    }
+  </style>
+
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    * { box-sizing: border-box; }
+    body { background: #0b0f1a; color: #e2e8f0; font-family: 'Segoe UI', sans-serif; padding: 2rem; margin: 0; }
+    h1 { color: #38bdf8; }
+    h2 { color: #94a3b8; font-weight: 400; font-size: 1rem; margin-top: 0; }
+    h3 { color: #7dd3fc; border-bottom: 1px solid #1e293b; padding-bottom: 0.5rem; }
+    .card { background: #1e293b; border: 1px solid #334155; border-radius: 10px; padding: 1rem 1.5rem; margin-bottom: 0.75rem; font-weight: 600; }
+    .note { background: #1c1f2e; border-left: 4px solid #f59e0b; padding: 0.75rem 1rem; border-radius: 0 8px 8px 0; color: #fcd34d; margin: 1rem 0; font-size: 0.87rem; }
+    .good { border-color: #22c55e; }
+    .bad  { border-color: #ef4444; }
+    code  { background: #0f172a; border: 1px solid #334155; border-radius: 4px; padding: 0.15rem 0.4rem; color: #7dd3fc; font-size: 0.82rem; }
+    button { background: #3b82f6; color: white; border: none; padding: 0.5rem 1.25rem; border-radius: 6px; cursor: pointer; margin-bottom: 1.5rem; font-size: 0.9rem; }
+    button:hover { background: #2563eb; }
+    .status { font-size: 0.8rem; padding: 0.3rem 0.8rem; border-radius: 999px; display: inline-block; margin-bottom: 1rem; }
+    .status.ready { background: #166534; color: #bbf7d0; }
+    .status.waiting { background: #7f1d1d; color: #fecaca; }
+  </style>
+</head>
+<body>
+
+  <!--
+    FOUC FIX STEP 2:
+    Add .ease-ready to body as early as possible via JS.
+    This "unlocks" animations only after DOM + CSS are ready.
+  -->
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.body.classList.add('ease-ready');
+    });
+  </script>
+
+  <h1>⚡ FOUC Prevention Fix</h1>
+  <h2>Fixes Flash of Unstyled Content on page load — EaseMotion CSS</h2>
+
+  <div id="status" class="status waiting">⏳ Waiting for ease-ready...</div>
+  <button onclick="location.reload()">↺ Replay / Simulate Reload</button>
+
+  <h3>✅ These cards are FOUC-safe</h3>
+  <p>On slow connections, these stay hidden until CSS loads — no flash.</p>
+
+  <div class="card ease-fade-in ease-delay-0 good">Card 1 — ease-fade-in (safe)</div>
+  <div class="card ease-slide-up ease-delay-200 good">Card 2 — ease-slide-up (safe)</div>
+  <div class="card ease-zoom-in ease-delay-400 good">Card 3 — ease-zoom-in (safe)</div>
+
+  <div class="note">
+    ℹ️ <strong>How it works:</strong> The inline critical CSS hides all
+    <code>[class*="ease-*"]</code> elements immediately. The JS snippet adds
+    <code>.ease-ready</code> to <code>&lt;body&gt;</code> after DOM loads,
+    which releases the animations cleanly.
+  </div>
+
+  <h3>⚠️ Without this fix (simulated)</h3>
+  <p>On slow 3G, elements appear fully visible first, then snap into animation — jarring.</p>
+  <div class="card bad" style="opacity:1;">
+    This card has no FOUC protection — it would flash visible before animating
+  </div>
+
+  <script>
+    // Update status badge
+    document.addEventListener('DOMContentLoaded', () => {
+      const s = document.getElementById('status');
+      s.textContent = '✅ ease-ready active — animations unlocked';
+      s.className = 'status ready';
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-fouc-fix/styles.css
+++ b/submissions/examples/ease-fouc-fix/styles.css
@@ -1,0 +1,36 @@
+/* =============================================================
+   FOUC (Flash of Unstyled Content) Prevention Fix
+   For EaseMotion CSS entrance animation classes
+   
+   Fixes: Elements flashing visible before CSS is parsed
+   ============================================================= */
+
+/*
+  Step 1: Hide all elements with entrance animation classes
+  by default so they don't flash visible on slow connections.
+  
+  These are overridden once the body gets the .ease-ready class
+  (added by the JS snippet below after DOM is loaded).
+*/
+body:not(.ease-ready) [class*="ease-fade"],
+body:not(.ease-ready) [class*="ease-slide"],
+body:not(.ease-ready) [class*="ease-zoom"],
+body:not(.ease-ready) [class*="ease-bounce"],
+body:not(.ease-ready) [class*="ease-flip"],
+body:not(.ease-ready) [class*="ease-rotate"] {
+  opacity: 0;
+  animation: none !important;
+}
+
+/*
+  Step 2: Once .ease-ready is on body, release all animations.
+  The transition gives a smooth "unlock" instead of a hard cut.
+*/
+body.ease-ready [class*="ease-fade"],
+body.ease-ready [class*="ease-slide"],
+body.ease-ready [class*="ease-zoom"],
+body.ease-ready [class*="ease-bounce"],
+body.ease-ready [class*="ease-flip"],
+body.ease-ready [class*="ease-rotate"] {
+  opacity: 1;
+}


### PR DESCRIPTION
Closes #7916 

## 🐛 What this fixes

On slow connections or low-end devices, elements with EaseMotion 
entrance animation classes (ease-fade-in, ease-slide-up, ease-zoom-in) 
flash fully visible before the CSS is parsed — then abruptly disappear 
and re-animate from scratch. This completely breaks the entrance effect 
and is jarring for users.

## ✅ The Fix (2-step approach)

### Step 1 — Critical inline CSS in <head>
Hides all animated elements immediately before any stylesheet loads:

body:not(.ease-ready) [class*="ease-fade"],
body:not(.ease-ready) [class*="ease-slide"],
body:not(.ease-ready) [class*="ease-zoom"] {
  opacity: 0;
  animation: none !important;
}

### Step 2 — JS adds .ease-ready to body after DOM loads
This unlocks all animations at exactly the right moment:

document.addEventListener('DOMContentLoaded', () => {
  document.body.classList.add('ease-ready');
});

## 📁 Files Added
- submissions/examples/ease-fouc-fix/style.css — FOUC guard CSS
- submissions/examples/ease-fouc-fix/demo.html — visual demo with reload button
- submissions/examples/ease-fouc-fix/README.md — usage guide for maintainers

## 🧪 How to test
1. Open submissions/examples/ease-fouc-fix/demo.html in browser
2. Open DevTools → Network → throttle to Slow 3G
3. Reload the page
4. Observe cards stay hidden until ready, then animate in cleanly — no flash

## 📌 Why this is different from existing issues
- Not related to ease-delay-* no-op (#6936)
- Not related to prefers-reduced-motion (#480)
- Not related to layout reflow (#482)
This specifically targets load-time FOUC affecting ALL entrance animation 
classes on slow connections.