### PR TITLE
Add field-sizing-input example

### DIFF
--- a/submissions/examples/field-sizing-input/README.md
+++ b/submissions/examples/field-sizing-input/README.md
@@ -1,0 +1,11 @@
+## What
+
+A form UI demonstrating `field-sizing: content`, which makes `input` and `textarea` elements automatically resize their width and height to fit their content. The example includes a single-line input that grows horizontally and a textarea that grows vertically up to a `max-height` limit, alongside a fallback textarea that uses a scrollbar.
+
+## How
+
+Apply `field-sizing: content` to the form field, then set `min-height`/`max-height` (or `min-width`/`max-width`) to constrain growth. A `@supports (field-sizing: content)` guard applies the property only on supporting browsers. On unsupported browsers, `field-sizing: fixed` (the default) keeps the element at its specified size with `overflow-y: auto` for scrolling.
+
+## Why
+
+Developers have long hacked auto-growing inputs via JavaScript that observes scrollHeight or contentEditable tricks. `field-sizing: content` provides native, performant, and accessible auto-sizing directly in CSS — reducing bundle weight, eliminating layout flicker, and simplifying form UX with no JS.

--- a/submissions/examples/field-sizing-input/demo.html
+++ b/submissions/examples/field-sizing-input/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>field-sizing: content — Auto-growing Inputs</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>CSS <code>field-sizing: content</code></h1>
+    <p class="subtitle">Auto-growing text inputs and textareas</p>
+
+    <form class="comment-form" novalidate>
+      <div class="form-group">
+        <label for="name">Your Name</label>
+        <input type="text" id="name" class="auto-grow-input" placeholder="e.g. Jane Doe" value="Jane Doe">
+      </div>
+
+      <div class="form-group">
+        <label for="subject">Subject</label>
+        <input type="text" id="subject" class="auto-grow-input" placeholder="What's this about?">
+      </div>
+
+      <div class="form-group">
+        <label for="message">Message</label>
+        <textarea id="message" class="auto-grow-textarea" placeholder="Write your message here..." rows="3">This is a demo of field-sizing: content. Start typing and the input and textarea will grow automatically!
+
+The textarea will expand as you add more lines, up to the max-height limit. This makes for a much more natural form experience.</textarea>
+      </div>
+
+      <div class="form-group">
+        <label for="bio">Short Bio (no field-sizing)</label>
+        <textarea id="bio" placeholder="Regular textarea with scrollbar" rows="3">This textarea does NOT use field-sizing. When content overflows, it shows a scrollbar instead.</textarea>
+      </div>
+
+      <button type="submit" class="submit-btn" disabled>Submit (demo only)</button>
+    </form>
+
+    <div class="note">
+      <p><strong>Note:</strong> <code>field-sizing: content</code> is supported in Chromium-based browsers (Chrome 122+, Edge 122+, Opera 108+). Firefox and Safari support is in development. The fallback shows a standard scrollbar.</p>
+    </div>
+  </div>
+
+  <script>
+    document.querySelector('.submit-btn').addEventListener('click', (e) => {
+      e.preventDefault();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/field-sizing-input/style.css
+++ b/submissions/examples/field-sizing-input/style.css
@@ -1,0 +1,221 @@
+/* ============================================================
+   Example 12: field-sizing-input
+   CSS `field-sizing: content` — Auto-growing text fields
+   ============================================================ */
+
+/* ---------- Reset & Base ---------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: #0a0f1e;
+  color: #e2e8f0;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+/* ---------- Container ---------- */
+.container {
+  max-width: 560px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+  letter-spacing: -0.025em;
+}
+
+h1 code {
+  font-weight: 600;
+}
+
+.subtitle {
+  color: #64748b;
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+}
+
+.note {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  background: #131a2e;
+  border: 1px solid #1e2a45;
+  border-radius: 0.5rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  line-height: 1.6;
+}
+
+.note strong {
+  color: #e2e8f0;
+}
+
+/* ---------- Form ---------- */
+.comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-group label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #94a3b8;
+  letter-spacing: 0.01em;
+}
+
+/* ---------- Field-sizing: content (progressive) ---------- */
+.auto-grow-input {
+  /* ---- THE KEY PROPERTY ---- */
+  field-sizing: content;
+
+  min-width: 100%;
+  max-width: 100%;
+  padding: 0.65rem 0.75rem;
+  background: #131a2e;
+  border: 1px solid #1e2a45;
+  border-radius: 0.375rem;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  font-family: inherit;
+  line-height: 1.5;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.auto-grow-textarea {
+  /* ---- THE KEY PROPERTY ---- */
+  field-sizing: content;
+
+  min-width: 100%;
+  max-width: 100%;
+  min-height: 4.5rem;
+  max-height: 16rem;
+  padding: 0.65rem 0.75rem;
+  background: #131a2e;
+  border: 1px solid #1e2a45;
+  border-radius: 0.375rem;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  font-family: inherit;
+  line-height: 1.5;
+  outline: none;
+  resize: none;
+  transition: border-color 0.2s ease;
+}
+
+.auto-grow-input::placeholder,
+.auto-grow-textarea::placeholder {
+  color: #475569;
+}
+
+.auto-grow-input:hover,
+.auto-grow-textarea:hover {
+  border-color: #334155;
+}
+
+.auto-grow-input:focus,
+.auto-grow-textarea:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+}
+
+/* ---------- @supports guard ---------- */
+@supports (field-sizing: content) {
+  .auto-grow-input,
+  .auto-grow-textarea {
+    field-sizing: content;
+  }
+}
+
+/* ---------- Fallback: overflow scroll ---------- */
+@supports not (field-sizing: content) {
+  .auto-grow-input,
+  .auto-grow-textarea {
+    field-sizing: fixed;
+    overflow-y: auto;
+  }
+
+  .auto-grow-textarea {
+    resize: vertical;
+  }
+}
+
+/* ---------- Non-field-sizing textarea (comparison) ---------- */
+#bio {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  background: #131a2e;
+  border: 1px solid #1e2a45;
+  border-radius: 0.375rem;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  font-family: inherit;
+  line-height: 1.5;
+  outline: none;
+  resize: vertical;
+  min-height: 4.5rem;
+  max-height: 16rem;
+  transition: border-color 0.2s ease;
+}
+
+#bio:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+}
+
+/* ---------- Submit Button ---------- */
+.submit-btn {
+  align-self: flex-start;
+  padding: 0.65rem 1.5rem;
+  background: #3b82f6;
+  color: #fff;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, opacity 0.2s ease;
+  font-family: inherit;
+}
+
+.submit-btn:hover {
+  background: #2563eb;
+}
+
+.submit-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.submit-btn:focus-visible {
+  outline: 2px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+/* ---------- prefers-reduced-motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained example under \submissions/examples/field-sizing-input/\ demonstrating modern CSS techniques.

## Files
- \demo.html\ - Demo page
- \style.css\ - Styles and animations
- \README.md\ - Documentation

Closes #8673