### PR TITLE
feat: add floating action button (FAB) component with speed dial (#7794)

### DIFF
--- a/submissions/examples/fab-speed-dial-pm/README.md
+++ b/submissions/examples/fab-speed-dial-pm/README.md
@@ -1,0 +1,39 @@
+# Floating Action Button (FAB) with Speed Dial
+
+A floating action button component with a speed dial variant for dashboards, content-heavy pages, and apps that need a fixed-position primary action.
+
+## Features
+
+- **`.ease-fab`** — fixed-position circular button at bottom-right, 3.5rem size with primary color and shadow
+- **`.ease-fab-sm`** — small variant at 2.5rem
+- **Position modifiers** — `.ease-fab-bottom-left`, `.ease-fab-top-right`, `.ease-fab-top-left`
+- **`.ease-fab-speed-dial`** — container that holds the main FAB and expandable action buttons
+- **`.ease-fab-actions`** — action buttons wrapper (hidden by default, fades in on hover/open)
+- **`.ease-fab-action`** — individual speed dial action button (2.5rem, circular)
+- **Staggered animation** — each action button gets a progressive delay for a cascading reveal effect
+- **Hover + click support** — speed dial opens on hover by default, also supports `.open` class toggle for click interaction
+
+## Files
+
+- `style.css` — all FAB and speed dial styles
+- `demo.html` — working demo with both standalone FAB and speed dial
+- `README.md` — this file
+
+## Usage
+
+```html
+<!-- Simple FAB -->
+<button class="ease-fab" aria-label="Add">+</button>
+
+<!-- Speed Dial -->
+<div class="ease-fab-speed-dial">
+  <div class="ease-fab-actions">
+    <button class="ease-fab-action" title="Edit">✏️</button>
+    <button class="ease-fab-action" title="Share">📤</button>
+  </div>
+  <button class="ease-fab" aria-label="More">⋯</button>
+</div>
+
+<!-- Position modifier -->
+<div class="ease-fab-speed-dial ease-fab-top-right">...</div>
+```

--- a/submissions/examples/fab-speed-dial-pm/demo.html
+++ b/submissions/examples/fab-speed-dial-pm/demo.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — FAB Speed Dial Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    .fab-badge {
+      position: absolute;
+      top: -4px;
+      right: -4px;
+      width: 1rem;
+      height: 1rem;
+      border-radius: 50%;
+      background: #ef4444;
+      color: white;
+      font-size: 0.6rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Simple FAB (bottom-right) -->
+  <button class="ease-fab" id="simpleFab" aria-label="Add new" title="Click me!">
+    <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+  </button>
+
+  <!-- Speed Dial (bottom-left) -->
+  <div class="ease-fab-speed-dial ease-fab-bottom-left" id="speedDial">
+    <div class="ease-fab-actions">
+      <button class="ease-fab-action" title="Edit" onclick="alert('Edit action')">
+        <svg viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+      </button>
+      <button class="ease-fab-action" title="Share" onclick="alert('Share action')">
+        <svg viewBox="0 0 24 24"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+      </button>
+      <button class="ease-fab-action" title="Delete" onclick="alert('Delete action')">
+        <svg viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+      </button>
+      <button class="ease-fab-action" title="Settings" onclick="alert('Settings action')">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      </button>
+    </div>
+    <button class="ease-fab" id="speedDialFab" aria-label="Speed dial">
+      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+    </button>
+  </div>
+
+  <div class="demo-container">
+
+    <div class="demo-header">
+      <h1>Floating Action Button</h1>
+      <p>Fixed-position circular button with speed dial variant, size options, and position modifiers.</p>
+    </div>
+
+    <div class="preview-section">
+      <h2>Variants Preview (inline)</h2>
+      <div class="fab-row fab-demo-inline">
+        <button class="ease-fab ease-fab-sm" aria-label="Small FAB" title="Small FAB">
+          <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        </button>
+        <span style="color:#94a3b8;font-size:0.85rem;">.ease-fab-sm</span>
+
+        <button class="ease-fab" aria-label="Default FAB" title="Default FAB">
+          <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        </button>
+        <span style="color:#94a3b8;font-size:0.85rem;">.ease-fab (default)</span>
+      </div>
+    </div>
+
+    <div class="preview-section">
+      <h2>Speed Dial Demo</h2>
+      <p style="color:#94a3b8;font-size:0.9rem;">The speed dial at the bottom-left shows action buttons on hover. The simple FAB at the bottom-right is a standalone button.</p>
+    </div>
+
+    <div class="preview-section">
+      <h2>CSS Classes Reference</h2>
+      <div class="code-block">.ease-fab                    Base FAB (fixed, bottom-right, 3.5rem)
+.ease-fab-sm                Small variant (2.5rem)
+.ease-fab-bottom-left       Position: bottom-left
+.ease-fab-top-right         Position: top-right
+.ease-fab-top-left          Position: top-left
+.ease-fab-speed-dial        Container for FAB + action buttons
+.ease-fab-actions           Action buttons wrapper (hidden by default)
+.ease-fab-action            Individual action button (2.5rem)</div>
+    </div>
+
+    <div class="preview-section">
+      <h2>Usage</h2>
+      <div class="code-block">&lt;button class="ease-fab" aria-label="Add"&gt;
+  &lt;!-- plus icon --&gt;
+&lt;/button&gt;
+
+&lt;div class="ease-fab-speed-dial"&gt;
+  &lt;div class="ease-fab-actions"&gt;
+    &lt;button class="ease-fab-action"&gt;Edit&lt;/button&gt;
+    &lt;button class="ease-fab-action"&gt;Share&lt;/button&gt;
+  &lt;/div&gt;
+  &lt;button class="ease-fab"&gt;
+    &lt;!-- more icon --&gt;
+  &lt;/button&gt;
+&lt;/div&gt;</div>
+    </div>
+
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const speedDial = document.getElementById('speedDial');
+      const speedDialFab = document.getElementById('speedDialFab');
+
+      if (speedDial && speedDialFab) {
+        speedDialFab.addEventListener('click', (e) => {
+          e.stopPropagation();
+          speedDial.classList.toggle('open');
+        });
+
+        document.addEventListener('click', (e) => {
+          if (!speedDial.contains(e.target)) {
+            speedDial.classList.remove('open');
+          }
+        });
+      }
+
+      const simpleFab = document.getElementById('simpleFab');
+      if (simpleFab) {
+        simpleFab.addEventListener('click', () => {
+          alert('FAB clicked!');
+        });
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/fab-speed-dial-pm/style.css
+++ b/submissions/examples/fab-speed-dial-pm/style.css
@@ -1,0 +1,253 @@
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, -apple-system, sans-serif);
+  background: #0f0f1a;
+  color: #e2e8f0;
+  min-height: 100vh;
+}
+
+.demo-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.demo-header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #fff, #a855f7);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.demo-header p {
+  margin-top: 0.5rem;
+  color: #94a3b8;
+  font-size: 1.05rem;
+}
+
+.preview-section {
+  margin-bottom: 2.5rem;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+.preview-section h2 {
+  font-size: 1.15rem;
+  color: #a855f7;
+  margin-bottom: 1rem;
+}
+
+.fab-row {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* ── Base FAB ──────────────────────────────────── */
+
+.ease-fab {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: var(--ease-z-fab, 40);
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-primary, #6c63ff);
+  color: white;
+  border: none;
+  box-shadow: var(--ease-shadow-lg, 0 4px 14px rgba(0,0,0,0.3));
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-fab:hover {
+  transform: scale(1.1);
+  box-shadow: var(--ease-shadow-xl, 0 6px 20px rgba(0,0,0,0.4));
+}
+
+.ease-fab svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* ── Size Variants ─────────────────────────────── */
+
+.ease-fab-sm {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.ease-fab-sm svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+/* ── Position Modifiers ────────────────────────── */
+
+.ease-fab-bottom-left {
+  right: auto;
+  left: 1.5rem;
+}
+
+.ease-fab-top-right {
+  bottom: auto;
+  top: 1.5rem;
+}
+
+.ease-fab-top-left {
+  bottom: auto;
+  top: 1.5rem;
+  right: auto;
+  left: 1.5rem;
+}
+
+/* ── Speed Dial ────────────────────────────────── */
+
+.ease-fab-speed-dial {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: var(--ease-z-fab, 40);
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ease-fab-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(1rem);
+  transition: all 0.2s ease;
+}
+
+.ease-fab-speed-dial:hover .ease-fab-actions,
+.ease-fab-speed-dial.open .ease-fab-actions {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.ease-fab-action {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: #1e1e32;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #e2e8f0;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.ease-fab-action:hover {
+  transform: scale(1.15);
+  background: #2a2a45;
+}
+
+.ease-fab-action svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* ── Staggered animation ───────────────────────── */
+
+.ease-fab-speed-dial:hover .ease-fab-action:nth-child(1),
+.ease-fab-speed-dial.open .ease-fab-action:nth-child(1) {
+  transition-delay: 0s;
+}
+
+.ease-fab-speed-dial:hover .ease-fab-action:nth-child(2),
+.ease-fab-speed-dial.open .ease-fab-action:nth-child(2) {
+  transition-delay: 0.05s;
+}
+
+.ease-fab-speed-dial:hover .ease-fab-action:nth-child(3),
+.ease-fab-speed-dial.open .ease-fab-action:nth-child(3) {
+  transition-delay: 0.1s;
+}
+
+.ease-fab-speed-dial:hover .ease-fab-action:nth-child(4),
+.ease-fab-speed-dial.open .ease-fab-action:nth-child(4) {
+  transition-delay: 0.15s;
+}
+
+.ease-fab-speed-dial:hover .ease-fab-action:nth-child(5),
+.ease-fab-speed-dial.open .ease-fab-action:nth-child(5) {
+  transition-delay: 0.2s;
+}
+
+/* ── Demo inline FAB preview (non-fixed) ────────── */
+
+.fab-demo-inline {
+  position: static !important;
+  display: inline-flex;
+}
+
+.fab-demo-inline .ease-fab {
+  position: static;
+}
+
+.fab-demo-inline .ease-fab-speed-dial {
+  position: static;
+  flex-direction: column;
+}
+
+.fab-demo-inline .ease-fab-actions {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  flex-direction: row;
+  gap: 0.5rem;
+}
+
+.code-block {
+  font-family: "SF Mono", Monaco, "Cascadia Code", monospace;
+  font-size: 0.85rem;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  color: #a5b4fc;
+  white-space: pre;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
### Description

Adds a floating action button (FAB) component with speed dial variant for fixed-position primary actions in dashboards and content-heavy pages.

### Changes Made

| File | Description |
|------|-------------|
| `submissions/examples/fab-speed-dial-pm/style.css` | CSS for `.ease-fab`, `.ease-fab-sm`, position modifiers, `.ease-fab-speed-dial` with staggered action buttons |
| `submissions/examples/fab-speed-dial-pm/demo.html` | Working demo with standalone FAB and speed dial with click/hover interaction |
| `submissions/examples/fab-speed-dial-pm/README.md` | Documentation and usage examples |

### Key Features

- **`.ease-fab`** — fixed bottom-right, 3.5rem circular, primary color, shadow, hover scale
- **`.ease-fab-sm`** — small variant at 2.5rem
- **Position modifiers** — `.ease-fab-bottom-left`, `.ease-fab-top-right`, `.ease-fab-top-left`
- **`.ease-fab-speed-dial`** — container with expandable `.ease-fab-actions` that fade/slide in on hover
- **Staggered delays** — each action button has a progressive `transition-delay` for cascading reveal
- **Hover + click** — speed dial opens on hover and also supports `.open` class toggle for click interaction
- **No core files modified** — all changes in `submissions/examples/`

### Related Issue

Closes #7794

### Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's coding style
- [x] I have tested the component in modern browsers (Chrome, Firefox, Safari)
- [x] No core files were modified
- [x] All changes are placed in `submissions/examples/fab-speed-dial-pm/`