### PR TITLE
fix: add forms.css to easemotion/all.css and smoke test coverage

### DIFF
--- a/easemotion/all.css
+++ b/easemotion/all.css
@@ -18,6 +18,4 @@
 @import "../components/loaders.css";
 @import "../components/tooltips.css";
 @import "../components/modals.css";
-
-
-
+@import "../components/forms.css";

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -28,8 +28,9 @@ const badges = readFileSync(resolve(componentsDir, 'badges.css'), 'utf8');
 const loaders = readFileSync(resolve(componentsDir, 'loaders.css'), 'utf8');
 const tooltips = readFileSync(resolve(componentsDir, 'tooltips.css'), 'utf8');
 const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
+const forms = readFileSync(resolve(componentsDir, 'forms.css'), 'utf8');
     
-    css = variables + base + animations + utilities + buttons + cards + chip + footer + masonry + navbar + scrollProgress + sidebar + tabs + badges + loaders + tooltips + modals;
+    css = variables + base + animations + utilities + buttons + cards + chip + footer + masonry + navbar + scrollProgress + sidebar + tabs + badges + loaders + tooltips + modals + forms;
     dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>');
     document = dom.window.document;
     
@@ -128,6 +129,17 @@ const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
     expect(css).toContain('.ease-modal-header');
   });
   
+  it('should have form component classes defined', () => {
+    expect(css).toContain('.ease-field');
+    expect(css).toContain('.ease-field-label');
+    expect(css).toContain('.ease-input');
+    expect(css).toContain('.ease-textarea');
+    expect(css).toContain('.ease-select');
+    expect(css).toContain('.ease-input-success');
+    expect(css).toContain('.ease-input-danger');
+    expect(css).toContain('.ease-input-warning');
+  });
+
   it('should not have duplicate @keyframes definitions', () => {
     const keyframeCounts = {};
     const keyframeRegex = /@keyframes\s+([^\s{]+)/g;


### PR DESCRIPTION
## What does this PR do?

Fixes #8465.

`components/forms.css` was present in `easemotion.css` (the main entry point) but was missing from `easemotion/all.css` (the modular full-bundle). Users who import the framework via the modular path received no form styles — no `.ease-input`, no `.ease-field`, no `.ease-select` — silently, with no error or warning.

The smoke test suite also never loaded `forms.css`, meaning `.ease-input`, `.ease-field`, `.ease-textarea`, `.ease-select`, and all their state variants had zero test coverage. Regressions in the forms component could not be caught by CI.

---

## Root Cause

When `components/forms.css` was added to the framework, it was wired into `easemotion.css` correctly but the same import was never added to `easemotion/all.css`. The two entry points fell out of sync.

```css
/* easemotion.css — correctly included */
@import "./components/forms.css"; /* ✅ */

/* easemotion/all.css — was missing */
@import "../components/modals.css";
/* ❌ forms.css not here */
```

The smoke test `beforeAll` block loads each component file manually. Every component was listed except `forms.css`, so the entire forms component had zero test coverage.

---

## Changes

### `easemotion/all.css`

Added the missing import line at the end of the component list, keeping it consistent with the order in `easemotion.css`:

```css
@import "../components/modals.css";
@import "../components/forms.css"; /* added */
```

### `tests/smoke.test.js`

Loaded `forms.css` in `beforeAll`:

```js
const forms = readFileSync(resolve(componentsDir, 'forms.css'), 'utf8');
```

Added `forms` to the concatenated `css` string:

```js
css = variables + base + animations + utilities + buttons + cards + chip
    + footer + masonry + navbar + scrollProgress + sidebar + tabs
    + badges + loaders + tooltips + modals + forms; // added
```

Added a new test block covering all core form classes:

```js
it('should have form component classes defined', () => {
  expect(css).toContain('.ease-field');
  expect(css).toContain('.ease-field-label');
  expect(css).toContain('.ease-input');
  expect(css).toContain('.ease-textarea');
  expect(css).toContain('.ease-select');
  expect(css).toContain('.ease-input-success');
  expect(css).toContain('.ease-input-danger');
  expect(css).toContain('.ease-input-warning');
});
```

---

## Impact Before This Fix

| Import path | Forms styles available? |
|---|---|
| `easemotion.css` (main entry) | ✅ Yes |
| `easemotion/all.css` (modular bundle) | ❌ No — broken |
| Granular `@import "components/forms.css"` | ✅ Yes (only if user knew to add it manually) |
| `easemotion.min.css` (CDN build) | ✅ Yes (built from `easemotion.css`) |

---


## Files Changed

| File | Change |
|---|---|
| `easemotion/all.css` | Added `@import "../components/forms.css"` |
| `tests/smoke.test.js` | Loaded `forms.css`; added 8 form class assertions |

No changes to `core/`, `components/`, `submissions/`, `docs/`, or any other file.

