### PR TITLE
fix: document patch for ease-float hardcoded tokens (issue #5757)

### DIFF
--- a/submissions/examples/fix-ease-float-tokens-gn/README.md
+++ b/submissions/examples/fix-ease-float-tokens-gn/README.md
@@ -1,0 +1,17 @@
+# Fix: .ease-float Hardcodes Duration/Easing (#5757)
+
+> ⚠️ **For Maintainer:** This fix requires editing `core/animations.css` (line 683), which contributors cannot modify directly. This submission documents the proposed patch for review.
+
+1. **What's the bug?** `.ease-float` (line 682-684 in `core/animations.css`) hardcodes `animation: ease-float 3s ease-in-out infinite;`, ignoring the framework's `--ease-speed-*` and `--ease-ease-*` design tokens. Sibling classes like `.ease-bounce` (line 903) correctly use `var(--ease-animation-iterations, infinite)`.
+2. **Proposed fix:**
+```diff
+.ease-float {
+-  animation: ease-float 3s ease-in-out infinite;
++  animation: ease-float
++    var(--ease-speed-slow, 3s)
++    var(--ease-ease, ease-in-out)
++    var(--ease-animation-iterations, infinite);
+}
+```
+3. **How is it tested?** `demo.html` shows three floating boxes: the current hardcoded behavior, the token-driven default (visually identical — `--ease-speed-slow` defaults to `3s` and `--ease-ease` to `ease-in-out`), and a third box overriding `--ease-speed-slow: 1s` to prove the animation now responds to design tokens.
+4. **Why is this correct?** Using `var(--ease-speed-slow, 3s)`, `var(--ease-ease, ease-in-out)`, and `var(--ease-animation-iterations, infinite)` preserves the exact current default behavior (identical fallback values) while making `.ease-float` themeable and consistent with `.ease-bounce`, `.ease-rotate`, `.ease-pulse`, and other looping animation utilities.

--- a/submissions/examples/fix-ease-float-tokens-gn/demo.html
+++ b/submissions/examples/fix-ease-float-tokens-gn/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Fix: ease-float tokens – EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: sans-serif; background: #1e1e2e; color: #f5f5f5; padding: 2rem; max-width: 750px; }
+    h1 { font-size: 1.2rem; }
+    p { color: #aaa; font-size: 0.9rem; }
+    .row { display: flex; gap: 3rem; flex-wrap: wrap; margin: 1.5rem 0; }
+    .col { display: flex; flex-direction: column; align-items: center; gap: 0.75rem; }
+    h3 { font-size: 0.75rem; color: #999; text-transform: uppercase; letter-spacing: 0.5px; margin: 0; }
+    pre { background: #11111b; padding: 1rem; border-radius: 8px; font-size: 0.8rem; overflow-x: auto; }
+    .diff-remove { color: #f87171; }
+    .diff-add { color: #4ade80; }
+  </style>
+</head>
+<body>
+
+  <h1>Fix #5757: .ease-float ignores design tokens</h1>
+  <p>
+    <code>.ease-float</code> currently hardcodes <code>3s ease-in-out infinite</code>,
+    so it can't be customized via <code>--ease-speed-*</code>, <code>--ease-ease</code>,
+    or <code>--ease-animation-iterations</code> like sibling classes (e.g. <code>.ease-bounce</code>).
+  </p>
+
+  <div class="row">
+    <div class="col">
+      <h3>Before (hardcoded)</h3>
+      <div class="demo-box demo-float-before">3s, fixed</div>
+    </div>
+
+    <div class="col">
+      <h3>After (token-driven, default)</h3>
+      <div class="demo-box demo-float-after">var(--ease-speed-slow, 3s)</div>
+    </div>
+
+    <div class="col">
+      <h3>After + custom override (1s)</h3>
+      <div class="demo-box demo-float-after demo-fast">--ease-speed-slow: 1s</div>
+    </div>
+  </div>
+
+  <h3>Proposed core/animations.css diff</h3>
+  <pre>
+.ease-float {
+<span class="diff-remove">-  animation: ease-float 3s ease-in-out infinite;</span>
+<span class="diff-add">+  animation: ease-float
++    var(--ease-speed-slow, 3s)
++    var(--ease-ease, ease-in-out)
++    var(--ease-animation-iterations, infinite);</span>
+}
+  </pre>
+
+</body>
+</html>

--- a/submissions/examples/fix-ease-float-tokens-gn/style.css
+++ b/submissions/examples/fix-ease-float-tokens-gn/style.css
@@ -1,0 +1,44 @@
+/* ============================================
+   Fix for #5757 — .ease-float hardcodes
+   3s ease-in-out instead of using design tokens
+
+   This is a documentation/demo file only.
+   See README.md for the proposed core/animations.css diff.
+   ============================================ */
+
+@keyframes ease-float-demo {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-10px); }
+}
+
+.demo-box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 90px;
+  height: 90px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #6366f1, #a78bfa);
+  color: #fff;
+  font-family: sans-serif;
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+/* Before: hardcoded 3s ease-in-out */
+.demo-float-before {
+  animation: ease-float-demo 3s ease-in-out infinite;
+}
+
+/* After: driven by design tokens */
+.demo-float-after {
+  animation: ease-float-demo
+    var(--ease-speed-slow, 3s)
+    var(--ease-ease, ease-in-out)
+    var(--ease-animation-iterations, infinite);
+}
+
+/* Demonstrates the fix actually responds to token overrides */
+.demo-fast {
+  --ease-speed-slow: 1s;
+}


### PR DESCRIPTION
## Pull Request Description
Documents the proposed fix for #5757 — `.ease-float` in `core/animations.css` hardcodes `animation: ease-float 3s ease-in-out infinite;`, ignoring the `--ease-speed-*`/`--ease-ease-*`/`--ease-animation-iterations` design tokens used by sibling classes like `.ease-bounce`. Proposes replacing the hardcoded values with token-driven equivalents that preserve the current default behavior. Closes #5757

---
## Type of Change
- [x] 🐛 Bug fix in an existing submission

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/fix-ease-float-tokens-gn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A documented patch proposal for `core/animations.css`: replace `.ease-float`'s hardcoded `3s ease-in-out infinite` with `var(--ease-speed-slow, 3s) var(--ease-ease, ease-in-out) var(--ease-animation-iterations, infinite)`.

**How does a developer use it?**
```diff
.ease-float {
-  animation: ease-float 3s ease-in-out infinite;
+  animation: ease-float
+    var(--ease-speed-slow, 3s)
+    var(--ease-ease, ease-in-out)
+    var(--ease-animation-iterations, infinite);
}
```

**Why does it fit EaseMotion CSS?**
Makes `.ease-float` themeable and consistent with `.ease-bounce`, `.ease-rotate`, and `.ease-pulse`, which already use these design tokens — without changing any default visual behavior (fallback values match the current hardcoded values exactly).

---
## Demo
- [x] Demo added (`demo.html` shows before/after side-by-side, plus a third box with `--ease-speed-slow: 1s` proving the fix responds to token overrides)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---
## Notes for Maintainer
This PR intentionally does not modify `core/animations.css` directly, since it's part of the project's core which contributors cannot edit. The README documents the exact one-rule diff at line 683.