### PR TITLE
fix: add prefers-reduced-motion support to loaders component (issue #8485)

### DIFF
--- a/submissions/examples/loaders-reduced-motion-8485/README.md
+++ b/submissions/examples/loaders-reduced-motion-8485/README.md
@@ -1,0 +1,76 @@
+# Loaders Reduced Motion Fix — Issue #8485
+
+**Fixes:** #8485
+
+## What does this do?
+
+Adds a `@media (prefers-reduced-motion: reduce)` block to
+`components/loaders.css` so all four loader animations stop when the user
+has enabled Reduce Motion in their OS accessibility settings.
+
+## The problem
+
+`components/loaders.css` defines four continuously looping animations:
+
+```css
+.ease-loader-spin  { animation: ease-kf-rotate 0.8s ... infinite; }
+.ease-loader-pulse { animation: ease-kf-pulse  1.2s ... infinite; }
+.ease-loader-ping  { animation: ease-kf-ping   1s   ... infinite; }
+.ease-loader-dot   { animation: ease-kf-bounce 1s   ... infinite; }
+```
+
+The file ends with no `@media (prefers-reduced-motion: reduce)` block.
+All four animations keep running at full speed even when the user has
+enabled Reduce Motion — a system accessibility setting intended to
+prevent motion-triggered symptoms in people with vestibular disorders,
+epilepsy, motion sickness, or ADHD.
+
+Loaders are particularly high-risk because they run continuously and are
+displayed prominently while users are waiting and looking directly at them.
+
+`loaders.css` is the only animated component file in the framework
+missing this accessibility safeguard. Every other component has it:
+buttons, cards, modals, forms, sidebar, tooltips, chip, footer, marquee,
+and scroll-progress.
+
+## How to reproduce
+
+1. Chrome DevTools → More Tools → Rendering
+2. Set **Emulate CSS media feature prefers-reduced-motion** to `reduce`
+3. Open any page with `.ease-loader-spin`, `.ease-loader-dots`, or
+   `.ease-loader-pulse` — all animations continue running with no change
+
+## The fix
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-loader-spin,
+  .ease-loader-pulse,
+  .ease-loader-ping,
+  .ease-loader-dot {
+    animation: none !important;
+  }
+}
+```
+
+Four lines. Same pattern used by every other animated component in the
+framework.
+
+## What users see after the fix
+
+| Loader | Motion enabled | Reduce motion enabled |
+|---|---|---|
+| `.ease-loader-spin` | Spinning circle | Static arc — still visible |
+| `.ease-loader-pulse` | Pulsing dot | Solid dot — still visible |
+| `.ease-loader-ping` | Expanding ring | Static dot — still visible |
+| `.ease-loader-dot` | Bouncing dots | Static dots — still visible |
+
+All loaders remain visible. They simply stop animating. The loading
+state is still communicated — just without motion.
+
+## Demo
+
+The demo includes a **Simulate Reduce Motion** toggle button so the
+before/after difference is visible without needing OS settings or
+DevTools. It also responds to the real `prefers-reduced-motion: reduce`
+media query through the `style.css` fix when tested with DevTools.

--- a/submissions/examples/loaders-reduced-motion-8485/demo.html
+++ b/submissions/examples/loaders-reduced-motion-8485/demo.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Loaders Reduced Motion Fix — Issue #8485</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+    }
+
+    .page {
+      max-width: 820px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    h1 {
+      font-size: var(--ease-text-2xl, 1.5rem);
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .hint strong { display: block; margin-bottom: 0.2rem; }
+
+    /* ── Toggle button ──────────────────────────────────────── */
+    .toggle-row {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 2rem;
+      flex-wrap: wrap;
+    }
+
+    .toggle-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 600;
+      border: 2px solid var(--ease-color-primary, #6c63ff);
+      border-radius: var(--ease-radius-full, 9999px);
+      background: transparent;
+      color: var(--ease-color-primary, #6c63ff);
+      cursor: pointer;
+      transition: background 150ms ease, color 150ms ease;
+    }
+
+    .toggle-btn:hover {
+      background: var(--ease-color-primary, #6c63ff);
+      color: #fff;
+    }
+
+    .toggle-btn.active {
+      background: var(--ease-color-primary, #6c63ff);
+      color: #fff;
+    }
+
+    .motion-status {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+    }
+
+    .motion-status strong { color: var(--ease-color-text, #1e293b); }
+
+    /* ── Loader grid ────────────────────────────────────────── */
+    .loader-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+
+    .loader-card {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.75rem 1.25rem 1.25rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+      min-height: 140px;
+    }
+
+    .loader-name {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--ease-color-muted, #64748b);
+      font-family: var(--ease-font-mono, monospace);
+      text-align: center;
+    }
+
+    .loader-state {
+      font-size: 0.68rem;
+      padding: 0.1rem 0.5rem;
+      border-radius: 999px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .state-running {
+      background: var(--ease-color-success, #22c55e);
+      color: #fff;
+    }
+
+    .state-stopped {
+      background: var(--ease-color-warning, #f59e0b);
+      color: #fff;
+    }
+
+    /* ── Reduced motion simulation ──────────────────────────── */
+    /* Applied by JS toggle to simulate prefers-reduced-motion  */
+    .reduce-motion .ease-loader-spin,
+    .reduce-motion .ease-loader-pulse,
+    .reduce-motion .ease-loader-ping,
+    .reduce-motion .ease-loader-dot {
+      animation: none !important;
+    }
+
+    /* ── Code block ─────────────────────────────────────────── */
+    pre {
+      background: var(--ease-color-neutral-900, #0f172a);
+      color: #e2e8f0;
+      padding: 1.1rem 1.25rem;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      font-size: 0.79rem;
+      line-height: 1.75;
+      overflow-x: auto;
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    .section-title {
+      font-size: var(--ease-text-base, 1rem);
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .hint { background: rgba(108,99,255,0.1); }
+      .loader-card {
+        background: var(--ease-color-surface, #141e33);
+        border-color: var(--ease-color-neutral-700, #334155);
+      }
+      code { background: #1e293b; }
+    }
+
+    /* Actual prefers-reduced-motion (from style.css fix) applies here */
+  </style>
+</head>
+<body>
+  <div class="page" id="demo-root">
+
+    <h1>Loaders Reduced Motion Fix</h1>
+    <p class="sub">Issue #8485 — all four loader animations ignore <code>prefers-reduced-motion: reduce</code></p>
+
+    <div class="hint">
+      <strong>Two ways to test:</strong>
+      1. Click <strong>Simulate Reduce Motion</strong> below to toggle the fix on/off in this demo.<br>
+      2. Chrome DevTools → More Tools → Rendering →
+         set <em>Emulate CSS media feature prefers-reduced-motion</em> to <code>reduce</code>
+         — the fix in <code>style.css</code> will stop all loaders automatically.
+    </div>
+
+    <!-- Toggle -->
+    <div class="toggle-row">
+      <button class="toggle-btn" id="toggle-btn" onclick="toggleMotion()">
+        Simulate Reduce Motion: OFF
+      </button>
+      <span class="motion-status" id="motion-status">
+        Current state: <strong>Animations running</strong>
+      </span>
+    </div>
+
+    <!-- Loader grid -->
+    <p class="section-title">All four loader variants</p>
+    <div class="loader-grid">
+
+      <div class="loader-card">
+        <div
+          class="ease-loader ease-loader-spin"
+          role="status"
+          aria-label="Loading"
+        ></div>
+        <span class="loader-name">.ease-loader-spin</span>
+        <span class="loader-state state-running" id="state-spin">Running</span>
+      </div>
+
+      <div class="loader-card">
+        <div
+          class="ease-loader ease-loader-pulse"
+          role="status"
+          aria-label="Loading"
+        ></div>
+        <span class="loader-name">.ease-loader-pulse</span>
+        <span class="loader-state state-running" id="state-pulse">Running</span>
+      </div>
+
+      <div class="loader-card">
+        <div
+          class="ease-loader ease-loader-ping"
+          role="status"
+          aria-label="Loading"
+        ></div>
+        <span class="loader-name">.ease-loader-ping</span>
+        <span class="loader-state state-running" id="state-ping">Running</span>
+      </div>
+
+      <div class="loader-card">
+        <div
+          class="ease-loader-dots"
+          role="status"
+          aria-label="Loading"
+        >
+          <div class="ease-loader-dot"></div>
+          <div class="ease-loader-dot"></div>
+          <div class="ease-loader-dot"></div>
+        </div>
+        <span class="loader-name">.ease-loader-dots</span>
+        <span class="loader-state state-running" id="state-dots">Running</span>
+      </div>
+
+    </div>
+
+    <!-- The fix -->
+    <p class="section-title">The fix — add to <code>components/loaders.css</code></p>
+    <pre>@media (prefers-reduced-motion: reduce) {
+  .ease-loader-spin,
+  .ease-loader-pulse,
+  .ease-loader-ping,
+  .ease-loader-dot {
+    animation: none !important;
+  }
+}</pre>
+
+  </div>
+
+  <script>
+    var reduced = false;
+
+    function toggleMotion() {
+      reduced = !reduced;
+      var root = document.getElementById('demo-root');
+      var btn  = document.getElementById('toggle-btn');
+      var status = document.getElementById('motion-status');
+      var states = ['state-spin','state-pulse','state-ping','state-dots'];
+
+      if (reduced) {
+        root.classList.add('reduce-motion');
+        btn.textContent = 'Simulate Reduce Motion: ON';
+        btn.classList.add('active');
+        status.innerHTML = 'Current state: <strong>Animations stopped</strong>';
+        states.forEach(function(id) {
+          var el = document.getElementById(id);
+          el.textContent = 'Stopped';
+          el.className = 'loader-state state-stopped';
+        });
+      } else {
+        root.classList.remove('reduce-motion');
+        btn.textContent = 'Simulate Reduce Motion: OFF';
+        btn.classList.remove('active');
+        status.innerHTML = 'Current state: <strong>Animations running</strong>';
+        states.forEach(function(id) {
+          var el = document.getElementById(id);
+          el.textContent = 'Running';
+          el.className = 'loader-state state-running';
+        });
+      }
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/loaders-reduced-motion-8485/style.css
+++ b/submissions/examples/loaders-reduced-motion-8485/style.css
@@ -1,0 +1,25 @@
+/* ============================================================
+   Fix for issue #8485
+   components/loaders.css defines four continuously looping
+   animations but has no @media (prefers-reduced-motion: reduce)
+   block. All four loader variants keep running forever even when
+   the user has enabled Reduce Motion in their OS settings.
+
+   This is the only animated component file in the framework
+   missing this accessibility safeguard.
+
+   The fix adds the same pattern already used by buttons.css,
+   cards.css, modals.css, forms.css, sidebar.css, tooltips.css,
+   chip.css, footer.css, ease-marquee.css, and scroll-progress.css.
+   ============================================================ */
+
+/* ── Proposed addition to components/loaders.css ───────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-loader-spin,
+  .ease-loader-pulse,
+  .ease-loader-ping,
+  .ease-loader-dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
# Add prefers-reduced-motion support to loaders component (issue #8485)

Fixes #8485

## What

`components/loaders.css` has four continuously looping animations but
no `@media (prefers-reduced-motion: reduce)` block. All four variants
keep running when the user has enabled Reduce Motion in their OS
accessibility settings — ignoring a preference that exists to prevent
physical discomfort for users with vestibular disorders, epilepsy, and
motion sickness.

Loaders are the only animated component in the framework missing this
safeguard. Every other animated component has it.

## Submission

`submissions/examples/loaders-reduced-motion-8485/`

The demo includes a **Simulate Reduce Motion** toggle button showing
the before/after difference without needing OS settings or DevTools.
It also responds to the real `prefers-reduced-motion: reduce` media
query when tested in Chrome DevTools → Rendering.

## Fix

```css
@media (prefers-reduced-motion: reduce) {
  .ease-loader-spin,
  .ease-loader-pulse,
  .ease-loader-ping,
  .ease-loader-dot {
    animation: none !important;
  }
}
