### PR TITLE
feat: add sticky header that shrinks on scroll component (#7795)

### DIFF
--- a/submissions/examples/header-shrink-pm/README.md
+++ b/submissions/examples/header-shrink-pm/README.md
@@ -1,0 +1,51 @@
+# Sticky Header That Shrinks on Scroll
+
+A sticky navigation header that smoothly transitions from large/tall to compact/small as the user scrolls down — a common parallax-style pattern for marketing sites, landing pages, and blogs.
+
+## Features
+
+- **`.ease-header-shrink`** — fixed-position header with large padding and prominent logo
+- **`.ease-header-shrink.scrolled`** — compact padding, smaller logo, glassmorphism background
+- **Smooth transitions** — 0.3s ease on padding, background, box-shadow, logo size, tagline opacity
+- **Tagline fade-out** — the tagline collapses to zero height and fades out on scroll
+- **requestAnimationFrame throttle** — performant scroll listener with passive event
+- **Glassmorphism** — `backdrop-filter: blur(12px)` activates in the scrolled state
+
+## Files
+
+- `style.css` — styles for the shrink header and demo layout
+- `demo.html` — working demo page
+- `README.md` — this file
+
+## Usage
+
+```html
+<header class="ease-header-shrink">
+  <div class="ease-header-logo">
+    <img src="logo.svg" alt="Logo">
+    <div>
+      <div class="logo-text">Brand</div>
+      <div class="ease-header-tagline">Tagline</div>
+    </div>
+  </div>
+  <nav>
+    <ul>
+      <li><a href="#">Link</a></li>
+    </ul>
+  </nav>
+</header>
+
+<script>
+  const header = document.querySelector('.ease-header-shrink');
+  let ticking = false;
+  window.addEventListener('scroll', () => {
+    if (!ticking) {
+      requestAnimationFrame(() => {
+        header.classList.toggle('scrolled', window.scrollY > 80);
+        ticking = false;
+      });
+      ticking = true;
+    }
+  }, { passive: true });
+</script>
+```

--- a/submissions/examples/header-shrink-pm/demo.html
+++ b/submissions/examples/header-shrink-pm/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Shrink Header Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="ease-header-shrink" id="shrinkHeader">
+    <div class="ease-header-logo">
+      <img src="https://placehold.co/48x48/6c63ff/ffffff?text=EM" alt="EaseMotion logo">
+      <div>
+        <div class="logo-text">EaseMotion</div>
+        <div class="ease-header-tagline">CSS made effortless</div>
+      </div>
+    </div>
+    <nav>
+      <ul>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Features</a></li>
+        <li><a href="#">Docs</a></li>
+        <li><a href="#" class="nav-cta">Get Started</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <section class="hero">
+    <h1>Sticky Header That Shrinks</h1>
+    <p>Scroll down to see the header smoothly transition from large to compact — logo shrinks, tagline fades, background gains glassmorphism.</p>
+  </section>
+
+  <div class="content">
+    <section>
+      <h2>Parallax-Style Header Effect</h2>
+      <p>This pattern is widely used in marketing sites, landing pages, and blogs where the header transitions from large and tall to compact and small as the user scrolls down. The effect draws attention to the hero area while keeping navigation accessible.</p>
+    </section>
+    <section>
+      <h2>Smooth Transitions</h2>
+      <p>All properties animate with a 0.3s ease transition — padding, logo size, tagline opacity, background blur, and box-shadow. The JavaScript uses requestAnimationFrame with a throttle for optimal scroll performance.</p>
+    </section>
+    <section>
+      <h2>Glassmorphism on Scroll</h2>
+      <p>Once scrolled past 80px, the header gains a semi-transparent background with backdrop-filter blur, creating a sleek glass effect. The box-shadow subtly lifts the header above the page content.</p>
+    </section>
+    <section>
+      <h2>Responsive &amp; Accessible</h2>
+      <p>Built with CSS custom properties and works seamlessly on mobile. The nav links are keyboard-accessible and the header maintains proper contrast ratios in both states.</p>
+    </section>
+    <section>
+      <h2>Usage</h2>
+      <p>Add <code>.ease-header-shrink</code> to your header. The included JavaScript automatically toggles the <code>.scrolled</code> class when <code>scrollY &gt; 80</code>. Customize the breakpoint by adjusting the threshold in the scroll listener.</p>
+    </section>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const header = document.querySelector('.ease-header-shrink');
+      if (!header) return;
+
+      let ticking = false;
+      window.addEventListener('scroll', () => {
+        if (!ticking) {
+          window.requestAnimationFrame(() => {
+            header.classList.toggle('scrolled', window.scrollY > 80);
+            ticking = false;
+          });
+          ticking = true;
+        }
+      }, { passive: true });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/header-shrink-pm/style.css
+++ b/submissions/examples/header-shrink-pm/style.css
@@ -1,0 +1,163 @@
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, -apple-system, sans-serif);
+  background: #0f0f1a;
+  color: #e2e8f0;
+  min-height: 200vh;
+}
+
+.ease-header-shrink {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: var(--ease-z-header, 100);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  background: transparent;
+  transition: padding 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ease-header-shrink.scrolled {
+  padding: 0.6rem 2rem;
+  background: rgba(15, 15, 26, 0.92);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
+.ease-header-shrink .ease-header-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  transition: gap 0.3s ease;
+}
+
+.ease-header-shrink .ease-header-logo img {
+  height: 3rem;
+  width: auto;
+  transition: height 0.3s ease, width 0.3s ease;
+  border-radius: 8px;
+}
+
+.ease-header-shrink.scrolled .ease-header-logo img {
+  height: 2rem;
+}
+
+.ease-header-shrink .ease-header-logo .logo-text {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  transition: font-size 0.3s ease;
+}
+
+.ease-header-shrink.scrolled .ease-header-logo .logo-text {
+  font-size: 1.1rem;
+}
+
+.ease-header-shrink .ease-header-tagline {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  max-height: 2rem;
+  opacity: 1;
+  overflow: hidden;
+  transition: opacity 0.3s ease, max-height 0.3s ease, margin 0.3s ease;
+}
+
+.ease-header-shrink.scrolled .ease-header-tagline {
+  max-height: 0;
+  opacity: 0;
+  margin: 0;
+}
+
+.ease-header-shrink nav ul {
+  display: flex;
+  list-style: none;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.ease-header-shrink nav a {
+  color: #cbd5e1;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.ease-header-shrink nav a:hover {
+  color: #fff;
+}
+
+.ease-header-shrink .nav-cta {
+  background: linear-gradient(135deg, #6c63ff, #a855f7);
+  color: #fff;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-header-shrink .nav-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 15px rgba(108, 99, 255, 0.4);
+}
+
+.hero {
+  margin-top: 5rem;
+  padding: 6rem 2rem 3rem;
+  text-align: center;
+  background: linear-gradient(180deg, rgba(108, 99, 255, 0.08) 0%, transparent 100%);
+}
+
+.hero h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #fff, #a855f7);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero p {
+  margin-top: 1rem;
+  font-size: 1.1rem;
+  color: #94a3b8;
+  max-width: 600px;
+  margin-inline: auto;
+}
+
+.content {
+  max-width: 800px;
+  margin: 3rem auto;
+  padding: 0 2rem;
+}
+
+.content section {
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+.content h2 {
+  font-size: 1.25rem;
+  color: #a855f7;
+  margin-bottom: 0.5rem;
+}
+
+.content p {
+  line-height: 1.7;
+  color: #94a3b8;
+}


### PR DESCRIPTION
### Description

Adds a sticky header that dynamically shrinks on scroll — transitions from a large/tall hero header to a compact navigation bar using a `.scrolled` CSS class toggle.

### Changes Made

| File | Description |
|------|-------------|
| `submissions/examples/header-shrink-pm/style.css` | CSS for `.ease-header-shrink` with `.scrolled` state, smooth transitions, glassmorphism effect |
| `submissions/examples/header-shrink-pm/demo.html` | Working demo with hero section, scrollable content, and inline JS with rAF throttle |
| `submissions/examples/header-shrink-pm/README.md` | Documentation and usage example |

### Key Features

- **`.ease-header-shrink`** — fixed header with large padding (1.5rem) and big logo (3rem)
- **`.ease-header-shrink.scrolled`** — compact padding (0.6rem), small logo (2rem), backdrop blur glass effect
- **Tagline fade-out** — `.ease-header-tagline` collapses with max-height + opacity transition
- **Smooth CSS transitions** — 0.3s ease on all animated properties
- **requestAnimationFrame throttle** — performant scroll listener
- **No core files modified** — all changes in `submissions/examples/`

### Related Issue

Closes #7795

### Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's coding style
- [x] I have tested the component in modern browsers (Chrome, Firefox, Safari)
- [x] No core files were modified
- [x] All changes are placed in `submissions/examples/header-shrink-pm/`