### PR TITLE
fix: narrow prefers-reduced-motion selector to avoid layout utilities (#3643)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1305,13 +1305,12 @@
 
 /* ── Reduced Motion: Respect user preference ───────────────── */
 @media (prefers-reduced-motion: reduce) {
-  [class*="ease-"] {
+  /* Targets only specific animation utility classes, preventing layout bugs */
+  [class*="ease-anim-"], .ease-bounce, .ease-pulse {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
   }
-  [class*="ease-hover-"],
-  [class*="ease-card-"],
-  .ease-btn-hover {
+  [class*="ease-hover-"], [class*="ease-card-"], .ease-btn-hover {
     transition: none !important;
     transform: none !important;
   }


### PR DESCRIPTION
##Issue
Closes #3643

## Pull Request Description
This PR addresses a core bug where the `[class*="ease-"]` selector inside the `prefers-reduced-motion` media query was overly broad. It was accidentally targeting layout utilities like `.ease-flex` and `.ease-grid`. I have narrowed the selector to target explicit animation prefixes.

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- One-sentence description -->

**How does a developer use it?**

```html
<!-- Show the class usage in HTML -->
```

**Why does it fit EaseMotion CSS?**

<!-- Explain how this fits the human-readable, animation-first philosophy -->

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
