### PR TITLE
fix(badges): add missing green pulse override for success badge

### DIFF
--- a/components/badges.css
+++ b/components/badges.css
@@ -66,4 +66,9 @@
   .ease-badge-danger.ease-badge-pulse::after {
     box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
   }
+
+  .em-badge-success.em-badge-pulse::after,
+  .ease-badge-success.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #8135

## Problem
The  variant was falling back to the default purple glow `rgba(108, 99, 255, 0.7)` because a `box-shadow` override for success badges was missing. This caused green success badges to pulse with an incorrect purple/blue glow.

## Fix
Added the missing green `box-shadow` override matching the success badge's background color:

```css
.ease-badge-success.ease-badge-pulse::after {
    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
}
```

## Testing
The fix can be verified with:
```html
<span class="ease-badge ease-badge-success ease-badge-pulse">Online</span>
```
The badge should now pulse with a green glow instead of purple.

## Screenshots
Before: Green badge pulsing with purple glow
After: Green badge pulsing with matching green glow

## Labels
GSSoC-26 contribution