### PR TITLE
feat(submission): add ease-chromatic-aberration RGB channel-split text effect

### DIFF
--- a/submissions/examples/ease-chromatic-aberration/README.md
+++ b/submissions/examples/ease-chromatic-aberration/README.md
@@ -1,0 +1,36 @@
+# ease-chromatic-aberration
+
+Simulates a lens chromatic aberration / RGB channel-split glitch on text. Two pseudo-elements mirror the text with red and blue tints and `mix-blend-mode: screen`, then offset horizontally to create the split-channel illusion. Two variants: hover-triggered and auto-glitching.
+
+## Usage
+
+```html
+<!-- Hover-triggered -->
+<span class="chromatic-text" data-text="Your Text">Your Text</span>
+
+<!-- Auto-glitch pulse -->
+<div class="chromatic-text-auto">Your Text</div>
+```
+
+Note: `.chromatic-text` requires the `data-text` attribute to mirror the text content into `::before` / `::after` via `content: attr(data-text)`.
+
+## How it works
+
+- `::before` is tinted red (`#ff0033`) and offset left; `::after` is tinted blue (`#0033ff`) and offset right
+- `mix-blend-mode: screen` blends the colored copies onto the white text, creating the RGB fringe
+- On hover, the offsets increase from ±3px to ±6px and opacity fades in
+- The auto variant uses `@keyframes` with sparse glitch intervals (fires at 88% and 94% of a 4s loop)
+- `prefers-reduced-motion` disables both transitions and animations
+
+## Customization
+
+| Property | Description |
+|----------|-------------|
+| `translate()` values on `::before` / `::after` | Red/blue channel separation distance |
+| `color` on pseudo-elements | RGB channel tint colors |
+| `animation` interval in keyframes | How often the auto-glitch fires |
+| `mix-blend-mode` | Try `multiply` on light backgrounds |
+
+## Accessibility
+
+Respects `prefers-reduced-motion`. Transitions and keyframe animations are disabled when reduced motion is preferred.

--- a/submissions/examples/ease-chromatic-aberration/demo.html
+++ b/submissions/examples/ease-chromatic-aberration/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chromatic Aberration - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+
+    <span class="chromatic-text" data-text="Glitch">Glitch</span>
+    <p class="chromatic-label">Hover for RGB split</p>
+
+    <div class="chromatic-text-auto">Signal</div>
+    <p class="chromatic-label">Auto-glitch pulse</p>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-chromatic-aberration/style.css
+++ b/submissions/examples/ease-chromatic-aberration/style.css
@@ -1,0 +1,120 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0a0a0a;
+  color: white;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+/* =============================================
+   Chromatic Aberration RGB Text Split
+   Uses ::before (red) and ::after (blue) pseudo-
+   elements with mix-blend-mode: screen and
+   translate offsets to simulate a lens aberration
+   / channel-split glitch on text.
+   ============================================= */
+
+.chromatic-text {
+  position: relative;
+  font-size: clamp(3rem, 8vw, 6rem);
+  font-weight: 900;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ffffff;
+  display: inline-block;
+  cursor: default;
+}
+
+.chromatic-text::before,
+.chromatic-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+/* Red channel — offset left */
+.chromatic-text::before {
+  color: #ff0033;
+  transform: translate(-3px, 0);
+  opacity: 0;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+/* Blue channel — offset right */
+.chromatic-text::after {
+  color: #0033ff;
+  transform: translate(3px, 0);
+  opacity: 0;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.chromatic-text:hover::before {
+  transform: translate(-6px, 1px);
+  opacity: 1;
+}
+
+.chromatic-text:hover::after {
+  transform: translate(6px, -1px);
+  opacity: 1;
+}
+
+/* Auto-glitch variant */
+@keyframes rgb-split {
+  0%, 85%, 100% {
+    text-shadow: none;
+  }
+  88% {
+    text-shadow:
+      -5px 0 0 rgba(255, 0, 51, 0.8),
+      5px 0 0 rgba(0, 51, 255, 0.8);
+  }
+  91% {
+    text-shadow: none;
+  }
+  94% {
+    text-shadow:
+      -3px 1px 0 rgba(255, 0, 51, 0.6),
+      3px -1px 0 rgba(0, 51, 255, 0.6);
+  }
+}
+
+.chromatic-text-auto {
+  font-size: clamp(3rem, 8vw, 6rem);
+  font-weight: 900;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ffffff;
+  display: inline-block;
+  animation: rgb-split 4s ease-in-out infinite;
+  margin-top: 2rem;
+}
+
+.chromatic-label {
+  font-size: 0.8rem;
+  color: #4b5563;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin: 0.4rem 0 1.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chromatic-text::before,
+  .chromatic-text::after {
+    transition: none;
+  }
+  .chromatic-text-auto {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a chromatic aberration effect for text. `::before` (red, `#ff0033`) and `::after` (blue, `#0033ff`) pseudo-elements mirror the text via `content: attr(data-text)`, apply `mix-blend-mode: screen`, and offset horizontally to simulate an RGB channel split / lens aberration. Two variants: hover-triggered (opacity + offset transition) and auto-glitch (sparse `@keyframes` via `text-shadow`). `prefers-reduced-motion` disables both.

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-chromatic-aberration/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Lens chromatic aberration / RGB channel-split glitch on text using `::before`/`::after` pseudo-elements and `mix-blend-mode: screen`.

**How does a developer use it?**

```html
<span class="chromatic-text" data-text="Glitch">Glitch</span>
```

**Why does it fit EaseMotion CSS?**

Pure CSS, no JavaScript. Single element with a `data-text` attribute. Distinct from clip-path glitch effects — this one simulates optical physics rather than digital artifacts.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

`mix-blend-mode: screen` requires a dark background to be visible (demo uses `#0a0a0a`). On light backgrounds, `multiply` works better — maintainer may want to note this in docs.

Closes #8495