### PR TITLE
Add container-query-typography example

### DIFF
--- a/submissions/examples/container-query-typography/README.md
+++ b/submissions/examples/container-query-typography/README.md
@@ -1,0 +1,10 @@
+# Container Query Typography
+
+## What
+Demonstrates responsive typography inside cards using CSS Container Queries. Cards resize based on a slider, and their font sizes, padding, and badge styles adapt at container breakpoints (300px, 450px).
+
+## How
+Each card has `container-type: inline-size` set. `@container` queries target different width ranges (`min-width: 300px`, `min-width: 450px`) to scale headings, body text, and spacing. The `cqw` unit is used for the badge font size. JavaScript adjusts each card's `width` via an inline style bound to a range slider.
+
+## Why
+Container Queries allow components to be truly self-contained and responsive without depending on the viewport. This is essential for design systems and reusable components that must work in any layout context.

--- a/submissions/examples/container-query-typography/demo.html
+++ b/submissions/examples/container-query-typography/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Container Query Typography</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Container Query Typography</h1>
+    <p class="subtitle">Resize the cards below to see responsive typography in action.</p>
+
+    <label for="width-slider">Card Width: <span id="width-value">300px</span></label>
+    <input type="range" id="width-slider" min="180" max="600" value="300" step="10">
+
+    <div class="card-grid">
+      <div class="card" id="card-1">
+        <span class="badge">Featured</span>
+        <h2>Container Queries</h2>
+        <p>CSS Container Queries let elements respond to their container's size rather than the viewport.</p>
+      </div>
+      <div class="card" id="card-2">
+        <span class="badge">New</span>
+        <h2>Responsive Typography</h2>
+        <p>Font sizes, line heights, and spacing adapt seamlessly as the container grows or shrinks.</p>
+      </div>
+      <div class="card" id="card-3">
+        <span class="badge">Pro Tip</span>
+        <h2>CQW Units</h2>
+        <p>Use <code>cqw</code>, <code>cqi</code>, and other container-relative units for fine-grained control.</p>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const slider = document.getElementById('width-slider');
+    const widthValue = document.getElementById('width-value');
+    const cards = document.querySelectorAll('.card');
+
+    slider.addEventListener('input', () => {
+      const val = slider.value;
+      widthValue.textContent = val + 'px';
+      cards.forEach(card => {
+        card.style.width = val + 'px';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/container-query-typography/style.css
+++ b/submissions/examples/container-query-typography/style.css
@@ -1,0 +1,169 @@
+/* ===== Container Query Typography Demo ===== */
+
+/* ---------- Reset & Variables ---------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  color-scheme: dark;
+  --bg: #0d0f14;
+  --surface: #1a1d27;
+  --surface-alt: #242836;
+  --text: #e4e6ed;
+  --text-muted: #8b8fa3;
+  --accent: #7c93ff;
+  --accent-glow: #7c93ff33;
+  --radius: 12px;
+  --transition: 0.3s ease;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main {
+  width: 100%;
+  max-width: 900px;
+  text-align: center;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  margin-bottom: 2rem;
+}
+
+/* ---------- Slider ---------- */
+label {
+  display: block;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+input[type="range"] {
+  width: 300px;
+  max-width: 100%;
+  accent-color: var(--accent);
+  margin-bottom: 2.5rem;
+}
+
+/* ---------- Card Grid ---------- */
+.card-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+/* ---------- Cards (Containers) ---------- */
+.card {
+  container-type: inline-size;
+  container-name: card;
+  background: var(--surface);
+  border: 1px solid var(--surface-alt);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  width: 300px;
+  transition: width var(--transition), background var(--transition);
+}
+
+.card:hover {
+  background: var(--surface-alt);
+}
+
+/* ---------- Badge ---------- */
+.badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: var(--accent-glow);
+  color: var(--accent);
+  margin-bottom: 0.75rem;
+}
+
+/* ---------- Default (small) card styles ---------- */
+.card h2 {
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.3;
+}
+
+.card p {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.card code {
+  font-size: 0.85em;
+  background: var(--surface-alt);
+  padding: 0.1em 0.3em;
+  border-radius: 4px;
+}
+
+/* ---------- Container Query: >= 300px (medium+) ---------- */
+@container card (min-width: 300px) {
+  .card h2 {
+    font-size: 1.5rem;
+  }
+
+  .card p {
+    font-size: 1rem;
+  }
+
+  .badge {
+    font-size: 0.8rem;
+    padding: 0.3rem 0.8rem;
+  }
+
+  .card {
+    padding: 2rem;
+  }
+}
+
+/* ---------- Container Query: >= 450px (large) ---------- */
+@container card (min-width: 450px) {
+  .card h2 {
+    font-size: 1.8rem;
+  }
+
+  .card p {
+    font-size: 1.1rem;
+  }
+
+  .card {
+    padding: 2.5rem;
+  }
+}
+
+/* ---------- CQW unit demo ---------- */
+.card .badge {
+  font-size: clamp(0.65rem, 2cqw, 0.9rem);
+}
+
+/* ---------- Reduced Motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained example under \submissions/examples/container-query-typography/\ demonstrating modern CSS techniques.

## Files
- \demo.html\ - Demo page
- \style.css\ - Styles and animations
- \README.md\ - Documentation

Closes #8622