### PR TITLE
feat: add daily habit tracker example (Issue #8184)

### DIFF
--- a/submissions/examples/daily-habit-tracker/README.md
+++ b/submissions/examples/daily-habit-tracker/README.md
@@ -1,0 +1,21 @@
+# Daily Habit Tracker
+
+## What does this do?
+A daily habit tracker where users can add habits, check off completion for
+each day of the week (Mon-Sun), see weekly progress as a percentage, track
+current streaks, and delete habits. All data persists via `localStorage`.
+
+## How is it used?
+Open `index.html`. Type a habit name and click **Add**. Click the day
+boxes (M, T, W, T, F, S, S) to mark a habit complete for that day —
+the weekly progress bar and streak counter update automatically. Click
+✕ to delete a habit.
+
+## Why is it useful?
+Provides a complete, self-contained interactive example demonstrating
+EaseMotion CSS utility classes (`.ease-card`, `.ease-flex`, `.ease-btn`,
+`.ease-check`, `.ease-strike`) combined with vanilla JS CRUD and
+`localStorage` persistence — a real-world reference for building stateful
+UI components with the framework. Pure CSS transitions/animations for
+checkboxes, progress bar, and new habit entries, with
+prefers-reduced-motion support.

--- a/submissions/examples/daily-habit-tracker/index.html
+++ b/submissions/examples/daily-habit-tracker/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Daily Habit Tracker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="ease-card">
+    <h1>Daily Habit Tracker</h1>
+    <p class="ease-subtitle">Build streaks, one day at a time.</p>
+
+    <form id="addHabitForm" class="ease-flex">
+      <input type="text" id="habitInput" placeholder="Add a new habit..." />
+      <button type="submit" class="ease-btn">Add</button>
+    </form>
+
+    <div class="ease-progress-wrap">
+      <div class="ease-progress-label">
+        <span id="progressLabel">Weekly progress: 0%</span>
+      </div>
+      <div class="ease-progress-track">
+        <div class="ease-progress-fill" id="progressFill"></div>
+      </div>
+    </div>
+
+    <ul class="ease-habit-list" id="habitList"></ul>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/daily-habit-tracker/script.js
+++ b/submissions/examples/daily-habit-tracker/script.js
@@ -1,0 +1,124 @@
+/* Daily Habit Tracker logic */
+
+const STORAGE_KEY = 'ease-habit-tracker-data';
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function loadHabits() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+function saveHabits(habits) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(habits));
+}
+
+let habits = loadHabits();
+
+const listEl = document.getElementById('habitList');
+const formEl = document.getElementById('addHabitForm');
+const inputEl = document.getElementById('habitInput');
+const progressFill = document.getElementById('progressFill');
+const progressLabel = document.getElementById('progressLabel');
+
+function calcStreak(days) {
+  let streak = 0;
+  for (let i = days.length - 1; i >= 0; i--) {
+    if (days[i]) streak++;
+    else break;
+  }
+  return streak;
+}
+
+function calcWeeklyProgress() {
+  if (habits.length === 0) return 0;
+  const totalPossible = habits.length * DAYS.length;
+  const totalChecked = habits.reduce(
+    (sum, h) => sum + h.days.filter(Boolean).length,
+    0
+  );
+  return Math.round((totalChecked / totalPossible) * 100);
+}
+
+function render() {
+  listEl.innerHTML = '';
+
+  if (habits.length === 0) {
+    listEl.innerHTML = '<li class="ease-empty">No habits yet. Add one above to get started!</li>';
+  }
+
+  habits.forEach((habit, habitIndex) => {
+    const li = document.createElement('li');
+    li.className = 'ease-habit-item' + (habit.days.every(Boolean) ? ' ease-strike' : '');
+
+    const info = document.createElement('div');
+    info.className = 'ease-habit-info';
+
+    const name = document.createElement('span');
+    name.className = 'ease-habit-name';
+    name.textContent = habit.name;
+
+    const streak = document.createElement('span');
+    streak.className = 'ease-habit-streak';
+    const streakCount = calcStreak(habit.days);
+    streak.textContent = streakCount > 0 ? `🔥 ${streakCount} day streak` : 'No streak yet';
+
+    info.appendChild(name);
+    info.appendChild(streak);
+
+    const dayRow = document.createElement('div');
+    dayRow.className = 'ease-day-row';
+
+    DAYS.forEach((day, dayIndex) => {
+      const box = document.createElement('div');
+      box.className = 'ease-check' + (habit.days[dayIndex] ? ' checked' : '');
+      box.textContent = day[0];
+      box.title = day;
+      box.addEventListener('click', () => {
+        habits[habitIndex].days[dayIndex] = !habits[habitIndex].days[dayIndex];
+        saveHabits(habits);
+        render();
+      });
+      dayRow.appendChild(box);
+    });
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'ease-btn ease-btn-danger';
+    deleteBtn.textContent = '✕';
+    deleteBtn.title = 'Delete habit';
+    deleteBtn.addEventListener('click', () => {
+      habits.splice(habitIndex, 1);
+      saveHabits(habits);
+      render();
+    });
+
+    li.appendChild(info);
+    li.appendChild(dayRow);
+    li.appendChild(deleteBtn);
+    listEl.appendChild(li);
+  });
+
+  const progress = calcWeeklyProgress();
+  progressFill.style.width = progress + '%';
+  progressLabel.textContent = `Weekly progress: ${progress}%`;
+}
+
+formEl.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const name = inputEl.value.trim();
+  if (!name) return;
+
+  habits.push({
+    name,
+    days: new Array(DAYS.length).fill(false),
+  });
+
+  saveHabits(habits);
+  inputEl.value = '';
+  render();
+});
+
+render();

--- a/submissions/examples/daily-habit-tracker/style.css
+++ b/submissions/examples/daily-habit-tracker/style.css
@@ -1,0 +1,215 @@
+/* Daily Habit Tracker */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: sans-serif;
+  background: #f0f4f8;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+  margin: 0;
+}
+
+.ease-card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  width: 420px;
+}
+
+.ease-card h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.2rem;
+  color: #1e293b;
+}
+
+.ease-card .ease-subtitle {
+  margin: 0 0 1.25rem;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+/* Add form */
+.ease-flex {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.ease-flex input[type="text"] {
+  flex: 1;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-flex input[type="text"]:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.ease-btn {
+  border: none;
+  border-radius: 8px;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: #6366f1;
+  color: white;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.ease-btn:hover {
+  background: #4f46e5;
+}
+
+.ease-btn:active {
+  transform: scale(0.97);
+}
+
+.ease-btn-danger {
+  background: transparent;
+  color: #ef4444;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.8rem;
+}
+
+.ease-btn-danger:hover {
+  background: #fee2e2;
+}
+
+/* Weekly progress */
+.ease-progress-wrap {
+  margin-bottom: 1.25rem;
+}
+
+.ease-progress-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.78rem;
+  color: #64748b;
+  margin-bottom: 0.35rem;
+}
+
+.ease-progress-track {
+  height: 8px;
+  background: #e2e8f0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.ease-progress-fill {
+  height: 100%;
+  background: #6366f1;
+  border-radius: 999px;
+  width: 0%;
+  transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Habit list */
+.ease-habit-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.ease-habit-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+  animation: ease-habit-in 0.3s ease;
+}
+
+@keyframes ease-habit-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.ease-habit-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-habit-name {
+  font-size: 0.92rem;
+  color: #1e293b;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.ease-strike .ease-habit-name {
+  color: #94a3b8;
+  text-decoration: line-through;
+}
+
+.ease-habit-streak {
+  font-size: 0.72rem;
+  color: #f59e0b;
+  margin-top: 2px;
+}
+
+/* Day checkboxes */
+.ease-day-row {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.ease-check {
+  width: 24px;
+  height: 24px;
+  border: 2px solid #cbd5e1;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: transparent;
+  background: white;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+}
+
+.ease-check:hover {
+  border-color: #6366f1;
+  transform: scale(1.08);
+}
+
+.ease-check.checked {
+  background: #6366f1;
+  border-color: #6366f1;
+  color: white;
+}
+
+/* Empty state */
+.ease-empty {
+  text-align: center;
+  color: #94a3b8;
+  font-size: 0.85rem;
+  padding: 1.5rem 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-habit-item,
+  .ease-progress-fill,
+  .ease-check,
+  .ease-btn {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #8184

Adds a daily habit tracker example as a self-contained submission.

### Files added:
- submissions/examples/daily-habit-tracker/index.html
- submissions/examples/daily-habit-tracker/style.css
- submissions/examples/daily-habit-tracker/script.js
- submissions/examples/daily-habit-tracker/README.md

### What it does:
A full habit tracker: add habits, check off completion per day of the
week, view weekly progress percentage and current streaks, and delete
habits, with data persisted via localStorage. Uses EaseMotion CSS
utility classes (.ease-card, .ease-flex, .ease-btn, .ease-check,
.ease-strike) with smooth CSS transitions for checkboxes, progress bar,
and list entries. Includes prefers-reduced-motion support.