### PR TITLE
feat: add chip/tag component with removable animation (#7791)

### DIFF
--- a/submissions/examples/chip-removable-pm/README.md
+++ b/submissions/examples/chip-removable-pm/README.md
@@ -1,0 +1,49 @@
+# Chip/Tag Component with Removable Animation
+
+A chip/tag component for displaying labels, filters, skills, and categories — with color variants, sizes, outline mode, and a removable animation.
+
+## Features
+
+- **`.ease-chip`** — inline-flex, pill-shaped, small font, background color
+- **Color variants** — default, `.ease-chip-primary`, `.ease-chip-success`, `.ease-chip-danger`, `.ease-chip-warning`, `.ease-chip-info`
+- **`.ease-chip-outline`** — border-only variant with transparent background
+- **`.ease-chip-sm`** — small size variant
+- **`.ease-chip-removable`** — adds right padding to accommodate the close button
+- **`.ease-chip-close`** — circular close button with hover effect
+- **`.ease-chip.removing`** — triggers `scale(0.8)` + `opacity(0)` animation before DOM removal
+- **`@keyframes ease-chip-remove`** — the removal animation at 0.25s ease
+
+## Files
+
+- `style.css` — all chip styles and demo layout
+- `demo.html` — working demo with removable examples
+- `README.md` — this file
+
+## Usage
+
+```html
+<!-- Basic chip -->
+<span class="ease-chip ease-chip-primary">Label</span>
+
+<!-- Removable chip -->
+<span class="ease-chip ease-chip-danger ease-chip-removable">
+  Tag
+  <button class="ease-chip-close" aria-label="Remove">✕</button>
+</span>
+
+<!-- Outline variant -->
+<span class="ease-chip ease-chip-outline ease-chip-primary">Outline</span>
+
+<!-- Small -->
+<span class="ease-chip ease-chip-sm">Small</span>
+
+<script>
+  document.querySelectorAll('.ease-chip-close').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      const chip = e.currentTarget.closest('.ease-chip');
+      chip.classList.add('removing');
+      setTimeout(() => chip.remove(), 300);
+    });
+  });
+</script>
+```

--- a/submissions/examples/chip-removable-pm/demo.html
+++ b/submissions/examples/chip-removable-pm/demo.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Chip/Tag Component Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-container">
+
+    <div class="demo-header">
+      <h1>Chip &amp; Tag Component</h1>
+      <p>Compact labels for skills, filters, categories, and tags — with color variants, sizes, outline mode, and removable animation.</p>
+    </div>
+
+    <div class="section">
+      <h2>Color Variants</h2>
+      <div class="chip-group">
+        <span class="ease-chip">Default</span>
+        <span class="ease-chip ease-chip-primary">Primary</span>
+        <span class="ease-chip ease-chip-success">Success</span>
+        <span class="ease-chip ease-chip-danger">Danger</span>
+        <span class="ease-chip ease-chip-warning">Warning</span>
+        <span class="ease-chip ease-chip-info">Info</span>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>Outline Variant</h2>
+      <div class="chip-group">
+        <span class="ease-chip ease-chip-outline">Default</span>
+        <span class="ease-chip ease-chip-outline ease-chip-primary">Primary</span>
+        <span class="ease-chip ease-chip-outline ease-chip-success">Success</span>
+        <span class="ease-chip ease-chip-outline ease-chip-danger">Danger</span>
+        <span class="ease-chip ease-chip-outline ease-chip-warning">Warning</span>
+        <span class="ease-chip ease-chip-outline ease-chip-info">Info</span>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>Sizes</h2>
+      <div class="chip-group">
+        <span class="ease-chip ease-chip-sm ease-chip-primary">Small</span>
+        <span class="ease-chip ease-chip-primary">Base (default)</span>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>Removable Chips (click the ✕ to remove)</h2>
+      <div class="chip-group" id="removableChips">
+        <span class="ease-chip ease-chip-primary ease-chip-removable">
+          JavaScript
+          <button class="ease-chip-close" aria-label="Remove">✕</button>
+        </span>
+        <span class="ease-chip ease-chip-success ease-chip-removable">
+          TypeScript
+          <button class="ease-chip-close" aria-label="Remove">✕</button>
+        </span>
+        <span class="ease-chip ease-chip-danger ease-chip-removable">
+          React
+          <button class="ease-chip-close" aria-label="Remove">✕</button>
+        </span>
+        <span class="ease-chip ease-chip-warning ease-chip-removable">
+          Python
+          <button class="ease-chip-close" aria-label="Remove">✕</button>
+        </span>
+        <span class="ease-chip ease-chip-info ease-chip-removable">
+          Rust
+          <button class="ease-chip-close" aria-label="Remove">✕</button>
+        </span>
+        <span class="ease-chip ease-chip-removable">
+          Go
+          <button class="ease-chip-close" aria-label="Remove">✕</button>
+        </span>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>Skills Tags (non-removable)</h2>
+      <div class="chip-group">
+        <span class="ease-chip ease-chip-primary">CSS</span>
+        <span class="ease-chip ease-chip-success">HTML</span>
+        <span class="ease-chip ease-chip-info">Node.js</span>
+        <span class="ease-chip ease-chip-warning">Docker</span>
+        <span class="ease-chip ease-chip-danger">Kubernetes</span>
+        <span class="ease-chip ease-chip-outline ease-chip-primary">GraphQL</span>
+        <span class="ease-chip ease-chip-sm ease-chip-success">API</span>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>Usage</h2>
+      <div class="code-block">&lt;!-- Basic chip --&gt;
+&lt;span class="ease-chip ease-chip-primary"&gt;Label&lt;/span&gt;
+
+&lt;!-- Removable chip --&gt;
+&lt;span class="ease-chip ease-chip-danger ease-chip-removable"&gt;
+  Tag
+  &lt;button class="ease-chip-close"&gt;✕&lt;/button&gt;
+&lt;/span&gt;
+
+&lt;!-- Outline variant --&gt;
+&lt;span class="ease-chip ease-chip-outline ease-chip-primary"&gt;
+  Outline
+&lt;/span&gt;
+
+&lt;!-- Small size --&gt;
+&lt;span class="ease-chip ease-chip-sm"&gt;Small&lt;/span&gt;</div>
+    </div>
+
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.ease-chip-close').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+          const chip = e.currentTarget.closest('.ease-chip');
+          if (!chip || chip.classList.contains('removing')) return;
+          chip.classList.add('removing');
+          setTimeout(() => {
+            chip.remove();
+          }, 300);
+        });
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/chip-removable-pm/style.css
+++ b/submissions/examples/chip-removable-pm/style.css
@@ -1,0 +1,204 @@
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, -apple-system, sans-serif);
+  background: #0f0f1a;
+  color: #e2e8f0;
+  min-height: 100vh;
+}
+
+.demo-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.demo-header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #fff, #a855f7);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.demo-header p {
+  margin-top: 0.5rem;
+  color: #94a3b8;
+  font-size: 1.05rem;
+}
+
+.section {
+  margin-bottom: 2.5rem;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+.section h2 {
+  font-size: 1.15rem;
+  color: #a855f7;
+  margin-bottom: 1rem;
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+/* ── Base Chip ─────────────────────────────────── */
+
+.ease-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #cbd5e1;
+  line-height: 1.5;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+/* ── Color Variants ────────────────────────────── */
+
+.ease-chip-primary {
+  background: rgba(99, 102, 241, 0.2);
+  color: #a5b4fc;
+}
+
+.ease-chip-success {
+  background: rgba(34, 197, 94, 0.2);
+  color: #86efac;
+}
+
+.ease-chip-danger {
+  background: rgba(239, 68, 68, 0.2);
+  color: #fca5a5;
+}
+
+.ease-chip-warning {
+  background: rgba(234, 179, 8, 0.2);
+  color: #fde047;
+}
+
+.ease-chip-info {
+  background: rgba(59, 130, 246, 0.2);
+  color: #93c5fd;
+}
+
+/* ── Outline Variant ───────────────────────────── */
+
+.ease-chip-outline {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.ease-chip-outline.ease-chip-primary {
+  border-color: #6c63ff;
+  background: transparent;
+}
+
+.ease-chip-outline.ease-chip-success {
+  border-color: #22c55e;
+  background: transparent;
+}
+
+.ease-chip-outline.ease-chip-danger {
+  border-color: #ef4444;
+  background: transparent;
+}
+
+.ease-chip-outline.ease-chip-warning {
+  border-color: #eab308;
+  background: transparent;
+}
+
+.ease-chip-outline.ease-chip-info {
+  border-color: #3b82f6;
+  background: transparent;
+}
+
+/* ── Size Variant ──────────────────────────────── */
+
+.ease-chip-sm {
+  padding: 0.125rem 0.5rem;
+  font-size: 0.625rem;
+}
+
+/* ── Close Button ──────────────────────────────── */
+
+.ease-chip-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0;
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+  color: inherit;
+  line-height: 1;
+}
+
+.ease-chip-close:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.15);
+}
+
+/* ── Removing Animation ────────────────────────── */
+
+.ease-chip.removing {
+  animation: ease-chip-remove 0.25s ease forwards;
+  pointer-events: none;
+}
+
+@keyframes ease-chip-remove {
+  to {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+}
+
+/* ── Removable chip (extra right padding) ──────── */
+
+.ease-chip.ease-chip-removable {
+  padding-right: 0.25rem;
+}
+
+/* ── Code block ────────────────────────────────── */
+
+.code-block {
+  font-family: "SF Mono", Monaco, "Cascadia Code", monospace;
+  font-size: 0.85rem;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  color: #a5b4fc;
+  white-space: pre;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
### Description

Adds a chip/tag component for displaying labels, filters, skills, and categories with color variants, sizes, outline mode, and a removable animation.

### Changes Made

| File | Description |
|------|-------------|
| `submissions/examples/chip-removable-pm/style.css` | CSS for `.ease-chip` with color variants, outline, sizes, close button, and `@keyframes ease-chip-remove` |
| `submissions/examples/chip-removable-pm/demo.html` | Working demo with removable chips, color variants, outline mode, and inline JS for removal |
| `submissions/examples/chip-removable-pm/README.md` | Documentation and usage examples |

### Key Features

- **`.ease-chip`** — inline-flex pill shape, 0.75rem font, 9999px border-radius
- **Color variants** — default, `.ease-chip-primary`, `.ease-chip-success`, `.ease-chip-danger`, `.ease-chip-warning`, `.ease-chip-info`
- **`.ease-chip-outline`** — border-only with transparent background
- **`.ease-chip-sm`** — small size (0.625rem)
- **`.ease-chip-close`** — circular close button with hover effect
- **`.ease-chip.removing`** — triggers `scale(0.8) + opacity(0)` animation via `@keyframes ease-chip-remove`
- **No core files modified** — all changes in `submissions/examples/`

### Related Issue

Closes #7791

### Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's coding style
- [x] I have tested the component in modern browsers (Chrome, Firefox, Safari)
- [x] No core files were modified
- [x] All changes are placed in `submissions/examples/chip-removable-pm/`