### PR TITLE
feat: add hint bubble tooltip example

### DIFF
--- a/submissions/examples/hint-bubble-tooltip-zt/README.md
+++ b/submissions/examples/hint-bubble-tooltip-zt/README.md
@@ -1,0 +1,44 @@
+# Hint Bubble Tooltip
+
+A CSS-only hint tooltip system with rounded pill bubbles, soft transitions, and placement variants.
+
+## Description
+
+This component creates floating hint bubbles around trigger elements using only HTML and CSS. Tooltips can appear at the top, bottom, left, or right of the trigger with smooth fade and translate animation.
+
+## Features
+
+- Pure HTML + CSS implementation
+- No JavaScript or dependencies
+- Rounded pill-shaped tooltip bubbles
+- Smooth fade and translate animation
+- Multiple placements: top, bottom, left, right
+- Small arrow pointer for each placement
+- Dark theme with soft glow styling
+- Responsive layout for mobile
+- Accessible hover / focus interactions
+
+## Usage
+
+1. Copy `demo.html` and `style.css` into your submission folder.
+2. Open `demo.html` in a browser.
+3. Customize tooltip text and placement classes.
+
+```html
+<link rel="stylesheet" href="style.css" />
+<div class="tooltip-page">
+  <section class="tooltip-card ease-fade-in">
+    <!-- tooltip demo content -->
+  </section>
+</div>
+```
+
+## Customization notes
+
+- Update tooltip colors by changing the bubble background and text color.
+- Adjust the shadow or glow by modifying `box-shadow` values on `.tooltip-bubble`.
+- Fine-tune animation timing in the `.tooltip-bubble` transition.
+
+## Why it fits EaseMotion CSS
+
+This submission fits EaseMotion CSS because it delivers a motion-forward, self-contained UI pattern with premium dashboard styling. The tooltip uses refined transitions and clean markup, matching the framework's emphasis on accessible, animation-friendly components.

--- a/submissions/examples/hint-bubble-tooltip-zt/demo.html
+++ b/submissions/examples/hint-bubble-tooltip-zt/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hint Bubble Tooltip</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="tooltip-page">
+      <section class="tooltip-card ease-fade-in">
+        <header class="tooltip-card__header">
+          <p class="eyebrow">Tooltip demo</p>
+          <h1>Hint Bubble Tooltip</h1>
+          <p class="description">
+            A CSS-only hint tooltip system with pill-shaped bubbles, soft glow, and placement variants.
+          </p>
+        </header>
+
+        <div class="tooltip-grid">
+          <div class="tooltip-item tooltip-item--top">
+            <button class="tooltip-trigger">Top hint</button>
+            <span class="tooltip-bubble tooltip-bubble--top">Pinned above the trigger.</span>
+          </div>
+
+          <div class="tooltip-item tooltip-item--right">
+            <button class="tooltip-trigger">Right hint</button>
+            <span class="tooltip-bubble tooltip-bubble--right">Flows from the right side.</span>
+          </div>
+
+          <div class="tooltip-item tooltip-item--left">
+            <button class="tooltip-trigger">Left hint</button>
+            <span class="tooltip-bubble tooltip-bubble--left">Appears to the left.</span>
+          </div>
+
+          <div class="tooltip-item tooltip-item--bottom">
+            <button class="tooltip-trigger">Bottom hint</button>
+            <span class="tooltip-bubble tooltip-bubble--bottom">Displays below the trigger.</span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/hint-bubble-tooltip-zt/style.css
+++ b/submissions/examples/hint-bubble-tooltip-zt/style.css
@@ -1,0 +1,190 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #080b14;
+  color: #e2e8f0;
+  --panel: #111827;
+  --panel-soft: rgba(148, 163, 184, 0.08);
+  --text-muted: #94a3b8;
+  --accent: #818cf8;
+  --shadow: 0 24px 80px rgba(8, 11, 22, 0.34);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.14), transparent 24%),
+    radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.08), transparent 26%),
+    linear-gradient(180deg, #070b14 0%, #0b1120 100%);
+  color: var(--text-primary);
+}
+
+.tooltip-page {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.tooltip-card {
+  width: min(100%, 640px);
+  background: linear-gradient(180deg, rgba(18, 24, 44, 0.96), rgba(15, 23, 42, 0.98));
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 28px;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+}
+
+.tooltip-card__header {
+  margin-bottom: 1.75rem;
+}
+
+.eyebrow {
+  display: inline-flex;
+  margin: 0 0 0.75rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #93c5fd;
+}
+
+.tooltip-card h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.5rem);
+  line-height: 1.05;
+}
+
+.description {
+  margin: 1rem 0 0;
+  color: var(--text-muted);
+  line-height: 1.8;
+}
+
+.tooltip-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.tooltip-item {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 140px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.tooltip-trigger {
+  padding: 0.85rem 1.15rem;
+  border: none;
+  border-radius: 999px;
+  background: rgba(125, 211, 252, 0.12);
+  color: #eff6ff;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.28s ease, transform 0.28s ease;
+}
+
+.tooltip-trigger:hover {
+  transform: translateY(-1px);
+}
+
+.tooltip-bubble {
+  position: absolute;
+  max-width: 200px;
+  padding: 0.9rem 1rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.96);
+  color: #f8fafc;
+  font-size: 0.9rem;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(0) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s ease;
+  box-shadow: 0 20px 40px rgba(8, 11, 22, 0.28);
+}
+
+.tooltip-item:hover .tooltip-bubble,
+.tooltip-item:focus-within .tooltip-bubble {
+  opacity: 1;
+  transform: translateY(-6px) scale(1);
+}
+
+.tooltip-bubble::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: rgba(15, 23, 42, 0.96);
+  transform: rotate(45deg);
+}
+
+.tooltip-bubble--top {
+  bottom: 100%;
+  left: 50%;
+  transform-origin: bottom center;
+}
+
+.tooltip-bubble--top::after {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltip-bubble--bottom {
+  top: 100%;
+  left: 50%;
+  transform-origin: top center;
+}
+
+.tooltip-bubble--bottom::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltip-bubble--left {
+  right: 100%;
+  top: 50%;
+  transform-origin: right center;
+}
+
+.tooltip-bubble--left::after {
+  right: -6px;
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.tooltip-bubble--right {
+  left: 100%;
+  top: 50%;
+  transform-origin: left center;
+}
+
+.tooltip-bubble--right::after {
+  left: -6px;
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+}
+
+@media (max-width: 620px) {
+  .tooltip-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tooltip-item {
+    min-height: 120px;
+  }
+
+  .tooltip-bubble {
+    max-width: 100%;
+    font-size: 0.88rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS-only Hint Bubble Tooltip component featuring rounded tooltip bubbles, directional placement support, and smooth entrance animations.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be closed without review.

* [x] All changes are inside `submissions/examples/hint-bubble-tooltip-zt/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A lightweight tooltip component styled as a floating hint bubble with smooth animations.

**How does a developer use it?**

```html
<div class="hint-wrapper">
  <button>Hover me</button>
  <span class="hint-bubble">Helpful information</span>
</div>
```

**Why does it fit EaseMotion CSS?**

The component prioritizes clean motion, simple integration, and human-readable CSS while providing a reusable UI pattern for modern interfaces.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Designed as a reusable tooltip variant with a softer visual style than traditional tooltips. The implementation focuses on simplicity, accessibility, and customization.
Closes #8079 