### PR TITLE
feat: add star rating component with data-rating binding, size/color variants, hover interaction, readonly mode

### DIFF
--- a/submissions/examples/rating-star-pm/README.md
+++ b/submissions/examples/rating-star-pm/README.md
@@ -1,0 +1,27 @@
+# Star Rating Component
+
+## 1. What does this do?
+A CSS-first star rating component using `data-rating` attribute binding with size variants (sm/base/lg), color variants (gold/primary/secondary/success), hover interaction, and a readonly mode.
+
+## 2. How is it used?
+
+```html
+<div class="rating-star" data-rating="3">
+  <span class="star">&#9733;</span>
+  <span class="star">&#9733;</span>
+  <span class="star">&#9733;</span>
+  <span class="star">&#9733;</span>
+  <span class="star">&#9733;</span>
+</div>
+
+<div class="rating-star rating-star-sm" data-rating="4" data-color="primary" data-readonly>
+  <span class="star">&#9733;</span>
+  <span class="star">&#9733;</span>
+  <span class="star">&#9733;</span>
+  <span class="star">&#9733;</span>
+  <span class="star">&#9733;</span>
+</div>
+```
+
+## 3. Why is it useful?
+Star ratings are a universal UI pattern for reviews and feedback. The `data-rating` attribute approach keeps markup clean and framework-agnostic. Works statically with CSS only, with optional JS for interactivity.

--- a/submissions/examples/rating-star-pm/demo.html
+++ b/submissions/examples/rating-star-pm/demo.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Star Rating Component Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background: #f9fafb;
+      font-family: system-ui, sans-serif;
+      padding: 2rem;
+      gap: 1.5rem;
+    }
+    .card {
+      background: white;
+      border-radius: 0.75rem;
+      padding: 2rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+      text-align: center;
+      width: 100%;
+      max-width: 400px;
+    }
+    .card h2 {
+      font-size: 1.125rem;
+      font-weight: 600;
+      margin: 0 0 1rem;
+      color: #111827;
+    }
+    .card p {
+      font-size: 0.875rem;
+      color: #6b7280;
+      margin: 0.75rem 0 0;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="card">
+    <h2>Default (Gold) - 3/5</h2>
+    <div class="rating-star" data-rating="3">
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Size Variants</h2>
+    <p>Small</p>
+    <div class="rating-star rating-star-sm" data-rating="4">
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+    </div>
+    <p>Base</p>
+    <div class="rating-star" data-rating="3">
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+    </div>
+    <p>Large</p>
+    <div class="rating-star rating-star-lg" data-rating="5">
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Color Variants</h2>
+    <p>Default Gold</p>
+    <div class="rating-star" data-rating="4">
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+    </div>
+    <p>Primary</p>
+    <div class="rating-star" data-rating="3" data-color="primary">
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+    </div>
+    <p>Secondary</p>
+    <div class="rating-star" data-rating="5" data-color="secondary">
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+    </div>
+    <p>Success</p>
+    <div class="rating-star" data-rating="2" data-color="success">
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Readonly Mode</h2>
+    <div class="rating-star" data-rating="4" data-readonly>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+    </div>
+    <p>No hover interaction</p>
+  </div>
+
+  <div class="card">
+    <h2>Interactive</h2>
+    <div class="rating-star" data-rating="0" id="interactive">
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+      <span class="star">&#9733;</span>
+    </div>
+    <span class="rating-label" id="interactiveLabel">Click a star to rate</span>
+  </div>
+
+  <script>
+    document.querySelectorAll('.rating-star:not([data-readonly])').forEach(function(el) {
+      el.addEventListener('click', function(e) {
+        var star = e.target.closest('.star');
+        if (!star) return;
+        var stars = this.querySelectorAll('.star');
+        var idx = Array.prototype.indexOf.call(stars, star);
+        var val = stars.length - idx;
+        this.setAttribute('data-rating', val);
+        var label = this.parentNode.querySelector('.rating-label');
+        if (label) label.textContent = 'Rating: ' + val + '/5';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/rating-star-pm/style.css
+++ b/submissions/examples/rating-star-pm/style.css
@@ -1,0 +1,69 @@
+.rating-star {
+  --star-size: 1.25rem;
+  --star-color: #f59e0b;
+  --star-empty: #d1d5db;
+  display: inline-flex;
+  gap: 0.125rem;
+}
+
+.rating-star .star {
+  font-size: var(--star-size);
+  color: var(--star-empty);
+  cursor: default;
+  transition: color 0.15s, transform 0.15s;
+  line-height: 1;
+}
+
+.rating-star[data-rating="1"] .star:nth-child(-n+5):nth-child(-n+1),
+.rating-star[data-rating="2"] .star:nth-child(-n+5):nth-child(-n+2),
+.rating-star[data-rating="3"] .star:nth-child(-n+5):nth-child(-n+3),
+.rating-star[data-rating="4"] .star:nth-child(-n+5):nth-child(-n+4),
+.rating-star[data-rating="5"] .star:nth-child(-n+5):nth-child(-n+5) {
+  color: var(--star-color);
+}
+
+.rating-star:not([data-readonly]) .star {
+  cursor: pointer;
+}
+
+.rating-star:not([data-readonly]) .star:hover,
+.rating-star:not([data-readonly]) .star:hover ~ .star {
+  color: var(--star-color) !important;
+}
+
+.rating-star:not([data-readonly]) .star:hover {
+  transform: scale(1.2);
+}
+
+.rating-star-sm {
+  --star-size: 1rem;
+}
+
+.rating-star-lg {
+  --star-size: 1.75rem;
+}
+
+.rating-star[data-color="primary"] {
+  --star-color: #6366f1;
+}
+
+.rating-star[data-color="secondary"] {
+  --star-color: #ec4899;
+}
+
+.rating-star[data-color="success"] {
+  --star-color: #10b981;
+}
+
+.rating-label {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rating-star .star {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## ✦ Description
Add a CSS-first star rating component using `data-rating` attribute binding with hover interaction, size variants (sm/base/lg), color variants (gold/primary/secondary/success), and readonly mode. Uses CSS custom properties and nth-child selectors — no JS required for static rendering.

Fixes #7797

## Type of Change
- [x] New feature

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings

## Additional Notes
- Branch: Pcmhacker-piro:feat/rating-star-7797
- Submission: submissions/examples/rating-star-pm/