### PR TITLE
fix(modals): replace undefined --ease-color-text-muted with --ease-color-muted (fix #8565)

### DIFF
--- a/submissions/examples/modal-text-muted-8565/README.md
+++ b/submissions/examples/modal-text-muted-8565/README.md
@@ -1,0 +1,14 @@
+# Modal body uses non-existent CSS variable (Issue #8565)
+
+## Problem
+
+`components/modals.css:127` references `var(--ease-color-text-muted, #4b5563)` but `--ease-color-text-muted` is never defined in the codebase. It always falls back to `#4b5563` instead of using the proper `--ease-color-muted` token (`#64748b` light / `#94a3b8` dark).
+
+## Fix
+
+Replace `var(--ease-color-text-muted, #4b5563)` with `var(--ease-color-muted, #64748b)` in `.ease-modal-body` so modal text uses the correct muted color token consistent with the rest of the framework.
+
+## Files
+
+- `style.css` — modal component demonstrating the corrected CSS variable
+- `demo.html` — interactive modal with verification notes

--- a/submissions/examples/modal-text-muted-8565/demo.html
+++ b/submissions/examples/modal-text-muted-8565/demo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal — Fix #8565 text-muted variable</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-header">
+    <h1>Modal Body Color Fix <span class="bug-badge">#8565</span></h1>
+    <p>
+      <code>--ease-color-text-muted</code> was undefined &mdash; replaced with
+      <code>--ease-color-muted</code> in <code>.ease-modal-body</code>.
+    </p>
+  </div>
+
+  <div class="card">
+    <h2>How to verify</h2>
+    <p>
+      The modal body below uses <code>var(--ease-color-muted, #64748b)</code>
+      instead of the non-existent <code>var(--ease-color-text-muted, #4b5563)</code>.
+      In dark mode the text will be <code>#94a3b8</code> (the correct dark muted token)
+      rather than falling back to the wrong grey.
+    </p>
+    <button class="open-btn" onclick="openModal()">Open Modal</button>
+  </div>
+
+  <div class="card">
+    <h2>Before / After</h2>
+    <table style="width:100%; border-collapse: collapse; font-size: 0.85rem;">
+      <tr><th style="text-align:left;padding:0.5rem 0;border-bottom:1px solid var(--ease-color-neutral-200)">File</th>
+          <th style="text-align:left;padding:0.5rem 0;border-bottom:1px solid var(--ease-color-neutral-200)">Before</th>
+          <th style="text-align:left;padding:0.5rem 0;border-bottom:1px solid var(--ease-color-neutral-200)">After</th></tr>
+      <tr>
+        <td style="padding:0.5rem 0;white-space:nowrap"><code>modals.css:127</code></td>
+        <td style="padding:0.5rem 0"><code>var(--ease-color-text-muted, #4b5563)</code></td>
+        <td style="padding:0.5rem 0"><code>var(--ease-color-muted, #64748b)</code></td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>Demonstration code</h2>
+    <pre><code>&lt;div class="ease-modal-body-8565"&gt;
+  &lt;p&gt;
+    This text uses &lt;strong&gt;--ease-color-muted&lt;/strong&gt;
+    (&lt;code&gt;#64748b&lt;/code&gt; in light,
+     &lt;code&gt;#94a3b8&lt;/code&gt; in dark).
+  &lt;/p&gt;
+&lt;/div&gt;</code></pre>
+  </div>
+
+  <!-- ─── Modal ─── -->
+  <div class="ease-modal-overlay-8565" id="modalOverlay" style="display:none;">
+    <div class="ease-modal-8565" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="ease-modal-header-8565">
+        <h2 id="modalTitle">Example Modal</h2>
+        <button class="ease-modal-close-8565" onclick="closeModal()" aria-label="Close">&times;</button>
+      </div>
+      <div class="ease-modal-body-8565">
+        <p>
+          This body text uses <code>var(--ease-color-muted, #64748b)</code>
+          &mdash; the correct framework token &mdash; <em>not</em> the
+          non-existent <code>--ease-color-text-muted</code>.
+        </p>
+        <p>
+          <strong>Dark mode check:</strong> toggle your system appearance.
+          This text should use <code>#94a3b8</code> (the correct dark muted
+          token), not fall back to an arbitrary grey.
+        </p>
+      </div>
+      <div class="ease-modal-footer-8565">
+        <button class="ease-btn-8565 ease-btn-secondary-8565" onclick="closeModal()">Cancel</button>
+        <button class="ease-btn-8565 ease-btn-primary-8565">Confirm</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function openModal() { document.getElementById('modalOverlay').style.display = 'grid'; }
+    function closeModal() { document.getElementById('modalOverlay').style.display = 'none'; }
+    document.getElementById('modalOverlay').addEventListener('click', function(e) {
+      if (e.target === this) closeModal();
+    });
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') { var m = document.getElementById('modalOverlay'); if (m.style.display !== 'none') closeModal(); }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/modal-text-muted-8565/style.css
+++ b/submissions/examples/modal-text-muted-8565/style.css
@@ -1,0 +1,188 @@
+/* ============================================================
+   EaseMotion CSS — Fix non-existent --ease-color-text-muted
+   Issue #8565 — Replace with correct --ease-color-muted token
+   ============================================================ */
+
+@layer easemotion-components {
+
+/* ── Modal overlay & base ───────────────────────────── */
+
+.ease-modal-overlay-8565 {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  padding: 1rem;
+}
+
+.ease-modal-8565 {
+  background: var(--ease-color-surface, #fff);
+  border-radius: var(--ease-radius-lg, 12px);
+  box-shadow: var(--ease-shadow-xl, 0 20px 60px rgba(0, 0, 0, 0.15));
+  max-width: 480px;
+  width: 100%;
+  max-height: calc(100vh - 2rem);
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-modal-header-8565 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem);
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.ease-modal-header-8565 h2 {
+  margin: 0;
+  font-size: var(--ease-text-lg, 1.125rem);
+  font-weight: 700;
+  color: var(--ease-color-text, #1e293b);
+}
+
+.ease-modal-close-8565 {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: var(--ease-radius-md, 8px);
+  background: transparent;
+  color: var(--ease-color-muted);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  font-size: 1.25rem;
+  transition: background 0.2s;
+}
+
+.ease-modal-close-8565:hover {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+}
+
+/* ── Body — uses --ease-color-muted (FIX for #8565) ── */
+.ease-modal-body-8565 {
+  padding: var(--ease-space-6, 1.5rem);
+  color: var(--ease-color-muted, #64748b);
+  line-height: 1.6;
+  overflow-y: auto;
+}
+
+.ease-modal-body-8565 p {
+  margin: 0 0 var(--ease-space-4, 1rem) 0;
+}
+
+.ease-modal-body-8565 p:last-child {
+  margin-bottom: 0;
+}
+
+.ease-modal-footer-8565 {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem);
+  border-top: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.ease-modal-footer-8565 .ease-btn-8565 {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: var(--ease-radius-md, 8px);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.15s;
+}
+
+.ease-modal-footer-8565 .ease-btn-8565:active {
+  transform: scale(0.97);
+}
+
+.ease-btn-secondary-8565 {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  color: var(--ease-color-text, #1e293b);
+}
+
+.ease-btn-primary-8565 {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+
+/* ── Badge line (issue reference) ─────────────────── */
+.bug-badge {
+  display: inline-block;
+  background: #ef4444;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  vertical-align: middle;
+  margin-left: 0.5rem;
+}
+
+/* ── Demo page ───────────────────────────────────── */
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  min-height: 100vh;
+}
+
+.demo-header { max-width: 640px; margin: 0 auto 1.5rem; }
+.demo-header h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.demo-header p { color: var(--ease-color-muted, #64748b); font-size: 0.9rem; }
+code {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+pre code {
+  display: block;
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  background: #1e293b;
+  color: #e2e8f0;
+  border-radius: 8px;
+  margin: 0.5rem 0;
+  font-size: 0.8rem;
+}
+
+.card {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 12px;
+  padding: 1.5rem;
+  max-width: 640px;
+  margin: 0 auto 1rem;
+}
+
+.open-btn {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+  border: none;
+  padding: 0.65rem 1.5rem;
+  border-radius: var(--ease-radius-md, 8px);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.15s;
+}
+.open-btn:hover { background: var(--ease-color-primary-hover, #5a52e0); }
+.open-btn:active { transform: scale(0.97); }
+
+@media (prefers-color-scheme: dark) {
+  .ease-modal-8565 { background: var(--ease-color-surface, #1e293b); }
+  .ease-modal-header-8565 { border-color: #334155; }
+  .ease-modal-footer-8565 { border-color: #334155; }
+  .ease-modal-close-8565:hover { background: #334155; }
+  .ease-modal-body-8565 { color: var(--ease-color-muted, #94a3b8); }
+  .card { background: var(--ease-color-surface, #1e293b); border-color: #334155; }
+  pre code { background: #0f172a; }
+}
+
+}


### PR DESCRIPTION
### Description

`components/modals.css:127` references `var(--ease-color-text-muted, #4b5563)` but `--ease-color-text-muted` is never defined anywhere in the codebase. This submission demonstrates the fix: replacing it with `var(--ease-color-muted, #64748b)`, the correct framework token.

### Related Issue

Fixes #8565

### Proposed Changes

- `submissions/examples/modal-text-muted-8565/` — self-contained demo with the corrected CSS variable