### PR TITLE
Add anchor-popover-tooltip example

### DIFF
--- a/submissions/examples/anchor-popover-tooltip/README.md
+++ b/submissions/examples/anchor-popover-tooltip/README.md
@@ -1,0 +1,13 @@
+# Anchor Popover Tooltip
+
+## What
+
+Three buttons with `popover` tooltips positioned using the CSS Anchor Positioning API. Each tooltip uses `anchor-name`, `anchor()`, and `position-try-options` to smartly position itself relative to its target button. A `@supports` guard and fallback ensure it works everywhere.
+
+## How
+
+Each button gets a unique `anchor-name` (e.g. `--btn-top`). The corresponding tooltip uses `position-anchor` to reference it and `anchor()` functions to set `top`, `left`, etc. `position-try-options: flip-block, flip-inline` enables automatic repositioning when space runs low. JavaScript toggles `showPopover()`/`hidePopover()` on hover/focus. The fallback uses manual positioning.
+
+## Why
+
+Anchor Positioning replaces JavaScript-based tooltip libraries with a native CSS solution. `position-try-options` handles edge cases like viewport edges automatically. By layering `popover`, tooltips get the right z-index and top-layer behavior without extra code. The `@supports` check provides a clean fallback path.

--- a/submissions/examples/anchor-popover-tooltip/demo.html
+++ b/submissions/examples/anchor-popover-tooltip/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Anchor Popover Tooltip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="wrapper">
+    <h1>CSS Anchor Positioning Tooltips</h1>
+    <p>Hover or focus each button to see its tooltip via <code>popover</code> + anchor positioning.</p>
+    <div class="demo-group">
+      <div class="anchor-container">
+        <button class="anchor-btn" id="btn-top" popovertarget="tip-top" popovertargetaction="show">
+          Top
+        </button>
+        <div id="tip-top" class="tooltip" popover anchor="btn-top">I'm anchored to the top!</div>
+      </div>
+
+      <div class="anchor-container">
+        <button class="anchor-btn" id="btn-bottom" popovertarget="tip-bottom" popovertargetaction="show">
+          Bottom
+        </button>
+        <div id="tip-bottom" class="tooltip" popover anchor="btn-bottom">Anchored to the bottom!</div>
+      </div>
+
+      <div class="anchor-container">
+        <button class="anchor-btn" id="btn-right" popovertarget="tip-right" popovertargetaction="show">
+          Right
+        </button>
+        <div id="tip-right" class="tooltip" popover anchor="btn-right">Anchored to the right!</div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.anchor-btn').forEach(btn => {
+      const tipId = btn.getAttribute('popovertarget');
+      const tip = document.getElementById(tipId);
+      btn.addEventListener('mouseenter', () => tip?.showPopover());
+      btn.addEventListener('mouseleave', () => tip?.hidePopover());
+      btn.addEventListener('focus', () => tip?.showPopover());
+      btn.addEventListener('blur', () => tip?.hidePopover());
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/anchor-popover-tooltip/style.css
+++ b/submissions/examples/anchor-popover-tooltip/style.css
@@ -1,0 +1,166 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: #0d0d0d;
+  color: #e0e0e0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wrapper {
+  text-align: center;
+  padding: 2rem;
+  max-width: 700px;
+}
+
+.wrapper h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #00bcd4, #7c4dff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.wrapper p {
+  color: #999;
+  margin-bottom: 2rem;
+}
+
+.demo-group {
+  display: flex;
+  gap: 3rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.anchor-container {
+  position: relative;
+}
+
+.anchor-btn {
+  padding: 0.8rem 1.8rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #00bcd4, #7c4dff);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  anchor-name: --anchor-btn;
+}
+
+.anchor-btn:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 20px rgba(0, 188, 212, 0.4);
+}
+
+@supports (anchor-name: --x) {
+  .tooltip {
+    position: absolute;
+    position-anchor: --anchor-btn;
+    top: anchor(--anchor-btn bottom);
+    left: anchor(--anchor-btn center);
+    translate: -50% 8px;
+    background: #1a1a2e;
+    color: #e0e0e0;
+    padding: 0.6rem 1rem;
+    border-radius: 8px;
+    border: 1px solid #2a2a4a;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+    pointer-events: none;
+    transition: opacity 0.2s, transform 0.2s;
+    position-try-options: flip-block, flip-inline;
+  }
+
+  #btn-top {
+    anchor-name: --btn-top;
+  }
+
+  #tip-top {
+    position-anchor: --btn-top;
+    bottom: anchor(--btn-top top);
+    top: auto;
+    left: anchor(--btn-top center);
+    translate: -50% -8px;
+  }
+
+  #btn-bottom {
+    anchor-name: --btn-bottom;
+  }
+
+  #tip-bottom {
+    position-anchor: --btn-bottom;
+    top: anchor(--btn-bottom bottom);
+    left: anchor(--btn-bottom center);
+    translate: -50% 8px;
+  }
+
+  #btn-right {
+    anchor-name: --btn-right;
+  }
+
+  #tip-right {
+    position-anchor: --btn-right;
+    left: anchor(--btn-right right);
+    top: anchor(--btn-right center);
+    translate: 8px -50%;
+  }
+}
+
+.tooltip {
+  display: none;
+  z-index: 50;
+}
+
+.tooltip:popover-open {
+  display: block;
+}
+
+@supports not (anchor-name: --x) {
+  .anchor-container {
+    position: relative;
+  }
+
+  .tooltip {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 50%;
+    translate: -50% 0;
+    background: #1a1a2e;
+    color: #e0e0e0;
+    padding: 0.4rem 0.8rem;
+    border-radius: 6px;
+    border: 1px solid #2a2a4a;
+    font-size: 0.85rem;
+    white-space: nowrap;
+    pointer-events: none;
+  }
+
+  .anchor-container:first-child .tooltip {
+    bottom: calc(100% + 8px);
+    top: auto;
+  }
+
+  .anchor-container:last-child .tooltip {
+    left: calc(100% + 8px);
+    top: 50%;
+    translate: 0 -50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained example under \submissions/examples/anchor-popover-tooltip/\ demonstrating modern CSS techniques.

## Files
- \demo.html\ - Demo page
- \style.css\ - Styles and animations
- \README.md\ - Documentation

Closes #8624