### PR TITLE
fix: add dark mode overrides to modal component and correct undefined tokens (issue #8486)

### DIFF
--- a/submissions/examples/modal-dark-mode-fix-8486/README.md
+++ b/submissions/examples/modal-dark-mode-fix-8486/README.md
@@ -1,0 +1,110 @@
+# Modal Dark Mode Fix — Issue #8486
+
+**Fixes:** #8486
+
+## What does this do?
+
+Adds a `@media (prefers-color-scheme: dark)` block to `components/modals.css`
+so the modal footer, borders, and close button use dark-appropriate colors
+in dark mode. Also corrects two undefined token references in the modal
+component.
+
+## Problems fixed
+
+### 1. `.ease-modal-footer` background stays near-white in dark mode
+
+```css
+/* Current — stays #f8fafc (near white) in dark mode */
+.ease-modal-footer {
+  background: var(--ease-color-neutral-50, #f9fafb);
+}
+```
+
+`--ease-color-neutral-50` has no dark mode override in `variables.css`.
+The footer background stays `#f8fafc` while the rest of the modal turns
+dark — creating a jarring white stripe at the bottom.
+
+### 2. Close button hover is a near-white flash in dark mode
+
+`--ease-color-neutral-100` (used for `.ease-modal-close:hover` background)
+also has no dark mode override. Hovering the × button in dark mode shows
+a near-white flash on a dark surface.
+
+### 3. Undefined token `--ease-color-text-muted`
+
+```css
+/* modals.css — this token does not exist in variables.css */
+.ease-modal-body {
+  color: var(--ease-color-text-muted, #4b5563);
+}
+```
+
+The correct token is `--ease-color-muted`. Because `--ease-color-text-muted`
+is undefined, the body text always falls back to hardcoded `#4b5563` — a
+medium-grey that is low-contrast in dark mode.
+
+### 4. Undefined token `--ease-shadow-2xl`
+
+```css
+/* modals.css — this token does not exist in variables.css */
+.ease-modal {
+  box-shadow: var(--ease-shadow-2xl, 0 25px 50px -12px rgba(0,0,0,0.25));
+}
+```
+
+The framework only defines shadows up to `--ease-shadow-xl`. The modal
+always falls back to a hardcoded light-mode shadow. The fix uses
+`--ease-shadow-xl` which exists and has a dark mode override.
+
+## The fix
+
+```css
+/* Correct the two undefined token references */
+.ease-modal-body {
+  color: var(--ease-color-muted, #64748b);
+}
+
+.ease-modal {
+  box-shadow: var(--ease-shadow-xl,
+    0 20px 25px -5px rgba(0,0,0,0.10),
+    0 10px 10px -5px rgba(0,0,0,0.04));
+}
+
+/* Add dark mode overrides for neutral-scale tokens */
+@media (prefers-color-scheme: dark) {
+  .ease-modal-footer {
+    background: var(--ease-color-surface, #141e33);
+    border-top-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  .ease-modal-header {
+    border-bottom-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  .ease-modal-close {
+    color: var(--ease-color-neutral-400, #94a3b8);
+  }
+
+  .ease-modal-close:hover {
+    background: var(--ease-color-neutral-800, #1e293b);
+    color: var(--ease-color-text, #e2e8f0);
+  }
+}
+```
+
+## How to reproduce the bug
+
+1. Open any page with `.ease-modal-overlay` and `.ease-modal` markup.
+2. Chrome DevTools → More Tools → Rendering → set
+   **Emulate CSS media feature prefers-color-scheme** to `dark`.
+3. Open the modal — the footer is near-white `#f8fafc` against the dark body.
+
+## Before vs after in dark mode
+
+| Element | Before | After |
+|---|---|---|
+| Footer background | `#f8fafc` near-white | `#141e33` dark surface |
+| Header/footer borders | `#e2e8f0` light grey | `#334155` dark border |
+| Body text | `#4b5563` low-contrast | `--ease-color-muted` dark |
+| Close button | `#64748b` dim | `#94a3b8` appropriate |
+| Close button hover | `#f1f5f9` near-white flash | `#1e293b` dark |

--- a/submissions/examples/modal-dark-mode-fix-8486/demo.html
+++ b/submissions/examples/modal-dark-mode-fix-8486/demo.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal Dark Mode Fix — Issue #8486</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+    }
+
+    .demo-page {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    h1 {
+      font-size: var(--ease-text-2xl, 1.5rem);
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .demo-row {
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 2rem;
+    }
+
+    .demo-col {
+      flex: 1;
+      min-width: 280px;
+    }
+
+    .demo-label {
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .tag {
+      font-size: 0.68rem;
+      font-weight: 700;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    /* ── Simulated modal previews (no overlay — inline for comparison) ── */
+    .modal-preview {
+      border-radius: var(--ease-radius-lg, 1rem);
+      overflow: hidden;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+      display: flex;
+      flex-direction: column;
+    }
+
+    .modal-preview-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 1.5rem;
+      font-weight: 700;
+      font-size: var(--ease-text-base, 1rem);
+    }
+
+    .modal-preview-body {
+      padding: 1.25rem 1.5rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.6;
+      flex: 1;
+    }
+
+    .modal-preview-footer {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.75rem;
+      padding: 0.875rem 1.5rem;
+    }
+
+    .mock-btn {
+      padding: 0.4rem 1rem;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 600;
+      border: none;
+      cursor: default;
+    }
+
+    .close-x {
+      width: 2rem;
+      height: 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      font-size: 1.1rem;
+      cursor: default;
+    }
+
+    /* ── BROKEN modal (no dark mode overrides) ──────────────── */
+    .modal-broken {
+      background: #0b1121;  /* simulates dark --ease-color-bg */
+    }
+    .modal-broken .modal-preview-header {
+      color: #e2e8f0;
+      border-bottom: 1px solid #e2e8f0;  /* light border — broken */
+    }
+    .modal-broken .close-x {
+      color: #64748b;  /* dim on dark — broken */
+    }
+    .modal-broken .modal-preview-body {
+      background: #0b1121;
+      color: #4b5563;  /* hardcoded fallback — low contrast */
+    }
+    .modal-broken .modal-preview-footer {
+      background: #f8fafc;  /* near-white — broken */
+      border-top: 1px solid #e2e8f0;
+    }
+    .modal-broken .mock-btn.primary {
+      background: var(--ease-color-primary, #6c63ff);
+      color: #fff;
+    }
+    .modal-broken .mock-btn.cancel {
+      background: #e2e8f0;
+      color: #1e293b;
+    }
+
+    /* ── FIXED modal (with dark mode overrides) ─────────────── */
+    .modal-fixed {
+      background: #0b1121;
+    }
+    .modal-fixed .modal-preview-header {
+      color: #e2e8f0;
+      border-bottom: 1px solid #334155;  /* dark border — fixed */
+    }
+    .modal-fixed .close-x {
+      color: #94a3b8;  /* lighter on dark — fixed */
+    }
+    .modal-fixed .modal-preview-body {
+      background: #0b1121;
+      color: #94a3b8;  /* --ease-color-muted in dark — fixed */
+    }
+    .modal-fixed .modal-preview-footer {
+      background: #141e33;  /* dark surface — fixed */
+      border-top: 1px solid #334155;
+    }
+    .modal-fixed .mock-btn.primary {
+      background: var(--ease-color-primary, #6c63ff);
+      color: #fff;
+    }
+    .modal-fixed .mock-btn.cancel {
+      background: #1e293b;
+      color: #e2e8f0;
+    }
+
+    /* ── Live modal (uses actual framework + fix styles) ─────── */
+    .open-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.55rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 600;
+      border: none;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      background: var(--ease-color-primary, #6c63ff);
+      color: #fff;
+      cursor: pointer;
+      margin-bottom: 2rem;
+      transition: background 150ms ease;
+    }
+    .open-btn:hover { background: var(--ease-color-primary-dark, #4b44cc); }
+
+    /* Fix: use --ease-color-muted for modal body text */
+    .ease-modal-body { color: var(--ease-color-muted, #64748b); }
+
+    /* Fix: use existing shadow token */
+    .ease-modal {
+      box-shadow: var(--ease-shadow-xl,
+        0 20px 25px -5px rgba(0,0,0,0.10),
+        0 10px 10px -5px rgba(0,0,0,0.04));
+    }
+
+    /* Fix: dark mode overrides */
+    @media (prefers-color-scheme: dark) {
+      .ease-modal-footer {
+        background: var(--ease-color-surface, #141e33);
+        border-top-color: var(--ease-color-neutral-700, #334155);
+      }
+      .ease-modal-header {
+        border-bottom-color: var(--ease-color-neutral-700, #334155);
+      }
+      .ease-modal-close {
+        color: var(--ease-color-neutral-400, #94a3b8);
+      }
+      .ease-modal-close:hover {
+        background: var(--ease-color-neutral-800, #1e293b);
+        color: var(--ease-color-text, #e2e8f0);
+      }
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    .section-title {
+      font-size: var(--ease-text-base, 1rem);
+      font-weight: 700;
+      margin-bottom: 1rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0a0f1e; }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="demo-page">
+
+    <h1>Modal Dark Mode Fix</h1>
+    <p class="sub">Issue #8486 — <code>.ease-modal-footer</code> white stripe and token bugs in dark mode</p>
+
+    <div class="hint">
+      <strong>How to see the dark mode bug:</strong>
+      Chrome DevTools → More Tools → Rendering →
+      set <em>Emulate CSS media feature prefers-color-scheme</em> to <code>dark</code>.
+      The static previews below always show the dark-mode state.
+      The live modal at the bottom uses the fixed styles.
+    </div>
+
+    <!-- Static side-by-side comparison (always dark) -->
+    <p class="section-title">Dark mode appearance — before vs after</p>
+    <div class="demo-row">
+
+      <div class="demo-col">
+        <div class="demo-label">
+          <span class="tag tag-broken">Broken</span>
+          Current behaviour in dark mode
+        </div>
+        <div class="modal-preview modal-broken">
+          <div class="modal-preview-header">
+            Confirm action
+            <span class="close-x">✕</span>
+          </div>
+          <div class="modal-preview-body">
+            Are you sure you want to delete this item?
+            This action cannot be undone.
+            <br><br>
+            <small style="color:#4b5563;">
+              ← Body text uses undefined token<br>
+              --ease-color-text-muted → falls to #4b5563
+            </small>
+          </div>
+          <div class="modal-preview-footer">
+            <button class="mock-btn cancel">Cancel</button>
+            <button class="mock-btn primary">Delete</button>
+          </div>
+        </div>
+        <p style="font-size:0.78rem;color:#ef4444;margin-top:0.5rem;line-height:1.5;">
+          ❌ Footer is near-white #f8fafc<br>
+          ❌ Body text is low-contrast<br>
+          ❌ Header/footer borders are light grey
+        </p>
+      </div>
+
+      <div class="demo-col">
+        <div class="demo-label">
+          <span class="tag tag-fixed">Fixed</span>
+          After dark mode overrides are added
+        </div>
+        <div class="modal-preview modal-fixed">
+          <div class="modal-preview-header">
+            Confirm action
+            <span class="close-x">✕</span>
+          </div>
+          <div class="modal-preview-body">
+            Are you sure you want to delete this item?
+            This action cannot be undone.
+            <br><br>
+            <small style="color:#94a3b8;">
+              ← Body text now uses --ease-color-muted<br>
+              which is correctly overridden in dark mode
+            </small>
+          </div>
+          <div class="modal-preview-footer">
+            <button class="mock-btn cancel">Cancel</button>
+            <button class="mock-btn primary">Delete</button>
+          </div>
+        </div>
+        <p style="font-size:0.78rem;color:#22c55e;margin-top:0.5rem;line-height:1.5;">
+          ✅ Footer uses dark surface #141e33<br>
+          ✅ Body text uses --ease-color-muted<br>
+          ✅ Borders use dark token #334155
+        </p>
+      </div>
+
+    </div>
+
+    <!-- Live interactive modal using real framework classes + fix -->
+    <p class="section-title">Live modal — uses EaseMotion classes with the fix applied</p>
+    <p style="font-size:var(--ease-text-sm,0.875rem);color:var(--ease-color-muted,#64748b);margin-bottom:1rem;">
+      Enable dark mode emulation in DevTools to see the corrected dark modal.
+    </p>
+
+    <button class="open-btn" onclick="document.getElementById('demo-modal').classList.add('is-active')">
+      Open modal
+    </button>
+
+    <div id="demo-modal" class="ease-modal-overlay">
+      <div class="ease-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+        <div class="ease-modal-header">
+          <h2 id="modal-title">Confirm action</h2>
+          <button
+            class="ease-modal-close"
+            aria-label="Close"
+            onclick="document.getElementById('demo-modal').classList.remove('is-active')"
+          >✕</button>
+        </div>
+        <div class="ease-modal-body">
+          <p>Are you sure you want to delete this item? This action cannot be undone.</p>
+          <p>In dark mode: this footer should be dark, not white. The body text should be readable.</p>
+        </div>
+        <div class="ease-modal-footer">
+          <button
+            class="ease-btn ease-btn-ghost"
+            onclick="document.getElementById('demo-modal').classList.remove('is-active')"
+          >Cancel</button>
+          <button
+            class="ease-btn ease-btn-danger"
+            onclick="document.getElementById('demo-modal').classList.remove('is-active')"
+          >Delete</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/modal-dark-mode-fix-8486/style.css
+++ b/submissions/examples/modal-dark-mode-fix-8486/style.css
@@ -1,0 +1,78 @@
+/* ============================================================
+   Fix for issue #8486
+   .ease-modal-footer stays near-white in dark mode because
+   --ease-color-neutral-50 and --ease-color-neutral-100 have
+   no dark mode overrides in variables.css.
+
+   Two additional problems fixed here:
+   1. --ease-color-text-muted does not exist in the framework
+      (the correct token is --ease-color-muted)
+   2. --ease-shadow-2xl does not exist in the framework
+      (the scale only goes to --ease-shadow-xl)
+
+   This submission adds an explicit dark mode block to modals
+   and corrects the two undefined token references.
+   ============================================================ */
+
+/* ── Fix undefined token in modal body ─────────────────────── */
+/*
+   Before (--ease-color-text-muted does not exist — falls through
+   to hardcoded #4b5563 which is low-contrast in dark mode):
+
+   .ease-modal-body {
+     color: var(--ease-color-text-muted, #4b5563);
+   }
+
+   After (uses the token that actually exists):
+*/
+.ease-modal-body {
+  color: var(--ease-color-muted, #64748b);
+}
+
+/* ── Fix undefined shadow token ─────────────────────────────── */
+/*
+   Before (--ease-shadow-2xl does not exist — always falls through
+   to hardcoded rgba(0,0,0,0.25) light-mode shadow):
+
+   .ease-modal {
+     box-shadow: var(--ease-shadow-2xl, 0 25px 50px -12px rgba(0,0,0,0.25));
+   }
+
+   After (uses --ease-shadow-xl which exists and has a dark override):
+*/
+.ease-modal {
+  box-shadow: var(--ease-shadow-xl, 0 20px 25px -5px rgba(0, 0, 0, 0.10),
+                                    0 10px 10px -5px rgba(0, 0, 0, 0.04));
+}
+
+/* ── Dark mode overrides for neutral-scale tokens ───────────── */
+/*
+   The dark mode block in variables.css overrides semantic tokens
+   (--ease-color-bg, --ease-color-surface, --ease-color-text) but
+   not the raw neutral-scale tokens (--ease-color-neutral-50 etc).
+   Modals use neutral-scale tokens directly for footer background,
+   borders, and the close button — so they stay at light-mode values.
+*/
+@media (prefers-color-scheme: dark) {
+  /* Footer: was near-white #f8fafc — now uses dark surface */
+  .ease-modal-footer {
+    background: var(--ease-color-surface, #141e33);
+    border-top-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  /* Header border: was light grey — now uses dark border */
+  .ease-modal-header {
+    border-bottom-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  /* Close button: was medium grey on dark bg — now lighter */
+  .ease-modal-close {
+    color: var(--ease-color-neutral-400, #94a3b8);
+  }
+
+  /* Close button hover: was near-white flash — now dark */
+  .ease-modal-close:hover {
+    background: var(--ease-color-neutral-800, #1e293b);
+    color: var(--ease-color-text, #e2e8f0);
+  }
+}


### PR DESCRIPTION
# Add dark mode overrides to modal component and correct undefined tokens

Fixes #8486

## What

`components/modals.css` uses neutral-scale tokens (`--ease-color-neutral-50`,
`--ease-color-neutral-100`, `--ease-color-neutral-200`) that have no dark
mode override in `variables.css`. The most visible result is `.ease-modal-footer`
rendering as a near-white `#f8fafc` stripe at the bottom of every dark modal.

Two undefined token references are also corrected:
- `--ease-color-text-muted` does not exist — the correct token is `--ease-color-muted`
- `--ease-shadow-2xl` does not exist — the scale only goes to `--ease-shadow-xl`

## Submission

`submissions/examples/modal-dark-mode-fix-8486/`

The demo shows a static side-by-side comparison (always dark) plus a
live interactive modal using real EaseMotion classes with the fix applied.
Enable dark mode emulation in Chrome DevTools → Rendering to verify.

## Checklist

- [x] Files added only inside `submissions/examples/modal-dark-mode-fix-8486/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/`, `components/`, or any other framework file
- [x] Single focused fix, one commit
