### PR TITLE
feat: add shimmer skeleton loading placeholder example

### DIFF
--- a/submissions/examples/shimmer-skeleton-loader/README.md
+++ b/submissions/examples/shimmer-skeleton-loader/README.md
@@ -1,0 +1,16 @@
+# Shimmer Skeleton Loading Placeholder
+
+Skeleton placeholders with a shimmer animation that simulates content loading. Two card layouts are shown: a profile card with avatar and text lines, and a thumbnail card with image placeholder. The shimmer effect sweeps across the skeleton elements using a pseudo-element overlay.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser. Skeleton elements animate continuously with a shimmer sweep.
+
+## Accessibility notes
+
+Reduced motion hides the shimmer overlay. Skeleton elements remain visible as static placeholders.

--- a/submissions/examples/shimmer-skeleton-loader/demo.html
+++ b/submissions/examples/shimmer-skeleton-loader/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shimmer Skeleton Loading Placeholder</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #f1f5f9;">
+    <div class="skeleton-card">
+      <div class="skeleton-avatar skeleton-shimmer"></div>
+      <div class="skeleton-body">
+        <div class="skeleton-line skeleton-shimmer" style="width: 60%;"></div>
+        <div class="skeleton-line skeleton-shimmer" style="width: 90%;"></div>
+        <div class="skeleton-line skeleton-shimmer" style="width: 75%;"></div>
+      </div>
+    </div>
+    <div class="skeleton-card skeleton-card-sm">
+      <div class="skeleton-thumb skeleton-shimmer"></div>
+      <div class="skeleton-line skeleton-shimmer" style="width: 80%;"></div>
+      <div class="skeleton-line skeleton-shimmer" style="width: 55%;"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/shimmer-skeleton-loader/style.css
+++ b/submissions/examples/shimmer-skeleton-loader/style.css
@@ -1,0 +1,72 @@
+.skeleton-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  display: flex;
+  gap: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  max-width: 360px;
+  width: 100%;
+}
+
+.skeleton-card-sm {
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 240px;
+}
+
+.skeleton-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #e2e8f0;
+  flex-shrink: 0;
+}
+
+.skeleton-thumb {
+  width: 100%;
+  height: 120px;
+  border-radius: 8px;
+  background: #e2e8f0;
+}
+
+.skeleton-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding-top: 0.25rem;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 6px;
+  background: #e2e8f0;
+}
+
+.skeleton-shimmer {
+  position: relative;
+  overflow: hidden;
+}
+
+.skeleton-shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.5), transparent);
+  transform: translateX(-100%);
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-shimmer::after {
+    animation: none;
+    display: none;
+  }
+}


### PR DESCRIPTION
Skeleton placeholders with a shimmer animation that simulates content loading. Two card layouts are shown: a profile card with avatar and text lines, and a thumbnail card with image placeholder.

Closes #8203