### PR TITLE
feat(submission): add ease-domino-chain-fall toppling sequence

### DIFF
--- a/submissions/examples/ease-domino-chain-fall/README.md
+++ b/submissions/examples/ease-domino-chain-fall/README.md
@@ -1,0 +1,43 @@
+# ease-domino-chain-fall
+
+A hover-triggered domino chain-fall animation. Each piece rotates from upright to fallen using `rotateZ(90deg)` with `transform-origin: center bottom` to simulate a physical pivot point. Staggered `animation-delay` on each `nth-child` creates the cascading chain effect. Pure CSS — no JavaScript.
+
+## Usage
+
+```html
+<div class="domino-track">
+  <div class="domino"></div>
+  <div class="domino"></div>
+  <div class="domino"></div>
+  <div class="domino"></div>
+  <div class="domino"></div>
+  <div class="domino"></div>
+  <div class="domino"></div>
+  <div class="domino"></div>
+  <div class="domino"></div>
+  <div class="domino"></div>
+</div>
+```
+
+## How it works
+
+- Each `.domino` starts with `animation-play-state: paused`
+- Hovering `.domino-track` switches all dominoes to `animation-play-state: running`
+- Each domino's `animation-delay` is staggered by ~0.1s per piece
+- `transform-origin: center bottom` makes each piece pivot at its base like a physical domino
+- `animation-timing-function` switches from `ease-in` (falling) to `ease-out` (landing) within the keyframe
+- `animation: forwards` freezes each piece in the fallen position
+
+## Customization
+
+| Property | Description |
+|----------|-------------|
+| `.domino` width / height | Domino proportions |
+| `gap` on `.domino-track` | Spacing between pieces |
+| `animation-delay` step | Time between each domino falling (default: ~0.1s) |
+| Per-child `background` | Piece colors — adjust the `nth-child` rules |
+| `animation` duration | Per-piece fall speed (default: `0.5s`) |
+
+## Accessibility
+
+Respects `prefers-reduced-motion`. When reduced motion is preferred, hover snaps all pieces to the fallen position instantly without animation.

--- a/submissions/examples/ease-domino-chain-fall/demo.html
+++ b/submissions/examples/ease-domino-chain-fall/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Domino Chain Fall - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h1>Domino Chain Fall</h1>
+
+    <div class="domino-track">
+      <div class="domino"></div>
+      <div class="domino"></div>
+      <div class="domino"></div>
+      <div class="domino"></div>
+      <div class="domino"></div>
+      <div class="domino"></div>
+      <div class="domino"></div>
+      <div class="domino"></div>
+      <div class="domino"></div>
+      <div class="domino"></div>
+    </div>
+
+    <p class="domino-label">Hover to trigger the chain</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-domino-chain-fall/style.css
+++ b/submissions/examples/ease-domino-chain-fall/style.css
@@ -1,0 +1,89 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0f0f;
+  color: white;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+/* =============================================
+   Domino Chain-Fall Toppling Sequence
+   Each piece rotates from upright to fallen via
+   rotateZ with staggered animation-delay.
+   transform-origin at bottom center simulates
+   a physical pivot point on the ground.
+   ============================================= */
+
+@keyframes domino-fall {
+  0%, 40% {
+    transform: rotateZ(0deg);
+    animation-timing-function: ease-in;
+  }
+  70% {
+    transform: rotateZ(85deg);
+    animation-timing-function: ease-out;
+  }
+  80%, 100% {
+    transform: rotateZ(90deg);
+  }
+}
+
+.domino-track {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 10px;
+  height: 120px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.domino {
+  width: 28px;
+  height: 80px;
+  border-radius: 4px;
+  transform-origin: center bottom;
+  animation: domino-fall 0.5s forwards;
+  animation-play-state: paused;
+  flex-shrink: 0;
+}
+
+/* Stagger each domino's delay */
+.domino:nth-child(1)  { animation-delay: 0s;    background: #6366f1; }
+.domino:nth-child(2)  { animation-delay: 0.12s; background: #7c3aed; }
+.domino:nth-child(3)  { animation-delay: 0.22s; background: #8b5cf6; }
+.domino:nth-child(4)  { animation-delay: 0.32s; background: #a78bfa; }
+.domino:nth-child(5)  { animation-delay: 0.42s; background: #c4b5fd; }
+.domino:nth-child(6)  { animation-delay: 0.52s; background: #a78bfa; }
+.domino:nth-child(7)  { animation-delay: 0.62s; background: #8b5cf6; }
+.domino:nth-child(8)  { animation-delay: 0.72s; background: #7c3aed; }
+.domino:nth-child(9)  { animation-delay: 0.82s; background: #6366f1; }
+.domino:nth-child(10) { animation-delay: 0.92s; background: #4f46e5; }
+
+/* Trigger on hover of the container */
+.domino-track:hover .domino {
+  animation-play-state: running;
+}
+
+.domino-label {
+  font-size: 0.8rem;
+  color: #4b5563;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .domino {
+    animation: none;
+  }
+  .domino-track:hover .domino {
+    transform: rotateZ(90deg);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a domino chain-fall animation. Ten `.domino` pieces stand upright at rest. Hovering `.domino-track` sets `animation-play-state: running`, triggering a staggered `rotateZ(90deg)` on each piece via `animation-delay`. `transform-origin: center bottom` makes each piece pivot at its base. `animation: forwards` freezes pieces in the fallen state. `prefers-reduced-motion` snaps to fallen without animation.

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-domino-chain-fall/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A hover-triggered cascading topple sequence — each piece falls in turn with realistic pivot physics simulated by `transform-origin`.

**How does a developer use it?**

```html
<div class="domino-track">
  <div class="domino"></div>
  <!-- repeat as needed -->
</div>
```

**Why does it fit EaseMotion CSS?**

Pure CSS, zero JavaScript. Distinctive sequential animation with a physical feel — suits loaders, decorative section dividers, or game-like UIs.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

The `animation-play-state` trick means the animation only runs once per hover entry (doesn't loop). If the maintainer wants a repeating loop, changing `animation` to `infinite` is trivial.

Closes #8494