### PR TITLE
Fix: Increase navbar logo size for better visibility

### DIFF
--- a/submissions/examples/navbar-logo-fix-swastik/README.md
+++ b/submissions/examples/navbar-logo-fix-swastik/README.md
@@ -1,0 +1,13 @@
+# Navbar Logo Size Fix
+
+## Issue
+The `.docs-logo-img` height in `docs/docs.css` is currently `36px`, making the logo appear too small and visually weak compared to the rest of the navbar branding.
+
+## Fix
+Increased `.docs-logo-img` height from `36px` to `52px` for better visibility and a more balanced look in the header, while keeping `width: auto` so the SVG scales proportionally without distortion.
+
+## Files
+- `style.css` — updated logo size rule
+- `demo.html` — preview of the navbar with the new logo size
+
+Closes #8583

--- a/submissions/examples/navbar-logo-fix-swastik/demo.html
+++ b/submissions/examples/navbar-logo-fix-swastik/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Navbar Logo Size Fix - Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background:#0b0f19; color:#fff; font-family:sans-serif; padding:20px;">
+  <header class="docs-header" style="display:flex; align-items:center; gap:12px; padding:10px 20px; border-bottom:1px solid #333;">
+    <a href="#" class="docs-logo">
+      <img src="../../../docs/assets/logo.svg" alt="EaseMotion CSS" class="docs-logo-img" />
+    </a>
+    <span>EaseMotion CSS</span>
+  </header>
+  <p style="margin-top:20px;">
+    This demo shows the navbar logo increased from <strong>36px</strong> to <strong>52px</strong> height,
+    making the branding more visible and proportionate in the header.
+  </p>
+</body>
+</html>

--- a/submissions/examples/navbar-logo-fix-swastik/style.css
+++ b/submissions/examples/navbar-logo-fix-swastik/style.css
@@ -1,0 +1,6 @@
+/* Fix: increase logo size for better visibility in navbar */
+.docs-logo-img {
+  height: 52px;
+  width: auto;
+  display: block;
+}


### PR DESCRIPTION
Closes #8583

   Increases the `.docs-logo-img` height from 36px to 52px for better visibility and proportion in the navbar, as proposed in this submission folder.