### PR TITLE
feat: add callout/alert component with color variants and dismiss animation (#7787)

### DIFF
--- a/submissions/examples/callout-alert-pm/README.md
+++ b/submissions/examples/callout-alert-pm/README.md
@@ -1,0 +1,43 @@
+# Callout/Alert Component with Color Variants and Dismiss Animation
+
+A contextual message component for displaying info, success, warning, and error notifications — with border-left accent stripe, icon slot, and slide-out dismiss animation.
+
+## Features
+
+- **`.ease-callout`** — base class with padding, border-radius, border-left accent, flex layout
+- **Color variants** — `.ease-callout-info` (blue), `.ease-callout-success` (green), `.ease-callout-warning` (yellow), `.ease-callout-danger` (red)
+- **CSS custom properties** — `--ease-callout-border`, `--ease-callout-bg`, `--ease-callout-text`
+- **`.ease-callout-icon`** — icon slot aligned to the left
+- **`.ease-callout-title`** — optional bold title within the body
+- **`.ease-callout-dismiss`** — close button with hover effect
+- **`.ease-callout.hiding`** — triggers `@keyframes ease-slide-out-right` (slides right + fades out)
+- **Callout body** — `.ease-callout-body` wraps content text
+
+## Files
+
+- `style.css` — all callout styles and demo layout
+- `demo.html` — working demo with all 4 variants in dismissible and non-dismissible modes
+- `README.md` — this file
+
+## Usage
+
+```html
+<div class="ease-callout ease-callout-info">
+  <span class="ease-callout-icon">ℹ</span>
+  <div class="ease-callout-body">
+    <div class="ease-callout-title">Info</div>
+    Message text here.
+  </div>
+  <button class="ease-callout-dismiss">&times;</button>
+</div>
+
+<script>
+  document.querySelectorAll('.ease-callout-dismiss').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      const callout = e.currentTarget.closest('.ease-callout');
+      callout.classList.add('hiding');
+      setTimeout(() => callout.remove(), 350);
+    });
+  });
+</script>
+```

--- a/submissions/examples/callout-alert-pm/demo.html
+++ b/submissions/examples/callout-alert-pm/demo.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Callout/Alert Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-container">
+
+    <div class="demo-header">
+      <h1>Callout &amp; Alert</h1>
+      <p>Contextual messages for info, success, warning, and error states — with border-left accent, icon slot, and dismiss animation.</p>
+    </div>
+
+    <h2 class="section-title">Color Variants (dismissible)</h2>
+    <div class="callout-group" id="calloutGroup">
+
+      <div class="ease-callout ease-callout-info">
+        <span class="ease-callout-icon">ℹ</span>
+        <div class="ease-callout-body">
+          <div class="ease-callout-title">Information</div>
+          Your account has been updated successfully. New features are available in your dashboard.
+        </div>
+        <button class="ease-callout-dismiss" aria-label="Dismiss">&times;</button>
+      </div>
+
+      <div class="ease-callout ease-callout-success">
+        <span class="ease-callout-icon">✓</span>
+        <div class="ease-callout-body">
+          <div class="ease-callout-title">Success</div>
+          All changes have been saved. Your deployment is now live at the production URL.
+        </div>
+        <button class="ease-callout-dismiss" aria-label="Dismiss">&times;</button>
+      </div>
+
+      <div class="ease-callout ease-callout-warning">
+        <span class="ease-callout-icon">⚠</span>
+        <div class="ease-callout-body">
+          <div class="ease-callout-title">Warning</div>
+          Your API key will expire in 7 days. Generate a new key to avoid service interruptions.
+        </div>
+        <button class="ease-callout-dismiss" aria-label="Dismiss">&times;</button>
+      </div>
+
+      <div class="ease-callout ease-callout-danger">
+        <span class="ease-callout-icon">✕</span>
+        <div class="ease-callout-body">
+          <div class="ease-callout-title">Error</div>
+          Failed to connect to the database. Please check your connection string and try again.
+        </div>
+        <button class="ease-callout-dismiss" aria-label="Dismiss">&times;</button>
+      </div>
+
+    </div>
+
+    <h2 class="section-title">Non-Dismissible (simple message)</h2>
+    <div class="callout-group">
+      <div class="ease-callout ease-callout-info">
+        <span class="ease-callout-icon">ℹ</span>
+        <div class="ease-callout-body">This is a simple info callout without a title or dismiss button.</div>
+      </div>
+      <div class="ease-callout ease-callout-success">
+        <span class="ease-callout-icon">✓</span>
+        <div class="ease-callout-body">Operation completed successfully.</div>
+      </div>
+      <div class="ease-callout ease-callout-warning">
+        <span class="ease-callout-icon">⚠</span>
+        <div class="ease-callout-body">Your session will expire in 5 minutes.</div>
+      </div>
+      <div class="ease-callout ease-callout-danger">
+        <span class="ease-callout-icon">✕</span>
+        <div class="ease-callout-body">An unexpected error occurred. Please refresh the page.</div>
+      </div>
+    </div>
+
+    <h2 class="section-title">Usage</h2>
+    <div class="code-block">&lt;div class="ease-callout ease-callout-info"&gt;
+  &lt;span class="ease-callout-icon"&gt;ℹ&lt;/span&gt;
+  &lt;div class="ease-callout-body"&gt;
+    &lt;div class="ease-callout-title"&gt;Info&lt;/div&gt;
+    Message text here.
+  &lt;/div&gt;
+  &lt;button class="ease-callout-dismiss"&gt;&amp;times;&lt;/button&gt;
+&lt;/div&gt;
+
+&lt;script&gt;
+  document.querySelectorAll('.ease-callout-dismiss')
+    .forEach(btn =&gt; {
+      btn.addEventListener('click', (e) =&gt; {
+        const callout = e.currentTarget.closest('.ease-callout');
+        callout.classList.add('hiding');
+        setTimeout(() =&gt; callout.remove(), 350);
+      });
+    });
+&lt;/script&gt;</div>
+
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.ease-callout-dismiss').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+          const callout = e.currentTarget.closest('.ease-callout');
+          if (callout.classList.contains('hiding')) return;
+          callout.classList.add('hiding');
+          setTimeout(() => {
+            callout.remove();
+          }, 350);
+        });
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/callout-alert-pm/style.css
+++ b/submissions/examples/callout-alert-pm/style.css
@@ -1,0 +1,165 @@
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, -apple-system, sans-serif);
+  background: #0f0f1a;
+  color: #e2e8f0;
+  min-height: 100vh;
+}
+
+.demo-container {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.demo-header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #fff, #a855f7);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.demo-header p {
+  margin-top: 0.5rem;
+  color: #94a3b8;
+  font-size: 1.05rem;
+}
+
+.section-title {
+  font-size: 1.15rem;
+  color: #a855f7;
+  margin-bottom: 1rem;
+}
+
+.callout-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+/* ── Callout ───────────────────────────────────── */
+
+.ease-callout {
+  position: relative;
+  padding: 1rem 1.25rem;
+  border-radius: var(--ease-radius, 0.5rem);
+  border-left: 4px solid var(--ease-callout-border, rgba(255, 255, 255, 0.2));
+  background: var(--ease-callout-bg, rgba(255, 255, 255, 0.04));
+  color: var(--ease-callout-text, #e2e8f0);
+  font-size: 0.875rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  line-height: 1.6;
+}
+
+.ease-callout-icon {
+  flex-shrink: 0;
+  font-size: 1.1rem;
+  line-height: 1.4;
+}
+
+.ease-callout-body {
+  flex: 1;
+}
+
+.ease-callout-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+/* ── Color Variants ────────────────────────────── */
+
+.ease-callout-info {
+  --ease-callout-border: #3b82f6;
+  --ease-callout-bg: rgba(59, 130, 246, 0.1);
+  --ease-callout-text: #93c5fd;
+}
+
+.ease-callout-success {
+  --ease-callout-border: #22c55e;
+  --ease-callout-bg: rgba(34, 197, 94, 0.1);
+  --ease-callout-text: #86efac;
+}
+
+.ease-callout-warning {
+  --ease-callout-border: #f59e0b;
+  --ease-callout-bg: rgba(245, 158, 11, 0.1);
+  --ease-callout-text: #fde047;
+}
+
+.ease-callout-danger {
+  --ease-callout-border: #ef4444;
+  --ease-callout-bg: rgba(239, 68, 68, 0.1);
+  --ease-callout-text: #fca5a5;
+}
+
+/* ── Dismiss Button ────────────────────────────── */
+
+.ease-callout-dismiss {
+  margin-left: auto;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  opacity: 0.5;
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0 0.25rem;
+  color: inherit;
+  transition: opacity 0.15s ease;
+}
+
+.ease-callout-dismiss:hover {
+  opacity: 1;
+}
+
+/* ── Hiding Animation ──────────────────────────── */
+
+.ease-callout.hiding {
+  animation: ease-slide-out-right 0.3s ease forwards;
+}
+
+@keyframes ease-slide-out-right {
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    border-left-width: 0;
+    overflow: hidden;
+  }
+}
+
+/* ── Code Block ────────────────────────────────── */
+
+.code-block {
+  font-family: "SF Mono", Monaco, "Cascadia Code", monospace;
+  font-size: 0.85rem;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  color: #a5b4fc;
+  white-space: pre;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
### Description

Adds a callout/alert component for displaying contextual messages (info, success, warning, error) with color variants, icon slot, border-left accent, and slide-out dismiss animation.

### Changes Made

| File | Description |
|------|-------------|
| `submissions/examples/callout-alert-pm/style.css` | CSS for `.ease-callout` with 4 color variants, dismiss button, `@keyframes ease-slide-out-right` |
| `submissions/examples/callout-alert-pm/demo.html` | Working demo with dismissible and non-dismissible callouts across all 4 variants |
| `submissions/examples/callout-alert-pm/README.md` | Documentation and usage examples |

### Key Features

- **`.ease-callout`** — border-left accent, padding, border-radius, flex layout with icon slot
- **Color variants** — `.ease-callout-info` (blue), `.ease-callout-success` (green), `.ease-callout-warning` (yellow), `.ease-callout-danger` (red)
- **CSS custom properties** — `--ease-callout-border`, `--ease-callout-bg`, `--ease-callout-text`
- **`.ease-callout-icon`** / **`.ease-callout-title`** — icon and title slots
- **`.ease-callout-dismiss`** — close button with opacity hover
- **`.ease-callout.hiding`** — triggers `ease-slide-out-right` keyframe (translateX + opacity + collapse)
- **No core files modified** — all changes in `submissions/examples/`

### Related Issue

Closes #7787

### Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's coding style
- [x] I have tested the component in modern browsers (Chrome, Firefox, Safari)
- [x] No core files were modified
- [x] All changes are placed in `submissions/examples/callout-alert-pm/`