### PR TITLE
feat: add notification badge submission

### DIFF
--- a/submissions/examples/notification-badge-sb/README.md
+++ b/submissions/examples/notification-badge-sb/README.md
@@ -1,0 +1,15 @@
+# Notification Badge Dots
+
+A self-contained badge component for icons in navbars, inboxes, and task bars.
+
+## Features
+
+- Supports numeric badges and empty pulse dots.
+- Uses a reusable `.ease-notif-wrapper` around icon buttons.
+- Includes a pulsing animation for alert states.
+- Keeps contrast readable with a clipped badge outline.
+- Stacks cleanly on smaller screens and respects reduced motion.
+
+## Usage
+
+Open `demo.html` to preview the badge variants. Add `.ease-notif-dot.count` for numeric alerts and `.ease-notif-dot.pulse` for an empty attention dot.

--- a/submissions/examples/notification-badge-sb/demo.html
+++ b/submissions/examples/notification-badge-sb/demo.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notification Badge</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="badge-title">
+        <p class="eyebrow">Attention indicator</p>
+        <h1 id="badge-title">Notification badge dots</h1>
+        <p class="intro">
+          Count badges and empty pulse dots for navbar icons, inbox actions, and
+          mobile alerts.
+        </p>
+
+        <div class="badge-grid">
+          <div class="ease-notif-wrapper">
+            <button type="button" aria-label="Notifications">🔔</button>
+            <span class="ease-notif-dot count">3</span>
+          </div>
+
+          <div class="ease-notif-wrapper">
+            <button type="button" aria-label="Messages">💬</button>
+            <span class="ease-notif-dot pulse" aria-hidden="true"></span>
+          </div>
+
+          <div class="ease-notif-wrapper">
+            <button type="button" aria-label="Tasks">✅</button>
+            <span class="ease-notif-dot count">12</span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/notification-badge-sb/style.css
+++ b/submissions/examples/notification-badge-sb/style.css
@@ -1,0 +1,174 @@
+:root {
+  --badge-bg: #f8fafc;
+  --badge-surface: #ffffff;
+  --badge-text: #111827;
+  --badge-muted: #64748b;
+  --badge-border: #dbe4f0;
+  --badge-primary: #2563eb;
+  --badge-alert: #ef4444;
+  --badge-focus: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--badge-text);
+  background:
+    radial-gradient(
+      circle at 18% 16%,
+      rgba(37, 99, 235, 0.18),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f8fafc 0%, #ecfeff 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 42rem);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--badge-primary);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 34rem;
+  margin: 1rem 0 2rem;
+  color: var(--badge-muted);
+  line-height: 1.7;
+}
+
+.badge-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.ease-notif-wrapper {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 8rem;
+  border: 1px solid var(--badge-border);
+  border-radius: 1.1rem;
+  background: var(--badge-bg);
+}
+
+.ease-notif-wrapper button {
+  display: grid;
+  width: 4rem;
+  height: 4rem;
+  place-items: center;
+  border: 0;
+  border-radius: 999px;
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--badge-primary), #0f172a);
+  cursor: pointer;
+  font: inherit;
+  font-size: 1.4rem;
+  box-shadow: 0 14px 30px rgba(37, 99, 235, 0.24);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.ease-notif-wrapper button:hover {
+  transform: translateY(-2px);
+}
+
+.ease-notif-wrapper button:focus-visible {
+  outline: 3px solid var(--badge-focus);
+  outline-offset: 4px;
+}
+
+.ease-notif-dot {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+  display: grid;
+  place-items: center;
+}
+
+.ease-notif-dot.count {
+  min-width: 1.3rem;
+  min-height: 1.3rem;
+  padding: 0 0.35rem;
+  border: 2px solid var(--badge-surface);
+  border-radius: 999px;
+  color: #ffffff;
+  background: var(--badge-alert);
+  font-size: 0.72rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.ease-notif-dot.pulse {
+  width: 0.8rem;
+  height: 0.8rem;
+  border: 2px solid var(--badge-surface);
+  border-radius: 50%;
+  background: var(--badge-alert);
+  box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4);
+  animation: badge-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes badge-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.45);
+  }
+
+  50% {
+    box-shadow: 0 0 0 0.65rem rgba(239, 68, 68, 0);
+  }
+}
+
+@media (max-width: 700px) {
+  .badge-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-notif-wrapper button {
+    transition: none;
+  }
+
+  .ease-notif-dot.pulse {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained notification badge demo under submissions/examples/notification-badge-sb
- include numeric count badges and a pulsing empty dot variant
- keep the component accessible with focus states and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/notification-badge-sb/demo.html submissions/examples/notification-badge-sb/style.css submissions/examples/notification-badge-sb/README.md
- git diff --cached --check

Closes #6268