### PR TITLE
feat: add dropdown menu component with hover and click variants (#7788)

### DIFF
--- a/submissions/examples/dropdown-menu-pm/README.md
+++ b/submissions/examples/dropdown-menu-pm/README.md
@@ -1,0 +1,55 @@
+# Dropdown Menu Component with Hover and Click Variants
+
+A dropdown menu component for navigation submenus, user menus, and action menus with hover trigger and click trigger variants, right-alignment, dividers, and fade + slide-down entrance animation.
+
+## Features
+
+- **`.ease-dropdown`** — relative inline-block container
+- **`.ease-dropdown-trigger`** — styled trigger button
+- **`.ease-dropdown-menu`** — absolutely positioned menu panel with z-index, shadow, border-radius
+- **`.ease-dropdown-item`** — individual menu items with hover highlight
+- **`.ease-dropdown-item-danger`** — destructive action item (red hover)
+- **`.ease-dropdown-divider`** — visual separator between menu groups
+- **`.ease-dropdown-label`** — section label (uppercase, muted)
+- **`.ease-dropdown-right`** — right-aligns the menu panel
+- **Hover variant** — `.ease-dropdown:hover .ease-dropdown-menu` shows on hover
+- **Click variant** — `.ease-dropdown.open .ease-dropdown-menu` toggled via JavaScript
+- **Entrance animation** — fade in + slide down on open (transition on opacity, transform, visibility)
+
+## Files
+
+- `style.css` — all dropdown styles and demo layout
+- `demo.html` — working demo with hover, click, and right-aligned variants
+- `README.md` — this file
+
+## Usage
+
+```html
+<!-- Hover dropdown -->
+<div class="ease-dropdown">
+  <span class="ease-dropdown-trigger">Hover ▼</span>
+  <div class="ease-dropdown-menu">
+    <a class="ease-dropdown-item" href="#">Profile</a>
+    <div class="ease-dropdown-divider"></div>
+    <a class="ease-dropdown-item ease-dropdown-item-danger" href="#">Logout</a>
+  </div>
+</div>
+
+<!-- Click dropdown -->
+<div class="ease-dropdown" id="dd">
+  <button class="ease-dropdown-trigger">Click ▼</button>
+  <div class="ease-dropdown-menu">...</div>
+</div>
+
+<script>
+  document.querySelector('#dd > .ease-dropdown-trigger')
+    .addEventListener('click', (e) => {
+      e.currentTarget.closest('.ease-dropdown').classList.toggle('open');
+    });
+  document.addEventListener('click', (e) => {
+    if (!e.target.closest('#dd')) {
+      document.querySelector('#dd').classList.remove('open');
+    }
+  });
+</script>
+```

--- a/submissions/examples/dropdown-menu-pm/demo.html
+++ b/submissions/examples/dropdown-menu-pm/demo.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Dropdown Menu Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-container">
+
+    <div class="demo-header">
+      <h1>Dropdown Menu</h1>
+      <p>Navigation submenus, user menus, and action menus with hover and click variants, right-alignment, dividers, and entrance animation.</p>
+    </div>
+
+    <div class="dropdown-demo-box">
+      <div class="section-header"><h2>Hover Dropdown</h2></div>
+      <div class="dropdown-demo-row">
+        <div class="ease-dropdown">
+          <span class="ease-dropdown-trigger">
+            Hover me
+            <span class="arrow">▼</span>
+          </span>
+          <div class="ease-dropdown-menu">
+            <a class="ease-dropdown-item" href="#">Profile</a>
+            <a class="ease-dropdown-item" href="#">Settings</a>
+            <a class="ease-dropdown-item" href="#">Account</a>
+            <div class="ease-dropdown-divider"></div>
+            <a class="ease-dropdown-item ease-dropdown-item-danger" href="#">Logout</a>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="dropdown-demo-box">
+      <div class="section-header"><h2>Click Dropdown</h2></div>
+      <div class="dropdown-demo-row">
+        <div class="ease-dropdown" id="clickDropdown">
+          <button class="ease-dropdown-trigger">
+            Click me
+            <span class="arrow">▼</span>
+          </button>
+          <div class="ease-dropdown-menu">
+            <button class="ease-dropdown-item" onclick="alert('Edit action')">Edit</button>
+            <button class="ease-dropdown-item" onclick="alert('Duplicate action')">Duplicate</button>
+            <div class="ease-dropdown-divider"></div>
+            <button class="ease-dropdown-item ease-dropdown-item-danger" onclick="alert('Delete action')">Delete</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="dropdown-demo-box">
+      <div class="section-header"><h2>Right-Aligned</h2></div>
+      <div class="dropdown-demo-row" style="justify-content: flex-end;">
+        <div class="ease-dropdown ease-dropdown-right">
+          <span class="ease-dropdown-trigger">
+            Right aligned
+            <span class="arrow">▼</span>
+          </span>
+          <div class="ease-dropdown-menu">
+            <div class="ease-dropdown-label">User Menu</div>
+            <a class="ease-dropdown-item" href="#">Dashboard</a>
+            <a class="ease-dropdown-item" href="#">Orders</a>
+            <div class="ease-dropdown-divider"></div>
+            <a class="ease-dropdown-item" href="#">Help</a>
+            <a class="ease-dropdown-item ease-dropdown-item-danger" href="#">Sign out</a>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="dropdown-demo-box">
+      <div class="section-header"><h2>Usage</h2></div>
+      <div class="code-block">&lt;!-- Hover dropdown --&gt;
+&lt;div class="ease-dropdown"&gt;
+  &lt;span class="ease-dropdown-trigger"&gt;
+    Hover me &lt;span class="arrow"&gt;▼&lt;/span&gt;
+  &lt;/span&gt;
+  &lt;div class="ease-dropdown-menu"&gt;
+    &lt;a class="ease-dropdown-item" href="#"&gt;Profile&lt;/a&gt;
+    &lt;div class="ease-dropdown-divider"&gt;&lt;/div&gt;
+    &lt;a class="ease-dropdown-item ease-dropdown-item-danger" href="#"&gt;Logout&lt;/a&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- Click dropdown --&gt;
+&lt;div class="ease-dropdown" id="myDropdown"&gt;
+  &lt;button class="ease-dropdown-trigger"&gt;Click&lt;/button&gt;
+  &lt;div class="ease-dropdown-menu"&gt;...&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;script&gt;
+  document.querySelector('#myDropdown &gt; .ease-dropdown-trigger')
+    .addEventListener('click', (e) =&gt; {
+      e.currentTarget.closest('.ease-dropdown').classList.toggle('open');
+    });
+
+  document.addEventListener('click', (e) =&gt; {
+    if (!e.target.closest('#myDropdown')) {
+      document.querySelector('#myDropdown').classList.remove('open');
+    }
+  });
+&lt;/script&gt;</div>
+    </div>
+
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const clickDropdown = document.getElementById('clickDropdown');
+      const trigger = clickDropdown?.querySelector('.ease-dropdown-trigger');
+
+      if (clickDropdown && trigger) {
+        trigger.addEventListener('click', (e) => {
+          e.stopPropagation();
+          clickDropdown.classList.toggle('open');
+        });
+
+        document.addEventListener('click', (e) => {
+          if (!clickDropdown.contains(e.target)) {
+            clickDropdown.classList.remove('open');
+          }
+        });
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/dropdown-menu-pm/style.css
+++ b/submissions/examples/dropdown-menu-pm/style.css
@@ -1,0 +1,200 @@
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, -apple-system, sans-serif);
+  background: #0f0f1a;
+  color: #e2e8f0;
+  min-height: 100vh;
+}
+
+.demo-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.demo-header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #fff, #a855f7);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.demo-header p {
+  margin-top: 0.5rem;
+  color: #94a3b8;
+  font-size: 1.05rem;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.section-header h2 {
+  font-size: 1.15rem;
+  color: #a855f7;
+  margin-bottom: 0.5rem;
+}
+
+/* ── Demo row ──────────────────────────────────── */
+
+.dropdown-demo-row {
+  display: flex;
+  gap: 3rem;
+  align-items: flex-start;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.dropdown-demo-box {
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  margin-bottom: 2rem;
+}
+
+/* ── Dropdown ──────────────────────────────────── */
+
+.ease-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.25rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: #e2e8f0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: background 0.2s ease, border-color 0.2s ease;
+  user-select: none;
+}
+
+.ease-dropdown-trigger:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.ease-dropdown-trigger .arrow {
+  font-size: 0.6rem;
+  transition: transform 0.2s ease;
+}
+
+.ease-dropdown.open .ease-dropdown-trigger .arrow {
+  transform: rotate(180deg);
+}
+
+.ease-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  z-index: var(--ease-z-dropdown, 50);
+  min-width: 12rem;
+  padding: 0.5rem 0;
+  background: #1a1a2e;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-0.5rem);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+}
+
+.ease-dropdown:hover .ease-dropdown-menu,
+.ease-dropdown.open .ease-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+/* ── Right-aligned ─────────────────────────────── */
+
+.ease-dropdown-right .ease-dropdown-menu {
+  left: auto;
+  right: 0;
+}
+
+/* ── Menu Items ────────────────────────────────── */
+
+.ease-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  color: #cbd5e1;
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 400;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ease-dropdown-item:hover {
+  background: rgba(108, 99, 255, 0.12);
+  color: #a5b4fc;
+}
+
+.ease-dropdown-item-danger:hover {
+  background: rgba(239, 68, 68, 0.12);
+  color: #fca5a5;
+}
+
+/* ── Divider ───────────────────────────────────── */
+
+.ease-dropdown-divider {
+  height: 1px;
+  margin: 0.25rem 0;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* ── Label / disabled styling ──────────────────── */
+
+.ease-dropdown-label {
+  display: block;
+  padding: 0.5rem 1rem 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+  pointer-events: none;
+}
+
+/* ── Code block ────────────────────────────────── */
+
+.code-block {
+  font-family: "SF Mono", Monaco, "Cascadia Code", monospace;
+  font-size: 0.85rem;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  color: #a5b4fc;
+  white-space: pre;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
### Description

Adds a dropdown menu component for navigation submenus, user menus, and action menus with hover and click trigger variants.

### Changes Made

| File | Description |
|------|-------------|
| `submissions/examples/dropdown-menu-pm/style.css` | CSS for `.ease-dropdown`, `.ease-dropdown-menu`, `.ease-dropdown-item`, hover/click variants, right-alignment, dividers, entrance animation |
| `submissions/examples/dropdown-menu-pm/demo.html` | Working demo with hover dropdown, click dropdown with JS toggle, and right-aligned variant |
| `submissions/examples/dropdown-menu-pm/README.md` | Documentation and usage examples |

### Key Features

- **`.ease-dropdown`** — relative inline-block container
- **`.ease-dropdown-trigger`** — styled trigger with arrow indicator
- **`.ease-dropdown-menu`** — absolutely positioned panel with z-index, shadow, border-radius
- **`.ease-dropdown-item`** — menu items with purple hover highlight
- **`.ease-dropdown-item-danger`** — red hover for destructive actions
- **`.ease-dropdown-divider`** — visual separator
- **`.ease-dropdown-label`** — uppercase muted section label
- **`.ease-dropdown-right`** — right-aligned menu panel
- **Hover variant** — `.ease-dropdown:hover .ease-dropdown-menu`
- **Click variant** — `.ease-dropdown.open .ease-dropdown-menu` with JS toggle and outside-click dismiss
- **Entrance animation** — fade in + slide down
- **No core files modified** — all changes in `submissions/examples/`

### Related Issue

Closes #7788

### Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's coding style
- [x] I have tested the component in modern browsers (Chrome, Firefox, Safari)
- [x] No core files were modified
- [x] All changes are placed in `submissions/examples/dropdown-menu-pm/`