### PR TITLE
feat(examples): accent-color themed form controls (fix #8681)

### DIFF
--- a/submissions/examples/accent-color-forms-8681/README.md
+++ b/submissions/examples/accent-color-forms-8681/README.md
@@ -1,0 +1,30 @@
+# accent-color Themed Form Controls (Issue #8681)
+
+## Description
+
+A self-contained example demonstrating CSS `accent-color` for theming native form controls — checkboxes, radios, range sliders, progress bars, meters, and select menus — with a live color picker to dynamically change the accent color.
+
+## Features
+
+- Checkboxes (checked, unchecked, disabled)
+- Radio buttons (selected, unselected, disabled)
+- Range slider with live value display
+- Progress bar and meter elements
+- Select dropdown
+- Color picker to change accent color in real time
+- Dark mode support
+
+## CSS highlight
+
+```css
+.theme-8681 {
+  accent-color: #6c63ff;
+}
+```
+
+A single property on any ancestor themes all supported form controls.
+
+## Files
+
+- `style.css` — styling for the demo page and form control layout
+- `demo.html` — interactive demo with live color picker

--- a/submissions/examples/accent-color-forms-8681/demo.html
+++ b/submissions/examples/accent-color-forms-8681/demo.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>accent-color Themed Form Controls (#8681)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="theme-8681" id="themeRoot">
+  <div class="container">
+    <h1><code>accent-color</code> Themed Form Controls</h1>
+    <p class="sub">
+      Use a single CSS property &mdash; <code>accent-color</code> &mdash; to theme
+      native form controls. Pick a color below to see it applied instantly.
+    </p>
+
+    <div class="card">
+      <div class="color-picker-8681">
+        <label for="accentPicker">Accent color:</label>
+        <input type="color" id="accentPicker" value="#6c63ff">
+        <span class="color-hex-8681" id="hexDisplay">#6c63ff</span>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Checkboxes</h2>
+      <div class="form-group-8681">
+        <label class="form-row-8681">
+          <input type="checkbox" checked> Option A
+        </label>
+        <label class="form-row-8681">
+          <input type="checkbox"> Option B
+        </label>
+        <label class="form-row-8681">
+          <input type="checkbox" checked> Option C
+        </label>
+        <label class="form-row-8681">
+          <input type="checkbox" disabled> Disabled
+        </label>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Radio Buttons</h2>
+      <div class="form-group-8681">
+        <label class="form-row-8681">
+          <input type="radio" name="radioGroup" checked> Small
+        </label>
+        <label class="form-row-8681">
+          <input type="radio" name="radioGroup"> Medium
+        </label>
+        <label class="form-row-8681">
+          <input type="radio" name="radioGroup"> Large
+        </label>
+        <label class="form-row-8681">
+          <input type="radio" name="radioGroup" disabled> Extra Large (disabled)
+        </label>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Range Slider</h2>
+      <div class="range-row-8681">
+        <input type="range" min="0" max="100" value="65" id="rangeSlider" class="theme-8681">
+        <span class="range-value-8681" id="rangeValue">65</span>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Progress &amp; Meter</h2>
+      <div class="progress-row-8681">
+        <label style="font-size:0.85rem;font-weight:600">Progress</label>
+        <progress value="70" max="100" class="theme-8681"></progress>
+        <label style="font-size:0.85rem;font-weight:600;margin-top:0.5rem">Meter</label>
+        <meter value="0.6" min="0" max="1" low="0.3" high="0.8" optimum="0.9" class="theme-8681"></meter>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Select Menu</h2>
+      <select class="theme-8681" style="width:100%">
+        <option>Option 1</option>
+        <option selected>Option 2</option>
+        <option>Option 3</option>
+      </select>
+    </div>
+
+    <div class="card">
+      <h2>Code</h2>
+      <pre><code>/* Single line themes all native form controls */
+.theme-8681 {
+  accent-color: #6c63ff;
+}
+
+&lt;!-- Apply to any ancestor --&gt;
+&lt;body class="theme-8681"&gt;
+  &lt;input type="checkbox" checked&gt;
+  &lt;input type="radio" checked&gt;
+  &lt;input type="range"&gt;
+  &lt;progress value="70" max="100"&gt;&lt;/progress&gt;
+  &lt;meter value="0.6"&gt;&lt;/meter&gt;
+&lt;/body&gt;</code></pre>
+    </div>
+  </div>
+
+  <script>
+    const picker = document.getElementById('accentPicker');
+    const hexDisplay = document.getElementById('hexDisplay');
+    const themeRoot = document.getElementById('themeRoot');
+    const rangeSlider = document.getElementById('rangeSlider');
+    const rangeValue = document.getElementById('rangeValue');
+
+    picker.addEventListener('input', () => {
+      const color = picker.value;
+      themeRoot.style.accentColor = color;
+      hexDisplay.textContent = color;
+    });
+
+    rangeSlider.addEventListener('input', () => {
+      rangeValue.textContent = rangeSlider.value;
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/accent-color-forms-8681/style.css
+++ b/submissions/examples/accent-color-forms-8681/style.css
@@ -1,0 +1,161 @@
+/* ============================================================
+   EaseMotion CSS — accent-color Themed Form Controls
+   Issue #8681 — Demo of CSS accent-color theming
+   ============================================================ */
+
+@layer easemotion-components {
+
+/* ── Demo page ───────────────────────────────────── */
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  min-height: 100vh;
+}
+
+.container { max-width: 640px; margin: 0 auto; }
+
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+p.sub { color: var(--ease-color-muted, #64748b); font-size: 0.9rem; margin-bottom: 1.5rem; }
+code {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+pre code {
+  display: block;
+  padding: 0.75rem 1rem;
+  background: #1e293b;
+  color: #e2e8f0;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  overflow-x: auto;
+}
+
+.card {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.card h2 {
+  font-size: 1rem;
+  margin: 0 0 1rem;
+}
+
+/* ── accent-color theme — overridden by JS color picker ── */
+.theme-8681 {
+  accent-color: #6c63ff;
+}
+
+/* ── Form control rows ────────────────────────── */
+.form-group-8681 {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form-row-8681 {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.form-row-8681 input[type="checkbox"],
+.form-row-8681 input[type="radio"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+/* ── Range slider ──────────────────────────────── */
+.range-row-8681 {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.range-row-8681 input[type="range"] {
+  flex: 1;
+  height: 6px;
+  cursor: pointer;
+}
+
+.range-row-8681 .range-value-8681 {
+  min-width: 2.5rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ease-color-muted, #64748b);
+  text-align: right;
+}
+
+/* ── Progress & meter ─────────────────────────── */
+.progress-row-8681 {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.progress-row-8681 progress,
+.progress-row-8681 meter {
+  width: 100%;
+  height: 12px;
+  border-radius: 6px;
+}
+
+/* ── Select ────────────────────────────────── */
+select.theme-8681 {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--ease-color-neutral-300, #d1d5db);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  background: var(--ease-color-surface, #fff);
+  color: var(--ease-color-text, #1e293b);
+  cursor: pointer;
+}
+
+/* ── Color picker ─────────────────────────── */
+.color-picker-8681 {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.color-picker-8681 label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.color-picker-8681 input[type="color"] {
+  width: 40px;
+  height: 40px;
+  border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 8px;
+  padding: 2px;
+  cursor: pointer;
+  background: none;
+}
+
+.color-hex-8681 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ease-color-muted, #64748b);
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+/* ── Dark mode ──────────────────────────────── */
+@media (prefers-color-scheme: dark) {
+  .card { background: var(--ease-color-surface, #1e293b); border-color: #334155; }
+  pre code { background: #0f172a; }
+  code { background: #334155; color: #e2e8f0; }
+  select.theme-8681 { background: #1e293b; border-color: #475569; color: #e2e8f0; }
+}
+
+}


### PR DESCRIPTION
### Description

A self-contained example demonstrating CSS `accent-color` for theming native form controls (checkboxes, radios, range sliders, progress, meter, select) with a live color picker.

### Related Issue

Fixes #8681

### Proposed Changes

- `submissions/examples/accent-color-forms-8681/` — demo with interactive color picker