### PR TITLE
feat(submission): add ease-dog-ear-corner folded card effect

### DIFF
--- a/submissions/examples/ease-dog-ear-corner/README.md
+++ b/submissions/examples/ease-dog-ear-corner/README.md
@@ -1,0 +1,42 @@
+# ease-dog-ear-corner
+
+A folded-corner card effect using the CSS border triangle technique on `::before`. The card looks like a physical piece of paper with one corner dog-eared. Hover grows the fold size via a `border-width` transition. Two variants: top-right and bottom-left fold. No images, no SVG — pure CSS.
+
+## Usage
+
+```html
+<!-- Top-right fold -->
+<div class="dog-ear-card">
+  <h3>Card Title</h3>
+  <p>Card content goes here.</p>
+</div>
+
+<!-- Bottom-left fold -->
+<div class="dog-ear-card-bl">
+  <h3>Card Title</h3>
+  <p>Card content goes here.</p>
+</div>
+```
+
+## How it works
+
+- `::before` is positioned `absolute` at the fold corner (`top: 0; right: 0` for top-right)
+- Zero width/height with opposing `border-width` values creates a CSS triangle
+- `border-color` on the outer side matches the page background, making the triangle appear to cut into the card
+- `::after` adds a shadow triangle offset by 2px to simulate depth on the fold
+- `border-radius` on the card is set to `0` on the folded corner so the flat edge aligns with the triangle apex
+- `transition: border-width` animates the fold size on hover
+
+## Customization
+
+| Property | Description |
+|----------|-------------|
+| `border-width` on `::before` | Fold size at rest (default: `36px`) |
+| Hover `border-width` | Fold size on hover (default: `56px`) |
+| `border-color` outer side | Must match page/container background |
+| Card background | `background` on `.dog-ear-card` |
+| Corner position | Adjust `top/bottom/left/right` and `border-width` sides accordingly |
+
+## Accessibility
+
+Respects `prefers-reduced-motion`. The fold size transition is disabled when reduced motion is preferred.

--- a/submissions/examples/ease-dog-ear-corner/demo.html
+++ b/submissions/examples/ease-dog-ear-corner/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dog-Ear Folded Corner Card - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h1>Dog-Ear Corner Card</h1>
+
+    <div class="dog-ear-card">
+      <h3>Top-Right Fold</h3>
+      <p>Hover to grow the folded corner. The CSS border triangle trick — no images, no SVG.</p>
+    </div>
+
+    <div class="dog-ear-card-bl">
+      <h3>Bottom-Left Fold</h3>
+      <p>Same technique, opposite corner. Works on any card element.</p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-dog-ear-corner/style.css
+++ b/submissions/examples/ease-dog-ear-corner/style.css
@@ -1,0 +1,140 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0f0f;
+  color: white;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+/* =============================================
+   Dog-Ear Folded Corner Card
+   Uses ::before positioned at top-right to
+   render a triangular fold via the CSS border
+   triangle trick. Hover animates the fold size.
+   ============================================= */
+
+.dog-ear-card {
+  position: relative;
+  width: 280px;
+  background: #1e1b4b;
+  border-radius: 8px 0 8px 8px; /* flat top-right to meet the fold */
+  padding: 2rem;
+  margin: 2rem auto;
+  text-align: left;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+  transition: box-shadow 0.3s ease;
+}
+
+.dog-ear-card:hover {
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6);
+}
+
+/* The folded corner triangle */
+.dog-ear-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 36px 36px 0;
+  border-color: transparent #0f0f0f transparent transparent;
+  transition: border-width 0.25s ease;
+}
+
+/* Shadow/depth on the fold using ::after */
+.dog-ear-card::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 36px 36px 0;
+  border-color: transparent rgba(0,0,0,0.25) transparent transparent;
+  transform: translate(-2px, 2px);
+  transition: border-width 0.25s ease;
+  pointer-events: none;
+}
+
+.dog-ear-card:hover::before {
+  border-width: 0 56px 56px 0;
+}
+
+.dog-ear-card:hover::after {
+  border-width: 0 56px 56px 0;
+}
+
+.dog-ear-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+  color: #c4b5fd;
+}
+
+.dog-ear-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #9ca3af;
+  line-height: 1.5;
+}
+
+/* Variant: bottom-left fold */
+.dog-ear-card-bl {
+  position: relative;
+  width: 280px;
+  background: #1e2a3a;
+  border-radius: 8px 8px 8px 0;
+  padding: 2rem;
+  margin: 1rem auto;
+  text-align: left;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  transition: box-shadow 0.3s ease;
+}
+
+.dog-ear-card-bl::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 36px 0 0 36px;
+  border-color: transparent transparent transparent #0f0f0f;
+  transition: border-width 0.25s ease;
+}
+
+.dog-ear-card-bl:hover::before {
+  border-width: 56px 0 0 56px;
+}
+
+.dog-ear-card-bl h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+  color: #6ee7b7;
+}
+
+.dog-ear-card-bl p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #9ca3af;
+  line-height: 1.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dog-ear-card::before,
+  .dog-ear-card::after,
+  .dog-ear-card-bl::before {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a dog-ear folded corner card. `::before` is positioned at the card corner with zero width/height; opposing `border-width` values create a CSS triangle. The outer border color matches the page background, making it appear to cut into the card. Hover grows the fold via `transition: border-width`. `::after` adds a shadow triangle offset 2px for depth. Two variants: top-right and bottom-left fold. `prefers-reduced-motion` disables the transition.

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-dog-ear-corner/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A folded paper-corner effect on cards, growing on hover. No images, no SVG — pure CSS border triangle.

**How does a developer use it?**

```html
<div class="dog-ear-card">
  <h3>Title</h3>
  <p>Content</p>
</div>
```

**Why does it fit EaseMotion CSS?**

Pure CSS, no JavaScript. Common UI pattern for cards, tickets, and notes that isn't covered by any existing submission. The hover-animated fold makes it an active effect rather than just a static decoration.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

The outer `border-color` of the triangle (`#0f0f0f`) must match the page background for the cut-out illusion to work. The README documents this constraint clearly.

Closes #8499