### PR TITLE
fix(a11y): add prefers-reduced-motion global support, .ease-reduced utility, and .ease-motion-safe wrapper

### DIFF
--- a/submissions/examples/reduced-motion-fix/README.md
+++ b/submissions/examples/reduced-motion-fix/README.md
@@ -1,0 +1,92 @@
+# prefers-reduced-motion — Global Support
+
+**Fixes:** Issue #8373
+
+## Problem
+
+EaseMotion-css is an animation-first framework with no
+`@media (prefers-reduced-motion)` support. Users with:
+
+- Vestibular disorders / motion sickness
+- Epilepsy / seizure sensitivity
+- Cognitive disabilities that make motion distracting
+
+...have **no way to opt out** of the animations the framework applies.
+This is a **WCAG 2.1 SC 2.3.3 violation** (Animation from Interactions).
+
+## Fix — Three Layers
+
+### Layer 1: Global CSS Override (add to end of `easemotion.css`)
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration:        0.01ms !important;
+    animation-iteration-count: 1      !important;
+    animation-delay:           0.01ms !important;
+    transition-duration:       0.01ms !important;
+    transition-delay:          0.01ms !important;
+    scroll-behavior:           auto   !important;
+  }
+}
+```
+
+Uses `0.01ms` (not `0s`) so `animationend` / `transitionend` events
+still fire and JS callbacks don't break.
+
+### Layer 2: `.ease-reduced` Utility Class
+
+```html
+<!-- Disable all animations in a section — no OS setting required -->
+<section class="ease-reduced">
+  <div class="ease-fade-in card">...</div>
+</section>
+```
+
+Useful when an app has its own motion preference toggle independent
+of the OS setting.
+
+### Layer 3: `.ease-motion-safe` Wrapper
+
+```html
+<!-- Decorative animation — removed entirely when motion is reduced -->
+<div class="ease-motion-safe">
+  <div class="ease-bounce">🎉</div>
+</div>
+```
+
+Difference from Layer 1/2: sets `animation: none` rather than
+`0.01ms`, so truly decorative elements disappear rather than
+flash for a single frame.
+
+## Behaviour Summary
+
+| User scenario | Layer 1 (global) | .ease-reduced | .ease-motion-safe |
+|---|---|---|---|
+| OS reduce-motion ON | ✅ all stop | — | ✅ removed |
+| Developer toggles off | — | ✅ all stop | — |
+| Normal user | ❌ no effect | ❌ no effect | ✅ plays |
+
+## WCAG Reference
+
+| Criterion | Level | Status after fix |
+|---|---|---|
+| 2.3.3 Animation from Interactions | AAA | ✅ Satisfied |
+| 1.4.3 Contrast (spin/pulse) | AA | Unaffected |
+| 2.1.1 Keyboard | A | Unaffected |
+
+## Integration
+
+Add `style.css` content to the **end** of `easemotion.css` or import
+it as a separate `reduced-motion.css` file after the main bundle.
+Being at the end ensures the `!important` overrides win over all
+preceding component styles.
+
+## Acceptance Criteria
+
+- [x] Global `@media (prefers-reduced-motion: reduce)` block added
+- [x] Uses `0.01ms` to preserve JS event callbacks
+- [x] `.ease-reduced` utility class for developer opt-in
+- [x] `.ease-motion-safe` wrapper for decorative-only animations
+- [x] Demo shows live OS detection + JS toggle
+- [x] WCAG 2.1 SC 2.3.3 satisfied

--- a/submissions/examples/reduced-motion-fix/demo.html
+++ b/submissions/examples/reduced-motion-fix/demo.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>prefers-reduced-motion Fix — #8373</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      max-width: 700px;
+      margin: 0 auto;
+      padding: 3rem 1.5rem;
+      font-family: 'Inter', system-ui, sans-serif;
+      background: #0f0f17;
+      color: #cdd6f4;
+      line-height: 1.7;
+    }
+    h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+    h2 {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      opacity: 0.5;
+      margin: 2.5rem 0 0.75rem;
+    }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1rem;
+      margin-top: 0.75rem;
+    }
+    .demo-box {
+      background: #1e1e2e;
+      border: 1px solid #313244;
+      border-radius: 0.5rem;
+      padding: 1.25rem;
+      text-align: center;
+      font-size: 0.9rem;
+    }
+    .demo-box span {
+      display: block;
+      font-size: 0.75rem;
+      opacity: 0.5;
+      margin-top: 0.4rem;
+    }
+
+    /* Demo animations — these are overridden globally in
+       reduced-motion mode by style.css Layer 1 */
+    .anim-bounce {
+      animation: em-bounce 1s ease infinite;
+    }
+    .anim-pulse {
+      animation: em-pulse 1.2s ease infinite;
+    }
+    .anim-spin {
+      width: 2rem; height: 2rem;
+      border: 3px solid #6c63ff;
+      border-top-color: transparent;
+      border-radius: 50%;
+      margin: 0 auto 0.5rem;
+      animation: em-spin 1s linear infinite;
+    }
+    .anim-fade {
+      animation: em-fade-in 1.5s ease infinite alternate;
+    }
+
+    @keyframes em-bounce {
+      0%, 100% { transform: translateY(0); }
+      50%       { transform: translateY(-12px); }
+    }
+    @keyframes em-pulse {
+      0%, 100% { opacity: 1; }
+      50%       { opacity: 0.5; }
+    }
+    @keyframes em-spin {
+      to { transform: rotate(360deg); }
+    }
+    @keyframes em-fade-in {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+
+    /* Toggle button */
+    #toggle-reduced {
+      margin-top: 1.5rem;
+      padding: 0.5rem 1.25rem;
+      background: #6c63ff;
+      color: #fff;
+      border: none;
+      border-radius: 0.4rem;
+      cursor: pointer;
+      font-size: 0.9rem;
+    }
+    #toggle-reduced:hover { opacity: 0.85; }
+
+    .status-badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      margin-left: 0.5rem;
+      vertical-align: middle;
+    }
+    .badge-on  { background: #a6e3a1; color: #1e2e1e; }
+    .badge-off { background: #f38ba8; color: #2e1e1e; }
+
+    .note {
+      background: #1e1e2e;
+      border-left: 3px solid #6c63ff;
+      border-radius: 0 0.5rem 0.5rem 0;
+      padding: 0.85rem 1rem;
+      font-size: 0.875rem;
+      margin-top: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>prefers-reduced-motion Support</h1>
+  <p>Fixes <strong>#8373</strong> — adds global reduced-motion override and
+     <code>.ease-reduced</code> / <code>.ease-motion-safe</code> utility classes.</p>
+
+  <!-- OS Setting Status -->
+  <p id="os-status" style="font-size:0.875rem; margin-top:1rem;"></p>
+
+  <h2>Live Animation Demo</h2>
+  <p style="font-size:0.85rem; opacity:0.7;">
+    Enable "Reduce Motion" in your OS settings — all animations below
+    should stop immediately (via the global CSS override in Layer 1).
+  </p>
+
+  <div class="demo-grid" id="animated-section">
+    <div class="demo-box">
+      <div class="anim-bounce">⬆️</div>
+      <span>em-bounce</span>
+    </div>
+    <div class="demo-box">
+      <div class="anim-pulse">💜</div>
+      <span>em-pulse</span>
+    </div>
+    <div class="demo-box">
+      <div class="anim-spin"></div>
+      <span>em-spin</span>
+    </div>
+    <div class="demo-box">
+      <div class="anim-fade">Fade</div>
+      <span>em-fade-in</span>
+    </div>
+  </div>
+
+  <!-- JS toggle for .ease-reduced (simulates developer opt-in) -->
+  <h2>.ease-reduced Utility Class</h2>
+  <p style="font-size:0.85rem; opacity:0.7;">
+    Click the button to toggle <code>.ease-reduced</code> on the section above —
+    simulating a developer-controlled motion toggle independent of OS settings.
+  </p>
+  <button id="toggle-reduced" onclick="toggleReduced()">
+    Toggle .ease-reduced
+    <span class="status-badge badge-off" id="reduced-badge">OFF</span>
+  </button>
+
+  <h2>.ease-motion-safe Pattern</h2>
+  <p style="font-size:0.85rem; opacity:0.7;">
+    Decorative animations wrapped in <code>.ease-motion-safe</code> are
+    completely removed (not just shortened) when reduced motion is active.
+  </p>
+  <div class="ease-motion-safe demo-box" style="margin-top:0.5rem; max-width:220px;">
+    <div class="anim-bounce">🎉 Decorative</div>
+    <span>plays only if motion is OK</span>
+  </div>
+
+  <div class="note">
+    <strong>OS-level detection:</strong> Enable "Reduce Motion" in
+    <strong>macOS</strong> → Accessibility → Display,
+    <strong>Windows</strong> → Ease of Access → Display → Show animations,
+    or <strong>iOS/Android</strong> → Accessibility → Motion.
+    All animations in this demo will stop automatically via the CSS media query.
+  </div>
+
+  <script>
+    // Show OS reduced-motion status
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    function updateStatus() {
+      const el = document.getElementById('os-status');
+      if (mq.matches) {
+        el.innerHTML = '🟢 OS reduced-motion: <strong>ENABLED</strong> — animations suppressed globally by CSS.';
+      } else {
+        el.innerHTML = '🔴 OS reduced-motion: <strong>DISABLED</strong> — animations playing normally.';
+      }
+    }
+    mq.addEventListener('change', updateStatus);
+    updateStatus();
+
+    // .ease-reduced toggle
+    function toggleReduced() {
+      const section = document.getElementById('animated-section');
+      const badge   = document.getElementById('reduced-badge');
+      const active  = section.classList.toggle('ease-reduced');
+      badge.textContent = active ? 'ON' : 'OFF';
+      badge.className = 'status-badge ' + (active ? 'badge-on' : 'badge-off');
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/reduced-motion-fix/style.css
+++ b/submissions/examples/reduced-motion-fix/style.css
@@ -1,0 +1,81 @@
+/* === EaseMotion CSS — prefers-reduced-motion global support ===
+   Fixes #8373
+
+   Two-layer approach:
+   1. Global override — catches ALL animations/transitions library-wide
+   2. .ease-reduced utility class — per-component opt-in for developers
+      who want to respect reduced-motion without enabling OS setting
+*/
+
+
+/* ── Layer 1: Global OS-level override ──────────────────────
+   Placed at the END of easemotion.css (or as a separate
+   reduced-motion.css imported last).
+
+   Uses 0.01ms instead of 0s so animationend / transitionend
+   events still fire — JS that listens for these won't break.
+
+   !important is intentional here: this is an accessibility
+   override that must win over all component-level durations.
+*/
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration:         0.01ms !important;
+    animation-iteration-count:  1      !important;
+    animation-delay:            0.01ms !important;
+    transition-duration:        0.01ms !important;
+    transition-delay:           0.01ms !important;
+    scroll-behavior:            auto   !important;
+  }
+}
+
+
+/* ── Layer 2: .ease-reduced utility class ───────────────────
+   Developer opt-in — apply to any element to honour reduced
+   motion regardless of OS setting.
+
+   Use cases:
+   - Embedding EaseMotion in an app that has its own motion
+     preference toggle
+   - Disabling animation for a specific section / widget only
+
+   Example:
+     <section class="ease-reduced">
+       <div class="ease-fade-in">...</div>  ← no animation
+     </section>
+*/
+.ease-reduced,
+.ease-reduced *,
+.ease-reduced *::before,
+.ease-reduced *::after {
+  animation-duration:         0.01ms !important;
+  animation-iteration-count:  1      !important;
+  animation-delay:            0.01ms !important;
+  transition-duration:        0.01ms !important;
+  transition-delay:           0.01ms !important;
+  scroll-behavior:            auto   !important;
+}
+
+
+/* ── Layer 3: .ease-motion-safe wrapper ─────────────────────
+   Opt-IN pattern — animations inside this wrapper only play
+   when the user has NOT requested reduced motion.
+   Useful for decorative animations that should be skipped
+   entirely (not just shortened to 0.01ms).
+
+   Example:
+     <div class="ease-motion-safe">
+       <div class="ease-bounce">decorative element</div>
+     </div>
+*/
+@media (prefers-reduced-motion: reduce) {
+  .ease-motion-safe,
+  .ease-motion-safe *,
+  .ease-motion-safe *::before,
+  .ease-motion-safe *::after {
+    animation:  none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #8373

EaseMotion-css had zero `prefers-reduced-motion` support. Users with
vestibular disorders, epilepsy, or motion sensitivity had no way to
opt out of framework animations — a WCAG 2.1 SC 2.3.3 violation.

## Changes

**`style.css` → add to end of `easemotion.css`**

Three-layer approach:

1. **Global OS override** — `@media (prefers-reduced-motion: reduce)`
   kills all animation/transition durations to `0.01ms` (not `0s` —
   preserves `animationend` / `transitionend` JS events)

2. **`.ease-reduced` utility** — developer-controlled opt-in for
   apps with their own motion preference toggle

3. **`.ease-motion-safe` wrapper** — decorative animations wrapped
   here are fully removed (`animation: none`) when reduced motion
   is active, rather than just shortened

## WCAG Compliance

| Criterion | Before | After |
|---|---|---|
| 2.3.3 Animation from Interactions (AAA) | ❌ Violated | ✅ Satisfied |

## Why `0.01ms` not `0s`

Setting `animation-duration: 0s` prevents `animationend` from firing
in some browsers. `0.01ms` causes the animation to complete in one
paint frame — instant to users, but callbacks still fire correctly.

## Acceptance Criteria (from issue)

- [x] Global `@media (prefers-reduced-motion: reduce)` block added
- [x] `.ease-reduced` utility class provided
- [x] Demo with live OS detection and JS toggle
- [x] WCAG 2.1 SC 2.3.3 satisfied

## Notes

Per contribution policy, no `core/` or `components/` files modified
directly. Full implementation in
`submissions/examples/reduced-motion-fix/` for maintainer
integration into `easemotion.css` and `core/utilities.css`.