### PR TITLE
feat: add neo-brutalism tabs component

### DIFF
--- a/submissions/examples/neo-brutalism-tabs-sk/README.md
+++ b/submissions/examples/neo-brutalism-tabs-sk/README.md
@@ -1,0 +1,16 @@
+# Neo-Brutalism Navigation Tabs
+
+A stark, high-contrast navigation tabs component with a highly tactile pressing mechanism.
+
+## Files
+- `demo.html`: The HTML structure for the tabs and their content containers.
+- `style.css`: The styling utilizing brutalist shadow offsets and translation transitions.
+- `README.md`: This file.
+
+## Features
+- **Zero JS Layout:** The layout and hover states function entirely via CSS. (In a real app, JS or radio buttons would manage the `active` class or `:checked` state, but the visual styles are purely CSS).
+- **Tactile Feedback:** Inactive tabs sit on top of a heavy, unblurred shadow. The active tab translates down and right to cover its shadow, indicating it has been "pressed" into the page.
+- **High Contrast:** Uses stark white, bright primary colors, and pitch black borders for the neo-brutalism aesthetic.
+
+## Usage
+Add the `.neo-tabs` structure and apply `.active` to the currently selected tab.

--- a/submissions/examples/neo-brutalism-tabs-sk/demo.html
+++ b/submissions/examples/neo-brutalism-tabs-sk/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neo-Brutalism Tabs | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="tabs-container">
+    
+    <!-- Tab Navigation -->
+    <div class="neo-tabs-nav">
+      <!-- Active tab is "pressed" in -->
+      <button class="neo-tab active" onclick="switchTab(0)">Tab One</button>
+      <button class="neo-tab" onclick="switchTab(1)">Tab Two</button>
+      <button class="neo-tab" onclick="switchTab(2)">Tab Three</button>
+    </div>
+
+    <!-- Tab Content -->
+    <div class="neo-tab-content-wrapper">
+      
+      <div class="neo-tab-content active" id="content-0">
+        <h2>First Panel</h2>
+        <p>This is the first tab's content. Notice how the active tab above appears to be pressed down physically into the page, hiding its shadow entirely.</p>
+      </div>
+
+      <div class="neo-tab-content" id="content-1">
+        <h2>Second Panel</h2>
+        <p>This is the second tab's content. A stark, fast animation reveals the content instantly, perfectly aligning with brutalist principles.</p>
+      </div>
+
+      <div class="neo-tab-content" id="content-2">
+        <h2>Third Panel</h2>
+        <p>This is the third tab's content. No soft blurs, no subtle fades—just high-contrast, mechanical UI elements.</p>
+      </div>
+
+    </div>
+
+  </div>
+
+  <!-- Simple JS for demo purposes -->
+  <script>
+    function switchTab(index) {
+      // Remove active class from all tabs
+      document.querySelectorAll('.neo-tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.neo-tab-content').forEach(c => c.classList.remove('active'));
+      
+      // Add active class to target
+      document.querySelectorAll('.neo-tab')[index].classList.add('active');
+      document.getElementById(`content-${index}`).classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/neo-brutalism-tabs-sk/style.css
+++ b/submissions/examples/neo-brutalism-tabs-sk/style.css
@@ -1,0 +1,106 @@
+/* Neo-Brutalism Tabs CSS */
+
+:root {
+  --brutal-bg: #e2e8f0;
+  --brutal-border: #000000;
+  --brutal-shadow: #000000;
+  --brutal-active: #ff5252;
+  --brutal-inactive: #ffffff;
+  --brutal-text: #1a1a1a;
+}
+
+body {
+  background-color: var(--brutal-bg);
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--brutal-text);
+  margin: 0;
+  padding: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.tabs-container {
+  width: 100%;
+  max-width: 600px;
+}
+
+/* Tab Headers */
+.neo-tabs-nav {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.neo-tab {
+  background-color: var(--brutal-inactive);
+  border: 3px solid var(--brutal-border);
+  border-radius: 0;
+  padding: 12px 24px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 6px 6px 0 var(--brutal-shadow);
+  transition: transform 0.15s ease-out, box-shadow 0.15s ease-out, background-color 0.15s ease-out;
+  flex: 1;
+  text-align: center;
+  color: var(--brutal-text);
+}
+
+.neo-tab:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 8px 8px 0 var(--brutal-shadow);
+}
+
+/* The Active "Pressed" Tab */
+.neo-tab.active {
+  background-color: var(--brutal-active);
+  transform: translate(6px, 6px) !important;
+  box-shadow: 0 0 0 var(--brutal-shadow) !important;
+  color: #ffffff;
+  border-color: var(--brutal-border);
+}
+
+/* Tab Content Area */
+.neo-tab-content-wrapper {
+  background-color: #ffffff;
+  border: 4px solid var(--brutal-border);
+  box-shadow: 8px 8px 0 var(--brutal-shadow);
+  padding: 32px;
+  min-height: 200px;
+  position: relative;
+}
+
+.neo-tab-content {
+  display: none;
+  animation: brutalPop 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+}
+
+.neo-tab-content.active {
+  display: block;
+}
+
+.neo-tab-content h2 {
+  margin-top: 0;
+  font-size: 1.8rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.neo-tab-content p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+/* Content Entrance Animation */
+@keyframes brutalPop {
+  0% {
+    opacity: 0;
+    transform: scale(0.95) translate(-10px, -10px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translate(0, 0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Resolves #8357
Adds a highly tactile neo-brutalist navigation tabs component, where active tabs translate downwards to cover their heavy unblurred drop shadows, mimicking a physical mechanical button press.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/neo-brutalism-tabs-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
High-contrast navigation tabs with a physical "pressed" state effect.

**How does a developer use it?**
Use `.neo-tabs-nav` to structure the tabs, and toggle `.active` on the pressed tab.

**Why does it fit EaseMotion CSS?**
It provides an excellent demonstration of using CSS `transform` and `box-shadow` combinations to create complex, tactile UI states.
