### PR TITLE
feat: add ease-pop scale spring entrance animation utility (closes #3…

### DIFF
--- a/submissions/examples/ease-pop/README.md
+++ b/submissions/examples/ease-pop/README.md
@@ -1,0 +1,44 @@
+# ease-pop
+
+Submission for Issue #3868
+
+## What this adds
+
+A `ease-pop` CSS utility that scales an element from 0 → 1.1 → 1
+with a spring overshoot entrance — zero JavaScript required.
+
+## Classes
+
+| Class | Description |
+|---|---|
+| `ease-pop` | Default spring pop (0 → 1.1 → 1) |
+| `ease-pop--subtle` | Gentle overshoot (0 → 1.03 → 1) |
+| `ease-pop--hard` | Strong overshoot (0 → 1.25 → 0.95 → 1) |
+| `ease-pop--fast` | 0.25s duration |
+| `ease-pop--slow` | 0.9s duration |
+
+## Usage
+
+```html
+<!-- Pops in -->
+<div class="ease-pop">Hello</div>
+
+<!-- Subtle pop -->
+<div class="ease-pop ease-pop--subtle">Hello</div>
+
+<!-- Hard overshoot, fast -->
+<div class="ease-pop ease-pop--hard ease-pop--fast">Hello</div>
+```
+
+## Cubic Bezier Values
+
+| Variant | Curve |
+|---|---|
+| Default | cubic-bezier(0.34, 1.56, 0.64, 1) |
+| Subtle  | cubic-bezier(0.22, 1, 0.36, 1) |
+| Hard    | cubic-bezier(0.34, 1.8, 0.64, 1) |
+
+## Accessibility
+
+Respects `prefers-reduced-motion` — falls back to a simple
+fade-in with no scale transform.

--- a/submissions/examples/ease-pop/demo.html
+++ b/submissions/examples/ease-pop/demo.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ease-pop — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      background: #0f172a;
+      font-family: sans-serif;
+      color: #e2e8f0;
+      padding: 2rem;
+    }
+    h2 {
+      margin-top: 2.5rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #64748b;
+    }
+    .demo-row {
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin: 1rem 0 2rem;
+      align-items: center;
+    }
+    .box {
+      width: 80px;
+      height: 80px;
+      border-radius: 12px;
+      background: #4ade80;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.65rem;
+      font-weight: 600;
+      color: #052e16;
+      text-align: center;
+      cursor: pointer;
+    }
+    .box--blue   { background: #60a5fa; color: #1e3a5f; }
+    .box--purple { background: #a78bfa; color: #2e1065; }
+    .box--orange { background: #fb923c; color: #431407; }
+    .box--pink   { background: #f472b6; color: #500724; }
+    label { font-size: 0.72rem; color: #475569; display: block; margin-top: 0.5rem; }
+    .controls { display: flex; gap: 0.75rem; margin: 1.5rem 0; flex-wrap: wrap; }
+    button {
+      padding: 6px 14px;
+      cursor: pointer;
+      background: #1e293b;
+      color: #e2e8f0;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      font-size: 0.8rem;
+    }
+    button:hover { background: #334155; }
+  </style>
+</head>
+<body>
+
+<h1>✨ ease-pop</h1>
+<p>Scale pop entrance animation — zero JavaScript, pure CSS spring effect.</p>
+
+<!-- VARIANTS -->
+<h2>Variants</h2>
+<div class="demo-row">
+  <div>
+    <div class="box ease-pop">Default</div>
+    <label>.ease-pop</label>
+  </div>
+  <div>
+    <div class="box box--blue ease-pop ease-pop--subtle">Subtle</div>
+    <label>.ease-pop--subtle</label>
+  </div>
+  <div>
+    <div class="box box--purple ease-pop ease-pop--hard">Hard</div>
+    <label>.ease-pop--hard</label>
+  </div>
+</div>
+
+<!-- SPEED VARIANTS -->
+<h2>Speed Variants</h2>
+<div class="demo-row">
+  <div>
+    <div class="box box--orange ease-pop ease-pop--fast">Fast</div>
+    <label>.ease-pop--fast</label>
+  </div>
+  <div>
+    <div class="box ease-pop">Normal</div>
+    <label>.ease-pop (default)</label>
+  </div>
+  <div>
+    <div class="box box--pink ease-pop ease-pop--slow">Slow</div>
+    <label>.ease-pop--slow</label>
+  </div>
+</div>
+
+<!-- COMBINATIONS -->
+<h2>Combinations</h2>
+<div class="demo-row">
+  <div>
+    <div class="box box--blue ease-pop ease-pop--hard ease-pop--fast">Hard + Fast</div>
+    <label>.ease-pop--hard.ease-pop--fast</label>
+  </div>
+  <div>
+    <div class="box box--purple ease-pop ease-pop--subtle ease-pop--slow">Subtle + Slow</div>
+    <label>.ease-pop--subtle.ease-pop--slow</label>
+  </div>
+</div>
+
+<!-- REPLAY BUTTON -->
+<div class="controls">
+  <button onclick="replayAll()">↺ Replay All</button>
+</div>
+
+<script>
+  function replayAll() {
+    document.querySelectorAll('[class*="ease-pop"]').forEach(el => {
+      el.style.animation = 'none';
+      el.offsetHeight; // reflow
+      el.style.animation = '';
+    });
+  }
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-pop/style.css
+++ b/submissions/examples/ease-pop/style.css
@@ -1,0 +1,77 @@
+/* =============================================
+   ease-pop — Scale Pop Entrance Animation
+   Zero JavaScript | CSS-only spring effect
+   ============================================= */
+
+/* --- Keyframes --- */
+
+/* Default: 0 → 1.1 → 1 spring */
+@keyframes ease-pop {
+  0%   { transform: scale(0); opacity: 0; }
+  70%  { transform: scale(1.1); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+/* Subtle: 0 → 1.03 → 1 */
+@keyframes ease-pop-subtle {
+  0%   { transform: scale(0); opacity: 0; }
+  70%  { transform: scale(1.03); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+/* Hard overshoot: 0 → 1.25 → 1 */
+@keyframes ease-pop-hard {
+  0%   { transform: scale(0); opacity: 0; }
+  65%  { transform: scale(1.25); opacity: 1; }
+  85%  { transform: scale(0.95); }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+/* Reduced motion fallback */
+@keyframes ease-pop-reduced {
+  0%   { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+/* =====================
+   BASE CLASS
+   ===================== */
+.ease-pop {
+  animation: ease-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+/* =====================
+   VARIANT: subtle
+   ===================== */
+.ease-pop--subtle {
+  animation: ease-pop-subtle 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* =====================
+   VARIANT: hard overshoot
+   ===================== */
+.ease-pop--hard {
+  animation: ease-pop-hard 0.6s cubic-bezier(0.34, 1.8, 0.64, 1) both;
+}
+
+/* =====================
+   SPEED MODIFIERS
+   ===================== */
+.ease-pop--fast {
+  animation-duration: 0.25s;
+}
+
+.ease-pop--slow {
+  animation-duration: 0.9s;
+}
+
+/* =====================
+   REDUCED MOTION
+   ===================== */
+@media (prefers-reduced-motion: reduce) {
+  .ease-pop,
+  .ease-pop--subtle,
+  .ease-pop--hard {
+    animation: ease-pop-reduced 0.3s ease both;
+  }
+}


### PR DESCRIPTION
## Closes #3868

## What this PR adds

Implements the `ease-pop` CSS utility — a zero-JavaScript scale pop
entrance animation with spring overshoot effect, exactly as specified
in issue #3868.

---

## Files Added

submissions/examples/ease-pop/
├── style.css    ← keyframes + all variant/speed utility classes
├── demo.html    ← live visual demo with replay button
└── README.md    ← usage docs, class reference, cubic-bezier values

---

## Variants Implemented

### Overshoot Variants
| Class | Behavior |
|---|---|
| `ease-pop` | Default spring — scale 0 → 1.1 → 1 |
| `ease-pop--subtle` | Gentle spring — scale 0 → 1.03 → 1 |
| `ease-pop--hard` | Strong spring — scale 0 → 1.25 → 0.95 → 1 |

### Speed Modifiers
| Class | Duration |
|---|---|
| `ease-pop--fast` | 0.25s |
| `ease-pop` (default) | 0.5s |
| `ease-pop--slow` | 0.9s |

---

## Cubic Bezier Values

| Variant | Curve |
|---|---|
| Default | cubic-bezier(0.34, 1.56, 0.64, 1) |
| Subtle  | cubic-bezier(0.22, 1, 0.36, 1)    |
| Hard    | cubic-bezier(0.34, 1.8, 0.64, 1)  |

---

## Accessibility

Fully respects `prefers-reduced-motion` — all pop variants fall back
to a simple opacity fade with no scale transform, ensuring no
vestibular discomfort for sensitive users.

---

## Checklist

- [x] Files placed inside `submissions/examples/` only
- [x] No changes to `core/` or `components/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] One feature per PR
- [x] Zero JavaScript in the animation itself
- [x] prefers-reduced-motion fallback included
- [x] Subtle, default, and hard overshoot variants present
- [x] Fast and slow speed modifiers present
- [x] References issue #3868