### PR TITLE
feat: add scroll-driven text highlight sweep

### DIFF
--- a/submissions/examples/scroll-highlight-sweep/README.md
+++ b/submissions/examples/scroll-highlight-sweep/README.md
@@ -1,0 +1,20 @@
+# ease-scroll-highlight
+
+Scroll-driven text highlight sweep for editorial copy and landing pages.
+
+## Classes
+
+| Class | Description |
+| --- | --- |
+| `ease-scroll-highlight` | Inline marker that sweeps in as it enters the viewport |
+| `focus-reveal` | Content reveal class for headings and lead text |
+
+## Usage
+
+```html
+<p>
+  EaseMotion CSS is
+  <mark class="ease-scroll-highlight">animation-first without being flashy</mark>
+  and stays readable when motion is reduced.
+</p>
+```

--- a/submissions/examples/scroll-highlight-sweep/demo.html
+++ b/submissions/examples/scroll-highlight-sweep/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-scroll-highlight - Scroll-Driven Text Highlight Sweep</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page-shell">
+    <section class="hero-panel">
+      <p class="eyebrow">EaseMotion CSS</p>
+      <h1>Scroll-Driven Text Highlight Sweep</h1>
+      <p class="lede">
+        A pure CSS editorial highlight that feels like a digital marker moving across
+        the page as the reader scrolls. It keeps the layout readable, crisp, and
+        accessible when motion is reduced or unsupported.
+      </p>
+    </section>
+
+    <section class="story-layout" aria-label="Highlight demo">
+      <article class="story-card">
+        <p class="story-kicker">Use case</p>
+        <h2 class="focus-reveal">Designed for docs, landing pages, and long-form feature copy.</h2>
+        <p class="focus-copy">
+          EaseMotion CSS is a human-readable design language built on a simple belief:
+          <mark class="ease-scroll-highlight" style="--hl-color: rgba(56, 189, 248, 0.28);">if you can say it in English,</mark>
+          you should be able to write it as a class. The sweep lands as the phrase enters
+          the middle of the viewport, then settles into a clean static highlight.
+        </p>
+      </article>
+
+      <aside class="signal-panel">
+        <div class="signal-chip">entry 20%</div>
+        <div class="signal-chip">view()</div>
+        <div class="signal-chip">entry 70%</div>
+        <p>
+          Supported browsers animate the marker in place. Browsers without scroll
+          timelines simply render the highlight statically so the copy stays readable.
+        </p>
+      </aside>
+    </section>
+
+    <section class="article-grid">
+      <article class="note-card focus-reveal">
+        <h3>Marker sweep</h3>
+        <p>
+          The background fill expands from left to right, making the highlighted phrase
+          feel like it is being marked in real time.
+        </p>
+      </article>
+
+      <article class="note-card focus-reveal">
+        <h3>Editorial pacing</h3>
+        <p>
+          The surrounding text stays calm and steady, so the reader's eye naturally lands
+          on the emphasized sentence without layout jumps.
+        </p>
+      </article>
+
+      <article class="note-card focus-reveal">
+        <h3>Reduced motion safe</h3>
+        <p>
+          When motion is reduced, the sweep stays visible as a static highlight and the
+          text keeps its original scale and clarity.
+        </p>
+      </article>
+    </section>
+
+    <section class="article-panel">
+      <p class="focus-copy">
+        Scroll until the phrase
+        <mark class="ease-scroll-highlight" style="--hl-color: rgba(251, 191, 36, 0.3);">animation-first without being flashy</mark>
+        enters the viewport and the highlight glides across the line. The result feels
+        close to a magazine marker, but it remains CSS-only and lightweight.
+      </p>
+      <p class="focus-copy">
+        The component is intentionally composable. You can drop the highlight class on a
+        single word, a short clause, or an entire sentence, and the sweep will still keep
+        the typography readable.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/scroll-highlight-sweep/style.css
+++ b/submissions/examples/scroll-highlight-sweep/style.css
@@ -1,0 +1,248 @@
+:root {
+  color-scheme: dark;
+  --bg: #060b16;
+  --panel: rgba(12, 18, 34, 0.9);
+  --panel-strong: rgba(14, 24, 43, 0.98);
+  --border: rgba(148, 163, 184, 0.16);
+  --text: #e5eefc;
+  --muted: #8ea1c4;
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.12);
+  --shadow: 0 24px 70px rgba(0, 0, 0, 0.34);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  background:
+    linear-gradient(180deg, #0a1020 0%, #060b16 100%);
+  color: var(--text);
+  line-height: 1.6;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.page-shell {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(1rem, 2.5vw, 1.5rem);
+}
+
+.hero-panel,
+.story-card,
+.signal-panel,
+.note-card,
+.article-panel {
+  border: 1px solid var(--border);
+  background: linear-gradient(180deg, var(--panel), rgba(9, 14, 26, 0.88));
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+}
+
+.hero-panel {
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+.eyebrow,
+.story-kicker {
+  margin: 0 0 0.5rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(2rem, 6vw, 4.5rem);
+  line-height: 0.98;
+  letter-spacing: -0.04em;
+  max-width: 12ch;
+}
+
+.lede {
+  margin: 0;
+  max-width: 64ch;
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.15rem);
+}
+
+.story-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(290px, 0.9fr);
+  gap: clamp(1rem, 2vw, 1.25rem);
+}
+
+.story-card,
+.signal-panel,
+.note-card,
+.article-panel {
+  padding: clamp(1.1rem, 2.5vw, 1.5rem);
+}
+
+.focus-reveal,
+.note-card h3 {
+  margin-bottom: 0.65rem;
+  letter-spacing: -0.03em;
+}
+
+.focus-reveal {
+  font-size: clamp(1.5rem, 3vw, 2.4rem);
+  line-height: 1.08;
+  transform-origin: center left;
+}
+
+.focus-copy,
+.signal-panel p,
+.note-card p {
+  margin-bottom: 0;
+  color: #c5d0ea;
+  font-size: 1rem;
+}
+
+.ease-scroll-highlight {
+  display: inline;
+  padding: 0 0.18em;
+  border-radius: 0.25rem;
+  color: inherit;
+  background-image: linear-gradient(
+    120deg,
+    var(--hl-color, rgba(56, 189, 248, 0.28)) 0%,
+    var(--hl-color, rgba(56, 189, 248, 0.28)) 100%
+  );
+  background-repeat: no-repeat;
+  background-position: 0 100%;
+  background-size: 0% 0.88em;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  will-change: background-size;
+}
+
+.signal-panel {
+  display: grid;
+  align-content: start;
+  gap: 0.8rem;
+  background: linear-gradient(180deg, rgba(9, 16, 31, 0.98), rgba(14, 24, 43, 0.92));
+}
+
+.signal-chip {
+  width: fit-content;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.22);
+  background: rgba(56, 189, 248, 0.08);
+  color: #dff6ff;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.article-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(1rem, 2vw, 1.25rem);
+}
+
+.note-card {
+  min-height: 100%;
+}
+
+.note-card h3 {
+  font-size: 1.2rem;
+}
+
+.article-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.article-panel .focus-copy:last-child {
+  color: #e6edf8;
+}
+
+@supports (animation-timeline: view()) {
+  .focus-reveal,
+  .ease-scroll-highlight {
+    animation-duration: 1s;
+    animation-fill-mode: both;
+    animation-timing-function: linear;
+    animation-timeline: view();
+  }
+
+  .focus-reveal {
+    animation-name: ease-kf-focus-reveal;
+    animation-range: entry 15% entry 65%;
+  }
+
+  .ease-scroll-highlight {
+    animation-name: ease-kf-highlight-sweep;
+    animation-range: entry 20% entry 75%;
+  }
+}
+
+@keyframes ease-kf-focus-reveal {
+  from {
+    opacity: 0.22;
+    filter: blur(14px);
+    transform: translateY(16px) scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ease-kf-highlight-sweep {
+  from {
+    background-size: 0% 0.88em;
+  }
+
+  to {
+    background-size: 100% 0.88em;
+  }
+}
+
+@media (max-width: 920px) {
+  .story-layout,
+  .article-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    max-width: 14ch;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .focus-reveal,
+  .ease-scroll-highlight {
+    animation: none !important;
+    transition: none !important;
+    filter: none !important;
+    transform: none !important;
+  }
+
+  .ease-scroll-highlight {
+    background-size: 100% 0.88em;
+  }
+}


### PR DESCRIPTION
Summary
- Add a scroll-driven editorial highlight sweep component for inline text and headings
- Include viewport-timeline reveal states plus reduced-motion fallback
- Provide a small demo page and usage notes under submissions/examples/scroll-highlight-sweep

Validation
- git diff --check
- Playwright render check against http://127.0.0.1:8000/submissions/examples/scroll-highlight-sweep/demo.html

Closes #6112