### PR TITLE
feat: add demo for missing forms.css import in easemotion/all.css (#8566)

### DIFF
--- a/submissions/examples/missing-forms-import-8566/README.md
+++ b/submissions/examples/missing-forms-import-8566/README.md
@@ -1,0 +1,31 @@
+# Missing forms.css Import — Issue #8566
+
+`easemotion/all.css` (modular bundle) omits the `forms.css` import that exists in the main `easemotion.css` entry point.
+
+## The Bug
+
+**`easemotion.css` line 44** (has it):
+```css
+@import "./components/forms.css";
+```
+
+**`easemotion/all.css`** (missing):
+```css
+/* No import for forms.css */
+```
+
+Users loading the framework via `easemotion/all.css` get all components (buttons, cards, navbar, chip, footer, sidebar, tabs, badges, loaders, tooltips, modals) but no form styles.
+
+## Suggested Fix
+
+Add to `easemotion/all.css` after the modals import:
+
+```css
+@import "../components/forms.css";
+```
+
+## Files
+
+- `style.css` — form component styles demonstrating what's missing
+- `demo.html` — form demo with inputs, selects, textareas, checkboxes, radios, validation states
+- `README.md` — this file

--- a/submissions/examples/missing-forms-import-8566/demo.html
+++ b/submissions/examples/missing-forms-import-8566/demo.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Missing forms.css Import — Issue #8566</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="demo-page">
+    <h1>Missing <code>forms.css</code> Import</h1>
+    <p>Issue #8566 — <code>easemotion/all.css</code> (modular bundle) omits the <code>forms.css</code> import that exists in the main <code>easemotion.css</code> entry point.</p>
+
+    <h2>The Problem</h2>
+    <p><code>easemotion.css</code> imports <code>forms.css</code> at line 44, but <code>easemotion/all.css</code> has no such import. Any user loading the framework via <code>easemotion/all.css</code> gets buttons, cards, navbar, etc. — but <strong>no form styles</strong>.</p>
+
+    <div class="file-diff">
+      <span class="line-info">--- easemotion.css (line 44) ✓</span>
+      <span class="line-add">@import "./components/forms.css";</span>
+      <span class="line-info" style="margin-top:0.5rem;">--- easemotion/all.css ✗ (missing)</span>
+      <span class="line-add">@import "../components/forms.css";  &lt;-- NOT PRESENT</span>
+    </div>
+
+    <div class="demo-card">
+      <h2>Demo: Form Components</h2>
+      <p style="margin-bottom:1rem;">These form elements come from <code>components/forms.css</code>, which is not loaded when using <code>easemotion/all.css</code>. The styles below demonstrate what's missing — they are recreated here in <code>submissions/examples/</code> for the demo.</p>
+
+      <div class="ease-form-group">
+        <label class="ease-form-label" for="name">Full Name</label>
+        <input class="ease-form-input" id="name" type="text" placeholder="Enter your name" />
+        <span class="ease-form-hint">Must be at least 2 characters</span>
+      </div>
+
+      <div class="ease-form-group">
+        <label class="ease-form-label" for="email">Email Address</label>
+        <input class="ease-form-input" id="email" type="email" placeholder="you@example.com" value="bad-email" />
+        <span class="ease-form-error">Please enter a valid email address</span>
+      </div>
+
+      <div class="ease-form-group">
+        <label class="ease-form-label" for="role">Role</label>
+        <select class="ease-form-select" id="role">
+          <option value="">Select a role...</option>
+          <option value="dev">Developer</option>
+          <option value="design">Designer</option>
+          <option value="pm">Product Manager</option>
+        </select>
+      </div>
+
+      <div class="ease-form-group">
+        <label class="ease-form-label" for="bio">Bio</label>
+        <textarea class="ease-form-textarea" id="bio" placeholder="Tell us about yourself..."></textarea>
+      </div>
+
+      <div class="ease-form-group">
+        <label class="ease-form-checkbox">
+          <input type="checkbox" checked />
+          Subscribe to newsletter
+        </label>
+        <label class="ease-form-checkbox">
+          <input type="checkbox" />
+          I agree to the terms
+        </label>
+      </div>
+
+      <div class="ease-form-group">
+        <label class="ease-form-label">Preferred Framework</label>
+        <label class="ease-form-radio">
+          <input type="radio" name="framework" checked />
+          React
+        </label>
+        <label class="ease-form-radio">
+          <input type="radio" name="framework" />
+          Vue
+        </label>
+        <label class="ease-form-radio">
+          <input type="radio" name="framework" />
+          Svelte
+        </label>
+      </div>
+
+      <div class="ease-form-actions">
+        <button class="btn btn-primary">Submit</button>
+        <button class="btn btn-secondary">Cancel</button>
+      </div>
+    </div>
+
+    <h2>Affected Files</h2>
+    <table style="width:100%;border-collapse:collapse;margin:1rem 0;">
+      <tr>
+        <th style="text-align:left;padding:0.5rem;border-bottom:2px solid var(--ease-color-neutral-300,#cbd5e1);">File</th>
+        <th style="text-align:left;padding:0.5rem;border-bottom:2px solid var(--ease-color-neutral-300,#cbd5e1);">Status</th>
+      </tr>
+      <tr>
+        <td style="padding:0.5rem;border-bottom:1px solid var(--ease-color-neutral-200,#e2e8f0);font-family:monospace;font-size:0.85rem;">easemotion.css line 44</td>
+        <td style="padding:0.5rem;border-bottom:1px solid var(--ease-color-neutral-200,#e2e8f0);color:#22c55e;font-weight:600;">✅ Has forms.css import</td>
+      </tr>
+      <tr>
+        <td style="padding:0.5rem;border-bottom:1px solid var(--ease-color-neutral-200,#e2e8f0);font-family:monospace;font-size:0.85rem;">easemotion/all.css</td>
+        <td style="padding:0.5rem;border-bottom:1px solid var(--ease-color-neutral-200,#e2e8f0);color:#ef4444;font-weight:600;">❌ Missing forms.css import</td>
+      </tr>
+    </table>
+
+    <h2>Suggested Fix</h2>
+    <p>Add the following line to <code>easemotion/all.css</code> (after <code>modals.css</code>):</p>
+    <div class="file-diff">
+      <span class="line-add">@import "../components/forms.css";</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/missing-forms-import-8566/style.css
+++ b/submissions/examples/missing-forms-import-8566/style.css
@@ -1,0 +1,216 @@
+/* ============================================================
+   EaseMotion CSS — missing forms.css import demo
+   Issue #8566 — easemotion/all.css omits forms.css
+   ============================================================ */
+
+@layer easemotion-components {
+
+/* ── Form components (to demonstrate what's missing) ────── */
+.ease-form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-1, 0.25rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.ease-form-label {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--ease-color-text, #1e293b);
+}
+
+.ease-form-input,
+.ease-form-select,
+.ease-form-textarea {
+  width: 100%;
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  font-size: var(--ease-text-base, 1rem);
+  font-family: inherit;
+  color: var(--ease-color-text, #1e293b);
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-300, #cbd5e1);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  transition: border-color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+              box-shadow var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.ease-form-input:focus,
+.ease-form-select:focus,
+.ease-form-textarea:focus {
+  outline: none;
+  border-color: var(--ease-color-primary, #6c63ff);
+  box-shadow: 0 0 0 3px var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+}
+
+.ease-form-input:disabled,
+.ease-form-select:disabled,
+.ease-form-textarea:disabled {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  color: var(--ease-color-neutral-500, #64748b);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.ease-form-input.error,
+.ease-form-select.error,
+.ease-form-textarea.error {
+  border-color: var(--ease-color-danger, #ef4444);
+  box-shadow: 0 0 0 3px var(--ease-color-danger-alpha, rgba(239, 68, 68, 0.15));
+}
+
+.ease-form-textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.ease-form-select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%2364748b' d='M6 8L0 0h12z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  padding-right: 2rem;
+}
+
+.ease-form-hint {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #64748b);
+}
+
+.ease-form-error {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-danger, #ef4444);
+}
+
+.ease-form-checkbox,
+.ease-form-radio {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  cursor: pointer;
+}
+
+.ease-form-checkbox input[type="checkbox"],
+.ease-form-radio input[type="radio"] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-form-actions {
+  display: flex;
+  gap: var(--ease-space-3, 0.75rem);
+  margin-top: var(--ease-space-6, 1.5rem);
+}
+
+/* ── Button styles for demo ─────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-4, 1rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  font-family: inherit;
+  border: none;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  cursor: pointer;
+  transition: background var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.btn-primary {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+.btn-primary:hover {
+  background: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.btn-secondary {
+  background: var(--ease-color-neutral-200, #e2e8f0);
+  color: var(--ease-color-text, #1e293b);
+}
+.btn-secondary:hover {
+  background: var(--ease-color-neutral-300, #cbd5e1);
+}
+
+/* ── Demo page styles ───────────────────────────────────── */
+.demo-page {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+.demo-page h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.demo-page h2 {
+  font-size: 1rem;
+  margin: 1.5rem 0 0.75rem;
+}
+
+.demo-page p { color: #64748b; font-size: 0.9rem; line-height: 1.6; }
+.demo-page code {
+  background: #f1f5f9;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.demo-card {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin: 1rem 0;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+
+.file-diff {
+  background: #0f172a;
+  border-radius: 8px;
+  padding: 1rem;
+  margin: 0.75rem 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  overflow-x: auto;
+}
+
+.file-diff .line-add {
+  color: #86efac;
+  display: block;
+  padding: 0.1rem 0;
+}
+
+.file-diff .line-info {
+  color: #94a3b8;
+  display: block;
+  padding: 0.1rem 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .demo-page code { background: #1e293b; color: #e2e8f0; }
+  .demo-card { background: #1e293b; border-color: #334155; }
+  .ease-form-input, .ease-form-select, .ease-form-textarea {
+    background: #0f172a;
+    border-color: #334155;
+    color: #e2e8f0;
+  }
+  .ease-form-input:disabled, .ease-form-select:disabled, .ease-form-textarea:disabled {
+    background: #1e293b;
+  }
+  .btn-secondary {
+    background: #334155;
+    color: #e2e8f0;
+  }
+  .btn-secondary:hover { background: #475569; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-form-input, .ease-form-select, .ease-form-textarea, .btn { transition: none; }
+}
+
+}


### PR DESCRIPTION
### Description

Demonstrates the missing `forms.css` import in `easemotion/all.css` (modular bundle). The main entry point `easemotion.css` imports `forms.css` at line 44, but `easemotion/all.css` omits it entirely, meaning users of the modular bundle get no form styles.

### Changes Made

| File | Description |
|------|-------------|
| `submissions/examples/missing-forms-import-8566/style.css` | Form component styles (input, select, textarea, checkbox, radio, validation states) |
| `submissions/examples/missing-forms-import-8566/demo.html` | Form demo with diff view showing the missing import |
| `submissions/examples/missing-forms-import-8566/README.md` | Documentation |

### The Fix

Add to `easemotion/all.css`:
```css
@import "../components/forms.css";
```

- **No core files modified** — all changes in `submissions/examples/`

### Related Issue

Closes #8566

### Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's coding style
- [x] I have tested the component in modern browsers (Chrome, Firefox, Safari)
- [x] No core files were modified
- [x] All changes are placed in `submissions/examples/missing-forms-import-8566/`