### PR TITLE
feat: add dark mode and reduced motion support to badges (#8561)

### DIFF
--- a/submissions/examples/badges-dark-mode-8561/README.md
+++ b/submissions/examples/badges-dark-mode-8561/README.md
@@ -1,0 +1,19 @@
+# Badges Dark Mode Support — Issue #8561
+
+Adds dark mode (`@media prefers-color-scheme: dark`) and reduced motion (`@media prefers-reduced-motion: reduce`) support to the badges component.
+
+## The Problem
+
+`components/badges.css` (69 lines) has zero dark mode or reduced motion overrides. Every other major component (cards, chip, navbar, forms, footer, sidebar) includes both.
+
+## Features Added
+
+- **Dark mode** — adjusted pulse glow colors for dark backgrounds (uses lighter variants)
+- **Outline variant** — `.ease-badge-outline` with transparent background and colored border; adapts to dark mode
+- **Reduced motion** — pulse animation is disabled when `prefers-reduced-motion: reduce` is active
+
+## Files
+
+- `style.css` — badges with dark mode, reduced motion, outline variant
+- `demo.html` — comparison table, color/size/pulse/outline demos
+- `README.md` — this file

--- a/submissions/examples/badges-dark-mode-8561/demo.html
+++ b/submissions/examples/badges-dark-mode-8561/demo.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Badges Dark Mode — Issue #8561</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="demo-container">
+    <h1>Badges — Dark Mode Support</h1>
+    <p>Issue #8561 — Adding <code>@media (prefers-color-scheme: dark)</code> and <code>@media (prefers-reduced-motion: reduce)</code> support to the badges component.</p>
+
+    <div class="section">
+      <h2>What's Missing in <code>components/badges.css</code></h2>
+      <table class="diff-table">
+        <tr>
+          <th>Feature</th>
+          <th>Current Status</th>
+          <th>Expected</th>
+        </tr>
+        <tr>
+          <td>Dark mode (<code>prefers-color-scheme: dark</code>)</td>
+          <td style="color:#ef4444;font-weight:600;">❌ Missing</td>
+          <td style="color:#22c55e;">✅ Present in cards, chip, navbar, forms</td>
+        </tr>
+        <tr>
+          <td>Reduced motion (<code>prefers-reduced-motion: reduce</code>)</td>
+          <td style="color:#ef4444;font-weight:600;">❌ Missing</td>
+          <td style="color:#22c55e;">✅ Present in buttons, cards, tooltips, modals, chip, marquee</td>
+        </tr>
+        <tr>
+          <td>Outline variant</td>
+          <td style="color:#ef4444;font-weight:600;">❌ Missing</td>
+          <td style="color:#22c55e;">✅ Useful for dark mode contrast</td>
+        </tr>
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>Color Variants</h2>
+      <div class="badge-row">
+        <span class="ease-badge-dm">Primary</span>
+        <span class="ease-badge-dm ease-badge-dm-success">Success</span>
+        <span class="ease-badge-dm ease-badge-dm-danger">Danger</span>
+        <span class="ease-badge-dm ease-badge-dm-warning">Warning</span>
+        <span class="ease-badge-dm ease-badge-dm-info">Info</span>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>Size Variants</h2>
+      <div class="badge-row">
+        <span class="ease-badge-dm ease-badge-dm-sm">SM</span>
+        <span class="ease-badge-dm">Default</span>
+        <span class="ease-badge-dm ease-badge-dm-lg">Large</span>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>Outline Variant</h2>
+      <div class="badge-row">
+        <span class="ease-badge-dm ease-badge-dm-outline">Primary</span>
+        <span class="ease-badge-dm ease-badge-dm-outline ease-badge-dm-success">Success</span>
+        <span class="ease-badge-dm ease-badge-dm-outline ease-badge-dm-danger">Danger</span>
+      </div>
+      <p style="margin-top:0.5rem;">Outline badges adapt their border/text colors in dark mode for proper contrast.</p>
+    </div>
+
+    <div class="section">
+      <h2>Pulse Variant</h2>
+      <div class="badge-row">
+        <span class="ease-badge-dm ease-badge-dm-pulse">Live</span>
+        <span class="ease-badge-dm ease-badge-dm-pulse ease-badge-dm-success">Active</span>
+        <span class="ease-badge-dm ease-badge-dm-pulse ease-badge-dm-danger">Alert</span>
+      </div>
+      <p style="margin-top:0.5rem;">Try enabling <code>prefers-reduced-motion: reduce</code> in dev tools — the pulse animation stops.</p>
+    </div>
+
+    <div class="section">
+      <h2>Suggested Fix</h2>
+      <p>Add the following blocks to the end of <code>components/badges.css</code>:</p>
+      <div style="background:#0f172a;border-radius:8px;padding:1rem;font-family:'JetBrains Mono',monospace;font-size:0.8rem;overflow-x:auto;">
+        <span style="color:#86efac;display:block;padding:0.1rem 0;">/* Dark mode */</span>
+        <span style="color:#94a3b8;display:block;padding:0.1rem 0;">@media (prefers-color-scheme: dark) {</span>
+        <span style="color:#e2e8f0;display:block;padding:0.1rem 0 0.1rem 1rem;">.ease-badge-pulse::after {</span>
+        <span style="color:#e2e8f0;display:block;padding:0.1rem 0 0.1rem 2rem;">box-shadow: 0 0 0 0 rgba(160, 154, 248, 0.6);</span>
+        <span style="color:#e2e8f0;display:block;padding:0.1rem 0 0.1rem 1rem;">}</span>
+        <span style="color:#94a3b8;display:block;padding:0.1rem 0;">}</span>
+        <span style="color:#86efac;display:block;padding:0.1rem 0;">/* Reduced motion */</span>
+        <span style="color:#94a3b8;display:block;padding:0.1rem 0;">@media (prefers-reduced-motion: reduce) {</span>
+        <span style="color:#e2e8f0;display:block;padding:0.1rem 0 0.1rem 1rem;">.ease-badge-pulse::after {</span>
+        <span style="color:#e2e8f0;display:block;padding:0.1rem 0 0.1rem 2rem;">animation: none;</span>
+        <span style="color:#e2e8f0;display:block;padding:0.1rem 0 0.1rem 2rem;">display: none;</span>
+        <span style="color:#e2e8f0;display:block;padding:0.1rem 0 0.1rem 1rem;">}</span>
+        <span style="color:#94a3b8;display:block;padding:0.1rem 0;">}</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/badges-dark-mode-8561/style.css
+++ b/submissions/examples/badges-dark-mode-8561/style.css
@@ -1,0 +1,196 @@
+/* ============================================================
+   EaseMotion CSS — badges dark mode support
+   Issue #8561 — Add dark mode and reduced-motion to badges
+   ============================================================ */
+
+@layer easemotion-components {
+
+.ease-badge-dm {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--ease-space-2, 0.5rem);
+  height: 20px;
+  min-width: 20px;
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  color: #ffffff;
+  background-color: var(--ease-color-primary, #6c63ff);
+  border-radius: var(--ease-radius-full, 9999px);
+  box-shadow: var(--ease-shadow-sm, 0 1px 3px rgba(0,0,0,0.08));
+}
+
+.ease-badge-dm-danger {
+  background-color: var(--ease-color-danger, #ef4444);
+}
+
+.ease-badge-dm-success {
+  background-color: var(--ease-color-success, #22c55e);
+}
+
+.ease-badge-dm-warning {
+  background-color: var(--ease-color-warning, #f59e0b);
+  color: #000;
+}
+
+.ease-badge-dm-info {
+  background-color: var(--ease-color-info, #3b82f6);
+}
+
+.ease-badge-dm-sm {
+  height: 16px;
+  min-width: 16px;
+  padding: 0 var(--ease-space-1, 0.25rem);
+  font-size: 0.625rem;
+}
+
+.ease-badge-dm-lg {
+  height: 24px;
+  min-width: 24px;
+  padding: 0 var(--ease-space-3, 0.75rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.ease-badge-dm-pulse {
+  position: relative;
+}
+
+.ease-badge-dm-pulse::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.7);
+  animation: ease-kf-ping-dm 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+  z-index: -1;
+}
+
+.ease-badge-dm-danger.ease-badge-dm-pulse::after {
+  box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
+}
+
+.ease-badge-dm-success.ease-badge-dm-pulse::after {
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
+}
+
+@keyframes ease-kf-ping-dm {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+.ease-badge-dm-outline {
+  background: transparent;
+  border: 1px solid var(--ease-color-primary, #6c63ff);
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-badge-dm-outline.ease-badge-dm-danger {
+  border-color: var(--ease-color-danger, #ef4444);
+  color: var(--ease-color-danger, #ef4444);
+}
+
+.ease-badge-dm-outline.ease-badge-dm-success {
+  border-color: var(--ease-color-success, #22c55e);
+  color: var(--ease-color-success, #22c55e);
+}
+
+/* ── Dark mode ─────────────────────────────────────────── */
+@media (prefers-color-scheme: dark) {
+  .ease-badge-dm {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  }
+
+  .ease-badge-dm-pulse::after {
+    box-shadow: 0 0 0 0 rgba(160, 154, 248, 0.6);
+  }
+
+  .ease-badge-dm-danger.ease-badge-dm-pulse::after {
+    box-shadow: 0 0 0 0 rgba(252, 165, 165, 0.6);
+  }
+
+  .ease-badge-dm-success.ease-badge-dm-pulse::after {
+    box-shadow: 0 0 0 0 rgba(134, 239, 172, 0.6);
+  }
+
+  .ease-badge-dm-outline {
+    border-color: var(--ease-color-primary-light, #a09af8);
+    color: var(--ease-color-primary-light, #a09af8);
+  }
+
+  .ease-badge-dm-outline.ease-badge-dm-danger {
+    border-color: var(--ease-color-danger-light, #fca5a5);
+    color: var(--ease-color-danger-light, #fca5a5);
+  }
+
+  .ease-badge-dm-outline.ease-badge-dm-success {
+    border-color: var(--ease-color-success-light, #86efac);
+    color: var(--ease-color-success-light, #86efac);
+  }
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-badge-dm-pulse::after {
+    animation: none;
+    display: none;
+  }
+}
+
+/* ── Demo page ────────────────────────────────────────────── */
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  transition: background 0.3s, color 0.3s;
+}
+
+.demo-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+h2 { font-size: 1rem; margin: 1.5rem 0 0.75rem; }
+p { color: var(--ease-color-muted, #64748b); font-size: 0.9rem; margin-bottom: 1rem; }
+code {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.section {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  transition: background 0.3s, border-color 0.3s;
+}
+
+.badge-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.diff-table { width: 100%; border-collapse: collapse; margin: 1rem 0; }
+.diff-table th, .diff-table td {
+  padding: 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  font-size: 0.85rem;
+}
+.diff-table th { font-weight: 600; color: var(--ease-color-muted, #64748b); }
+.diff-table td { font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; }
+
+@media (prefers-color-scheme: dark) {
+  code { background: var(--ease-color-neutral-200, #334155); color: #e2e8f0; }
+  .section { background: var(--ease-color-surface, #1e293b); border-color: #334155; }
+}
+
+}


### PR DESCRIPTION
### Description

Adds dark mode (`@media prefers-color-scheme: dark`) and reduced motion (`@media prefers-reduced-motion: reduce`) support to the badges component, which currently has neither.

### Changes Made

| File | Description |
|------|-------------|
| `submissions/examples/badges-dark-mode-8561/style.css` | Badges with dark mode glow colors, reduced motion guard, outline variant |
| `submissions/examples/badges-dark-mode-8561/demo.html` | Comparison table, all variants (color, size, outline, pulse) |
| `submissions/examples/badges-dark-mode-8561/README.md` | Documentation |

### What's Missing in `components/badges.css`

| Feature | Status |
|---------|--------|
| `@media (prefers-color-scheme: dark)` | ❌ Missing (present in cards, chip, navbar, forms) |
| `@media (prefers-reduced-motion: reduce)` | ❌ Missing (present in buttons, cards, tooltips, chip) |

- **No core files modified** — all changes in `submissions/examples/`

### Related Issue

Closes #8561

### Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's coding style
- [x] I have tested the component in modern browsers (Chrome, Firefox, Safari)
- [x] No core files were modified
- [x] All changes are placed in `submissions/examples/badges-dark-mode-8561/`