### PR TITLE
feat: add neo-brutalism tooltip component

### DIFF
--- a/submissions/examples/neo-brutalism-tooltip-sk/README.md
+++ b/submissions/examples/neo-brutalism-tooltip-sk/README.md
@@ -1,0 +1,16 @@
+# Neo-Brutalism Tooltip
+
+A stark, high-contrast tooltip component that pops into view instantly with a hard drop shadow.
+
+## Files
+- `demo.html`: The HTML structure utilizing a `data-tooltip` attribute.
+- `style.css`: The styling to create the pure CSS tooltip using `::after` pseudo-elements.
+- `README.md`: This file.
+
+## Features
+- **Pure CSS:** No JavaScript required. Relies on `attr(data-tooltip)` and `:hover`.
+- **High Visibility:** Bright, neon background colors and thick black borders ensure it commands attention.
+- **Instant Pop:** Avoids soft fades in favor of a mechanical scale-and-snap animation.
+
+## Usage
+Add the `.neo-tooltip-wrapper` class to an element and provide your text in `data-tooltip="..."`.

--- a/submissions/examples/neo-brutalism-tooltip-sk/demo.html
+++ b/submissions/examples/neo-brutalism-tooltip-sk/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neo-Brutalism Tooltip | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Pure CSS Tooltip using data attribute -->
+  <div class="neo-tooltip-wrapper" tabindex="0" data-tooltip="WARNING: Highly Brutalist!">
+    Hover or Focus Me
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/neo-brutalism-tooltip-sk/style.css
+++ b/submissions/examples/neo-brutalism-tooltip-sk/style.css
@@ -1,0 +1,95 @@
+/* Neo-Brutalism Tooltip CSS */
+
+:root {
+  --brutal-bg: #e2e8f0;
+  --brutal-tooltip-bg: #00ff7f; /* Neon green */
+  --brutal-border: #000000;
+  --brutal-shadow: #000000;
+  --brutal-text: #000000;
+}
+
+body {
+  background-color: var(--brutal-bg);
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--brutal-text);
+  margin: 0;
+  padding: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+/* Tooltip Wrapper */
+.neo-tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+  cursor: help;
+  font-size: 1.25rem;
+  font-weight: 800;
+  padding: 10px 20px;
+  background: #fff;
+  border: 3px solid var(--brutal-border);
+  box-shadow: 4px 4px 0 var(--brutal-shadow);
+  transition: transform 0.1s;
+}
+
+.neo-tooltip-wrapper:active {
+  transform: translate(2px, 2px);
+  box-shadow: 2px 2px 0 var(--brutal-shadow);
+}
+
+/* Tooltip Body */
+.neo-tooltip-wrapper::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 15px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.8);
+  transform-origin: bottom center;
+  background-color: var(--brutal-tooltip-bg);
+  color: var(--brutal-text);
+  padding: 8px 16px;
+  font-size: 1rem;
+  font-weight: 700;
+  white-space: nowrap;
+  border: 3px solid var(--brutal-border);
+  box-shadow: 6px 6px 0 var(--brutal-shadow);
+  opacity: 0;
+  visibility: hidden;
+  transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), opacity 0.15s;
+  pointer-events: none;
+  z-index: 100;
+}
+
+/* The brutalist connector triangle */
+.neo-tooltip-wrapper::before {
+  content: "";
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) scale(0);
+  border-width: 8px 8px 0 8px;
+  border-style: solid;
+  border-color: var(--brutal-border) transparent transparent transparent;
+  opacity: 0;
+  visibility: hidden;
+  transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), opacity 0.15s;
+  pointer-events: none;
+  z-index: 99;
+}
+
+/* Hover States */
+.neo-tooltip-wrapper:hover::after,
+.neo-tooltip-wrapper:focus::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) scale(1);
+}
+
+.neo-tooltip-wrapper:hover::before,
+.neo-tooltip-wrapper:focus::before {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) scale(1);
+}


### PR DESCRIPTION
## Pull Request Description
Resolves #8356
Adds a stark, boxy tooltip that utilizes a bright neon background, thick borders, and a pure CSS `data-tooltip` attribute approach to pop into view instantly without soft fades.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/neo-brutalism-tooltip-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
A highly visible, pure CSS tooltip.

**How does a developer use it?**
Add `class="neo-tooltip-wrapper"` and `data-tooltip="Your text here"` to any HTML element.

**Why does it fit EaseMotion CSS?**
It leverages `attr()` in CSS content generation to avoid JavaScript, and adds an aggressive, eye-catching hover interaction missing from the current collection.
