### PR TITLE
fix: add contrast to animation preview boxes in light theme

### DIFF
--- a/docs/animations-preview.css
+++ b/docs/animations-preview.css
@@ -136,3 +136,21 @@
   padding: var(--ease-space-2) var(--ease-space-3);
 }
 
+/* Fix: preview boxes lack contrast in light theme */
+.animation-preview-box {
+  background: var(--code-bg) !important;
+  border: 1px solid var(--border-color) !important;
+  color: var(--page-text) !important;
+}
+
+[data-theme="light"] .animation-preview-box {
+  background: #f0f0f0 !important;
+  border: 1px solid #c0c0c0 !important;
+  color: #222222 !important;
+}
+
+[data-theme="dark"] .animation-preview-box {
+  background: #1e1e2e !important;
+  border: 1px solid #444460 !important;
+  color: #e0e0e0 !important;
+}

--- a/submissions/examples/animation-preview-box-colors/README.md
+++ b/submissions/examples/animation-preview-box-colors/README.md
@@ -1,0 +1,16 @@
+# Animation Preview Box Colors Fix
+
+Fixes #7931
+
+## Problem
+On the Animation Preview page, the inner preview boxes lack adequate background contrast or distinct borders when rendering in Light Theme. This makes them blend directly into the card containers, reducing visibility.
+
+## Solution
+Added explicit background, border, and text color styles for `.animation-preview-box` in both light and dark themes using `[data-theme]` attribute selectors.
+
+## Files
+- `style.css` — theme-aware styles for `.animation-preview-box`
+- `demo.html` — interactive demo with theme toggle to see the fix in action
+
+## Usage
+Add the class `animation-preview-box` to any preview element inside an animation card. The styles will automatically adapt to the current theme.

--- a/submissions/examples/animation-preview-box-colors/demo.html
+++ b/submissions/examples/animation-preview-box-colors/demo.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Animation Preview Box Colors Demo</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+    <link rel="stylesheet" href="style.css" />
+    <script>
+      (function () {
+        var t = localStorage.getItem("em-theme") || "dark";
+        document.documentElement.setAttribute("data-theme", t);
+      })();
+    </script>
+    <style>
+      body { font-family: sans-serif; padding: 2rem; background: var(--page-bg); color: var(--page-text); }
+      .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; margin-top: 1rem; }
+      .animation-card { background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 8px; padding: 1rem; display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+      button { margin-top: 1rem; padding: 0.5rem 1rem; cursor: pointer; }
+    </style>
+  </head>
+  <body>
+    <h1>Animation Preview Box Colors</h1>
+    <p>Toggle theme to see contrast fix in action.</p>
+    <button onclick="toggleTheme()">Toggle Theme</button>
+    <div class="demo-grid">
+      <div class="animation-card"><div class="animation-preview-box ease-fade-in" style="width:80px;height:80px;display:flex;align-items:center;justify-content:center;">Fade In</div></div>
+      <div class="animation-card"><div class="animation-preview-box ease-slide-up" style="width:80px;height:80px;display:flex;align-items:center;justify-content:center;">Slide Up</div></div>
+      <div class="animation-card"><div class="animation-preview-box ease-bounce" style="width:80px;height:80px;display:flex;align-items:center;justify-content:center;">Bounce</div></div>
+      <div class="animation-card"><div class="animation-preview-box ease-rotate" style="width:80px;height:80px;display:flex;align-items:center;justify-content:center;">Rotate</div></div>
+    </div>
+    <script>
+      function toggleTheme() {
+        const html = document.documentElement;
+        const current = html.getAttribute("data-theme") || "dark";
+        const next = current === "dark" ? "light" : "dark";
+        html.setAttribute("data-theme", next);
+        localStorage.setItem("em-theme", next);
+      }
+    </script>
+  </body>
+</html>

--- a/submissions/examples/animation-preview-box-colors/style.css
+++ b/submissions/examples/animation-preview-box-colors/style.css
@@ -1,0 +1,18 @@
+/* Fix: preview boxes lack contrast in light theme */
+.animation-preview-box {
+  background: var(--code-bg) !important;
+  border: 1px solid var(--border-color) !important;
+  color: var(--page-text) !important;
+}
+
+[data-theme="light"] .animation-preview-box {
+  background: #f0f0f0 !important;
+  border: 1px solid #c0c0c0 !important;
+  color: #222222 !important;
+}
+
+[data-theme="dark"] .animation-preview-box {
+  background: #1e1e2e !important;
+  border: 1px solid #444460 !important;
+  color: #e0e0e0 !important;
+}


### PR DESCRIPTION
Fixes #7931

# Summary
Preview boxes on the Animation Preview page had no background contrast or distinct borders in Light Theme, causing them to blend into the card containers. Added explicit background, border, and text color for both light and dark themes.

## Related Issue
Fixes #7931

## Type of Change
- [x] Bug Fix

## Changes Implemented
- Added `submissions/examples/animation-preview-box-colors/style.css` with theme-aware styles for `.animation-preview-box`
- Added `submissions/examples/animation-preview-box-colors/demo.html` with interactive theme toggle demo
- Added `submissions/examples/animation-preview-box-colors/README.md` with documentation

## Technical Details

### Frontend
- `.animation-preview-box` base styles using `var(--code-bg)` and `var(--border-color)`
- `[data-theme="light"]` override with `#f0f0f0` background and `#c0c0c0` border
- `[data-theme="dark"]` override with `#1e1e2e` background and `#444460` border

## Testing

### Manual Testing
- [x] Verified preview boxes are visible in light theme
- [x] Verified preview boxes look correct in dark theme
- [x] Theme toggle works in demo.html

## Breaking Changes
- [x] No Breaking Changes

## Checklist
- [x] Code follows project standards
- [x] Ready for review