### PR TITLE
fix(cards): replace undefined --ease-color-text-dark with --ease-color-text (fix #8564)

### DIFF
--- a/submissions/examples/card-text-dark-8564/README.md
+++ b/submissions/examples/card-text-dark-8564/README.md
@@ -1,0 +1,14 @@
+# Glass card references non-existent --ease-color-text-dark (Issue #8564)
+
+## Problem
+
+`components/cards.css:180` uses `var(--ease-color-text-dark, #f8fafc)` but `--ease-color-text-dark` is never defined. In dark mode the glass card text falls back to `#f8fafc` instead of the correct `--ease-color-text: #e2e8f0`.
+
+## Fix
+
+Replace `var(--ease-color-text-dark, #f8fafc)` with `var(--ease-color-text, #e2e8f0)` — the proper framework token for text color in both light and dark mode.
+
+## Files
+
+- `style.css` — glass card component with corrected dark mode text color
+- `demo.html` — side-by-side comparison (glass + solid card)

--- a/submissions/examples/card-text-dark-8564/demo.html
+++ b/submissions/examples/card-text-dark-8564/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Card — Fix #8564 text-dark variable</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Glass Card Text Color Fix <code style="font-size:0.9rem">#8564</code></h1>
+    <p class="subtitle">
+      <code>--ease-color-text-dark</code> was undefined &mdash; replaced with
+      <code>--ease-color-text</code> for glass cards in dark mode.
+    </p>
+
+    <div class="info-box">
+      <strong>Test:</strong> Toggle your system appearance. Both cards below
+      should show readable text — the glass card uses <code>--ease-color-text</code>
+      (<code>#e2e8f0</code> in dark) instead of the wrong <code>#f8fafc</code> fallback.
+    </div>
+
+    <div class="card-row">
+      <div class="ease-card-glass-8564">
+        <h3>Glass Card</h3>
+        <p>
+          This text uses <code>var(--ease-color-text, #e2e8f0)</code> in dark mode
+          — the correct framework token.
+        </p>
+      </div>
+
+      <div class="ease-card-solid-8564">
+        <h3>Solid Card</h3>
+        <p>
+          Reference: this card also uses <code>--ease-color-text</code>.
+          Glass and solid text should match in dark mode.
+        </p>
+      </div>
+    </div>
+
+    <h2>What changed</h2>
+    <table style="width:100%; border-collapse: collapse; font-size: 0.85rem;">
+      <tr><th style="text-align:left;padding:0.5rem 0;border-bottom:1px solid var(--ease-color-neutral-200)">File</th>
+          <th style="text-align:left;padding:0.5rem 0;border-bottom:1px solid var(--ease-color-neutral-200)">Before</th>
+          <th style="text-align:left;padding:0.5rem 0;border-bottom:1px solid var(--ease-color-neutral-200)">After</th></tr>
+      <tr>
+        <td style="padding:0.5rem 0"><code>components/cards.css:180</code></td>
+        <td style="padding:0.5rem 0"><span class="diff-remove"><code>var(--ease-color-text-dark, #f8fafc)</code></span></td>
+        <td style="padding:0.5rem 0"><span class="diff-add"><code>var(--ease-color-text, #e2e8f0)</code></span></td>
+      </tr>
+    </table>
+
+    <h2>Code</h2>
+    <pre><code>@media (prefers-color-scheme: dark) {
+  .ease-card-glass {
+    --ease-glass-bg: color-mix(in srgb, var(--ease-color-surface) 50%, transparent);
+    color: <del style="color:#f87171;">var(--ease-color-text-dark, #f8fafc)</del>
+           <ins style="color:#4ade80;">var(--ease-color-text, #e2e8f0)</ins>;
+  }
+}</code></pre>
+  </div>
+</body>
+</html>

--- a/submissions/examples/card-text-dark-8564/style.css
+++ b/submissions/examples/card-text-dark-8564/style.css
@@ -1,0 +1,118 @@
+/* ============================================================
+   EaseMotion CSS — Fix non-existent --ease-color-text-dark
+   Issue #8564 — Replace with correct --ease-color-text token
+   ============================================================ */
+
+@layer easemotion-components {
+
+/* ── Glass card with corrected dark mode text ──── */
+.ease-card-glass-8564 {
+  position: relative;
+  background: var(--ease-glass-bg, rgba(255, 255, 255, 0.7));
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--ease-color-neutral-200, rgba(226, 232, 240, 0.5));
+  border-radius: var(--ease-radius-xl, 16px);
+  padding: 1.5rem;
+  color: var(--ease-color-text, #1e293b);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  box-shadow: var(--ease-shadow-md, 0 4px 12px rgba(0, 0, 0, 0.06));
+}
+
+.ease-card-glass-8564:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--ease-shadow-lg, 0 12px 32px rgba(0, 0, 0, 0.1));
+}
+
+.ease-card-glass-8564 h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.ease-card-glass-8564 p {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
+/* ── Dark mode: use --ease-color-text (not undefined --ease-color-text-dark) ── */
+@media (prefers-color-scheme: dark) {
+  .ease-card-glass-8564 {
+    --ease-glass-bg: color-mix(in srgb, var(--ease-color-surface, #1e293b) 50%, transparent);
+    color: var(--ease-color-text, #e2e8f0);
+    border-color: rgba(51, 65, 85, 0.5);
+  }
+}
+
+/* ── Light card for context ───────────────────── */
+.ease-card-solid-8564 {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-xl, 16px);
+  padding: 1.5rem;
+  color: var(--ease-color-text, #1e293b);
+  box-shadow: var(--ease-shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.08));
+}
+
+.ease-card-solid-8564 h3 { margin: 0 0 0.5rem; font-size: 1.125rem; font-weight: 700; }
+.ease-card-solid-8564 p { margin: 0; font-size: 0.875rem; line-height: 1.6; opacity: 0.85; }
+
+@media (prefers-color-scheme: dark) {
+  .ease-card-solid-8564 { background: var(--ease-color-surface, #1e293b); border-color: #334155; color: var(--ease-color-text, #e2e8f0); }
+}
+
+/* ── Demo page ────────────────────────────────── */
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  min-height: 100vh;
+}
+
+.container { max-width: 700px; margin: 0 auto; }
+
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+h2 { font-size: 1rem; margin: 1.5rem 0 0.75rem; }
+p.subtitle { color: var(--ease-color-muted, #64748b); font-size: 0.9rem; margin-bottom: 1.5rem; }
+code {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+pre code {
+  display: block;
+  padding: 0.75rem 1rem;
+  background: #1e293b;
+  color: #e2e8f0;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  overflow-x: auto;
+}
+
+.card-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+@media (max-width: 600px) { .card-row { grid-template-columns: 1fr; } }
+
+.info-box {
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.85rem;
+  color: #92400e;
+  margin: 1rem 0;
+}
+
+.diff-remove { color: #f87171; }
+.diff-add { color: #4ade80; }
+
+@media (prefers-color-scheme: dark) {
+  pre code { background: #0f172a; }
+  .info-box { background: #422006; border-color: #a16207; color: #fde68a; }
+  code { background: #334155; color: #e2e8f0; }
+}
+
+}


### PR DESCRIPTION
### Description

`components/cards.css:180` references `var(--ease-color-text-dark, #f8fafc)` which is never defined anywhere in the codebase. This submission replaces it with `var(--ease-color-text, #e2e8f0)` — the correct framework token.

### Related Issue

Fixes #8564

### Proposed Changes

- `submissions/examples/card-text-dark-8564/` — glass card demo with corrected dark mode text color