### PR TITLE
Add hash modal routing demo

### DIFF
--- a/submissions/examples/hash-modal-ts/README.md
+++ b/submissions/examples/hash-modal-ts/README.md
@@ -1,0 +1,36 @@
+# Hash Modal Routing
+
+## What does this do?
+
+This adds a self-contained modal pattern that opens panels through URL hash links using only HTML and CSS.
+
+## How is it used?
+
+Link to a modal by matching the anchor `href` with the modal `id`:
+
+```html
+<a class="primary-action" href="#details-modal">Open details</a>
+
+<section class="hash-modal" id="details-modal" role="dialog" aria-modal="true">
+  <a class="modal-backdrop" href="#" aria-label="Close modal"></a>
+  <div class="modal-window">
+    <a class="icon-close" href="#" aria-label="Close modal">x</a>
+    <h2>Modal title</h2>
+    <p>Modal content goes here.</p>
+  </div>
+</section>
+```
+
+The CSS activates the modal with the `:target` selector:
+
+```css
+.hash-modal:target {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+}
+```
+
+## Why is it useful?
+
+It fits EaseMotion CSS because it turns a common interface pattern into a lightweight, dependency-free motion component that works by opening the demo file directly in a browser.

--- a/submissions/examples/hash-modal-ts/demo.html
+++ b/submissions/examples/hash-modal-ts/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hash Modal Routing</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="intro-panel" aria-labelledby="demo-title">
+        <p class="eyebrow">CSS modal pattern</p>
+        <h1 id="demo-title">Hash routed modal windows</h1>
+        <p>
+          Open a modal from an anchor link, share the URL, and close it without
+          losing the page layout.
+        </p>
+
+        <div class="action-row" aria-label="Modal examples">
+          <a class="primary-action" href="#details-modal">Open details</a>
+          <a class="secondary-action" href="#settings-modal">Open settings</a>
+        </div>
+      </section>
+
+      <section class="preview-grid" aria-label="Example cards">
+        <article class="preview-card">
+          <span class="card-index">01</span>
+          <h2>Deep link</h2>
+          <p>The modal can be opened directly with a URL hash.</p>
+        </article>
+        <article class="preview-card">
+          <span class="card-index">02</span>
+          <h2>Keyboard friendly</h2>
+          <p>Close controls are regular links, so they work without scripts.</p>
+        </article>
+        <article class="preview-card">
+          <span class="card-index">03</span>
+          <h2>Layered motion</h2>
+          <p>The overlay and dialog animate with separate transitions.</p>
+        </article>
+      </section>
+    </main>
+
+    <section
+      class="hash-modal"
+      id="details-modal"
+      aria-labelledby="details-title"
+      aria-modal="true"
+      role="dialog"
+    >
+      <a class="modal-backdrop" href="#" aria-label="Close details modal"></a>
+      <div class="modal-window" role="document">
+        <header class="modal-header">
+          <p class="eyebrow">Project details</p>
+          <a class="icon-close" href="#" aria-label="Close details modal">x</a>
+        </header>
+        <h2 id="details-title">Shareable product notes</h2>
+        <p>
+          This pattern is useful for docs, dashboards, galleries, and product
+          pages where a focused panel should have a stable link.
+        </p>
+        <div class="modal-actions">
+          <a class="primary-action small" href="#settings-modal">Next modal</a>
+          <a class="secondary-action small" href="#">Close</a>
+        </div>
+      </div>
+    </section>
+
+    <section
+      class="hash-modal"
+      id="settings-modal"
+      aria-labelledby="settings-title"
+      aria-modal="true"
+      role="dialog"
+    >
+      <a class="modal-backdrop" href="#" aria-label="Close settings modal"></a>
+      <div class="modal-window compact" role="document">
+        <header class="modal-header">
+          <p class="eyebrow">Preferences</p>
+          <a class="icon-close" href="#" aria-label="Close settings modal">x</a>
+        </header>
+        <h2 id="settings-title">Motion settings preview</h2>
+        <div class="setting-list">
+          <label>
+            <span>Overlay blur</span>
+            <input type="checkbox" checked />
+          </label>
+          <label>
+            <span>Soft entrance</span>
+            <input type="checkbox" checked />
+          </label>
+          <label>
+            <span>Compact mode</span>
+            <input type="checkbox" />
+          </label>
+        </div>
+        <div class="modal-actions">
+          <a class="secondary-action small" href="#">Done</a>
+        </div>
+      </div>
+    </section>
+  </body>
+</html>

--- a/submissions/examples/hash-modal-ts/style.css
+++ b/submissions/examples/hash-modal-ts/style.css
@@ -1,0 +1,309 @@
+:root {
+  --page-bg: #f6f7fb;
+  --ink: #182230;
+  --muted: #637083;
+  --panel: #ffffff;
+  --line: #d9deea;
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
+  --mint: #14b8a6;
+  --coral: #f97362;
+  --shadow: 0 28px 70px rgb(24 34 48 / 18%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 20% 12%, rgb(20 184 166 / 16%), transparent 32rem),
+    radial-gradient(circle at 85% 18%, rgb(249 115 98 / 14%), transparent 28rem),
+    linear-gradient(135deg, #f8fafc 0%, var(--page-bg) 100%);
+}
+
+.demo-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.intro-panel {
+  max-width: 760px;
+  padding: 44px 0 36px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 700px;
+  margin-bottom: 18px;
+  font-size: clamp(2.4rem, 6vw, 5.2rem);
+  line-height: 0.98;
+}
+
+h2 {
+  margin-bottom: 12px;
+  font-size: 1.45rem;
+}
+
+p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.intro-panel > p {
+  max-width: 570px;
+  font-size: 1.08rem;
+}
+
+.action-row,
+.modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 26px;
+}
+
+.primary-action,
+.secondary-action {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  padding: 0 18px;
+  font-weight: 800;
+  text-decoration: none;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background 180ms ease;
+}
+
+.primary-action {
+  color: white;
+  background: var(--accent);
+  box-shadow: 0 14px 30px rgb(37 99 235 / 24%);
+}
+
+.secondary-action {
+  border: 1px solid var(--line);
+  color: var(--ink);
+  background: rgb(255 255 255 / 76%);
+}
+
+.primary-action:hover,
+.secondary-action:hover,
+.primary-action:focus-visible,
+.secondary-action:focus-visible {
+  transform: translateY(-2px);
+}
+
+.primary-action:hover,
+.primary-action:focus-visible {
+  background: var(--accent-dark);
+}
+
+.small {
+  min-height: 40px;
+  padding-inline: 14px;
+  font-size: 0.9rem;
+}
+
+.preview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.preview-card {
+  min-height: 210px;
+  border: 1px solid rgb(217 222 234 / 86%);
+  border-radius: 8px;
+  padding: 24px;
+  background: rgb(255 255 255 / 72%);
+  box-shadow: 0 18px 50px rgb(24 34 48 / 8%);
+  backdrop-filter: blur(14px);
+}
+
+.card-index {
+  display: inline-flex;
+  width: 42px;
+  height: 42px;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 40px;
+  border-radius: 50%;
+  color: white;
+  font-weight: 900;
+  background: linear-gradient(135deg, var(--mint), var(--accent));
+}
+
+.preview-card:nth-child(2) .card-index {
+  background: linear-gradient(135deg, var(--coral), #f59e0b);
+}
+
+.preview-card:nth-child(3) .card-index {
+  background: linear-gradient(135deg, #7c3aed, var(--accent));
+}
+
+.hash-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 220ms ease,
+    visibility 220ms ease;
+}
+
+.hash-modal:target {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgb(15 23 42 / 58%);
+  backdrop-filter: blur(8px);
+}
+
+.modal-window {
+  position: relative;
+  width: min(560px, 100%);
+  border: 1px solid rgb(255 255 255 / 62%);
+  border-radius: 8px;
+  padding: 28px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  transform: translateY(22px) scale(0.96);
+  opacity: 0;
+  transition:
+    transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 180ms ease;
+}
+
+.hash-modal:target .modal-window {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+}
+
+.modal-window.compact {
+  max-width: 430px;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.icon-close {
+  display: inline-flex;
+  width: 38px;
+  height: 38px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  color: var(--ink);
+  font-size: 1.1rem;
+  font-weight: 800;
+  text-decoration: none;
+  text-transform: uppercase;
+  background: #f8fafc;
+}
+
+.setting-list {
+  display: grid;
+  gap: 12px;
+  margin: 22px 0;
+}
+
+.setting-list label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px 16px;
+  color: var(--ink);
+  font-weight: 750;
+  background: #f8fafc;
+}
+
+.setting-list input {
+  width: 20px;
+  height: 20px;
+  accent-color: var(--accent);
+}
+
+@media (max-width: 760px) {
+  .demo-shell {
+    padding: 36px 0;
+  }
+
+  .intro-panel {
+    padding-top: 22px;
+  }
+
+  .preview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .preview-card {
+    min-height: auto;
+  }
+
+  .card-index {
+    margin-bottom: 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained hash-routed modal demo under `submissions/examples/hash-modal-ts/`.

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only modal pattern that opens panels through URL hash links and supports shareable modal states.

**How does a developer use it?**

```html
<a class="primary-action" href="#details-modal">Open details</a>

<section class="hash-modal" id="details-modal" role="dialog" aria-modal="true">
  <a class="modal-backdrop" href="#" aria-label="Close modal"></a>
  <div class="modal-window">
    <a class="icon-close" href="#" aria-label="Close modal">x</a>
    <h2>Modal title</h2>
    <p>Modal content goes here.</p>
  </div>
</section>
```

**Why does it fit EaseMotion CSS?**

It keeps the interaction lightweight and dependency-free while adding smooth overlay and dialog motion for a common UI pattern.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The demo is intentionally self-contained and uses only HTML and CSS.

Fixes: #8341