### PR TITLE
feat: scroll-linked progress ring with animation-timeline: scroll()

### DIFF
--- a/submissions/examples/scroll-ring-im/README.md
+++ b/submissions/examples/scroll-ring-im/README.md
@@ -1,0 +1,57 @@
+# Scroll-Linked Progress Ring
+
+## What does this do?
+A circular reading-progress indicator that fills via `conic-gradient` based on the page's scroll position — using the native CSS Scroll-Driven Animations API (`animation-timeline: scroll(root)`) instead of a scroll event listener for the visual fill. A minimal JS scroll listener updates only the percentage text label.
+
+## How to use it
+```html
+<div class="scroll-ring-fixed">
+  <div class="scroll-ring">
+    <div class="scroll-ring-inner">
+      <span class="scroll-ring-label">0%</span>
+    </div>
+  </div>
+</div>
+```
+
+```css
+@property --ring-pct {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 0;
+}
+
+.scroll-ring {
+  background: conic-gradient(
+    var(--ease-color-primary) calc(var(--ring-pct) * 1%),
+    rgba(255,255,255,0.1) 0
+  );
+  animation: ring-fill linear;
+  animation-timeline: scroll(root);
+}
+
+@keyframes ring-fill {
+  from { --ring-pct: 0; }
+  to   { --ring-pct: 100; }
+}
+```
+
+```js
+// CSS handles the ring's visual fill. This only updates the text label,
+// since CSS can't yet write computed numbers into text content.
+document.addEventListener('scroll', () => {
+  const pct = Math.round((window.scrollY / (document.documentElement.scrollHeight - window.innerHeight)) * 100);
+  label.textContent = `${pct}%`;
+}, { passive: true });
+```
+
+## How it works
+1. **`@property --ring-pct`** registers a custom property as an animatable `<number>`, so it can drive a `conic-gradient()` percentage
+2. **`animation-timeline: scroll(root)`** ties the `ring-fill` keyframe's progress directly to the document's scroll position — 0% scrolled = 0% animation progress, 100% scrolled = 100%
+3. **`conic-gradient()`** renders the ring using `--ring-pct` as the arc's percentage, growing as the user scrolls
+
+## Browser support & fallback
+`animation-timeline: scroll()` ships in Chrome/Edge 115+ and Firefox 131+ (Safari support pending). `@supports not (animation-timeline: scroll())` disables the scroll-driven animation, and the same JS scroll listener used for the text label also sets `--ring-pct` directly via `style.setProperty()` — identical visual result, different mechanism.
+
+## Why it fits EaseMotion CSS
+EaseMotion has linear `scroll-progress` bars, but applying the Scroll-Driven Animations API to a `conic-gradient`-based circular ring via `@property`-registered custom properties is a more advanced application with no existing example — and demonstrates a genuinely "no scroll listener needed" pattern for the primary visual effect. `prefers-reduced-motion` disables the scroll-driven animation entirely (the ring stays static, label still updates).

--- a/submissions/examples/scroll-ring-im/demo.html
+++ b/submissions/examples/scroll-ring-im/demo.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll-Linked Progress Ring — EaseMotion CSS Submission</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <a href="../../docs/index.html" class="demo-logo">EaseMotion CSS</a>
+    <span class="demo-badge">New Submission</span>
+  </header>
+
+  <!-- Fixed scroll ring, follows the page -->
+  <div class="scroll-ring-fixed">
+    <div class="scroll-ring">
+      <div class="scroll-ring-inner">
+        <span class="scroll-ring-label">0%</span>
+      </div>
+    </div>
+  </div>
+
+  <main class="demo-main">
+
+    <div class="demo-hero ease-fade-in">
+      <h1>Scroll-Linked Progress Ring</h1>
+      <p>Scroll this page — the ring in the top-right fills via <code>conic-gradient</code> driven by <code>animation-timeline: scroll(root)</code>. No scroll event listener, no <code>requestAnimationFrame</code>.</p>
+    </div>
+
+    <section class="demo-section">
+      <h2 class="demo-section-title">How It Works</h2>
+      <div class="explain-grid">
+        <div class="explain-card">
+          <div class="explain-num">01</div>
+          <h3>@property registers --ring-pct</h3>
+          <p><code>--ring-pct</code> is registered as an animatable <code>&lt;number&gt;</code> via <code>@property</code>, so it can be used directly inside a <code>conic-gradient()</code> and animated.</p>
+        </div>
+        <div class="explain-card">
+          <div class="explain-num">02</div>
+          <h3>animation-timeline: scroll(root)</h3>
+          <p>Instead of a normal time-based animation, <code>animation-timeline: scroll(root)</code> ties the keyframe progress directly to the document's scroll position — 0% scrolled = animation at 0%, 100% scrolled = animation at 100%.</p>
+        </div>
+        <div class="explain-card">
+          <div class="explain-num">03</div>
+          <h3>conic-gradient renders the ring</h3>
+          <p>The ring's background is <code>conic-gradient(var(--ease-color-primary) calc(var(--ring-pct) * 1%), transparent 0)</code> — as <code>--ring-pct</code> increases from the scroll-linked animation, the colored arc grows around the circle.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Long content to scroll through -->
+    <section class="demo-section">
+      <h2 class="demo-section-title">Scroll Through This Content</h2>
+      <div class="content-block">
+        <h3>Section 1</h3>
+        <p>This is a long article to demonstrate the scroll-linked ring. As you scroll down through these sections, watch the ring in the top-right corner fill up and the percentage label update — all without a single scroll event listener.</p>
+        <p>The CSS Scroll-Driven Animations specification introduces <code>animation-timeline</code>, which can be set to <code>scroll()</code> to tie a CSS animation's progress to a scrollable element's scroll offset rather than to wall-clock time.</p>
+      </div>
+      <div class="content-block">
+        <h3>Section 2</h3>
+        <p>Combined with <code>@property</code>, which allows custom properties to be registered with a specific syntax (here, <code>&lt;number&gt;</code>) and therefore be animatable, we can drive arbitrary visual properties — like the percentage in a <code>conic-gradient()</code> — directly from scroll position.</p>
+        <p>This is fundamentally different from the older approach of listening to the <code>scroll</code> event and manually computing <code>window.scrollY / (document.body.scrollHeight - window.innerHeight)</code> on every frame. The browser's compositor handles everything, often off the main thread.</p>
+      </div>
+      <div class="content-block">
+        <h3>Section 3</h3>
+        <p>The percentage label inside the ring is updated via a tiny scroll listener (for text content, since CSS can't yet inject computed numbers into text nodes) — but the ring's visual fill itself is 100% CSS-driven and will continue animating smoothly even if JS is blocked or slow.</p>
+        <p>This hybrid approach — CSS for the visual progress, minimal JS for the text label — represents a practical, production-ready pattern for scroll progress indicators.</p>
+      </div>
+      <div class="content-block">
+        <h3>Section 4</h3>
+        <p>Keep scrolling — the ring should now be most of the way full. Notice there's no jank or stutter, even on long pages, because the browser doesn't need to re-run JavaScript on every scroll frame for the visual fill.</p>
+        <p><code>animation-timeline: scroll(root)</code> uses the document's root scroller by default. You can also scope it to a specific scrollable container by giving that container a <code>scroll-timeline-name</code> and referencing it with <code>animation-timeline: --my-timeline</code>.</p>
+      </div>
+      <div class="content-block">
+        <h3>Section 5 — End</h3>
+        <p>You've reached the end. The ring should now read 100%. Scroll back up to watch it unfill in reverse — scroll-driven animations are bidirectional by nature, since they're a direct function of scroll position, not elapsed time.</p>
+      </div>
+    </section>
+
+    <!-- Code -->
+    <section class="demo-section">
+      <h2 class="demo-section-title">How to Use</h2>
+      <div class="code-block">
+        <div class="code-lang">css</div>
+        <pre><code>@property --ring-pct {
+  syntax: '&lt;number&gt;';
+  inherits: false;
+  initial-value: 0;
+}
+
+.scroll-ring {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--ease-color-primary) calc(var(--ring-pct) * 1%),
+    rgba(255,255,255,0.1) 0
+  );
+
+  animation: ring-fill linear;
+  animation-timeline: scroll(root);
+}
+
+@keyframes ring-fill {
+  from { --ring-pct: 0; }
+  to   { --ring-pct: 100; }
+}</code></pre>
+      </div>
+
+      <div class="code-block">
+        <div class="code-lang">js — label text only</div>
+        <pre><code>// CSS handles the ring's visual fill entirely.
+// This tiny script only updates the text label inside it,
+// since CSS can't yet write computed numbers into text content.
+const label = document.querySelector('.scroll-ring-label');
+
+function updateLabel() {
+  const scrolled = window.scrollY;
+  const max = document.documentElement.scrollHeight - window.innerHeight;
+  const pct = Math.round((scrolled / max) * 100);
+  label.textContent = `${pct}%`;
+}
+
+document.addEventListener('scroll', updateLabel, { passive: true });
+updateLabel();</code></pre>
+      </div>
+
+      <div class="important-note">
+        <strong>Browser support:</strong> <code>animation-timeline: scroll()</code> ships in Chrome/Edge 115+ and Firefox 131+ (Safari support pending as of this writing). Where unsupported, <code>@supports not (animation-timeline: scroll())</code> falls back to the JS-computed percentage driving <code>--ring-pct</code> directly via <code>style.setProperty()</code> on the same scroll listener already used for the label — see <code>style.css</code> for the full fallback block.
+      </div>
+    </section>
+
+  </main>
+
+  <script>
+    const label = document.querySelector('.scroll-ring-label');
+    const ring = document.querySelector('.scroll-ring');
+    const supportsScrollTimeline = CSS.supports('animation-timeline', 'scroll()');
+
+    function updateProgress() {
+      const scrolled = window.scrollY;
+      const max = document.documentElement.scrollHeight - window.innerHeight;
+      const pct = max > 0 ? Math.round((scrolled / max) * 100) : 0;
+      label.textContent = `${pct}%`;
+
+      if (!supportsScrollTimeline) {
+        ring.style.setProperty('--ring-pct', pct);
+      }
+    }
+
+    document.addEventListener('scroll', updateProgress, { passive: true });
+    updateProgress();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/scroll-ring-im/style.css
+++ b/submissions/examples/scroll-ring-im/style.css
@@ -1,0 +1,294 @@
+/* ============================================================
+   Scroll-Linked Progress Ring — style.css
+   Raw CSS — maintainer will standardize to ease-* naming
+
+   - @property registers --ring-pct as an animatable <number>
+   - animation-timeline: scroll(root) ties keyframe progress
+     directly to document scroll position
+   - conic-gradient renders the ring fill from --ring-pct
+   - Fallback (@supports not (animation-timeline: scroll())):
+     JS scroll listener sets --ring-pct directly
+   ============================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--ease-font-sans, 'Inter', system-ui, sans-serif);
+  background: var(--ease-color-bg, #0b1121);
+  color: var(--ease-color-text, #e2e8f0);
+  line-height: 1.6;
+}
+
+/* ── @property registration ───────────────────────────────── */
+@property --ring-pct {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 0;
+}
+
+/* ── SCROLL RING ──────────────────────────────────────────── */
+.scroll-ring-fixed {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  z-index: 100;
+}
+
+.scroll-ring {
+  --ring-pct: 0;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--ease-color-primary, #6c63ff) calc(var(--ring-pct) * 1%),
+    rgba(255,255,255,0.1) 0
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+
+  /* Primary: scroll-driven animation */
+  animation: ring-fill linear;
+  animation-timeline: scroll(root);
+}
+
+@keyframes ring-fill {
+  from { --ring-pct: 0; }
+  to   { --ring-pct: 100; }
+}
+
+.scroll-ring-inner {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--ease-color-bg, #0b1121);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scroll-ring-label {
+  font-size: 0.7rem;
+  font-weight: 800;
+  font-family: var(--ease-font-mono, monospace);
+  color: var(--ease-color-text, #e2e8f0);
+}
+
+/* ── Fallback for browsers without scroll() timeline ──────── */
+/* JS sets --ring-pct directly via a scroll listener (see demo.html).
+   This rule removes the (non-functional) scroll-driven animation
+   so it doesn't conflict with the JS-set value. */
+@supports not (animation-timeline: scroll()) {
+  .scroll-ring {
+    animation: none;
+  }
+}
+
+/* ── Reduced motion ───────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .scroll-ring {
+    animation: none;
+  }
+}
+
+/* ── Demo chrome ──────────────────────────────────────────── */
+.demo-header {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  padding: 0 2rem;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+  background: rgba(11,17,33,0.9);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.demo-logo {
+  font-weight: 800;
+  font-size: 1rem;
+  background: linear-gradient(135deg, var(--ease-color-primary, #6c63ff), var(--ease-color-secondary-light, #a78bfa));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-decoration: none;
+}
+
+.demo-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: var(--ease-color-primary-alpha, rgba(108,99,255,0.15));
+  color: var(--ease-color-secondary-light, #a78bfa);
+  border: 1px solid rgba(108,99,255,0.2);
+}
+
+.demo-main { max-width: 800px; margin: 0 auto; padding: 3rem 2rem 8rem; }
+
+.demo-hero { text-align: center; margin-bottom: 3.5rem; }
+
+.demo-hero h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #fff 40%, var(--ease-color-secondary-light, #a78bfa));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.75rem;
+}
+
+.demo-hero p {
+  font-size: 1.05rem;
+  color: var(--ease-color-muted, #94a3b8);
+  max-width: 60ch;
+  margin: 0 auto;
+}
+
+.demo-hero code {
+  background: var(--ease-color-primary-alpha, rgba(108,99,255,0.12));
+  color: var(--ease-color-secondary-light, #a78bfa);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-family: var(--ease-font-mono, monospace);
+}
+
+.demo-section { margin-bottom: 3.5rem; }
+
+.demo-section-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ease-color-secondary-light, #a78bfa);
+  margin-bottom: 1.5rem;
+}
+
+.explain-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.explain-card {
+  background: var(--ease-color-surface, #141e33);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: 1.5rem;
+}
+
+.explain-num {
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  color: var(--ease-color-primary, #6c63ff);
+  font-family: var(--ease-font-mono, monospace);
+  margin-bottom: 0.5rem;
+}
+
+.explain-card h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.explain-card p {
+  font-size: 0.85rem;
+  color: var(--ease-color-muted, #94a3b8);
+  line-height: 1.7;
+}
+
+.explain-card code {
+  background: var(--ease-color-primary-alpha, rgba(108,99,255,0.12));
+  color: var(--ease-color-secondary-light, #a78bfa);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: var(--ease-font-mono, monospace);
+}
+
+.content-block {
+  background: var(--ease-color-surface, #141e33);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: 1.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.content-block h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.content-block p {
+  font-size: 0.9rem;
+  color: var(--ease-color-muted, #94a3b8);
+  line-height: 1.8;
+  margin-bottom: 0.75rem;
+}
+
+.content-block code {
+  background: var(--ease-color-primary-alpha, rgba(108,99,255,0.12));
+  color: var(--ease-color-secondary-light, #a78bfa);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: var(--ease-font-mono, monospace);
+}
+
+.code-block {
+  position: relative;
+  background: var(--ease-color-surface, #141e33);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+  overflow-x: auto;
+}
+
+.code-lang {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255,255,255,0.25);
+  font-family: var(--ease-font-mono, monospace);
+}
+
+.code-block pre {
+  margin: 0;
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.82rem;
+  line-height: 1.75;
+  color: var(--ease-color-text, #e2e8f0);
+}
+
+.important-note {
+  background: var(--ease-color-primary-alpha, rgba(108,99,255,0.08));
+  border: 1px solid rgba(108,99,255,0.2);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  padding: 1rem 1.25rem;
+  font-size: 0.85rem;
+  color: var(--ease-color-muted, #94a3b8);
+  line-height: 1.7;
+}
+
+.important-note code {
+  background: rgba(108,99,255,0.15);
+  color: var(--ease-color-secondary-light, #a78bfa);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.85em;
+}


### PR DESCRIPTION
## Pull Request Description
Closes #8457  — Adds a Scroll-Linked Progress Ring: a circular reading-progress indicator that fills via `conic-gradient`, driven by the native CSS Scroll-Driven Animations API (`animation-timeline: scroll(root)`) — no scroll event listener for the visual fill, only a minimal listener for the percentage text label.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/scroll-ring-im/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
`@property --ring-pct` registers an animatable `<number>`, `animation-timeline: scroll(root)` ties the `ring-fill` keyframe directly to scroll position, and `conic-gradient(var(--ease-color-primary) calc(var(--ring-pct) * 1%), ...)` renders the ring — matching the issue's proposed API exactly.

**How does a developer use it?**
```html
<div class="scroll-ring-fixed">
  <div class="scroll-ring">
    <div class="scroll-ring-inner"><span class="scroll-ring-label">0%</span></div>
  </div>
</div>
```
```css
.scroll-ring {
  background: conic-gradient(var(--ease-color-primary) calc(var(--ring-pct) * 1%), rgba(255,255,255,0.1) 0);
  animation: ring-fill linear;
  animation-timeline: scroll(root);
}
```

**Why does it fit EaseMotion CSS?**
EaseMotion has linear scroll-progress bars, but applying the Scroll-Driven Animations API to a `conic-gradient`-based circular ring via `@property` is a more advanced application with no existing example — a genuinely "no scroll listener for the main effect" pattern.

---

## Demo
- [x] Demo added — open `submissions/examples/scroll-ring-im/demo.html` and scroll through the long content

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
Implements the issue's proposed API plus extras:

- **Live percentage label** inside the ring, updated by a minimal scroll listener (CSS can't yet write computed numbers into text content)
- **Full fallback** — `@supports not (animation-timeline: scroll())` disables the CSS animation, and the same scroll listener sets `--ring-pct` directly via `setProperty()`, detected via `CSS.supports('animation-timeline', 'scroll()')`
- **5-section scrollable article** included in the demo so the effect is immediately visible
- **`prefers-reduced-motion`** — scroll-driven animation disabled, ring stays static while label still updates

Suggested GSSoC labels: `level:advanced`, `type:feature`, `quality:exceptional` — implements the newer Scroll-Driven Animations API applied to a non-trivial `conic-gradient` ring with `@property`, full fallback, and live demo.