### PR TITLE
fix: add forms.css to easemotion/all.css and smoke test coverage

### DIFF
--- a/easemotion/all.css
+++ b/easemotion/all.css
@@ -18,6 +18,6 @@
 @import "../components/loaders.css";
 @import "../components/tooltips.css";
 @import "../components/modals.css";
-
+@import "../components/forms.css";
 
 

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -28,8 +28,9 @@ const badges = readFileSync(resolve(componentsDir, 'badges.css'), 'utf8');
 const loaders = readFileSync(resolve(componentsDir, 'loaders.css'), 'utf8');
 const tooltips = readFileSync(resolve(componentsDir, 'tooltips.css'), 'utf8');
 const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
+const forms = readFileSync(resolve(componentsDir, 'forms.css'), 'utf8');
     
-    css = variables + base + animations + utilities + buttons + cards + chip + footer + masonry + navbar + scrollProgress + sidebar + tabs + badges + loaders + tooltips + modals;
+    css = variables + base + animations + utilities + buttons + cards + chip + footer + masonry + navbar + scrollProgress + sidebar + tabs + badges + loaders + tooltips + modals + forms;
     dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>');
     document = dom.window.document;
     
@@ -128,6 +129,17 @@ const modals = readFileSync(resolve(componentsDir, 'modals.css'), 'utf8');
     expect(css).toContain('.ease-modal-header');
   });
   
+  it('should have form component classes defined', () => {
+    expect(css).toContain('.ease-field');
+    expect(css).toContain('.ease-field-label');
+    expect(css).toContain('.ease-input');
+    expect(css).toContain('.ease-textarea');
+    expect(css).toContain('.ease-select');
+    expect(css).toContain('.ease-input-success');
+    expect(css).toContain('.ease-input-danger');
+    expect(css).toContain('.ease-input-warning');
+  });
+
   it('should not have duplicate @keyframes definitions', () => {
     const keyframeCounts = {};
     const keyframeRegex = /@keyframes\s+([^\s{]+)/g;


### PR DESCRIPTION
Fixes #8465

`components/forms.css` was present in `easemotion.css` (the main entry point) but was missing from `easemotion/all.css` (the modular full-bundle). Users who import the framework via the modular path received no form styles — no `.ease-input`, no `.ease-field`, no `.ease-select` — silently, with no error or warning.

The smoke test suite also never loaded `forms.css`, meaning `.ease-input`, `.ease-field`, `.ease-textarea`, `.ease-select`, and all their state variants had zero test coverage. Regressions in the forms component could not be caught by CI.

### Changes

**`easemotion/all.css`** — Added the missing import line:
```css
@import "../components/forms.css";
```

**`tests/smoke.test.js`** — Loaded `forms.css` in `beforeAll` and added 8 form class assertions for `.ease-field`, `.ease-field-label`, `.ease-input`, `.ease-textarea`, `.ease-select`, `.ease-input-success`, `.ease-input-danger`, `.ease-input-warning`.
