### PR TITLE
feat(submission): add ease-scroll-driven-text-reveal native CSS scroll animation

### DIFF
--- a/submissions/examples/ease-scroll-driven-text-reveal/README.md
+++ b/submissions/examples/ease-scroll-driven-text-reveal/README.md
@@ -1,0 +1,49 @@
+# ease-scroll-driven-text-reveal
+
+A scroll-linked text reveal using the native CSS Scroll-Driven Animations API (`animation-timeline: view()`). Text is clipped from bottom and revealed as the element enters the viewport — no JavaScript, no IntersectionObserver. A second variant slides up from below while fading in.
+
+## Usage
+
+```html
+<!-- Clip-mask reveal -->
+<p class="scroll-reveal-text">Your headline text here.</p>
+
+<!-- Slide-up + fade reveal -->
+<p class="scroll-reveal-subtitle">Supporting text here.</p>
+```
+
+Wrap in a tall page so scrolling is required:
+
+```html
+<body>
+  <div style="height: 60vh;"></div>
+  <p class="scroll-reveal-text">Revealed on scroll</p>
+  <div style="height: 60vh;"></div>
+</body>
+```
+
+## How it works
+
+- `animation-timeline: view()` ties the animation progress to the element's position in the viewport
+- `animation-range: entry 10% cover 40%` defines when in the scroll timeline the animation plays (starts when 10% of the element enters, completes when it covers 40% of the viewport)
+- `clip-path: inset(100% 0 0 0)` starts the text fully clipped from the bottom; `inset(0%)` is the fully visible state
+- `@keyframes clip-reveal` transitions between these two states, driven entirely by scroll position
+- `@supports not (animation-timeline: view())` falls back to always-visible text for unsupported browsers
+- `prefers-reduced-motion` also skips the animation and renders text immediately
+
+## Browser support
+
+Native Scroll-Driven Animations are supported in Chrome 115+, Edge 115+, and Safari 18+. Firefox support is behind a flag as of writing. The `@supports` guard ensures graceful fallback.
+
+## Customization
+
+| Property | Description |
+|----------|-------------|
+| `animation-range` | Controls when in the scroll the reveal triggers |
+| `clip-path` keyframe values | Change reveal direction (e.g., `inset(0 0 100% 0)` for top-to-bottom clip) |
+| `animation-timeline` | `view()` for element-relative; `scroll()` for page-relative |
+| Font size / color | Adjust on `.scroll-reveal-text` |
+
+## Accessibility
+
+Respects `prefers-reduced-motion`. Text renders immediately in its final visible state when reduced motion is preferred.

--- a/submissions/examples/ease-scroll-driven-text-reveal/demo.html
+++ b/submissions/examples/ease-scroll-driven-text-reveal/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll-Driven Text Reveal - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="scroll-page">
+
+    <div class="scroll-spacer">
+      Scroll down to trigger the reveal
+    </div>
+
+    <div class="scroll-reveal-section">
+      <p class="scroll-reveal-text">
+        Scroll-linked animations.<br>No JavaScript required.
+      </p>
+      <p class="scroll-reveal-subtitle">
+        Powered by the native CSS Scroll-Driven Animations API —
+        animation-timeline: view() with animation-range.
+      </p>
+    </div>
+
+    <div class="scroll-spacer"></div>
+
+    <div class="scroll-reveal-section">
+      <p class="scroll-reveal-text">
+        Pure CSS.<br>Zero dependencies.
+      </p>
+      <p class="scroll-reveal-subtitle">
+        Each element reveals independently as it enters the viewport.
+      </p>
+    </div>
+
+    <div class="scroll-spacer"></div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scroll-driven-text-reveal/style.css
+++ b/submissions/examples/ease-scroll-driven-text-reveal/style.css
@@ -1,0 +1,98 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  background: #0f0f0f;
+  color: white;
+}
+
+/* =============================================
+   Scroll-Driven Text Clip Mask Reveal
+   Uses the native CSS Scroll-Driven Animations
+   API: animation-timeline: view() with a
+   clip-path reveal tied to scroll position.
+   No JavaScript — no IntersectionObserver.
+   ============================================= */
+
+.scroll-page {
+  padding: 0 2rem;
+}
+
+.scroll-spacer {
+  height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #374151;
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.scroll-reveal-section {
+  min-height: 40vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 0;
+}
+
+/* Clip-path reveal: inset(100% 0 0 0) = fully hidden (clipped from bottom)
+   inset(0% 0 0 0)   = fully visible */
+@keyframes clip-reveal {
+  from { clip-path: inset(100% 0 0 0); opacity: 0.4; }
+  to   { clip-path: inset(0% 0 0 0);   opacity: 1; }
+}
+
+.scroll-reveal-text {
+  font-size: clamp(2rem, 5vw, 4rem);
+  font-weight: 800;
+  text-align: center;
+  line-height: 1.2;
+  color: #a78bfa;
+  max-width: 700px;
+
+  /* Scroll-driven animation */
+  animation: clip-reveal linear both;
+  animation-timeline: view();
+  animation-range: entry 10% cover 40%;
+}
+
+/* Slide-up + fade variant */
+@keyframes slide-up-reveal {
+  from { transform: translateY(40px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+.scroll-reveal-subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.4rem);
+  color: #6b7280;
+  text-align: center;
+  max-width: 500px;
+  margin-top: 1rem;
+
+  animation: slide-up-reveal linear both;
+  animation-timeline: view();
+  animation-range: entry 20% cover 50%;
+}
+
+/* @supports guard for browsers without scroll-driven animations */
+@supports not (animation-timeline: view()) {
+  .scroll-reveal-text,
+  .scroll-reveal-subtitle {
+    animation: none;
+    clip-path: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-reveal-text,
+  .scroll-reveal-subtitle {
+    animation: none;
+    clip-path: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a scroll-driven text reveal using the native CSS Scroll-Driven Animations API. `animation-timeline: view()` ties the animation progress to the element's position in the viewport. `animation-range: entry 10% cover 40%` controls the trigger window. Two reveal styles: `clip-path: inset()` bottom-up reveal for headings, and `translateY + opacity` slide-up for subtitles. No JavaScript, no IntersectionObserver — pure CSS. `@supports not (animation-timeline: view())` provides graceful fallback for unsupported browsers. `prefers-reduced-motion` renders text immediately.

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scroll-driven-text-reveal/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Scroll-linked text reveal via the native CSS `animation-timeline: view()` API — no JS required.

**How does a developer use it?**

```html
<p class="scroll-reveal-text">Headline revealed on scroll</p>
<p class="scroll-reveal-subtitle">Subtitle slides up on scroll</p>
```

**Why does it fit EaseMotion CSS?**

All existing scroll-reveal submissions in this repo use JavaScript (IntersectionObserver or custom JS). This is the first pure CSS implementation using the native Scroll-Driven Animations API — a meaningfully different technical approach, not a duplicate.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome (115+ — full support)
- [x] Edge (115+ — full support)
- [ ] Firefox (behind flag; `@supports` fallback renders text immediately)

---

## Notes for Maintainer

`animation-timeline: view()` is Chrome 115+ / Edge 115+ / Safari 18+. The `@supports` guard means Firefox users see fully visible text — not broken, just no animation. README documents browser support and the `@supports` behavior clearly.

Closes #8500