### PR TITLE
Add starting-style-dialog example

### DIFF
--- a/submissions/examples/starting-style-dialog/README.md
+++ b/submissions/examples/starting-style-dialog/README.md
@@ -1,0 +1,13 @@
+# Starting Style Dialog
+
+## What
+
+A `<dialog>` element that opens with a smooth fade-and-scale animation using `@starting-style` and `transition-behavior: allow-discrete`. The backdrop also transitions in. The entire animation is guarded by `@supports` and degrades gracefully.
+
+## How
+
+The dialog uses CSS transitions on `opacity`, `transform`, `overlay`, and `display`. `@starting-style` defines the initial state when the element first renders (i.e., when `open` is added). `transition-behavior: allow-discrete` enables animating discrete properties like `overlay` and `display`. A `@supports` check prevents the animation from breaking in non-supporting browsers.
+
+## Why
+
+`@starting-style` solves the problem of animating elements on first render — previously only possible with JavaScript. Combined with `allow-discrete`, it makes `<dialog>` open/close animations declarative, reducing JS boilerplate while keeping animations accessible via `prefers-reduced-motion`.

--- a/submissions/examples/starting-style-dialog/demo.html
+++ b/submissions/examples/starting-style-dialog/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Starting Style Dialog</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="wrapper">
+    <h1>@starting-style Dialog</h1>
+    <p>Click to open a dialog with a smooth entrance animation.</p>
+    <button id="open-dialog" class="open-btn">Open Dialog</button>
+  </div>
+
+  <dialog id="demo-dialog">
+    <div class="dialog-content">
+      <h2>Hello from the Dialog!</h2>
+      <p>This dialog animates in using <code>@starting-style</code> combined with <code>transition-behavior: allow-discrete</code>. When opened, it fades and scales into view.</p>
+      <p>The backdrop also transitions smoothly, and the whole thing is guarded by a <code>@supports</code> check.</p>
+      <button id="close-dialog" class="close-btn">Close</button>
+    </div>
+  </dialog>
+
+  <script>
+    const dialog = document.getElementById('demo-dialog');
+    const openBtn = document.getElementById('open-dialog');
+    const closeBtn = document.getElementById('close-dialog');
+
+    openBtn.addEventListener('click', () => dialog.showModal());
+    closeBtn.addEventListener('click', () => dialog.close());
+  </script>
+</body>
+</html>

--- a/submissions/examples/starting-style-dialog/style.css
+++ b/submissions/examples/starting-style-dialog/style.css
@@ -1,0 +1,175 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: #0d0d0d;
+  color: #e0e0e0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wrapper {
+  text-align: center;
+  padding: 2rem;
+}
+
+.wrapper h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #f7971e, #ffd200);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.wrapper p {
+  color: #999;
+  margin-bottom: 1.5rem;
+}
+
+.open-btn {
+  padding: 0.8rem 2rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #f7971e, #ffd200);
+  color: #1a1a1a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.open-btn:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 20px rgba(247, 151, 30, 0.4);
+}
+
+dialog {
+  padding: 0;
+  border: none;
+  border-radius: 16px;
+  background: #1a1a2e;
+  color: #e0e0e0;
+  max-width: 480px;
+  width: 90vw;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.8);
+  overflow: visible;
+}
+
+dialog::backdrop {
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+}
+
+.dialog-content {
+  padding: 2rem;
+}
+
+.dialog-content h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: #fff;
+}
+
+.dialog-content p {
+  margin-bottom: 1rem;
+  color: #aaa;
+  line-height: 1.6;
+}
+
+.dialog-content code {
+  background: #2a2a4a;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.9em;
+  color: #ffd200;
+}
+
+.close-btn {
+  padding: 0.6rem 1.5rem;
+  font-size: 0.95rem;
+  border: none;
+  border-radius: 8px;
+  background: #2a2a4a;
+  color: #e0e0e0;
+  cursor: pointer;
+  transition: background 0.2s;
+  margin-top: 0.5rem;
+}
+
+.close-btn:hover {
+  background: #3a3a5a;
+}
+
+@supports (transition-behavior: allow-discrete) {
+  dialog {
+    transition: opacity 0.3s ease, transform 0.3s ease, overlay 0.3s ease, display 0.3s ease;
+    transition-behavior: allow-discrete;
+    opacity: 0;
+    transform: scale(0.85);
+    overlay: auto;
+  }
+
+  dialog[open] {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  @starting-style {
+    dialog[open] {
+      opacity: 0;
+      transform: scale(0.85);
+    }
+  }
+
+  dialog::backdrop {
+    transition: opacity 0.3s ease, overlay 0.3s ease, display 0.3s ease;
+    transition-behavior: allow-discrete;
+    opacity: 0;
+  }
+
+  dialog[open]::backdrop {
+    opacity: 1;
+  }
+
+  @starting-style {
+    dialog[open]::backdrop {
+      opacity: 0;
+    }
+  }
+}
+
+@supports not (transition-behavior: allow-discrete) {
+  dialog[open] {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  dialog:not([open]) {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+}
+
+dialog:not([open]) {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  dialog {
+    transition: none !important;
+    transform: none !important;
+    opacity: 1 !important;
+  }
+
+  dialog::backdrop {
+    transition: none !important;
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained example under \submissions/examples/starting-style-dialog/\ demonstrating modern CSS techniques.

## Files
- \demo.html\ - Demo page
- \style.css\ - Styles and animations
- \README.md\ - Documentation

Closes #8619