### PR TITLE
fix: guard footer hover rules with pointer media query (issue #9170)

### DIFF
--- a/submissions/examples/footer-hover-touch-guard-9170/README.md
+++ b/submissions/examples/footer-hover-touch-guard-9170/README.md
@@ -1,0 +1,67 @@
+# Footer Hover Touch Guard Fix — Issue #9170
+
+**Fixes:** #9170
+
+## What does this do?
+
+Wraps `.ease-footer-links a:hover` and `.ease-footer-social a:hover` in
+`@media (hover: hover) and (pointer: fine)` to prevent sticky hover on touch
+devices.
+
+## The problem
+
+`components/footer.css` has two unguarded hover rules:
+
+```css
+/* Line 51 — fires on touch tap */
+.ease-footer-links a:hover {
+  color: var(--ease-color-primary, #6366f1);
+}
+
+/* Line 78 — fires on touch tap, transform gets stuck */
+.ease-footer-social a:hover {
+  background: var(--ease-color-primary, #6366f1);
+  color: #fff;
+  transform: translateY(-2px);
+}
+```
+
+On touch devices, browsers synthesise a `:hover` event when a user taps. This
+synthetic hover does not end when the finger lifts — it sticks until focus moves
+elsewhere. Tapping a footer link makes it turn primary-purple and stay that color.
+Tapping a social icon makes it turn purple, shift 2px upward, and stay in that
+raised position — a visible layout disruption.
+
+## The fix
+
+```css
+@media (hover: hover) and (pointer: fine) {
+  .ease-footer-links a:hover {
+    color: var(--ease-color-primary, #6366f1);
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-footer-social a:hover {
+    background: var(--ease-color-primary, #6366f1);
+    color: #fff;
+    transform: translateY(-2px);
+  }
+}
+```
+
+Same pattern used by buttons, cards, and navbar across the framework.
+
+## Behaviour after fix
+
+| Interaction | Device | Before | After |
+|---|---|---|---|
+| Tap footer link | Touch | Color stuck at primary | No change |
+| Hover footer link | Mouse | Color changes | Color changes (unchanged) |
+| Tap social icon | Touch | Purple + shifted up, stuck | No change |
+| Hover social icon | Mouse | Purple + shifts up | Purple + shifts up (unchanged) |
+
+## Demo
+
+Open in Chrome DevTools with Device Toolbar enabled to see the broken vs
+fixed behaviour side by side.

--- a/submissions/examples/footer-hover-touch-guard-9170/demo.html
+++ b/submissions/examples/footer-hover-touch-guard-9170/demo.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Footer Hover Touch Guard Fix — Issue #9170</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+    }
+
+    .page {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 0;
+    }
+
+    h1 {
+      font-size: var(--ease-text-2xl, 1.5rem);
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .hint strong { display: block; margin-bottom: 0.2rem; }
+
+    .demo-label {
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 700;
+      margin-bottom: 0.6rem;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .tag {
+      font-size: 0.68rem;
+      font-weight: 700;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    .footer-demo-block {
+      margin-bottom: 2rem;
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    /* ── BROKEN footer (no hover guards — replicates the bug) ── */
+    .footer-broken {
+      background: var(--ease-color-neutral-900, #0f172a);
+      border-top: 1px solid var(--ease-color-neutral-700, #334155);
+      padding: 2rem;
+      color: var(--ease-color-neutral-400, #94a3b8);
+      font-size: 0.875rem;
+    }
+
+    .footer-broken .col-title {
+      font-weight: 600;
+      color: var(--ease-color-neutral-100, #f3f4f6);
+      margin-bottom: 0.75rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .footer-broken .links {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-bottom: 1.25rem;
+    }
+
+    /* BROKEN: no guard */
+    .footer-broken .links a {
+      color: var(--ease-color-neutral-400, #9ca3af);
+      text-decoration: none;
+      transition: color 150ms ease;
+    }
+
+    .footer-broken .links a:hover {
+      color: var(--ease-color-primary, #6c63ff);
+    }
+
+    .footer-broken .socials {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .footer-broken .socials a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      background: var(--ease-color-neutral-800, #1e293b);
+      color: var(--ease-color-neutral-300, #d1d5db);
+      text-decoration: none;
+      font-size: 0.75rem;
+      font-weight: 700;
+      transition: background 150ms ease, color 150ms ease,
+                  transform 150ms cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+
+    /* BROKEN: no guard — transform gets stuck on touch */
+    .footer-broken .socials a:hover {
+      background: var(--ease-color-primary, #6c63ff);
+      color: #fff;
+      transform: translateY(-2px);
+    }
+
+    /* ── FIXED footer (with hover guards) ─────────────────── */
+    .footer-fixed {
+      background: var(--ease-color-neutral-900, #0f172a);
+      border-top: 1px solid var(--ease-color-neutral-700, #334155);
+      padding: 2rem;
+      color: var(--ease-color-neutral-400, #94a3b8);
+      font-size: 0.875rem;
+    }
+
+    .footer-fixed .col-title {
+      font-weight: 600;
+      color: var(--ease-color-neutral-100, #f3f4f6);
+      margin-bottom: 0.75rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .footer-fixed .links {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-bottom: 1.25rem;
+    }
+
+    .footer-fixed .links a {
+      color: var(--ease-color-neutral-400, #9ca3af);
+      text-decoration: none;
+      transition: color 150ms ease;
+    }
+
+    /* FIXED: guarded */
+    @media (hover: hover) and (pointer: fine) {
+      .footer-fixed .links a:hover {
+        color: var(--ease-color-primary, #6c63ff);
+      }
+    }
+
+    .footer-fixed .socials {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .footer-fixed .socials a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      background: var(--ease-color-neutral-800, #1e293b);
+      color: var(--ease-color-neutral-300, #d1d5db);
+      text-decoration: none;
+      font-size: 0.75rem;
+      font-weight: 700;
+      transition: background 150ms ease, color 150ms ease,
+                  transform 150ms cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+
+    /* FIXED: guarded — no transform stuck on touch */
+    @media (hover: hover) and (pointer: fine) {
+      .footer-fixed .socials a:hover {
+        background: var(--ease-color-primary, #6c63ff);
+        color: #fff;
+        transform: translateY(-2px);
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0a0f1e; }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <h1>Footer Hover Touch Guard Fix</h1>
+    <p class="sub">Issue #9170 — sticky hover on footer links and social icons on touch devices</p>
+
+    <div class="hint">
+      <strong>How to reproduce the bug:</strong>
+      Chrome DevTools → toggle Device Toolbar → select any mobile preset →
+      tap links and social icons in the <strong>Broken</strong> footer below.
+      Links stay primary-colored, social icons stay shifted upward.
+      The <strong>Fixed</strong> footer shows no change on tap.
+    </div>
+
+    <!-- BROKEN -->
+    <div class="footer-demo-block">
+      <div class="demo-label">
+        <span class="tag tag-broken">Broken</span>
+        No <code>(hover: hover)</code> guard — sticky hover on tap
+      </div>
+      <footer class="footer-broken">
+        <div class="col-title">Navigation</div>
+        <ul class="links">
+          <li><a href="#" onclick="return false;">Home</a></li>
+          <li><a href="#" onclick="return false;">Components</a></li>
+          <li><a href="#" onclick="return false;">Animations</a></li>
+          <li><a href="#" onclick="return false;">GitHub</a></li>
+        </ul>
+        <div class="col-title">Social</div>
+        <div class="socials">
+          <a href="#" onclick="return false;" title="GitHub">GH</a>
+          <a href="#" onclick="return false;" title="Twitter">TW</a>
+          <a href="#" onclick="return false;" title="Discord">DC</a>
+        </div>
+      </footer>
+    </div>
+
+    <!-- FIXED -->
+    <div class="footer-demo-block">
+      <div class="demo-label">
+        <span class="tag tag-fixed">Fixed</span>
+        With <code>@media (hover: hover) and (pointer: fine)</code> guard
+      </div>
+      <footer class="footer-fixed">
+        <div class="col-title">Navigation</div>
+        <ul class="links">
+          <li><a href="#" onclick="return false;">Home</a></li>
+          <li><a href="#" onclick="return false;">Components</a></li>
+          <li><a href="#" onclick="return false;">Animations</a></li>
+          <li><a href="#" onclick="return false;">GitHub</a></li>
+        </ul>
+        <div class="col-title">Social</div>
+        <div class="socials">
+          <a href="#" onclick="return false;" title="GitHub">GH</a>
+          <a href="#" onclick="return false;" title="Twitter">TW</a>
+          <a href="#" onclick="return false;" title="Discord">DC</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/footer-hover-touch-guard-9170/style.css
+++ b/submissions/examples/footer-hover-touch-guard-9170/style.css
@@ -1,0 +1,31 @@
+/* ============================================================
+   Fix for issue #9170
+   .ease-footer-links a:hover and .ease-footer-social a:hover
+   are missing @media (hover: hover) and (pointer: fine) guards.
+
+   On touch devices browsers synthesise a :hover state on tap
+   that does not clear when the finger lifts — it sticks until
+   the user taps somewhere else. This creates a false "active"
+   state on footer links and leaves social icons shifted 2px
+   upward with a purple background until focus moves away.
+
+   Every other interactive component in the framework wraps its
+   :hover rules in this guard. This submission applies the same
+   pattern to the two unguarded rules in footer.css.
+   ============================================================ */
+
+/* ── Footer link hover — guarded ───────────────────────────── */
+@media (hover: hover) and (pointer: fine) {
+  .ease-footer-links a:hover {
+    color: var(--ease-color-primary, #6366f1);
+  }
+}
+
+/* ── Social icon hover — guarded ───────────────────────────── */
+@media (hover: hover) and (pointer: fine) {
+  .ease-footer-social a:hover {
+    background: var(--ease-color-primary, #6366f1);
+    color: #fff;
+    transform: translateY(-2px);
+  }
+}


### PR DESCRIPTION
# Guard footer hover rules with pointer media query (issue #9170)

Fixes #9170

## What

`.ease-footer-links a:hover` and `.ease-footer-social a:hover` in
`components/footer.css` have no `@media (hover: hover) and (pointer: fine)`
guard. On touch devices, tapping a footer link leaves it stuck in the
primary-color state. Tapping a social icon leaves it shifted 2px upward
with a purple background until the user taps elsewhere — a visible layout
disruption.

Every other interactive component in the framework already uses this guard.

## Submission

`submissions/examples/footer-hover-touch-guard-9170/`

The demo shows both footers side by side. Open in Chrome DevTools with
Device Toolbar enabled and tap the links and icons in each footer to see
the broken vs fixed behaviour.

## Checklist

- [x] Files added only inside `submissions/examples/footer-hover-touch-guard-9170/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/`, `components/`, or any other framework file
- [x] Single focused fix, one commit
