### PR TITLE
feature: add auto-generated contributors page to documentation site

### DIFF
--- a/.github/workflows/update-contributor-wall.yml
+++ b/.github/workflows/update-contributor-wall.yml
@@ -35,13 +35,17 @@ jobs:
       - name: Pull latest before building
         run: git pull --rebase origin main
 
-      - name: Build contributor wall
+            - name: Build contributor wall
         run: python3 scripts/build-contributor-wall.py
-        - name: Build contributor showcase page
-        run: python3 scripts/build-contributor-page.py  
+
+      - name: Build contributor showcase page
+        run: python3 scripts/build-contributor-page.py
+
       - name: Commit if changed
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: update contributor wall [skip ci]"
-          file_pattern: README.md
+          file_pattern: |
+            README.md
+            docs/contributors.html
           push_options: --force-with-lease

--- a/.github/workflows/update-contributor-wall.yml
+++ b/.github/workflows/update-contributor-wall.yml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Build contributor wall
         run: python3 scripts/build-contributor-wall.py
-
+        - name: Build contributor showcase page
+        run: python3 scripts/build-contributor-page.py  
       - name: Commit if changed
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/contributors.json
+++ b/contributors.json
@@ -1,0 +1,10 @@
+[
+  {
+    "login": "SAPTARSHI-coder",
+    "contributions": 120
+  },
+  {
+    "login": "rastogiradhika",
+    "contributions": 3
+  }
+]

--- a/docs/assets/css/contributors-wall.css
+++ b/docs/assets/css/contributors-wall.css
@@ -1,0 +1,84 @@
+/* Contributor Wall page styles — isolated from docs.css */
+
+.contributor-wall {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.contributor-wall__header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.contributor-wall__updated {
+  font-size: 0.875rem;
+  color: var(--ease-color-muted, #6b7280);
+}
+
+.contributor-wall__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.contributor-wall__footer {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+.contributor-card {
+  border: 1px solid var(--ease-color-border, #e5e7eb);
+  border-radius: var(--ease-radius-md, 0.75rem);
+  background: var(--ease-color-surface, #ffffff);
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.contributor-card:hover,
+.contributor-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+}
+
+.contributor-card__link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.contributor-card__link:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+  border-radius: var(--ease-radius-md, 0.75rem);
+}
+
+.contributor-card__avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.contributor-card__name {
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.contributor-card__count {
+  font-size: 0.8rem;
+  color: var(--ease-color-muted, #6b7280);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .contributor-card {
+    transition: none;
+  }
+}

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contributors · EaseMotion CSS</title>
+  <meta name="description" content="Meet the contributors who help build EaseMotion CSS." />
+  <link rel="stylesheet" href="../easemotion.css" />
+  <link rel="stylesheet" href="assets/css/contributors-wall.css" />
+</head>
+<body>
+  <main class="contributor-wall" aria-labelledby="contributor-wall-heading">
+    <header class="contributor-wall__header">
+      <h1 id="contributor-wall-heading">Our Contributors</h1>
+      <p>EaseMotion CSS is built with help from 2 contributors and counting.</p>
+      <p class="contributor-wall__updated">Last synced: 2026-06-14 17:27 UTC</p>
+    </header>
+    <ul class="contributor-wall__grid" role="list">
+      <li class="contributor-card">
+        <a class="contributor-card__link"
+           href="https://github.com/SAPTARSHI-coder"
+           target="_blank" rel="noopener noreferrer"
+           aria-label="View SAPTARSHI-coder's GitHub profile">
+          <img class="contributor-card__avatar"
+               src="https://avatars.githubusercontent.com/SAPTARSHI-coder?s=64"
+               alt="SAPTARSHI-coder's avatar" loading="lazy"
+               width="64" height="64" />
+          <span class="contributor-card__name">SAPTARSHI-coder</span>
+          <span class="contributor-card__count">120 commits</span>
+        </a>
+      </li>
+      <li class="contributor-card">
+        <a class="contributor-card__link"
+           href="https://github.com/rastogiradhika"
+           target="_blank" rel="noopener noreferrer"
+           aria-label="View rastogiradhika's GitHub profile">
+          <img class="contributor-card__avatar"
+               src="https://avatars.githubusercontent.com/rastogiradhika?s=64"
+               alt="rastogiradhika's avatar" loading="lazy"
+               width="64" height="64" />
+          <span class="contributor-card__name">rastogiradhika</span>
+          <span class="contributor-card__count">3 commits</span>
+        </a>
+      </li>
+    </ul>
+    <p class="contributor-wall__footer">
+      <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/graphs/contributors">View all on GitHub →</a>
+    </p>
+  </main>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -104,6 +104,8 @@
       </button>
 
       <ul class="docs-header-links">
+        
+       
         <li><a href="#getting-started">Getting Started</a></li>
         <li><a href="#utilities">Utilities</a></li>
         <li><a href="#animations">Animations</a></li>
@@ -122,6 +124,8 @@
             >Discord</a
           >
         </li>
+
+        <li> <a href="contributors.html">Contributors</a></li>
         <li>
           <a
             href="demo.html"

--- a/scripts/build-contributor-page.py
+++ b/scripts/build-contributor-page.py
@@ -1,0 +1,105 @@
+"""
+Build docs/contributors.html from /tmp/contributors.json.
+
+Reuses the SAME contributor data fetched by update-contributor-wall.yml
+(no extra API calls). Run this immediately after build-contributor-wall.py,
+in the same job, while /tmp/contributors.json still exists.
+
+Fallback: if /tmp/contributors.json is missing or empty, leave the existing
+docs/contributors.html untouched and exit 0 (never overwrite a working
+page with empty data).
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+INPUT = "contributors.json"
+OUTPUT = "docs/contributors.html"
+
+
+def escape(text):
+    return (
+        str(text)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def render_card(c):
+    login = c["login"]
+    count = c["contributions"]
+    return f'''      <li class="contributor-card">
+        <a class="contributor-card__link"
+           href="https://github.com/{login}"
+           target="_blank" rel="noopener noreferrer"
+           aria-label="View {escape(login)}'s GitHub profile">
+          <img class="contributor-card__avatar"
+               src="https://avatars.githubusercontent.com/{login}?s=64"
+               alt="{escape(login)}'s avatar" loading="lazy"
+               width="64" height="64" />
+          <span class="contributor-card__name">{escape(login)}</span>
+          <span class="contributor-card__count">{count} commit{"s" if count != 1 else ""}</span>
+        </a>
+      </li>'''
+
+
+def build_page(contributors):
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    cards = "\n".join(render_card(c) for c in contributors)
+
+    return f'''<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contributors · EaseMotion CSS</title>
+  <meta name="description" content="Meet the contributors who help build EaseMotion CSS." />
+  <link rel="stylesheet" href="../easemotion.css" />
+  <link rel="stylesheet" href="assets/css/contributors-wall.css" />
+</head>
+<body>
+  <main class="contributor-wall" aria-labelledby="contributor-wall-heading">
+    <header class="contributor-wall__header">
+      <h1 id="contributor-wall-heading">Our Contributors</h1>
+      <p>EaseMotion CSS is built with help from {len(contributors)} contributors and counting.</p>
+      <p class="contributor-wall__updated">Last synced: {timestamp}</p>
+    </header>
+    <ul class="contributor-wall__grid" role="list">
+{cards}
+    </ul>
+    <p class="contributor-wall__footer">
+      <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/graphs/contributors">View all on GitHub →</a>
+    </p>
+  </main>
+</body>
+</html>
+'''
+
+
+def main():
+    if not os.path.exists(INPUT):
+        print("contributors.json not found — leaving docs/contributors.html untouched.")
+        sys.exit(0)
+
+    with open(INPUT) as f:
+        contributors = json.load(f)
+
+    if not contributors:
+        print("contributors.json is empty — leaving docs/contributors.html untouched.")
+        sys.exit(0)
+
+    contributors.sort(key=lambda c: c.get("contributions", 0), reverse=True)
+    html = build_page(contributors)
+
+    with open(OUTPUT, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    print(f"Generated {OUTPUT} with {len(contributors)} contributors.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Pull Request Description

### Type of Change

* Documentation improvement
* Contributor automation enhancement

### Changes Included

* Added automatic contributor page generation using GitHub contributor data.
* Added `docs/contributors.html` contributor showcase page.
* Added contributor wall styling.
* Integrated contributors page into documentation navigation.
* Extended the existing contributor-wall workflow to keep the page updated automatically.

### Why This Change

The repository already maintains contributor information, but contributors are not visible through the documentation website. This PR exposes contributor recognition through a dedicated documentation page while reusing existing contributor data and automation.

### Notes for Maintainer

This contribution modifies documentation and workflow infrastructure rather than a component inside `submissions/examples` because the issue itself concerns contributor automation and documentation integration.
