### PR TITLE
feat(submission): add ease-ken-burns cinematic pan-zoom effect

### DIFF
--- a/submissions/examples/ease-ken-burns/README.md
+++ b/submissions/examples/ease-ken-burns/README.md
@@ -1,0 +1,38 @@
+# ease-ken-burns
+
+A cinematic pan-and-zoom effect inspired by the Ken Burns documentary technique. The element slowly scales up and drifts across keyframe positions, creating the illusion of a camera slowly moving across an image. Pure CSS `@keyframes` — no JavaScript.
+
+## Usage
+
+```html
+<!-- On an <img> element -->
+<div class="ken-burns-container">
+  <img class="ken-burns-img" src="your-image.jpg" alt="..." />
+</div>
+
+<!-- On a background-image div -->
+<div class="ken-burns-container">
+  <div class="ken-burns-bg"></div>
+</div>
+```
+
+## How it works
+
+- `.ken-burns-container` clips overflow so the zoomed/panned image stays bounded
+- The keyframe cycles through four `scale()` + `translate()` positions over 12 seconds
+- `ease-in-out` timing makes each movement feel like a natural camera settle
+- `will-change: transform` hints the browser to GPU-composite the animated layer
+- `prefers-reduced-motion` stops the animation entirely
+
+## Customization
+
+| Property | Description |
+|----------|-------------|
+| `animation` duration | Controls total cycle speed (default: `12s`) |
+| `scale()` values | Zoom level at each keyframe stop (keep between 1.0–1.2 for subtlety) |
+| `translate()` values | Pan direction and distance at each stop |
+| Container dimensions | Set width/height on `.ken-burns-container` to any size |
+
+## Accessibility
+
+Respects `prefers-reduced-motion`. The image renders statically when reduced motion is preferred.

--- a/submissions/examples/ease-ken-burns/demo.html
+++ b/submissions/examples/ease-ken-burns/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ken Burns Pan-Zoom - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h1>Ken Burns Effect</h1>
+
+    <div class="ken-burns-container">
+      <div class="ken-burns-bg">
+        <span style="font-size:3rem; opacity:0.15;">&#9728;</span>
+      </div>
+      <div class="ken-burns-caption">Slow cinematic pan &amp; zoom</div>
+    </div>
+
+    <p class="ken-burns-label">12s loop — scale + translate via pure CSS keyframes</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-ken-burns/style.css
+++ b/submissions/examples/ease-ken-burns/style.css
@@ -1,0 +1,96 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0f0f;
+  color: white;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+/* =============================================
+   Ken Burns Pan-Zoom Effect
+   Slow cinematic scale + translate animation on
+   an image/background, simulating documentary
+   camera movement. Pure CSS keyframes.
+   ============================================= */
+
+@keyframes ken-burns {
+  0% {
+    transform: scale(1) translate(0, 0);
+  }
+  25% {
+    transform: scale(1.08) translate(-2%, 1%);
+  }
+  50% {
+    transform: scale(1.12) translate(1.5%, -1.5%);
+  }
+  75% {
+    transform: scale(1.06) translate(-1%, 2%);
+  }
+  100% {
+    transform: scale(1) translate(0, 0);
+  }
+}
+
+.ken-burns-container {
+  position: relative;
+  width: min(480px, 90vw);
+  height: 280px;
+  overflow: hidden;
+  border-radius: 12px;
+  margin: 2rem auto;
+}
+
+.ken-burns-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  will-change: transform;
+  animation: ken-burns 12s ease-in-out infinite;
+}
+
+/* Works equally on a background-image div */
+.ken-burns-bg {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #1e3a5f 0%, #0f4c75 30%, #1b6ca8 60%, #16213e 100%);
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  will-change: transform;
+  animation: ken-burns 12s ease-in-out infinite;
+}
+
+.ken-burns-caption {
+  position: absolute;
+  bottom: 1.2rem;
+  left: 1.2rem;
+  font-size: 1.2rem;
+  font-weight: 700;
+  text-shadow: 0 2px 8px rgba(0,0,0,0.8);
+  pointer-events: none;
+}
+
+.ken-burns-label {
+  font-size: 0.8rem;
+  color: #4b5563;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-top: 0.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ken-burns-img,
+  .ken-burns-bg {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a Ken Burns pan-and-zoom effect. An `overflow: hidden` container clips the animated child, which runs a 12s looping `@keyframes` that slowly cycles through four `scale() + translate()` positions — giving the appearance of a documentary-style camera drifting across an image. Works on `<img>` elements or `background-image` divs. `will-change: transform` for GPU compositing. `prefers-reduced-motion` stops the animation.

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-ken-burns/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Cinematic slow pan-and-zoom animation for hero images or banner sections.

**How does a developer use it?**

```html
<div class="ken-burns-container">
  <img class="ken-burns-img" src="hero.jpg" alt="Hero image" />
</div>
```

**Why does it fit EaseMotion CSS?**

Zero JavaScript. Single class on the image. Common pattern for hero sections and landing pages that isn't covered by any existing submission.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

Demo uses a CSS gradient background instead of an external image to keep it offline-compatible. Scale values stay in the 1.0–1.12 range intentionally — beyond 1.2 the movement becomes distracting.

Closes #8493