### PR TITLE
feat: add premium bento accordion grid component

### DIFF
--- a/submissions/examples/bento-accordion-grid-sk/README.md
+++ b/submissions/examples/bento-accordion-grid-sk/README.md
@@ -1,0 +1,17 @@
+# Bento Accordion Grid
+
+A premium CSS-only interactive bento grid layout where hovering over a cell gracefully expands its dimensions (taking up a larger grid fraction) while proportionally shrinking its sibling cells. It features an advanced `grid-template-columns` and `grid-template-rows` transition, paired with a glassmorphic aesthetic.
+
+## Files
+- `demo.html`: The HTML structure of the grid.
+- `style.css`: The CSS rules defining the grid and hover transitions.
+- `README.md`: Documentation.
+
+## Features
+- **No JavaScript:** Built entirely using advanced CSS Grid and `:has()` or hover selectors.
+- **Fluid Grid Transitions:** Buttery smooth animation for `grid-template-columns` and `grid-template-rows`.
+- **Content Reveal:** Content seamlessly transitions in alignment with the expanding card.
+- **Glassmorphic UI:** A beautiful frosted glass aesthetic using native CSS.
+
+## Usage
+Simply drop the `.bento-accordion-grid` container and its child cards into your markup.

--- a/submissions/examples/bento-accordion-grid-sk/demo.html
+++ b/submissions/examples/bento-accordion-grid-sk/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bento Accordion Grid | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="bento-accordion-grid">
+    <div class="bento-card">
+      <div class="bento-content">
+        <div class="bento-icon">✨</div>
+        <h3 class="bento-title">Premium Design</h3>
+        <p class="bento-desc">Crafted with precision using modern CSS layout transitions.</p>
+      </div>
+    </div>
+    
+    <div class="bento-card">
+      <div class="bento-content">
+        <div class="bento-icon">🚀</div>
+        <h3 class="bento-title">High Performance</h3>
+        <p class="bento-desc">Hardware-accelerated animations for buttery smooth framerates.</p>
+      </div>
+    </div>
+    
+    <div class="bento-card">
+      <div class="bento-content">
+        <div class="bento-icon">🎨</div>
+        <h3 class="bento-title">Beautiful Glass</h3>
+        <p class="bento-desc">Native CSS backdrop-filters for an immersive glassmorphic effect.</p>
+      </div>
+    </div>
+
+    <div class="bento-card">
+      <div class="bento-content">
+        <div class="bento-icon">🧩</div>
+        <h3 class="bento-title">CSS Grid</h3>
+        <p class="bento-desc">Utilizes dynamic fr units and the modern CSS :has() selector.</p>
+      </div>
+    </div>
+
+    <div class="bento-card" style="grid-column: span 2;">
+      <div class="bento-content">
+        <div class="bento-icon">⚡</div>
+        <h3 class="bento-title">Zero JavaScript</h3>
+        <p class="bento-desc">Everything here is built natively without a single line of JS, keeping the DOM extremely lightweight.</p>
+      </div>
+    </div>
+
+    <div class="bento-card">
+      <div class="bento-content">
+        <div class="bento-icon">📱</div>
+        <h3 class="bento-title">Responsive</h3>
+        <p class="bento-desc">Adapts seamlessly to mobile and tablet devices automatically.</p>
+      </div>
+    </div>
+
+    <div class="bento-card">
+      <div class="bento-content">
+        <div class="bento-icon">🔒</div>
+        <h3 class="bento-title">Secure & Stable</h3>
+        <p class="bento-desc">No external dependencies required. 100% native support.</p>
+      </div>
+    </div>
+
+    <div class="bento-card">
+      <div class="bento-content">
+        <div class="bento-icon">🎯</div>
+        <h3 class="bento-title">Accessible</h3>
+        <p class="bento-desc">Designed with contrast ratios and user experience in mind.</p>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/bento-accordion-grid-sk/style.css
+++ b/submissions/examples/bento-accordion-grid-sk/style.css
@@ -1,0 +1,158 @@
+/* Premium Bento Accordion Grid Styles */
+:root {
+  --bento-bg: #0f172a;
+  --bento-card-bg: rgba(255, 255, 255, 0.05);
+  --bento-card-border: rgba(255, 255, 255, 0.1);
+  --bento-card-hover: rgba(255, 255, 255, 0.12);
+  --bento-text: #f8fafc;
+  --bento-text-muted: #94a3b8;
+  --bento-transition: 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: var(--bento-bg);
+  color: var(--bento-text);
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+/* Container defining the dynamic grid */
+.bento-accordion-grid {
+  display: grid;
+  width: 90vw;
+  max-width: 1000px;
+  height: 600px;
+  gap: 16px;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+  transition: grid-template-columns var(--bento-transition), grid-template-rows var(--bento-transition);
+}
+
+/* Hovering over any card inside the grid triggers column/row changes based on the card's position.
+   We use the modern CSS :has() selector to achieve this purely in CSS. */
+
+/* Columns Expansion */
+.bento-accordion-grid:has(.bento-card:nth-child(3n + 1):hover) {
+  grid-template-columns: 2fr 1fr 1fr;
+}
+.bento-accordion-grid:has(.bento-card:nth-child(3n + 2):hover) {
+  grid-template-columns: 1fr 2fr 1fr;
+}
+.bento-accordion-grid:has(.bento-card:nth-child(3n + 3):hover) {
+  grid-template-columns: 1fr 1fr 2fr;
+}
+
+/* Rows Expansion */
+.bento-accordion-grid:has(.bento-card:nth-child(-n+3):hover) {
+  grid-template-rows: 2fr 1fr 1fr;
+}
+.bento-accordion-grid:has(.bento-card:nth-child(n+4):nth-child(-n+6):hover) {
+  grid-template-rows: 1fr 2fr 1fr;
+}
+.bento-accordion-grid:has(.bento-card:nth-child(n+7):hover) {
+  grid-template-rows: 1fr 1fr 2fr;
+}
+
+/* Card Styling */
+.bento-card {
+  position: relative;
+  background: var(--bento-card-bg);
+  border: 1px solid var(--bento-card-border);
+  border-radius: 20px;
+  padding: 24px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  cursor: pointer;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition: background var(--bento-transition), border var(--bento-transition), transform var(--bento-transition);
+}
+
+.bento-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: radial-gradient(circle at center, rgba(255,255,255,0.1) 0%, transparent 60%);
+  opacity: 0;
+  transition: opacity var(--bento-transition);
+  pointer-events: none;
+}
+
+.bento-card:hover {
+  background: var(--bento-card-hover);
+  border-color: rgba(255,255,255,0.25);
+  box-shadow: 0 10px 40px rgba(0,0,0,0.3);
+}
+
+.bento-card:hover::before {
+  opacity: 1;
+}
+
+/* Content inside card */
+.bento-content {
+  position: relative;
+  z-index: 1;
+}
+
+.bento-icon {
+  font-size: 2rem;
+  margin-bottom: 12px;
+  transform: translateY(0);
+  transition: transform var(--bento-transition);
+}
+
+.bento-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+  letter-spacing: -0.5px;
+}
+
+.bento-desc {
+  font-size: 0.9rem;
+  color: var(--bento-text-muted);
+  margin: 0;
+  opacity: 0;
+  max-height: 0;
+  transform: translateY(10px);
+  transition: opacity var(--bento-transition), max-height var(--bento-transition), transform var(--bento-transition);
+}
+
+/* Animate content reveal on hover */
+.bento-card:hover .bento-icon {
+  transform: translateY(-5px);
+}
+
+.bento-card:hover .bento-desc {
+  opacity: 1;
+  max-height: 60px;
+  transform: translateY(0);
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .bento-accordion-grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(9, 1fr);
+    height: auto;
+  }
+  
+  .bento-accordion-grid:has(.bento-card:nth-child(n):hover) {
+    grid-template-columns: 1fr;
+  }
+  
+  .bento-card {
+    min-height: 120px;
+  }
+  
+  .bento-card:hover .bento-desc {
+    max-height: 100px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Resolves #8318 
Adds a highly interactive, pure CSS masonry/bento grid that dynamically expands hovered cards while proportionally shrinking others using CSS Grid Fraction (`fr`) transitions.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/bento-accordion-grid-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
A premium bento grid layout where hovering over a cell gracefully expands its dimensions (e.g., `1fr` to `2fr`) while seamlessly shrinking sibling cells, revealing extra content inside the expanded card.

**How does a developer use it?**
```html
<div class="bento-accordion-grid">
  <div class="bento-card">
    <div class="bento-content">...</div>
  </div>
</div>
