### PR TITLE
feat: add checkbox toggle switch example

### DIFF
--- a/submissions/examples/checkbox-toggle-switch/README.md
+++ b/submissions/examples/checkbox-toggle-switch/README.md
@@ -1,0 +1,16 @@
+# Checkbox Toggle Switch
+
+A CSS-only toggle switch component styled as a pill with a sliding circular thumb. The native checkbox is visually hidden but remains accessible. Includes checked/unchecked states with smooth thumb animation and color transition. Suitable for settings panels and preference toggles.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser. Click any toggle to switch it on or off. Tab to focus and press Space to toggle.
+
+## Accessibility notes
+
+The hidden native checkbox maintains keyboard operability and screen reader compatibility. Focus-visible outlines indicate keyboard focus. Uses prefers-reduced-motion to disable transitions.

--- a/submissions/examples/checkbox-toggle-switch/demo.html
+++ b/submissions/examples/checkbox-toggle-switch/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Checkbox Toggle Switch</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #f8fafc;">
+    <div class="toggle-list">
+      <h2 class="toggle-title">Notification Settings</h2>
+      <label class="toggle-row">
+        <span class="toggle-label">Email notifications</span>
+        <span class="toggle-switch">
+          <input type="checkbox" checked>
+          <span class="toggle-track">
+            <span class="toggle-thumb"></span>
+          </span>
+        </span>
+      </label>
+      <label class="toggle-row">
+        <span class="toggle-label">Push notifications</span>
+        <span class="toggle-switch">
+          <input type="checkbox">
+          <span class="toggle-track">
+            <span class="toggle-thumb"></span>
+          </span>
+        </span>
+      </label>
+      <label class="toggle-row">
+        <span class="toggle-label">SMS alerts</span>
+        <span class="toggle-switch">
+          <input type="checkbox" checked>
+          <span class="toggle-track">
+            <span class="toggle-thumb"></span>
+          </span>
+        </span>
+      </label>
+      <label class="toggle-row">
+        <span class="toggle-label">Weekly digest</span>
+        <span class="toggle-switch">
+          <input type="checkbox">
+          <span class="toggle-track">
+            <span class="toggle-thumb"></span>
+          </span>
+        </span>
+      </label>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/checkbox-toggle-switch/style.css
+++ b/submissions/examples/checkbox-toggle-switch/style.css
@@ -1,0 +1,90 @@
+.toggle-list {
+  width: 100%;
+  max-width: 420px;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.toggle-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0 0 1rem;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #f1f5f9;
+  cursor: pointer;
+}
+
+.toggle-row:last-child {
+  border-bottom: none;
+}
+
+.toggle-label {
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.toggle-switch input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-track {
+  position: absolute;
+  inset: 0;
+  background-color: #cbd5e1;
+  border-radius: 24px;
+  transition: background-color 0.25s ease;
+  cursor: pointer;
+}
+
+.toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background-color: #ffffff;
+  border-radius: 50%;
+  transition: transform 0.25s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-switch input:checked + .toggle-track {
+  background-color: #6366f1;
+}
+
+.toggle-switch input:checked + .toggle-track .toggle-thumb {
+  transform: translateX(20px);
+}
+
+.toggle-switch input:focus-visible + .toggle-track {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
A CSS-only toggle switch styled as a pill with a sliding circular thumb. Uses a hidden native checkbox for accessibility. The thumb slides smoothly on checked state with a color transition on the track. Uses ease-flex and ease-center for layout.

Closes #8197