### PR TITLE
 bug/fix: Resolve cross-browser grid frame overflow and text truncation ellipsis failure 

### DIFF
--- a/submissions/examples/text-overflow-collapse/README.md
+++ b/submissions/examples/text-overflow-collapse/README.md
@@ -1,0 +1,53 @@
+# EaseMotion Grid Frame Overflow & Text Truncation Ellipsis Guard
+
+This example demonstrates how to resolve cross-browser grid frame overflow and text truncation ellipsis computation failure inside fluid layouts.
+
+## 🐛 The Bug: Grid Track Expansion & Ellipsis Failure
+
+When working with CSS Grid layouts (e.g., `grid-template-columns: repeat(3, 1fr)`), columns can overflow their parent container or push out of alignment when populated with long, non-wrapping text strings.
+
+Even if the text elements have truncation styles applied:
+
+```css
+overflow: hidden;
+text-overflow: ellipsis;
+white-space: nowrap;
+```
+
+The truncation will fail and the columns will expand. This happens because:
+
+1. **Implicit Minimum Track Size**: The `1fr` unit in CSS Grid is a shorthand for `minmax(auto, 1fr)`. The default `auto` behavior resolves to the minimum width of the cell's content. If the content contains an unbroken string of text, the browser layout engine expands the grid track to accommodate the text width instead of truncating it.
+2. **Missing Card Sizing Context**: Grid items need to be allowed to shrink. Without setting an explicit minimum size (`min-width: 0` or `overflow: hidden`) on the direct grid items, the layout engine cannot establish standard boundaries to calculate text limits.
+
+```css
+/* ❌ Bugged state: implicit minmax auto behavior splits column integrity */
+.bugged-grid-layout {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+```
+
+## 🛠️ The Solution: Stabilized Grid Column Guard
+
+To stabilize columns and force text truncation ellipsis:
+
+1. **`minmax(0, 1fr)`**: Replaces `1fr` inside `grid-template-columns`. The minimum bound of `0` overrides the browser's default `auto` minimum content sizing, permitting grid tracks to shrink below their contents.
+2. **`min-width: 0` (On Card Element)**: Applied to the direct child elements of the grid tracks. This enables the grid cells to contract alongside the grid column track, creating a stable box context so that the text node's `text-overflow: ellipsis` rules can trigger.
+
+```css
+/* ✅ Guarded Grid Track */
+.ease-grid-layout {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+/* ✅ Guarded Card element */
+.ease-grid-card {
+  min-width: 0;
+}
+```
+
+## 📁 Files Created
+
+- [style.css](file:///C:/Users/Fujitsu/.gemini/antigravity/scratch/EaseMotion-css/submissions/examples/text-overflow-collapse/style.css) — Custom stylesheet containing root variables, grid layouts, and ellipsis guard classes.
+- [demo.html](file:///C:/Users/Fujitsu/.gemini/antigravity/scratch/EaseMotion-css/submissions/examples/text-overflow-collapse/demo.html) — Side-by-side comparison illustrating bugged grid overflow vs. guarded layout.

--- a/submissions/examples/text-overflow-collapse/demo.html
+++ b/submissions/examples/text-overflow-collapse/demo.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>
+      EaseMotion CSS — Grid Overflow & Text Truncation Ellipsis Demo
+    </title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <div class="ease-dashboard-container">
+      <header class="ease-header">
+        <h1>Grid Overflow & Text Truncation Ellipsis</h1>
+        <p>
+          Resize your screen to see how grid layouts behave under text
+          truncation stress. Long continuous strings push columns out of bounds
+          in the bugged layout, while the guarded layout stabilizes tracks and
+          truncates text cleanly.
+        </p>
+      </header>
+
+      <div class="comparison-grid">
+        <!-- ❌ Bugged Demonstration -->
+        <section class="comparison-section">
+          <span class="column-badge bugged"
+            >Bugged Layout (Implicit Track Sizing)</span
+          >
+
+          <div class="bugged-grid-layout">
+            <div class="ease-grid-card">
+              <h3>Card Title 01</h3>
+              <p class="bugged-text-ellipsis">
+                ThisIsAnExtremelyLongContinuousStringOfTextWithoutAnySpacesDesignedToForceTheBrowserGridTrackToExpandInsteadOfTruncatingWithAnEllipsis.
+              </p>
+            </div>
+            <div class="ease-grid-card">
+              <h3>Card Title 02</h3>
+              <p class="bugged-text-ellipsis">Short description here.</p>
+            </div>
+            <div class="ease-grid-card">
+              <h3>Card Title 03</h3>
+              <p class="bugged-text-ellipsis">Short description here.</p>
+            </div>
+          </div>
+
+          <div class="explanation-card">
+            <strong>Issue:</strong> The grid columns are set to
+            <code>repeat(3, 1fr)</code>. Because <code>1fr</code> defaults to
+            <code>minmax(auto, 1fr)</code>, the column track expands
+            horizontally to fit the minimum content width of the un-truncated
+            string, breaking the grid boundaries.
+          </div>
+        </section>
+
+        <!-- ✅ Patched/Guarded Demonstration -->
+        <section class="comparison-section">
+          <span class="column-badge fixed"
+            >Guarded Layout (Stabilized Track Sizing)</span
+          >
+
+          <div class="ease-grid-layout">
+            <div class="ease-grid-card">
+              <h3>Card Title 01</h3>
+              <p class="ease-ellipsis-shield">
+                ThisIsAnExtremelyLongContinuousStringOfTextWithoutAnySpacesDesignedToForceTheBrowserGridTrackToExpandInsteadOfTruncatingWithAnEllipsis.
+              </p>
+            </div>
+            <div class="ease-grid-card">
+              <h3>Card Title 02</h3>
+              <p class="ease-ellipsis-shield">Short description here.</p>
+            </div>
+            <div class="ease-grid-card">
+              <h3>Card Title 03</h3>
+              <p class="ease-ellipsis-shield">Short description here.</p>
+            </div>
+          </div>
+
+          <div class="explanation-card">
+            <strong>Solution:</strong> The columns are defined using
+            <code>repeat(3, minmax(0, 1fr))</code>. This establishes a maximum
+            track constraint of <code>0</code> minimum width, allowing the grid
+            item to compress, calculate text boundaries, and render ellipsis
+            truncations cleanly.
+          </div>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/text-overflow-collapse/style.css
+++ b/submissions/examples/text-overflow-collapse/style.css
@@ -1,0 +1,179 @@
+/* ==========================================================================
+   EaseMotion Grid Frame Overflow & Text Truncation Ellipsis Patch
+   ========================================================================== */
+
+:root {
+  --ease-overflow-bg: #030407;
+  --ease-panel-dark: #0d0f16;
+  --ease-accent-alert: #ff4a5a;
+  --ease-accent-fixed: #00e676;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background-color: var(--ease-overflow-bg);
+  color: #ffffff;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+/* Base Analytical Dashboard Card Grid Layout */
+.ease-dashboard-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  width: 100%;
+  max-width: 960px;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+/* Section Header */
+.ease-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.ease-header h1 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  margin: 0 0 0.75rem 0;
+  background: linear-gradient(135deg, #ffffff 0%, #a5b4fc 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.ease-header p {
+  color: #94a3b8;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Comparison View Wrapper */
+.comparison-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+  width: 100%;
+}
+
+.comparison-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.column-badge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.35rem 0.85rem;
+  border-radius: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  align-self: flex-start;
+}
+
+.column-badge.bugged {
+  background-color: rgba(255, 74, 90, 0.15);
+  color: var(--ease-accent-alert);
+}
+
+.column-badge.fixed {
+  background-color: rgba(0, 230, 118, 0.15);
+  color: var(--ease-accent-fixed);
+}
+
+/* ❌ Janky Bugged Grid Layout (grid tracks expand to content width, breaking columns) */
+.bugged-grid-layout {
+  display: grid;
+  grid-template-columns: repeat(
+    3,
+    1fr
+  ); /* 1fr has an implicit minmax(auto, 1fr) */
+  gap: 1.5rem;
+  width: 100%;
+  background: rgba(255, 74, 90, 0.02);
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px dashed var(--ease-accent-alert);
+  box-sizing: border-box;
+}
+
+/* 🚀 The Core Patched Balanced Grid Layout */
+.ease-grid-layout {
+  display: grid;
+  grid-template-columns: repeat(
+    3,
+    minmax(0, 1fr)
+  ); /* Crucial Fix 1: Hard-locks min column width to 0 */
+  gap: 1.5rem;
+  width: 100%;
+  background: rgba(0, 230, 118, 0.02);
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid var(--ease-accent-fixed);
+  box-sizing: border-box;
+}
+
+/* Base Card Item Styling */
+.ease-grid-card {
+  background: var(--ease-panel-dark);
+  padding: 1.25rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  /* Crucial Fix 2: Prevent flex/grid item layout overflow loops inside cells */
+  min-width: 0;
+}
+
+.ease-grid-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #f1f5f9;
+}
+
+/* ❌ Janky Bugged Ellipsis Node */
+.bugged-text-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #94a3b8;
+  font-size: 0.875rem;
+  margin: 0;
+  /* Missing container constraints, will fail to truncate if grid cell expands */
+}
+
+/* 🚀 The Core Patched Ellipsis Shield Class */
+.ease-ellipsis-shield {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #94a3b8;
+  font-size: 0.875rem;
+  margin: 0;
+  /* Stable ellipsis presentation under correct track constraints */
+}
+
+.explanation-card {
+  background: var(--ease-panel-dark);
+  padding: 1rem 1.25rem;
+  border-radius: 10px;
+  font-size: 0.825rem;
+  line-height: 1.5;
+  color: #94a3b8;
+  border: 1px solid rgba(255, 255, 255, 0.03);
+  box-sizing: border-box;
+}


### PR DESCRIPTION
### Target Issue
Closes #7974

### Description
Introduced an isolated horizontal layout fix—the Truncation Box Containment Guard—under the isolated examples layout structure. This patch resolves responsive layout overflow glitches where flexible parents expand and bleed past grid boxes due to standard line truncation calculation crashes.

- **Explicit Dimensional Overrides:** Implements `min-width: 0` rules onto component layout wrappers to mandate text boundaries.
- **Ellipsis Calculation Shield:** Stabilizes typography strings securely via single-line typography layers without breaking parent card ratios.
- **Autonomous Subfolder Execution:** Sandboxed 100% inside `submissions/examples/text-overflow-collapse/` ensuring zero global noise.

### Checklist
- [x] Code strictly adheres to the isolated subfolder architecture constraints (`submissions/examples/...`)
- [x] Sandboxed workspace features independent `demo.html`, `style.css`, and `README.md` assets
- [x] Prettier codebase linting and formatting pass with zero errors