### PR TITLE
feat: add ease-glass glassmorphism backdrop blur card utility (closes…

### DIFF
--- a/submissions/examples/ease-glass/README.md
+++ b/submissions/examples/ease-glass/README.md
@@ -1,0 +1,70 @@
+# ease-glass
+
+Submission for Issue #3843
+
+## What this adds
+
+CSS utility for glassmorphism-style cards using `backdrop-filter: blur()`
+and semi-transparent backgrounds. Zero JavaScript required.
+
+## Classes
+
+### Base
+| Class | Description |
+|---|---|
+| `ease-glass` | Base glassmorphism card, blur(12px) |
+| `ease-glass--dark` | Darker semi-transparent background |
+| `ease-glass--light` | Higher opacity white background |
+
+### Interaction
+| Class | Description |
+|---|---|
+| `ease-glass--hover` | Lifts card on hover with shadow |
+
+### Border
+| Class | Description |
+|---|---|
+| `ease-glass--border` | Bright inset top border highlight |
+| `ease-glass--border-glow` | Green outer glow border |
+
+### Blur Intensity
+| Class | Blur |
+|---|---|
+| `ease-glass--blur-sm` | 4px |
+| `ease-glass--blur-md` | 12px |
+| `ease-glass--blur-lg` | 24px |
+| `ease-glass--blur-xl` | 40px |
+
+### Color Tints
+| Class | Tint |
+|---|---|
+| `ease-glass--tint-green` | Green tint |
+| `ease-glass--tint-blue` | Blue tint |
+| `ease-glass--tint-purple` | Purple tint |
+| `ease-glass--tint-pink` | Pink tint |
+
+## Usage
+
+```html
+<!-- Base glass card -->
+<div class="ease-glass">Glass card content</div>
+
+<!-- Dark glass with hover lift -->
+<div class="ease-glass ease-glass--dark ease-glass--hover">Dark glass</div>
+
+<!-- Light glass with border highlight -->
+<div class="ease-glass ease-glass--light ease-glass--border">Light glass</div>
+
+<!-- Heavy blur with tint -->
+<div class="ease-glass ease-glass--blur-xl ease-glass--tint-purple">Purple glass</div>
+```
+
+## Browser Support
+
+`backdrop-filter` is supported in all modern browsers.
+For older browsers, the card degrades gracefully to a
+semi-transparent background without blur.
+
+## Theme Support
+
+Supports `data-theme="neon"`, `data-theme="dracula"`, `data-theme="dark"`.

--- a/submissions/examples/ease-glass/demo.html
+++ b/submissions/examples/ease-glass/demo.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ease-glass — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 2rem;
+      min-height: 100vh;
+      background:
+        radial-gradient(ellipse at 20% 50%, #1d4ed8 0%, transparent 50%),
+        radial-gradient(ellipse at 80% 20%, #7c3aed 0%, transparent 50%),
+        radial-gradient(ellipse at 60% 80%, #059669 0%, transparent 50%),
+        #0f172a;
+    }
+    h2 {
+      margin-top: 2.5rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: rgba(255,255,255,0.4);
+    }
+    h1 { color: #f1f5f9; }
+    p  { color: rgba(255,255,255,0.5); font-size: 0.9rem; }
+    .demo-row {
+      display: flex;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      margin: 1rem 0 2rem;
+      align-items: flex-start;
+    }
+    .card-title {
+      font-weight: 600;
+      margin: 0 0 0.4rem;
+      font-size: 0.95rem;
+    }
+    .card-body {
+      font-size: 0.8rem;
+      opacity: 0.75;
+      margin: 0;
+    }
+    .controls {
+      display: flex;
+      gap: 0.75rem;
+      margin: 1.5rem 0;
+      flex-wrap: wrap;
+    }
+    button {
+      padding: 6px 14px;
+      cursor: pointer;
+      background: rgba(255,255,255,0.1);
+      color: #e2e8f0;
+      border: 1px solid rgba(255,255,255,0.15);
+      border-radius: 6px;
+      font-size: 0.8rem;
+      backdrop-filter: blur(8px);
+    }
+    button:hover { background: rgba(255,255,255,0.18); }
+    label {
+      font-size: 0.68rem;
+      color: rgba(255,255,255,0.3);
+      display: block;
+      margin-top: 0.4rem;
+      font-family: monospace;
+    }
+  </style>
+</head>
+<body>
+
+<h1>🪟 ease-glass</h1>
+<p>Glassmorphism backdrop blur cards — zero JavaScript, pure CSS.</p>
+
+<!-- BASE VARIANTS -->
+<h2>Base Variants</h2>
+<div class="demo-row">
+  <div>
+    <div class="ease-glass" style="width:180px">
+      <p class="card-title">Base Glass</p>
+      <p class="card-body">Default glassmorphism card with blur(12px).</p>
+    </div>
+    <label>.ease-glass</label>
+  </div>
+  <div>
+    <div class="ease-glass ease-glass--dark" style="width:180px">
+      <p class="card-title">Dark Glass</p>
+      <p class="card-body">Darker semi-transparent background.</p>
+    </div>
+    <label>.ease-glass--dark</label>
+  </div>
+  <div>
+    <div class="ease-glass ease-glass--light" style="width:180px">
+      <p class="card-title">Light Glass</p>
+      <p class="card-body">Higher opacity white background.</p>
+    </div>
+    <label>.ease-glass--light</label>
+  </div>
+</div>
+
+<!-- HOVER LIFT -->
+<h2>Hover Lift Variant</h2>
+<div class="demo-row">
+  <div>
+    <div class="ease-glass ease-glass--hover" style="width:180px">
+      <p class="card-title">Hover Me</p>
+      <p class="card-body">Lifts on hover with shadow.</p>
+    </div>
+    <label>.ease-glass--hover</label>
+  </div>
+  <div>
+    <div class="ease-glass ease-glass--dark ease-glass--hover" style="width:180px">
+      <p class="card-title">Dark + Hover</p>
+      <p class="card-body">Dark glass with lift effect.</p>
+    </div>
+    <label>.ease-glass--dark.ease-glass--hover</label>
+  </div>
+</div>
+
+<!-- BORDER HIGHLIGHT -->
+<h2>Border Highlight Variants</h2>
+<div class="demo-row">
+  <div>
+    <div class="ease-glass ease-glass--border" style="width:180px">
+      <p class="card-title">Border Highlight</p>
+      <p class="card-body">Bright top border inset.</p>
+    </div>
+    <label>.ease-glass--border</label>
+  </div>
+  <div>
+    <div class="ease-glass ease-glass--border-glow" style="width:180px">
+      <p class="card-title">Glow Border</p>
+      <p class="card-body">Green glow border effect.</p>
+    </div>
+    <label>.ease-glass--border-glow</label>
+  </div>
+</div>
+
+<!-- BLUR INTENSITY -->
+<h2>Blur Intensity</h2>
+<div class="demo-row">
+  <div>
+    <div class="ease-glass ease-glass--blur-sm" style="width:130px">
+      <p class="card-title">blur-sm</p>
+      <p class="card-body">4px blur</p>
+    </div>
+    <label>.ease-glass--blur-sm</label>
+  </div>
+  <div>
+    <div class="ease-glass ease-glass--blur-md" style="width:130px">
+      <p class="card-title">blur-md</p>
+      <p class="card-body">12px blur</p>
+    </div>
+    <label>.ease-glass--blur-md</label>
+  </div>
+  <div>
+    <div class="ease-glass ease-glass--blur-lg" style="width:130px">
+      <p class="card-title">blur-lg</p>
+      <p class="card-body">24px blur</p>
+    </div>
+    <label>.ease-glass--blur-lg</label>
+  </div>
+  <div>
+    <div class="ease-glass ease-glass--blur-xl" style="width:130px">
+      <p class="card-title">blur-xl</p>
+      <p class="card-body">40px blur</p>
+    </div>
+    <label>.ease-glass--blur-xl</label>
+  </div>
+</div>
+
+<!-- TINT VARIANTS -->
+<h2>Color Tints</h2>
+<div class="demo-row">
+  <div>
+    <div class="ease-glass ease-glass--tint-green" style="width:130px">
+      <p class="card-title">Green</p>
+    </div>
+    <label>.ease-glass--tint-green</label>
+  </div>
+  <div>
+    <div class="ease-glass ease-glass--tint-blue" style="width:130px">
+      <p class="card-title">Blue</p>
+    </div>
+    <label>.ease-glass--tint-blue</label>
+  </div>
+  <div>
+    <div class="ease-glass ease-glass--tint-purple" style="width:130px">
+      <p class="card-title">Purple</p>
+    </div>
+    <label>.ease-glass--tint-purple</label>
+  </div>
+  <div>
+    <div class="ease-glass ease-glass--tint-pink" style="width:130px">
+      <p class="card-title">Pink</p>
+    </div>
+    <label>.ease-glass--tint-pink</label>
+  </div>
+</div>
+
+<!-- THEMES -->
+<h2>Themes</h2>
+<div class="controls">
+  <button onclick="setTheme('')">Default</button>
+  <button onclick="setTheme('neon')">Neon</button>
+  <button onclick="setTheme('dracula')">Dracula</button>
+  <button onclick="setTheme('dark')">Dark</button>
+</div>
+<div id="theme-demo">
+  <div class="demo-row">
+    <div class="ease-glass ease-glass--hover ease-glass--border" style="width:200px">
+      <p class="card-title">Theme Card</p>
+      <p class="card-body">Hover to see lift effect.</p>
+    </div>
+  </div>
+</div>
+
+<script>
+  function setTheme(t) {
+    document.getElementById('theme-demo').dataset.theme = t;
+  }
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-glass/style.css
+++ b/submissions/examples/ease-glass/style.css
@@ -1,0 +1,141 @@
+/* =============================================
+   ease-glass — Glassmorphism Backdrop Blur Card
+   Zero JavaScript | CSS backdrop-filter
+   ============================================= */
+
+/* =====================
+   BASE GLASS CARD
+   ===================== */
+.ease-glass {
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 1.5rem;
+  color: #e2e8f0;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+/* =====================
+   DARK VARIANT
+   ===================== */
+.ease-glass--dark {
+  background: rgba(0, 0, 0, 0.35);
+  border-color: rgba(255, 255, 255, 0.06);
+  color: #f1f5f9;
+}
+
+/* =====================
+   LIGHT VARIANT
+   ===================== */
+.ease-glass--light {
+  background: rgba(255, 255, 255, 0.45);
+  border-color: rgba(255, 255, 255, 0.6);
+  color: #1e293b;
+}
+
+/* =====================
+   HOVER LIFT VARIANT
+   ===================== */
+.ease-glass--hover:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.25),
+    0 2px 8px rgba(0, 0, 0, 0.15);
+  background: rgba(255, 255, 255, 0.13);
+}
+
+.ease-glass--dark.ease-glass--hover:hover {
+  background: rgba(0, 0, 0, 0.45);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.4),
+    0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.ease-glass--light.ease-glass--hover:hover {
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.12),
+    0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+/* =====================
+   BORDER HIGHLIGHT VARIANT
+   ===================== */
+.ease-glass--border {
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.ease-glass--border-glow {
+  border: 1px solid rgba(74, 222, 128, 0.35);
+  box-shadow:
+    inset 0 1px 0 rgba(74, 222, 128, 0.15),
+    0 0 16px rgba(74, 222, 128, 0.1);
+}
+
+/* =====================
+   BLUR INTENSITY VARIANTS
+   ===================== */
+.ease-glass--blur-sm {
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.ease-glass--blur-md {
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.ease-glass--blur-lg {
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+}
+
+.ease-glass--blur-xl {
+  backdrop-filter: blur(40px);
+  -webkit-backdrop-filter: blur(40px);
+}
+
+/* =====================
+   COLOR TINT VARIANTS
+   ===================== */
+.ease-glass--tint-green {
+  background: rgba(74, 222, 128, 0.1);
+  border-color: rgba(74, 222, 128, 0.2);
+}
+
+.ease-glass--tint-blue {
+  background: rgba(96, 165, 250, 0.1);
+  border-color: rgba(96, 165, 250, 0.2);
+}
+
+.ease-glass--tint-purple {
+  background: rgba(167, 139, 250, 0.1);
+  border-color: rgba(167, 139, 250, 0.2);
+}
+
+.ease-glass--tint-pink {
+  background: rgba(244, 114, 182, 0.1);
+  border-color: rgba(244, 114, 182, 0.2);
+}
+
+/* =====================
+   THEME OVERRIDES
+   ===================== */
+[data-theme="neon"] .ease-glass {
+  background: rgba(167, 139, 250, 0.08);
+  border-color: rgba(240, 171, 252, 0.2);
+  box-shadow: 0 0 20px rgba(167, 139, 250, 0.08);
+}
+
+[data-theme="dracula"] .ease-glass {
+  background: rgba(40, 42, 54, 0.75);
+  border-color: rgba(189, 147, 249, 0.25);
+}
+
+[data-theme="dark"] .ease-glass {
+  background: rgba(17, 24, 39, 0.65);
+  border-color: rgba(56, 189, 248, 0.15);
+}


### PR DESCRIPTION
## Closes #3843

## What this PR adds

Implements the `ease-glass` CSS utility — glassmorphism-style cards
using backdrop-filter: blur() and semi-transparent backgrounds with
dark/light variants, hover lift, border highlight, blur intensity
controls, and color tints. Zero JavaScript required.

---

## Files Added

submissions/examples/ease-glass/
├── style.css    ← all glass variants, blur levels, tints, theme overrides
├── demo.html    ← live visual demo on gradient background with theme switcher
└── README.md    ← usage docs and class reference table

---

## Variants Implemented

### Base Variants
| Class | Description |
|---|---|
| `ease-glass` | Base glassmorphism card, blur(12px) |
| `ease-glass--dark` | Darker semi-transparent background |
| `ease-glass--light` | Higher opacity white background |

### Interaction
| Class | Description |
|---|---|
| `ease-glass--hover` | translateY(-4px) lift + shadow on hover |

### Border Highlight
| Class | Description |
|---|---|
| `ease-glass--border` | Bright inset top border highlight |
| `ease-glass--border-glow` | Green outer glow border |

### Blur Intensity
| Class | Blur |
|---|---|
| `ease-glass--blur-sm` | 4px |
| `ease-glass--blur-md` | 12px |
| `ease-glass--blur-lg` | 24px |
| `ease-glass--blur-xl` | 40px |

### Color Tints
| Class | Tint |
|---|---|
| `ease-glass--tint-green` | Green |
| `ease-glass--tint-blue` | Blue |
| `ease-glass--tint-purple` | Purple |
| `ease-glass--tint-pink` | Pink |

---

## Implementation Notes

- Uses `backdrop-filter: blur()` with `-webkit-backdrop-filter` prefix
  for full Safari support
- Degrades gracefully in unsupported browsers — card still renders
  with semi-transparent background, just without blur
- Hover lift uses `transform: translateY(-4px)` with smooth
  `transition` on transform and box-shadow
- All variants are composable — mix and match freely

---

## Theme Support

All variants render correctly under:
- Default
- `data-theme="neon"`
- `data-theme="dracula"`
- `data-theme="dark"`

---

## Checklist

- [x] Files placed inside `submissions/examples/` only
- [x] No changes to `core/` or `components/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] One feature per PR
- [x] Zero JavaScript
- [x] Base glassmorphism card with backdrop-filter present
- [x] Dark and light variants present
- [x] Hover lift variant present
- [x] Border highlight variant present
- [x] -webkit-backdrop-filter prefix included for Safari
- [x] References issue #3843