### PR TITLE
Fix: Filter visually hidden elements in modal focus trap

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -55,9 +55,9 @@
 
       // Tab trap
       if (e.key === 'Tab') {
-        const focusableElements = overlay.querySelectorAll(
+        const focusableElements = Array.from(overlay.querySelectorAll(
           'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
-        );
+        )).filter(el => el.offsetWidth > 0 || el.offsetHeight > 0);
         if (focusableElements.length === 0) {
           e.preventDefault();
           return;


### PR DESCRIPTION
## Pull Request Description

Resolves #8399.

This PR fixes a focus trap vulnerability in \core/modal.js\. Previously, the keyboard navigation logic would select all theoretically focusable elements using \querySelectorAll\, including those that were visually hidden (e.g. \display: none\). This allowed the trap to be bypassed or caused focus to be lost. By filtering out elements with zero dimensions (\offsetWidth\ and \offsetHeight\), the focus trap now correctly bounds to visible elements only.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [x] Other (Accessibility/Core fix)

---

## Submission Checklist

- [ ] All changes are inside \submissions/examples/your-feature-name/\ (N/A, Core Fix)
- [ ] Includes \demo.html\ (N/A)
- [ ] Includes \style.css\ (N/A)
- [ ] Includes \README.md\ (N/A)
- [ ] **No changes to \core/\** (False, fixes a core bug)
- [ ] **No changes to \components/\**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
Fixes #8399 by ignoring hidden elements when trapping focus.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

Standard accessibility bug fix to prevent users from tabbing to invisible elements.