### PR TITLE
feat(submission): add ease-long-shadow-text 3D extrusion effect

### DIFF
--- a/submissions/examples/ease-long-shadow-text/README.md
+++ b/submissions/examples/ease-long-shadow-text/README.md
@@ -1,0 +1,30 @@
+# ease-long-shadow-text
+
+A 3D extruded text effect built entirely from stacked `text-shadow` layers. Each layer offsets 1px diagonally with a progressively darker color, creating the illusion of physical depth. Hover extends the extrusion from 14 to 24 layers, deepening the 3D effect.
+
+## Usage
+
+```html
+<h1 class="long-shadow-text">Your Text</h1>
+```
+
+## How it works
+
+- `text-shadow` accepts a comma-separated list of shadows
+- Each shadow steps 1px further on both X and Y axes with a darker shade of the base color
+- The final layers use `rgba` blur to soften the cast shadow beneath
+- `transition: text-shadow` animates between the resting (shallow) and hover (deep) states
+- `color` shifts slightly lighter on hover to maintain contrast against the deeper shadow
+
+## Customization
+
+| Property | Description |
+|----------|-------------|
+| Base color (`color`) | The face color of the text |
+| Shadow color progression | Edit the hex stops to match any palette |
+| Shadow layer count | Add more `Npx Npx 0` stops to increase depth |
+| `transition` duration | Controls how fast the depth change animates |
+
+## Accessibility
+
+Respects `prefers-reduced-motion`. When reduced motion is preferred, the hover depth transition is disabled.

--- a/submissions/examples/ease-long-shadow-text/demo.html
+++ b/submissions/examples/ease-long-shadow-text/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D Long-Shadow Text - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h1 class="long-shadow-text">Depth</h1>
+    <p class="long-shadow-demo-label">Hover to extend the extrusion</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-long-shadow-text/style.css
+++ b/submissions/examples/ease-long-shadow-text/style.css
@@ -1,0 +1,92 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0f0f;
+  color: white;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+/* =============================================
+   3D Extruded Long-Shadow Text
+   Stacks dozens of text-shadow layers at
+   1px offsets to simulate a deep 3D extrusion.
+   Hover animates the extrusion length.
+   ============================================= */
+
+.long-shadow-text {
+  font-size: clamp(3rem, 8vw, 6rem);
+  font-weight: 900;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #a78bfa;
+  cursor: default;
+  display: inline-block;
+  transition: text-shadow 0.3s ease, color 0.3s ease;
+
+  /* 30-layer extrusion toward bottom-right */
+  text-shadow:
+    1px 1px 0 #7c3aed,
+    2px 2px 0 #6d28d9,
+    3px 3px 0 #5b21b6,
+    4px 4px 0 #4c1d95,
+    5px 5px 0 #3b0764,
+    6px 6px 0 #2e1065,
+    7px 7px 0 #1e0a3c,
+    8px 8px 0 #150730,
+    9px 9px 0 #0d0520,
+    10px 10px 0 #080312,
+    11px 11px 2px rgba(0,0,0,0.4),
+    12px 12px 4px rgba(0,0,0,0.3),
+    14px 14px 6px rgba(0,0,0,0.2),
+    16px 16px 8px rgba(0,0,0,0.15);
+}
+
+.long-shadow-text:hover {
+  color: #c4b5fd;
+  text-shadow:
+    1px 1px 0 #7c3aed,
+    2px 2px 0 #6d28d9,
+    3px 3px 0 #5b21b6,
+    4px 4px 0 #4c1d95,
+    5px 5px 0 #3b0764,
+    6px 6px 0 #2e1065,
+    7px 7px 0 #1e0a3c,
+    8px 8px 0 #150730,
+    9px 9px 0 #0d0520,
+    10px 10px 0 #080312,
+    11px 11px 0 #050210,
+    12px 12px 0 #03010a,
+    13px 13px 0 #020107,
+    14px 14px 0 #010005,
+    15px 15px 0 #010004,
+    16px 16px 0 #010003,
+    17px 17px 0 #000003,
+    18px 18px 0 #000002,
+    19px 19px 0 #000002,
+    20px 20px 0 #000001,
+    22px 22px 2px rgba(0,0,0,0.5),
+    25px 25px 4px rgba(0,0,0,0.35),
+    28px 28px 6px rgba(0,0,0,0.25),
+    32px 32px 10px rgba(0,0,0,0.15);
+}
+
+.long-shadow-demo-label {
+  margin-top: 2rem;
+  font-size: 0.9rem;
+  color: #6b7280;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .long-shadow-text {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a 3D extruded long-shadow text effect. Uses stacked `text-shadow` layers with 1px diagonal increments and a progressively darkening color ramp to fake physical depth on text. Hover extends the extrusion from 14 to 24 layers, deepening the 3D appearance. `prefers-reduced-motion` guard included.

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-long-shadow-text/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only 3D extruded text effect using stacked `text-shadow` layers that animate on hover to increase perceived depth.

**How does a developer use it?**

```html
<h1 class="long-shadow-text">Your Text</h1>
```

**Why does it fit EaseMotion CSS?**

Zero JavaScript, single class. The effect is striking and purposeful — suited for hero headings and display typography — and follows the library's pattern of expressive CSS effects without framework dependencies.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

Shadow color ramp uses purple tones to match the demo palette — maintainer can adjust the hex stops to any brand color. Layer count is intentionally readable in the CSS for easy customization.

Closes #8491