### PR TITLE
feat(submission): add ease-svg-text-stroke-draw SVG text draw-on animation

### DIFF
--- a/submissions/examples/ease-svg-text-stroke-draw/README.md
+++ b/submissions/examples/ease-svg-text-stroke-draw/README.md
@@ -1,0 +1,43 @@
+# ease-svg-text-stroke-draw
+
+A draw-on text animation using SVG `stroke-dashoffset`. The stroke path traces from start to end like a pen drawing each letterform, then the `fill` fades in after the stroke completes. Two variants: auto-playing on load, and hover-triggered.
+
+## Usage
+
+```html
+<!-- Auto draw-on -->
+<svg class="svg-text-draw" width="420" height="110" viewBox="0 0 420 110">
+  <text x="50%" y="85" text-anchor="middle">Your Text</text>
+</svg>
+
+<!-- Hover to draw -->
+<svg class="svg-text-draw-hover" width="360" height="90" viewBox="0 0 360 90">
+  <text x="50%" y="72" text-anchor="middle">Your Text</text>
+</svg>
+```
+
+## How it works
+
+- `stroke-dasharray` sets the stroke to the approximate total path length of the text
+- `stroke-dashoffset` starts at the same value (fully hidden), then animates to `0` (fully drawn)
+- A second `@keyframes fill-in` delays until the stroke animation completes, then transitions `fill` from `transparent` to the desired color
+- The hover variant uses CSS `transition` on `stroke-dashoffset` and `fill` instead of `@keyframes`
+- `prefers-reduced-motion` skips the animation and renders the text fully drawn/filled immediately
+
+## Tuning `stroke-dasharray`
+
+The value must be >= the total stroke path length of the text. For different fonts or longer strings, increase the value until the text draws completely. Use `SVGGeometryElement.getTotalLength()` in the browser console for precision: `document.querySelector('.svg-text-draw text').getComputedTextLength()`.
+
+## Customization
+
+| Property | Description |
+|----------|-------------|
+| `stroke` | Stroke color during draw |
+| `stroke-width` | Stroke thickness |
+| `stroke-dasharray` | Must be >= text path length |
+| Draw duration | `animation` duration on `draw-stroke` keyframe |
+| Fill delay | `animation-delay` on `fill-in` keyframe |
+
+## Accessibility
+
+Respects `prefers-reduced-motion`. Text renders fully drawn and filled without animation when reduced motion is preferred.

--- a/submissions/examples/ease-svg-text-stroke-draw/demo.html
+++ b/submissions/examples/ease-svg-text-stroke-draw/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SVG Text Stroke Draw-On - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+
+    <svg class="svg-text-draw" width="420" height="110" viewBox="0 0 420 110">
+      <text x="50%" y="85" text-anchor="middle">EaseMotion</text>
+    </svg>
+    <p class="svg-label">Auto draw-on (stroke then fill)</p>
+
+    <svg class="svg-text-draw-hover" width="360" height="90" viewBox="0 0 360 90">
+      <text x="50%" y="72" text-anchor="middle">Hover Me</text>
+    </svg>
+    <p class="svg-label">Hover to draw</p>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-svg-text-stroke-draw/style.css
+++ b/submissions/examples/ease-svg-text-stroke-draw/style.css
@@ -1,0 +1,101 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0f0f;
+  color: white;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+/* =============================================
+   SVG Text Stroke Draw-On Animation
+   Animates stroke-dashoffset on SVG <text> from
+   full-length to 0, creating a handwriting / draw-
+   on effect. fill animates in after stroke completes.
+   ============================================= */
+
+.svg-text-draw {
+  overflow: visible;
+  display: block;
+  margin: 2rem auto;
+}
+
+.svg-text-draw text {
+  font-family: 'Georgia', serif;
+  font-size: 80px;
+  font-weight: 700;
+  fill: transparent;
+  stroke: #a78bfa;
+  stroke-width: 2;
+  stroke-dasharray: 1200;
+  stroke-dashoffset: 1200;
+  animation:
+    draw-stroke 2s ease forwards,
+    fill-in 0.6s ease 2s forwards;
+}
+
+@keyframes draw-stroke {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes fill-in {
+  to {
+    fill: #a78bfa;
+  }
+}
+
+/* Hover re-trigger variant: resets and replays on hover */
+.svg-text-draw-hover {
+  overflow: visible;
+  display: block;
+  margin: 1rem auto;
+  cursor: pointer;
+}
+
+.svg-text-draw-hover text {
+  font-family: 'Georgia', serif;
+  font-size: 64px;
+  font-weight: 700;
+  fill: transparent;
+  stroke: #34d399;
+  stroke-width: 2;
+  stroke-dasharray: 900;
+  stroke-dashoffset: 900;
+  transition: stroke-dashoffset 1.8s ease, fill 0.4s ease 1.8s;
+}
+
+.svg-text-draw-hover:hover text {
+  stroke-dashoffset: 0;
+  fill: #34d399;
+}
+
+.svg-label {
+  font-size: 0.8rem;
+  color: #4b5563;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin: 0.3rem 0 1.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .svg-text-draw text {
+    animation: none;
+    stroke-dashoffset: 0;
+    fill: #a78bfa;
+  }
+  .svg-text-draw-hover text {
+    transition: none;
+  }
+  .svg-text-draw-hover:hover text {
+    stroke-dashoffset: 0;
+    fill: #34d399;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an SVG text stroke draw-on effect. `stroke-dasharray` is set to the approximate path length of the text string; `stroke-dashoffset` animates from that value to `0`, tracing each letterform as if drawn by a pen. A second `@keyframes fill-in` transitions `fill` from transparent to solid after the stroke animation completes. Two variants: auto-plays on load, and hover-triggered via CSS `transition`. `prefers-reduced-motion` renders the text immediately in its final state.

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-svg-text-stroke-draw/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

SVG text that draws itself on page load or hover, simulating handwriting or a pen tracing letterforms.

**How does a developer use it?**

```html
<svg class="svg-text-draw" width="420" height="110" viewBox="0 0 420 110">
  <text x="50%" y="85" text-anchor="middle">Your Text</text>
</svg>
```

**Why does it fit EaseMotion CSS?**

Pure CSS on SVG — no JavaScript. Distinct from the existing `ease-svg-path-draw` which targets shape paths, not text. Serif fonts like Georgia give the most visible stroke detail.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

`stroke-dasharray` value of 1200 covers "EaseMotion" in Georgia 80px. Different fonts/sizes/strings need adjustment — README documents how to get the exact value via `getComputedTextLength()`.

Closes #8496