### PR TITLE
feat: add initial-letter drop cap submission using native CSS initial-letter property

### DIFF
--- a/submissions/examples/initial-letter-dropcap-ux/README.md
+++ b/submissions/examples/initial-letter-dropcap-ux/README.md
@@ -1,0 +1,19 @@
+# Initial Letter Dropcap Ux
+
+## What does this do?
+
+Demonstrates the native CSS `initial-letter` property for creating typographic drop caps without float + font-size hacks. Supports multiple sizes (sink 2, 3, 4 lines) and visual variants (solid, gradient, outline) with a graceful `@supports` fallback for Firefox and older browsers.
+
+## How is it used?
+
+```html
+<p class="il-card-text">
+  <span class="il-cap il-cap-3">T</span>ext content here...
+</p>
+```
+
+Variants: `il-cap-2` (sink 2 lines), `il-cap-3` (sink 3 lines), `il-cap-4` (sink 4 lines), `il-cap-primary`, `il-cap-gradient`, `il-cap-outline`, `il-cap-serif`.
+
+## Why is it useful?
+
+Drop caps add editorial polish to articles, blog posts, and documentation. Using the native `initial-letter` property is more maintainable and predictable than the traditional float approach.

--- a/submissions/examples/initial-letter-dropcap-ux/demo.html
+++ b/submissions/examples/initial-letter-dropcap-ux/demo.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Initial Letter Drop Caps — EaseMotion CSS</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="il-wrap">
+      <h1 class="il-title">Initial Letter Drop Caps</h1>
+      <p class="il-sub">
+        Native CSS <code>initial-letter</code> property — 4 variants
+      </p>
+
+      <div class="il-card">
+        <span class="il-card-label">Solid (3-line sink)</span>
+        <p class="il-card-text">
+          <span class="il-cap il-cap-primary">T</span>he native CSS
+          <code>initial-letter</code> property creates a drop cap without float
+          or font-size hacks. It tells the browser exactly how many lines the
+          letter should sink and its size relative to the surrounding text. This
+          is the default solid variant with a primary color accent.
+        </p>
+      </div>
+
+      <div class="il-card">
+        <span class="il-card-label">Gradient (3-line sink)</span>
+        <p class="il-card-text">
+          <span class="il-cap il-cap-gradient">G</span>radient text fills draw
+          the eye immediately. Combined with <code>initial-letter</code>, the
+          drop cap becomes a visual anchor for the paragraph. The gradient
+          transitions between primary and accent colors, adding personality to
+          editorial content without overwhelming the layout.
+        </p>
+      </div>
+
+      <div class="il-card">
+        <span class="il-card-label">Outline (2-line sink)</span>
+        <p class="il-card-text">
+          <span class="il-cap il-cap-2 il-cap-outline">O</span>utlined letters
+          use <code>-webkit-text-stroke</code> to create a transparent fill with
+          a colored border. This lighter variant works well for secondary
+          content or when the drop cap should recede slightly. Here the
+          <code>initial-letter: 2 2</code> makes it sink only 2 lines for a
+          subtler effect.
+        </p>
+      </div>
+
+      <div class="il-card">
+        <span class="il-card-label">Serif (4-line sink)</span>
+        <p class="il-card-text">
+          <span class="il-cap il-cap-4 il-cap-serif">S</span>erif-styled drop
+          caps evoke classic print typography and literary elegance. The
+          <code>initial-letter: 4 3</code> value makes this letter span 4 lines
+          deep, creating a dramatic opening statement. The warm gold tone adds a
+          premium feel suitable for feature articles and long-form content.
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/initial-letter-dropcap-ux/style.css
+++ b/submissions/examples/initial-letter-dropcap-ux/style.css
@@ -1,0 +1,171 @@
+:root {
+  --il-bg: #0b0f1a;
+  --il-surface: #141829;
+  --il-border: rgba(255, 255, 255, 0.08);
+  --il-text: #e8edf5;
+  --il-text-sec: #8892a8;
+  --il-primary: #6c5ce7;
+  --il-accent: #fd79a8;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family:
+    "Inter",
+    -apple-system,
+    sans-serif;
+  background: var(--il-bg);
+  color: var(--il-text);
+  padding: 2.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.il-wrap {
+  width: 100%;
+  max-width: 680px;
+}
+
+.il-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 4px;
+  text-align: center;
+}
+
+.il-sub {
+  font-size: 0.82rem;
+  color: var(--il-text-sec);
+  margin-bottom: 28px;
+  text-align: center;
+}
+
+.il-card {
+  background: var(--il-surface);
+  border: 1px solid var(--il-border);
+  border-radius: 14px;
+  padding: 28px;
+  margin-bottom: 20px;
+}
+
+.il-card-label {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--il-text-sec);
+  margin-bottom: 12px;
+}
+
+.il-card-text {
+  font-size: 0.88rem;
+  line-height: 1.75;
+  color: var(--il-text);
+}
+
+/* Native CSS initial-letter property for drop caps */
+
+.il-cap {
+  float: left;
+  font-weight: 700;
+  margin-right: 0.5rem;
+  line-height: 1;
+  initial-letter: 3 2;
+  -webkit-initial-letter: 3 2;
+}
+
+.il-cap-2 {
+  initial-letter: 2 2;
+  -webkit-initial-letter: 2 2;
+}
+
+.il-cap-4 {
+  initial-letter: 4 3;
+  -webkit-initial-letter: 4 3;
+}
+
+.il-cap-primary {
+  color: var(--il-primary);
+}
+
+.il-cap-gradient {
+  background: linear-gradient(135deg, var(--il-primary), var(--il-accent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.il-cap-outline {
+  color: transparent;
+  -webkit-text-stroke: 2px var(--il-primary);
+}
+
+.il-cap-serif {
+  font-family: Georgia, "Times New Roman", serif;
+  font-style: italic;
+  color: #fdcb6e;
+}
+
+@supports not (initial-letter: 3) {
+  .il-cap {
+    initial-letter: unset;
+    -webkit-initial-letter: unset;
+    font-size: 3.2em;
+    padding: 0.1em 0.15em 0 0;
+  }
+
+  .il-cap-2 {
+    font-size: 2.4em;
+  }
+
+  .il-cap-4 {
+    font-size: 4em;
+  }
+}
+
+@supports (-webkit-initial-letter: 3) {
+  .il-cap {
+    initial-letter: unset;
+    -webkit-initial-letter: 3 2;
+  }
+
+  .il-cap-2 {
+    -webkit-initial-letter: 2 2;
+  }
+
+  .il-cap-4 {
+    -webkit-initial-letter: 4 3;
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .il-card {
+    padding: 20px;
+  }
+
+  .il-cap {
+    font-size: 2.6em;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a submission demonstrating the native CSS `initial-letter` property for creating typographic drop caps without float + font-size hacks. Shows 4 variants (solid, gradient, outline, serif) with multiple sink sizes (2, 3, 4 lines) and a graceful @supports fallback for non-supporting browsers.

## How to Test

Open `submissions/examples/initial-letter-dropcap-ux/demo.html` in a browser. In Chrome 121+ / Safari 9+ the native initial-letter property renders. In Firefox the @supports fallback kicks in with the traditional float approach.

## Related Issues
Fixes #7994

## gssoc26
