### PR TITLE
fix: scale header logo image and resolve navigation link layout clipping

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -110,6 +110,7 @@ body {
   padding: 0 var(--ease-space-6);
   justify-content: space-between;
   gap: var(--ease-space-4);
+  box-sizing: border-box; 
 }
 
 .docs-logo {
@@ -125,10 +126,18 @@ body {
   align-items: center;
 }
 
+.docs-logo-img {
+  height: 38px;  
+  width: auto;   
+  display: block;
+  transform: scale(2.0);       
+  transform-origin: left center;
+}
+
 .docs-header-links {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--ease-space-5);
+  flex-wrap: nowrap;
+  gap: var(--ease-space-3);
   align-items: center;
   justify-content: flex-end;
   list-style: none;
@@ -141,7 +150,7 @@ body {
   font-size: var(--ease-text-sm);
   font-weight: 500;
   text-decoration: none;
-  padding: 10px 20px;
+  padding: 6px 12px !important; 
   border-radius: var(--ease-radius-md);
   transition:
     color 0.3s ease,


### PR DESCRIPTION
## Pull Request Description

This PR fixes the layout header constraints on the main documentation site (`docs/docs.css`). It addresses the missing padding on the logo, scales up the text-logo image asset for better readability, and fixes a flexbox wrapping bug that was pushing the navigation links out of the viewport bounds.

Closes #8959

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (Layout bug fix for the core documentation landing site)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/` *(N/A - This is a repository layout fix for an officially assigned issue rather than a component sandbox submission)*
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
This fixes layout alignments on the primary documentation navbar, stabilizing responsive logo visibility and preventing text link clipping.

**How does a developer use it?**
N/A (This is a visual styling repair patch for the documentation site, not an additions/utility change to the framework).

**Why does it fit EaseMotion CSS?**
It ensures that the core web portal and introductory guide for the animation library look polished, professional, and readable across different viewing dimensions.

---

## Demo

- [x] Demo added (Verified locally by opening `docs/index.html` directly in the web browser)

---

### Before & After Screenshots
<img width="947" height="293" alt="Screenshot 2026-06-15 130501" src="https://github.com/user-attachments/assets/8be154b4-f11c-4c20-b961-235ce35e9cd0" />
<img width="934" height="111" alt="Screenshot 2026-06-15 130515" src="https://github.com/user-attachments/assets/adb5b2dd-002a-4b87-9556-aaa376952e8f" />


## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This is a direct fix for Issue #8959. Modified the `docs/docs.css` file to enforce `flex-wrap: nowrap` on the header row items to prevent them from stacking and escaping the viewport ceiling. Also cleanly expanded the compressed SVG brand logo dimensions utilizing a centralized CSS transform scale.
