### PR TITLE
feat: add custom radio button group example

### DIFF
--- a/submissions/examples/custom-radio-group/README.md
+++ b/submissions/examples/custom-radio-group/README.md
@@ -1,0 +1,16 @@
+# Custom Radio Button Group
+
+A CSS-only styled radio button group with custom dot indicators, checked state fill animation, and card-style options. Uses the hidden native radio with a styled `::before` dot for a clean, accessible form control. Keyboard-navigable via Tab and arrow keys.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser. Click any option to select it, or Tab to focus and use arrow keys to change selection.
+
+## Accessibility notes
+
+The native `<input type="radio">` is visually hidden but remains in the DOM for screen readers and keyboard navigation. Focus-visible outlines are added for keyboard users.

--- a/submissions/examples/custom-radio-group/demo.html
+++ b/submissions/examples/custom-radio-group/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Custom Radio Button Group</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #f8fafc;">
+    <div class="radio-group">
+      <h2 class="radio-label">Select your plan</h2>
+      <label class="radio-option">
+        <input type="radio" name="plan" value="free" checked>
+        <span class="radio-dot"></span>
+        <span class="radio-text">
+          <strong>Free</strong>
+          <small>Basic access, 10 messages per day</small>
+        </span>
+      </label>
+      <label class="radio-option">
+        <input type="radio" name="plan" value="pro">
+        <span class="radio-dot"></span>
+        <span class="radio-text">
+          <strong>Pro</strong>
+          <small>Unlimited messages, priority support</small>
+        </span>
+      </label>
+      <label class="radio-option">
+        <input type="radio" name="plan" value="enterprise">
+        <span class="radio-dot"></span>
+        <span class="radio-text">
+          <strong>Enterprise</strong>
+          <small>Custom integrations, team accounts</small>
+        </span>
+      </label>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/custom-radio-group/style.css
+++ b/submissions/examples/custom-radio-group/style.css
@@ -1,0 +1,92 @@
+.radio-group {
+  width: 100%;
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.radio-label {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0 0 0.25rem;
+}
+
+.radio-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: #ffffff;
+  border: 2px solid #e2e8f0;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.radio-option:hover {
+  border-color: #818cf8;
+  background-color: #f8faff;
+}
+
+.radio-option input[type="radio"] {
+  display: none;
+}
+
+.radio-dot {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid #cbd5e1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.radio-option input[type="radio"]:checked + .radio-dot {
+  border-color: #6366f1;
+  background-color: #6366f1;
+  box-shadow: inset 0 0 0 4px #ffffff;
+}
+
+.radio-option input[type="radio"]:checked ~ .radio-text strong {
+  color: #6366f1;
+}
+
+.radio-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.radio-text strong {
+  font-size: 1rem;
+  color: #1e293b;
+  transition: color 0.2s ease;
+}
+
+.radio-text small {
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.radio-option:has(input[type="radio"]:checked) {
+  border-color: #6366f1;
+  background-color: #f4f4ff;
+}
+
+.radio-option:focus-within {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
A CSS-only custom radio button group with styled dot indicators and card-style options. Uses the hidden native radio for accessibility. Checked state shows a filled inner dot with accent color border. Uses ease-flex and ease-center for layout.

Closes #8196