### PR TITLE
feat: add dark mode design system showcase example

### DIFF
--- a/submissions/examples/dark-mode-design-system-bv/README.md
+++ b/submissions/examples/dark-mode-design-system-bv/README.md
@@ -1,0 +1,87 @@
+# Dark Mode Design System Showcase
+
+A comprehensive, production-ready dark-theme design system reference built entirely with CSS custom properties, glassmorphism effects, keyframe animations, and zero external JavaScript dependencies.
+
+## Preview
+
+Open `demo.html` in any modern browser to explore the full design system reference.
+
+## Sections (18 total)
+
+| #   | Section                    | Description                                       |
+| --- | -------------------------- | ------------------------------------------------- |
+| 01  | Design System Header       | Gradient header with version badge and stats      |
+| 02  | Color Palette              | Surface, brand, and semantic color swatches       |
+| 03  | Typography Scale           | H1–H6, body, caption, and code samples            |
+| 04  | Spacing & Sizing Scale     | Visual bar chart of all spacing tokens            |
+| 05  | Button Component Library   | Primary, secondary, ghost, danger, disabled       |
+| 06  | Card Variants              | Default, elevated, outlined, interactive, glass   |
+| 07  | Form Elements              | Inputs, textareas, selects, checkboxes, toggles   |
+| 08  | Navigation Patterns        | Tabs, breadcrumbs, pagination                     |
+| 09  | Badges & Tags              | Status badges and removable tags                  |
+| 10  | Alerts & Toasts            | Success, warning, error, info feedback messages   |
+| 11  | Table Component            | Sortable data table with status indicators        |
+| 12  | Modal / Dialog             | Inline modal preview with backdrop blur           |
+| 13  | Progress Indicators        | Bars, circular gauges, skeleton loading           |
+| 14  | Avatars & User Components  | Sized avatars, status dots, groups, user cards    |
+| 15  | Layout Grid Demonstrations | 2-col, 3-col, 4-col, sidebar, holy grail          |
+| 16  | Motion & Animation         | Live previews of all 8 keyframe animations        |
+| 17  | Accessibility Checklist    | WCAG 2.1 AA audit panel with pass/warn indicators |
+| 18  | Code Snippet Display       | Syntax-highlighted CSS, HTML, and JS examples     |
+
+## Design Tokens
+
+### Color Palette
+
+- **Surface Base:** `#0d0d1a`
+- **Surface 100:** `#1a1a2e`
+- **Surface 200:** `#16213e`
+- **Accent Blue:** `#0f3460`
+- **Highlight:** `#e94560`
+
+### Animations
+
+| Name          | Purpose                       | Duration |
+| ------------- | ----------------------------- | -------- |
+| `gentleFade`  | Fade in with upward translate | 0.6s     |
+| `slideIn`     | Slide in from left            | 0.4s     |
+| `scaleUp`     | Scale from 92% to 100%        | 0.35s    |
+| `shimmerLoad` | Skeleton loading shimmer      | 1.5s     |
+| `bounceIn`    | Elastic entrance              | 2s       |
+| `float`       | Gentle vertical float         | 3s       |
+| `pulse`       | Opacity pulse                 | 2s       |
+| `spin`        | 360° rotation                 | 2s       |
+
+## CSS Architecture
+
+- **80+ CSS custom properties** covering surfaces, brand, semantic, text, borders, spacing, typography, shadows, transitions, glassmorphism, and z-index
+- **Glassmorphism** via `backdrop-filter: blur()` and translucent backgrounds
+- **Responsive** with breakpoints at 1024px, 768px, and 480px
+- **Print-optimized** with animation-free fallbacks
+
+## Typography
+
+- **Sans-serif:** Inter (300–900 weights)
+- **Monospace:** JetBrains Mono (400–700 weights)
+
+## Technologies Used
+
+- Pure HTML5 & CSS3
+- CSS Custom Properties (Design Tokens)
+- CSS Grid & Flexbox
+- CSS Animations & Transitions
+- Glassmorphism (backdrop-filter)
+- Google Fonts (Inter, JetBrains Mono)
+
+## Browser Support
+
+| Browser | Version |
+| ------- | ------- |
+| Chrome  | 90+     |
+| Firefox | 88+     |
+| Safari  | 15+     |
+| Edge    | 90+     |
+
+## License
+
+MIT — Part of the [EaseMotion CSS](https://github.com/SAPTARSHI-coder/EaseMotion-css) project.

--- a/submissions/examples/dark-mode-design-system-bv/demo.html
+++ b/submissions/examples/dark-mode-design-system-bv/demo.html
@@ -1,0 +1,1484 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dark Mode Design System — EaseMotion CSS</title>
+    <meta
+      name="description"
+      content="A comprehensive dark-theme design system reference built entirely with CSS custom properties, glassmorphism, keyframe animations, and zero JavaScript dependencies."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- ============================================================
+         SECTION 1 — Design System Header
+         ============================================================ -->
+    <header class="ds-header">
+      <div class="ds-container ds-header__content">
+        <span class="ds-header__badge">
+          <span class="dot"></span>
+          v2.0.0 — Dark Mode Design System
+        </span>
+        <h1 class="ds-header__title">Dark Mode Design System</h1>
+        <p class="ds-header__desc">
+          A complete, production-ready dark-theme component library and design
+          token reference. Zero dependencies — pure CSS.
+        </p>
+        <div class="ds-header__meta">
+          <div class="ds-header__meta-item">
+            <span class="ds-header__meta-value">80+</span>
+            <span class="ds-header__meta-label">CSS Variables</span>
+          </div>
+          <div class="ds-header__meta-item">
+            <span class="ds-header__meta-value">18</span>
+            <span class="ds-header__meta-label">Sections</span>
+          </div>
+          <div class="ds-header__meta-item">
+            <span class="ds-header__meta-value">40+</span>
+            <span class="ds-header__meta-label">Components</span>
+          </div>
+          <div class="ds-header__meta-item">
+            <span class="ds-header__meta-value">8</span>
+            <span class="ds-header__meta-label">Animations</span>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <!-- ============================================================
+           SECTION 2 — Color Palette Showcase
+           ============================================================ -->
+      <section class="ds-section" id="colors">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">01</span>
+            Color Palette
+          </h2>
+          <p class="ds-section__subtitle">
+            Every design token color rendered as interactive swatches. Surfaces,
+            brand, and semantic palettes.
+          </p>
+
+          <h3 class="color-group__title">Surfaces</h3>
+          <div class="color-grid">
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #0d0d1a"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Base</div>
+                <div class="color-swatch__hex">#0d0d1a</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #1a1a2e"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Surface 100</div>
+                <div class="color-swatch__hex">#1a1a2e</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #16213e"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Surface 200</div>
+                <div class="color-swatch__hex">#16213e</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #1e2a4a"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Surface 300</div>
+                <div class="color-swatch__hex">#1e2a4a</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #263557"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Surface 400</div>
+                <div class="color-swatch__hex">#263557</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #2e4063"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Surface 500</div>
+                <div class="color-swatch__hex">#2e4063</div>
+              </div>
+            </div>
+          </div>
+
+          <h3 class="color-group__title">Brand</h3>
+          <div class="color-grid">
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #0f3460"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Accent Blue</div>
+                <div class="color-swatch__hex">#0f3460</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #1a5276"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Accent Light</div>
+                <div class="color-swatch__hex">#1a5276</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #2980b9"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Accent Lighter</div>
+                <div class="color-swatch__hex">#2980b9</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #e94560"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Highlight</div>
+                <div class="color-swatch__hex">#e94560</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #ff6b81"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Highlight Light</div>
+                <div class="color-swatch__hex">#ff6b81</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #c0392b"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Highlight Dark</div>
+                <div class="color-swatch__hex">#c0392b</div>
+              </div>
+            </div>
+          </div>
+
+          <h3 class="color-group__title">Semantic</h3>
+          <div class="color-grid">
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #00c853"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Success</div>
+                <div class="color-swatch__hex">#00c853</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #ffc107"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Warning</div>
+                <div class="color-swatch__hex">#ffc107</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #ef5350"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Error</div>
+                <div class="color-swatch__hex">#ef5350</div>
+              </div>
+            </div>
+            <div class="color-swatch">
+              <div
+                class="color-swatch__preview"
+                style="background: #29b6f6"
+              ></div>
+              <div class="color-swatch__info">
+                <div class="color-swatch__name">Info</div>
+                <div class="color-swatch__hex">#29b6f6</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 3 — Typography Scale
+           ============================================================ -->
+      <section class="ds-section" id="typography">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">02</span>
+            Typography Scale
+          </h2>
+          <p class="ds-section__subtitle">
+            Full heading hierarchy, body text, captions, and monospaced code
+            samples using Inter and JetBrains Mono.
+          </p>
+
+          <div class="type-scale-item">
+            <div class="type-scale-meta">
+              <div class="type-scale-meta__label">H1</div>
+              <div class="type-scale-meta__size">3.75rem / 900</div>
+            </div>
+            <span class="type-sample--h1">Display Heading</span>
+          </div>
+
+          <div class="type-scale-item">
+            <div class="type-scale-meta">
+              <div class="type-scale-meta__label">H2</div>
+              <div class="type-scale-meta__size">3rem / 800</div>
+            </div>
+            <span class="type-sample--h2">Section Title</span>
+          </div>
+
+          <div class="type-scale-item">
+            <div class="type-scale-meta">
+              <div class="type-scale-meta__label">H3</div>
+              <div class="type-scale-meta__size">2.25rem / 700</div>
+            </div>
+            <span class="type-sample--h3">Subsection</span>
+          </div>
+
+          <div class="type-scale-item">
+            <div class="type-scale-meta">
+              <div class="type-scale-meta__label">H4</div>
+              <div class="type-scale-meta__size">1.875rem / 600</div>
+            </div>
+            <span class="type-sample--h4">Card Heading</span>
+          </div>
+
+          <div class="type-scale-item">
+            <div class="type-scale-meta">
+              <div class="type-scale-meta__label">H5</div>
+              <div class="type-scale-meta__size">1.5rem / 600</div>
+            </div>
+            <span class="type-sample--h5">Widget Title</span>
+          </div>
+
+          <div class="type-scale-item">
+            <div class="type-scale-meta">
+              <div class="type-scale-meta__label">H6</div>
+              <div class="type-scale-meta__size">1.25rem / 500</div>
+            </div>
+            <span class="type-sample--h6">Small Heading</span>
+          </div>
+
+          <div class="type-scale-item">
+            <div class="type-scale-meta">
+              <div class="type-scale-meta__label">Body</div>
+              <div class="type-scale-meta__size">1rem / 400</div>
+            </div>
+            <span class="type-sample--body"
+              >Body text renders at the base size with comfortable line-height
+              for extended reading.</span
+            >
+          </div>
+
+          <div class="type-scale-item">
+            <div class="type-scale-meta">
+              <div class="type-scale-meta__label">Caption</div>
+              <div class="type-scale-meta__size">0.875rem / 400</div>
+            </div>
+            <span class="type-sample--caption"
+              >Caption text for secondary information and metadata</span
+            >
+          </div>
+
+          <div class="type-scale-item">
+            <div class="type-scale-meta">
+              <div class="type-scale-meta__label">Code</div>
+              <div class="type-scale-meta__size">0.875rem / mono</div>
+            </div>
+            <span class="type-sample--code">const theme = 'dark-mode';</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 4 — Spacing & Sizing Scale
+           ============================================================ -->
+      <section class="ds-section" id="spacing">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">03</span>
+            Spacing &amp; Sizing Scale
+          </h2>
+          <p class="ds-section__subtitle">
+            Visual representation of every spacing token from 2xs to 4xl.
+          </p>
+
+          <div class="spacing-scale">
+            <div class="spacing-item">
+              <div class="spacing-item__label">--space-2xs</div>
+              <div class="spacing-item__bar" style="width: 4px"></div>
+              <div class="spacing-item__value">0.25rem</div>
+            </div>
+            <div class="spacing-item">
+              <div class="spacing-item__label">--space-xs</div>
+              <div class="spacing-item__bar" style="width: 8px"></div>
+              <div class="spacing-item__value">0.5rem</div>
+            </div>
+            <div class="spacing-item">
+              <div class="spacing-item__label">--space-sm</div>
+              <div class="spacing-item__bar" style="width: 12px"></div>
+              <div class="spacing-item__value">0.75rem</div>
+            </div>
+            <div class="spacing-item">
+              <div class="spacing-item__label">--space-md</div>
+              <div class="spacing-item__bar" style="width: 16px"></div>
+              <div class="spacing-item__value">1rem</div>
+            </div>
+            <div class="spacing-item">
+              <div class="spacing-item__label">--space-lg</div>
+              <div class="spacing-item__bar" style="width: 24px"></div>
+              <div class="spacing-item__value">1.5rem</div>
+            </div>
+            <div class="spacing-item">
+              <div class="spacing-item__label">--space-xl</div>
+              <div class="spacing-item__bar" style="width: 32px"></div>
+              <div class="spacing-item__value">2rem</div>
+            </div>
+            <div class="spacing-item">
+              <div class="spacing-item__label">--space-2xl</div>
+              <div class="spacing-item__bar" style="width: 48px"></div>
+              <div class="spacing-item__value">3rem</div>
+            </div>
+            <div class="spacing-item">
+              <div class="spacing-item__label">--space-3xl</div>
+              <div class="spacing-item__bar" style="width: 64px"></div>
+              <div class="spacing-item__value">4rem</div>
+            </div>
+            <div class="spacing-item">
+              <div class="spacing-item__label">--space-4xl</div>
+              <div class="spacing-item__bar" style="width: 96px"></div>
+              <div class="spacing-item__value">6rem</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 5 — Button Component Library
+           ============================================================ -->
+      <section class="ds-section" id="buttons">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">04</span>
+            Button Component Library
+          </h2>
+          <p class="ds-section__subtitle">
+            Primary, secondary, ghost, danger, and disabled button variants in
+            multiple sizes.
+          </p>
+
+          <h3 class="color-group__title">Variants</h3>
+          <div class="btn-grid">
+            <button class="btn btn--primary">Primary</button>
+            <button class="btn btn--secondary">Secondary</button>
+            <button class="btn btn--ghost">Ghost</button>
+            <button class="btn btn--danger">Danger</button>
+            <button class="btn btn--disabled" disabled>Disabled</button>
+          </div>
+
+          <h3 class="color-group__title">Sizes</h3>
+          <div class="btn-grid">
+            <button class="btn btn--primary btn--sm">Small</button>
+            <button class="btn btn--primary">Default</button>
+            <button class="btn btn--primary btn--lg">Large</button>
+          </div>
+
+          <h3 class="color-group__title">With Icons</h3>
+          <div class="btn-grid">
+            <button class="btn btn--primary">⚡ Quick Action</button>
+            <button class="btn btn--secondary">📦 Export</button>
+            <button class="btn btn--ghost">🔗 Share Link</button>
+            <button class="btn btn--danger">🗑️ Delete</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 6 — Card Variants
+           ============================================================ -->
+      <section class="ds-section" id="cards">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">05</span>
+            Card Variants
+          </h2>
+          <p class="ds-section__subtitle">
+            Five distinct card styles — default, elevated, outlined,
+            interactive, and glassmorphic.
+          </p>
+
+          <div class="card-grid">
+            <div class="card card--default">
+              <span class="card__tag">Default</span>
+              <h3 class="card__title">Default Card</h3>
+              <p class="card__body">
+                Subtle background with a thin border. Ideal for content that
+                doesn't need emphasis.
+              </p>
+            </div>
+
+            <div class="card card--elevated">
+              <span class="card__tag">Elevated</span>
+              <h3 class="card__title">Elevated Card</h3>
+              <p class="card__body">
+                Raised with a prominent shadow. Draws attention and lifts
+                further on hover.
+              </p>
+            </div>
+
+            <div class="card card--outlined">
+              <span class="card__tag">Outlined</span>
+              <h3 class="card__title">Outlined Card</h3>
+              <p class="card__body">
+                Transparent background with a visible border. Clean and minimal
+                aesthetic.
+              </p>
+            </div>
+
+            <div class="card card--interactive">
+              <span class="card__tag">Interactive</span>
+              <h3 class="card__title">Interactive Card</h3>
+              <p class="card__body">
+                Responds to hover with color shift, glow, and subtle scale
+                transform.
+              </p>
+            </div>
+
+            <div class="card card--glass">
+              <span class="card__tag">Glassmorphic</span>
+              <h3 class="card__title">Glass Card</h3>
+              <p class="card__body">
+                Frosted glass effect using backdrop-filter blur and translucent
+                backgrounds.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 7 — Form Elements
+           ============================================================ -->
+      <section class="ds-section" id="forms">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">06</span>
+            Form Elements
+          </h2>
+          <p class="ds-section__subtitle">
+            Inputs, textareas, selects, checkboxes, radio buttons, and toggle
+            switches.
+          </p>
+
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label" for="input-text">Text Input</label>
+              <input
+                class="form-input"
+                type="text"
+                id="input-text"
+                placeholder="Enter your name…"
+              />
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="input-email">Email Input</label>
+              <input
+                class="form-input"
+                type="email"
+                id="input-email"
+                placeholder="you@example.com"
+              />
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="input-pass">Password</label>
+              <input
+                class="form-input"
+                type="password"
+                id="input-pass"
+                placeholder="••••••••"
+              />
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="input-select">Select</label>
+              <select class="form-select" id="input-select">
+                <option value="">Choose an option…</option>
+                <option value="1">Option Alpha</option>
+                <option value="2">Option Beta</option>
+                <option value="3">Option Gamma</option>
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="input-textarea">Textarea</label>
+              <textarea
+                class="form-textarea"
+                id="input-textarea"
+                placeholder="Write your message…"
+              ></textarea>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Checkboxes</label>
+              <label class="form-check">
+                <input type="checkbox" checked />
+                Dark mode enabled
+              </label>
+              <label class="form-check">
+                <input type="checkbox" />
+                Enable notifications
+              </label>
+              <label class="form-check">
+                <input type="checkbox" checked />
+                Auto-save drafts
+              </label>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Radio Buttons</label>
+              <label class="form-check">
+                <input type="radio" name="theme" checked />
+                Dark Theme
+              </label>
+              <label class="form-check">
+                <input type="radio" name="theme" />
+                Light Theme
+              </label>
+              <label class="form-check">
+                <input type="radio" name="theme" />
+                System Default
+              </label>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Toggle Switches</label>
+              <label class="toggle">
+                <input type="checkbox" checked />
+                <span class="toggle__track"></span>
+                Animations
+              </label>
+              <label class="toggle">
+                <input type="checkbox" />
+                <span class="toggle__track"></span>
+                Sound Effects
+              </label>
+              <label class="toggle">
+                <input type="checkbox" checked />
+                <span class="toggle__track"></span>
+                Reduced Motion
+              </label>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 8 — Navigation Patterns
+           ============================================================ -->
+      <section class="ds-section" id="navigation">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">07</span>
+            Navigation Patterns
+          </h2>
+          <p class="ds-section__subtitle">
+            Tabs, breadcrumbs, and pagination — the core navigation primitives.
+          </p>
+
+          <h3 class="color-group__title">Tabs</h3>
+          <div class="tabs" role="tablist">
+            <button class="tab tab--active" role="tab" aria-selected="true">
+              Overview
+            </button>
+            <button class="tab" role="tab">Components</button>
+            <button class="tab" role="tab">Tokens</button>
+            <button class="tab" role="tab">Guidelines</button>
+            <button class="tab" role="tab">Changelog</button>
+          </div>
+
+          <h3 class="color-group__title">Breadcrumbs</h3>
+          <nav class="breadcrumbs" aria-label="Breadcrumb">
+            <a href="#" class="breadcrumbs__link">Home</a>
+            <span class="breadcrumbs__sep">›</span>
+            <a href="#" class="breadcrumbs__link">Design System</a>
+            <span class="breadcrumbs__sep">›</span>
+            <a href="#" class="breadcrumbs__link">Components</a>
+            <span class="breadcrumbs__sep">›</span>
+            <span class="breadcrumbs__current">Buttons</span>
+          </nav>
+
+          <h3 class="color-group__title">Pagination</h3>
+          <nav class="pagination" aria-label="Pagination">
+            <button class="page-btn">‹ Prev</button>
+            <button class="page-btn page-btn--active">1</button>
+            <button class="page-btn">2</button>
+            <button class="page-btn">3</button>
+            <button class="page-btn">4</button>
+            <button class="page-btn">5</button>
+            <button class="page-btn">…</button>
+            <button class="page-btn">12</button>
+            <button class="page-btn">Next ›</button>
+          </nav>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 9 — Badge & Tag Collection
+           ============================================================ -->
+      <section class="ds-section" id="badges">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">08</span>
+            Badges &amp; Tags
+          </h2>
+          <p class="ds-section__subtitle">
+            Status indicators, labels, and removable tags.
+          </p>
+
+          <h3 class="color-group__title">Badges</h3>
+          <div class="badge-grid">
+            <span class="badge badge--default">Default</span>
+            <span class="badge badge--primary">Primary</span>
+            <span class="badge badge--success">✓ Active</span>
+            <span class="badge badge--warning">⚠ Pending</span>
+            <span class="badge badge--error">✕ Failed</span>
+            <span class="badge badge--info">ℹ Info</span>
+            <span class="badge badge--highlight">★ Featured</span>
+          </div>
+
+          <h3 class="color-group__title">Tags</h3>
+          <div class="badge-grid">
+            <span class="tag">CSS <span class="tag__close">×</span></span>
+            <span class="tag"
+              >Design System <span class="tag__close">×</span></span
+            >
+            <span class="tag">Dark Mode <span class="tag__close">×</span></span>
+            <span class="tag"
+              >Glassmorphism <span class="tag__close">×</span></span
+            >
+            <span class="tag"
+              >Custom Properties <span class="tag__close">×</span></span
+            >
+            <span class="tag"
+              >Accessibility <span class="tag__close">×</span></span
+            >
+            <span class="tag"
+              >Animations <span class="tag__close">×</span></span
+            >
+            <span class="tag"
+              >Responsive <span class="tag__close">×</span></span
+            >
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 10 — Alert / Toast Components
+           ============================================================ -->
+      <section class="ds-section" id="alerts">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">09</span>
+            Alerts &amp; Toasts
+          </h2>
+          <p class="ds-section__subtitle">
+            Contextual feedback messages for success, warning, error, and info.
+          </p>
+
+          <div class="alert-stack">
+            <div class="alert alert--success" role="alert">
+              <span class="alert__icon">✓</span>
+              <div class="alert__content">
+                <div class="alert__title">Success</div>
+                <div class="alert__message">
+                  Your changes have been saved successfully.
+                </div>
+              </div>
+              <button class="alert__close" aria-label="Close">×</button>
+            </div>
+
+            <div class="alert alert--warning" role="alert">
+              <span class="alert__icon">⚠</span>
+              <div class="alert__content">
+                <div class="alert__title">Warning</div>
+                <div class="alert__message">
+                  API rate limit approaching — 89% of quota used.
+                </div>
+              </div>
+              <button class="alert__close" aria-label="Close">×</button>
+            </div>
+
+            <div class="alert alert--error" role="alert">
+              <span class="alert__icon">✕</span>
+              <div class="alert__content">
+                <div class="alert__title">Error</div>
+                <div class="alert__message">
+                  Failed to connect to the database. Please check configuration.
+                </div>
+              </div>
+              <button class="alert__close" aria-label="Close">×</button>
+            </div>
+
+            <div class="alert alert--info" role="alert">
+              <span class="alert__icon">ℹ</span>
+              <div class="alert__content">
+                <div class="alert__title">Information</div>
+                <div class="alert__message">
+                  A new version of the design system is available (v2.1.0).
+                </div>
+              </div>
+              <button class="alert__close" aria-label="Close">×</button>
+            </div>
+          </div>
+
+          <h3 class="color-group__title">Toast Notifications</h3>
+          <div class="toast-demo">
+            <div class="toast">
+              <span class="toast__icon">✓</span>
+              File uploaded successfully
+            </div>
+            <div class="toast">
+              <span class="toast__icon">🔔</span>
+              You have 3 new notifications
+            </div>
+            <div class="toast">
+              <span class="toast__icon">⏳</span>
+              Processing your request…
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 11 — Table Component
+           ============================================================ -->
+      <section class="ds-section" id="table">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">10</span>
+            Table Component
+          </h2>
+          <p class="ds-section__subtitle">
+            Data table with sorting indicators, status badges, and hover rows.
+          </p>
+
+          <div class="table-wrapper">
+            <table class="ds-table">
+              <thead>
+                <tr>
+                  <th class="sorted">
+                    Component <span class="sort-icon">▲</span>
+                  </th>
+                  <th>Category <span class="sort-icon">▲▼</span></th>
+                  <th>Status <span class="sort-icon">▲▼</span></th>
+                  <th>Version <span class="sort-icon">▲▼</span></th>
+                  <th>Last Updated <span class="sort-icon">▲▼</span></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Button</td>
+                  <td>Actions</td>
+                  <td>
+                    <span class="table-status">
+                      <span
+                        class="table-status__dot table-status__dot--active"
+                      ></span>
+                      Active
+                    </span>
+                  </td>
+                  <td><span class="badge badge--primary">v2.1</span></td>
+                  <td>2 hours ago</td>
+                </tr>
+                <tr>
+                  <td>Card</td>
+                  <td>Layout</td>
+                  <td>
+                    <span class="table-status">
+                      <span
+                        class="table-status__dot table-status__dot--active"
+                      ></span>
+                      Active
+                    </span>
+                  </td>
+                  <td><span class="badge badge--primary">v2.0</span></td>
+                  <td>1 day ago</td>
+                </tr>
+                <tr>
+                  <td>Modal</td>
+                  <td>Overlays</td>
+                  <td>
+                    <span class="table-status">
+                      <span
+                        class="table-status__dot table-status__dot--pending"
+                      ></span>
+                      Review
+                    </span>
+                  </td>
+                  <td><span class="badge badge--warning">v1.9</span></td>
+                  <td>3 days ago</td>
+                </tr>
+                <tr>
+                  <td>Tooltip</td>
+                  <td>Feedback</td>
+                  <td>
+                    <span class="table-status">
+                      <span
+                        class="table-status__dot table-status__dot--active"
+                      ></span>
+                      Active
+                    </span>
+                  </td>
+                  <td><span class="badge badge--primary">v2.0</span></td>
+                  <td>5 days ago</td>
+                </tr>
+                <tr>
+                  <td>DatePicker</td>
+                  <td>Forms</td>
+                  <td>
+                    <span class="table-status">
+                      <span
+                        class="table-status__dot table-status__dot--inactive"
+                      ></span>
+                      Deprecated
+                    </span>
+                  </td>
+                  <td><span class="badge badge--error">v1.2</span></td>
+                  <td>2 weeks ago</td>
+                </tr>
+                <tr>
+                  <td>Avatar</td>
+                  <td>Data Display</td>
+                  <td>
+                    <span class="table-status">
+                      <span
+                        class="table-status__dot table-status__dot--active"
+                      ></span>
+                      Active
+                    </span>
+                  </td>
+                  <td><span class="badge badge--primary">v2.1</span></td>
+                  <td>4 hours ago</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 12 — Modal / Dialog Showcase
+           ============================================================ -->
+      <section class="ds-section" id="modal">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">11</span>
+            Modal / Dialog
+          </h2>
+          <p class="ds-section__subtitle">
+            Inline preview of a modal dialog with header, body, and footer
+            actions.
+          </p>
+
+          <div class="modal-showcase">
+            <div class="modal-backdrop"></div>
+            <div class="modal-dialog">
+              <div class="modal-header">
+                <h3 class="modal-header__title">Confirm Action</h3>
+                <button class="modal-header__close" aria-label="Close modal">
+                  ×
+                </button>
+              </div>
+              <div class="modal-body">
+                <p>
+                  Are you sure you want to deploy this design system update to
+                  production? This action will affect all consumers of the token
+                  library.
+                </p>
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn--ghost">Cancel</button>
+                <button class="btn btn--primary">Deploy Now</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 13 — Progress Indicators
+           ============================================================ -->
+      <section class="ds-section" id="progress">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">12</span>
+            Progress Indicators
+          </h2>
+          <p class="ds-section__subtitle">
+            Linear bars, circular gauges, and skeleton loading placeholders.
+          </p>
+
+          <h3 class="color-group__title">Progress Bars</h3>
+          <div class="progress-grid">
+            <div class="progress-bar-wrap">
+              <div class="progress-bar-label">
+                <span>Token Coverage</span><span>78%</span>
+              </div>
+              <div class="progress-bar">
+                <div
+                  class="progress-bar__fill progress-bar__fill--accent"
+                  style="width: 78%"
+                ></div>
+              </div>
+            </div>
+
+            <div class="progress-bar-wrap">
+              <div class="progress-bar-label">
+                <span>Component Adoption</span><span>92%</span>
+              </div>
+              <div class="progress-bar">
+                <div
+                  class="progress-bar__fill progress-bar__fill--success"
+                  style="width: 92%"
+                ></div>
+              </div>
+            </div>
+
+            <div class="progress-bar-wrap">
+              <div class="progress-bar-label">
+                <span>Accessibility Score</span><span>65%</span>
+              </div>
+              <div class="progress-bar">
+                <div
+                  class="progress-bar__fill progress-bar__fill--highlight"
+                  style="width: 65%"
+                ></div>
+              </div>
+            </div>
+
+            <div class="progress-bar-wrap">
+              <div class="progress-bar-label">
+                <span>Loading…</span><span>∞</span>
+              </div>
+              <div class="progress-bar progress-bar--indeterminate">
+                <div
+                  class="progress-bar__fill progress-bar__fill--accent"
+                  style="width: 25%"
+                ></div>
+              </div>
+            </div>
+          </div>
+
+          <h3 class="color-group__title">Circular Progress</h3>
+          <div class="avatar-row">
+            <div class="progress-circular">
+              <svg viewBox="0 0 80 80">
+                <circle
+                  class="progress-circular__track"
+                  cx="40"
+                  cy="40"
+                  r="34"
+                />
+                <circle
+                  class="progress-circular__fill"
+                  cx="40"
+                  cy="40"
+                  r="34"
+                  stroke="var(--accent-blue-lighter)"
+                  stroke-dasharray="213.6"
+                  stroke-dashoffset="46.9"
+                />
+              </svg>
+              <span class="progress-circular__label">78%</span>
+            </div>
+
+            <div class="progress-circular">
+              <svg viewBox="0 0 80 80">
+                <circle
+                  class="progress-circular__track"
+                  cx="40"
+                  cy="40"
+                  r="34"
+                />
+                <circle
+                  class="progress-circular__fill"
+                  cx="40"
+                  cy="40"
+                  r="34"
+                  stroke="var(--color-success)"
+                  stroke-dasharray="213.6"
+                  stroke-dashoffset="17.1"
+                />
+              </svg>
+              <span class="progress-circular__label">92%</span>
+            </div>
+
+            <div class="progress-circular">
+              <svg viewBox="0 0 80 80">
+                <circle
+                  class="progress-circular__track"
+                  cx="40"
+                  cy="40"
+                  r="34"
+                />
+                <circle
+                  class="progress-circular__fill"
+                  cx="40"
+                  cy="40"
+                  r="34"
+                  stroke="var(--highlight)"
+                  stroke-dasharray="213.6"
+                  stroke-dashoffset="74.8"
+                />
+              </svg>
+              <span class="progress-circular__label">65%</span>
+            </div>
+          </div>
+
+          <h3 class="color-group__title">Skeleton Loading</h3>
+          <div class="card card--default" style="max-width: 380px">
+            <div
+              style="
+                display: flex;
+                gap: 12px;
+                align-items: center;
+                margin-bottom: 16px;
+              "
+            >
+              <div class="skeleton skeleton--avatar"></div>
+              <div style="flex: 1">
+                <div class="skeleton skeleton--title"></div>
+                <div class="skeleton skeleton--text" style="width: 40%"></div>
+              </div>
+            </div>
+            <div class="skeleton skeleton--text"></div>
+            <div class="skeleton skeleton--text"></div>
+            <div class="skeleton skeleton--text" style="width: 75%"></div>
+            <div class="skeleton skeleton--card" style="margin-top: 12px"></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 14 — Avatar & User Components
+           ============================================================ -->
+      <section class="ds-section" id="avatars">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">13</span>
+            Avatars &amp; User Components
+          </h2>
+          <p class="ds-section__subtitle">
+            User avatars in multiple sizes, with status indicators and group
+            stacking.
+          </p>
+
+          <h3 class="color-group__title">Sizes</h3>
+          <div class="avatar-row">
+            <div class="avatar avatar--sm avatar--a">S</div>
+            <div class="avatar avatar--md avatar--b">MD</div>
+            <div class="avatar avatar--lg avatar--c">LG</div>
+            <div class="avatar avatar--xl avatar--d">XL</div>
+          </div>
+
+          <h3 class="color-group__title">With Status</h3>
+          <div class="avatar-row">
+            <div class="avatar avatar--lg avatar--a">
+              JD
+              <span class="avatar__status avatar__status--online"></span>
+            </div>
+            <div class="avatar avatar--lg avatar--b">
+              AK
+              <span class="avatar__status avatar__status--away"></span>
+            </div>
+            <div class="avatar avatar--lg avatar--c">
+              MR
+              <span class="avatar__status avatar__status--offline"></span>
+            </div>
+          </div>
+
+          <h3 class="color-group__title">Avatar Group</h3>
+          <div class="avatar-group">
+            <div class="avatar avatar--md avatar--a">A</div>
+            <div class="avatar avatar--md avatar--b">B</div>
+            <div class="avatar avatar--md avatar--c">C</div>
+            <div class="avatar avatar--md avatar--d">D</div>
+            <span class="avatar-group__more">+5</span>
+          </div>
+
+          <h3 class="color-group__title">User Cards</h3>
+          <div class="card-grid">
+            <div class="user-card">
+              <div class="avatar avatar--lg avatar--a">
+                JD
+                <span class="avatar__status avatar__status--online"></span>
+              </div>
+              <div class="user-card__info">
+                <div class="user-card__name">Jane Doe</div>
+                <div class="user-card__role">Lead Designer</div>
+              </div>
+              <span class="badge badge--success">Online</span>
+            </div>
+
+            <div class="user-card">
+              <div class="avatar avatar--lg avatar--b">
+                AK
+                <span class="avatar__status avatar__status--away"></span>
+              </div>
+              <div class="user-card__info">
+                <div class="user-card__name">Alex Kim</div>
+                <div class="user-card__role">Frontend Engineer</div>
+              </div>
+              <span class="badge badge--warning">Away</span>
+            </div>
+
+            <div class="user-card">
+              <div class="avatar avatar--lg avatar--c">
+                MR
+                <span class="avatar__status avatar__status--offline"></span>
+              </div>
+              <div class="user-card__info">
+                <div class="user-card__name">Morgan Rivera</div>
+                <div class="user-card__role">Product Manager</div>
+              </div>
+              <span class="badge badge--default">Offline</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 15 — Layout Grid Demonstrations
+           ============================================================ -->
+      <section class="ds-section" id="grid">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">14</span>
+            Layout Grid Demonstrations
+          </h2>
+          <p class="ds-section__subtitle">
+            Common grid patterns — 2-column, 3-column, 4-column, sidebar, and
+            holy grail layouts.
+          </p>
+
+          <div class="grid-label">2-Column</div>
+          <div class="grid-demo grid-demo--2">
+            <div class="grid-cell">1 / 2</div>
+            <div class="grid-cell">2 / 2</div>
+          </div>
+
+          <div class="grid-label">3-Column</div>
+          <div class="grid-demo grid-demo--3">
+            <div class="grid-cell">1 / 3</div>
+            <div class="grid-cell">2 / 3</div>
+            <div class="grid-cell">3 / 3</div>
+          </div>
+
+          <div class="grid-label">4-Column</div>
+          <div class="grid-demo grid-demo--4">
+            <div class="grid-cell">1 / 4</div>
+            <div class="grid-cell">2 / 4</div>
+            <div class="grid-cell">3 / 4</div>
+            <div class="grid-cell">4 / 4</div>
+          </div>
+
+          <div class="grid-label">Sidebar Layout (1fr 3fr)</div>
+          <div class="grid-demo grid-demo--sidebar">
+            <div class="grid-cell">Sidebar</div>
+            <div class="grid-cell">Main Content</div>
+          </div>
+
+          <div class="grid-label">Holy Grail (1fr 3fr 1fr)</div>
+          <div class="grid-demo grid-demo--holy-grail">
+            <div class="grid-cell">Left</div>
+            <div class="grid-cell">Center</div>
+            <div class="grid-cell">Right</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 16 — Motion / Animation Reference
+           ============================================================ -->
+      <section class="ds-section" id="motion">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">15</span>
+            Motion &amp; Animation Reference
+          </h2>
+          <p class="ds-section__subtitle">
+            Live animation previews for every keyframe defined in the design
+            system.
+          </p>
+
+          <div class="motion-grid">
+            <div class="motion-card">
+              <div
+                class="motion-card__preview motion-card__preview--fade"
+              ></div>
+              <div class="motion-card__name">gentleFade</div>
+              <div class="motion-card__timing">ease-decelerate · 2s</div>
+            </div>
+
+            <div class="motion-card">
+              <div
+                class="motion-card__preview motion-card__preview--slide"
+              ></div>
+              <div class="motion-card__name">slideIn</div>
+              <div class="motion-card__timing">ease-decelerate · 2s</div>
+            </div>
+
+            <div class="motion-card">
+              <div
+                class="motion-card__preview motion-card__preview--scale"
+              ></div>
+              <div class="motion-card__name">scaleUp</div>
+              <div class="motion-card__timing">ease-spring · 2s</div>
+            </div>
+
+            <div class="motion-card">
+              <div
+                class="motion-card__preview motion-card__preview--bounce"
+              ></div>
+              <div class="motion-card__name">bounceIn</div>
+              <div class="motion-card__timing">ease · 2s</div>
+            </div>
+
+            <div class="motion-card">
+              <div
+                class="motion-card__preview motion-card__preview--spin"
+              ></div>
+              <div class="motion-card__name">spin</div>
+              <div class="motion-card__timing">linear · 2s</div>
+            </div>
+
+            <div class="motion-card">
+              <div
+                class="motion-card__preview motion-card__preview--float"
+              ></div>
+              <div class="motion-card__name">float</div>
+              <div class="motion-card__timing">ease-in-out · 3s</div>
+            </div>
+
+            <div class="motion-card">
+              <div
+                class="motion-card__preview motion-card__preview--pulse"
+              ></div>
+              <div class="motion-card__name">pulse</div>
+              <div class="motion-card__timing">ease-in-out · 2s</div>
+            </div>
+
+            <div class="motion-card">
+              <div
+                class="motion-card__preview motion-card__preview--shimmer"
+              ></div>
+              <div class="motion-card__name">shimmerLoad</div>
+              <div class="motion-card__timing">ease · 1.5s</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 17 — Accessibility Checklist
+           ============================================================ -->
+      <section class="ds-section" id="a11y">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">16</span>
+            Accessibility Checklist
+          </h2>
+          <p class="ds-section__subtitle">
+            WCAG 2.1 compliance audit panel for design system components.
+          </p>
+
+          <div class="a11y-panel">
+            <div class="a11y-panel__header">
+              <h3 class="a11y-panel__title">WCAG 2.1 AA Audit</h3>
+              <div class="a11y-score">
+                <span>Score: 94/100</span>
+                <span class="badge badge--success">Pass</span>
+              </div>
+            </div>
+            <ul class="a11y-list">
+              <li class="a11y-item">
+                <span class="a11y-item__check a11y-item__check--pass">✓</span>
+                Color contrast ratio ≥ 4.5:1 for normal text
+              </li>
+              <li class="a11y-item">
+                <span class="a11y-item__check a11y-item__check--pass">✓</span>
+                Color contrast ratio ≥ 3:1 for large text
+              </li>
+              <li class="a11y-item">
+                <span class="a11y-item__check a11y-item__check--pass">✓</span>
+                All interactive elements have visible focus indicators
+              </li>
+              <li class="a11y-item">
+                <span class="a11y-item__check a11y-item__check--pass">✓</span>
+                Form inputs have associated labels
+              </li>
+              <li class="a11y-item">
+                <span class="a11y-item__check a11y-item__check--pass">✓</span>
+                ARIA roles applied to navigation components
+              </li>
+              <li class="a11y-item">
+                <span class="a11y-item__check a11y-item__check--pass">✓</span>
+                Sufficient touch target size (≥ 44×44px)
+              </li>
+              <li class="a11y-item">
+                <span class="a11y-item__check a11y-item__check--warn">!</span>
+                prefers-reduced-motion media query recommended
+              </li>
+              <li class="a11y-item">
+                <span class="a11y-item__check a11y-item__check--pass">✓</span>
+                Semantic HTML elements used throughout
+              </li>
+              <li class="a11y-item">
+                <span class="a11y-item__check a11y-item__check--pass">✓</span>
+                Skip-to-content link available
+              </li>
+              <li class="a11y-item">
+                <span class="a11y-item__check a11y-item__check--warn">!</span>
+                Screen reader testing pending for modal component
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           SECTION 18 — Code Snippet Display
+           ============================================================ -->
+      <section class="ds-section" id="code">
+        <div class="ds-container">
+          <h2 class="ds-section__title">
+            <span class="section-number">17</span>
+            Code Snippet Display
+          </h2>
+          <p class="ds-section__subtitle">
+            Syntax-highlighted code blocks with the design system's monospace
+            styling.
+          </p>
+
+          <div class="code-block" style="margin-bottom: 24px">
+            <div class="code-block__header">
+              <div class="code-block__dots">
+                <span class="code-block__dot code-block__dot--red"></span>
+                <span class="code-block__dot code-block__dot--yellow"></span>
+                <span class="code-block__dot code-block__dot--green"></span>
+              </div>
+              <span class="code-block__lang">CSS</span>
+            </div>
+            <div class="code-block__body">
+              <pre><span class="code-comment">/* Dark Mode Design System Tokens */</span>
+<span class="code-keyword">:root</span> {
+  <span class="code-property">--surface-base</span>: <span class="code-value">#0d0d1a</span>;
+  <span class="code-property">--surface-100</span>: <span class="code-value">#1a1a2e</span>;
+  <span class="code-property">--accent-blue</span>: <span class="code-value">#0f3460</span>;
+  <span class="code-property">--highlight</span>: <span class="code-value">#e94560</span>;
+  <span class="code-property">--text-primary</span>: <span class="code-value">#f0f0f8</span>;
+  <span class="code-property">--font-sans</span>: <span class="code-string">"Inter"</span>, sans-serif;
+  <span class="code-property">--ease-spring</span>: <span class="code-value">cubic-bezier(0.34, 1.56, 0.64, 1)</span>;
+}</pre>
+            </div>
+          </div>
+
+          <div class="code-block" style="margin-bottom: 24px">
+            <div class="code-block__header">
+              <div class="code-block__dots">
+                <span class="code-block__dot code-block__dot--red"></span>
+                <span class="code-block__dot code-block__dot--yellow"></span>
+                <span class="code-block__dot code-block__dot--green"></span>
+              </div>
+              <span class="code-block__lang">HTML</span>
+            </div>
+            <div class="code-block__body">
+              <pre><span class="code-comment">&lt;!-- Using a design system button --&gt;</span>
+<span class="code-keyword">&lt;button</span> <span class="code-property">class</span>=<span class="code-string">"btn btn--primary btn--lg"</span><span class="code-keyword">&gt;</span>
+  ⚡ Deploy Now
+<span class="code-keyword">&lt;/button&gt;</span>
+
+<span class="code-comment">&lt;!-- Glassmorphic card --&gt;</span>
+<span class="code-keyword">&lt;div</span> <span class="code-property">class</span>=<span class="code-string">"card card--glass"</span><span class="code-keyword">&gt;</span>
+  <span class="code-keyword">&lt;h3</span> <span class="code-property">class</span>=<span class="code-string">"card__title"</span><span class="code-keyword">&gt;</span>Frosted<span class="code-keyword">&lt;/h3&gt;</span>
+  <span class="code-keyword">&lt;p</span> <span class="code-property">class</span>=<span class="code-string">"card__body"</span><span class="code-keyword">&gt;</span>Content here<span class="code-keyword">&lt;/p&gt;</span>
+<span class="code-keyword">&lt;/div&gt;</span></pre>
+            </div>
+          </div>
+
+          <div class="code-block">
+            <div class="code-block__header">
+              <div class="code-block__dots">
+                <span class="code-block__dot code-block__dot--red"></span>
+                <span class="code-block__dot code-block__dot--yellow"></span>
+                <span class="code-block__dot code-block__dot--green"></span>
+              </div>
+              <span class="code-block__lang">JavaScript</span>
+            </div>
+            <div class="code-block__body">
+              <pre><span class="code-comment">// Reading design tokens at runtime</span>
+<span class="code-keyword">const</span> <span class="code-property">styles</span> = <span class="code-value">getComputedStyle</span>(document.documentElement);
+<span class="code-keyword">const</span> <span class="code-property">highlight</span> = styles.<span class="code-value">getPropertyValue</span>(<span class="code-string">'--highlight'</span>);
+<span class="code-keyword">const</span> <span class="code-property">surface</span> = styles.<span class="code-value">getPropertyValue</span>(<span class="code-string">'--surface-100'</span>);
+
+console.<span class="code-value">log</span>(<span class="code-string">'Highlight:'</span>, highlight); <span class="code-comment">// #e94560</span></pre>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- ============================================================
+         FOOTER
+         ============================================================ -->
+    <footer class="ds-footer">
+      <div class="ds-container">
+        <p class="ds-footer__text">
+          Dark Mode Design System — Built with
+          <span class="ds-footer__heart">♥</span> using EaseMotion CSS · Zero
+          Dependencies · v2.0.0
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/submissions/examples/dark-mode-design-system-bv/style.css
+++ b/submissions/examples/dark-mode-design-system-bv/style.css
@@ -1,0 +1,2181 @@
+/* ============================================================
+   Dark Mode Design System — style.css
+   A comprehensive dark-theme design-token reference
+   ============================================================ */
+
+/* ---------- Google Fonts ---------- */
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap");
+
+/* ============================================================
+   1. DESIGN TOKENS — CSS Custom Properties
+   ============================================================ */
+:root {
+  /* --- Surfaces --- */
+  --surface-base: #0d0d1a;
+  --surface-100: #1a1a2e;
+  --surface-200: #16213e;
+  --surface-300: #1e2a4a;
+  --surface-400: #263557;
+  --surface-500: #2e4063;
+  --surface-overlay: rgba(13, 13, 26, 0.85);
+
+  /* --- Brand Palette --- */
+  --accent-blue: #0f3460;
+  --accent-blue-light: #1a5276;
+  --accent-blue-lighter: #2980b9;
+  --highlight: #e94560;
+  --highlight-light: #ff6b81;
+  --highlight-dark: #c0392b;
+
+  /* --- Semantic Colors --- */
+  --color-success: #00c853;
+  --color-success-bg: rgba(0, 200, 83, 0.12);
+  --color-warning: #ffc107;
+  --color-warning-bg: rgba(255, 193, 7, 0.12);
+  --color-error: #ef5350;
+  --color-error-bg: rgba(239, 83, 80, 0.12);
+  --color-info: #29b6f6;
+  --color-info-bg: rgba(41, 182, 246, 0.12);
+
+  /* --- Text --- */
+  --text-primary: #f0f0f8;
+  --text-secondary: #a0a0c0;
+  --text-tertiary: #6b6b8d;
+  --text-disabled: #4a4a6a;
+  --text-inverse: #0d0d1a;
+
+  /* --- Borders --- */
+  --border-subtle: rgba(255, 255, 255, 0.06);
+  --border-default: rgba(255, 255, 255, 0.1);
+  --border-strong: rgba(255, 255, 255, 0.18);
+  --border-accent: var(--accent-blue-lighter);
+  --border-radius-sm: 6px;
+  --border-radius-md: 10px;
+  --border-radius-lg: 16px;
+  --border-radius-xl: 24px;
+  --border-radius-full: 9999px;
+
+  /* --- Spacing --- */
+  --space-2xs: 0.25rem;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+  --space-3xl: 4rem;
+  --space-4xl: 6rem;
+
+  /* --- Typography --- */
+  --font-sans:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+  --text-5xl: 3rem;
+  --text-6xl: 3.75rem;
+
+  --leading-tight: 1.15;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.75;
+
+  --weight-light: 300;
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+  --weight-extrabold: 800;
+  --weight-black: 900;
+
+  /* --- Shadows --- */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+  --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.6);
+  --shadow-glow-accent: 0 0 20px rgba(41, 128, 185, 0.25);
+  --shadow-glow-highlight: 0 0 20px rgba(233, 69, 96, 0.25);
+
+  /* --- Transitions --- */
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-decelerate: cubic-bezier(0, 0, 0.2, 1);
+  --ease-accelerate: cubic-bezier(0.4, 0, 1, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --duration-fast: 150ms;
+  --duration-normal: 250ms;
+  --duration-slow: 400ms;
+  --duration-slower: 600ms;
+
+  /* --- Glassmorphism --- */
+  --glass-bg: rgba(26, 26, 46, 0.6);
+  --glass-blur: blur(16px);
+  --glass-border: 1px solid rgba(255, 255, 255, 0.08);
+  --glass-bg-strong: rgba(22, 33, 62, 0.75);
+  --glass-blur-strong: blur(24px);
+
+  /* --- Z-Index Scale --- */
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-modal-backdrop: 300;
+  --z-modal: 400;
+  --z-toast: 500;
+}
+
+/* ============================================================
+   2. KEYFRAME ANIMATIONS
+   ============================================================ */
+@keyframes gentleFade {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(-24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes scaleUp {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes shimmerLoad {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes progressIndeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+
+@keyframes bounceIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.3);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+  70% {
+    transform: scale(0.96);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+
+@keyframes gradientShift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+/* ============================================================
+   3. RESET & BASE
+   ============================================================ */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--text-primary);
+  background: var(--surface-base);
+  min-height: 100vh;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: var(--surface-100);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--surface-400);
+  border-radius: var(--border-radius-full);
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--surface-500);
+}
+
+::selection {
+  background: var(--highlight);
+  color: var(--text-primary);
+}
+
+a {
+  color: var(--accent-blue-lighter);
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--ease-standard);
+}
+a:hover {
+  color: var(--highlight-light);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+/* ============================================================
+   4. LAYOUT CONTAINER
+   ============================================================ */
+.ds-container {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 0 var(--space-lg);
+}
+
+/* ============================================================
+   5. SECTIONS
+   ============================================================ */
+.ds-section {
+  padding: var(--space-4xl) 0;
+  border-bottom: 1px solid var(--border-subtle);
+  animation: gentleFade 0.6s var(--ease-decelerate) both;
+}
+
+.ds-section:last-child {
+  border-bottom: none;
+}
+
+.ds-section__title {
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-bold);
+  margin-bottom: var(--space-xs);
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.ds-section__title .section-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: var(--highlight);
+  color: #fff;
+  border-radius: var(--border-radius-sm);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  flex-shrink: 0;
+}
+
+.ds-section__subtitle {
+  font-size: var(--text-lg);
+  color: var(--text-secondary);
+  margin-bottom: var(--space-2xl);
+  max-width: 640px;
+}
+
+/* ============================================================
+   6. HEADER
+   ============================================================ */
+.ds-header {
+  padding: var(--space-4xl) 0;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(
+    145deg,
+    var(--surface-100) 0%,
+    var(--accent-blue) 50%,
+    var(--surface-200) 100%
+  );
+  background-size: 200% 200%;
+  animation: gradientShift 8s ease infinite;
+}
+
+.ds-header::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(
+      circle at 20% 50%,
+      rgba(233, 69, 96, 0.15) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      circle at 80% 50%,
+      rgba(41, 128, 185, 0.15) 0%,
+      transparent 50%
+    );
+  pointer-events: none;
+}
+
+.ds-header__content {
+  position: relative;
+  z-index: 1;
+}
+
+.ds-header__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-2xs) var(--space-md);
+  background: rgba(233, 69, 96, 0.2);
+  border: 1px solid rgba(233, 69, 96, 0.4);
+  border-radius: var(--border-radius-full);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--highlight-light);
+  margin-bottom: var(--space-lg);
+}
+
+.ds-header__badge .dot {
+  width: 8px;
+  height: 8px;
+  background: var(--highlight);
+  border-radius: 50%;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.ds-header__title {
+  font-size: clamp(var(--text-4xl), 5vw, var(--text-6xl));
+  font-weight: var(--weight-black);
+  line-height: var(--leading-tight);
+  margin-bottom: var(--space-md);
+  background: linear-gradient(
+    135deg,
+    var(--text-primary) 0%,
+    var(--accent-blue-lighter) 50%,
+    var(--highlight-light) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.ds-header__desc {
+  font-size: var(--text-xl);
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto var(--space-xl);
+  line-height: var(--leading-relaxed);
+}
+
+.ds-header__meta {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-xl);
+  flex-wrap: wrap;
+}
+
+.ds-header__meta-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2xs);
+}
+
+.ds-header__meta-value {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-bold);
+  color: var(--text-primary);
+}
+
+.ds-header__meta-label {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+/* ============================================================
+   7. COLOR PALETTE
+   ============================================================ */
+.color-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: var(--space-md);
+}
+
+.color-swatch {
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  transition:
+    transform var(--duration-normal) var(--ease-spring),
+    box-shadow var(--duration-normal) var(--ease-standard);
+}
+
+.color-swatch:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
+}
+
+.color-swatch__preview {
+  height: 100px;
+  position: relative;
+}
+
+.color-swatch__info {
+  padding: var(--space-sm);
+  background: var(--surface-100);
+}
+
+.color-swatch__name {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.color-swatch__hex {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.color-group__title {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  margin: var(--space-xl) 0 var(--space-md);
+  color: var(--text-secondary);
+}
+
+/* ============================================================
+   8. TYPOGRAPHY SCALE
+   ============================================================ */
+.type-scale-item {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-xl);
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.type-scale-item:last-child {
+  border-bottom: none;
+}
+
+.type-scale-meta {
+  flex-shrink: 0;
+  width: 140px;
+  text-align: right;
+}
+
+.type-scale-meta__label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--accent-blue-lighter);
+  font-weight: var(--weight-medium);
+}
+
+.type-scale-meta__size {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.type-sample--h1 {
+  font-size: var(--text-6xl);
+  font-weight: var(--weight-black);
+  line-height: var(--leading-tight);
+}
+.type-sample--h2 {
+  font-size: var(--text-5xl);
+  font-weight: var(--weight-extrabold);
+  line-height: var(--leading-tight);
+}
+.type-sample--h3 {
+  font-size: var(--text-4xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
+}
+.type-sample--h4 {
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-semibold);
+}
+.type-sample--h5 {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-semibold);
+}
+.type-sample--h6 {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-medium);
+}
+.type-sample--body {
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  color: var(--text-secondary);
+}
+.type-sample--caption {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+}
+.type-sample--code {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--highlight-light);
+  background: var(--surface-200);
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--border-radius-sm);
+}
+
+/* ============================================================
+   9. SPACING SCALE
+   ============================================================ */
+.spacing-scale {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.spacing-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-lg);
+}
+
+.spacing-item__bar {
+  height: 24px;
+  background: linear-gradient(
+    90deg,
+    var(--accent-blue),
+    var(--accent-blue-lighter)
+  );
+  border-radius: var(--border-radius-sm);
+  transition: width var(--duration-slow) var(--ease-spring);
+}
+
+.spacing-item__label {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  min-width: 120px;
+  flex-shrink: 0;
+}
+
+.spacing-item__value {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  min-width: 60px;
+}
+
+/* ============================================================
+   10. BUTTONS
+   ============================================================ */
+.btn-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  align-items: flex-start;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-xl);
+  border: 2px solid transparent;
+  border-radius: var(--border-radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+  transition: all var(--duration-normal) var(--ease-standard);
+  position: relative;
+  overflow: hidden;
+  text-decoration: none;
+  outline: none;
+}
+
+.btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0);
+  transition: background var(--duration-fast);
+}
+
+.btn:active::after {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--accent-blue-lighter);
+  outline-offset: 2px;
+}
+
+/* Primary */
+.btn--primary {
+  background: var(--highlight);
+  color: #fff;
+  border-color: var(--highlight);
+}
+.btn--primary:hover {
+  background: var(--highlight-light);
+  border-color: var(--highlight-light);
+  box-shadow: var(--shadow-glow-highlight);
+  transform: translateY(-1px);
+}
+.btn--primary:active {
+  background: var(--highlight-dark);
+  transform: translateY(0);
+}
+
+/* Secondary */
+.btn--secondary {
+  background: var(--accent-blue);
+  color: var(--text-primary);
+  border-color: var(--accent-blue-lighter);
+}
+.btn--secondary:hover {
+  background: var(--accent-blue-light);
+  box-shadow: var(--shadow-glow-accent);
+  transform: translateY(-1px);
+}
+
+/* Ghost */
+.btn--ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+}
+.btn--ghost:hover {
+  background: var(--surface-200);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+
+/* Danger */
+.btn--danger {
+  background: var(--color-error);
+  color: #fff;
+  border-color: var(--color-error);
+}
+.btn--danger:hover {
+  background: #d32f2f;
+  box-shadow: 0 0 20px rgba(239, 83, 80, 0.3);
+  transform: translateY(-1px);
+}
+
+/* Disabled */
+.btn--disabled {
+  background: var(--surface-300);
+  color: var(--text-disabled);
+  border-color: var(--surface-300);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.btn--disabled:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+/* Sizes */
+.btn--sm {
+  padding: var(--space-2xs) var(--space-md);
+  font-size: var(--text-xs);
+}
+.btn--lg {
+  padding: var(--space-md) var(--space-2xl);
+  font-size: var(--text-lg);
+}
+
+/* ============================================================
+   11. CARDS
+   ============================================================ */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-lg);
+}
+
+.card {
+  padding: var(--space-xl);
+  border-radius: var(--border-radius-lg);
+  transition: all var(--duration-normal) var(--ease-standard);
+}
+
+.card__title {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  margin-bottom: var(--space-xs);
+}
+
+.card__body {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+.card__tag {
+  display: inline-block;
+  padding: 2px var(--space-xs);
+  background: var(--accent-blue);
+  color: var(--accent-blue-lighter);
+  border-radius: var(--border-radius-sm);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  margin-bottom: var(--space-sm);
+}
+
+/* Default */
+.card--default {
+  background: var(--surface-100);
+  border: 1px solid var(--border-subtle);
+}
+.card--default:hover {
+  border-color: var(--border-default);
+}
+
+/* Elevated */
+.card--elevated {
+  background: var(--surface-200);
+  box-shadow: var(--shadow-lg);
+}
+.card--elevated:hover {
+  box-shadow: var(--shadow-xl);
+  transform: translateY(-4px);
+}
+
+/* Outlined */
+.card--outlined {
+  background: transparent;
+  border: 2px solid var(--border-default);
+}
+.card--outlined:hover {
+  border-color: var(--accent-blue-lighter);
+}
+
+/* Interactive */
+.card--interactive {
+  background: var(--surface-100);
+  border: 1px solid var(--border-subtle);
+  cursor: pointer;
+}
+.card--interactive:hover {
+  background: var(--surface-200);
+  border-color: var(--highlight);
+  box-shadow: var(--shadow-glow-highlight);
+  transform: translateY(-2px) scale(1.01);
+}
+
+/* Glassmorphic */
+.card--glass {
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: var(--glass-border);
+}
+.card--glass:hover {
+  background: var(--glass-bg-strong);
+  box-shadow: var(--shadow-glow-accent);
+}
+
+/* ============================================================
+   12. FORM ELEMENTS
+   ============================================================ */
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--space-xl);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.form-label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+}
+
+.form-input,
+.form-textarea,
+.form-select {
+  padding: var(--space-sm) var(--space-md);
+  background: var(--surface-200);
+  border: 1px solid var(--border-default);
+  border-radius: var(--border-radius-md);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  transition: all var(--duration-fast) var(--ease-standard);
+  outline: none;
+}
+
+.form-input:hover,
+.form-textarea:hover,
+.form-select:hover {
+  border-color: var(--border-strong);
+}
+
+.form-input:focus,
+.form-textarea:focus,
+.form-select:focus {
+  border-color: var(--accent-blue-lighter);
+  box-shadow: 0 0 0 3px rgba(41, 128, 185, 0.2);
+}
+
+.form-input::placeholder,
+.form-textarea::placeholder {
+  color: var(--text-tertiary);
+}
+
+.form-textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.form-select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23a0a0c0' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 36px;
+  cursor: pointer;
+}
+
+/* Checkbox & Radio */
+.form-check {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.form-check input[type="checkbox"],
+.form-check input[type="radio"] {
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--border-strong);
+  background: var(--surface-200);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+  flex-shrink: 0;
+}
+
+.form-check input[type="checkbox"] {
+  border-radius: var(--border-radius-sm);
+}
+.form-check input[type="radio"] {
+  border-radius: 50%;
+}
+
+.form-check input[type="checkbox"]:checked,
+.form-check input[type="radio"]:checked {
+  background: var(--highlight);
+  border-color: var(--highlight);
+}
+
+.form-check input[type="checkbox"]:checked::after {
+  content: "✓";
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.form-check input[type="radio"]:checked::after {
+  content: "";
+  display: block;
+  width: 8px;
+  height: 8px;
+  background: #fff;
+  border-radius: 50%;
+  margin: 4px auto;
+}
+
+.form-check input:focus-visible {
+  outline: 2px solid var(--accent-blue-lighter);
+  outline-offset: 2px;
+}
+
+/* Toggle Switch */
+.toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle__track {
+  width: 44px;
+  height: 24px;
+  background: var(--surface-400);
+  border-radius: var(--border-radius-full);
+  position: relative;
+  transition: background var(--duration-fast);
+  flex-shrink: 0;
+}
+
+.toggle__track::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  background: var(--text-primary);
+  border-radius: 50%;
+  transition: transform var(--duration-normal) var(--ease-spring);
+}
+
+.toggle input:checked + .toggle__track {
+  background: var(--color-success);
+}
+
+.toggle input:checked + .toggle__track::after {
+  transform: translateX(20px);
+}
+
+.toggle input:focus-visible + .toggle__track {
+  outline: 2px solid var(--accent-blue-lighter);
+  outline-offset: 2px;
+}
+
+/* ============================================================
+   13. NAVIGATION PATTERNS
+   ============================================================ */
+
+/* Tabs */
+.tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--border-subtle);
+  margin-bottom: var(--space-lg);
+}
+
+.tab {
+  padding: var(--space-sm) var(--space-xl);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-tertiary);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  transition: all var(--duration-fast);
+  background: none;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  font-family: var(--font-sans);
+}
+
+.tab:hover {
+  color: var(--text-secondary);
+  background: var(--surface-100);
+}
+
+.tab--active {
+  color: var(--highlight);
+  border-bottom-color: var(--highlight);
+}
+
+/* Breadcrumbs */
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  margin-bottom: var(--space-lg);
+}
+
+.breadcrumbs__sep {
+  color: var(--text-disabled);
+}
+
+.breadcrumbs__link {
+  color: var(--text-secondary);
+  transition: color var(--duration-fast);
+}
+
+.breadcrumbs__link:hover {
+  color: var(--accent-blue-lighter);
+}
+
+.breadcrumbs__current {
+  color: var(--text-primary);
+  font-weight: var(--weight-medium);
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2xs);
+}
+
+.page-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 var(--space-xs);
+  border: 1px solid var(--border-default);
+  border-radius: var(--border-radius-sm);
+  background: var(--surface-100);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+  font-family: var(--font-sans);
+}
+
+.page-btn:hover {
+  background: var(--surface-200);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.page-btn--active {
+  background: var(--highlight);
+  border-color: var(--highlight);
+  color: #fff;
+}
+
+/* ============================================================
+   14. BADGES & TAGS
+   ============================================================ */
+.badge-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-sm);
+  border-radius: var(--border-radius-full);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+}
+
+.badge--default {
+  background: var(--surface-300);
+  color: var(--text-secondary);
+}
+.badge--primary {
+  background: rgba(15, 52, 96, 0.5);
+  color: var(--accent-blue-lighter);
+  border: 1px solid var(--accent-blue);
+}
+.badge--success {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+  border: 1px solid rgba(0, 200, 83, 0.3);
+}
+.badge--warning {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  border: 1px solid rgba(255, 193, 7, 0.3);
+}
+.badge--error {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+  border: 1px solid rgba(239, 83, 80, 0.3);
+}
+.badge--info {
+  background: var(--color-info-bg);
+  color: var(--color-info);
+  border: 1px solid rgba(41, 182, 246, 0.3);
+}
+.badge--highlight {
+  background: rgba(233, 69, 96, 0.15);
+  color: var(--highlight-light);
+  border: 1px solid rgba(233, 69, 96, 0.3);
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-sm);
+  background: var(--surface-200);
+  border: 1px solid var(--border-default);
+  border-radius: var(--border-radius-sm);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+}
+
+.tag:hover {
+  background: var(--surface-300);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.tag__close {
+  font-size: 10px;
+  opacity: 0.6;
+  transition: opacity var(--duration-fast);
+}
+
+.tag:hover .tag__close {
+  opacity: 1;
+}
+
+/* ============================================================
+   15. ALERTS & TOASTS
+   ============================================================ */
+.alert-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.alert {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  border-radius: var(--border-radius-md);
+  border-left: 4px solid;
+  animation: slideIn 0.4s var(--ease-decelerate) both;
+}
+
+.alert__icon {
+  font-size: var(--text-xl);
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.alert__content {
+  flex: 1;
+}
+
+.alert__title {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  margin-bottom: 2px;
+}
+
+.alert__message {
+  font-size: var(--text-sm);
+  opacity: 0.85;
+}
+
+.alert__close {
+  background: none;
+  border: none;
+  color: inherit;
+  opacity: 0.5;
+  cursor: pointer;
+  font-size: var(--text-lg);
+  padding: 0;
+  transition: opacity var(--duration-fast);
+}
+
+.alert__close:hover {
+  opacity: 1;
+}
+
+.alert--success {
+  background: var(--color-success-bg);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+.alert--warning {
+  background: var(--color-warning-bg);
+  border-color: var(--color-warning);
+  color: var(--color-warning);
+}
+.alert--error {
+  background: var(--color-error-bg);
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+.alert--info {
+  background: var(--color-info-bg);
+  border-color: var(--color-info);
+  color: var(--color-info);
+}
+
+/* Toast */
+.toast-demo {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  max-width: 380px;
+  margin-top: var(--space-lg);
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--glass-bg-strong);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: var(--glass-border);
+  border-radius: var(--border-radius-md);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-lg);
+  animation: scaleUp 0.3s var(--ease-spring) both;
+}
+
+.toast__icon {
+  font-size: var(--text-lg);
+  flex-shrink: 0;
+}
+
+/* ============================================================
+   16. TABLE
+   ============================================================ */
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--border-subtle);
+}
+
+.ds-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.ds-table thead {
+  background: var(--surface-200);
+}
+
+.ds-table th {
+  padding: var(--space-sm) var(--space-md);
+  text-align: left;
+  font-weight: var(--weight-semibold);
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-default);
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: color var(--duration-fast);
+}
+
+.ds-table th:hover {
+  color: var(--text-primary);
+}
+
+.ds-table th .sort-icon {
+  font-size: 10px;
+  margin-left: var(--space-2xs);
+  opacity: 0.4;
+}
+
+.ds-table th.sorted .sort-icon {
+  opacity: 1;
+  color: var(--highlight);
+}
+
+.ds-table td {
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+}
+
+.ds-table tbody tr {
+  transition: background var(--duration-fast);
+}
+
+.ds-table tbody tr:hover {
+  background: var(--surface-100);
+}
+
+.ds-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  font-size: var(--text-xs);
+}
+
+.table-status__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.table-status__dot--active {
+  background: var(--color-success);
+}
+.table-status__dot--pending {
+  background: var(--color-warning);
+}
+.table-status__dot--inactive {
+  background: var(--color-error);
+}
+
+/* ============================================================
+   17. MODAL / DIALOG
+   ============================================================ */
+.modal-showcase {
+  position: relative;
+  min-height: 400px;
+  background: var(--surface-100);
+  border-radius: var(--border-radius-lg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.modal-dialog {
+  position: relative;
+  z-index: 1;
+  width: 90%;
+  max-width: 480px;
+  background: var(--surface-200);
+  border-radius: var(--border-radius-lg);
+  border: 1px solid var(--border-default);
+  box-shadow: var(--shadow-xl);
+  animation: scaleUp 0.35s var(--ease-spring) both;
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-lg) var(--space-xl);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.modal-header__title {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+}
+
+.modal-header__close {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: var(--surface-300);
+  color: var(--text-secondary);
+  border-radius: var(--border-radius-sm);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+  font-size: var(--text-lg);
+}
+
+.modal-header__close:hover {
+  background: var(--surface-400);
+  color: var(--text-primary);
+}
+
+.modal-body {
+  padding: var(--space-xl);
+}
+
+.modal-body p {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-xl);
+  border-top: 1px solid var(--border-subtle);
+  background: var(--surface-100);
+}
+
+/* ============================================================
+   18. PROGRESS INDICATORS
+   ============================================================ */
+.progress-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--space-xl);
+}
+
+/* Bar */
+.progress-bar-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.progress-bar-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.progress-bar {
+  height: 8px;
+  background: var(--surface-300);
+  border-radius: var(--border-radius-full);
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-bar__fill {
+  height: 100%;
+  border-radius: var(--border-radius-full);
+  transition: width 1s var(--ease-decelerate);
+}
+
+.progress-bar__fill--accent {
+  background: linear-gradient(
+    90deg,
+    var(--accent-blue),
+    var(--accent-blue-lighter)
+  );
+}
+.progress-bar__fill--highlight {
+  background: linear-gradient(90deg, var(--highlight-dark), var(--highlight));
+}
+.progress-bar__fill--success {
+  background: linear-gradient(90deg, #00897b, var(--color-success));
+}
+
+.progress-bar--indeterminate .progress-bar__fill {
+  width: 25% !important;
+  animation: progressIndeterminate 1.5s var(--ease-standard) infinite;
+}
+
+/* Circular */
+.progress-circular {
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+
+.progress-circular svg {
+  transform: rotate(-90deg);
+  width: 80px;
+  height: 80px;
+}
+
+.progress-circular__track {
+  fill: none;
+  stroke: var(--surface-300);
+  stroke-width: 6;
+}
+
+.progress-circular__fill {
+  fill: none;
+  stroke-width: 6;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 1s var(--ease-decelerate);
+}
+
+.progress-circular__label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+}
+
+/* Skeleton */
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--surface-200) 25%,
+    var(--surface-300) 50%,
+    var(--surface-200) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmerLoad 1.5s ease infinite;
+  border-radius: var(--border-radius-sm);
+}
+
+.skeleton--text {
+  height: 14px;
+  margin-bottom: var(--space-xs);
+}
+
+.skeleton--title {
+  height: 22px;
+  width: 60%;
+  margin-bottom: var(--space-sm);
+}
+
+.skeleton--avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
+.skeleton--card {
+  height: 160px;
+  border-radius: var(--border-radius-md);
+}
+
+/* ============================================================
+   19. AVATARS & USER COMPONENTS
+   ============================================================ */
+.avatar-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-weight: var(--weight-semibold);
+  color: #fff;
+  overflow: hidden;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.avatar--sm {
+  width: 32px;
+  height: 32px;
+  font-size: var(--text-xs);
+}
+.avatar--md {
+  width: 40px;
+  height: 40px;
+  font-size: var(--text-sm);
+}
+.avatar--lg {
+  width: 56px;
+  height: 56px;
+  font-size: var(--text-xl);
+}
+.avatar--xl {
+  width: 72px;
+  height: 72px;
+  font-size: var(--text-2xl);
+}
+
+.avatar--a {
+  background: linear-gradient(135deg, var(--highlight), var(--highlight-dark));
+}
+.avatar--b {
+  background: linear-gradient(
+    135deg,
+    var(--accent-blue-lighter),
+    var(--accent-blue)
+  );
+}
+.avatar--c {
+  background: linear-gradient(135deg, var(--color-success), #00897b);
+}
+.avatar--d {
+  background: linear-gradient(135deg, var(--color-warning), #f57f17);
+}
+
+.avatar__status {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--surface-base);
+}
+
+.avatar__status--online {
+  background: var(--color-success);
+}
+.avatar__status--away {
+  background: var(--color-warning);
+}
+.avatar__status--offline {
+  background: var(--text-disabled);
+}
+
+.user-card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--surface-100);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--border-radius-md);
+  transition: all var(--duration-fast);
+}
+
+.user-card:hover {
+  background: var(--surface-200);
+  border-color: var(--border-default);
+}
+
+.user-card__info {
+  flex: 1;
+}
+
+.user-card__name {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.user-card__role {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+/* Avatar Group */
+.avatar-group {
+  display: flex;
+}
+
+.avatar-group .avatar {
+  border: 2px solid var(--surface-base);
+  margin-left: -10px;
+}
+
+.avatar-group .avatar:first-child {
+  margin-left: 0;
+}
+
+.avatar-group__more {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--surface-300);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  border: 2px solid var(--surface-base);
+  margin-left: -10px;
+}
+
+/* ============================================================
+   20. LAYOUT GRID
+   ============================================================ */
+.grid-demo {
+  display: grid;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+.grid-demo--2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+.grid-demo--3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+.grid-demo--4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+.grid-demo--sidebar {
+  grid-template-columns: 1fr 3fr;
+}
+.grid-demo--holy-grail {
+  grid-template-columns: 1fr 3fr 1fr;
+}
+
+.grid-cell {
+  padding: var(--space-lg);
+  background: var(--surface-200);
+  border: 1px dashed var(--border-default);
+  border-radius: var(--border-radius-sm);
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+
+.grid-label {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  margin-bottom: var(--space-xs);
+  font-family: var(--font-mono);
+}
+
+/* ============================================================
+   21. MOTION / ANIMATION
+   ============================================================ */
+.motion-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--space-lg);
+}
+
+.motion-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-xl);
+  background: var(--surface-100);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--border-radius-md);
+  text-align: center;
+}
+
+.motion-card__preview {
+  width: 48px;
+  height: 48px;
+  background: var(--highlight);
+  border-radius: var(--border-radius-md);
+}
+
+.motion-card__preview--fade {
+  animation: gentleFade 2s var(--ease-decelerate) infinite alternate;
+}
+
+.motion-card__preview--slide {
+  animation: slideIn 2s var(--ease-decelerate) infinite alternate;
+}
+
+.motion-card__preview--scale {
+  animation: scaleUp 2s var(--ease-spring) infinite alternate;
+}
+
+.motion-card__preview--bounce {
+  animation: bounceIn 2s ease infinite;
+}
+
+.motion-card__preview--spin {
+  animation: spin 2s linear infinite;
+}
+
+.motion-card__preview--float {
+  animation: float 3s ease-in-out infinite;
+}
+
+.motion-card__preview--pulse {
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.motion-card__preview--shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--surface-200) 25%,
+    var(--highlight) 50%,
+    var(--surface-200) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmerLoad 1.5s ease infinite;
+}
+
+.motion-card__name {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.motion-card__timing {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+/* ============================================================
+   22. ACCESSIBILITY CHECKLIST
+   ============================================================ */
+.a11y-panel {
+  background: var(--surface-100);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+}
+
+.a11y-panel__header {
+  padding: var(--space-lg) var(--space-xl);
+  background: var(--surface-200);
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.a11y-panel__title {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+}
+
+.a11y-score {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  color: var(--color-success);
+}
+
+.a11y-list {
+  list-style: none;
+  padding: var(--space-md) var(--space-xl);
+}
+
+.a11y-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.a11y-item:last-child {
+  border-bottom: none;
+}
+
+.a11y-item__check {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.a11y-item__check--pass {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+  border: 1px solid rgba(0, 200, 83, 0.3);
+}
+
+.a11y-item__check--warn {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  border: 1px solid rgba(255, 193, 7, 0.3);
+}
+
+/* ============================================================
+   23. CODE SNIPPET
+   ============================================================ */
+.code-block {
+  background: var(--surface-200);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+}
+
+.code-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--surface-300);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.code-block__dots {
+  display: flex;
+  gap: 6px;
+}
+
+.code-block__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.code-block__dot--red {
+  background: #ef5350;
+}
+.code-block__dot--yellow {
+  background: #ffc107;
+}
+.code-block__dot--green {
+  background: #00c853;
+}
+
+.code-block__lang {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.code-block__body {
+  padding: var(--space-md) var(--space-lg);
+  overflow-x: auto;
+}
+
+.code-block pre {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+  color: var(--text-primary);
+}
+
+.code-block .code-keyword {
+  color: var(--highlight-light);
+}
+.code-block .code-string {
+  color: var(--color-success);
+}
+.code-block .code-comment {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+.code-block .code-property {
+  color: var(--accent-blue-lighter);
+}
+.code-block .code-value {
+  color: var(--color-warning);
+}
+
+/* ============================================================
+   24. FOOTER
+   ============================================================ */
+.ds-footer {
+  padding: var(--space-2xl) 0;
+  text-align: center;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.ds-footer__text {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+}
+
+.ds-footer__heart {
+  color: var(--highlight);
+}
+
+/* ============================================================
+   25. RESPONSIVE
+   ============================================================ */
+@media (max-width: 1024px) {
+  .grid-demo--holy-grail {
+    grid-template-columns: 1fr 2fr;
+  }
+  .card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .ds-container {
+    padding: 0 var(--space-md);
+  }
+
+  .ds-section {
+    padding: var(--space-2xl) 0;
+  }
+
+  .ds-section__title {
+    font-size: var(--text-2xl);
+  }
+
+  .ds-header__title {
+    font-size: var(--text-4xl);
+  }
+
+  .ds-header__meta {
+    gap: var(--space-md);
+  }
+
+  .type-scale-item {
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .type-scale-meta {
+    text-align: left;
+    width: auto;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .grid-demo--2,
+  .grid-demo--3,
+  .grid-demo--4,
+  .grid-demo--sidebar,
+  .grid-demo--holy-grail {
+    grid-template-columns: 1fr;
+  }
+
+  .color-grid {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  }
+
+  .motion-grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  }
+
+  .progress-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tabs {
+    overflow-x: auto;
+  }
+
+  .modal-dialog {
+    width: 95%;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .btn-grid {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn-grid .btn {
+    text-align: center;
+  }
+
+  .ds-header__title {
+    font-size: var(--text-3xl);
+  }
+
+  .badge-grid {
+    gap: var(--space-xs);
+  }
+
+  .pagination {
+    flex-wrap: wrap;
+  }
+}
+
+/* ============================================================
+   26. PRINT STYLES
+   ============================================================ */
+@media print {
+  body {
+    background: #fff;
+    color: #000;
+  }
+
+  .ds-header {
+    background: none;
+    animation: none;
+  }
+
+  .motion-card__preview {
+    animation: none !important;
+  }
+
+  .skeleton {
+    animation: none !important;
+    background: #eee;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #8853

Adds the **Dark Mode Design System Showcase** example to the EaseMotion CSS Elite Showcase series.

---

## Type of Change

- [x] New component / showcase page
- [x] Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/dark-mode-design-system-bv/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**

---

## Feature Description

**What does this add?**
reference library showcasing dark mode color swatches, typography scale ranges, buttons, inputs, alerts, grids, and skeleton loaders

**Why does it fit EaseMotion CSS?**
It demonstrates premium enterprise UX, smooth responsive transitions, and visual polish utilizing pure CSS.