### PR TITLE
feat: add neumorphic toggle component

### DIFF
--- a/submissions/examples/neumorphic-toggle-sk/README.md
+++ b/submissions/examples/neumorphic-toggle-sk/README.md
@@ -1,0 +1,16 @@
+# Neumorphic Toggle Switch
+
+A buttery-smooth toggle switch designed using the Neumorphism (Soft UI) aesthetic. 
+
+## Files
+- `demo.html`: The HTML structure utilizing a hidden native checkbox.
+- `style.css`: The styling that creates the soft inset and outset shadows.
+- `README.md`: This file.
+
+## Features
+- **Neumorphism Design:** Uses a specific background color and a combination of light and dark drop shadows to make the UI element appear seamlessly extruded from the background.
+- **Pure CSS:** Relies on the `<input type="checkbox">` and the `:checked` pseudo-class to drive the switch animation entirely without JavaScript.
+- **Soft Shadows:** The track uses an `inset` shadow to look indented, while the thumb uses an standard outset shadow to look raised.
+
+## Usage
+Wrap an `<input type="checkbox">` and a `<span class="slider">` inside the `.neumorphic-toggle` label.

--- a/submissions/examples/neumorphic-toggle-sk/demo.html
+++ b/submissions/examples/neumorphic-toggle-sk/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neumorphic Toggle Switch | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- 
+    The label acts as the clickable wrapper.
+    The checkbox is visually hidden but drives the logic. 
+  -->
+  <label class="neumorphic-toggle" aria-label="Toggle setting">
+    <input type="checkbox">
+    <span class="slider"></span>
+  </label>
+
+</body>
+</html>

--- a/submissions/examples/neumorphic-toggle-sk/style.css
+++ b/submissions/examples/neumorphic-toggle-sk/style.css
@@ -1,0 +1,96 @@
+/* Neumorphic Toggle Switch CSS */
+
+:root {
+  /* Neumorphism requires a very specific background color to work properly */
+  --neumorphic-bg: #e0e5ec;
+  
+  /* Shadow colors derived from the background */
+  --shadow-light: #ffffff;
+  --shadow-dark: #a3b1c6;
+  
+  /* Active state color */
+  --toggle-active: #4facfe;
+}
+
+body {
+  background-color: var(--neumorphic-bg);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+/* The wrapper label */
+.neumorphic-toggle {
+  position: relative;
+  display: inline-block;
+  width: 100px;
+  height: 50px;
+}
+
+/* Hide default HTML checkbox */
+.neumorphic-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* The slider/track */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--neumorphic-bg);
+  border-radius: 50px;
+  
+  /* Inset shadows make it look indented into the background */
+  box-shadow: inset 5px 5px 10px var(--shadow-dark),
+              inset -5px -5px 10px var(--shadow-light);
+  
+  transition: 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+/* The toggle thumb */
+.slider::before {
+  position: absolute;
+  content: "";
+  height: 38px;
+  width: 38px;
+  left: 6px;
+  bottom: 6px;
+  background-color: var(--neumorphic-bg);
+  border-radius: 50%;
+  
+  /* Outset shadows make it look raised/extruded */
+  box-shadow: 4px 4px 8px var(--shadow-dark),
+              -4px -4px 8px var(--shadow-light);
+              
+  transition: 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+/* Checked State */
+input:checked + .slider {
+  /* Optional: slightly tint the track when active */
+  /* background-color: #d1d8e0; */
+}
+
+input:checked + .slider::before {
+  transform: translateX(50px);
+  /* Change the color of the thumb when active */
+  background: var(--toggle-active);
+  /* The shadow adjusts slightly to maintain depth */
+  box-shadow: 4px 4px 8px var(--shadow-dark),
+              -4px -4px 8px var(--shadow-light),
+              inset 2px 2px 4px rgba(255,255,255,0.4);
+}
+
+/* Focus State for accessibility */
+input:focus + .slider {
+  outline: 2px solid var(--toggle-active);
+  outline-offset: 4px;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves #8382
Adds a buttery-smooth toggle switch utilizing the Neumorphism (Soft UI) aesthetic. It relies on precise CSS `box-shadow` inset and outset techniques to make elements appear extruded from or pressed into the background.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/neumorphic-toggle-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
A soft-UI neumorphic toggle switch driven entirely by CSS and a native checkbox.

**Why does it fit EaseMotion CSS?**
Neumorphism relies entirely on complex shadow math to pull off correctly. Adding a ready-to-use toggle switch in this style demonstrates advanced shadow manipulation while keeping the logic strictly CSS-only.
