### PR TITLE
Submission: Fix loaders reduced motion (#8432)

### DIFF
--- a/submissions/examples/fix-loaders-reduced-motion/README.md
+++ b/submissions/examples/fix-loaders-reduced-motion/README.md
@@ -1,0 +1,30 @@
+# Fix for Loaders Reduced Motion
+
+Resolves Issue #8432.
+
+## Description
+This submission fixes a WCAG 2.2.2 violation where `.ease-loader` animations (spin, pulse, ping, dots) animate infinitely with no way to stop them, even for users who have requested reduced motion in their OS.
+
+In `components/loaders.css`, the loaders are defined with infinite animations but no fallback. This can trigger symptoms in users with vestibular disorders.
+
+This fix adds a `@media (prefers-reduced-motion: reduce)` block that forces the animations to `none` when requested. For the spin loader, it also sets a solid border color so it doesn't look like a broken circle when stopped.
+
+## How to Apply
+Maintainers should update `components/loaders.css` by appending this at the end of the file:
+
+```css
+  /* Reduced motion fallback for loaders */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-loader-spin,
+    .ease-loader-pulse,
+    .ease-loader-ping,
+    .ease-loader-dot {
+      animation: none !important;
+    }
+
+    /* For spin loader, ensure it looks like a complete circle when stopped */
+    .ease-loader-spin {
+      border-color: var(--ease-color-primary) !important;
+    }
+  }
+```

--- a/submissions/examples/fix-loaders-reduced-motion/demo.html
+++ b/submissions/examples/fix-loaders-reduced-motion/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fix Loaders Reduced Motion</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-neutral-50 ease-color-neutral-900" style="padding: 2rem; font-family: sans-serif;">
+  <h1 class="ease-text-2xl ease-font-bold ease-mb-6">Loaders Reduced Motion Fix</h1>
+  <p class="ease-mb-6">This demonstrates the fix for issue #8432. The various loader animations now properly disable themselves when `prefers-reduced-motion` is enabled, complying with WCAG 2.1.</p>
+  
+  <div style="display: flex; gap: 2rem; margin-top: 50px;">
+    <div class="ease-loader ease-loader-spin" aria-label="Loading"></div>
+    <div class="ease-loader ease-loader-pulse" aria-label="Loading"></div>
+    <div class="ease-loader ease-loader-ping" aria-label="Loading"></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-loaders-reduced-motion/style.css
+++ b/submissions/examples/fix-loaders-reduced-motion/style.css
@@ -1,0 +1,16 @@
+/* Fix for loaders ignoring reduced motion */
+@layer easemotion-components {
+  @media (prefers-reduced-motion: reduce) {
+    .ease-loader-spin,
+    .ease-loader-pulse,
+    .ease-loader-ping,
+    .ease-loader-dot {
+      animation: none !important;
+    }
+
+    /* For spin loader, ensure it looks like a complete circle when stopped */
+    .ease-loader-spin {
+      border-color: var(--ease-color-primary) !important;
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #8432.

This submission fixes a WCAG 2.2.2 violation where \.ease-loader\ animations animate infinitely with no way to stop them, even for users who have requested reduced motion in their OS. This fix adds a \@media (prefers-reduced-motion: reduce)\ block that forces the animations to \
one\ when requested.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [x] Other (Accessibility/Core fix via submission)

---

## Submission Checklist

- [x] All changes are inside \submissions/examples/your-feature-name/\`n- [x] Includes \demo.html\ — self-contained, opens in browser with no server
- [x] Includes \style.css\ — raw CSS for the proposed feature
- [x] Includes \README.md\ — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to \core/\**
- [x] **No changes to \components/\**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
Demonstrates the fix for #8432 without touching core files to pass validation.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

Since PRs modifying \components/\ are automatically closed, this submission provides the fix. Please review and apply the fix to \components/loaders.css\.