### PR TITLE
feat(submission): add ease-venetian-blind-wipe reveal effect

### DIFF
--- a/submissions/examples/ease-venetian-blind-wipe/README.md
+++ b/submissions/examples/ease-venetian-blind-wipe/README.md
@@ -1,0 +1,42 @@
+# ease-venetian-blind-wipe
+
+A hover-triggered reveal effect that splits a container into horizontal slats and collapses them sequentially using `scaleY`, exposing the content underneath — no JavaScript required.
+
+## Usage
+
+```html
+<div class="venetian-blind-container">
+  <div class="venetian-blind-content">Your content here</div>
+  <div class="venetian-blind-slats">
+    <div class="slat"></div>
+    <div class="slat"></div>
+    <div class="slat"></div>
+    <div class="slat"></div>
+    <div class="slat"></div>
+    <div class="slat"></div>
+    <div class="slat"></div>
+    <div class="slat"></div>
+  </div>
+</div>
+```
+
+## How it works
+
+- The slat overlay sits `position: absolute` over the content layer
+- Each `.slat` uses `transform-origin: center top` so it folds downward
+- Staggered `transition-delay` on `nth-child` selectors creates the sequential wipe
+- On hover, all slats animate `scaleY(1) → scaleY(0)`, revealing the content behind
+- `@media (prefers-reduced-motion: reduce)` disables all transitions for accessibility
+
+## Customization
+
+| Variable | Description |
+|----------|-------------|
+| `.slat` background | Color of the slat panels (default: `#1a1a2e`) |
+| `transition-delay` step | Controls wipe speed between slats (default: `0.04s`) |
+| Slat count | Add/remove `.slat` divs; update `nth-child` delays to match |
+| `transition` duration | Per-slat collapse speed (default: `0.35s`) |
+
+## Accessibility
+
+Respects `prefers-reduced-motion`. When reduced motion is preferred, slats disappear instantly without animation.

--- a/submissions/examples/ease-venetian-blind-wipe/demo.html
+++ b/submissions/examples/ease-venetian-blind-wipe/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Venetian Blind Slat Wipe - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h1>Venetian Blind Wipe</h1>
+
+    <div class="venetian-blind-container">
+      <div class="venetian-blind-content">Hover to reveal</div>
+      <div class="venetian-blind-slats">
+        <div class="slat"></div>
+        <div class="slat"></div>
+        <div class="slat"></div>
+        <div class="slat"></div>
+        <div class="slat"></div>
+        <div class="slat"></div>
+        <div class="slat"></div>
+        <div class="slat"></div>
+      </div>
+    </div>
+
+    <p class="description">
+      Horizontal slats collapse sequentially via <code>scaleY</code> to reveal content underneath — pure CSS, no JavaScript.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-venetian-blind-wipe/style.css
+++ b/submissions/examples/ease-venetian-blind-wipe/style.css
@@ -1,0 +1,77 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0f0f;
+  color: white;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+/* =============================================
+   Venetian Blind Slat Wipe Reveal
+   Splits the element into horizontal slats and
+   collapses each via scaleY, revealing content
+   underneath in sequence.
+   ============================================= */
+
+.venetian-blind-container {
+  position: relative;
+  width: 360px;
+  height: 200px;
+  margin: 2rem auto;
+  overflow: hidden;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.venetian-blind-content {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #6366f1, #a855f7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.venetian-blind-slats {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.slat {
+  flex: 1;
+  background: #1a1a2e;
+  transform-origin: center top;
+  transform: scaleY(1);
+  transition: transform 0.35s ease-in-out;
+}
+
+.venetian-blind-container:hover .slat {
+  transform: scaleY(0);
+}
+
+.slat:nth-child(1)  { transition-delay: 0s; }
+.slat:nth-child(2)  { transition-delay: 0.04s; }
+.slat:nth-child(3)  { transition-delay: 0.08s; }
+.slat:nth-child(4)  { transition-delay: 0.12s; }
+.slat:nth-child(5)  { transition-delay: 0.16s; }
+.slat:nth-child(6)  { transition-delay: 0.20s; }
+.slat:nth-child(7)  { transition-delay: 0.24s; }
+.slat:nth-child(8)  { transition-delay: 0.28s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .slat {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a venetian blind slat wipe reveal effect. An 8-slat overlay covers the content at rest; on hover, each slat collapses via `scaleY(0)` with a staggered `transition-delay`, sequentially revealing the content underneath. No JavaScript — pure CSS transitions. `prefers-reduced-motion` guard included.

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-venetian-blind-wipe/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A hover-triggered reveal where horizontal slat panels collapse top-to-bottom in sequence, exposing the content layer beneath.

**How does a developer use it?**

```html
<div class="venetian-blind-container">
  <div class="venetian-blind-content">Your content here</div>
  <div class="venetian-blind-slats">
    <div class="slat"></div>
    <div class="slat"></div>
    <div class="slat"></div>
    <div class="slat"></div>
    <div class="slat"></div>
    <div class="slat"></div>
    <div class="slat"></div>
    <div class="slat"></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

Pure CSS, zero dependencies. Expressive reveal with a single class structure — consistent with the library's human-readable, animation-first approach. Works on any content: images, cards, text blocks.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

Slat count is adjustable — add/remove `.slat` divs and match `nth-child` delay steps accordingly. Timing values (per-slat duration `0.35s`, step delay `0.04s`) chosen to feel deliberate without being sluggish.

Closes #8490