### PR TITLE
fix(tabs): increase hardcoded tab limit from 8 to 15 (fixes #8112)

### DIFF
--- a/components/tabs.css
+++ b/components/tabs.css
@@ -44,7 +44,14 @@
   .ease-tab-input:nth-of-type(5):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
   .ease-tab-input:nth-of-type(6):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6),
   .ease-tab-input:nth-of-type(7):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(7),
-  .ease-tab-input:nth-of-type(8):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8) {
+  .ease-tab-input:nth-of-type(8):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8),
+  .ease-tab-input:nth-of-type(9):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(9),
+  .ease-tab-input:nth-of-type(10):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(10),
+  .ease-tab-input:nth-of-type(11):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(11),
+  .ease-tab-input:nth-of-type(12):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(12),
+  .ease-tab-input:nth-of-type(13):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(13),
+  .ease-tab-input:nth-of-type(14):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(14),
+  .ease-tab-input:nth-of-type(15):focus-visible ~ .ease-tabs-nav .ease-tab-label:nth-of-type(15) {
     outline: 2px solid var(--ease-color-primary);
     outline-offset: -2px;
   }
@@ -74,12 +81,19 @@
   .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
   .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6),
   .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(7),
-  .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8) {
+  .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8),
+  .ease-tab-input:nth-of-type(9):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(9),
+  .ease-tab-input:nth-of-type(10):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(10),
+  .ease-tab-input:nth-of-type(11):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(11),
+  .ease-tab-input:nth-of-type(12):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(12),
+  .ease-tab-input:nth-of-type(13):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(13),
+  .ease-tab-input:nth-of-type(14):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(14),
+  .ease-tab-input:nth-of-type(15):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(15) {
     color: var(--ease-color-primary);
   }
 
   /* Underline translation */
-  .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(0); }
+  .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(0%); }
   .ease-tab-input:nth-of-type(2):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(100%); }
   .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(200%); }
   .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(300%); }
@@ -87,6 +101,13 @@
   .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(500%); }
   .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(600%); }
   .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(700%); }
+  .ease-tab-input:nth-of-type(9):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(800%); }
+  .ease-tab-input:nth-of-type(10):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(900%); }
+  .ease-tab-input:nth-of-type(11):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(1000%); }
+  .ease-tab-input:nth-of-type(12):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(1100%); }
+  .ease-tab-input:nth-of-type(13):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(1200%); }
+  .ease-tab-input:nth-of-type(14):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(1300%); }
+  .ease-tab-input:nth-of-type(15):checked ~ .ease-tabs-nav .ease-tab-underline { transform: translateX(1400%); }
 
   /* Content Panel toggling */
   .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(1),
@@ -94,7 +115,16 @@
   .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(3),
   .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(4),
   .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(5),
-  .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(6) {
+  .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(6),
+  .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(7),
+  .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(8),
+  .ease-tab-input:nth-of-type(9):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(9),
+  .ease-tab-input:nth-of-type(10):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(10),
+  .ease-tab-input:nth-of-type(11):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(11),
+  .ease-tab-input:nth-of-type(12):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(12),
+  .ease-tab-input:nth-of-type(13):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(13),
+  .ease-tab-input:nth-of-type(14):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(14),
+  .ease-tab-input:nth-of-type(15):checked ~ .ease-tabs-content .ease-tab-panel:nth-of-type(15) {
     display: block;
   }
 
@@ -113,7 +143,16 @@
   .ease-tabs-auto .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3),
   .ease-tabs-auto .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(4),
   .ease-tabs-auto .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
-  .ease-tabs-auto .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6) {
+  .ease-tabs-auto .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(7),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(9):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(9),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(10):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(10),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(11):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(11),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(12):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(12),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(13):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(13),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(14):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(14),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(15):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(15) {
     border-bottom: 2px solid var(--ease-color-primary);
   }
 }


### PR DESCRIPTION
## 🐛 What's broken?

In `components/buttons.css`, the `.ease-btn-loading::after` pseudo-element uses a CSS rotation animation for the loading spinner. However, inside the `@media (prefers-reduced-motion: reduce)` block, the animation is completely disabled using `animation: none !important;`. This causes the spinner to completely freeze in place rather than slowing down or changing to a safe pulsing state, leaving the user with a broken static circle.

---

## 📋 Steps to Reproduce

1. Link EaseMotion CSS (latest `main` branch).
2. Add a button with the loading class: `<button class="ease-btn ease-btn-primary ease-btn-loading">Submit</button>`.
3. Enable "Reduced Motion" in your operating system accessibility settings (or emulate it via Chrome DevTools Rendering tab).
4. Reload the page and notice the issue.

---

## ✅ Expected Behavior

The loading spinner should provide a clear visual indication that a process is ongoing, without triggering motion sickness. Instead of completely freezing, it should gracefully fall back to a safe opacity pulse effect (e.g., slowly fading in and out over 1.5 seconds).

---

## ❌ Actual Behavior

The loading spinner is completely frozen as a static incomplete circle because the animation is entirely disabled via `animation: none !important;`.

---

## 🔗 Reproduction

```html
<!DOCTYPE html>
<html>
<head>
  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.css" />
</head>
<body>
  <div style="padding: 2rem;">
    <button class="ease-btn ease-btn-primary ease-btn-loading">
      Submit
    </button>
  </div>
</body>
</html>
