### PR TITLE
feat: add text-decoration-skip-ink utility submission

### DIFF
--- a/submissions/examples/text-decoration-skip-ink-ux/README.md
+++ b/submissions/examples/text-decoration-skip-ink-ux/README.md
@@ -1,0 +1,25 @@
+# Text Decoration Skip Ink UX
+
+## What does this do?
+
+Demonstrates the `text-decoration-skip-ink` CSS property which controls whether underlines skip over descenders (the tails on letters like g, j, p, q, y).
+
+## How is it used?
+
+```css
+.tsi-skip-auto {
+  text-decoration-skip-ink: auto;
+} /* default — skips descenders */
+.tsi-skip-none {
+  text-decoration-skip-ink: none;
+} /* draws through descenders */
+```
+
+```html
+<p class="tsi-underline tsi-skip-auto">glyph jumping quickly</p>
+<p class="tsi-underline tsi-skip-none">glyph jumping quickly</p>
+```
+
+## Why is it useful?
+
+Underlines that cut through descenders reduce readability. `text-decoration-skip-ink: auto` (default in modern browsers) visually breaks the underline around descenders. This demo shows the difference and gives developers control with `none` for specific design needs.

--- a/submissions/examples/text-decoration-skip-ink-ux/demo.html
+++ b/submissions/examples/text-decoration-skip-ink-ux/demo.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text Decoration Skip Ink — EaseMotion CSS</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="tsi-wrap">
+      <h1 class="tsi-title">Text Decoration Skip Ink</h1>
+      <p class="tsi-sub">
+        <code>text-decoration-skip-ink</code> — controlling underline behavior
+        around descenders
+      </p>
+
+      <div class="tsi-intro">
+        Descenders are the tails on letters like <strong>g</strong>,
+        <strong>j</strong>, <strong>p</strong>, <strong>q</strong>, and
+        <strong>y</strong>. With
+        <code>text-decoration-skip-ink: auto</code> (the default), underlines
+        visually break around these tails for better readability. With
+        <code>none</code>, the underline cuts straight through them.
+      </div>
+
+      <div class="tsi-section">
+        <h2 class="tsi-section-title">Side-by-side comparison</h2>
+        <div class="tsi-compare">
+          <div class="tsi-compare-card">
+            <div class="tsi-compare-title"><code>skip-ink: auto</code></div>
+            <div class="tsi-demo-text tsi-text-md tsi-underline tsi-skip-auto">
+              gypsy juggling pygmy glyphs
+            </div>
+          </div>
+          <div class="tsi-compare-card">
+            <div class="tsi-compare-title"><code>skip-ink: none</code></div>
+            <div class="tsi-demo-text tsi-text-md tsi-underline tsi-skip-none">
+              gypsy juggling pygmy glyphs
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="tsi-section">
+        <h2 class="tsi-section-title">At different sizes</h2>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Small — auto</span>
+          <div class="tsi-text-sm tsi-underline tsi-skip-auto">
+            jumping jackrabbits jog gently past green grassy glades
+          </div>
+        </div>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Small — none</span>
+          <div class="tsi-text-sm tsi-underline tsi-skip-none">
+            jumping jackrabbits jog gently past green grassy glades
+          </div>
+        </div>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Large — auto</span>
+          <div class="tsi-text-lg tsi-underline tsi-skip-auto">
+            gypsy pygmies juggle
+          </div>
+        </div>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Large — none</span>
+          <div class="tsi-text-lg tsi-underline tsi-skip-none">
+            gypsy pygmies juggle
+          </div>
+        </div>
+      </div>
+
+      <div class="tsi-section">
+        <h2 class="tsi-section-title">With different underline styles</h2>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Wavy — auto</span>
+          <div class="tsi-text-md tsi-underline-wavy tsi-skip-auto">
+            jumping jackrabbits jogging gently
+          </div>
+        </div>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Wavy — none</span>
+          <div class="tsi-text-md tsi-underline-wavy tsi-skip-none">
+            jumping jackrabbits jogging gently
+          </div>
+        </div>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Dotted — auto</span>
+          <div class="tsi-text-md tsi-underline-dotted tsi-skip-auto">
+            glyph juggling pygmy gypsies
+          </div>
+        </div>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Dotted — none</span>
+          <div class="tsi-text-md tsi-underline-dotted tsi-skip-none">
+            glyph juggling pygmy gypsies
+          </div>
+        </div>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Double — auto</span>
+          <div class="tsi-text-md tsi-underline-double tsi-skip-auto">
+            gypsy pygmies juggling glyphs
+          </div>
+        </div>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Double — none</span>
+          <div class="tsi-text-md tsi-underline-double tsi-skip-none">
+            gypsy pygmies juggling glyphs
+          </div>
+        </div>
+      </div>
+
+      <div class="tsi-section">
+        <h2 class="tsi-section-title">Link example</h2>
+        <div class="tsi-card">
+          <span class="tsi-card-label">Hover to see underline</span>
+          <div class="tsi-text-md">
+            <span class="tsi-link tsi-underline tsi-skip-auto"
+              >jumping gypsy pygmies (auto — hover me)</span
+            >
+          </div>
+          <div class="tsi-card-desc">
+            Links default to <code>text-decoration-skip-ink: auto</code> in
+            modern browsers.
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/text-decoration-skip-ink-ux/style.css
+++ b/submissions/examples/text-decoration-skip-ink-ux/style.css
@@ -1,0 +1,215 @@
+:root {
+  --tsi-bg: #0b0f1a;
+  --tsi-surface: #141829;
+  --tsi-border: rgba(255, 255, 255, 0.08);
+  --tsi-text: #e8edf5;
+  --tsi-text-sec: #8892a8;
+  --tsi-primary: #6c5ce7;
+  --tsi-accent: #fd79a8;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family:
+    "Inter",
+    -apple-system,
+    sans-serif;
+  background: var(--tsi-bg);
+  color: var(--tsi-text);
+  padding: 2.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.tsi-wrap {
+  width: 100%;
+  max-width: 680px;
+}
+
+.tsi-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 4px;
+  text-align: center;
+}
+
+.tsi-sub {
+  font-size: 0.82rem;
+  color: var(--tsi-text-sec);
+  margin-bottom: 28px;
+  text-align: center;
+  line-height: 1.6;
+}
+
+.tsi-intro {
+  background: var(--tsi-surface);
+  border: 1px solid var(--tsi-border);
+  border-radius: 14px;
+  padding: 20px 24px;
+  margin-bottom: 24px;
+  font-size: 0.85rem;
+  line-height: 1.7;
+  color: var(--tsi-text-sec);
+}
+
+.tsi-intro code {
+  color: var(--tsi-primary);
+}
+
+.tsi-section {
+  margin-bottom: 32px;
+}
+
+.tsi-section-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: var(--tsi-text);
+}
+
+.tsi-card {
+  background: var(--tsi-surface);
+  border: 1px solid var(--tsi-border);
+  border-radius: 14px;
+  padding: 24px;
+  margin-bottom: 16px;
+}
+
+.tsi-card-label {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--tsi-text-sec);
+  margin-bottom: 12px;
+}
+
+.tsi-card-desc {
+  font-size: 0.78rem;
+  color: var(--tsi-text-sec);
+  margin-top: 8px;
+}
+
+/* The key utility / demo classes */
+
+.tsi-underline {
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+}
+
+.tsi-underline-wavy {
+  text-decoration-line: underline;
+  text-decoration-style: wavy;
+}
+
+.tsi-underline-dotted {
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+}
+
+.tsi-underline-dashed {
+  text-decoration-line: underline;
+  text-decoration-style: dashed;
+}
+
+.tsi-underline-double {
+  text-decoration-line: underline;
+  text-decoration-style: double;
+}
+
+.tsi-skip-auto {
+  text-decoration-skip-ink: auto;
+}
+
+.tsi-skip-none {
+  text-decoration-skip-ink: none;
+}
+
+.tsi-link {
+  color: var(--tsi-primary);
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.tsi-link:hover {
+  color: var(--tsi-accent);
+}
+
+.tsi-text-sm {
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
+.tsi-text-md {
+  font-size: 1.4rem;
+  line-height: 1.7;
+}
+
+.tsi-text-lg {
+  font-size: 2rem;
+  line-height: 1.5;
+}
+
+.tsi-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.tsi-compare-card {
+  background: var(--tsi-surface);
+  border: 1px solid var(--tsi-border);
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.tsi-compare-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: var(--tsi-text-sec);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  text-align: center;
+}
+
+.tsi-demo-text {
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+  .tsi-compare {
+    grid-template-columns: 1fr;
+  }
+  .tsi-card {
+    padding: 18px;
+  }
+  .tsi-text-lg {
+    font-size: 1.4rem;
+  }
+  .tsi-text-md {
+    font-size: 1.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a submission demonstrating , a CSS property that controls whether underlines skip over descenders (letters like g, j, p, q, y). Shows auto vs none behavior across different font sizes and underline styles (solid, wavy, dotted, double).

## How to Test

Open  in a browser. Compare the auto vs none columns — with auto, the underline visually breaks around descenders; with none, it cuts straight through.

## Related Issues
Fixes #7998

## gssoc26
