### PR TITLE
fix: demonstrate reveal.js live prefers-reduced-motion listener fix (issue #9177)

### DIFF
--- a/submissions/examples/reveal-js-live-motion-9177/README.md
+++ b/submissions/examples/reveal-js-live-motion-9177/README.md
@@ -1,0 +1,74 @@
+# reveal.js Live Motion Fix — Issue #9177
+
+**Fixes:** #9177
+
+## What does this do?
+
+Demonstrates the bug in `core/reveal.js` where `prefers-reduced-motion` is
+checked once at script parse time using `.matches`, and shows the correct fix
+using a live `MediaQueryList` change listener.
+
+## The problem
+
+In `core/reveal.js`, lines 12–14:
+
+```js
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+if (prefersReducedMotion) return;
+```
+
+`.matches` is a one-time boolean snapshot. The `MediaQueryList` object is
+discarded immediately. If a user enables Reduce Motion after the page loads,
+the already-running `IntersectionObserver` keeps adding `ease-reveal-active`
+to elements as they scroll into view — triggering animations that the user has
+just asked to stop.
+
+## How to see it
+
+1. Open `demo.html` in a browser.
+2. Scroll down a little in both panels to trigger a few reveals (confirms both
+   observers are working).
+3. Click **Enable Reduce Motion (mid-session)** to simulate a live preference
+   change.
+4. Scroll further in both panels.
+
+**Broken panel:** Items continue to animate in.
+
+**Fixed panel:** The observer disconnects immediately. No more animations.
+
+## The fix
+
+Store the `MediaQueryList` and attach a `change` listener:
+
+```js
+var mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+// Listen for live changes
+if (mql.addEventListener) {
+  mql.addEventListener('change', handleMotionChange);
+} else {
+  mql.addListener(handleMotionChange); // older browsers
+}
+
+function handleMotionChange(e) {
+  if (e.matches) {
+    stopObserver();   // user just enabled Reduce Motion
+  } else {
+    startObserver();  // user just disabled Reduce Motion
+  }
+}
+
+// Initial check
+if (mql.matches) return;
+startObserver();
+```
+
+## Why this matters
+
+Users can toggle Reduce Motion without reloading the page:
+- iOS: Control Centre → Accessibility Shortcuts
+- macOS: Accessibility shortcut keys
+- Chrome DevTools: Rendering panel → prefers-reduced-motion
+
+When any of these change, the browser fires a `change` event on active
+`MediaQueryList` objects. Without a listener, `reveal.js` never hears about it.

--- a/submissions/examples/reveal-js-live-motion-9177/demo.html
+++ b/submissions/examples/reveal-js-live-motion-9177/demo.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>reveal.js Live Motion Fix — Issue #9177</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+    }
+
+    .page {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    h1 {
+      font-size: var(--ease-text-2xl, 1.5rem);
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .hint strong { display: block; margin-bottom: 0.2rem; }
+
+    .controls {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 1.5rem;
+    }
+
+    .btn-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.5rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 600;
+      border: 2px solid var(--ease-color-danger, #ef4444);
+      border-radius: var(--ease-radius-full, 9999px);
+      background: transparent;
+      color: var(--ease-color-danger, #ef4444);
+      cursor: pointer;
+      transition: background 150ms ease, color 150ms ease;
+    }
+
+    .btn-toggle.reduced {
+      background: var(--ease-color-danger, #ef4444);
+      color: #fff;
+    }
+
+    .btn-reset {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.5rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 600;
+      border: 2px solid var(--ease-color-neutral-300, #cbd5e1);
+      border-radius: var(--ease-radius-full, 9999px);
+      background: transparent;
+      color: var(--ease-color-muted, #64748b);
+      cursor: pointer;
+      transition: background 150ms ease, color 150ms ease;
+    }
+
+    .btn-reset:hover { background: var(--ease-color-neutral-100, #f1f5f9); }
+
+    .section-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    @media (max-width: 640px) {
+      .section-row { grid-template-columns: 1fr; }
+    }
+
+    .section-label {
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 700;
+      margin-bottom: 0.6rem;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .tag {
+      font-size: 0.68rem;
+      font-weight: 700;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    .log {
+      margin-top: 0.5rem;
+      font-size: 0.72rem;
+      color: var(--ease-color-muted, #64748b);
+      font-family: var(--ease-font-mono, monospace);
+      min-height: 1.4rem;
+    }
+
+    .log .anim { color: var(--ease-color-danger, #ef4444); font-weight: 700; }
+    .log .stop { color: var(--ease-color-success, #22c55e); font-weight: 700; }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <h1>reveal.js Live Motion Fix</h1>
+    <p class="sub">Issue #9177 — <code>prefers-reduced-motion</code> checked once at load — live changes ignored</p>
+
+    <div class="hint">
+      <strong>How to use this demo:</strong>
+      Both panels start with motion allowed. Click
+      <strong>Enable Reduce Motion (mid-session)</strong> to simulate a user
+      turning on Reduce Motion after the page loaded.
+      Then scroll inside each panel and watch whether new items animate in.
+      The <strong>Broken</strong> observer keeps animating.
+      The <strong>Fixed</strong> observer stops immediately.
+    </div>
+
+    <!-- Controls -->
+    <div class="controls">
+      <button class="btn-toggle" id="motion-btn" onclick="toggleMotion()">
+        Enable Reduce Motion (mid-session)
+      </button>
+      <button class="btn-reset" onclick="resetDemo()">Reset demo</button>
+      <span id="motion-indicator" class="motion-indicator motion-off">
+        Motion: allowed
+      </span>
+    </div>
+
+    <!-- Side-by-side panels -->
+    <div class="section-row">
+
+      <!-- BROKEN -->
+      <div>
+        <div class="section-label">
+          <span class="tag tag-broken">Broken</span>
+          Snapshot — one-time check
+        </div>
+        <div class="demo-scroll" id="scroll-broken">
+          <div style="height:320px;display:flex;align-items:flex-end;padding-bottom:0.5rem;color:var(--ease-color-muted);font-size:0.75rem;">
+            ↓ Scroll down to reveal items
+          </div>
+          <!-- Items injected by JS below -->
+        </div>
+        <div class="log" id="log-broken">Waiting for scroll...</div>
+      </div>
+
+      <!-- FIXED -->
+      <div>
+        <div class="section-label">
+          <span class="tag tag-fixed">Fixed</span>
+          Live listener — disconnects on change
+        </div>
+        <div class="demo-scroll" id="scroll-fixed">
+          <div style="height:320px;display:flex;align-items:flex-end;padding-bottom:0.5rem;color:var(--ease-color-muted);font-size:0.75rem;">
+            ↓ Scroll down to reveal items
+          </div>
+          <!-- Items injected by JS below -->
+        </div>
+        <div class="log" id="log-fixed">Waiting for scroll...</div>
+      </div>
+
+    </div>
+
+  </div>
+
+  <script>
+    // ── Shared state ─────────────────────────────────────────
+    var simulatedReducedMotion = false;
+
+    // ── Build reveal items in both containers ─────────────────
+    function buildItems(containerId, count) {
+      var container = document.getElementById(containerId);
+      var placeholder = container.querySelector('div');
+      for (var i = 0; i < count; i++) {
+        var item = document.createElement('div');
+        item.className = 'demo-reveal-item';
+        item.textContent = 'Reveal item ' + (i + 1) + ' — slides up when entering view';
+        item.dataset.index = i;
+        container.appendChild(item);
+      }
+    }
+
+    buildItems('scroll-broken', 8);
+    buildItems('scroll-fixed', 8);
+
+    // ─────────────────────────────────────────────────────────
+    // BROKEN observer — one-time snapshot (replicates reveal.js bug)
+    // The reduced motion state is captured once and never updated.
+    // ─────────────────────────────────────────────────────────
+    var brokenObserver = null;
+    var brokenReducedMotion = simulatedReducedMotion; // snapshot at setup time
+
+    function setupBrokenObserver() {
+      // Simulates: const prefersReducedMotion = window.matchMedia(...).matches;
+      // if (prefersReducedMotion) return;
+      if (brokenReducedMotion) return; // one-time gate — never revisited
+
+      brokenObserver = new IntersectionObserver(function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-active');
+            document.getElementById('log-broken').innerHTML =
+              '<span class="anim">▶ Animation playing</span> — motion preference ignored';
+            brokenObserver.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.15, root: document.getElementById('scroll-broken') });
+
+      var items = document.querySelectorAll('#scroll-broken .demo-reveal-item');
+      items.forEach(function (el) { brokenObserver.observe(el); });
+    }
+
+    setupBrokenObserver();
+
+    // ─────────────────────────────────────────────────────────
+    // FIXED observer — stores mql, listens for live changes
+    // ─────────────────────────────────────────────────────────
+    var fixedObserver = null;
+
+    // Simulates: var mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    // In the demo we use a fake mql backed by simulatedReducedMotion.
+    var fakeMql = {
+      matches: false,
+      listeners: [],
+      addEventListener: function (type, fn) {
+        if (type === 'change') this.listeners.push(fn);
+      },
+      dispatchChange: function (newMatches) {
+        this.matches = newMatches;
+        this.listeners.forEach(function (fn) { fn({ matches: newMatches }); });
+      }
+    };
+
+    function startFixedObserver() {
+      if (!('IntersectionObserver' in window)) return;
+
+      fixedObserver = new IntersectionObserver(function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-active');
+            document.getElementById('log-fixed').innerHTML =
+              '<span class="anim">▶ Animation playing</span>';
+            fixedObserver.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.15, root: document.getElementById('scroll-fixed') });
+
+      var items = document.querySelectorAll('#scroll-fixed .demo-reveal-item');
+      items.forEach(function (el) {
+        if (!el.classList.contains('is-active')) {
+          fixedObserver.observe(el);
+        }
+      });
+    }
+
+    function stopFixedObserver() {
+      if (fixedObserver) {
+        fixedObserver.disconnect();
+        fixedObserver = null;
+        document.getElementById('log-fixed').innerHTML =
+          '<span class="stop">■ Observer disconnected</span> — no new animations';
+      }
+    }
+
+    // Live change listener — this is the fix
+    fakeMql.addEventListener('change', function (e) {
+      if (e.matches) {
+        stopFixedObserver();
+      } else {
+        startFixedObserver();
+      }
+    });
+
+    // Initial setup
+    if (!fakeMql.matches) {
+      startFixedObserver();
+    }
+
+    // ── Toggle button ─────────────────────────────────────────
+    function toggleMotion() {
+      simulatedReducedMotion = !simulatedReducedMotion;
+
+      var btn = document.getElementById('motion-btn');
+      var ind = document.getElementById('motion-indicator');
+
+      if (simulatedReducedMotion) {
+        btn.textContent = 'Disable Reduce Motion';
+        btn.classList.add('reduced');
+        ind.textContent = 'Motion: REDUCE';
+        ind.className = 'motion-indicator motion-on';
+
+        // Broken: does nothing — brokenReducedMotion was set at startup
+        document.getElementById('log-broken').innerHTML =
+          '<span class="anim">▶ Still animating</span> — preference change not heard';
+
+        // Fixed: fires the live change event
+        fakeMql.dispatchChange(true);
+      } else {
+        btn.textContent = 'Enable Reduce Motion (mid-session)';
+        btn.classList.remove('reduced');
+        ind.textContent = 'Motion: allowed';
+        ind.className = 'motion-indicator motion-off';
+
+        document.getElementById('log-broken').textContent = 'Waiting for scroll...';
+
+        // Fixed: fires the live change event — restarts observer
+        fakeMql.dispatchChange(false);
+        document.getElementById('log-fixed').textContent = 'Observer restarted — scroll to reveal';
+      }
+    }
+
+    // ── Reset button ─────────────────────────────────────────
+    function resetDemo() {
+      // Reset motion state
+      if (simulatedReducedMotion) toggleMotion();
+
+      // Clear all active classes
+      document.querySelectorAll('.demo-reveal-item').forEach(function (el) {
+        el.classList.remove('is-active');
+      });
+
+      // Rebuild broken observer
+      if (brokenObserver) { brokenObserver.disconnect(); brokenObserver = null; }
+      brokenReducedMotion = false;
+      setupBrokenObserver();
+
+      // Rebuild fixed observer
+      stopFixedObserver();
+      startFixedObserver();
+
+      document.getElementById('log-broken').textContent = 'Waiting for scroll...';
+      document.getElementById('log-fixed').textContent = 'Waiting for scroll...';
+
+      // Scroll both panels back to top
+      document.getElementById('scroll-broken').scrollTop = 0;
+      document.getElementById('scroll-fixed').scrollTop = 0;
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/reveal-js-live-motion-9177/style.css
+++ b/submissions/examples/reveal-js-live-motion-9177/style.css
@@ -1,0 +1,69 @@
+/* ============================================================
+   Demo styles for issue #9177
+   reveal.js live prefers-reduced-motion fix
+   ============================================================ */
+
+/* ── Scroll container ───────────────────────────────────────── */
+.demo-scroll {
+  height: 420px;
+  overflow-y: auto;
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: 1rem;
+  background: var(--ease-color-surface, #fff);
+  scroll-behavior: smooth;
+}
+
+/* ── Reveal item base (hidden state) ────────────────────────── */
+.demo-reveal-item {
+  opacity: 0;
+  transform: translateY(32px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+  margin-bottom: 1rem;
+  padding: 1rem 1.25rem;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  border-left: 4px solid var(--ease-color-neutral-300, #cbd5e1);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+/* ── Revealed (active) state ────────────────────────────────── */
+.demo-reveal-item.is-active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ── Status indicator ───────────────────────────────────────── */
+.motion-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+}
+
+.motion-indicator.motion-on {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--ease-color-danger, #ef4444);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.motion-indicator.motion-off {
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--ease-color-success, #22c55e);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+@media (prefers-color-scheme: dark) {
+  .demo-scroll {
+    background: var(--ease-color-surface, #141e33);
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  .demo-reveal-item {
+    background: var(--ease-color-neutral-800, #1e293b);
+    border-left-color: var(--ease-color-neutral-600, #475569);
+  }
+}


### PR DESCRIPTION
# Demonstrate reveal.js live prefers-reduced-motion listener fix (issue #9177)

Fixes #9177

## What

`core/reveal.js` reads `window.matchMedia(...).matches` once at script parse
time and discards the `MediaQueryList` object. If a user enables Reduce Motion
after page load, the running `IntersectionObserver` continues adding
`ease-reveal-active` to elements — ignoring the preference change entirely.

The fix stores the `MediaQueryList` and attaches a `change` listener so the
observer disconnects immediately when the preference changes and restarts when
it is turned off.

## Submission

`submissions/examples/reveal-js-live-motion-9177/`

The demo shows both behaviours side by side with a **"Enable Reduce Motion
(mid-session)"** toggle button. No OS settings or DevTools required:

1. Scroll down in both panels to see elements animate in
2. Click the toggle button to simulate a live preference change
3. Scroll further — the broken panel keeps animating, the fixed panel stops

## The fix (for `core/reveal.js`)

```js
var mql = window.matchMedia('(prefers-reduced-motion: reduce)');

if (mql.addEventListener) {
  mql.addEventListener('change', handleMotionChange);
} else {
  mql.addListener(handleMotionChange);
}

function handleMotionChange(e) {
  if (e.matches) {
    stopObserver();
  } else {
    startObserver();
  }
}

if (mql.matches) return;
startObserver();


## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

