### PR TITLE
feat(typography): add animated gradient underline utility

### DIFF
--- a/submissions/examples/underline-gradient/README.md
+++ b/submissions/examples/underline-gradient/README.md
@@ -1,0 +1,12 @@
+# Animated Gradient Underline Utility
+
+A small CSS utility that animates a gradient underline on hover/focus using CSS variables.
+
+## Files
+- `demo.html` — examples for links, headings, and custom durations
+- `style.css` — core utility + demo styles
+
+## Usage
+Add the class to any text element:
+```html
+<a class="underline-gradient" href="#">Read more</a>

--- a/submissions/examples/underline-gradient/demo.html
+++ b/submissions/examples/underline-gradient/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Underline Gradient — EaseMotion CSS Example</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+    <main class="wrap">
+        <h1>Animated Gradient Underline</h1>
+
+        <p>
+            Inline usage on a link:
+            <a class="underline-gradient" href="#">Learn more</a>
+        </p>
+
+        <p>
+            Heading example:
+            <span class="underline-gradient lg">Feature Title</span>
+        </p>
+
+        <p>
+            Custom duration & height:
+            <a class="underline-gradient" style="--ug-duration:0.6s; --ug-height:4px;">Slow thick underline</a>
+        </p>
+
+        <p>
+            Text-gradient companion (optional):
+            <span class="text-gradient">Gradient text</span>
+        </p>
+    </main>
+</body>
+
+</html>

--- a/submissions/examples/underline-gradient/style.css
+++ b/submissions/examples/underline-gradient/style.css
@@ -1,0 +1,72 @@
+:root {
+    --ug-height: 2px;
+    --ug-duration: 0.35s;
+    --ug-colors: linear-gradient(90deg, #ff7a7a, #ffd76a, #7af7ff);
+}
+
+.underline-gradient {
+    background-image: var(--ug-colors);
+    background-repeat: no-repeat;
+    background-size: 0% var(--ug-height);
+    background-position: 0 100%;
+    transition: background-size var(--ug-duration) ease;
+    text-decoration: none;
+    padding-bottom: 2px;
+    box-shadow: none;
+    color: inherit;
+}
+
+.underline-gradient:hover,
+.underline-gradient:focus {
+    background-size: 100% var(--ug-height);
+    outline: none;
+}
+
+.underline-gradient.lg {
+    font-weight: 700;
+    font-size: 1.2rem;
+}
+
+.text-gradient {
+    background: linear-gradient(90deg, #7af7ff, #7c5aff);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    font-weight: 700;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0
+}
+
+body {
+    font-family: system-ui, Segoe UI, Roboto, "Helvetica Neue", Arial;
+    padding: 48px 20px;
+    background: #f6fbff;
+    color: #0b1220;
+}
+
+.wrap {
+    max-width: 720px;
+    margin: 0 auto
+}
+
+h1 {
+    text-align: center;
+    margin-bottom: 28px
+}
+
+p {
+    margin: 18px 0;
+    font-size: 1rem
+}
+
+a.underline-gradient {
+    color: #1e3a8a
+}
+
+span.underline-gradient {
+    color: #0b1220
+}


### PR DESCRIPTION
## Pull Request Description
Added a self-contained example under `submissions/examples/underline-gradient/` demonstrating an animated gradient underline effect on hover/focus.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/underline-gradient/`
- [x] Includes `demo.html`
- [x] Includes `style.css` 
- [x] Includes `README.md`
- [x] **No changes to `core/` or `components/`**
- [x] One feature per PR

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)