### PR TITLE
Add text-wrap-balance example

### DIFF
--- a/submissions/examples/text-wrap-balance/README.md
+++ b/submissions/examples/text-wrap-balance/README.md
@@ -1,0 +1,19 @@
+# CSS text-wrap: balance &amp; pretty
+
+## What does this do?
+
+Compares CSS `text-wrap: normal`, `text-wrap: balance`, and `text-wrap: pretty` side by side. A resizable container lets you see how each mode re-wraps the same content at different widths.
+
+## How is it used?
+
+```css
+.wrap-normal  { text-wrap: normal; }   /* default */
+.wrap-balance { text-wrap: balance; }   /* equalises line lengths */
+.wrap-pretty  { text-wrap: pretty; }    /* prevents orphans */
+```
+
+A range slider updates the container width, and the three columns reflow in real time. A mobile breakstack stacks the columns vertically on small screens.
+
+## Why is it useful?
+
+Default text-wrapping often leaves ragged right edges with awkward orphaned words. `text-wrap: balance` creates visually even lines ideal for headings, while `text-wrap: pretty` polishes the last line of paragraphs by avoiding single-word orphans. Both properties improve typographic quality with a single CSS declaration — no JavaScript line-counting needed.

--- a/submissions/examples/text-wrap-balance/demo.html
+++ b/submissions/examples/text-wrap-balance/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS text-wrap: balance &amp; pretty</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>text-wrap Modes</h1>
+    <p>See how <code>normal</code>, <code>balance</code>, and <code>pretty</code> affect the same headline.</p>
+  </header>
+
+  <div class="controls">
+    <label for="container-width">Container width: <span id="width-display">400</span>px</label>
+    <input type="range" id="container-width" min="200" max="600" value="400" step="10" />
+  </div>
+
+  <div class="triptych" id="triptych">
+    <section class="column">
+      <h2>normal</h2>
+      <p class="tag">Default word-wrap — no optimization</p>
+      <div class="card wrap-normal">
+        <h3>text-wrap: normal</h3>
+        <p>The quick brown fox jumps over the lazy dog near the banks of the river Thames in London, England.</p>
+      </div>
+    </section>
+
+    <section class="column">
+      <h2>balance</h2>
+      <p class="tag">Equalises line lengths for headings</p>
+      <div class="card wrap-balance">
+        <h3>text-wrap: balance</h3>
+        <p>The quick brown fox jumps over the lazy dog near the banks of the river Thames in London, England.</p>
+      </div>
+    </section>
+
+    <section class="column">
+      <h2>pretty</h2>
+      <p class="tag">Optimises the last line (no orphans)</p>
+      <div class="card wrap-pretty">
+        <h3>text-wrap: pretty</h3>
+        <p>The quick brown fox jumps over the lazy dog near the banks of the river Thames in London, England.</p>
+      </div>
+    </section>
+  </div>
+
+  <div class="info">
+    <p><strong>Tip:</strong> Resize the container or the browser window to see how each mode re-wraps differently.</p>
+    <p><code>balance</code> is best for short headings (&lt; 5 lines). <code>pretty</code> prevents single-word orphans on the last line.</p>
+  </div>
+
+  <footer>
+    <p>Requires Chrome 114+ or Firefox 121+. Falls back to <code>normal</code> in older browsers.</p>
+  </footer>
+
+  <script>
+    var slider = document.getElementById('container-width');
+    var display = document.getElementById('width-display');
+    var triptych = document.getElementById('triptych');
+
+    slider.addEventListener('input', function () {
+      var val = slider.value;
+      display.textContent = val;
+      triptych.style.maxWidth = val + 'px';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/text-wrap-balance/style.css
+++ b/submissions/examples/text-wrap-balance/style.css
@@ -1,0 +1,205 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  color-scheme: dark;
+  --bg: #0a0f1e;
+  --surface: #111827;
+  --surface-2: #1f2937;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --text-dim: #64748b;
+  --primary: #6c63ff;
+  --primary-glow: #a09af8;
+  --border: #1e293b;
+  --radius: 12px;
+  --font: system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--primary), var(--primary-glow));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+header p {
+  color: var(--text-muted);
+  margin-top: 0.4rem;
+  font-size: 0.9rem;
+}
+
+header code {
+  background: var(--surface-2);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+  width: 100%;
+  max-width: 500px;
+}
+
+.controls label {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.controls #width-display {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.controls input[type="range"] {
+  width: 100%;
+  accent-color: var(--primary);
+  background: var(--border);
+  height: 6px;
+  border-radius: 99px;
+  cursor: pointer;
+}
+
+.triptych {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+  width: 100%;
+  max-width: 400px;
+  transition: max-width 0.2s ease;
+}
+
+.column {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.column h2 {
+  font-size: 0.95rem;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.tag {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.25rem;
+}
+
+.card {
+  background: var(--surface-2);
+  border-radius: 8px;
+  padding: 1rem;
+  border: 1px solid var(--border);
+}
+
+.card h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--primary-glow);
+  margin-bottom: 0.5rem;
+  max-width: 100%;
+  transition: text-wrap 0.3s;
+}
+
+.card p {
+  font-size: 0.85rem;
+  color: var(--text);
+  line-height: 1.5;
+  max-width: 100%;
+  transition: text-wrap 0.3s;
+}
+
+.wrap-normal h3,
+.wrap-normal p {
+  text-wrap: normal;
+}
+
+.wrap-balance h3,
+.wrap-balance p {
+  text-wrap: balance;
+}
+
+.wrap-pretty h3,
+.wrap-pretty p {
+  text-wrap: pretty;
+}
+
+.info {
+  max-width: 680px;
+  margin-top: 1.5rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.info strong {
+  color: var(--text);
+}
+
+.info code {
+  background: var(--surface-2);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  color: var(--primary-glow);
+}
+
+footer {
+  margin-top: 1.5rem;
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+@media (max-width: 700px) {
+  .triptych {
+    grid-template-columns: 1fr;
+    max-width: 100% !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .triptych,
+  .card h3,
+  .card p {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained example under \submissions/examples/text-wrap-balance/\ demonstrating modern CSS techniques.

## Files
- \demo.html\ - Demo page
- \style.css\ - Styles and animations
- \README.md\ - Documentation

Closes #8680