### PR TITLE
Add interpolate-size-accordion example

### DIFF
--- a/submissions/examples/interpolate-size-accordion/README.md
+++ b/submissions/examples/interpolate-size-accordion/README.md
@@ -1,0 +1,11 @@
+## What
+
+A CSS-only accordion component demonstrating `interpolate-size: allow-keywords`, which enables smooth CSS transitions between numeric lengths (like `0`) and keyword values (like `auto`). Three clickable sections expand and collapse with a fluid height animation.
+
+## How
+
+Set `interpolate-size: allow-keywords` on the accordion body element, then toggle `height` between `0` and `auto` via JavaScript (or a CSS class). The browser interpolates the keyword value as if it were a numeric length. A `@supports (interpolate-size: allow-keywords)` guard provides progressive enhancement, and a `prefers-reduced-motion` media query disables all animation for accessibility.
+
+## Why
+
+Historically, animating to `height: auto` required brittle JavaScript that measured pixel offsets. `interpolate-size: allow-keywords` delegates this to the browser, producing smoother, more accessible, and more maintainable expand/collapse interactions without hacks or external dependencies.

--- a/submissions/examples/interpolate-size-accordion/demo.html
+++ b/submissions/examples/interpolate-size-accordion/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>interpolate-size: allow-keywords — Smooth Accordion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>CSS <code>interpolate-size: allow-keywords</code></h1>
+    <p class="subtitle">Smooth <code>height: auto</code> accordion transitions</p>
+
+    <div class="accordion">
+      <section class="accordion-section">
+        <button class="accordion-trigger" aria-expanded="true">
+          <span>What is interpolate-size?</span>
+          <span class="chevron" aria-hidden="true">&#9660;</span>
+        </button>
+        <div class="accordion-body" style="height: auto;">
+          <div class="accordion-content">
+            <p><code>interpolate-size</code> is a CSS property that allows keyword values like <code>auto</code>, <code>fit-content</code>, <code>max-content</code>, and <code>min-content</code> to participate in CSS transitions and animations. By default, CSS cannot animate to or from these keyword values.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="accordion-section">
+        <button class="accordion-trigger" aria-expanded="false">
+          <span>How does it work?</span>
+          <span class="chevron" aria-hidden="true">&#9660;</span>
+        </button>
+        <div class="accordion-body">
+          <div class="accordion-content">
+            <p>When you set <code>interpolate-size: allow-keywords</code> on an element, the browser can interpolate between a numeric length (like <code>0</code>) and a keyword value (like <code>auto</code>). This enables smooth open/close animations for elements with dynamic content sizes, without needing JavaScript to calculate exact pixel heights.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="accordion-section">
+        <button class="accordion-trigger" aria-expanded="false">
+          <span>Browser support</span>
+          <span class="chevron" aria-hidden="true">&#9660;</span>
+        </button>
+        <div class="accordion-body">
+          <div class="accordion-content">
+            <p>As of 2024, <code>interpolate-size: allow-keywords</code> is supported in Chromium-based browsers and Firefox. Safari support is coming. This demo uses <code>@supports</code> to provide a graceful fallback—instant expand/collapse without animation—for browsers that don't support it yet.</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.accordion-trigger').forEach(button => {
+      button.addEventListener('click', () => {
+        const expanded = button.getAttribute('aria-expanded') === 'true';
+        button.setAttribute('aria-expanded', !expanded);
+        const body = button.nextElementSibling;
+        if (!expanded) {
+          body.style.height = 'auto';
+        } else {
+          body.style.height = '0';
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/interpolate-size-accordion/style.css
+++ b/submissions/examples/interpolate-size-accordion/style.css
@@ -1,0 +1,169 @@
+/* ============================================================
+   Example 11: interpolate-size-accordion
+   CSS `interpolate-size: allow-keywords` — Smooth height: auto
+   ============================================================ */
+
+/* ---------- Reset & Base ---------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: #0a0f1e;
+  color: #e2e8f0;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+/* ---------- Container ---------- */
+.container {
+  max-width: 640px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+  letter-spacing: -0.025em;
+}
+
+h1 code {
+  font-weight: 600;
+}
+
+.subtitle {
+  color: #64748b;
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+}
+
+/* ---------- Accordion ---------- */
+.accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.accordion-section {
+  background: #131a2e;
+  border: 1px solid #1e2a45;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+/* ---------- Trigger Button ---------- */
+.accordion-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  background: none;
+  border: none;
+  color: #e2e8f0;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s ease;
+  font-family: inherit;
+}
+
+.accordion-trigger:hover {
+  background: hsl(218, 35%, 14%);
+}
+
+.accordion-trigger:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: -2px;
+}
+
+/* ---------- Chevron ---------- */
+.chevron {
+  font-size: 0.75rem;
+  color: #64748b;
+  transition: transform 0.3s ease;
+  flex-shrink: 0;
+}
+
+.accordion-trigger[aria-expanded="true"] .chevron {
+  transform: rotate(180deg);
+}
+
+/* ---------- Accordion Body (interpolate-size region) ---------- */
+.accordion-body {
+  height: 0;
+  overflow: hidden;
+  transition: height 0.35s ease;
+
+  /* ---- THE KEY PROPERTY ---- */
+  interpolate-size: allow-keywords;
+}
+
+.accordion-content {
+  padding: 0 1.25rem 1.25rem;
+}
+
+.accordion-content p {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  line-height: 1.7;
+}
+
+/* ---------- Progressive Enhancement via @supports ---------- */
+@supports (interpolate-size: allow-keywords) {
+  .accordion-body {
+    transition: height 0.35s ease;
+  }
+}
+
+/* ---------- Fallback: instant toggling ---------- */
+@supports not (interpolate-size: allow-keywords) {
+  .accordion-body {
+    transition: none;
+  }
+
+  .accordion-trigger[aria-expanded="false"] + .accordion-body {
+    height: 0;
+  }
+
+  .accordion-trigger[aria-expanded="true"] + .accordion-body {
+    height: auto;
+  }
+}
+
+/* ---------- prefers-reduced-motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .chevron {
+    transition: none;
+  }
+
+  .accordion-body {
+    transition: none;
+  }
+
+  .accordion-trigger[aria-expanded="false"] + .accordion-body {
+    height: 0;
+  }
+
+  .accordion-trigger[aria-expanded="true"] + .accordion-body {
+    height: auto;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained example under \submissions/examples/interpolate-size-accordion/\ demonstrating modern CSS techniques.

## Files
- \demo.html\ - Demo page
- \style.css\ - Styles and animations
- \README.md\ - Documentation

Closes #8672