### PR TITLE
Submission: Fix forms high contrast focus (#8427)

### DIFF
--- a/submissions/examples/fix-forms-high-contrast/README.md
+++ b/submissions/examples/fix-forms-high-contrast/README.md
@@ -1,0 +1,25 @@
+# Fix for Forms High Contrast Focus Failure
+
+Resolves Issue #8427.
+
+## Description
+This submission fixes a critical accessibility issue where `.ease-input`, `.ease-textarea`, and `.ease-select` lose all focus indication in Windows High Contrast mode (or when `forced-colors: active` is true). 
+
+The original code sets `outline: none` and relies on `box-shadow` for focus. However, `box-shadow` is completely removed in forced-colors mode, leaving keyboard users with no visual feedback.
+
+This fix adds `outline: 2px solid transparent` and `outline-offset: 2px` to the focus states. A transparent outline does not affect the default appearance (which still uses `box-shadow`), but in high contrast mode, the browser forces the outline to become visible using the system's text color, restoring accessibility.
+
+## How to Apply
+Maintainers should update `components/forms.css` around line 79:
+
+```css
+  /* Focus Animation */
+  .ease-input:focus,
+  .ease-textarea:focus,
+  .ease-select:focus {
+    border-color: var(--ease-color-primary, #6c63ff);
+    box-shadow: 0 0 0 3px var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.18));
+    outline: 2px solid transparent; /* Added */
+    outline-offset: 2px; /* Added */
+  }
+```

--- a/submissions/examples/fix-forms-high-contrast/demo.html
+++ b/submissions/examples/fix-forms-high-contrast/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fix Forms High Contrast Focus</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-neutral-50 ease-color-neutral-900" style="padding: 2rem; font-family: sans-serif;">
+  <h1 class="ease-text-2xl ease-font-bold ease-mb-6">High Contrast Focus Fix</h1>
+  <p class="ease-mb-6">This demonstrates the fix for issue #8427. When Windows High Contrast mode is active, the `box-shadow` used for focus is stripped. Adding `outline: 2px solid transparent` ensures a focus ring is still drawn by the browser in forced-colors mode.</p>
+  
+  <div class="ease-field">
+    <label class="ease-field-label" for="test-input">Test Input (Tab to focus)</label>
+    <input type="text" id="test-input" class="ease-input" placeholder="Type here...">
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-forms-high-contrast/style.css
+++ b/submissions/examples/fix-forms-high-contrast/style.css
@@ -1,0 +1,10 @@
+/* Fix for high contrast focus visibility */
+@layer easemotion-components {
+  /* Add transparent outline for high contrast mode compatibility */
+  .ease-input:focus,
+  .ease-textarea:focus,
+  .ease-select:focus {
+    outline: 2px solid transparent !important;
+    outline-offset: 2px !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #8427.

This submission fixes a critical accessibility issue where \.ease-input\, \.ease-textarea\, and \.ease-select\ lose all focus indication in Windows High Contrast mode. The original code sets \outline: none\ and relies on \ox-shadow\ for focus, which is stripped in forced-colors mode. This fix adds \outline: 2px solid transparent\ and \outline-offset: 2px\ to the focus states to ensure a focus ring is drawn by the browser.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [x] Other (Accessibility/Core fix via submission)

---

## Submission Checklist

- [x] All changes are inside \submissions/examples/your-feature-name/\`n- [x] Includes \demo.html\ — self-contained, opens in browser with no server
- [x] Includes \style.css\ — raw CSS for the proposed feature
- [x] Includes \README.md\ — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to \core/\**
- [x] **No changes to \components/\**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
Demonstrates the fix for #8427 without touching core files to pass validation.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

Since PRs modifying \components/\ are automatically closed, this submission provides the fix. Please review and apply the fix to \components/forms.css\.