### PR TITLE
feat: add paint-order utility submission for text rendering control

### DIFF
--- a/submissions/examples/paint-order-ux/README.md
+++ b/submissions/examples/paint-order-ux/README.md
@@ -1,0 +1,24 @@
+# Paint Order UX
+
+## What does this do?
+
+Demonstrates the `paint-order` CSS property for controlling the drawing order of text fill and stroke. Makes outlined/ stroked text look clean by rendering the stroke behind the fill.
+
+## How is it used?
+
+```css
+.po-stroke-behind {
+  paint-order: stroke fill;
+}
+.po-normal {
+  paint-order: normal;
+}
+```
+
+```html
+<span class="po-stroke-behind po-text-lg">Outlined Text</span>
+```
+
+## Why is it useful?
+
+Without `paint-order`, text with a thick stroke appears jagged or bloated because the stroke draws on top of the fill. Changing the paint order to `stroke fill` places the stroke behind the fill, creating clean outlined text for headings, logos, and decorative typography.

--- a/submissions/examples/paint-order-ux/demo.html
+++ b/submissions/examples/paint-order-ux/demo.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Paint Order — EaseMotion CSS</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="po-wrap">
+      <h1 class="po-title">Paint Order</h1>
+      <p class="po-sub">
+        <code>paint-order</code> — controlling text fill and stroke rendering
+        order
+      </p>
+
+      <div class="po-intro">
+        The <code>paint-order</code> CSS property controls whether text
+        <strong>fill</strong> or <strong>stroke</strong> is drawn first. With
+        <code>paint-order: stroke fill</code>, the stroke renders behind the
+        fill, creating clean outlined text. The default
+        <code>normal</code> (fill then stroke) often makes thick strokes look
+        jagged.
+      </div>
+
+      <div class="po-section">
+        <h2 class="po-section-title">Side-by-side comparison</h2>
+        <div class="po-compare">
+          <div class="po-compare-card">
+            <div class="po-compare-title">
+              <code>paint-order: normal</code> (default)
+            </div>
+            <div class="po-text-xl po-stroke-thick po-fill-white po-normal">
+              STROKE
+            </div>
+            <div class="po-card-desc">
+              Stroke drawn <em>on top</em> of fill — looks jagged
+            </div>
+          </div>
+          <div class="po-compare-card">
+            <div class="po-compare-title">
+              <code>paint-order: stroke fill</code>
+            </div>
+            <div
+              class="po-text-xl po-stroke-thick po-fill-white po-stroke-behind"
+            >
+              STROKE
+            </div>
+            <div class="po-card-desc">
+              Stroke drawn <em>behind</em> fill — clean outline
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-section">
+        <h2 class="po-section-title">Thick stroke comparison</h2>
+        <div class="po-card">
+          <span class="po-card-label">Normal paint order</span>
+          <div class="po-text-xl po-stroke-thick po-fill-white po-normal">
+            OUTLINED
+          </div>
+          <div class="po-card-desc">
+            Stroke bleeds into the fill — looks rough at large sizes
+          </div>
+        </div>
+        <div class="po-card">
+          <span class="po-card-label">Stroke behind fill</span>
+          <div
+            class="po-text-xl po-stroke-thick po-fill-white po-stroke-behind"
+          >
+            OUTLINED
+          </div>
+          <div class="po-card-desc">
+            Stroke sits cleanly behind the fill — sharp edges
+          </div>
+        </div>
+      </div>
+
+      <div class="po-section">
+        <h2 class="po-section-title">Color variations with stroke-behind</h2>
+        <div class="po-card">
+          <span class="po-card-label">Primary stroke</span>
+          <div
+            class="po-text-lg po-stroke-thick po-fill-white po-stroke-behind"
+          >
+            Paint Order
+          </div>
+        </div>
+        <div class="po-card">
+          <span class="po-card-label">Accent stroke</span>
+          <div
+            class="po-text-lg po-stroke-accent po-fill-white po-stroke-behind"
+          >
+            Paint Order
+          </div>
+        </div>
+        <div class="po-card">
+          <span class="po-card-label">Gold stroke</span>
+          <div class="po-text-lg po-stroke-gold po-fill-white po-stroke-behind">
+            Paint Order
+          </div>
+        </div>
+      </div>
+
+      <div class="po-section">
+        <h2 class="po-section-title">With transparent fill</h2>
+        <div class="po-card">
+          <span class="po-card-label">Stroke only (fill transparent)</span>
+          <div class="po-text-xl po-stroke-thick po-fill-transparent po-normal">
+            HOLLOW
+          </div>
+          <div class="po-card-desc">
+            With transparent fill, paint order has no visible effect
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/paint-order-ux/style.css
+++ b/submissions/examples/paint-order-ux/style.css
@@ -1,0 +1,222 @@
+:root {
+  --po-bg: #0b0f1a;
+  --po-surface: #141829;
+  --po-border: rgba(255, 255, 255, 0.08);
+  --po-text: #e8edf5;
+  --po-text-sec: #8892a8;
+  --po-primary: #6c5ce7;
+  --po-accent: #fd79a8;
+  --po-gold: #fdcb6e;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family:
+    "Inter",
+    -apple-system,
+    sans-serif;
+  background: var(--po-bg);
+  color: var(--po-text);
+  padding: 2.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.po-wrap {
+  width: 100%;
+  max-width: 680px;
+}
+
+.po-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 4px;
+  text-align: center;
+}
+
+.po-sub {
+  font-size: 0.82rem;
+  color: var(--po-text-sec);
+  margin-bottom: 28px;
+  text-align: center;
+  line-height: 1.6;
+}
+
+.po-intro {
+  background: var(--po-surface);
+  border: 1px solid var(--po-border);
+  border-radius: 14px;
+  padding: 20px 24px;
+  margin-bottom: 24px;
+  font-size: 0.85rem;
+  line-height: 1.7;
+  color: var(--po-text-sec);
+}
+
+.po-intro code {
+  color: var(--po-primary);
+}
+
+.po-section {
+  margin-bottom: 32px;
+}
+
+.po-section-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: var(--po-text);
+}
+
+.po-card {
+  background: var(--po-surface);
+  border: 1px solid var(--po-border);
+  border-radius: 14px;
+  padding: 28px;
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.po-card-label {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--po-text-sec);
+  margin-bottom: 16px;
+}
+
+.po-card-desc {
+  font-size: 0.78rem;
+  color: var(--po-text-sec);
+  margin-top: 12px;
+}
+
+/* Paint-order utility classes */
+
+.po-normal {
+  paint-order: normal;
+}
+
+.po-stroke-behind {
+  paint-order: stroke fill;
+}
+
+.po-stroke-behind-markers {
+  paint-order: stroke fill markers;
+}
+
+.po-fill-stroke {
+  paint-order: fill stroke;
+}
+
+/* Styling for text examples */
+
+.po-stroke-thin {
+  -webkit-text-stroke: 1px var(--po-primary);
+  text-stroke: 1px var(--po-primary);
+}
+
+.po-stroke-thick {
+  -webkit-text-stroke: 3px var(--po-primary);
+  text-stroke: 3px var(--po-primary);
+}
+
+.po-stroke-accent {
+  -webkit-text-stroke: 3px var(--po-accent);
+  text-stroke: 3px var(--po-accent);
+}
+
+.po-stroke-gold {
+  -webkit-text-stroke: 3px var(--po-gold);
+  text-stroke: 3px var(--po-gold);
+}
+
+.po-fill-white {
+  -webkit-text-fill-color: #e8edf5;
+  color: #e8edf5;
+}
+
+.po-fill-transparent {
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.po-text-xl {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.po-text-lg {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+.po-text-md {
+  font-size: 1.4rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.po-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.po-compare-card {
+  background: var(--po-surface);
+  border: 1px solid var(--po-border);
+  border-radius: 12px;
+  padding: 24px 16px;
+  text-align: center;
+}
+
+.po-compare-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: var(--po-text-sec);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+  .po-compare {
+    grid-template-columns: 1fr;
+  }
+  .po-text-xl {
+    font-size: 2rem;
+  }
+  .po-text-lg {
+    font-size: 1.5rem;
+  }
+  .po-card {
+    padding: 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a submission demonstrating the  CSS property which controls whether text fill or stroke renders first. With , thick strokes render cleanly behind the fill text instead of bleeding into it.

## How to Test

Open  in a browser. Compare the normal vs stroke-behind columns — normal paint order makes thick strokes look jagged, while stroke-behind creates clean outlined text.

## Related Issues
Fixes #8000

## gssoc26
