### PR TITLE
Submission: Fix navbar dark mode contrast (#8400)

### DIFF
--- a/submissions/examples/fix-navbar-contrast/README.md
+++ b/submissions/examples/fix-navbar-contrast/README.md
@@ -1,0 +1,27 @@
+# Fix for Navbar Dark Mode Contrast
+
+Resolves Issue #8400.
+
+## Description
+This submission fixes a severe contrast issue in `components/navbar.css`. The `@supports not (backdrop-filter: blur(0))` fallback originally only provided a light mode background. Because the `prefers-color-scheme: dark` media query appears later in the file, it overrides the fallback with a highly transparent `rgba(15, 23, 42, 0.3)` background, which is unreadable on browsers lacking blur filter support.
+
+This fix adds a dark mode specific fallback inside the `@supports not` block with a solid dark background (`0.92` opacity), ensuring text remains legible.
+
+## How to Apply
+Maintainers should update `components/navbar.css` line 102:
+```css
+  @supports not (backdrop-filter: blur(0)) {
+    .ease-navbar-glass,
+    .ease-navbar-glass-blur {
+      background: rgba(255, 255, 255, 0.92);
+      border-color: rgba(15, 23, 42, 0.12);
+    }
+    @media (prefers-color-scheme: dark) {
+      .ease-navbar-glass,
+      .ease-navbar-glass-blur {
+        background: rgba(15, 23, 42, 0.92) !important;
+        border-color: rgba(255, 255, 255, 0.12) !important;
+      }
+    }
+  }
+```

--- a/submissions/examples/fix-navbar-contrast/demo.html
+++ b/submissions/examples/fix-navbar-contrast/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fix Navbar Dark Mode Contrast</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-neutral-900 ease-color-neutral-100" style="padding: 2rem; font-family: sans-serif; height: 200vh; background-image: linear-gradient(#1e293b, #0f172a);">
+  <h1 class="ease-text-3xl ease-font-bold ease-mb-6 ease-mt-24">Fix for Navbar Dark Mode Contrast</h1>
+  <p class="ease-mb-4">Demonstrates fix for issue #8400 where dark mode navbars become unreadable in browsers lacking backdrop-filter.</p>
+  
+  <nav class="ease-navbar ease-navbar-glass ease-fixed ease-top-0 ease-left-0 ease-w-full">
+    <div class="ease-navbar-container">
+      <a href="#" class="ease-navbar-logo">Brand</a>
+      <ul class="ease-navbar-menu">
+        <li><a href="#" class="ease-navbar-link">Home</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <p>Scroll down to see the fixed navbar background opacity.</p>
+</body>
+</html>

--- a/submissions/examples/fix-navbar-contrast/style.css
+++ b/submissions/examples/fix-navbar-contrast/style.css
@@ -1,0 +1,10 @@
+/* Fix for navbar dark mode contrast */
+@supports not (backdrop-filter: blur(0)) {
+  @media (prefers-color-scheme: dark) {
+    .ease-navbar-glass,
+    .ease-navbar-glass-blur {
+      background: rgba(15, 23, 42, 0.92) !important;
+      border-color: rgba(255, 255, 255, 0.12) !important;
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #8400.

This submission fixes a severe contrast issue in \components/navbar.css\. The \@supports not (backdrop-filter: blur(0))\ fallback originally only provided a light mode background. Because the \prefers-color-scheme: dark\ media query appears later in the file, it overrides the fallback with a highly transparent \gba(15, 23, 42, 0.3)\ background, which is unreadable on browsers lacking blur filter support.

This fix adds a dark mode specific fallback inside the \@supports not\ block with a solid dark background (\