### PR TITLE
feat: add cyberpunk glitch button component

### DIFF
--- a/submissions/examples/cyberpunk-glitch-btn-sk/README.md
+++ b/submissions/examples/cyberpunk-glitch-btn-sk/README.md
@@ -1,0 +1,16 @@
+# Cyberpunk Glitch Button Effect
+
+A futuristic, high-tech button that "glitches" rapidly on hover, shifting its red and cyan color channels.
+
+## Files
+- `demo.html`: The HTML structure for the glitch button.
+- `style.css`: The CSS that generates the glitch layers and the clip-path animations.
+- `README.md`: This file.
+
+## Features
+- **Pure CSS Glitch:** Uses `::before` and `::after` pseudo-elements to duplicate the button text.
+- **Color Channel Shift:** The pseudo-elements are colored red and cyan and offset slightly to mimic a broken chromatic aberration effect.
+- **Keyframe Slicing:** Uses `clip-path: polygon()` inside an `@keyframes` animation to randomly slice and shift the layers on hover.
+
+## Usage
+Simply add the `.cyberpunk-glitch-btn` class to your button. The button relies on standard HTML text content.

--- a/submissions/examples/cyberpunk-glitch-btn-sk/demo.html
+++ b/submissions/examples/cyberpunk-glitch-btn-sk/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Glitch Button | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Note: The text here should match the 'content' string in the CSS pseudo-elements -->
+  <button class="cyberpunk-glitch-btn">
+    INITIATE SYSTEM
+  </button>
+
+</body>
+</html>

--- a/submissions/examples/cyberpunk-glitch-btn-sk/style.css
+++ b/submissions/examples/cyberpunk-glitch-btn-sk/style.css
@@ -1,0 +1,103 @@
+/* Cyberpunk Glitch Button CSS */
+
+:root {
+  --cyberpunk-bg: #fdf220; /* Bright Cyberpunk yellow */
+  --cyberpunk-text: #000000;
+  --cyberpunk-red: #ff003c;
+  --cyberpunk-blue: #00e6f6;
+}
+
+body {
+  background-color: #1a1a1a;
+  font-family: 'Courier New', Courier, monospace;
+  margin: 0;
+  padding: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+/* The Base Button */
+.cyberpunk-glitch-btn {
+  position: relative;
+  background-color: var(--cyberpunk-bg);
+  color: var(--cyberpunk-text);
+  border: none;
+  font-size: 1.5rem;
+  font-weight: 900;
+  letter-spacing: 2px;
+  padding: 20px 40px;
+  text-transform: uppercase;
+  cursor: pointer;
+  outline: none;
+  border-bottom: 4px solid var(--cyberpunk-blue);
+  border-right: 4px solid var(--cyberpunk-blue);
+  transition: background-color 0.1s, transform 0.1s;
+}
+
+.cyberpunk-glitch-btn:active {
+  transform: translate(2px, 2px);
+}
+
+/* Glitch Pseudo Elements */
+.cyberpunk-glitch-btn::after,
+.cyberpunk-glitch-btn::before {
+  content: "INITIATE SYSTEM"; /* This must match the HTML text, or be set via attr(data-text) */
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--cyberpunk-bg);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+}
+
+/* Red layer */
+.cyberpunk-glitch-btn::before {
+  left: 2px;
+  text-shadow: -2px 0 var(--cyberpunk-red);
+  color: var(--cyberpunk-text);
+  z-index: -1;
+}
+
+/* Cyan layer */
+.cyberpunk-glitch-btn::after {
+  left: -2px;
+  text-shadow: -2px 0 var(--cyberpunk-blue);
+  color: var(--cyberpunk-text);
+  z-index: -2;
+}
+
+/* Hover triggers the animation */
+.cyberpunk-glitch-btn:hover::before {
+  opacity: 1;
+  animation: glitch-anim-1 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) both infinite;
+}
+
+.cyberpunk-glitch-btn:hover::after {
+  opacity: 1;
+  animation: glitch-anim-2 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) both infinite reverse;
+}
+
+/* Glitch Animations using clip-path */
+@keyframes glitch-anim-1 {
+  0% { clip-path: polygon(0 2%, 100% 2%, 100% 5%, 0 5%); }
+  20% { clip-path: polygon(0 15%, 100% 15%, 100% 15%, 0 15%); }
+  40% { clip-path: polygon(0 10%, 100% 10%, 100% 20%, 0 20%); }
+  60% { clip-path: polygon(0 1%, 100% 1%, 100% 2%, 0 2%); }
+  80% { clip-path: polygon(0 33%, 100% 33%, 100% 33%, 0 33%); }
+  100% { clip-path: polygon(0 44%, 100% 44%, 100% 44%, 0 44%); }
+}
+
+@keyframes glitch-anim-2 {
+  0% { clip-path: polygon(0 65%, 100% 65%, 100% 70%, 0 70%); }
+  20% { clip-path: polygon(0 50%, 100% 50%, 100% 55%, 0 55%); }
+  40% { clip-path: polygon(0 70%, 100% 70%, 100% 80%, 0 80%); }
+  60% { clip-path: polygon(0 80%, 100% 80%, 100% 80%, 0 80%); }
+  80% { clip-path: polygon(0 50%, 100% 50%, 100% 55%, 0 55%); }
+  100% { clip-path: polygon(0 60%, 100% 60%, 100% 70%, 0 70%); }
+}


### PR DESCRIPTION
## Pull Request Description
Resolves #8383
Adds a futuristic Cyberpunk Glitch Button. On hover, it utilizes CSS `@keyframes` and `clip-path` to rapidly "glitch" the button, shifting red and cyan color channels to mimic a broken interface.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/cyberpunk-glitch-btn-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
A highly complex, pure CSS cyberpunk glitch animation.

**Why does it fit EaseMotion CSS?**
It provides an advanced CSS animation technique (animating `clip-path` polygons on multiple pseudo-elements) that perfectly matches popular high-tech UI trends, offering great value to developers building gaming or crypto interfaces.
