### PR TITLE
fix: Add missing success badge pulse override

### DIFF
--- a/components/badges.css
+++ b/components/badges.css
@@ -66,4 +66,9 @@
   .ease-badge-danger.ease-badge-pulse::after {
     box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
   }
+
+  .em-badge-success.em-badge-pulse::after,
+  .ease-badge-success.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
+  }
 }

--- a/submissions/examples/issue-8135-badge-success-pulse-fix/README.md
+++ b/submissions/examples/issue-8135-badge-success-pulse-fix/README.md
@@ -1,0 +1,18 @@
+# Issue #8135: Success Badge Pulse Color Fix
+
+This submission overrides the core `components/badges.css` component to resolve a visual bug reported in Issue #8135.
+
+## What it does
+
+The core `.ease-badge-pulse` animation works by animating a `box-shadow` on a pseudo-element. By default, this glow uses the primary purple color. The core library provided a specific override for `.ease-badge-danger` to use a red glow, but it entirely forgot to provide an override for `.ease-badge-success`. 
+
+This submission adds the missing CSS override so that `.ease-badge-success` correctly pulses with a green glow `rgba(34, 197, 94, 0.7)`, matching its background color.
+
+## How to use it
+
+Include the `style.css` provided in this directory *after* you include the main `easemotion.css` framework:
+
+```html
+<link rel="stylesheet" href="path/to/easemotion.css">
+<link rel="stylesheet" href="path/to/issue-8135-badge-success-pulse-fix/style.css">
+```

--- a/submissions/examples/issue-8135-badge-success-pulse-fix/demo.html
+++ b/submissions/examples/issue-8135-badge-success-pulse-fix/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Badge Pulse Fix (Issue #8135)</title>
+  
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+
+  <style>
+    body {
+      background-color: var(--ease-color-bg, #f8fafc);
+      padding: var(--ease-space-8, 4rem);
+      font-family: var(--ease-font-sans);
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+
+  <h2>Issue #8135: Success Badge Pulse Color Fix</h2>
+  <p style="margin-bottom: 2rem;">The success badge now correctly emits a green glow instead of a purple one.</p>
+  
+  <div style="display: flex; gap: 2rem; justify-content: center; align-items: center;">
+    
+    <!-- Fixed Success Badge -->
+    <div>
+      <span class="ease-badge ease-badge-success ease-badge-pulse">System Online</span>
+      <p style="font-size: 0.8rem; margin-top: 1rem; color: #64748b;">Fixed (Green Glow)</p>
+    </div>
+
+    <!-- Existing Danger Badge for comparison -->
+    <div>
+      <span class="ease-badge ease-badge-danger ease-badge-pulse">Critical Error</span>
+      <p style="font-size: 0.8rem; margin-top: 1rem; color: #64748b;">Danger (Red Glow)</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/issue-8135-badge-success-pulse-fix/style.css
+++ b/submissions/examples/issue-8135-badge-success-pulse-fix/style.css
@@ -1,0 +1,7 @@
+/* Fix for Issue #8135: Success Badge Pulse Color */
+
+.em-badge-success.em-badge-pulse::after,
+.ease-badge-success.ease-badge-pulse::after {
+  /* Override the default purple primary glow with a green success glow */
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
+}


### PR DESCRIPTION
Resolves #8135. This PR fixes the bug where \.ease-badge-success.ease-badge-pulse\ emitted a purple glow instead of a matching green glow. The proper override for the \ox-shadow\ pseudo-element has been added to \components/badges.css\.