### PR TITLE
fix: resolve unreadable text on demo page in light mode

### DIFF
--- a/submissions/examples/docs-demo-light-mode-fix-sk/README.md
+++ b/submissions/examples/docs-demo-light-mode-fix-sk/README.md
@@ -1,0 +1,14 @@
+# Docs Demo Light Mode Fix
+
+Fixes the bug in `docs/demo.html` where text colors are hardcoded to `#ffffff` or `rgba(255, 255, 255, X)`. This causes text to remain white even when the light mode theme is toggled, making the text unreadable against the light background.
+
+## Files
+- `demo.html` - A simplified version of the docs demo demonstrating the fix
+- `style.css` - The corrected CSS for `docs/demo.html` using theme variables instead of hardcoded white colors
+- `README.md` - This file
+
+## Root Cause
+The `<style>` block in `docs/demo.html` uses hardcoded white colors for `.demo-nav-links a`, `.demo-hero p`, `.demo-section-title`, `.ease-card`, etc. Furthermore, there are multiple inline styles hardcoding `#fff` and `rgba(255, 255, 255, X)`.
+
+## The Fix
+Replaced hardcoded colors with the existing theme variables defined in `docs/docs.css` (e.g., `var(--page-text)`, `var(--page-text-muted)`, `var(--heading-color)`, `var(--nav-link-color)`, `var(--border-color)`, `var(--card-bg)`). This allows the demo page elements to seamlessly invert colors when the `data-theme="light"` toggle is activated.

--- a/submissions/examples/docs-demo-light-mode-fix-sk/demo.html
+++ b/submissions/examples/docs-demo-light-mode-fix-sk/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Light Mode Fix Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    /* Simulated variables from docs.css */
+    :root {
+      --page-bg: #0f0e17;
+      --page-text: #fffffe;
+      --page-text-muted: rgba(255, 255, 255, 0.65);
+      --heading-color: #ffffff;
+      --heading-sub-color: rgba(255, 255, 255, 0.9);
+      --card-bg: rgba(255, 255, 255, 0.04);
+      --border-color: rgba(255, 255, 255, 0.07);
+    }
+    [data-theme="light"] {
+      --page-bg: #f8fafc;
+      --page-text: #0f172a;
+      --page-text-muted: #475569;
+      --heading-color: #0f172a;
+      --heading-sub-color: #1e293b;
+      --card-bg: #ffffff;
+      --border-color: rgba(15, 23, 42, 0.08);
+    }
+    
+    /* Base styles to replicate the issue visually */
+    body {
+      background-color: var(--page-bg);
+      color: var(--page-text);
+      font-family: sans-serif;
+      padding: 2rem;
+      transition: background-color 0.3s, color 0.3s;
+    }
+    
+    button { 
+      margin-bottom: 2rem; 
+      padding: 0.5rem 1rem; 
+      cursor: pointer; 
+    }
+  </style>
+</head>
+<body>
+  <button onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light')">Toggle Theme</button>
+  
+  <h2 class="demo-section-title">Section Title</h2>
+  <p class="demo-section-desc">This description is no longer hardcoded to white, so it adapts to light mode.</p>
+
+  <div class="ease-card" style="padding: 1rem; border: 1px solid var(--border-color); border-radius: 8px;">
+    <h3 class="ease-card-title">Card Title</h3>
+    <p class="ease-card-subtitle">Card Subtitle</p>
+    <p>Card content that is now readable in both dark and light modes.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/docs-demo-light-mode-fix-sk/style.css
+++ b/submissions/examples/docs-demo-light-mode-fix-sk/style.css
@@ -1,0 +1,79 @@
+/* Corrected CSS to replace the hardcoded colors in docs/demo.html's <style> tag */
+
+.demo-nav-links a {
+  color: var(--nav-link-color);
+  font-size: var(--ease-text-sm);
+  font-weight: 500;
+  transition: color var(--ease-speed-fast) var(--ease-ease), background-color var(--ease-speed-fast) var(--ease-ease), box-shadow var(--ease-speed-fast) var(--ease-ease);
+  text-decoration: none;
+  position: relative;
+  padding: 6px 12px;
+  border-radius: var(--ease-radius-md);
+}
+
+.demo-nav-links a:hover,
+.demo-nav-links a.active {
+  color: var(--nav-link-active-text);
+  text-decoration: none;
+  background: var(--nav-link-active-bg);
+  box-shadow: 0 0 10px rgba(108, 99, 255, 0.2);
+}
+
+.demo-hero p {
+  font-size: var(--ease-text-lg);
+  color: var(--page-text-muted);
+  max-width: 560px;
+  margin: 0 auto var(--ease-space-8);
+}
+
+.demo-section-title {
+  font-size: var(--ease-text-3xl);
+  font-weight: 700;
+  color: var(--heading-color);
+  margin-bottom: var(--ease-space-2);
+}
+
+.demo-section-desc {
+  color: var(--page-text-muted);
+  font-size: var(--ease-text-base);
+  max-width: 520px;
+  margin-bottom: var(--ease-space-10);
+}
+
+.demo-chip {
+  font-size: var(--ease-text-xs);
+  font-weight: 600;
+  color: var(--page-text-muted);
+  margin-bottom: var(--ease-space-3);
+  font-family: var(--ease-font-mono);
+}
+
+.ease-card {
+  background-color: var(--card-bg);
+  border-color: var(--border-color);
+  color: var(--page-text);
+}
+
+.ease-card-title {
+  color: var(--heading-sub-color);
+}
+
+.ease-card-subtitle {
+  color: var(--page-text-muted);
+}
+
+.ease-card p {
+  color: var(--page-text-muted);
+}
+
+.ease-card-header, .ease-card-footer {
+  border-color: var(--border-color);
+}
+
+.demo-footer {
+  text-align: center;
+  padding: var(--ease-space-12) 0;
+  border-top: 1px solid var(--border-color);
+  color: var(--page-text-muted);
+  font-size: var(--ease-text-sm);
+}


### PR DESCRIPTION
## Pull Request Description
Resolves #8291
Fixes the bug where text on the docs demo page remains invisible/white when toggling into light mode. This submission provides the corrected CSS that uses proper theme variables instead of hardcoded white colors.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/docs-demo-light-mode-fix-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
Provides a fixed `style.css` snippet that replaces hardcoded `#ffffff` colors in `docs/demo.html` with variables like `var(--page-text)` and `var(--heading-color)`.

**How does a developer use it?**
```html
<!-- Replaces hardcoded styles with properly themed variables -->
<h1 class="demo-section-title">Section Title</h1>
