### PR TITLE
feat: add CSS-only modals and tooltips

### DIFF
--- a/submissions/examples/css-only-modals-tooltips/README.md
+++ b/submissions/examples/css-only-modals-tooltips/README.md
@@ -1,0 +1,49 @@
+# CSS-Only Modals & Tooltips
+
+Fixes #6946
+
+## Overview
+Pure CSS implementation of Modals and Tooltips with zero JavaScript, using EaseMotion CSS utility classes.
+
+## Features
+
+### Tooltips
+- Reads text directly from `data-tooltip` HTML attribute via `::after` pseudo-element
+- Smooth animated entrance with scale and translate
+- Works on any element
+
+### Modals
+- Fully functional popup dialog using CSS `:target` pseudo-class
+- Blurred backdrop via `backdrop-filter`
+- Bouncy entrance animation
+- Close via link to `#`
+
+## Usage
+
+### Tooltip
+```html
+<span class="ease-tooltip-trigger" data-tooltip="Your tooltip text">
+  <button class="ease-btn ease-btn-primary">Hover me</button>
+</span>
+```
+
+### Modal
+```html
+<a href="#my-modal" class="ease-btn ease-btn-primary">Open Modal</a>
+
+<div id="my-modal" class="ease-modal-overlay">
+  <div class="ease-modal-content">
+    <a href="#" class="ease-modal-close-icon">&times;</a>
+    <h3>Modal Title</h3>
+    <p>Modal content here.</p>
+    <a href="#" class="ease-btn ease-btn-outline">Close</a>
+  </div>
+</div>
+```
+
+## Files
+- `style.css` — tooltip and modal styles
+- `demo.html` — interactive demo with multiple tooltips and modals
+
+## No JavaScript Required
+Both components rely entirely on CSS pseudo-classes and pseudo-elements.

--- a/submissions/examples/css-only-modals-tooltips/demo.html
+++ b/submissions/examples/css-only-modals-tooltips/demo.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS-Only Modals & Tooltips</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body { font-family: sans-serif; padding: 3rem 2rem; background: var(--page-bg, #f8fafc); color: var(--page-text, #1e293b); }
+      h1 { margin-bottom: 0.5rem; }
+      h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+      .demo-row { display: flex; gap: 1rem; flex-wrap: wrap; align-items: center; margin-top: 1rem; }
+    </style>
+  </head>
+  <body>
+    <h1>CSS-Only Modals & Tooltips</h1>
+    <p>Zero JavaScript. Powered by <code>:target</code> and <code>::after</code> pseudo-elements.</p>
+
+    <h2>Tooltips</h2>
+    <div class="demo-row">
+      <span class="ease-tooltip-trigger" data-tooltip="This is an info tooltip!">
+        <button class="ease-btn ease-btn-primary">Hover me</button>
+      </span>
+      <span class="ease-tooltip-trigger" data-tooltip="Delete this item?">
+        <button class="ease-btn ease-btn-danger">Danger action</button>
+      </span>
+      <span class="ease-tooltip-trigger" data-tooltip="Settings panel">
+        <button class="ease-btn ease-btn-outline">Settings</button>
+      </span>
+    </div>
+
+    <h2>Modals</h2>
+    <div class="demo-row">
+      <a href="#confirm-modal" class="ease-btn ease-btn-success">Open Confirm Modal</a>
+      <a href="#info-modal" class="ease-btn ease-btn-primary">Open Info Modal</a>
+    </div>
+
+    <!-- Confirm Modal -->
+    <div id="confirm-modal" class="ease-modal-overlay">
+      <div class="ease-modal-content">
+        <a href="#" class="ease-modal-close-icon">&times;</a>
+        <h3>Are you sure?</h3>
+        <p>This action cannot be undone.</p>
+        <div style="display:flex; gap:0.75rem; margin-top:1.5rem;">
+          <a href="#" class="ease-btn ease-btn-danger">Confirm</a>
+          <a href="#" class="ease-btn ease-btn-outline">Cancel</a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Info Modal -->
+    <div id="info-modal" class="ease-modal-overlay">
+      <div class="ease-modal-content">
+        <a href="#" class="ease-modal-close-icon">&times;</a>
+        <h3>Information</h3>
+        <p>This modal uses the CSS <code>:target</code> pseudo-class — no JavaScript needed!</p>
+        <div style="margin-top:1.5rem;">
+          <a href="#" class="ease-btn ease-btn-primary">Got it</a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/css-only-modals-tooltips/style.css
+++ b/submissions/examples/css-only-modals-tooltips/style.css
@@ -1,0 +1,95 @@
+/* ====================================================
+   CSS-Only Tooltips
+   ==================================================== */
+.ease-tooltip-trigger {
+  position: relative;
+  display: inline-flex;
+}
+
+.ease-tooltip-trigger::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(10px) scale(0.95);
+  background-color: var(--ease-text-color, #1e293b);
+  color: #ffffff;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  margin-bottom: 0.5rem;
+  z-index: 999;
+}
+
+.ease-tooltip-trigger:hover::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0) scale(1);
+}
+
+/* ====================================================
+   CSS-Only Modals (Using :target pseudo-class)
+   ==================================================== */
+.ease-modal-overlay {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100vw; height: 100vh;
+  background-color: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 1000;
+}
+
+.ease-modal-content {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 1rem;
+  width: 90%;
+  max-width: 28rem;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+  transform: scale(0.95) translateY(1rem);
+  opacity: 0;
+  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-modal-overlay:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.ease-modal-overlay:target .ease-modal-content {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+}
+
+.ease-modal-close-icon {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 1.5rem;
+  color: #64748b;
+  text-decoration: none;
+  line-height: 1;
+}
+
+.ease-modal-close-icon:hover {
+  color: #1e293b;
+}
+
+.ease-modal-content {
+  position: relative;
+}


### PR DESCRIPTION
Fixes #6946

# Summary
Implemented CSS-Only Modals and Tooltips with zero JavaScript. Tooltips use the `::after` pseudo-element reading from `data-tooltip` attribute. Modals use the CSS `:target` pseudo-class with a blurred backdrop and bouncy entrance animation.

## Related Issue
Fixes #6946

## Type of Change
- [x] Feature

## Changes Implemented
- Added `.ease-tooltip-trigger` with `::after` pseudo-element that reads from `data-tooltip`
- Added `.ease-modal-overlay` and `.ease-modal-content` using `:target` pseudo-class
- Smooth animated entrance/exit for both components
- Created `demo.html` with multiple tooltip and modal examples
- Created `README.md` with usage documentation

## Technical Details

### Frontend
- `submissions/examples/css-only-modals-tooltips/style.css` — tooltip and modal styles
- `submissions/examples/css-only-modals-tooltips/demo.html` — interactive demo
- `submissions/examples/css-only-modals-tooltips/README.md` — documentation

### Tooltips
- Uses `::after` with `content: attr(data-tooltip)`
- Animated with `opacity`, `visibility`, `transform` transition

### Modals
- Uses `:target` pseudo-class — zero JS
- `backdrop-filter: blur(4px)` for blurred overlay
- Bouncy entrance via `cubic-bezier(0.34, 1.56, 0.64, 1)`

## Testing

### Manual Testing
- [x] Tooltip appears on hover
- [x] Modal opens on link click
- [x] Modal closes on close icon click
- [x] No JavaScript used

## Breaking Changes
- [x] No Breaking Changes

## Checklist
- [x] Code follows project standards
- [x] Files placed inside `submissions/examples/` only
- [x] Ready for review