### PR TITLE
feat: add image reveal on hover with mask animation example

### DIFF
--- a/submissions/examples/image-reveal-hover-mask/README.md
+++ b/submissions/examples/image-reveal-hover-mask/README.md
@@ -1,0 +1,16 @@
+# Image Reveal on Hover with Mask Animation
+
+A hover effect where images transition from grayscale to full color, accompanied by a masking overlay that reveals the image. Three variants are demonstrated: circle wipe expands from center, diagonal slide sweeps across, and curtain effect peels from top. Uses CSS transitions and pseudo-elements for the overlay.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser. Hover over any image to see the reveal effect. Each card shows a different mask style.
+
+## Accessibility notes
+
+Images include descriptive alt text. The effect is purely decorative and does not convey information. Reduced motion disables all transitions.

--- a/submissions/examples/image-reveal-hover-mask/demo.html
+++ b/submissions/examples/image-reveal-hover-mask/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Reveal on Hover with Mask</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #0f172a;">
+    <div class="gallery">
+      <div class="reveal-card">
+        <div class="reveal-image reveal-circle">
+          <img src="https://picsum.photos/id/1015/400/500" alt="Mountain landscape">
+        </div>
+        <span class="reveal-label">Circle Wipe</span>
+      </div>
+      <div class="reveal-card">
+        <div class="reveal-image reveal-diagonal">
+          <img src="https://picsum.photos/id/1036/400/500" alt="Forest path">
+        </div>
+        <span class="reveal-label">Diagonal Slide</span>
+      </div>
+      <div class="reveal-card">
+        <div class="reveal-image reveal-curtain">
+          <img src="https://picsum.photos/id/1043/400/500" alt="Waterfall">
+        </div>
+        <span class="reveal-label">Curtain Effect</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/image-reveal-hover-mask/style.css
+++ b/submissions/examples/image-reveal-hover-mask/style.css
@@ -1,0 +1,84 @@
+.gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.reveal-card {
+  text-align: center;
+}
+
+.reveal-image {
+  width: 280px;
+  height: 350px;
+  overflow: hidden;
+  border-radius: 12px;
+  position: relative;
+}
+
+.reveal-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  filter: grayscale(100%) brightness(0.6);
+  transition: filter 0.5s ease;
+}
+
+.reveal-image:hover img {
+  filter: grayscale(0%) brightness(1);
+}
+
+.reveal-image::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: #6366f1;
+  pointer-events: none;
+  transition: transform 0.5s ease;
+}
+
+.reveal-circle::after {
+  border-radius: 50%;
+  transform: scale(1);
+}
+
+.reveal-circle:hover::after {
+  transform: scale(0);
+}
+
+.reveal-diagonal::after {
+  transform: translateX(-100%) skewX(-15deg);
+  transform-origin: left;
+}
+
+.reveal-diagonal:hover::after {
+  transform: translateX(100%) skewX(-15deg);
+}
+
+.reveal-curtain::after {
+  transform: scaleY(1);
+  transform-origin: top;
+}
+
+.reveal-curtain:hover::after {
+  transform: scaleY(0);
+}
+
+.reveal-label {
+  display: block;
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
A hover effect where images transition from grayscale to full color with a masking overlay animation. Three variants are shown: circle wipe, diagonal slide, and curtain effect. Uses plain CSS for the overlay transitions. Uses ease-flex and ease-center for layout.

Closes #8198