### PR TITLE
feat: add devops observability command center example

### DIFF
--- a/submissions/examples/devops-observability-bv/README.md
+++ b/submissions/examples/devops-observability-bv/README.md
@@ -1,0 +1,21 @@
+# DevOps Observability Command Center
+
+An enterprise-grade DevOps monitoring and pipeline orchestration dashboard featuring CI/CD pipeline steppers, microservice health cards, replica status tables, and live deployment log streams. Built with pure HTML and EaseMotion CSS.
+
+---
+
+## ✨ Features
+
+### Key UI Sections
+
+- **DevOps Header**: Logo alignments, active pipeline listings, and rollout statuses.
+- **CI/CD Stepper Progress**: Stepper timeline showing build, tests, rollouts, and cache purges.
+- **Services Health Matrix**: Quad layouts detailing app services, deployment velocities, error rates, and escalations.
+- **Replica Status Table**: Table listing container replicas, CPU allocations, and deployment statuses.
+- **Log Stream Terminal**: Monospaced terminal outputting server logs.
+
+## 🎨 Theme Details
+
+- **Palette**: Dark Charcoal (`#09090e`), Deep Purple (`#a855f7`), Accent Blue (`#2563eb`), Success Emerald (`#10b981`), Threat Red (`#ef4444`).
+- **Typography**: Google Fonts Inter and JetBrains Mono.
+- **Animations**: Timeline transitions, pulsing active badges, and card lifts.

--- a/submissions/examples/devops-observability-bv/demo.html
+++ b/submissions/examples/devops-observability-bv/demo.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DevOps Observability Command Center — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="do-layout">
+      <!-- ── SECTION 1: DevOps Header ── -->
+      <header class="do-header">
+        <div
+          style="
+            font-size: 1.5rem;
+            font-weight: 800;
+            color: #fff;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+          "
+        >
+          <span>♾️</span>
+          <span>DevOps Observability</span>
+        </div>
+        <div
+          style="
+            font-size: var(--text-sm);
+            font-weight: 600;
+            color: var(--do-primary);
+          "
+        >
+          Global Pipelines: 14 Active
+        </div>
+      </header>
+
+      <!-- ── SECTION 2: Pipeline Stepper ── -->
+      <section class="do-section">
+        <h3>CI/CD Master Pipeline: devsync-app</h3>
+        <div class="do-pipeline-stepper" style="margin-top: 1.5rem">
+          <div class="do-step done">
+            <div class="do-step-icon">✔</div>
+            <h5>1. Lint &amp; Test</h5>
+          </div>
+          <div class="do-step done">
+            <div class="do-step-icon">✔</div>
+            <h5>2. Build Docker Stack</h5>
+          </div>
+          <div class="do-step active">
+            <div class="do-step-icon">⚡</div>
+            <h5>3. Kubernetes Rollout</h5>
+          </div>
+          <div class="do-step">
+            <div class="do-step-icon">4</div>
+            <h5>4. CDN Cache Purge</h5>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── SECTION 3: Service Health Row ── -->
+      <section class="do-section">
+        <div class="do-grid-4">
+          <div class="do-card">
+            <h3>App Services</h3>
+            <div
+              style="
+                font-size: 2.5rem;
+                font-weight: 800;
+                color: var(--do-success);
+                margin-top: 1rem;
+              "
+            >
+              12 / 12
+            </div>
+            <p
+              style="
+                color: var(--do-text-muted);
+                font-size: 0.85rem;
+                margin-top: 0.5rem;
+              "
+            >
+              All microservices operational
+            </p>
+          </div>
+          <div class="do-card">
+            <h3>Deploy Velocity</h3>
+            <div
+              style="
+                font-size: 2.5rem;
+                font-weight: 800;
+                color: var(--do-accent);
+                margin-top: 1rem;
+              "
+            >
+              18 / day
+            </div>
+            <p
+              style="
+                color: var(--do-text-muted);
+                font-size: 0.85rem;
+                margin-top: 0.5rem;
+              "
+            >
+              Production deployments
+            </p>
+          </div>
+          <div class="do-card">
+            <h3>Error Rate</h3>
+            <div
+              style="
+                font-size: 2.5rem;
+                font-weight: 800;
+                color: var(--do-success);
+                margin-top: 1rem;
+              "
+            >
+              0.04%
+            </div>
+            <p
+              style="
+                color: var(--do-text-muted);
+                font-size: 0.85rem;
+                margin-top: 0.5rem;
+              "
+            >
+              HTTP 5xx error indices
+            </p>
+          </div>
+          <div
+            class="soc-card"
+            style="
+              border: 1px solid var(--do-border);
+              padding: 2rem;
+              border-radius: 1rem;
+            "
+          >
+            <h3>Active Incident</h3>
+            <div
+              style="
+                font-size: 2.5rem;
+                font-weight: 800;
+                color: var(--do-success);
+                margin-top: 1rem;
+              "
+            >
+              None
+            </div>
+            <p
+              style="
+                color: var(--do-text-muted);
+                font-size: 0.85rem;
+                margin-top: 0.5rem;
+              "
+            >
+              No active escalations
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── SECTION 4: Deployment Monitor & Action Controls ── -->
+      <section class="do-section do-flex-2">
+        <div>
+          <h3>Deployments &amp; Replica Statuses</h3>
+          <div style="margin-top: 1.5rem">
+            <table class="do-table">
+              <thead>
+                <tr>
+                  <th>Deployment</th>
+                  <th>Image Tag</th>
+                  <th>Replicas</th>
+                  <th>CPU Usage</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>api-gateway</td>
+                  <td>v2.4.12</td>
+                  <td>3 / 3</td>
+                  <td>14%</td>
+                  <td style="color: var(--do-success)">Available</td>
+                </tr>
+                <tr>
+                  <td>auth-service</td>
+                  <td>v2.4.10</td>
+                  <td>2 / 2</td>
+                  <td>8%</td>
+                  <td style="color: var(--do-success)">Available</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="do-card">
+          <h3>Observability Controls</h3>
+          <p
+            style="
+              font-size: 0.9rem;
+              color: var(--do-text-muted);
+              margin-top: 0.5rem;
+              margin-bottom: 1.5rem;
+            "
+          >
+            Manage deployment pipelines and container clusters.
+          </p>
+          <button
+            style="
+              width: 100%;
+              padding: 0.75rem;
+              background-color: var(--do-primary);
+              border: none;
+              color: #fff;
+              font-weight: 700;
+              border-radius: 0.5rem;
+              cursor: pointer;
+              margin-bottom: 1rem;
+            "
+          >
+            Rollback Deployment
+          </button>
+          <button
+            style="
+              width: 100%;
+              padding: 0.75rem;
+              background-color: transparent;
+              border: 1px solid var(--do-border);
+              color: var(--do-text);
+              font-weight: 600;
+              border-radius: 0.5rem;
+              cursor: pointer;
+            "
+          >
+            Force Re-Deploy
+          </button>
+        </div>
+      </section>
+
+      <!-- ── SECTION 5: Log stream ── -->
+      <section class="do-section">
+        <h3>Live Deployment Event Stream</h3>
+        <div style="margin-top: 1.5rem">
+          <pre><code>$ kubectl get pods -n production
+NAME                           READY   STATUS    RESTARTS   AGE
+api-gateway-7848fd8b-x     1/1     Running   0          12m
+auth-service-6888cb4d-y    1/1     Running   0          14m
+[INFO] Deployment rollout of auth-service v2.4.10 completed successfully.</code></pre>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/devops-observability-bv/style.css
+++ b/submissions/examples/devops-observability-bv/style.css
@@ -1,0 +1,166 @@
+/* ============================================================
+   DEVOPS OBSERVABILITY COMMAND CENTER — Style Sheet
+   ============================================================ */
+
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap");
+
+:root {
+  --do-bg: #09090e;
+  --do-surface: #13131f;
+  --do-elevated: #212135;
+  --do-primary: #a855f7;
+  --do-accent: #2563eb;
+  --do-success: #10b981;
+  --do-danger: #ef4444;
+  --do-text: #f3f4f6;
+  --do-text-muted: #9ca3af;
+  --do-border: rgba(255, 255, 255, 0.08);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background-color: var(--do-bg);
+  color: var(--do-text);
+  font-family: "Inter", sans-serif;
+  overflow-x: hidden;
+  line-height: 1.6;
+}
+
+.do-layout {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.do-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--do-border);
+  padding-bottom: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.do-section {
+  margin-bottom: 3.5rem;
+  animation: fadeInUp 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.do-grid-4 {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem;
+}
+
+.do-card {
+  background: rgba(19, 19, 31, 0.7);
+  border: 1px solid var(--do-border);
+  backdrop-filter: blur(16px);
+  padding: 2rem;
+  border-radius: 1rem;
+  transition: all 0.3s;
+}
+
+.do-card:hover {
+  transform: translateY(-5px);
+  border-color: var(--do-primary);
+  box-shadow: 0 10px 20px rgba(168, 85, 247, 0.1);
+}
+
+.do-flex-2 {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 2rem;
+}
+
+.do-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.do-table th,
+.do-table td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--do-border);
+}
+
+.do-table th {
+  color: var(--do-text-muted);
+  font-size: 0.85rem;
+}
+
+pre {
+  background-color: #020617;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--do-border);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85rem;
+  overflow-x: auto;
+}
+
+/* Stepper progress */
+.do-pipeline-stepper {
+  display: flex;
+  justify-content: space-between;
+  margin: 1.5rem 0;
+}
+
+.do-step {
+  flex: 1;
+  text-align: center;
+  position: relative;
+}
+
+.do-step-icon {
+  width: 36px;
+  height: 36px;
+  line-height: 34px;
+  border: 2px solid var(--do-border);
+  background-color: var(--do-surface);
+  border-radius: 50%;
+  margin: 0 auto 0.5rem;
+  font-weight: bold;
+}
+
+.do-step.done .do-step-icon {
+  border-color: var(--do-success);
+  color: var(--do-success);
+}
+
+.do-step.active .do-step-icon {
+  border-color: var(--do-primary);
+  color: var(--do-primary);
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(15px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1024px) {
+  .do-grid-4 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .do-flex-2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .do-grid-4 {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #8878

Adds the **DevOps Observability Command Center** example to the EaseMotion CSS Elite Showcase series.

---

## Type of Change

- [x] New component / showcase page
- [x] Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/devops-observability-bv/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to framework core or templates**

---

## Feature Description

**What does this add?**
devops observability dashboard with CI/CD pipeline progress bars, microservice status metrics, deployment replica tables, and active kubectl logs

**Why does it fit EaseMotion CSS?**
It demonstrates premium enterprise UX, smooth responsive transitions, and visual polish utilizing pure CSS.