### PR TITLE
feat: add retro pixel button component

### DIFF
--- a/submissions/examples/retro-pixel-btn-sk/README.md
+++ b/submissions/examples/retro-pixel-btn-sk/README.md
@@ -1,0 +1,16 @@
+# Retro 8-bit Pixel Button
+
+A chunky, nostalgic button perfect for retro, Web3, or gaming interfaces.
+
+## Files
+- `demo.html`: The HTML structure for the pixel button.
+- `style.css`: The massive CSS `box-shadow` calculation that draws the 8-bit border.
+- `README.md`: This file.
+
+## Features
+- **Pure CSS:** No images or SVGs used. The pixelated border is drawn entirely using stacked `box-shadow` values.
+- **Infinite Scalability:** Because it's CSS, the "pixels" scale perfectly without raster blur.
+- **Interactive:** Features a chunky `:active` state that presses the button down.
+
+## Usage
+Add the `.retro-pixel-btn` class to your button. The button's "pixel size" is derived from the box-shadow offsets, which are based on a base pixel size of `4px`.

--- a/submissions/examples/retro-pixel-btn-sk/demo.html
+++ b/submissions/examples/retro-pixel-btn-sk/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retro 8-bit Pixel Button | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Try clicking the button to see the chunky pixel press animation -->
+  <button class="retro-pixel-btn">
+    START GAME
+  </button>
+
+</body>
+</html>

--- a/submissions/examples/retro-pixel-btn-sk/style.css
+++ b/submissions/examples/retro-pixel-btn-sk/style.css
@@ -1,0 +1,82 @@
+/* Retro 8-bit Pixel Button CSS */
+
+:root {
+  --pixel-bg: #8b9bb4;
+  --pixel-border: #1a1a1a;
+  --pixel-highlight: #c0cbdc;
+  --pixel-shadow: #5a6988;
+  --pixel-text: #ffffff;
+}
+
+body {
+  background-color: #2b2b2b;
+  /* Use a retro or monospace font if available */
+  font-family: 'Courier New', Courier, monospace;
+  margin: 0;
+  padding: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+/* 
+  The "Pixel" technique:
+  We use box-shadow to draw 4px squares all around the button.
+  This creates a jagged, 8-bit corner effect.
+*/
+.retro-pixel-btn {
+  background: var(--pixel-bg);
+  color: var(--pixel-text);
+  font-size: 1.5rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  padding: 16px 32px;
+  border: none;
+  cursor: pointer;
+  position: relative;
+  
+  /* The core pixel drawing */
+  box-shadow: 
+    /* Inner highlights */
+    inset -4px -4px 0 0 var(--pixel-shadow),
+    inset 4px 4px 0 0 var(--pixel-highlight),
+    /* Outer borders */
+    0 -4px 0 0 var(--pixel-border),
+    0 4px 0 0 var(--pixel-border),
+    -4px 0 0 0 var(--pixel-border),
+    4px 0 0 0 var(--pixel-border),
+    /* Outer border corners */
+    -4px -4px 0 0 var(--pixel-border),
+    4px -4px 0 0 var(--pixel-border),
+    -4px 4px 0 0 var(--pixel-border),
+    4px 4px 0 0 var(--pixel-border),
+    /* The drop shadow */
+    0 8px 0 0 var(--pixel-border),
+    4px 8px 0 0 var(--pixel-border),
+    -4px 8px 0 0 var(--pixel-border),
+    8px 4px 0 0 var(--pixel-border);
+    
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.retro-pixel-btn:active {
+  transform: translateY(4px);
+  /* Compress the shadow when pressed */
+  box-shadow: 
+    inset -4px -4px 0 0 var(--pixel-shadow),
+    inset 4px 4px 0 0 var(--pixel-highlight),
+    0 -4px 0 0 var(--pixel-border),
+    0 4px 0 0 var(--pixel-border),
+    -4px 0 0 0 var(--pixel-border),
+    4px 0 0 0 var(--pixel-border),
+    -4px -4px 0 0 var(--pixel-border),
+    4px -4px 0 0 var(--pixel-border),
+    -4px 4px 0 0 var(--pixel-border),
+    4px 4px 0 0 var(--pixel-border),
+    /* Shadow is reduced */
+    0 4px 0 0 var(--pixel-border),
+    4px 4px 0 0 var(--pixel-border),
+    -4px 4px 0 0 var(--pixel-border),
+    8px 0 0 0 var(--pixel-border);
+}


### PR DESCRIPTION
## Pull Request Description
Resolves #8379
Adds a chunky, nostalgic 8-bit pixel button. Instead of standard CSS borders or images, it uses an advanced multi-layered `box-shadow` technique to mathematically "draw" a jagged, pixelated edge.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/retro-pixel-btn-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
A retro, infinitely scalable 8-bit pixel button drawn entirely with CSS.

**Why does it fit EaseMotion CSS?**
Drawing pixel art using `box-shadow` is an advanced CSS technique. This provides a ready-made pixel button that doesn't rely on raster images, perfectly aligning with the project's CSS-only goals.
