### PR TITLE
docs: add button accessibility usage guide with ARIA patterns (issue …

### DIFF
--- a/submissions/examples/btn-accessibility-guide-gn/README.md
+++ b/submissions/examples/btn-accessibility-guide-gn/README.md
@@ -1,0 +1,17 @@
+# Button Accessibility & Interaction Feedback Guide (#4563)
+
+> **Audit result:** `components/buttons.css` already implements most of the requested CSS-level improvements:
+> - `.ease-btn:focus-visible` — visible focus ring via `--ease-btn-focus`/`--ease-color-primary` (line 41)
+> - `.ease-btn:active` — scale feedback (line 36), combined with `.ease-btn-hover:active` lift+squish (added in #3650)
+> - `.ease-btn:disabled` / `.ease-btn[disabled]` / `.ease-btn-disabled` — consistent disabled styling across all interaction states (lines 189–214)
+> - `.ease-btn-loading` — spinner overlay that hides button text (lines 218+)
+>
+> The remaining gaps in the issue's checklist (proper ARIA attributes, consistent usage across variants) are **HTML-authoring concerns**, not missing CSS. This submission is a usage guide.
+
+1. **What does this add?** A reference `demo.html` pairing each existing `.ease-btn` state with the correct ARIA attribute:
+   - **Disabled:** `disabled aria-disabled="true"`
+   - **Loading:** `.ease-btn-loading` + `aria-busy="true"` + a visually-hidden `role="status" aria-live="polite"` announcement
+   - **Icon-only:** `aria-label` (required since there's no visible text for screen readers)
+   - **Toggle buttons:** `aria-pressed` to communicate on/off state
+2. **How is it used?** Copy the markup patterns from `demo.html` — no new CSS classes are introduced.
+3. **Why is it useful?** Closes the gap between "the CSS supports accessible states" and "developers know how to wire up the matching ARIA attributes" — directly addressing the issue's checklist items around ARIA and consistent behavior, without altering the existing design system (per the issue's note: "should not change the overall design system, only enhance usability and accessibility").

--- a/submissions/examples/btn-accessibility-guide-gn/demo.html
+++ b/submissions/examples/btn-accessibility-guide-gn/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Button Accessibility Guide – EaseMotion CSS</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 700px;
+      margin: 0 auto;
+      padding: 3rem 1.5rem;
+      background: #1e1e2e;
+      color: #f5f5f5;
+    }
+    h1 { font-size: 1.3rem; }
+    p { color: #aaa; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+
+  <h1>Accessible Button Patterns — EaseMotion CSS</h1>
+  <p>
+    Tab through these buttons to test <code>:focus-visible</code>. Each example
+    pairs an existing <code>.ease-btn</code> state with the correct ARIA attribute.
+  </p>
+
+  <div class="demo-row">
+    <div>
+      <span class="demo-label">Standard (focus-visible ring)</span>
+      <button class="ease-btn ease-btn-primary ease-btn-hover">Save</button>
+    </div>
+  </div>
+
+  <div class="demo-row">
+    <div>
+      <span class="demo-label">Disabled — aria-disabled</span>
+      <button class="ease-btn ease-btn-primary" disabled aria-disabled="true">
+        Save (disabled)
+      </button>
+    </div>
+  </div>
+
+  <div class="demo-row">
+    <div>
+      <span class="demo-label">Loading — aria-busy + aria-live</span>
+      <button class="ease-btn ease-btn-primary ease-btn-loading" aria-busy="true" aria-disabled="true">
+        Saving...
+      </button>
+      <span role="status" aria-live="polite" style="position:absolute; left:-9999px;">
+        Saving, please wait
+      </span>
+    </div>
+  </div>
+
+  <div class="demo-row">
+    <div>
+      <span class="demo-label">Icon-only — aria-label required</span>
+      <button class="ease-btn ease-btn-outline ease-btn-icon-only" aria-label="Settings" style="color:#fff; border-color:rgba(255,255,255,0.3);">
+        ⚙
+      </button>
+    </div>
+  </div>
+
+  <div class="demo-row">
+    <div>
+      <span class="demo-label">Toggle button — aria-pressed</span>
+      <button class="ease-btn ease-btn-outline" aria-pressed="false" style="color:#fff; border-color:rgba(255,255,255,0.3);"
+        onclick="this.setAttribute('aria-pressed', this.getAttribute('aria-pressed') === 'true' ? 'false' : 'true')">
+        Toggle
+      </button>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/btn-accessibility-guide-gn/style.css
+++ b/submissions/examples/btn-accessibility-guide-gn/style.css
@@ -1,0 +1,23 @@
+/* ============================================
+   Accessibility usage guide for .ease-btn
+   Issue #4563 — demonstrates correct ARIA
+   pairing with existing button states.
+   No new classes — pure documentation/demo.
+   ============================================ */
+
+.demo-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.demo-label {
+  font-size: 0.75rem;
+  color: #999;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.5rem;
+  display: block;
+}


### PR DESCRIPTION
## Pull Request Description
Addresses #4563 — an audit of `components/buttons.css` shows `:focus-visible`, `:disabled`/`[disabled]`/`.ease-btn-disabled`, and `.ease-btn-loading` are already implemented at the CSS level. The remaining gaps in the issue's checklist (proper ARIA attributes, consistent accessible markup across button states) are HTML-authoring concerns. This submission is a reference usage guide demonstrating correct ARIA pairing for each existing button state. Closes #4563

---
## Type of Change
- [x] 📝 Documentation improvement

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/btn-accessibility-guide-gn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A `demo.html` reference showing correct ARIA attributes paired with existing `.ease-btn` states: `disabled`/`aria-disabled`, `.ease-btn-loading` + `aria-busy` + `aria-live` status announcement, `aria-label` for icon-only buttons, and `aria-pressed` for toggle buttons.

**How does a developer use it?**
```html
<!-- Loading state with accessible announcement -->
<button class="ease-btn ease-btn-primary ease-btn-loading" aria-busy="true" aria-disabled="true">
  Saving...
</button>
<span role="status" aria-live="polite" style="position:absolute; left:-9999px;">
  Saving, please wait
</span>

<!-- Icon-only button -->
<button class="ease-btn ease-btn-outline" aria-label="Settings">⚙</button>

<!-- Toggle button -->
<button class="ease-btn ease-btn-outline" aria-pressed="false">Toggle</button>
```

**Why does it fit EaseMotion CSS?**
Closes the gap between "the CSS already supports accessible interaction states" and "developers know the matching ARIA wiring" — directly addressing the issue's accessibility checklist without altering the existing design system, as the issue explicitly requests.

---
## Demo
- [x] Demo added (`demo.html` covers standard, disabled, loading, icon-only, and toggle button patterns — tab through to test `:focus-visible`)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
No CSS changes proposed — `components/buttons.css` already implements `:focus-visible` (line 41), `:active` scale + `.ease-btn-hover:active` lift+squish (from #3650), `:disabled`/`[disabled]`/`.ease-btn-disabled` (lines 189–214), and `.ease-btn-loading` (line 218+). This PR is purely a markup/ARIA reference guide. Happy to expand with more variant combinations if useful.