### PR TITLE
fix: guard navbar item hover with pointer media query (issue #8476)

### DIFF
--- a/submissions/examples/navbar-hover-touch-guard-8476/README.md
+++ b/submissions/examples/navbar-hover-touch-guard-8476/README.md
@@ -1,0 +1,72 @@
+# Navbar Hover Touch Guard Fix — Issue #8476
+
+**Fixes:** #8476
+
+## What does this do?
+
+Wraps the `.ease-navbar-glass .ease-navbar-item:hover` rule in
+`@media (hover: hover) and (pointer: fine)` to prevent sticky hover on
+touch devices.
+
+## The problem
+
+In `components/navbar.css`, the base hover rule has no pointer guard:
+
+```css
+/* Current — fires on touch tap */
+.ease-navbar-glass .ease-navbar-item:hover {
+  color: var(--ease-color-text, #1e293b);
+}
+```
+
+On touch devices, browsers synthesise a `:hover` state when a user taps an
+element. This synthetic hover does not end when the finger lifts — it persists
+until focus moves elsewhere. This causes nav items to appear permanently
+"active" in colour after a single tap, which is confusing and misleading to
+users.
+
+## How to reproduce the bug
+
+1. Open any page with `.ease-navbar-glass` in Chrome DevTools.
+2. Enable Device Toolbar and select any mobile preset.
+3. Tap a `.ease-navbar-item` link.
+4. Lift your finger — the color stays stuck on the hover state.
+
+## The fix
+
+Wrap the hover rule in the standard pointer guard used by every other
+interactive component in the framework:
+
+```css
+@media (hover: hover) and (pointer: fine) {
+  .ease-navbar-glass .ease-navbar-item:hover {
+    color: var(--ease-color-text, #1e293b);
+  }
+}
+```
+
+- `hover: hover` — matches only devices that support true hovering
+- `pointer: fine` — matches only precise pointing devices (mouse, trackpad)
+
+Together they ensure touch devices never receive the hover colour change.
+
+## Why this fits EaseMotion CSS
+
+Every other interactive component already uses this guard:
+
+| Component | Guard applied? |
+|---|---|
+| `buttons.css` — all 6 variants | ✅ Yes |
+| `cards.css` — all hover variants | ✅ Yes |
+| `core/base.css` — `a:hover` | ✅ Yes |
+| `navbar.css` — `.ease-navbar-item:hover` | ❌ Missing — this fix |
+
+This is a one-line correction to make the navbar consistent with the rest of
+the framework.
+
+## Behaviour after the fix
+
+| Device | Before | After |
+|---|---|---|
+| Desktop mouse | ✅ Hover works | ✅ Hover works |
+| Touch device | ❌ Sticky hover on tap | ✅ No colour change on tap |

--- a/submissions/examples/navbar-hover-touch-guard-8476/demo.html
+++ b/submissions/examples/navbar-hover-touch-guard-8476/demo.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Navbar Hover Touch Guard Fix — Issue #8476</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--ease-color-bg, #f8fafc);
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      color: var(--ease-color-text, #1e293b);
+    }
+
+    .demo-wrapper {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    .demo-section {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .demo-section h2 {
+      font-size: var(--ease-text-base, 1rem);
+      font-weight: 700;
+      margin-bottom: 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .tag {
+      display: inline-block;
+      font-size: 0.7rem;
+      font-weight: 700;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      vertical-align: middle;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+    }
+
+    .tag-broken {
+      background: var(--ease-color-danger, #ef4444);
+      color: #fff;
+    }
+
+    .tag-fixed {
+      background: var(--ease-color-success, #22c55e);
+      color: #fff;
+    }
+
+    .demo-nav {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      align-items: center;
+      margin-bottom: 1rem;
+    }
+
+    /* ── BROKEN navbar — no hover guard (replicates current bug) ── */
+    .navbar-broken .ease-navbar-item:hover {
+      color: var(--ease-color-text, #1e293b);
+    }
+
+    /* ── FIXED navbar — guarded with (hover: hover) and (pointer: fine) ── */
+    @media (hover: hover) and (pointer: fine) {
+      .navbar-fixed .ease-navbar-item:hover {
+        color: var(--ease-color-text, #1e293b);
+      }
+    }
+
+    .desc {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      line-height: 1.6;
+      margin-top: 0.75rem;
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.4em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    .instructions {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 1rem 1.25rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.7;
+      margin-bottom: 1.5rem;
+    }
+
+    .instructions strong {
+      display: block;
+      margin-bottom: 0.25rem;
+      color: var(--ease-color-text, #1e293b);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; color: #e2e8f0; }
+
+      .demo-section {
+        background: var(--ease-color-surface, #141e33);
+        border-color: var(--ease-color-neutral-700, #334155);
+      }
+
+      .instructions {
+        background: rgba(108, 99, 255, 0.1);
+      }
+
+      code {
+        background: var(--ease-color-neutral-800, #1e293b);
+      }
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-wrapper">
+
+    <h1 style="font-size: var(--ease-text-2xl, 1.5rem); margin-bottom: 0.5rem;">
+      Navbar Hover Touch Guard Fix
+    </h1>
+    <p style="color: var(--ease-color-muted, #64748b); margin-bottom: 1.5rem; font-size: var(--ease-text-sm, 0.875rem);">
+      Issue #8476 — <code>.ease-navbar-item:hover</code> causes sticky hover on touch devices
+    </p>
+
+    <div class="instructions">
+      <strong>How to reproduce the bug</strong>
+      Open this page in Chrome DevTools → toggle Device Toolbar → select any
+      mobile preset (e.g. iPhone 14). Tap each nav item in the two navbars
+      below and observe the difference in behaviour.
+    </div>
+
+    <!-- BROKEN: no hover guard -->
+    <div class="demo-section">
+      <h2>
+        <span class="tag tag-broken">Broken</span>
+        Without <code>(hover: hover)</code> guard — current behaviour in <code>navbar.css</code>
+      </h2>
+
+      <nav class="ease-navbar-glass navbar-broken demo-nav" aria-label="Broken navbar demo">
+        <span style="font-weight: 700; font-size: 0.9rem; color: var(--ease-color-primary, #6c63ff);">Logo</span>
+        <div style="display: flex; gap: 0.25rem;">
+          <a href="#" class="ease-navbar-item" onclick="return false;">Home</a>
+          <a href="#" class="ease-navbar-item" onclick="return false;">Docs</a>
+          <a href="#" class="ease-navbar-item" onclick="return false;">Components</a>
+          <a href="#" class="ease-navbar-item" onclick="return false;">GitHub</a>
+        </div>
+      </nav>
+
+      <p class="desc">
+        On touch: tap any link — the color changes to
+        <code>var(--ease-color-text)</code> and <strong>stays stuck</strong>
+        until you tap elsewhere. This creates a false "active" state.
+        The <code>:hover</code> rule has no pointer guard so the browser's
+        synthetic tap-hover fires and never resets.
+      </p>
+    </div>
+
+    <!-- FIXED: guarded with (hover: hover) and (pointer: fine) -->
+    <div class="demo-section">
+      <h2>
+        <span class="tag tag-fixed">Fixed</span>
+        With <code>@media (hover: hover) and (pointer: fine)</code> guard
+      </h2>
+
+      <nav class="ease-navbar-glass navbar-fixed demo-nav" aria-label="Fixed navbar demo">
+        <span style="font-weight: 700; font-size: 0.9rem; color: var(--ease-color-primary, #6c63ff);">Logo</span>
+        <div style="display: flex; gap: 0.25rem;">
+          <a href="#" class="ease-navbar-item" onclick="return false;">Home</a>
+          <a href="#" class="ease-navbar-item" onclick="return false;">Docs</a>
+          <a href="#" class="ease-navbar-item" onclick="return false;">Components</a>
+          <a href="#" class="ease-navbar-item" onclick="return false;">GitHub</a>
+        </div>
+      </nav>
+
+      <p class="desc">
+        On touch: tap any link — no color change occurs. The hover rule is
+        wrapped in <code>@media (hover: hover) and (pointer: fine)</code>,
+        which only matches real pointer devices (mouse, trackpad). Touch
+        devices are excluded entirely.
+        On desktop with a mouse, hover still works correctly.
+      </p>
+    </div>
+
+    <!-- Code comparison -->
+    <div class="demo-section">
+      <h2>The Fix</h2>
+      <p style="font-size: var(--ease-text-sm, 0.875rem); color: var(--ease-color-muted, #64748b); margin-bottom: 1rem;">
+        One change to <code>components/navbar.css</code> — wrap the existing rule in the pointer guard:
+      </p>
+      <pre style="background: var(--ease-color-neutral-900, #0f172a); color: #e2e8f0; padding: 1.25rem; border-radius: var(--ease-radius-md, 0.5rem); overflow-x: auto; font-size: 0.82rem; line-height: 1.7;">
+<span style="color:#94a3b8;">/* Before — fires on touch tap */</span>
+<span style="color:#fca5a5;">.ease-navbar-glass .ease-navbar-item:hover {
+  color: var(--ease-color-text, #1e293b);
+}</span>
+
+<span style="color:#94a3b8;">/* After — only fires on hover-capable pointer devices */</span>
+<span style="color:#86efac;">@media (hover: hover) and (pointer: fine) {
+  .ease-navbar-glass .ease-navbar-item:hover {
+    color: var(--ease-color-text, #1e293b);
+  }
+}</span></pre>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/navbar-hover-touch-guard-8476/style.css
+++ b/submissions/examples/navbar-hover-touch-guard-8476/style.css
@@ -1,0 +1,29 @@
+/* ============================================================
+   Fix for issue #8476
+   .ease-navbar-item:hover missing @media (hover: hover) guard
+
+   The base hover rule in navbar.css fires on touch devices
+   because it has no pointer-capability guard. On touchscreens
+   the browser synthesises a :hover state on tap and it sticks
+   until focus moves elsewhere, making nav items appear
+   permanently "active" after a single tap.
+
+   Every other interactive component in the framework wraps
+   its :hover styles in @media (hover: hover) and (pointer: fine).
+   This submission applies the same pattern to the navbar.
+   ============================================================ */
+
+/* ── Guard the base light-mode hover rule ─────────────────── */
+
+/* Before (fires on touch tap — sticky hover bug):
+   .ease-navbar-glass .ease-navbar-item:hover {
+     color: var(--ease-color-text, #1e293b);
+   }
+*/
+
+/* After (only fires on true hover-capable pointer devices): */
+@media (hover: hover) and (pointer: fine) {
+  .ease-navbar-glass .ease-navbar-item:hover {
+    color: var(--ease-color-text, #1e293b);
+  }
+}


### PR DESCRIPTION
Fixes #8476

## What

`.ease-navbar-glass .ease-navbar-item:hover` in `components/navbar.css`
has no `@media (hover: hover) and (pointer: fine)` guard. On touch
devices, tapping a nav link triggers a synthetic `:hover` that sticks
until the user taps elsewhere — making nav items appear permanently
"active" after a single tap.

## Submission

`submissions/examples/navbar-hover-touch-guard-8476/`

The demo shows both the broken behaviour (sticky hover) and the fixed
behaviour (no colour change on tap) side by side. Reproduce with Chrome
DevTools → Device Toolbar → any mobile preset.

## Fix

Wrap the existing rule in the standard guard used by every other
interactive component in the framework:

```css
@media (hover: hover) and (pointer: fine) {
  .ease-navbar-glass .ease-navbar-item:hover {
    color: var(--ease-color-text, #1e293b);
  }
}