### PR TITLE
feat: add scroll-triggered reading progress bar component (#7792)

### DIFF
--- a/submissions/examples/reading-progress-pm/README.md
+++ b/submissions/examples/reading-progress-pm/README.md
@@ -1,0 +1,34 @@
+# Scroll-Triggered Reading Progress Bar
+
+A thin animated progress bar fixed at the top of the viewport that fills proportionally as the user scrolls down the page — ideal for blog posts, documentation, and long-form content.
+
+## Features
+
+- **`.ease-reading-progress`** — fixed to top, full width, 3px default height
+- **CSS custom properties** — `--ease-scroll` (0–100) drives the bar width via `calc()`
+- **Customizable** — `--ease-progress-height`, `--ease-progress-color`, `--ease-z-progress`
+- **`::after` pseudo-element** — no extra DOM elements needed, `pointer-events: none`
+- **requestAnimationFrame throttle** — performant scroll listener with passive event
+- **Smooth transition** — `width 0.1s linear` for a polished feel
+
+## Files
+
+- `style.css` — progress bar styles and demo layout
+- `demo.html` — working demo page with scrollable article content
+- `README.md` — this file
+
+## Usage
+
+```html
+<div class="ease-reading-progress"></div>
+
+<script>
+  const bar = document.querySelector('.ease-reading-progress');
+  window.addEventListener('scroll', () => {
+    const scrollTop = window.scrollY;
+    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    const percent = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+    bar.style.setProperty('--ease-scroll', percent);
+  }, { passive: true });
+</script>
+```

--- a/submissions/examples/reading-progress-pm/demo.html
+++ b/submissions/examples/reading-progress-pm/demo.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Reading Progress Bar Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Reading Progress Bar -->
+  <div class="ease-reading-progress" id="readingProgress"></div>
+
+  <!-- Progress percentage indicator -->
+  <div class="progress-info" id="progressInfo">Scroll Progress: 0%</div>
+
+  <div class="demo-container">
+
+    <div class="demo-header">
+      <h1>Reading Progress Bar</h1>
+      <p>A thin bar at the top of the viewport that fills as you scroll — perfect for blog posts, documentation, and long-form content.</p>
+    </div>
+
+    <div class="article-section">
+      <h2>What is a Reading Progress Bar?</h2>
+      <p>A reading progress bar is a thin visual indicator fixed at the top of the page that fills from left to right as the user scrolls down. It gives readers a quick sense of how much content remains and how far they've progressed.</p>
+      <p>This pattern is popular on blogs, documentation sites, and news articles. EaseMotion CSS now provides <code>.ease-reading-progress</code> as a ready-made component.</p>
+    </div>
+
+    <div class="article-section">
+      <h2>How It Works</h2>
+      <p>The bar uses a <code>::after</code> pseudo-element whose width is driven by the CSS custom property <code>--ease-scroll</code>. A lightweight scroll listener updates this value based on the ratio of <code>window.scrollY</code> to the total scrollable document height.</p>
+      <p>The approach uses <code>requestAnimationFrame</code> for smooth, performant updates and a <code>linear</code> CSS transition for a polished feel.</p>
+    </div>
+
+    <div class="article-section">
+      <h2>Customization</h2>
+      <p>The progress bar is fully customizable through CSS custom properties:</p>
+      <div class="code-block">--ease-progress-height: 3px;     /* Bar thickness */
+--ease-progress-color: #6c63ff;   /* Bar fill color */
+--ease-z-progress: 9999;           /* Stack order */
+--ease-scroll: 0;                  /* Driven by JS (0-100) */</div>
+    </div>
+
+    <div class="article-section">
+      <h2>Lorem Ipsum Dolor</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
+    </div>
+
+    <div class="article-section">
+      <h2>Nemo Enim Ipsam</h2>
+      <p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.</p>
+      <p>Sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur.</p>
+      <p>Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?</p>
+    </div>
+
+    <div class="article-section">
+      <h2>At Vero Eos</h2>
+      <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident.</p>
+      <p>Similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus.</p>
+    </div>
+
+    <div class="article-section">
+      <h2>Usage</h2>
+      <div class="code-block">&lt;div class="ease-reading-progress" id="progress"&gt;&lt;/div&gt;
+
+&lt;script&gt;
+  const bar = document.querySelector('.ease-reading-progress');
+  window.addEventListener('scroll', () =&gt; {
+    const scrollTop = window.scrollY;
+    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    const percent = docHeight &gt; 0 ? (scrollTop / docHeight) * 100 : 0;
+    bar.style.setProperty('--ease-scroll', percent);
+  }, { passive: true });
+&lt;/script&gt;</div>
+    </div>
+
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const bar = document.querySelector('.ease-reading-progress');
+      const info = document.getElementById('progressInfo');
+      if (!bar) return;
+
+      let ticking = false;
+      const updateProgress = () => {
+        const scrollTop = window.scrollY;
+        const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        const percent = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+        bar.style.setProperty('--ease-scroll', percent);
+        if (info) {
+          info.textContent = `Scroll Progress: ${Math.round(percent)}%`;
+        }
+        ticking = false;
+      };
+
+      window.addEventListener('scroll', () => {
+        if (!ticking) {
+          window.requestAnimationFrame(updateProgress);
+          ticking = true;
+        }
+      }, { passive: true });
+
+      updateProgress();
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/reading-progress-pm/style.css
+++ b/submissions/examples/reading-progress-pm/style.css
@@ -1,0 +1,116 @@
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, -apple-system, sans-serif);
+  background: #0f0f1a;
+  color: #e2e8f0;
+  min-height: 200vh;
+}
+
+/* ── Reading Progress Bar ──────────────────────── */
+
+.ease-reading-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--ease-progress-height, 3px);
+  z-index: var(--ease-z-progress, 9999);
+  background: var(--ease-neutral-200, rgba(255, 255, 255, 0.1));
+  pointer-events: none;
+}
+
+.ease-reading-progress::after {
+  content: "";
+  display: block;
+  width: calc(var(--ease-scroll, 0) * 1%);
+  height: 100%;
+  background: var(--ease-progress-color, var(--ease-primary, #6c63ff));
+  transition: width 0.1s linear;
+  border-radius: 0 2px 2px 0;
+}
+
+/* ── Demo Content ──────────────────────────────── */
+
+.demo-container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.demo-header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #fff, #a855f7);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.demo-header p {
+  margin-top: 0.5rem;
+  color: #94a3b8;
+  font-size: 1.05rem;
+}
+
+.article-section {
+  margin-bottom: 2.5rem;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+.article-section h2 {
+  font-size: 1.25rem;
+  color: #a855f7;
+  margin-bottom: 0.75rem;
+}
+
+.article-section p {
+  line-height: 1.8;
+  color: #cbd5e1;
+  margin-bottom: 0.75rem;
+}
+
+.article-section p:last-child {
+  margin-bottom: 0;
+}
+
+.code-block {
+  font-family: "SF Mono", Monaco, "Cascadia Code", monospace;
+  font-size: 0.85rem;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  color: #a5b4fc;
+  white-space: pre;
+  margin-top: 1rem;
+}
+
+.progress-info {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  background: rgba(15, 15, 26, 0.85);
+  backdrop-filter: blur(8px);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  z-index: 999;
+}


### PR DESCRIPTION
### Description

Adds a reading progress bar component that shows how far a user has scrolled down a page — a common UI pattern for blog posts, documentation, and long-form content.

### Changes Made

| File | Description |
|------|-------------|
| `submissions/examples/reading-progress-pm/style.css` | CSS for `.ease-reading-progress` with `::after` pseudo-element driven by `--ease-scroll` custom property |
| `submissions/examples/reading-progress-pm/demo.html` | Working demo with long-form article content, rAF-throttled scroll listener, and progress indicator |
| `submissions/examples/reading-progress-pm/README.md` | Documentation and usage example |

### Key Features

- **`.ease-reading-progress`** — fixed to top of viewport, full width, 3px default height
- **CSS custom property** — `--ease-scroll` (0–100) drives `::after` width via `calc(var(--ease-scroll, 0) * 1%)`
- **Customizable** — `--ease-progress-height`, `--ease-progress-color`, `--ease-z-progress`
- **`::after` pseudo-element** — no extra DOM, `pointer-events: none`
- **requestAnimationFrame throttle** — performant scroll listener
- **Smooth transition** — `width 0.1s linear`
- **No core files modified** — all changes in `submissions/examples/`

### Related Issue

Closes #7792

### Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's coding style
- [x] I have tested the component in modern browsers (Chrome, Firefox, Safari)
- [x] No core files were modified
- [x] All changes are placed in `submissions/examples/reading-progress-pm/`