### PR TITLE
fix: add contrast to animation preview boxes in light theme

### DIFF
--- a/docs/animations-preview.css
+++ b/docs/animations-preview.css
@@ -136,3 +136,21 @@
   padding: var(--ease-space-2) var(--ease-space-3);
 }
 
+/* Fix: preview boxes lack contrast in light theme */
+.animation-preview-box {
+  background: var(--code-bg) !important;
+  border: 1px solid var(--border-color) !important;
+  color: var(--page-text) !important;
+}
+
+[data-theme="light"] .animation-preview-box {
+  background: #f0f0f0 !important;
+  border: 1px solid #c0c0c0 !important;
+  color: #222222 !important;
+}
+
+[data-theme="dark"] .animation-preview-box {
+  background: #1e1e2e !important;
+  border: 1px solid #444460 !important;
+  color: #e0e0e0 !important;
+}


### PR DESCRIPTION
Fixes #7931

# Summary
Preview boxes on the Animation Preview page had no background contrast or distinct borders in Light Theme, causing them to blend into the card containers. Added explicit background, border, and text color for both light and dark themes.

## Related Issue
Fixes #7931

## Type of Change
- [x] Bug Fix

## Changes Implemented
- Added `.animation-preview-box` base styles with `var(--code-bg)` and `var(--border-color)`
- Added `[data-theme="light"]` override with explicit `#f0f0f0` background and `#c0c0c0` border
- Added `[data-theme="dark"]` override with `#1e1e2e` background and `#444460` border

## Technical Details

### Frontend
- `docs/animations-preview.css` — added theme-aware styles for `.animation-preview-box`

## Testing

### Manual Testing
- [x] Verified preview boxes are visible in light theme
- [x] Verified preview boxes look correct in dark theme

## Breaking Changes
- [x] No Breaking Changes

## Checklist
- [x] Code follows project standards
- [x] Ready for review