### PR TITLE
feat: add pure CSS skeleton shimmer loader

### DIFF
--- a/submissions/examples/skeleton-shimmer-loaderss/README.md
+++ b/submissions/examples/skeleton-shimmer-loaderss/README.md
@@ -1,0 +1,37 @@
+# Skeleton Shimmer Loader
+
+## What does this do?
+Placeholder loading blocks with a left-to-right shimmer sweep — 
+like Facebook or YouTube's loading states. Zero JavaScript.
+
+## How is it used?
+Add `.skeleton` to any block element, then layer in variants:
+
+```html
+<!-- Avatar + text lines -->
+<div class="skeleton-card">
+  <div class="skeleton-row">
+    <div class="skeleton skeleton-avatar"></div>
+    <div class="skeleton-lines">
+      <div class="skeleton skeleton-line skeleton-line-full"></div>
+      <div class="skeleton skeleton-line skeleton-line-md"></div>
+    </div>
+  </div>
+</div>
+```
+
+Variants:
+- Shape: `skeleton-avatar`, `skeleton-image`, `skeleton-line`
+- Width: `skeleton-line-sm`, `skeleton-line-md`, `skeleton-line-full`
+- Speed: `shimmer-slow`, `shimmer-fast`
+
+## Why is it useful?
+Skeleton loaders are a standard loading UX pattern. Pure CSS keeps
+it lightweight — no JavaScript or dependencies needed.
+
+## Tech Stack
+- HTML
+- CSS only (`@keyframes`, `linear-gradient`, `::after`)
+
+## Preview
+Open `demo.html` directly in your browser.

--- a/submissions/examples/skeleton-shimmer-loaderss/demo.html
+++ b/submissions/examples/skeleton-shimmer-loaderss/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Skeleton Shimmer Loader Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2.5rem;
+      font-family: sans-serif;
+      background: #f4f5f7;
+      padding: 2rem;
+    }
+
+    h3 {
+      margin: 0 0 0.75rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #888;
+    }
+
+    section {
+      width: 100%;
+      max-width: 360px;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Demo 1: Post card with avatar -->
+  <section>
+    <h3>Post Card</h3>
+    <div class="skeleton-card">
+      <div class="skeleton-row">
+        <div class="skeleton skeleton-avatar"></div>
+        <div class="skeleton-lines">
+          <div class="skeleton skeleton-line skeleton-line-full"></div>
+          <div class="skeleton skeleton-line skeleton-line-md"></div>
+        </div>
+      </div>
+      <div class="skeleton skeleton-image"></div>
+      <div class="skeleton skeleton-line skeleton-line-full"></div>
+      <div class="skeleton skeleton-line skeleton-line-sm"></div>
+    </div>
+  </section>
+
+  <!-- Demo 2: Text block -->
+  <section>
+    <h3>Text Block</h3>
+    <div class="skeleton-card">
+      <div class="skeleton skeleton-line skeleton-line-full"></div>
+      <div class="skeleton skeleton-line skeleton-line-full"></div>
+      <div class="skeleton skeleton-line skeleton-line-md"></div>
+      <div class="skeleton skeleton-line skeleton-line-sm"></div>
+    </div>
+  </section>
+
+  <!-- Demo 3: Slow speed variant -->
+  <section>
+    <h3>Slow Shimmer Variant</h3>
+    <div class="skeleton-card">
+      <div class="skeleton-row">
+        <div class="skeleton skeleton-avatar skeleton-avatar-lg shimmer-slow"></div>
+        <div class="skeleton-lines">
+          <div class="skeleton skeleton-line skeleton-line-full shimmer-slow"></div>
+          <div class="skeleton skeleton-line skeleton-line-md shimmer-slow"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/skeleton-shimmer-loaderss/style.css
+++ b/submissions/examples/skeleton-shimmer-loaderss/style.css
@@ -1,0 +1,92 @@
+/* Skeleton Shimmer Loader — pure CSS */
+
+/* Base skeleton block */
+.skeleton {
+  background: #e5e7eb;
+  border-radius: 6px;
+  position: relative;
+  overflow: hidden;
+}
+
+/* The shimmer sweep using a pseudo-element */
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.6) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: shimmer 1.6s infinite ease-in-out;
+}
+
+@keyframes shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+/* Avatar circle */
+.skeleton-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skeleton-avatar-lg {
+  width: 72px;
+  height: 72px;
+}
+
+/* Text line variants */
+.skeleton-line {
+  height: 14px;
+  border-radius: 4px;
+  width: 100%;
+}
+
+.skeleton-line-sm  { width: 40%; }
+.skeleton-line-md  { width: 65%; }
+.skeleton-line-full { width: 100%; }
+
+/* Image / banner block */
+.skeleton-image {
+  width: 100%;
+  height: 180px;
+  border-radius: 8px;
+}
+
+/* Card wrapper */
+.skeleton-card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: 320px;
+}
+
+/* Row layout for avatar + lines side by side */
+.skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.skeleton-lines {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* Speed variants */
+.shimmer-slow::after { animation-duration: 2.4s; }
+.shimmer-fast::after { animation-duration: 0.9s; }


### PR DESCRIPTION
## Summary
Adds a pure CSS skeleton shimmer loader — placeholder loading blocks
with a left-to-right shimmer sweep using `linear-gradient` on a
`::after` pseudo-element animated with `@keyframes`. Zero JavaScript.

## Files Added
- `style.css` — shimmer animation, shape variants, speed modifiers
- `demo.html` — post card, text block, and slow-variant demos
- `README.md` — usage instructions and code snippet

## What's included
- Base `.skeleton` class + shimmer sweep animation
- Shape variants: avatar (circle), image block, text lines
- Width variants: `sm`, `md`, `full`
- Speed modifiers: `shimmer-slow`, `shimmer-fast`

## Testing
- [ ] Verified in Chrome
- [ ] Verified in Firefox
- [ ] All three demo variants shimmer correctly

Closes #7964 