### PR TITLE
Fix: Ensure reveal.js makes content visible for prefers-reduced-motion

### DIFF
--- a/core/reveal.js
+++ b/core/reveal.js
@@ -12,7 +12,20 @@
 
   // Check if user prefers reduced motion
   const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (prefersReducedMotion) return;
+  if (prefersReducedMotion) {
+    var readyFallback = function () {
+      var els = document.querySelectorAll('.' + revealClass);
+      Array.prototype.forEach.call(els, function (el) {
+        el.classList.add(activeClass);
+      });
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', readyFallback);
+    } else {
+      readyFallback();
+    }
+    return;
+  }
 
   var supportsObserver = 'IntersectionObserver' in window;
 


### PR DESCRIPTION
## Pull Request Description

Resolves #8398.

This PR fixes a critical accessibility issue where elements using \.ease-reveal\ remained permanently hidden for users with \prefers-reduced-motion: reduce\. By immediately applying the \.ease-reveal-active\ class in the early return block, content is shown without animation instead of remaining hidden.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [x] Other (Accessibility/Core fix)

---

## Submission Checklist

- [ ] All changes are inside \submissions/examples/your-feature-name/\ (N/A, Core Fix)
- [ ] Includes \demo.html\ (N/A)
- [ ] Includes \style.css\ (N/A)
- [ ] Includes \README.md\ (N/A)
- [ ] **No changes to \core/\** (False, fixes a core bug)
- [ ] **No changes to \components/\**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
Fixes #8398 by making content accessible when animations are disabled.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

This ensures users who disable animations can still see the content.