### PR TITLE
fix: replace display:none with visibility:hidden in sidebar mobile overlay (issue #8478)

### DIFF
--- a/submissions/examples/sidebar-mobile-animation-8478/README.md
+++ b/submissions/examples/sidebar-mobile-animation-8478/README.md
@@ -1,0 +1,94 @@
+# Sidebar Mobile Overlay Animation Fix — Issue #8478
+
+**Fixes:** #8478
+
+## What does this do?
+
+Replaces `display:none` / `display:block` with `visibility:hidden` /
+`visibility:visible` in the mobile breakpoint of `.ease-sidebar` so the
+`transform: translateX` slide-in transition actually plays.
+
+## The problem
+
+In `components/sidebar.css`, the mobile overlay variant hides and shows
+the sidebar by toggling `display`:
+
+```css
+/* Current — broken */
+@media (max-width: 768px) {
+  .ease-sidebar {
+    display: none;
+    transform: translateX(-100%);
+    transition: transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1), ...
+  }
+  .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
+    display: block;
+    transform: translateX(0);
+  }
+}
+```
+
+When `display:none` is set, the element does not exist in the browser's
+render tree — it has no geometry and no computed transform. When
+`display:block` is applied, the browser inserts the element in a single
+frame directly at its final position. The `transition` has no starting
+state to animate from, so it is silently skipped every time. The sidebar
+snaps into view with no animation despite a `0.6s` spring easing being
+defined.
+
+## How to reproduce
+
+1. Open any page with `.ease-sidebar-layout` and `.ease-sidebar`.
+2. Open Chrome DevTools → Device Toolbar → select a mobile preset.
+3. Run in the console:
+   ```js
+   document.querySelector('.ease-sidebar-layout').classList.add('ease-sidebar-open');
+   ```
+4. The sidebar snaps to its final position instantly — no slide animation.
+
+## The fix
+
+Replace `display:none` with `visibility:hidden` combined with
+`pointer-events:none`:
+
+```css
+/* Fixed */
+@media (max-width: 768px) {
+  .ease-sidebar {
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateX(-100%);
+    transition:
+      transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+      visibility 0.6s,
+      box-shadow 0.3s ease;
+  }
+  .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(0);
+    box-shadow: 12px 0 36px rgba(0, 0, 0, 0.15);
+  }
+}
+```
+
+`visibility:hidden` keeps the element in the render tree so the browser
+can compute its starting `transform`. The transition fires correctly.
+`pointer-events:none` prevents the hidden sidebar from blocking taps on
+the page behind it.
+
+## Why the fix works
+
+| Property | In render tree | Transform animatable |
+|---|---|---|
+| `display: none` | No | No — transition skipped |
+| `visibility: hidden` | Yes | Yes — transition fires |
+
+## Behaviour after the fix
+
+| Action | Before | After |
+|---|---|---|
+| Sidebar opening | Snaps in instantly | Slides in with 0.6s spring |
+| Sidebar closing | Snaps away instantly | Slides out with 0.6s spring |
+| Hidden sidebar blocks taps | N/A | Prevented by `pointer-events:none` |
+| `prefers-reduced-motion` | Transition ignored anyway | `transition:none` override still works |

--- a/submissions/examples/sidebar-mobile-animation-8478/demo.html
+++ b/submissions/examples/sidebar-mobile-animation-8478/demo.html
@@ -1,0 +1,398 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sidebar Mobile Animation Fix — Issue #8478</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+    }
+
+    /* ── Demo page layout ──────────────────────────────────── */
+    .demo-page {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    .demo-heading {
+      font-size: var(--ease-text-2xl, 1.5rem);
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+
+    .demo-sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .demo-section {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .demo-label {
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 700;
+      margin-bottom: 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .tag {
+      font-size: 0.68rem;
+      font-weight: 700;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-broken  { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed   { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 1.5rem;
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    /* ── Shared sidebar demo wrapper ───────────────────────── */
+    .sidebar-demo-wrapper {
+      position: relative;
+      height: 280px;
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-md, 0.5rem);
+      overflow: hidden;
+      background: var(--ease-color-neutral-100, #f1f5f9);
+    }
+
+    /* ── Simulated main content ─────────────────────────────── */
+    .fake-main {
+      position: absolute;
+      inset: 0;
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      transition:
+        transform 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+        border-radius 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .fake-bar {
+      height: 12px;
+      border-radius: 6px;
+      background: var(--ease-color-neutral-300, #cbd5e1);
+    }
+
+    .fake-bar.w-full  { width: 100%; }
+    .fake-bar.w-75    { width: 75%; }
+    .fake-bar.w-50    { width: 50%; }
+    .fake-bar.w-85    { width: 85%; }
+
+    /* ── Broken sidebar (display:none) ──────────────────────── */
+    .sidebar-broken {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 200px;
+      background: var(--ease-color-neutral-900, #1e293b);
+      color: #e2e8f0;
+      padding: 1rem;
+      z-index: 10;
+      display: none;                        /* broken: no animation possible */
+      transform: translateX(-100%);
+      transition:
+        transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+        box-shadow 0.3s ease;
+    }
+
+    .open-broken .sidebar-broken {
+      display: block;                       /* snaps in instantly */
+      transform: translateX(0);
+      box-shadow: 12px 0 36px rgba(0, 0, 0, 0.25);
+    }
+
+    .open-broken .fake-main {
+      transform: translateX(80px) scale(0.95);
+      border-radius: 12px;
+    }
+
+    /* ── Fixed sidebar (visibility:hidden) ──────────────────── */
+    .sidebar-fixed-el {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 200px;
+      background: var(--ease-color-neutral-900, #1e293b);
+      color: #e2e8f0;
+      padding: 1rem;
+      z-index: 10;
+      visibility: hidden;                   /* fixed: stays in render tree */
+      pointer-events: none;
+      transform: translateX(-100%);
+      transition:
+        transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+        visibility 0.6s,
+        box-shadow 0.3s ease;
+    }
+
+    .open-fixed .sidebar-fixed-el {
+      visibility: visible;
+      pointer-events: auto;
+      transform: translateX(0);            /* slides in with spring animation */
+      box-shadow: 12px 0 36px rgba(0, 0, 0, 0.25);
+    }
+
+    .open-fixed .fake-main {
+      transform: translateX(80px) scale(0.95);
+      border-radius: 12px;
+    }
+
+    /* ── Sidebar content ────────────────────────────────────── */
+    .sidebar-nav {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-top: 0.5rem;
+    }
+
+    .sidebar-nav a {
+      display: block;
+      padding: 0.4rem 0.6rem;
+      border-radius: 6px;
+      font-size: 0.82rem;
+      color: #94a3b8;
+      text-decoration: none;
+    }
+
+    .sidebar-nav a:hover { background: rgba(255,255,255,0.08); color: #f1f5f9; }
+
+    .sidebar-brand {
+      font-weight: 700;
+      font-size: 0.9rem;
+      color: var(--ease-color-primary-light, #a09af8);
+      margin-bottom: 0.5rem;
+    }
+
+    /* ── Toggle buttons ─────────────────────────────────────── */
+    .toggle-row {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+
+    .btn-demo {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.45rem 0.9rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      border: none;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      cursor: pointer;
+      transition: background 150ms ease;
+    }
+
+    .btn-open  { background: var(--ease-color-primary, #6c63ff); color: #fff; }
+    .btn-close { background: var(--ease-color-neutral-200, #e2e8f0); color: var(--ease-color-text, #1e293b); }
+
+    .btn-open:hover  { background: var(--ease-color-primary-dark, #4b44cc); }
+    .btn-close:hover { background: var(--ease-color-neutral-300, #cbd5e1); }
+
+    /* ── Code diff block ────────────────────────────────────── */
+    pre.diff {
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 1.1rem 1.25rem;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      font-size: 0.79rem;
+      line-height: 1.75;
+      overflow-x: auto;
+    }
+    .del { color: #fca5a5; }
+    .ins { color: #86efac; }
+    .cmt { color: #64748b; }
+
+    /* ── Desc text ──────────────────────────────────────────── */
+    .desc {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      line-height: 1.6;
+      margin-top: 0.75rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; color: #e2e8f0; }
+      .demo-section {
+        background: var(--ease-color-surface, #141e33);
+        border-color: var(--ease-color-neutral-700, #334155);
+      }
+      .hint { background: rgba(108,99,255,0.1); }
+      .sidebar-demo-wrapper { background: #1e293b; border-color: #334155; }
+      .fake-bar { background: #334155; }
+      code { background: var(--ease-color-neutral-800, #1e293b); }
+      .btn-close { background: #334155; color: #e2e8f0; }
+      .btn-close:hover { background: #475569; }
+    }
+  </style>
+</head>
+<body>
+  <div class="demo-page">
+
+    <h1 class="demo-heading">Sidebar Mobile Animation Fix</h1>
+    <p class="demo-sub">Issue #8478 — <code>display:none</code> kills the <code>transform</code> transition on mobile</p>
+
+    <div class="hint">
+      <strong>How to test:</strong>
+      Click <strong>Open</strong> in each demo below. The broken sidebar snaps in instantly.
+      The fixed sidebar slides in with the spring animation.
+      You can also resize the browser to a narrow width or use
+      Chrome DevTools → Device Toolbar to simulate mobile.
+    </div>
+
+    <!-- BROKEN -->
+    <div class="demo-section">
+      <div class="demo-label">
+        <span class="tag tag-broken">Broken</span>
+        Current behaviour — <code>display:none → display:block</code> (no animation)
+      </div>
+
+      <div id="broken-wrapper" class="sidebar-demo-wrapper">
+        <div class="sidebar-broken">
+          <div class="sidebar-brand">EaseMotion</div>
+          <nav class="sidebar-nav">
+            <a href="#">Dashboard</a>
+            <a href="#">Components</a>
+            <a href="#">Animations</a>
+            <a href="#">Settings</a>
+          </nav>
+        </div>
+        <div class="fake-main">
+          <div class="fake-bar w-full"></div>
+          <div class="fake-bar w-75"></div>
+          <div class="fake-bar w-50"></div>
+          <div class="fake-bar w-85"></div>
+          <div class="fake-bar w-75"></div>
+          <div class="fake-bar w-50"></div>
+        </div>
+      </div>
+
+      <div class="toggle-row">
+        <button class="btn-demo btn-open"  onclick="document.getElementById('broken-wrapper').classList.add('open-broken')">Open</button>
+        <button class="btn-demo btn-close" onclick="document.getElementById('broken-wrapper').classList.remove('open-broken')">Close</button>
+      </div>
+
+      <p class="desc">
+        The sidebar uses <code>display:none</code> for the hidden state.
+        When opened, the element is inserted into the render tree in one frame —
+        straight to its final position. The <code>transition: transform 0.6s</code>
+        defined in <code>sidebar.css</code> never fires because there is no
+        "before" state to animate from. The sidebar just snaps in.
+      </p>
+    </div>
+
+    <!-- FIXED -->
+    <div class="demo-section">
+      <div class="demo-label">
+        <span class="tag tag-fixed">Fixed</span>
+        Proposed fix — <code>visibility:hidden → visibility:visible</code> (spring animation plays)
+      </div>
+
+      <div id="fixed-wrapper" class="sidebar-demo-wrapper">
+        <div class="sidebar-fixed-el">
+          <div class="sidebar-brand">EaseMotion</div>
+          <nav class="sidebar-nav">
+            <a href="#">Dashboard</a>
+            <a href="#">Components</a>
+            <a href="#">Animations</a>
+            <a href="#">Settings</a>
+          </nav>
+        </div>
+        <div class="fake-main">
+          <div class="fake-bar w-full"></div>
+          <div class="fake-bar w-75"></div>
+          <div class="fake-bar w-50"></div>
+          <div class="fake-bar w-85"></div>
+          <div class="fake-bar w-75"></div>
+          <div class="fake-bar w-50"></div>
+        </div>
+      </div>
+
+      <div class="toggle-row">
+        <button class="btn-demo btn-open"  onclick="document.getElementById('fixed-wrapper').classList.add('open-fixed')">Open</button>
+        <button class="btn-demo btn-close" onclick="document.getElementById('fixed-wrapper').classList.remove('open-fixed')">Close</button>
+      </div>
+
+      <p class="desc">
+        The sidebar uses <code>visibility:hidden</code> for the hidden state.
+        The element stays in the render tree, so the browser can compute its
+        starting <code>transform: translateX(-100%)</code>. When opened, the
+        transition fires and the sidebar slides in with the
+        <code>cubic-bezier(0.34, 1.56, 0.64, 1)</code> spring easing.
+        <code>pointer-events:none</code> prevents the hidden sidebar from
+        intercepting taps while off-screen.
+      </p>
+    </div>
+
+    <!-- Code diff -->
+    <div class="demo-section">
+      <div class="demo-label">The fix — mobile breakpoint in <code>sidebar.css</code></div>
+      <pre class="diff"><span class="cmt">/* mobile breakpoint */</span>
+@media (max-width: 768px) {
+  .ease-sidebar {
+    position: fixed; top: 0; left: 0;
+    height: 100vh; z-index: 100;
+    width: var(--ease-sidebar-width, 260px);
+
+<span class="del">-   display: none;            /* removes element from render tree */</span>
+<span class="ins">+   visibility: hidden;        /* keeps element in render tree     */</span>
+<span class="ins">+   pointer-events: none;      /* prevents blocking touch events    */</span>
+
+    transform: translateX(-100%);
+    transition:
+      transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+<span class="ins">+     visibility 0.6s,           /* instant-on, delayed-off           */</span>
+      box-shadow 0.3s ease;
+  }
+
+  .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
+<span class="del">-   display: block;</span>
+<span class="ins">+   visibility: visible;</span>
+<span class="ins">+   pointer-events: auto;</span>
+    transform: translateX(0);
+    box-shadow: 12px 0 36px rgba(0, 0, 0, 0.15);
+  }
+}</pre>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/sidebar-mobile-animation-8478/style.css
+++ b/submissions/examples/sidebar-mobile-animation-8478/style.css
@@ -1,0 +1,100 @@
+/* ============================================================
+   Fix for issue #8478
+   .ease-sidebar mobile overlay animation never plays because
+   display:none/block toggle removes the element from the render
+   tree, preventing the transform transition from running.
+
+   The fix replaces display:none with visibility:hidden so the
+   element stays in the render tree and the transform can animate.
+   ============================================================ */
+
+/* ── Layout wrapper ─────────────────────────────────────────── */
+.ease-sidebar-layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* ── Desktop sidebar (always visible) ──────────────────────── */
+.ease-sidebar {
+  flex-shrink: 0;
+  flex-basis: var(--ease-sidebar-width, 260px);
+  background: var(--ease-color-neutral-900, #111);
+  border-right: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+  overflow-y: auto;
+  overflow-x: hidden;
+  white-space: nowrap;
+  transition:
+    flex-basis var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    opacity var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+/* ── Main content area ──────────────────────────────────────── */
+.ease-sidebar-main {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: var(--ease-sidebar-main-padding, 2rem);
+  transition:
+    transform 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+    border-radius 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* ── Mobile: overlay sidebar ────────────────────────────────── */
+/*
+   BEFORE (broken — display:none removes element from render tree,
+   transform transition never fires, sidebar snaps in instantly):
+
+   .ease-sidebar {
+     display: none;
+     transform: translateX(-100%);
+     transition: transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1), ...
+   }
+   .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
+     display: block;
+     transform: translateX(0);
+   }
+
+   AFTER (fixed — visibility:hidden keeps element in render tree,
+   transform transition fires correctly):
+*/
+@media (max-width: 768px) {
+  .ease-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    z-index: 100;
+    width: var(--ease-sidebar-width, 260px);
+
+    /* Keep element in render tree so transform can be computed */
+    visibility: hidden;
+    pointer-events: none;
+
+    transform: translateX(-100%);
+    transition:
+      transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+      visibility 0.6s,
+      box-shadow 0.3s ease;
+  }
+
+  .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(0);
+    box-shadow: 12px 0 36px rgba(0, 0, 0, 0.15);
+  }
+
+  .ease-sidebar-layout.ease-sidebar-open .ease-sidebar-main {
+    transform: translateX(120px) scale(0.95);
+    border-radius: 20px;
+  }
+}
+
+/* ── Reduced motion ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-sidebar-layout,
+  .ease-sidebar,
+  .ease-sidebar-main {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
# replace display:none with visibility:hidden in sidebar mobile overlay (issue #8478)

Fixes #8478

## Summary

The mobile breakpoint in `components/sidebar.css` hides `.ease-sidebar`
with `display:none`. This removes the element from the render tree, so
when toggled to `display:block` it is inserted in one frame directly at
its final position — the `transition: transform 0.6s` spring animation
never fires and the sidebar snaps in instantly.

## Submission

`submissions/examples/sidebar-mobile-animation-8478/`

The demo shows both behaviours side by side with Open/Close buttons.
The broken demo snaps. The fixed demo slides with the spring animation.

## Fix

Replace `display:none/block` with `visibility:hidden/visible` combined
with `pointer-events:none/auto`. `visibility:hidden` keeps the element
in the render tree so the browser computes a starting transform position
and the transition plays correctly.

```css
/* visibility:hidden — element stays in render tree, transform animates */
visibility: hidden;
pointer-events: none;
transform: translateX(-100%);
transition:
  transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
  visibility 0.6s,
  box-shadow 0.3s ease;
