### PR TITLE
feat: add neo-brutalism dropdown component

### DIFF
--- a/submissions/examples/neo-brutalism-dropdown-sk/README.md
+++ b/submissions/examples/neo-brutalism-dropdown-sk/README.md
@@ -1,0 +1,16 @@
+# Neo-Brutalism Dropdown Menu
+
+A high-contrast, stark dropdown menu component without soft blurs or gentle fades.
+
+## Files
+- `demo.html`: The HTML structure for the dropdown wrapper, toggle button, and list.
+- `style.css`: The styling to create the hover/focus revealing animation and the brutalist aesthetics.
+- `README.md`: This file.
+
+## Features
+- **Pure CSS:** Relies on `:focus-within` and `:hover` to toggle the dropdown list visibility, keeping it lightweight and JS-free.
+- **Neo-Brutalism:** Features thick black borders, solid color blocks, and a heavy, unblurred offset shadow.
+- **Mechanical Drop:** Instead of a soft opacity fade, it scales slightly and snaps into view, fitting the brutalist theme perfectly.
+
+## Usage
+Wrap your button and list in `.neo-brutal-dropdown`.

--- a/submissions/examples/neo-brutalism-dropdown-sk/demo.html
+++ b/submissions/examples/neo-brutalism-dropdown-sk/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neo-Brutalism Dropdown | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Dropdown component -->
+  <div class="neo-brutal-dropdown">
+    <button class="neo-dropdown-toggle">Settings</button>
+    
+    <ul class="neo-dropdown-menu">
+      <li><a href="#">Account Profile</a></li>
+      <li><a href="#">Billing Info</a></li>
+      <li><a href="#">Security</a></li>
+      <li><button>Log Out</button></li>
+    </ul>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/neo-brutalism-dropdown-sk/style.css
+++ b/submissions/examples/neo-brutalism-dropdown-sk/style.css
@@ -1,0 +1,127 @@
+/* Neo-Brutalism Dropdown CSS */
+
+:root {
+  --brutal-bg: #fdfbf7;
+  --brutal-btn-bg: #ff9800;
+  --brutal-list-bg: #ffffff;
+  --brutal-hover-bg: #000000;
+  --brutal-border: #000000;
+  --brutal-shadow: #000000;
+  --brutal-text: #1a1a1a;
+  --brutal-text-inverse: #ffffff;
+}
+
+body {
+  background-color: var(--brutal-bg);
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--brutal-text);
+  margin: 0;
+  padding: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+/* Dropdown Container */
+.neo-brutal-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+/* Toggle Button */
+.neo-dropdown-toggle {
+  background-color: var(--brutal-btn-bg);
+  color: var(--brutal-text);
+  border: 3px solid var(--brutal-border);
+  padding: 12px 24px;
+  font-size: 1.25rem;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 6px 6px 0 var(--brutal-shadow);
+  transition: transform 0.1s, box-shadow 0.1s;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.neo-dropdown-toggle:active {
+  transform: translate(4px, 4px);
+  box-shadow: 2px 2px 0 var(--brutal-shadow);
+}
+
+.neo-dropdown-toggle::after {
+  content: "▼";
+  font-size: 0.8rem;
+  transition: transform 0.2s;
+}
+
+.neo-brutal-dropdown:hover .neo-dropdown-toggle::after,
+.neo-brutal-dropdown:focus-within .neo-dropdown-toggle::after {
+  transform: rotate(180deg);
+}
+
+/* Dropdown List */
+.neo-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 15px);
+  left: 0;
+  min-width: 200px;
+  background-color: var(--brutal-list-bg);
+  border: 3px solid var(--brutal-border);
+  box-shadow: 8px 8px 0 var(--brutal-shadow);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  
+  /* Hidden by default */
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-10px) scale(0.98);
+  transform-origin: top center;
+  transition: opacity 0.15s ease-out, transform 0.15s ease-out, visibility 0.15s;
+  z-index: 10;
+}
+
+/* Show on hover or focus-within */
+.neo-brutal-dropdown:hover .neo-dropdown-menu,
+.neo-brutal-dropdown:focus-within .neo-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+}
+
+/* List Items */
+.neo-dropdown-menu li {
+  border-bottom: 2px solid var(--brutal-border);
+}
+
+.neo-dropdown-menu li:last-child {
+  border-bottom: none;
+}
+
+.neo-dropdown-menu a,
+.neo-dropdown-menu button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 14px 20px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--brutal-text);
+  text-decoration: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.1s, color 0.1s;
+}
+
+/* Hover States for List Items */
+.neo-dropdown-menu a:hover,
+.neo-dropdown-menu button:hover,
+.neo-dropdown-menu a:focus,
+.neo-dropdown-menu button:focus {
+  background-color: var(--brutal-hover-bg);
+  color: var(--brutal-text-inverse);
+  outline: none;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves #8355
Adds a rigid, high-contrast dropdown menu. It utilizes `:focus-within` and `:hover` to toggle visibility without JavaScript, snapping into view with a mechanical scale animation.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/neo-brutalism-dropdown-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
A stark dropdown list for complex navigation, completely JS-free.

**How does a developer use it?**
Wrap a button and a `<ul>` inside `.neo-brutal-dropdown`.

**Why does it fit EaseMotion CSS?**
It offers an advanced structural element that perfectly matches the brutalist styling trend, demonstrating how to handle focus management and visibility toggling through CSS alone.
