### PR TITLE
Add accent-color-forms example

### DIFF
--- a/submissions/examples/accent-color-forms/README.md
+++ b/submissions/examples/accent-color-forms/README.md
@@ -1,0 +1,24 @@
+# CSS accent-color Forms
+
+## What does this do?
+
+Demonstrates CSS `accent-color` applied to native form controls — checkboxes, radio buttons, range sliders, progress bars, and switches (`role="switch"`). A color picker lets you dynamically change the accent color in real time.
+
+## How is it used?
+
+```css
+:root { --accent: #6c63ff; }
+
+input[type="checkbox"],
+input[type="radio"],
+input[type="range"],
+progress {
+  accent-color: var(--accent);
+}
+```
+
+A JS color input sets `--accent` on the wrapper, and the browser re-themes all native controls instantly without custom CSS overrides.
+
+## Why is it useful?
+
+Before `accent-color`, custom-themed form controls required hiding native inputs and building custom checkboxes/radios with pseudo-elements, SVG, and complex CSS. With `accent-color`, a single property themes all native controls — lighter markup, better accessibility (native focus rings, form validation, keyboard interaction), and consistent behavior across platforms.

--- a/submissions/examples/accent-color-forms/demo.html
+++ b/submissions/examples/accent-color-forms/demo.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS accent-color Forms</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>accent-color Forms</h1>
+    <p>Native form controls themed entirely via <code>accent-color</code> — no custom checkbox/radio markup needed.</p>
+  </header>
+
+  <main class="form-wrapper" style="--accent: #6c63ff">
+    <section class="picker-section">
+      <label for="accent-picker">Pick an accent color:</label>
+      <div class="picker-row">
+        <input type="color" id="accent-picker" value="#6c63ff" />
+        <span id="accent-value">#6c63ff</span>
+      </div>
+    </section>
+
+    <form class="demo-form">
+      <fieldset>
+        <legend>Checkboxes</legend>
+        <label class="control-row">
+          <input type="checkbox" checked />
+          Subscribe to newsletter
+        </label>
+        <label class="control-row">
+          <input type="checkbox" />
+          Accept terms of service
+        </label>
+        <label class="control-row">
+          <input type="checkbox" checked />
+          Enable notifications
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Radio Buttons</legend>
+        <label class="control-row">
+          <input type="radio" name="plan" checked />
+          Free plan
+        </label>
+        <label class="control-row">
+          <input type="radio" name="plan" />
+          Pro plan
+        </label>
+        <label class="control-row">
+          <input type="radio" name="plan" />
+          Enterprise plan
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Range Slider</legend>
+        <label for="volume" class="control-row slider-row">
+          <span>Volume</span>
+          <input type="range" id="volume" min="0" max="100" value="65" />
+          <span id="volume-value">65</span>
+        </label>
+        <label for="brightness" class="control-row slider-row">
+          <span>Brightness</span>
+          <input type="range" id="brightness" min="0" max="100" value="80" />
+          <span id="brightness-value">80</span>
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Progress Bars</legend>
+        <div class="control-row progress-row">
+          <span>Storage used</span>
+          <progress value="45" max="100">45%</progress>
+        </div>
+        <div class="control-row progress-row">
+          <span>Bandwidth</span>
+          <progress value="82" max="100">82%</progress>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Switches (via accent-color)</legend>
+        <label class="control-row">
+          <input type="checkbox" role="switch" checked />
+          Dark mode
+        </label>
+        <label class="control-row">
+          <input type="checkbox" role="switch" />
+          Auto-play
+        </label>
+        <label class="control-row">
+          <input type="checkbox" role="switch" checked />
+          Sound effects
+        </label>
+      </fieldset>
+    </form>
+  </main>
+
+  <footer>
+    <p>Works in Chrome 93+, Firefox 92+, Safari 15.4+. <code>accent-color</code> automatically themes native form controls without custom CSS.</p>
+  </footer>
+
+  <script>
+    var picker = document.getElementById('accent-picker');
+    var valueDisplay = document.getElementById('accent-value');
+    var wrapper = document.querySelector('.form-wrapper');
+
+    picker.addEventListener('input', function () {
+      var color = picker.value;
+      wrapper.style.setProperty('--accent', color);
+      valueDisplay.textContent = color;
+    });
+
+    var volume = document.getElementById('volume');
+    var volumeVal = document.getElementById('volume-value');
+    volume.addEventListener('input', function () {
+      volumeVal.textContent = volume.value;
+    });
+
+    var brightness = document.getElementById('brightness');
+    var brightnessVal = document.getElementById('brightness-value');
+    brightness.addEventListener('input', function () {
+      brightnessVal.textContent = brightness.value;
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/accent-color-forms/style.css
+++ b/submissions/examples/accent-color-forms/style.css
@@ -1,0 +1,270 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  color-scheme: dark;
+  --bg: #0a0f1e;
+  --surface: #111827;
+  --surface-2: #1f2937;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --text-dim: #64748b;
+  --border: #1e293b;
+  --radius: 12px;
+  --font: system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+header {
+  text-align: center;
+  max-width: 680px;
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #6c63ff, #a09af8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+header p {
+  color: var(--text-muted);
+  margin-top: 0.4rem;
+  font-size: 0.9rem;
+}
+
+header code {
+  background: var(--surface-2);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+.form-wrapper {
+  width: 100%;
+  max-width: 560px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2rem;
+}
+
+.picker-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.picker-section label {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.picker-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.picker-row input[type="color"] {
+  width: 48px;
+  height: 40px;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  padding: 2px;
+  background: var(--surface-2);
+  cursor: pointer;
+}
+
+.picker-row input[type="color"]::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.picker-row input[type="color"]::-webkit-color-swatch {
+  border: none;
+  border-radius: 5px;
+}
+
+.picker-row #accent-value {
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.demo-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+fieldset {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+legend {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+  padding: 0 0.35rem;
+}
+
+.control-row {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.4rem 0;
+  font-size: 0.9rem;
+  color: var(--text);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.control-row:hover {
+  color: #fff;
+}
+
+.control-row input[type="checkbox"],
+.control-row input[type="radio"] {
+  accent-color: var(--accent, #6c63ff);
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.control-row input[type="checkbox"][role="switch"] {
+  width: 38px;
+  height: 22px;
+  accent-color: var(--accent, #6c63ff);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.slider-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.slider-row span:first-child {
+  min-width: 80px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.slider-row input[type="range"] {
+  flex: 1;
+  accent-color: var(--accent, #6c63ff);
+  height: 6px;
+  cursor: pointer;
+  background: var(--border);
+  border-radius: 99px;
+}
+
+.slider-row input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent, #6c63ff);
+  border: 2px solid var(--surface);
+  box-shadow: 0 0 0 2px var(--accent, #6c63ff);
+  cursor: pointer;
+}
+
+.slider-row input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent, #6c63ff);
+  border: 2px solid var(--surface);
+  cursor: pointer;
+}
+
+.slider-row span:last-child {
+  min-width: 28px;
+  text-align: right;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-family: monospace;
+}
+
+.progress-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.progress-row span {
+  min-width: 100px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.progress-row progress {
+  flex: 1;
+  height: 8px;
+  border-radius: 99px;
+  overflow: hidden;
+  accent-color: var(--accent, #6c63ff);
+}
+
+.progress-row progress::-webkit-progress-bar {
+  background: var(--border);
+  border-radius: 99px;
+}
+
+.progress-row progress::-webkit-progress-value {
+  background: var(--accent, #6c63ff);
+  border-radius: 99px;
+  transition: width 0.3s;
+}
+
+.progress-row progress::-moz-progress-bar {
+  background: var(--accent, #6c63ff);
+  border-radius: 99px;
+}
+
+footer {
+  margin-top: 1.5rem;
+  max-width: 560px;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 0.8rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-row progress::-webkit-progress-value {
+    transition: none;
+  }
+
+  .control-row {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained example under \submissions/examples/accent-color-forms/\ demonstrating modern CSS techniques.

## Files
- \demo.html\ - Demo page
- \style.css\ - Styles and animations
- \README.md\ - Documentation

Closes #8681