### PR TITLE
feat: add display-contents CSS utility submission

### DIFF
--- a/submissions/examples/display-contents-zt/README.md
+++ b/submissions/examples/display-contents-zt/README.md
@@ -1,0 +1,7 @@
+# Display Contents Utility
+
+1. What does this do? Removes the element's box from the layout while keeping its children in the normal flow — useful for grid/flex layouts where a wrapping element would otherwise break alignment.
+
+2. How is it used? Apply `.display-contents-zt` to a wrapper element inside a grid or flex container.
+
+3. Why is it useful? It solves the common problem of wrapper elements disrupting CSS grid or flexbox layouts without requiring HTML restructuring.

--- a/submissions/examples/display-contents-zt/demo.html
+++ b/submissions/examples/display-contents-zt/demo.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Display Contents Demo</title>
+    <link rel="stylesheet" href="./style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        padding: 2rem;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1rem;
+      }
+      .card {
+        background: #f1f5f9;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        border: 1px solid #e2e8f0;
+      }
+      .card h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1rem;
+      }
+      .wrapper {
+        background: #fef9c3;
+        padding: 0.5rem;
+        border-radius: 0.25rem;
+        font-size: 0.8rem;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Without display: contents</h2>
+    <p><small>The wrapper element breaks the grid layout</small></p>
+    <div class="grid">
+      <div class="card"><h3>Card 1</h3></div>
+      <div class="wrapper">
+        <div class="card"><h3>Card 2 (wrapped)</h3></div>
+      </div>
+      <div class="card"><h3>Card 3</h3></div>
+    </div>
+
+    <h2 style="margin-top: 2rem">With display: contents</h2>
+    <p>
+      <small
+        >The wrapper is invisible to the grid; children act as direct grid
+        items</small
+      >
+    </p>
+    <div class="grid">
+      <div class="card"><h3>Card A</h3></div>
+      <div class="wrapper display-contents-zt">
+        <div class="card"><h3>Card B (contents)</h3></div>
+      </div>
+      <div class="card"><h3>Card C</h3></div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/display-contents-zt/style.css
+++ b/submissions/examples/display-contents-zt/style.css
@@ -1,0 +1,3 @@
+.display-contents-zt {
+  display: contents;
+}


### PR DESCRIPTION
## Summary

Adds a submission for a  CSS utility class that removes an element's box from layout while keeping children in the normal flow. Especially useful for grid/flexbox layouts.

### Files
- 
- 
- 

Closes #7990

gssoc26