### PR TITLE
Submission: Fix default tooltip mobile crop (#8428)

### DIFF
--- a/submissions/examples/fix-tooltip-mobile-crop/README.md
+++ b/submissions/examples/fix-tooltip-mobile-crop/README.md
@@ -1,0 +1,42 @@
+# Fix for Default Tooltip Mobile Crop
+
+Resolves Issue #8428.
+
+## Description
+This submission fixes a critical visual bug where default tooltips (those without `data-position` set) fail to adapt on mobile devices and get cropped out of the viewport.
+
+In `components/tooltips.css`, the `@media (max-width: 640px)` query correctly moves top-positioned tooltips to the bottom. However, it only targets explicitly declared top tooltips (`.ease-tooltip[data-position="top"]`). It completely misses `.ease-tooltip:not([data-position])`, meaning the default behavior is broken on mobile.
+
+This fix adds the missing `.ease-tooltip:not([data-position])` selectors to the media query fallback, ensuring all top-aligned tooltips safely move to the bottom on narrow screens.
+
+## How to Apply
+Maintainers should update `components/tooltips.css` line 194 to include the missing selectors:
+
+```css
+  @media (max-width: 640px) {
+    /* ... */
+    
+    /* Fallback to bottom positioning on narrow viewports to avoid cropping */
+    .ease-tooltip[data-position="top"]::after,
+    .ease-tooltip:not([data-position])::after {
+      bottom: auto;
+      top: calc(100% + var(--ease-tooltip-gap));
+      transform: translateX(-50%) translateY(-4px);
+    }
+
+    .ease-tooltip[data-position="top"]:hover::after,
+    .ease-tooltip[data-position="top"]:focus-within::after,
+    .ease-tooltip:not([data-position]):hover::after,
+    .ease-tooltip:not([data-position]):focus-within::after {
+      transform: translateX(-50%) translateY(0);
+    }
+
+    .ease-tooltip[data-position="top"]::before,
+    .ease-tooltip:not([data-position])::before {
+      bottom: auto;
+      top: calc(100% - 2px);
+      border-top-color: transparent;
+      border-bottom-color: var(--ease-tooltip-bg);
+    }
+  }
+```

--- a/submissions/examples/fix-tooltip-mobile-crop/demo.html
+++ b/submissions/examples/fix-tooltip-mobile-crop/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fix Tooltip Mobile Crop</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-neutral-50 ease-color-neutral-900" style="padding: 2rem; font-family: sans-serif;">
+  <h1 class="ease-text-2xl ease-font-bold ease-mb-6">Mobile Tooltip Fix</h1>
+  <p class="ease-mb-6">This demonstrates the fix for issue #8428. Default tooltips (without `data-position`) now properly move to the bottom on viewports below 640px, preventing them from being cropped off the top of the screen.</p>
+  
+  <div style="margin-top: 50px;">
+    <span class="ease-tooltip" data-tooltip="This is a default tooltip without data-position">
+      Hover over me (Default)
+    </span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-tooltip-mobile-crop/style.css
+++ b/submissions/examples/fix-tooltip-mobile-crop/style.css
@@ -1,0 +1,23 @@
+/* Fix for default tooltip mobile crop */
+@layer easemotion-components {
+  @media (max-width: 640px) {
+    /* Fallback to bottom positioning on narrow viewports for default tooltips too */
+    .ease-tooltip:not([data-position])::after {
+      bottom: auto;
+      top: calc(100% + var(--ease-tooltip-gap));
+      transform: translateX(-50%) translateY(-4px);
+    }
+
+    .ease-tooltip:not([data-position]):hover::after,
+    .ease-tooltip:not([data-position]):focus-within::after {
+      transform: translateX(-50%) translateY(0);
+    }
+
+    .ease-tooltip:not([data-position])::before {
+      bottom: auto;
+      top: calc(100% - 2px);
+      border-top-color: transparent;
+      border-bottom-color: var(--ease-tooltip-bg);
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #8428.

This submission fixes a visual bug where default tooltips (those without \data-position\) get cropped on mobile viewports. The \@media (max-width: 640px)\ query in \components/tooltips.css\ only targets \.ease-tooltip[data-position=top]\, completely missing the default top-aligned tooltips. This fix demonstrates adding the missing \.ease-tooltip:not([data-position])\ selector so all top tooltips safely fallback to the bottom on narrow screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [x] Other (Core fix via submission)

---

## Submission Checklist

- [x] All changes are inside \submissions/examples/your-feature-name/\`n- [x] Includes \demo.html\ — self-contained, opens in browser with no server
- [x] Includes \style.css\ — raw CSS for the proposed feature
- [x] Includes \README.md\ — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to \core/\**
- [x] **No changes to \components/\**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
Demonstrates the fix for #8428 without touching core files to pass validation.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

Since PRs modifying \components/\ are automatically closed, this submission provides the fix. Please review and apply the fix to \components/tooltips.css\.