### PR TITLE
fix: Apply global prefers-reduced-motion reset for accessibility comp…

### DIFF
--- a/core/base.css
+++ b/core/base.css
@@ -3,150 +3,171 @@
    Resets, base element styles, and typographic foundation
    ============================================================ */
 @layer easemotion-base {
-
-/* ── Box Model Reset ───────────────────────────────────────── */
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-
-/* ── Root & Body ───────────────────────────────────────────── */
-html {
-  font-size: 16px;
-  scroll-behavior: smooth;
-  -webkit-text-size-adjust: 100%;
-}
-
-body {
-  font-family: var(--ease-font-sans);
-  font-size: var(--ease-text-base);
-  line-height: var(--ease-leading-normal);
-  color: var(--ease-color-text);
-  background-color: var(--ease-color-bg);
-  overflow-x: hidden;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-/* ── Typography ────────────────────────────────────────────── */
-h1, h2, h3, h4, h5, h6 {
-  font-weight: 700;
-  line-height: var(--ease-leading-tight);
-  color: var(--ease-color-neutral-900);
-}
-
-h1 { font-size: var(--ease-text-4xl); }
-h2 { font-size: var(--ease-text-3xl); }
-h3 { font-size: var(--ease-text-2xl); }
-h4 { font-size: var(--ease-text-xl);  }
-h5 { font-size: var(--ease-text-lg);  }
-h6 { font-size: var(--ease-text-base); }
-
-p {
-  margin-bottom: var(--ease-space-4);
-  color: var(--ease-color-neutral-700);
-}
-
-a {
-  color: var(--ease-color-primary);
-  text-decoration: none;
-  transition: color var(--ease-speed-fast) var(--ease-ease);
-}
-
-@media (hover: hover) and (pointer: fine) {
-  a:hover {
-    color: var(--ease-color-primary-dark);
-    text-decoration: underline;
+  /* ── Box Model Reset ───────────────────────────────────────── */
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
   }
-}
 
-/* ── Lists ─────────────────────────────────────────────────── */
-ul, ol {
-  padding-left: var(--ease-space-6);
-}
-
-li {
-  margin-bottom: var(--ease-space-1);
-}
-
-/* ── Media ─────────────────────────────────────────────────── */
-img, video, svg {
-  display: block;
-  max-width: 100%;
-}
-
-/* ── Code ──────────────────────────────────────────────────── */
-code,
-kbd,
-samp,
-pre {
-  font-family: var(--ease-font-mono);
-  font-size: var(--ease-text-sm);
-}
-
-code {
-  background-color: var(--ease-color-neutral-100);
-  color: var(--ease-color-primary-dark);
-  padding: 0.1em 0.4em;
-  border-radius: var(--ease-radius-sm);
-}
-
-pre {
-  background-color: var(--ease-color-neutral-900);
-  color: var(--ease-color-neutral-50);
-  padding: var(--ease-space-6);
-  border-radius: var(--ease-radius-md);
-  overflow-x: auto;
-  line-height: var(--ease-leading-loose);
-}
-
-/* ── Form Elements ─────────────────────────────────────────── */
-input,
-textarea,
-select,
-button {
-  font-family: inherit;
-  font-size: inherit;
-}
-
-button {
-  cursor: pointer;
-  border: none;
-  background: none;
-}
-
-/* ── Horizontal Rule ───────────────────────────────────────── */
-hr {
-  border: none;
-  border-top: 1px solid var(--ease-color-neutral-200);
-  margin: var(--ease-space-8) 0;
-}
-
-/* ── Focus Ring (accessible) ───────────────────────────────── */
-:focus-visible,
-button:focus-visible,
-input:focus-visible,
-textarea:focus-visible,
-select:focus-visible,
-a:focus-visible {
-  outline: 2px solid var(--ease-color-primary);
-  outline-offset: 3px;
-}
-
-/* ── Selection ─────────────────────────────────────────────── */
-::selection {
-  background-color: var(--ease-color-primary);
-  color: var(--ease-selection-color, #ffffff);
-}
-
-@media (prefers-reduced-motion: reduce) {
+  /* ── Root & Body ───────────────────────────────────────────── */
   html {
-    scroll-behavior: auto;
+    font-size: 16px;
+    scroll-behavior: smooth;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  body {
+    font-family: var(--ease-font-sans);
+    font-size: var(--ease-text-base);
+    line-height: var(--ease-leading-normal);
+    color: var(--ease-color-text);
+    background-color: var(--ease-color-bg);
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* ── Typography ────────────────────────────────────────────── */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-weight: 700;
+    line-height: var(--ease-leading-tight);
+    color: var(--ease-color-neutral-900);
+  }
+
+  h1 {
+    font-size: var(--ease-text-4xl);
+  }
+  h2 {
+    font-size: var(--ease-text-3xl);
+  }
+  h3 {
+    font-size: var(--ease-text-2xl);
+  }
+  h4 {
+    font-size: var(--ease-text-xl);
+  }
+  h5 {
+    font-size: var(--ease-text-lg);
+  }
+  h6 {
+    font-size: var(--ease-text-base);
+  }
+
+  p {
+    margin-bottom: var(--ease-space-4);
+    color: var(--ease-color-neutral-700);
+  }
+
+  a {
+    color: var(--ease-color-primary);
+    text-decoration: none;
+    transition: color var(--ease-speed-fast) var(--ease-ease);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    a:hover {
+      color: var(--ease-color-primary-dark);
+      text-decoration: underline;
+    }
+  }
+
+  /* ── Lists ─────────────────────────────────────────────────── */
+  ul,
+  ol {
+    padding-left: var(--ease-space-6);
+  }
+
+  li {
+    margin-bottom: var(--ease-space-1);
+  }
+
+  /* ── Media ─────────────────────────────────────────────────── */
+  img,
+  video,
+  svg {
+    display: block;
+    max-width: 100%;
+  }
+
+  /* ── Code ──────────────────────────────────────────────────── */
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family: var(--ease-font-mono);
+    font-size: var(--ease-text-sm);
+  }
+
+  code {
+    background-color: var(--ease-color-neutral-100);
+    color: var(--ease-color-primary-dark);
+    padding: 0.1em 0.4em;
+    border-radius: var(--ease-radius-sm);
+  }
+
+  pre {
+    background-color: var(--ease-color-neutral-900);
+    color: var(--ease-color-neutral-50);
+    padding: var(--ease-space-6);
+    border-radius: var(--ease-radius-md);
+    overflow-x: auto;
+    line-height: var(--ease-leading-loose);
+  }
+
+  /* ── Form Elements ─────────────────────────────────────────── */
+  input,
+  textarea,
+  select,
+  button {
+    font-family: inherit;
+    font-size: inherit;
+  }
+
+  button {
+    cursor: pointer;
+    border: none;
+    background: none;
+  }
+
+  /* ── Horizontal Rule ───────────────────────────────────────── */
+  hr {
+    border: none;
+    border-top: 1px solid var(--ease-color-neutral-200);
+    margin: var(--ease-space-8) 0;
+  }
+
+  /* ── Focus Ring (accessible) ───────────────────────────────── */
+  :focus-visible,
+  button:focus-visible,
+  input:focus-visible,
+  textarea:focus-visible,
+  select:focus-visible,
+  a:focus-visible {
+    outline: 2px solid var(--ease-color-primary);
+    outline-offset: 3px;
+  }
+
+  /* ── Selection ─────────────────────────────────────────────── */
+  ::selection {
+    background-color: var(--ease-color-primary);
+    color: var(--ease-selection-color, #ffffff);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation: none !important;
+      transition: none !important;
+      scroll-behavior: auto !important;
+    }
   }
 }
-
-}
-

--- a/submissions/examples/reduced-motion-fix/README.md
+++ b/submissions/examples/reduced-motion-fix/README.md
@@ -1,0 +1,21 @@
+# Reduced Motion Accessibility Fix Test
+
+## What does this do?
+This is a test case verifying the global accessibility fix for `prefers-reduced-motion` inside `core/base.css`. 
+The core file was updated to include a global reset:
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+## How to test?
+1. Open `demo.html` in your browser.
+2. Enable "Reduce Motion" in your OS accessibility settings.
+3. Observe that animations (`ease-fade-in`, `ease-slide-up`, `ease-bounce`) do not play.

--- a/submissions/examples/reduced-motion-fix/demo.html
+++ b/submissions/examples/reduced-motion-fix/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reduced Motion Accessibility Fix Test</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="../../../core/base.css">
+  <link rel="stylesheet" href="../../../core/utilities.css">
+</head>
+<body>
+  <h1>Reduced Motion Fix Test</h1>
+  <p>If you have "Reduce Motion" enabled in your OS, these animations will not play due to the global `prefers-reduced-motion` reset.</p>
+  
+  <div class="ease-fade-in" style="padding: 20px; background: #eee; margin: 10px;">Fade Animation</div>
+  <div class="ease-slide-up" style="padding: 20px; background: #eee; margin: 10px;">Slide Animation</div>
+  <div class="ease-bounce" style="padding: 20px; background: #eee; margin: 10px;">Bounce Animation</div>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes an accessibility issue where several animation utilities and CSS transitions did not fully respect the user's prefers-reduced-motion operating system setting.
closes #8101 
Type of Change
 ✨ New animation / hover effect
 🧩 New component
 📝 Documentation improvement
 🐛 Bug fix in an existing submission / Core Framework
 Other
Feature Description
What's broken? Some animation utilities appeared to ignore the reduced-motion preference due to hardcoded animation or transition values inside individual components, resulting in unnecessary motion for users who explicitly requested reduced motion.

What does this fix? This PR introduces a global accessibility override in core/base.css. When prefers-reduced-motion: reduce is enabled, all animations, transitions, and smooth scrolling are stripped globally using !important, guaranteeing absolute compliance across all ease-* utilities and custom developer implementations.

css
/* Added to core/base.css */
@media (prefers-reduced-motion: reduce) {
  *,
  *::before,
  *::after {
    animation: none !important;
    transition: none !important;
    scroll-behavior: auto !important;
  }
}
Added Test Case: A test HTML file using the reproduction snippet was added to submissions/examples/reduced-motion-fix/demo.html to easily verify the behavior.

Browser Testing
 Chrome
 Firefox
 Edge
 Safari (optional but appreciated)
Notes for Maintainer
Important: Because this is a core bug fix, this PR actively modifies core/base.css to inject the global reset. This differs from a standard example submission, but is the most foolproof method for enforcing WCAG motion guidelines framework-wide.