### PR TITLE
[BUG] GSSoC points not reflecting on portal for accepted PR #6917 lin…

### DIFF
--- a/.github/workflows/auto-label-lifecycle.yml
+++ b/.github/workflows/auto-label-lifecycle.yml
@@ -98,6 +98,23 @@ jobs:
               console.log('Comment posted.');
             };
 
+            // Helper to get difficulty level based on text content
+            const getDifficultyLevel = (textContent, currentLabels) => {
+              const existingLevel = currentLabels.find(l => 
+                ['level:beginner', 'level:intermediate', 'level:advanced', 'level:critical'].includes(l)
+              );
+              if (existingLevel) return existingLevel;
+
+              if (textContent.includes('critical') || textContent.includes('urgent') || textContent.includes('security') || textContent.includes('severity:critical') || textContent.includes('broken')) {
+                return 'level:critical';
+              } else if (textContent.includes('advanced') || textContent.includes('complex') || textContent.includes('hard') || textContent.includes('performance') || textContent.includes('architecture') || textContent.includes('optimize')) {
+                return 'level:advanced';
+              } else if (textContent.includes('good first') || textContent.includes('easy') || textContent.includes('beginner') || textContent.includes('simple') || textContent.includes('typo') || textContent.includes('docs') || textContent.includes('documentation')) {
+                return 'level:beginner';
+              }
+              return 'level:intermediate';
+            };
+
             // ==========================================
             // 1. CLOSED lifecycle state
             // ==========================================
@@ -106,7 +123,16 @@ jobs:
                 const isMerged = item.merged || false;
                 if (isMerged) {
                   await removeLabels(['gssoc:invalid']);
-                  await addLabels(['accepted', 'integrated', 'GSSoC-26', 'gssoc:approved']);
+                  const title = item.title || '';
+                  const body = item.body || '';
+                  const textContent = `${title} ${body}`.toLowerCase();
+                  const levelLabel = getDifficultyLevel(textContent, currentLabels);
+                  
+                  const allLevels = ['level:beginner', 'level:intermediate', 'level:advanced', 'level:critical'];
+                  const levelsToRemove = allLevels.filter(l => l !== levelLabel);
+                  await removeLabels(levelsToRemove);
+
+                  await addLabels(['accepted', 'integrated', 'GSSoC-26', 'gssoc:approved', levelLabel]);
                   await addComment(`🎉 **Pull Request Integrated!**\n\nThank you for your contribution, @${itemAuthor}! Your changes have been successfully merged into \`main\` and will be credited to your wall. 🚀\n\n🎮 **Join our Discord Server!**\nWe have an official Discord server for EaseMotion CSS! Join us to connect with other developers, seek help, discuss design choices, and share your creations in the showcase channel: [Join the EaseMotion CSS Discord](https://discord.gg/hWSdGrccBU) 💜`);
                 } else {
                   await removeLabels(['accepted', 'integrated']);
@@ -116,7 +142,16 @@ jobs:
               } else {
                 // Issue closed
                 await removeLabels(['gssoc:invalid']);
-                await addLabels(['accepted']);
+                const title = item.title || '';
+                const body = item.body || '';
+                const textContent = `${title} ${body}`.toLowerCase();
+                const levelLabel = getDifficultyLevel(textContent, currentLabels);
+
+                const allLevels = ['level:beginner', 'level:intermediate', 'level:advanced', 'level:critical'];
+                const levelsToRemove = allLevels.filter(l => l !== levelLabel);
+                await removeLabels(levelsToRemove);
+
+                await addLabels(['accepted', 'GSSoC-26', 'gssoc:approved', levelLabel]);
                 await addComment(`🔒 **Issue Resolved & Closed.**\n\nThis issue has been marked as **accepted** and successfully resolved. Thanks for participating! ✨`);
               }
             }
@@ -144,7 +179,7 @@ jobs:
 
               const computedLabels = ['GSSoC-26', 'gssoc:approved'];
               if (!isPR) {
-                computedLabels.push('good first issue', 'help wanted');
+                computedLabels.push('help wanted');
               } else {
                 computedLabels.push('type:feature');
               }
@@ -161,10 +196,16 @@ jobs:
                 computedLabels.push('enhancement');
               }
 
-              if (textContent.includes('good first') || textContent.includes('easy')) {
+              const levelLabel = getDifficultyLevel(textContent, currentLabels);
+              
+              const allLevels = ['level:beginner', 'level:intermediate', 'level:advanced', 'level:critical'];
+              const levelsToRemove = allLevels.filter(l => l !== levelLabel);
+              await removeLabels(levelsToRemove);
+
+              computedLabels.push(levelLabel);
+
+              if (levelLabel === 'level:beginner' && !isPR) {
                 computedLabels.push('good first issue');
-              } else {
-                computedLabels.push('level:intermediate');
               }
 
               if (isPR) {


### PR DESCRIPTION
Closes #7427

## Problem
Currently, accepted GSSoC contributions are not having their points correctly reflected on the GSSoC portal. Additionally, issues are missing the appropriate difficulty labels (`level:beginner`, `level:intermediate`, `level:advanced`, or `level:critical`). 

Upon investigating the lifecycle automation script, we identified three root causes:
1. The script only assigned `level:intermediate` by default and had no provisions for other GSSoC levels.
2. For "easy" or "good first" tasks, the script added the `good first issue` label but omitted any `level:` labels (meaning the portal could not map the task to a specific point category).
3. The closed/merged workflows did not verify or enforce that the closed issue/PR possessed GSSoC-specific metadata and level labels required by the portal tracker.

## Solution
This PR resolves these issues by upgrading `.github/workflows/auto-label-lifecycle.yml`:
- **`getDifficultyLevel` Helper:** Introduced a parser to dynamically classify tasks into `level:beginner`, `level:intermediate`, `level:advanced`, or `level:critical` based on issue/PR titles and bodies, while respecting manually assigned level labels.
- **Level Deduping:** Cleans up previous level labels when a new level is computed, preventing overlapping level assignments.
- **Closed State Syncing:** Automatically applies the computed difficulty label and GSSoC labels (`GSSoC-26`, `gssoc:approved`) when issues are marked as resolved or PRs are integrated.

## Files Modified
- `.github/workflows/auto-label-lifecycle.yml` — Restructured helper functions, closed state lifecycle, and dynamic tagging.