### PR TITLE
feat: add neo-brutalism modal component

### DIFF
--- a/submissions/examples/neo-brutalism-modal-sk/README.md
+++ b/submissions/examples/neo-brutalism-modal-sk/README.md
@@ -1,0 +1,16 @@
+# Neo-Brutalism Modal Dialog
+
+A stark, high-contrast modal dialog box built using the native HTML `<dialog>` element.
+
+## Files
+- `demo.html`: The HTML structure utilizing the `<dialog>` element and native HTML forms for closing.
+- `style.css`: The styling to override default dialog styles and apply brutalist borders, shadows, and a stark backdrop.
+- `README.md`: This file.
+
+## Features
+- **Native HTML5:** Uses the semantic `<dialog>` tag which provides built-in accessibility and a top-layer placement without complex z-index management.
+- **Neo-Brutalism:** Features thick black borders, bright accents, and a rigid, unblurred drop shadow on both the modal and its buttons.
+- **Backdrop Styling:** The `::backdrop` is styled as a harsh, semi-transparent black overlay, contrasting with standard soft blurs.
+
+## Usage
+Simply invoke the modal via JS using `dialogElement.showModal()`, or close it automatically using `<form method="dialog">`.

--- a/submissions/examples/neo-brutalism-modal-sk/demo.html
+++ b/submissions/examples/neo-brutalism-modal-sk/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neo-Brutalism Modal | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Trigger Button -->
+  <button class="neo-trigger-btn" onclick="document.getElementById('brutalModal').showModal()">
+    Open Modal
+  </button>
+
+  <!-- Native HTML5 Dialog -->
+  <dialog class="neo-brutal-modal" id="brutalModal">
+    
+    <h2 class="neo-modal-header">System Alert</h2>
+    
+    <div class="neo-modal-body">
+      <p>This is a native HTML5 <code>&lt;dialog&gt;</code> component dressed in a stark neo-brutalist style.</p>
+      <p>It utilizes the built-in top-layer and <code>::backdrop</code> features to avoid complex z-index issues.</p>
+    </div>
+    
+    <!-- Using form method="dialog" closes the modal natively without JS -->
+    <form method="dialog" class="neo-modal-footer">
+      <button class="neo-modal-btn">Cancel</button>
+      <button class="neo-modal-btn primary">Acknowledge</button>
+    </form>
+    
+  </dialog>
+
+</body>
+</html>

--- a/submissions/examples/neo-brutalism-modal-sk/style.css
+++ b/submissions/examples/neo-brutalism-modal-sk/style.css
@@ -1,0 +1,121 @@
+/* Neo-Brutalism Modal CSS */
+
+:root {
+  --brutal-bg: #e2e8f0;
+  --brutal-modal-bg: #ffffff;
+  --brutal-header-bg: #ff5252;
+  --brutal-border: #000000;
+  --brutal-shadow: #000000;
+  --brutal-text: #1a1a1a;
+  --brutal-text-inverse: #ffffff;
+}
+
+body {
+  background-color: var(--brutal-bg);
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--brutal-text);
+  margin: 0;
+  padding: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+/* Base trigger button */
+.neo-trigger-btn {
+  background-color: #4caf50;
+  color: var(--brutal-text);
+  border: 3px solid var(--brutal-border);
+  padding: 16px 32px;
+  font-size: 1.25rem;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 6px 6px 0 var(--brutal-shadow);
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.neo-trigger-btn:active {
+  transform: translate(4px, 4px);
+  box-shadow: 2px 2px 0 var(--brutal-shadow);
+}
+
+/* Modal Dialog */
+.neo-brutal-modal {
+  padding: 0;
+  border: 4px solid var(--brutal-border);
+  border-radius: 0;
+  background-color: var(--brutal-modal-bg);
+  box-shadow: 12px 12px 0 var(--brutal-shadow);
+  max-width: 500px;
+  width: 90%;
+}
+
+/* Native backdrop styling */
+.neo-brutal-modal::backdrop {
+  background: rgba(0, 0, 0, 0.85);
+}
+
+/* Entrance Animation */
+.neo-brutal-modal[open] {
+  animation: brutalModalIn 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+}
+
+@keyframes brutalModalIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.9) translateY(-20px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+/* Modal Header */
+.neo-modal-header {
+  background-color: var(--brutal-header-bg);
+  color: var(--brutal-text-inverse);
+  padding: 20px 24px;
+  border-bottom: 4px solid var(--brutal-border);
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+/* Modal Body */
+.neo-modal-body {
+  padding: 24px;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+/* Modal Footer / Form */
+.neo-modal-footer {
+  padding: 0 24px 24px 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+/* Action Buttons inside Modal */
+.neo-modal-btn {
+  background-color: #ffffff;
+  border: 3px solid var(--brutal-border);
+  padding: 10px 20px;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 4px 4px 0 var(--brutal-shadow);
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.neo-modal-btn:active {
+  transform: translate(2px, 2px);
+  box-shadow: 2px 2px 0 var(--brutal-shadow);
+}
+
+.neo-modal-btn.primary {
+  background-color: #ffeb3b;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves #8354
Adds a stark pop-up dialog box utilizing the native HTML5 `<dialog>` element. It features a rigid layout, thick borders, an unblurred shadow, and a semi-transparent black `::backdrop`.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/neo-brutalism-modal-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
A fully accessible, native HTML dialog styled with neo-brutalism.

**How does a developer use it?**
Use the standard HTML `<dialog>` tag and apply the `.neo-brutal-modal` class.

**Why does it fit EaseMotion CSS?**
It leverages modern HTML features (`<dialog>`, `::backdrop`, `form method="dialog"`) to create complex UI states natively in the browser, adhering perfectly to the library's design philosophies.
