### PR TITLE
feat: add ease-zoom-out scale-down exit animation utility #3871

### DIFF
--- a/submissions/examples/ease-zoom-out/README.md
+++ b/submissions/examples/ease-zoom-out/README.md
@@ -1,0 +1,46 @@
+# ease-zoom-out
+
+Scale-down exit animation with opacity fade. Zero JavaScript required.
+
+## Usage
+
+```html
+<!-- On-load exit animation -->
+<div class="ease-zoom-out">Zooms out</div>
+
+<!-- Hover-triggered -->
+<div class="ease-zoom-out-hover">Hover to zoom out</div>
+
+<!-- Partial zoom (card hover effect) -->
+<div class="ease-zoom-out-partial">Subtle shrink on hover</div>
+```
+
+## Class Reference
+
+| Class | Description |
+|---|---|
+| `ease-zoom-out` | Scale 1 to 0 with fade on load |
+| `ease-zoom-out-hover` | Scale 1 to 0 with fade on hover |
+| `ease-zoom-out-partial` | Scale to 0.85 with fade on hover |
+| `ease-zoom-out-fast` | Fast speed variant |
+| `ease-zoom-out-slow` | Slow speed variant (1200ms) |
+
+## Delay Variants (staggered groups)
+
+| Class | Delay |
+|---|---|
+| `ease-delay-100` | 100ms |
+| `ease-delay-200` | 200ms |
+| `ease-delay-300` | 300ms |
+| `ease-delay-400` | 400ms |
+| `ease-delay-500` | 500ms |
+
+## Browser Support
+
+| Feature | Chrome | Edge | Firefox | Safari |
+|---|---|---|---|---|
+| CSS animations | yes | yes | yes | yes |
+| CSS transitions | yes | yes | yes | yes |
+| prefers-reduced-motion | yes | yes | yes | yes |
+
+Submitted under MIT License · EaseMotion CSS · 2026

--- a/submissions/examples/ease-zoom-out/demo.html
+++ b/submissions/examples/ease-zoom-out/demo.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-zoom-out -- EaseMotion CSS Submission</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/variables.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/base.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/core/animations.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/components/buttons.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: var(--ease-font-sans); background: var(--ease-color-bg); color: var(--ease-color-text); padding: 3rem 2rem; max-width: 700px; margin: 0 auto; }
+    .section { margin-bottom: 2.5rem; }
+    .label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ease-color-muted); margin-bottom: 0.75rem; }
+    .demo-box { background: var(--ease-color-surface); border: 1px solid rgba(0,0,0,0.08); border-radius: var(--ease-radius-lg); padding: 2rem; display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; }
+    .tile { width: 64px; height: 64px; border-radius: var(--ease-radius-md); background: var(--ease-color-primary); display: flex; align-items: center; justify-content: center; color: white; font-size: 1.5rem; }
+    .trigger-btn { cursor: pointer; padding: 0.5rem 1.2rem; border-radius: var(--ease-radius-md); border: 1px solid rgba(0,0,0,0.12); background: var(--ease-color-bg); font-size: 0.9rem; }
+    h1 { font-size: 2rem; margin-bottom: 0.25rem; }
+    h2 { font-size: 1.1rem; margin: 0 0 2rem; color: var(--ease-color-muted); font-weight: 400; }
+    .hint { font-size: 0.8rem; color: var(--ease-color-muted); margin-top: 0.5rem; }
+  </style>
+</head>
+<body>
+
+  <h1 class="ease-fade-in">ease-zoom-out</h1>
+  <h2 class="ease-fade-in ease-delay-100">Scale-down exit animation · EaseMotion CSS submission</h2>
+
+  <div class="section">
+    <div class="label">On-load exit (replay below)</div>
+    <div class="demo-box" id="loadDemo">
+      <div class="tile ease-zoom-out">A</div>
+      <div class="tile ease-zoom-out ease-delay-100">B</div>
+      <div class="tile ease-zoom-out ease-delay-200">C</div>
+    </div>
+    <div class="hint">
+      <button class="trigger-btn" onclick="replay()">Replay animation</button>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="label">Speed variants (click to replay)</div>
+    <div class="demo-box" id="speedDemo">
+      <div class="tile ease-zoom-out ease-zoom-out-fast">Fast</div>
+      <div class="tile ease-zoom-out">Default</div>
+      <div class="tile ease-zoom-out ease-zoom-out-slow">Slow</div>
+    </div>
+    <div class="hint">
+      <button class="trigger-btn" onclick="replaySpeed()">Replay</button>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="label">Hover-triggered -- zooms out on hover</div>
+    <div class="demo-box">
+      <div class="tile ease-zoom-out-hover">Hover</div>
+      <div class="tile ease-zoom-out-hover ease-zoom-out-fast">Fast hover</div>
+      <div class="tile ease-zoom-out-hover ease-zoom-out-slow">Slow hover</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="label">Partial zoom-out -- card hover effect</div>
+    <div class="demo-box">
+      <div class="tile ease-zoom-out-partial">Card</div>
+      <div class="tile ease-zoom-out-partial">Tile</div>
+      <div class="tile ease-zoom-out-partial">Item</div>
+    </div>
+  </div>
+
+  <p style="color: var(--ease-color-muted); font-size: 0.85rem; margin-top: 2rem;">Submission for EaseMotion CSS · MIT License</p>
+
+  <script>
+    function replay() {
+      const box = document.getElementById('loadDemo');
+      box.querySelectorAll('.tile').forEach(el => {
+        el.style.animation = 'none';
+        void el.offsetWidth;
+        el.style.animation = '';
+      });
+    }
+    function replaySpeed() {
+      const box = document.getElementById('speedDemo');
+      box.querySelectorAll('.tile').forEach(el => {
+        el.style.animation = 'none';
+        void el.offsetWidth;
+        el.style.animation = '';
+      });
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-zoom-out/style.css
+++ b/submissions/examples/ease-zoom-out/style.css
@@ -1,0 +1,88 @@
+/* ============================================================
+   EaseMotion CSS -- ease-zoom-out
+   Submission by: sudha09-git
+   Description: Scale-down exit animation with fade. Zero JS.
+   ============================================================ */
+
+/* On-load exit animation -- scales from 1 to 0 with fade */
+@keyframes ease-zoom-out {
+  from { transform: scale(1); opacity: 1; }
+  to   { transform: scale(0); opacity: 0; }
+}
+
+.ease-zoom-out {
+  animation: ease-zoom-out var(--ease-speed-slow) var(--ease-ease-out) forwards;
+}
+
+/* Speed variants */
+.ease-zoom-out-fast {
+  animation-duration: var(--ease-speed-fast);
+}
+
+.ease-zoom-out-slow {
+  animation-duration: 1200ms;
+}
+
+/* Hover-triggered variant -- scales down on hover */
+.ease-zoom-out-hover {
+  transition: transform var(--ease-speed-medium) var(--ease-ease-out),
+              opacity var(--ease-speed-medium) var(--ease-ease-out);
+}
+
+.ease-zoom-out-hover:hover {
+  transform: scale(0);
+  opacity: 0;
+}
+
+.ease-zoom-out-hover.ease-zoom-out-fast {
+  transition-duration: var(--ease-speed-fast);
+}
+
+.ease-zoom-out-hover.ease-zoom-out-slow {
+  transition-duration: 1200ms;
+}
+
+/* Partial zoom-out -- scales to 0.5 instead of 0, useful for cards/tiles */
+.ease-zoom-out-partial {
+  transition: transform var(--ease-speed-medium) var(--ease-ease-out),
+              opacity var(--ease-speed-medium) var(--ease-ease-out);
+}
+
+.ease-zoom-out-partial:hover {
+  transform: scale(0.85);
+  opacity: 0.6;
+}
+
+/* Delay helpers, consistent with other ease-* utilities */
+.ease-zoom-out.ease-delay-100 { animation-delay: 100ms; }
+.ease-zoom-out.ease-delay-200 { animation-delay: 200ms; }
+.ease-zoom-out.ease-delay-300 { animation-delay: 300ms; }
+.ease-zoom-out.ease-delay-400 { animation-delay: 400ms; }
+.ease-zoom-out.ease-delay-500 { animation-delay: 500ms; }
+
+.ease-zoom-out[class*="ease-delay-"] {
+  opacity: 1;
+  animation-fill-mode: both;
+}
+
+/* Reduced motion fallback */
+@media (prefers-reduced-motion: reduce) {
+  .ease-zoom-out,
+  .ease-zoom-out-fast,
+  .ease-zoom-out-slow {
+    animation: none;
+    opacity: 0;
+    transform: scale(0);
+  }
+
+  .ease-zoom-out-hover,
+  .ease-zoom-out-partial {
+    transition: none;
+  }
+
+  .ease-zoom-out-hover:hover,
+  .ease-zoom-out-partial:hover {
+    transform: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
Adds `ease-zoom-out` — scale-down exit animation with opacity fade. Zero JavaScript required.

## Changes
- `submissions/examples/ease-zoom-out/style.css` — zoom-out utility classes
- `submissions/examples/ease-zoom-out/demo.html` — live demo with replay buttons
- `submissions/examples/ease-zoom-out/README.md` — documentation

## Related Issue
Closes #3871

## Preview
- On-load scale 1 → 0 with opacity fade
- Hover-triggered variant (ease-zoom-out-hover)
- Partial zoom-out for card hover effects (ease-zoom-out-partial)
- Fast and slow speed variants
- Delay variants (100ms–500ms) for staggered groups
- prefers-reduced-motion fallback