### PR TITLE
Fix: Use --ease-animation-iterations for .ease-shimmer-sweep to respect reduced motion

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -731,7 +731,7 @@
       rgba(255, 255, 255, 0.15) 50%,
       transparent 70%);
   background-size: 200% auto;
-  animation: ease-kf-shimmer-sweep var(--ease-speed-slow) var(--ease-ease) infinite;
+  animation: ease-kf-shimmer-sweep var(--ease-speed-slow) var(--ease-ease) var(--ease-animation-iterations, infinite);
 }
 
 .ease-squish-button:hover,


### PR DESCRIPTION
## Pull Request Description

Resolves #8397.

This PR fixes a critical accessibility DoS where the \.ease-shimmer-sweep\ animation ignored the \--ease-animation-iterations\ variable and was hardcoded to \infinite\. When a user enables \prefers-reduced-motion: reduce\, \--ease-speed-slow\ becomes \