### PR TITLE
feat: add neo-brutalism accordion component

### DIFF
--- a/submissions/examples/neo-brutalism-accordion-sk/README.md
+++ b/submissions/examples/neo-brutalism-accordion-sk/README.md
@@ -1,0 +1,16 @@
+# Neo-Brutalism Accordion
+
+A stark, high-contrast accordion menu built entirely with native HTML `<details>` and `<summary>` tags, styled with a neo-brutalist aesthetic.
+
+## Files
+- `demo.html`: The HTML structure using native elements.
+- `style.css`: The styling to override default browser details appearance and apply brutalist borders, shadows, and spacing.
+- `README.md`: This file.
+
+## Features
+- **Zero JS:** Relies on the browser's native `<details>` toggling mechanism.
+- **Neo-Brutalism:** Thick black borders, a solid offset drop shadow, and bright colors.
+- **Mechanical Animation:** A slightly rigid transition that matches the brutalist aesthetic.
+
+## Usage
+Add the `.neo-accordion` class to your `<details>` elements.

--- a/submissions/examples/neo-brutalism-accordion-sk/demo.html
+++ b/submissions/examples/neo-brutalism-accordion-sk/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neo-Brutalism Accordion | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="accordion-container">
+    
+    <details class="neo-accordion" name="brutal-faq" open>
+      <summary>What is Neo-Brutalism?</summary>
+      <div class="neo-accordion-content">
+        <p>Neo-brutalism is a web design trend characterized by stark contrasts, solid, unblurred drop shadows, and thick borders. It rejects the soft gradients and blurs of flat design or glassmorphism in favor of a raw, mechanical look.</p>
+      </div>
+    </details>
+
+    <details class="neo-accordion" name="brutal-faq">
+      <summary>Does this require JavaScript?</summary>
+      <div class="neo-accordion-content">
+        <p>Nope! It utilizes the native HTML <code>&lt;details&gt;</code> and <code>&lt;summary&gt;</code> elements to handle the toggling logic perfectly without a single line of JS.</p>
+      </div>
+    </details>
+
+    <details class="neo-accordion" name="brutal-faq">
+      <summary>Is it accessible?</summary>
+      <div class="neo-accordion-content">
+        <p>Yes. Because it uses semantic HTML tags, screen readers and keyboard navigation natively understand how to interact with and read the accordion items.</p>
+      </div>
+    </details>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/neo-brutalism-accordion-sk/style.css
+++ b/submissions/examples/neo-brutalism-accordion-sk/style.css
@@ -1,0 +1,116 @@
+/* Neo-Brutalism Accordion CSS */
+
+:root {
+  --brutal-bg: #fdfbf7;
+  --brutal-primary: #ffeb3b;
+  --brutal-border: #000000;
+  --brutal-shadow: #000000;
+  --brutal-text: #1a1a1a;
+}
+
+body {
+  background-color: var(--brutal-bg);
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--brutal-text);
+  margin: 0;
+  padding: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.accordion-container {
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* Base accordion styling */
+.neo-accordion {
+  background-color: #ffffff;
+  border: 3px solid var(--brutal-border);
+  border-radius: 4px;
+  box-shadow: 6px 6px 0 var(--brutal-shadow);
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Hover effect on the whole details block */
+.neo-accordion:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 8px 8px 0 var(--brutal-shadow);
+}
+
+/* Style the summary (header) */
+.neo-accordion summary {
+  padding: 20px;
+  font-size: 1.25rem;
+  font-weight: 700;
+  cursor: pointer;
+  background-color: var(--brutal-primary);
+  list-style: none; /* remove default arrow */
+  position: relative;
+  user-select: none;
+  border-bottom: 3px solid transparent;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+/* Remove default webkit triangle */
+.neo-accordion summary::-webkit-details-marker {
+  display: none;
+}
+
+/* Custom Icon */
+.neo-accordion summary::after {
+  content: "+";
+  font-size: 1.5rem;
+  font-weight: 900;
+  line-height: 1;
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* When open */
+.neo-accordion[open] summary {
+  border-bottom-color: var(--brutal-border);
+}
+
+.neo-accordion[open] summary::after {
+  transform: rotate(45deg);
+}
+
+/* The content wrapper */
+.neo-accordion-content {
+  padding: 20px;
+  background-color: #ffffff;
+  font-size: 1.1rem;
+  line-height: 1.6;
+  border-top: 3px solid var(--brutal-border);
+  margin-top: -3px; /* overlap to hide border when closed */
+  animation: brutalSlideDown 0.3s ease-out forwards;
+}
+
+/* Mechanical slide down animation */
+@keyframes brutalSlideDown {
+  0% {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Color variations */
+.neo-accordion:nth-child(2) summary {
+  background-color: #ff9800;
+}
+
+.neo-accordion:nth-child(3) summary {
+  background-color: #4caf50;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves #8358
Adds a stark, high-contrast Neo-Brutalism accordion component built perfectly utilizing the native HTML `<details>` and `<summary>` tags without needing any JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/neo-brutalism-accordion-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
A completely JS-free brutalist accordion menu.

**How does a developer use it?**
Wrap your content in `<details class="neo-accordion">` and a `<summary>`.

**Why does it fit EaseMotion CSS?**
It adds a highly requested structural component (accordion) styled strictly in the popular neo-brutalist aesthetic, utilizing native browser toggling functionality to adhere to the JS-free philosophy.
