### PR TITLE
feat: add breadcrumb navigation component with arrow separators (#7784)

### DIFF
--- a/submissions/core_changes/breadcrumb-navigation-7784/README.md
+++ b/submissions/core_changes/breadcrumb-navigation-7784/README.md
@@ -1,0 +1,45 @@
+# Breadcrumb Navigation Component — Issue #7784
+
+A breadcrumb navigation component showing page hierarchy with customizable separators.
+
+## Features
+
+- **`.ease-breadcrumb`** — flex row container with wrapping
+- **`.ease-breadcrumb-item`** — individual crumb with auto-separator via `::before`
+- **Separator variants** — slash (`/`), arrow (`>`), chevron (`›`), bullet (`•`)
+- **`.ease-breadcrumb-item.active`** — bold, non-clickable current page
+- **`.ease-breadcrumb-collapse`** — truncates items on mobile (≤640px)
+- **Dark mode support** — via `prefers-color-scheme: dark`
+- **Reduced motion** — disables transitions when `prefers-reduced-motion: reduce`
+- **Focus-visible** — accessible focus ring on links
+
+## Files
+
+- `style.css` — all breadcrumb styles and responsive rules
+- `demo.html` — working demo with 4 separator variants, collapsible example
+- `README.md` — this file
+
+## Usage
+
+```html
+<nav aria-label="Breadcrumb">
+  <ol class="ease-breadcrumb ease-breadcrumb-separator-chevron">
+    <li class="ease-breadcrumb-item"><a href="#">Home</a></li>
+    <li class="ease-breadcrumb-item"><a href="#">Category</a></li>
+    <li class="ease-breadcrumb-item active" aria-current="page">Current</li>
+  </ol>
+</nav>
+```
+
+### Separator variants
+
+| Class | Separator |
+|-------|-----------|
+| `.ease-breadcrumb-separator-slash` | `/` |
+| `.ease-breadcrumb-separator-arrow` | `>` |
+| `.ease-breadcrumb-separator-chevron` | `›` |
+| `.ease-breadcrumb-separator-bullet` | `•` |
+
+### Mobile truncation
+
+Add `.ease-breadcrumb-collapse` to truncate items on screens ≤640px.

--- a/submissions/core_changes/breadcrumb-navigation-7784/demo.html
+++ b/submissions/core_changes/breadcrumb-navigation-7784/demo.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumb Navigation — Issue #7784</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    p { color: #64748b; margin-bottom: 2rem; font-size: 0.9rem; }
+    h2 { font-size: 1rem; margin-bottom: 1rem; margin-top: 2rem; color: #475569; }
+    .example {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 1rem;
+    }
+    .example-label {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #94a3b8;
+      margin-bottom: 0.5rem;
+    }
+    .separator-row { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .separator-row .example { flex: 1; min-width: 160px; }
+    nav[aria-label] { margin-top: 0.5rem; }
+
+    /* Page-specific breadcrumb styles for demo */
+    .ease-breadcrumb { margin: 0.5rem 0; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Breadcrumb Navigation</h1>
+    <p>Page hierarchy component with customizable separators — Issue #7784</p>
+
+    <h2>Default (Slash Separator)</h2>
+    <div class="example">
+      <div class="example-label">Home / Products / Category / Item</div>
+      <nav aria-label="Breadcrumb">
+        <ol class="ease-breadcrumb ease-breadcrumb-separator-slash">
+          <li class="ease-breadcrumb-item"><a href="#">Home</a></li>
+          <li class="ease-breadcrumb-item"><a href="#">Products</a></li>
+          <li class="ease-breadcrumb-item"><a href="#">Category</a></li>
+          <li class="ease-breadcrumb-item active" aria-current="page">Current Item</li>
+        </ol>
+      </nav>
+    </div>
+
+    <h2>Separator Variants</h2>
+    <div class="separator-row">
+      <div class="example">
+        <div class="example-label">Arrow (&gt;)</div>
+        <nav aria-label="Breadcrumb">
+          <ol class="ease-breadcrumb ease-breadcrumb-separator-arrow">
+            <li class="ease-breadcrumb-item"><a href="#">Home</a></li>
+            <li class="ease-breadcrumb-item"><a href="#">Blog</a></li>
+            <li class="ease-breadcrumb-item active" aria-current="page">Post</li>
+          </ol>
+        </nav>
+      </div>
+      <div class="example">
+        <div class="example-label">Chevron (›)</div>
+        <nav aria-label="Breadcrumb">
+          <ol class="ease-breadcrumb ease-breadcrumb-separator-chevron">
+            <li class="ease-breadcrumb-item"><a href="#">Dashboard</a></li>
+            <li class="ease-breadcrumb-item"><a href="#">Settings</a></li>
+            <li class="ease-breadcrumb-item active" aria-current="page">Profile</li>
+          </ol>
+        </nav>
+      </div>
+      <div class="example">
+        <div class="example-label">Bullet (•)</div>
+        <nav aria-label="Breadcrumb">
+          <ol class="ease-breadcrumb ease-breadcrumb-separator-bullet">
+            <li class="ease-breadcrumb-item"><a href="#">Docs</a></li>
+            <li class="ease-breadcrumb-item"><a href="#">Components</a></li>
+            <li class="ease-breadcrumb-item active" aria-current="page">Breadcrumb</li>
+          </ol>
+        </nav>
+      </div>
+    </div>
+
+    <h2>Long Breadcrumb (Collapsible on Mobile)</h2>
+    <div class="example">
+      <div class="example-label">With .ease-breadcrumb-collapse</div>
+      <nav aria-label="Breadcrumb">
+        <ol class="ease-breadcrumb ease-breadcrumb-separator-chevron ease-breadcrumb-collapse">
+          <li class="ease-breadcrumb-item"><a href="#">Home</a></li>
+          <li class="ease-breadcrumb-item"><a href="#">Documentation</a></li>
+          <li class="ease-breadcrumb-item"><a href="#">Components</a></li>
+          <li class="ease-breadcrumb-item"><a href="#">Navigation</a></li>
+          <li class="ease-breadcrumb-item active" aria-current="page">Breadcrumb Component</li>
+        </ol>
+      </nav>
+    </div>
+
+    <h2>Without Active Item</h2>
+    <div class="example">
+      <div class="example-label">All links (no current page)</div>
+      <nav aria-label="Breadcrumb">
+        <ol class="ease-breadcrumb ease-breadcrumb-separator-arrow">
+          <li class="ease-breadcrumb-item"><a href="#">Home</a></li>
+          <li class="ease-breadcrumb-item"><a href="#">Projects</a></li>
+          <li class="ease-breadcrumb-item"><a href="#">EaseMotion</a></li>
+          <li class="ease-breadcrumb-item"><a href="#">Components</a></li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes/breadcrumb-navigation-7784/style.css
+++ b/submissions/core_changes/breadcrumb-navigation-7784/style.css
@@ -1,0 +1,118 @@
+/* ============================================================
+   EaseMotion CSS — breadcrumb navigation component
+   Issue #7784
+   ============================================================ */
+
+@layer easemotion-components {
+  .ease-breadcrumb {
+    --ease-breadcrumb-gap: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--ease-breadcrumb-gap);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: var(--ease-text-sm, 0.875rem);
+    overflow: hidden;
+  }
+
+  .ease-breadcrumb-item {
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+  }
+
+  .ease-breadcrumb-item + .ease-breadcrumb-item::before {
+    content: var(--ease-breadcrumb-separator, "/");
+    margin-inline: var(--ease-breadcrumb-gap);
+    color: var(--ease-color-neutral-400, #94a3b8);
+    font-size: 0.75em;
+    user-select: none;
+  }
+
+  .ease-breadcrumb-item a {
+    color: var(--ease-color-primary, #6c63ff);
+    text-decoration: none;
+    transition: color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+  }
+
+  .ease-breadcrumb-item a:hover {
+    color: var(--ease-color-primary-light, #a09af8);
+    text-decoration: underline;
+  }
+
+  .ease-breadcrumb-item a:focus-visible {
+    outline: 2px solid var(--ease-color-primary, #6c63ff);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  .ease-breadcrumb-item.active,
+  .ease-breadcrumb-item:last-child {
+    color: var(--ease-color-text, #1e293b);
+    font-weight: 600;
+    pointer-events: none;
+  }
+
+  .ease-breadcrumb-item.active a,
+  .ease-breadcrumb-item:last-child a {
+    pointer-events: none;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  /* ── Separator Variants ────────────────────────────────── */
+  .ease-breadcrumb-separator-slash {
+    --ease-breadcrumb-separator: "/";
+  }
+  .ease-breadcrumb-separator-arrow {
+    --ease-breadcrumb-separator: ">";
+  }
+  .ease-breadcrumb-separator-chevron {
+    --ease-breadcrumb-separator: "›";
+  }
+  .ease-breadcrumb-separator-bullet {
+    --ease-breadcrumb-separator: "•";
+  }
+
+  /* ── Responsive (truncate on mobile) ──────────────────── */
+  @media (max-width: 640px) {
+    .ease-breadcrumb-collapse {
+      flex-wrap: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .ease-breadcrumb-collapse .ease-breadcrumb-item {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 6rem;
+    }
+    .ease-breadcrumb-collapse .ease-breadcrumb-item:last-child {
+      max-width: 8rem;
+    }
+  }
+
+  /* ── Dark mode via prefers-color-scheme ───────────────── */
+  @media (prefers-color-scheme: dark) {
+    .ease-breadcrumb-item.active,
+    .ease-breadcrumb-item:last-child {
+      color: var(--ease-color-neutral-200, #e2e8f0);
+    }
+    .ease-breadcrumb-item a {
+      color: var(--ease-color-primary-light, #a09af8);
+    }
+    .ease-breadcrumb-item a:hover {
+      color: var(--ease-color-primary, #6c63ff);
+    }
+    .ease-breadcrumb-item + .ease-breadcrumb-item::before {
+      color: var(--ease-color-neutral-500, #64748b);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ease-breadcrumb-item a {
+      transition: none;
+    }
+  }
+}


### PR DESCRIPTION
### Description

Adds a breadcrumb navigation component showing page hierarchy with customizable separators — slash, arrow, chevron, and bullet variants.

### Changes Made

| File | Description |
|------|-------------|
| `submissions/core_changes/breadcrumb-navigation-7784/style.css` | CSS for `.ease-breadcrumb`, `.ease-breadcrumb-item`, 4 separator variants, responsive collapse, dark mode |
| `submissions/core_changes/breadcrumb-navigation-7784/demo.html` | Working demo with all variants, collapsible example |
| `submissions/core_changes/breadcrumb-navigation-7784/README.md` | Documentation and usage examples |

### Key Features

- **`.ease-breadcrumb`** — flex row container with gap
- **`.ease-breadcrumb-item`** — auto-separator via `::before` pseudo-element
- **4 separator variants**: slash, arrow, chevron, bullet
- **`.ease-breadcrumb-item.active`** — bold, non-clickable current page state
- **`.ease-breadcrumb-collapse`** — truncates items on mobile (≤640px)
- **Dark mode** via `prefers-color-scheme: dark`
- **Accessible** focus-visible ring, aria-label, aria-current
- **No core files modified** — all changes in `submissions/core_changes/`

### Related Issue

Closes #7784

### Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's coding style
- [x] I have tested the component in modern browsers (Chrome, Firefox, Safari)
- [x] No core files were modified
- [x] All changes are placed in `submissions/core_changes/breadcrumb-navigation-7784/`