### PR TITLE
fix(badges): add prefers-reduced-motion guard for pulse animation (fix #8562)

### DIFF
--- a/submissions/examples/badges-reduced-motion-8562/README.md
+++ b/submissions/examples/badges-reduced-motion-8562/README.md
@@ -1,0 +1,18 @@
+# Badges — Reduced Motion Support (Issue #8562)
+
+## Problem
+
+The badges component had a `.ease-badge-pulse` variant with a ping animation but no `@media (prefers-reduced-motion: reduce)` guard. Users who request reduced motion in their system/browser settings would still see the pulsing animation.
+
+## Solution
+
+Added a `@media (prefers-reduced-motion: reduce)` block that:
+- Stops the `::after` ping animation entirely (`animation: none; display: none;`)
+- Replaces it with a static `box-shadow` ring as a subtle visual indicator
+
+Also includes dark-mode support for the pulse shadow colors.
+
+## Files
+
+- `style.css` — badges component with reduced-motion support
+- `demo.html` — demo showcasing sizes, colors, and pulse variants

--- a/submissions/examples/badges-reduced-motion-8562/demo.html
+++ b/submissions/examples/badges-reduced-motion-8562/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Badges — Reduced Motion (Issue #8562)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container">
+    <h1>Badges &mdash; <code>prefers-reduced-motion</code></h1>
+    <p>
+      Issue <strong>#8562</strong>: The pulse badge animation now respects the user&rsquo;s
+      <code>prefers-reduced-motion: reduce</code> setting.
+    </p>
+
+    <div class="card">
+      <h2>Sizes</h2>
+      <div class="badge-row">
+        <span class="ease-badge-rm ease-badge-rm-sm">SM</span>
+        <span class="ease-badge-rm">MD</span>
+        <span class="ease-badge-rm ease-badge-rm-lg">LG</span>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Colors</h2>
+      <div class="badge-row">
+        <span class="ease-badge-rm">Primary</span>
+        <span class="ease-badge-rm ease-badge-rm-danger">Danger</span>
+        <span class="ease-badge-rm ease-badge-rm-success">Success</span>
+        <span class="ease-badge-rm ease-badge-rm-warning">Warning</span>
+        <span class="ease-badge-rm ease-badge-rm-info">Info</span>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Pulse (animated)</h2>
+      <div class="badge-row">
+        <span class="ease-badge-rm ease-badge-rm-pulse">Primary</span>
+        <span class="ease-badge-rm ease-badge-rm-danger ease-badge-rm-pulse">Danger</span>
+        <span class="ease-badge-rm ease-badge-rm-success ease-badge-rm-pulse">Success</span>
+      </div>
+      <div class="badge-row" style="margin-top: 0.75rem;">
+        <span class="ease-badge-rm ease-badge-rm-sm ease-badge-rm-pulse">SM pulse</span>
+        <span class="ease-badge-rm ease-badge-rm-lg ease-badge-rm-pulse">LG pulse</span>
+      </div>
+    </div>
+
+    <div class="test-note">
+      <strong>How to test reduced-motion:</strong> Open DevTools &rarr; Rendering tab &rarr;
+      set <em>Emulate CSS media feature prefers-reduced-motion</em> to <code>reduce</code>.
+      Pulse badges should stop animating and show a subtle ring instead.
+    </div>
+
+    <div class="card">
+      <h2>Usage</h2>
+      <pre><code>&lt;span class="ease-badge-rm ease-badge-rm-pulse"&gt;Live&lt;/span&gt;
+
+&lt;span class="ease-badge-rm ease-badge-rm-danger ease-badge-rm-pulse"&gt;
+  Alert
+&lt;/span&gt;
+
+&lt;span class="ease-badge-rm ease-badge-rm-sm"&gt;NEW&lt;/span&gt;</code></pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/badges-reduced-motion-8562/style.css
+++ b/submissions/examples/badges-reduced-motion-8562/style.css
@@ -1,0 +1,156 @@
+/* ============================================================
+   EaseMotion CSS — badges reduced-motion support
+   Issue #8562 — Add prefers-reduced-motion guard to badges
+   ============================================================ */
+
+@layer easemotion-components {
+
+.ease-badge-rm {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--ease-space-2, 0.5rem);
+  height: 20px;
+  min-width: 20px;
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  color: #fff;
+  background: var(--ease-color-primary, #6c63ff);
+  border-radius: var(--ease-radius-full, 9999px);
+  box-shadow: var(--ease-shadow-sm, 0 1px 3px rgba(0,0,0,0.08));
+}
+
+.ease-badge-rm-danger { background: var(--ease-color-danger, #ef4444); }
+.ease-badge-rm-success { background: var(--ease-color-success, #22c55e); }
+.ease-badge-rm-warning { background: var(--ease-color-warning, #f59e0b); color: #000; }
+.ease-badge-rm-info { background: var(--ease-color-info, #3b82f6); }
+
+.ease-badge-rm-sm {
+  height: 16px;
+  min-width: 16px;
+  padding: 0 var(--ease-space-1, 0.25rem);
+  font-size: 0.625rem;
+}
+
+.ease-badge-rm-lg {
+  height: 24px;
+  min-width: 24px;
+  padding: 0 var(--ease-space-3, 0.75rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.ease-badge-rm-pulse {
+  position: relative;
+}
+
+.ease-badge-rm-pulse::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.7);
+  animation: ease-kf-ping-rm 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+  z-index: -1;
+}
+
+.ease-badge-rm-danger.ease-badge-rm-pulse::after {
+  box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
+}
+
+.ease-badge-rm-success.ease-badge-rm-pulse::after {
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
+}
+
+@keyframes ease-kf-ping-rm {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-badge-rm-pulse::after {
+    animation: none;
+    display: none;
+  }
+
+  .ease-badge-rm-pulse {
+    /* Visual indicator still shown without animation */
+    box-shadow: 0 0 0 2px rgba(108, 99, 255, 0.3);
+  }
+
+  .ease-badge-rm-danger.ease-badge-rm-pulse {
+    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.3);
+  }
+
+  .ease-badge-rm-success.ease-badge-rm-pulse {
+    box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.3);
+  }
+}
+
+/* ── Dark mode ─────────────────────────────────────────── */
+@media (prefers-color-scheme: dark) {
+  .ease-badge-rm-pulse::after {
+    box-shadow: 0 0 0 0 rgba(160, 154, 248, 0.6);
+  }
+  .ease-badge-rm-danger.ease-badge-rm-pulse::after {
+    box-shadow: 0 0 0 0 rgba(252, 165, 165, 0.6);
+  }
+  .ease-badge-rm-success.ease-badge-rm-pulse::after {
+    box-shadow: 0 0 0 0 rgba(134, 239, 172, 0.6);
+  }
+}
+
+/* ── Demo page ────────────────────────────────────────── */
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+}
+
+.demo-container { max-width: 720px; margin: 0 auto; }
+
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+h2 { font-size: 1rem; margin: 1.5rem 0 0.75rem; }
+p, li { color: var(--ease-color-muted, #64748b); font-size: 0.9rem; line-height: 1.6; }
+code {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+ul { padding-left: 1.25rem; margin: 0.5rem 0; }
+
+.card {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.badge-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.test-note {
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  font-size: 0.85rem;
+  color: #92400e;
+}
+
+@media (prefers-color-scheme: dark) {
+  code { background: var(--ease-color-neutral-200, #334155); color: #e2e8f0; }
+  .card { background: var(--ease-color-surface, #1e293b); border-color: #334155; }
+}
+
+}


### PR DESCRIPTION
### Description

Adds a `@media (prefers-reduced-motion: reduce)` block to the badges component, consistent with every other animated component in EaseMotion CSS. When reduced motion is requested, the pulse `::after` pseudo-element stops animating and a static `box-shadow` ring is shown instead.

### Related Issue

Fixes #8562

### Proposed Changes

- New submission `submissions/examples/badges-reduced-motion-8562/` with `style.css`, `demo.html`, `README.md`
- The CSS includes the reduced-motion guard plus dark-mode support for pulse shadows