### PR TITLE
feat: add ease-tab CSS-only animated tab switcher component - Radio-i…

### DIFF
--- a/submissions/examples/ease-tab/README.md
+++ b/submissions/examples/ease-tab/README.md
@@ -1,0 +1,77 @@
+# ease-tab
+
+> CSS-only animated tab switcher with sliding indicator for EaseMotion CSS
+
+## What it does
+
+A fully CSS-only tab component using radio inputs and sibling selectors
+to switch panels, with an animated sliding underline (or pill) indicator
+and fade transitions between panels. Zero JavaScript.
+
+## Usage
+
+    <div class="ease-tab">
+      <input type="radio" name="tabs" id="tab1" checked />
+      <input type="radio" name="tabs" id="tab2" />
+      <input type="radio" name="tabs" id="tab3" />
+
+      <div class="ease-tab-bar">
+        <label class="ease-tab-label" for="tab1">Tab 1</label>
+        <label class="ease-tab-label" for="tab2">Tab 2</label>
+        <label class="ease-tab-label" for="tab3">Tab 3</label>
+        <span class="ease-tab-indicator"></span>
+      </div>
+
+      <div class="ease-tab-panels">
+        <div class="ease-tab-panel" data-panel="1">Content 1</div>
+        <div class="ease-tab-panel" data-panel="2">Content 2</div>
+        <div class="ease-tab-panel" data-panel="3">Content 3</div>
+      </div>
+    </div>
+
+## Pill variant
+
+Add `ease-tab-pill` to the root `.ease-tab` element for a sliding
+pill-style indicator instead of an underline.
+
+    <div class="ease-tab ease-tab-pill">...</div>
+
+## Class Reference
+
+| Class | Description |
+|---|---|
+| ease-tab | Root container |
+| ease-tab-bar | Tab label row |
+| ease-tab-label | Individual tab label (use `for` to link radio input) |
+| ease-tab-indicator | Animated underline/pill that slides between tabs |
+| ease-tab-panels | Wrapper for content panels |
+| ease-tab-panel | Individual content panel (use `data-panel` to match) |
+| ease-tab-pill | Modifier for pill-style indicator |
+
+## How it works
+
+Radio inputs (`#tab1`, `#tab2`, etc.) are hidden and linked to labels
+via `for`. The `:checked` pseudo-class on each radio combined with the
+general sibling selector (`~`) toggles the active label color, slides
+the indicator using `left`/`width`, and shows the matching panel.
+
+## Notes on the indicator
+
+For 3+ tabs, set `left` and `width` percentages per tab index (e.g.
+33.33% per tab for 3 tabs). Adjust these values based on your tab count
+and label widths.
+
+## Accessibility
+
+Respects `prefers-reduced-motion` -- indicator transitions and panel
+fade animations are disabled when reduced motion is requested.
+
+## Browser support
+
+| Feature | Chrome | Edge | Firefox | Safari |
+|---|---|---|---|---|
+| :checked + sibling selectors | yes | yes | yes | yes |
+| CSS transitions | yes | yes | yes | yes |
+| prefers-reduced-motion | yes | yes | yes | yes |
+
+Submitted under MIT License · EaseMotion CSS · 2026

--- a/submissions/examples/ease-tab/demo.html
+++ b/submissions/examples/ease-tab/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-tab -- EaseMotion CSS Submission</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: var(--ease-font-sans); background: var(--ease-color-bg); color: var(--ease-color-text); padding: 3rem 2rem; max-width: 700px; margin: 0 auto; }
+    .section { margin-bottom: 3rem; }
+    .label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ease-color-muted); margin-bottom: 0.75rem; }
+    .demo-box { background: var(--ease-color-surface); border: 1px solid rgba(0,0,0,0.08); border-radius: var(--ease-radius-lg); padding: 2rem; }
+    .panel-content { font-size: 0.9rem; color: var(--ease-color-text); line-height: 1.6; }
+    h1 { font-size: 2rem; margin-bottom: 0.25rem; }
+    h2 { font-size: 1.1rem; margin: 0 0 2rem; color: var(--ease-color-muted); font-weight: 400; }
+  </style>
+</head>
+<body>
+
+  <h1 class="ease-fade-in">ease-tab</h1>
+  <h2 class="ease-fade-in ease-delay-100">CSS-only animated tab switcher · EaseMotion CSS submission</h2>
+
+  <div class="section">
+    <div class="label">Underline style (default)</div>
+    <div class="demo-box">
+      <div class="ease-tab">
+        <input type="radio" name="tabs-underline" id="tab1" checked />
+        <input type="radio" name="tabs-underline" id="tab2" />
+        <input type="radio" name="tabs-underline" id="tab3" />
+
+        <div class="ease-tab-bar">
+          <label class="ease-tab-label" for="tab1">Overview</label>
+          <label class="ease-tab-label" for="tab2">Features</label>
+          <label class="ease-tab-label" for="tab3">Pricing</label>
+          <span class="ease-tab-indicator"></span>
+        </div>
+
+        <div class="ease-tab-panels">
+          <div class="ease-tab-panel" data-panel="1">
+            <p class="panel-content">EaseMotion CSS is a zero-dependency, animation-first framework built for beginners and pros alike. Just add classes -- no build step needed.</p>
+          </div>
+          <div class="ease-tab-panel" data-panel="2">
+            <p class="panel-content">Includes fade, slide, zoom, shake, wobble, typewriter, scroll-reveal, and elastic spring animations -- all pure CSS.</p>
+          </div>
+          <div class="ease-tab-panel" data-panel="3">
+            <p class="panel-content">100% free and open-source under the MIT License. No premium tiers, no hidden costs.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="label">Pill style variant</div>
+    <div class="demo-box">
+      <div class="ease-tab ease-tab-pill">
+        <input type="radio" name="tabs-pill" id="ptab1" checked />
+        <input type="radio" name="tabs-pill" id="ptab2" />
+        <input type="radio" name="tabs-pill" id="ptab3" />
+
+        <div class="ease-tab-bar">
+          <label class="ease-tab-label" for="ptab1">Daily</label>
+          <label class="ease-tab-label" for="ptab2">Weekly</label>
+          <label class="ease-tab-label" for="ptab3">Monthly</label>
+          <span class="ease-tab-indicator"></span>
+        </div>
+
+        <div class="ease-tab-panels">
+          <div class="ease-tab-panel" data-panel="1" style="display:block;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <p style="color: var(--ease-color-muted); font-size: 0.85rem; margin-top: 2rem;">Submission for EaseMotion CSS · MIT License</p>
+
+  <style>
+    #ptab1:checked ~ .ease-tab-bar .ease-tab-indicator { left: 0; width: 33.33%; }
+    #ptab2:checked ~ .ease-tab-bar .ease-tab-indicator { left: 33.33%; width: 33.33%; }
+    #ptab3:checked ~ .ease-tab-bar .ease-tab-indicator { left: 66.66%; width: 33.34%; }
+    .ease-tab-pill .ease-tab-indicator { left: 0; width: 33.33%; }
+    #ptab1:checked ~ .ease-tab-bar .ease-tab-label[for="ptab1"],
+    #ptab2:checked ~ .ease-tab-bar .ease-tab-label[for="ptab2"],
+    #ptab3:checked ~ .ease-tab-bar .ease-tab-label[for="ptab3"] { color: white; }
+  </style>
+
+</body>
+</html>

--- a/submissions/examples/ease-tab/style.css
+++ b/submissions/examples/ease-tab/style.css
@@ -1,0 +1,135 @@
+/* ============================================================
+   EaseMotion CSS -- ease-tab
+   Submission by: sudha09-git
+   Description: CSS-only animated tab switcher using radio
+                inputs and sibling selectors. Zero JS required.
+   ============================================================ */
+
+.ease-tab {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.ease-tab input[type="radio"] {
+  display: none;
+}
+
+/* Tab bar */
+.ease-tab-bar {
+  display: flex;
+  position: relative;
+  border-bottom: 2px solid rgba(0,0,0,0.08);
+  gap: 0.5rem;
+}
+
+.ease-tab-label {
+  padding: 0.75rem 1.25rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ease-color-muted);
+  transition: color var(--ease-speed-medium) var(--ease-ease-out);
+  position: relative;
+  user-select: none;
+}
+
+.ease-tab-label:hover {
+  color: var(--ease-color-text);
+}
+
+/* Underline indicator -- default style */
+.ease-tab-indicator {
+  position: absolute;
+  bottom: -2px;
+  height: 2px;
+  background: var(--ease-color-primary);
+  border-radius: var(--ease-radius-full);
+  transition: left var(--ease-speed-slow) var(--ease-ease-out),
+              width var(--ease-speed-slow) var(--ease-ease-out);
+}
+
+/* Panels */
+.ease-tab-panels {
+  position: relative;
+  margin-top: 1.25rem;
+}
+
+.ease-tab-panel {
+  display: none;
+  animation: ease-tab-fade var(--ease-speed-slow) var(--ease-ease-out);
+}
+
+@keyframes ease-tab-fade {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Active state wiring -- 4 tab variant (extend pattern for more) */
+#tab1:checked ~ .ease-tab-bar .ease-tab-label[for="tab1"],
+#tab2:checked ~ .ease-tab-bar .ease-tab-label[for="tab2"],
+#tab3:checked ~ .ease-tab-bar .ease-tab-label[for="tab3"] {
+  color: var(--ease-color-primary);
+}
+
+#tab1:checked ~ .ease-tab-bar .ease-tab-indicator {
+  left: var(--ease-tab-1-left, 0);
+  width: var(--ease-tab-1-width, 33.33%);
+}
+
+#tab2:checked ~ .ease-tab-bar .ease-tab-indicator {
+  left: var(--ease-tab-2-left, 33.33%);
+  width: var(--ease-tab-2-width, 33.33%);
+}
+
+#tab3:checked ~ .ease-tab-bar .ease-tab-indicator {
+  left: var(--ease-tab-3-left, 66.66%);
+  width: var(--ease-tab-3-width, 33.34%);
+}
+
+#tab1:checked ~ .ease-tab-panels .ease-tab-panel[data-panel="1"],
+#tab2:checked ~ .ease-tab-panels .ease-tab-panel[data-panel="2"],
+#tab3:checked ~ .ease-tab-panels .ease-tab-panel[data-panel="3"] {
+  display: block;
+}
+
+/* Pill variant */
+.ease-tab-pill .ease-tab-bar {
+  border-bottom: none;
+  background: var(--ease-color-surface);
+  border-radius: var(--ease-radius-full);
+  padding: 0.25rem;
+  gap: 0;
+}
+
+.ease-tab-pill .ease-tab-label {
+  border-radius: var(--ease-radius-full);
+  padding: 0.5rem 1.25rem;
+  z-index: 1;
+}
+
+.ease-tab-pill .ease-tab-indicator {
+  bottom: 0;
+  top: 0;
+  height: auto;
+  border-radius: var(--ease-radius-full);
+  background: var(--ease-color-primary);
+  z-index: 0;
+}
+
+.ease-tab-pill #tab1:checked ~ .ease-tab-bar .ease-tab-label[for="tab1"],
+.ease-tab-pill #tab2:checked ~ .ease-tab-bar .ease-tab-label[for="tab2"],
+.ease-tab-pill #tab3:checked ~ .ease-tab-bar .ease-tab-label[for="tab3"] {
+  color: white;
+}
+
+/* Reduced motion fallback */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tab-indicator {
+    transition: none;
+  }
+
+  .ease-tab-panel {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds `ease-tab` — a CSS-only animated tab switcher using radio inputs and sibling selectors, with an animated sliding underline/pill indicator and fade transitions. Zero JavaScript.

## What's included
- `style.css` — tab structure, underline & pill variants, reduced-motion fallback
- `demo.html` — interactive showcase of both style variants
- `README.md` — usage, class reference, how-it-works explanation

## Classes added
- `ease-tab` — root container
- `ease-tab-bar` — tab label row
- `ease-tab-label` — individual tab label
- `ease-tab-indicator` — animated sliding underline/pill
- `ease-tab-panels` / `ease-tab-panel` — content panels with fade transition
- `ease-tab-pill` — pill-style indicator modifier

## Acceptance criteria met
- CSS-only tab switching using radio inputs ✅
- Animated sliding underline indicator ✅
- Fade transition between panels ✅
- Pill and underline style variants ✅
- prefers-reduced-motion fallback ✅
- style.css, demo.html, README.md present ✅
- Zero JavaScript ✅

Closes #3861