### PR TITLE
fix(cards): add explicit semantic colors to contextual alert variants

### DIFF
--- a/submissions/examples/card-accessible-alerts/README.md
+++ b/submissions/examples/card-accessible-alerts/README.md
@@ -1,0 +1,3 @@
+# Accessible Context Alert Cards
+
+Contextual variants now feature strict text pairing variables to guarantee text visibility against modern WCAG specifications.

--- a/submissions/examples/card-accessible-alerts/demo.html
+++ b/submissions/examples/card-accessible-alerts/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-card ease-card-success-bg" style="max-width: 400px; margin: 1rem; padding: 1rem;">
+    <p><strong>Success State:</strong> Content here meets WCAG accessibility guidelines in both color schemes.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/card-accessible-alerts/style.css
+++ b/submissions/examples/card-accessible-alerts/style.css
@@ -1,0 +1,25 @@
+@layer easemotion-components {
+  .ease-card-info {
+    background-color: color-mix(in srgb, var(--ease-color-primary, #6c63ff) 8%, transparent);
+    border-color: var(--ease-color-primary-light, #a09af8);
+    color: var(--ease-color-primary-dark, #4b44cc);
+  }
+
+  .ease-card-success-bg {
+    background-color: color-mix(in srgb, var(--ease-color-success, #22c55e) 8%, transparent);
+    border-color: var(--ease-color-success-light, #86efac);
+    color: var(--ease-color-success-dark, #15803d);
+  }
+
+  .ease-card-danger-bg {
+    background-color: color-mix(in srgb, var(--ease-color-danger, #ef4444) 8%, transparent);
+    border-color: var(--ease-color-danger-light, #fca5a5);
+    color: var(--ease-color-danger-dark, #b91c1c);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .ease-card-info { color: #e0e7ff; }
+    .ease-card-success-bg { color: #bbf7d0; }
+    .ease-card-danger-bg { color: #fecaca; }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

## Description
Addresses an accessibility issue where `.ease-card-success-bg` and `.ease-card-danger-bg` inherited base dark text against tint layers, generating contrast failures.

## Changes Made
- Appended explicit color tokens to semantic notification arrays.
- Setup explicit style adjustments to toggle correctly on dark mode interfaces.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- One-sentence description -->

**How does a developer use it?**

```html
<!-- Show the class usage in HTML -->
```

**Why does it fit EaseMotion CSS?**

<!-- Explain how this fits the human-readable, animation-first philosophy -->

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
