### PR TITLE
feat: add team availability board example

### DIFF
--- a/submissions/examples/team-availability-board-zt/README.md
+++ b/submissions/examples/team-availability-board-zt/README.md
@@ -1,0 +1,41 @@
+# Team Availability Board (EaseMotion)
+
+A lightweight, CSS-only team availability dashboard for teams and remote-first apps.
+
+Purpose
+- Provide a quick, scannable view of team member availability and presence using simple cards and status indicators.
+
+Use cases
+- Team dashboards and homepages
+- Standup panels and meeting readiness views
+- Support and ops presence boards
+- Onboarding and team directories
+
+Structure
+- `section.board-grid` — responsive grid container of team members
+- `article.member-card` — individual team member card (focusable)
+- `.avatar` — initials or image
+- `.status` + `.status-*` — colored indicator for presence
+- `.status-label` — short text label (Online, In Meeting, Focus Mode, Away, Offline)
+
+Customization
+- Colors and radii are defined via CSS variables in `style.css`'s `:root` block.
+- Replace initials with `<img>` inside `.avatar` for real photos.
+- Change columns by editing `.board-grid` `grid-template-columns` or media queries.
+- Add more statuses by creating additional `.status-*` classes with your color tokens.
+
+Accessibility
+- Cards are keyboard-focusable and include visible focus outlines.
+- Uses clear text labels and `em-text-*` utility classes for readable sizing.
+
+Why it fits EaseMotion CSS
+- Minimal: uses EaseMotion utility classes (`em-container`, `em-p-*`, `em-text-*`) and small, focused component CSS.
+- Composable: drop into docs, dashboards, or examples without JS.
+- Production-ready: subtle elevation, hover effects, and responsive behavior make it suitable for product UIs.
+
+Files
+- `demo.html` — demo page showing example members.
+- `style.css` — component styling.
+
+Preview
+Open `submissions/examples/team-availability-board-zt/demo.html` in a browser to view the board.

--- a/submissions/examples/team-availability-board-zt/demo.html
+++ b/submissions/examples/team-availability-board-zt/demo.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Team Availability Board — EaseMotion</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="em-bg-muted em-text-base">
+  <main class="em-container em-p-6 board-demo" role="main">
+    <header class="em-mb-6">
+      <h1 class="em-h3">Team Availability Board</h1>
+      <p class="em-text-muted">Quick view of team status: Online, In Meeting, Focus Mode, Away, Offline. Pure HTML + CSS.</p>
+    </header>
+
+    <section class="board-grid" aria-label="Team availability board">
+
+      <article class="member-card" tabindex="0" aria-labelledby="name-alex">
+        <div class="member-top">
+          <div class="avatar">AL</div>
+          <div class="meta">
+            <h2 id="name-alex" class="member-name">Alex Liu</h2>
+            <p class="member-role em-text-muted">Product Manager</p>
+          </div>
+        </div>
+        <div class="member-bottom">
+          <span class="status status-online" aria-hidden="true"></span>
+          <span class="status-label">Online</span>
+          <span class="since em-text-xs em-text-muted">Active 5m ago</span>
+        </div>
+      </article>
+
+      <article class="member-card" tabindex="0" aria-labelledby="name-rita">
+        <div class="member-top">
+          <div class="avatar"><img src="" alt="" aria-hidden="true"></div>
+          <div class="meta">
+            <h2 id="name-rita" class="member-name">Rita Gomez</h2>
+            <p class="member-role em-text-muted">Frontend Engineer</p>
+          </div>
+        </div>
+        <div class="member-bottom">
+          <span class="status status-meeting" aria-hidden="true"></span>
+          <span class="status-label">In Meeting</span>
+          <span class="since em-text-xs em-text-muted">Ends in 25m</span>
+        </div>
+      </article>
+
+      <article class="member-card" tabindex="0" aria-labelledby="name-dan">
+        <div class="member-top">
+          <div class="avatar">DN</div>
+          <div class="meta">
+            <h2 id="name-dan" class="member-name">Dana Nguyen</h2>
+            <p class="member-role em-text-muted">Backend Engineer</p>
+          </div>
+        </div>
+        <div class="member-bottom">
+          <span class="status status-focus" aria-hidden="true"></span>
+          <span class="status-label">Focus Mode</span>
+          <span class="since em-text-xs em-text-muted">Do not disturb</span>
+        </div>
+      </article>
+
+      <article class="member-card" tabindex="0" aria-labelledby="name-omar">
+        <div class="member-top">
+          <div class="avatar">OM</div>
+          <div class="meta">
+            <h2 id="name-omar" class="member-name">Omar Lee</h2>
+            <p class="member-role em-text-muted">UX Designer</p>
+          </div>
+        </div>
+        <div class="member-bottom">
+          <span class="status status-away" aria-hidden="true"></span>
+          <span class="status-label">Away</span>
+          <span class="since em-text-xs em-text-muted">Away 1h</span>
+        </div>
+      </article>
+
+      <article class="member-card" tabindex="0" aria-labelledby="name-ci">
+        <div class="member-top">
+          <div class="avatar">CI</div>
+          <div class="meta">
+            <h2 id="name-ci" class="member-name">CI Bot</h2>
+            <p class="member-role em-text-muted">Integration</p>
+          </div>
+        </div>
+        <div class="member-bottom">
+          <span class="status status-offline" aria-hidden="true"></span>
+          <span class="status-label">Offline</span>
+          <span class="since em-text-xs em-text-muted">Last seen 3d ago</span>
+        </div>
+      </article>
+
+    </section>
+
+    <footer class="em-mt-6 em-text-xs em-text-muted">This board is responsive and accessible — drop it into dashboards and team pages.</footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/team-availability-board-zt/style.css
+++ b/submissions/examples/team-availability-board-zt/style.css
@@ -1,0 +1,53 @@
+:root{
+  --card-bg: #ffffff;
+  --panel-bg: #f8fafc;
+  --border: rgba(15,23,42,0.06);
+  --shadow: 0 10px 24px rgba(2,6,23,0.06);
+  --radius: 12px;
+  --online: #10b981;
+  --meeting: #f59e0b;
+  --focus: #ef4444;
+  --away: #f97316;
+  --offline: #94a3b8;
+  --accent: #4f46e5;
+}
+
+.board-demo{max-width:1100px;margin:0 auto}
+.board-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1rem}
+
+@media (max-width:1000px){
+  .board-grid{grid-template-columns:repeat(3,1fr)}
+}
+@media (max-width:720px){
+  .board-grid{grid-template-columns:repeat(2,1fr)}
+}
+@media (max-width:420px){
+  .board-grid{grid-template-columns:1fr}
+}
+
+.member-card{background:var(--card-bg);border:1px solid var(--border);border-radius:var(--radius);padding:1rem;box-shadow:var(--shadow);display:flex;flex-direction:column;justify-content:space-between;transition:transform .18s ease,box-shadow .18s ease}
+.member-card:focus,.member-card:hover{transform:translateY(-6px);box-shadow:0 18px 36px rgba(2,6,23,0.08);outline:none}
+
+.member-top{display:flex;align-items:center;gap:.75rem}
+.avatar{width:56px;height:56px;border-radius:50%;display:inline-flex;align-items:center;justify-content:center;font-weight:700;color:var(--accent);background:linear-gradient(135deg,#eef2ff,#f8fbff);flex-shrink:0}
+.avatar img{width:100%;height:100%;object-fit:cover;border-radius:50%;display:block}
+.meta{min-width:0}
+.member-name{margin:0;font-size:1rem}
+.member-role{margin:0;font-size:.88rem}
+
+.member-bottom{display:flex;align-items:center;gap:.6rem;margin-top:1rem}
+.status{width:12px;height:12px;border-radius:50%;display:inline-block;border:2px solid var(--card-bg);box-shadow:0 2px 6px rgba(2,6,23,0.04)}
+.status-label{font-weight:600;color:#0f172a}
+.since{margin-left:auto;color:#64748b}
+
+.status-online{background:var(--online)}
+.status-meeting{background:var(--meeting)}
+.status-focus{background:var(--focus)}
+.status-away{background:var(--away)}
+.status-offline{background:var(--offline)}
+
+/* Focus ring for accessibility */
+.member-card:focus{outline:3px solid rgba(79,70,229,0.12);outline-offset:4px}
+
+/* Small tweaks */
+.status-label{font-size:.95rem}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS-only Team Availability Board component for displaying user presence, availability, and working status in team collaboration and productivity applications.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/examples/team-availability-board-zt/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A dashboard component that displays team members and their current availability states in a clean card-based layout.

**How does a developer use it?**

```html
<div class="team-member">
  <div class="status online"></div>
  <h3>Sarah Wilson</h3>
  <span>Available</span>
</div>
```

**Why does it fit EaseMotion CSS?**

The component combines readable HTML structure, reusable CSS patterns, and subtle motion effects to create a practical interface pattern aligned with EaseMotion CSS's animation-first philosophy.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This component is useful for collaboration tools, remote work dashboards, productivity platforms, project management software, and team portals where availability and presence information must be displayed clearly.
Closes #8985