### PR TITLE
fix: add reduced-motion, dark mode, and success glow to badge pulse (issue #9168)

### DIFF
--- a/submissions/examples/badges-dark-mode-reduced-motion-9168/README.md
+++ b/submissions/examples/badges-dark-mode-reduced-motion-9168/README.md
@@ -1,0 +1,75 @@
+# Badges Dark Mode & Reduced Motion Fix — Issue #9168
+
+**Fixes:** #9168
+
+## What does this do?
+
+Adds three missing fixes to `components/badges.css`:
+
+1. **Success variant ping color** — `.ease-badge-success.ease-badge-pulse` was
+   showing a purple glow instead of a green one
+2. **`prefers-reduced-motion` support** — the `::after` ping animation keeps
+   running even when Reduce Motion is enabled
+3. **Dark mode ping intensity** — reduces glow opacity from 70% to 45% in dark
+   mode, matching the framework's other dark-mode glow tokens
+
+## The problems
+
+### Missing success ping color
+
+`badges.css` overrides the ping glow color for the danger variant but not for
+success. A green `.ease-badge-success.ease-badge-pulse` falls back to the base
+primary (purple) glow — wrong for a green badge.
+
+### No prefers-reduced-motion
+
+The `::after` pseudo-element on `.ease-badge-pulse` runs `ease-kf-ping`
+infinitely. The blanket `[class*="ease-"]` rule in `core/animations.css` targets
+elements by class, **not pseudo-elements**. It never reaches `::after`, so the
+animation keeps running even when Reduce Motion is enabled.
+
+### Ping too intense in dark mode
+
+The current glow is `rgba(108, 99, 255, 0.7)` (70% opacity). Against the dark
+background `#0b1121`, this is proportionally more intense than on light. The
+framework's other dark-mode glow tokens use 45% opacity — this fix aligns badges
+with that convention.
+
+## The fix
+
+```css
+/* 1. Correct green glow for success badges */
+.ease-badge-success.ease-badge-pulse::after {
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
+}
+
+/* 2. Stop the ping when Reduce Motion is enabled */
+@media (prefers-reduced-motion: reduce) {
+  .em-badge-pulse::after,
+  .ease-badge-pulse::after {
+    animation: none !important;
+  }
+}
+
+/* 3. Reduce glow intensity in dark mode */
+@media (prefers-color-scheme: dark) {
+  .em-badge-pulse::after,
+  .ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.45);
+  }
+  .em-badge-danger.em-badge-pulse::after,
+  .ease-badge-danger.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.45);
+  }
+  .ease-badge-success.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.45);
+  }
+}
+```
+
+## Demo
+
+The demo shows all three issues side by side. A **Simulate Reduce Motion** toggle
+demonstrates the broken vs fixed ping behaviour without needing OS settings or
+DevTools. Dark mode and wrong glow color can be tested with the DevTools
+Rendering panel.

--- a/submissions/examples/badges-dark-mode-reduced-motion-9168/demo.html
+++ b/submissions/examples/badges-dark-mode-reduced-motion-9168/demo.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Badges Dark Mode & Reduced Motion Fix — Issue #9168</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+    }
+
+    .page {
+      max-width: 820px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    h1 {
+      font-size: var(--ease-text-2xl, 1.5rem);
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .section {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .section-title {
+      font-size: var(--ease-text-base, 1rem);
+      font-weight: 700;
+      margin-bottom: 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .tag {
+      font-size: 0.68rem;
+      font-weight: 700;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+    .tag-info   { background: var(--ease-color-primary, #6c63ff); color: #fff; }
+
+    .badge-row {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.75rem;
+    }
+
+    .badge-label {
+      font-size: 0.75rem;
+      color: var(--ease-color-muted, #64748b);
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    /* ── Broken badge (no reduced-motion override on ::after) ── */
+    .badge-broken-pulse {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 var(--ease-space-2, 0.5rem);
+      height: 20px;
+      min-width: 20px;
+      font-size: var(--ease-text-xs, 0.75rem);
+      font-weight: 700;
+      color: #fff;
+      background-color: var(--ease-color-primary, #6c63ff);
+      border-radius: 9999px;
+    }
+
+    .badge-broken-pulse::after {
+      content: "";
+      position: absolute;
+      top: 0; left: 0; right: 0; bottom: 0;
+      border-radius: inherit;
+      box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.7);
+      animation: ease-kf-ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+      z-index: -1;
+    }
+
+    /* Simulate reduce motion — broken (::after keeps animating) */
+    .simulate-reduced .badge-broken-pulse::after {
+      /* nothing — this is the bug */
+    }
+
+    /* ── Fixed badge (uses the fix from style.css) ── */
+    .badge-fixed-pulse {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 var(--ease-space-2, 0.5rem);
+      height: 20px;
+      min-width: 20px;
+      font-size: var(--ease-text-xs, 0.75rem);
+      font-weight: 700;
+      color: #fff;
+      background-color: var(--ease-color-primary, #6c63ff);
+      border-radius: 9999px;
+    }
+
+    .badge-fixed-pulse::after {
+      content: "";
+      position: absolute;
+      top: 0; left: 0; right: 0; bottom: 0;
+      border-radius: inherit;
+      box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.7);
+      animation: ease-kf-ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+      z-index: -1;
+    }
+
+    /* Fixed: explicitly target ::after */
+    .simulate-reduced .badge-fixed-pulse::after {
+      animation: none !important;
+    }
+
+    /* ── Wrong success pulse (purple glow on green badge — bug) ── */
+    .badge-success-wrong {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 var(--ease-space-2, 0.5rem);
+      height: 20px;
+      min-width: 20px;
+      font-size: var(--ease-text-xs, 0.75rem);
+      font-weight: 700;
+      color: #fff;
+      background-color: var(--ease-color-success, #22c55e);
+      border-radius: 9999px;
+    }
+
+    .badge-success-wrong::after {
+      content: "";
+      position: absolute;
+      top: 0; left: 0; right: 0; bottom: 0;
+      border-radius: inherit;
+      /* no override — falls back to purple, wrong! */
+      box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.7);
+      animation: ease-kf-ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+      z-index: -1;
+    }
+
+    /* ── Correct success pulse (green glow) ── */
+    .badge-success-fixed {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 var(--ease-space-2, 0.5rem);
+      height: 20px;
+      min-width: 20px;
+      font-size: var(--ease-text-xs, 0.75rem);
+      font-weight: 700;
+      color: #fff;
+      background-color: var(--ease-color-success, #22c55e);
+      border-radius: 9999px;
+    }
+
+    .badge-success-fixed::after {
+      content: "";
+      position: absolute;
+      top: 0; left: 0; right: 0; bottom: 0;
+      border-radius: inherit;
+      box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7); /* correct green */
+      animation: ease-kf-ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+      z-index: -1;
+    }
+
+    /* ── Toggle button ── */
+    .btn-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.5rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 600;
+      border: 2px solid var(--ease-color-danger, #ef4444);
+      border-radius: 9999px;
+      background: transparent;
+      color: var(--ease-color-danger, #ef4444);
+      cursor: pointer;
+      margin-bottom: 1.5rem;
+      transition: background 150ms ease, color 150ms ease;
+    }
+
+    .btn-toggle.active {
+      background: var(--ease-color-danger, #ef4444);
+      color: #fff;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .section {
+        background: var(--ease-color-surface, #141e33);
+        border-color: var(--ease-color-neutral-700, #334155);
+      }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page" id="demo-root">
+
+    <h1>Badges Dark Mode & Reduced Motion Fix</h1>
+    <p class="sub">Issue #9168 — <code>badges.css</code> has no <code>@media</code> blocks</p>
+
+    <div class="hint">
+      Use Chrome DevTools → Rendering → emulate
+      <code>prefers-color-scheme: dark</code> and
+      <code>prefers-reduced-motion: reduce</code> to test real behaviour.<br>
+      Use the toggle below to simulate reduced motion in this demo without DevTools.
+    </div>
+
+    <button class="btn-toggle" id="motion-btn" onclick="toggleMotion()">
+      Simulate Reduce Motion: OFF
+    </button>
+
+    <!-- Issue 1: reduced-motion -->
+    <div class="section">
+      <div class="section-title">
+        Problem 1 — <code>prefers-reduced-motion</code> not respected
+      </div>
+
+      <div class="badge-row">
+        <div>
+          <div class="section-title" style="font-size:0.75rem;margin-bottom:0.5rem;">
+            <span class="tag tag-broken">Broken</span> Ping keeps going after Reduce Motion enabled
+          </div>
+          <div style="display:flex;align-items:center;gap:1rem;padding:1rem 0;">
+            <div class="badge-broken-pulse">5</div>
+            <span class="badge-label"><code>.ease-badge-pulse::after</code> — animation ignores the preference</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="badge-row">
+        <div>
+          <div class="section-title" style="font-size:0.75rem;margin-bottom:0.5rem;">
+            <span class="tag tag-fixed">Fixed</span> Ping stops when Reduce Motion is enabled
+          </div>
+          <div style="display:flex;align-items:center;gap:1rem;padding:1rem 0;">
+            <div class="badge-fixed-pulse">5</div>
+            <span class="badge-label"><code>animation: none !important</code> on <code>::after</code> — stops correctly</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Issue 2: wrong success color -->
+    <div class="section">
+      <div class="section-title">
+        Problem 2 — Missing success variant ping glow color
+      </div>
+      <div class="badge-row" style="padding:0.5rem 0;">
+        <div style="display:flex;align-items:center;gap:0.75rem;">
+          <div class="badge-success-wrong">3</div>
+          <span class="badge-label">
+            <span class="tag tag-broken" style="margin-right:0.25rem;">Broken</span>
+            Green badge — <strong>purple</strong> glow (wrong, falls back to primary)
+          </span>
+        </div>
+      </div>
+      <div class="badge-row" style="padding:0.5rem 0;">
+        <div style="display:flex;align-items:center;gap:0.75rem;">
+          <div class="badge-success-fixed">3</div>
+          <span class="badge-label">
+            <span class="tag tag-fixed" style="margin-right:0.25rem;">Fixed</span>
+            Green badge — <strong>green</strong> glow (correct)
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Issue 3: dark mode glow -->
+    <div class="section">
+      <div class="section-title">
+        Problem 3 — Ping glow too intense in dark mode
+      </div>
+      <p style="font-size:var(--ease-text-sm,0.875rem);color:var(--ease-color-muted,#64748b);margin-bottom:1rem;line-height:1.6;">
+        Enable dark mode emulation in Chrome DevTools → Rendering → prefers-color-scheme: dark.
+        The current glow is 70% opacity. The fix reduces it to 45% to match
+        the framework's other dark-mode glow tokens
+        (<code>--ease-glow-primary</code> uses 45%).
+      </p>
+      <div style="display:flex;align-items:center;gap:1rem;padding:0.5rem 0;">
+        <span class="ease-badge ease-badge-pulse">7</span>
+        <span class="badge-label">Uses the framework's real <code>.ease-badge-pulse</code> class — glow is corrected by <code>style.css</code></span>
+      </div>
+    </div>
+
+  </div>
+
+  <script>
+    var reduced = false;
+
+    function toggleMotion() {
+      reduced = !reduced;
+      var root = document.getElementById('demo-root');
+      var btn = document.getElementById('motion-btn');
+
+      if (reduced) {
+        root.classList.add('simulate-reduced');
+        btn.textContent = 'Simulate Reduce Motion: ON';
+        btn.classList.add('active');
+      } else {
+        root.classList.remove('simulate-reduced');
+        btn.textContent = 'Simulate Reduce Motion: OFF';
+        btn.classList.remove('active');
+      }
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/badges-dark-mode-reduced-motion-9168/style.css
+++ b/submissions/examples/badges-dark-mode-reduced-motion-9168/style.css
@@ -1,0 +1,49 @@
+/* ============================================================
+   Fix for issue #9168
+   components/badges.css has no @media blocks of any kind:
+   1. Missing success variant ping glow color
+   2. No prefers-reduced-motion support for .ease-badge-pulse::after
+   3. No dark mode ping intensity adjustment
+
+   The ::after pseudo-element on .ease-badge-pulse runs ease-kf-ping
+   infinitely. The blanket [class*="ease-"] reduced-motion rule in
+   core/animations.css does NOT reach pseudo-elements, so nothing
+   stops this animation when Reduce Motion is enabled.
+   ============================================================ */
+
+/* ── 1. Missing success variant ping color ──────────────────── */
+/* Without this, .ease-badge-success.ease-badge-pulse shows a
+   purple glow instead of a green one — wrong for a green badge. */
+.ease-badge-success.ease-badge-pulse::after {
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
+}
+
+/* ── 2. Stop the ping animation when Reduce Motion is enabled ── */
+/* The [class*="ease-"] rule in animations.css targets elements,
+   not pseudo-elements. This block explicitly targets ::after. */
+@media (prefers-reduced-motion: reduce) {
+  .em-badge-pulse::after,
+  .ease-badge-pulse::after {
+    animation: none !important;
+  }
+}
+
+/* ── 3. Reduce ping glow intensity in dark mode ─────────────── */
+/* The framework uses ~45% opacity for glows on dark backgrounds
+   (matching --ease-glow-primary etc.). The current 70% opacity
+   is too intense against a #0b1121 dark background. */
+@media (prefers-color-scheme: dark) {
+  .em-badge-pulse::after,
+  .ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.45);
+  }
+
+  .em-badge-danger.em-badge-pulse::after,
+  .ease-badge-danger.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.45);
+  }
+
+  .ease-badge-success.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.45);
+  }
+}


### PR DESCRIPTION
# Add reduced-motion, dark mode, and success glow to badge pulse (issue #9168)
Fixes #9168

## What

`components/badges.css` has no `@media` blocks. Three problems fixed:

1. `.ease-badge-success.ease-badge-pulse::after` shows a purple ping glow instead
   of green — missing color override for the success variant

2. The `::after` ping animation ignores `prefers-reduced-motion`. The blanket
   `[class*="ease-"]` rule in `animations.css` targets elements, not
   pseudo-elements, so it never reaches `::after`

3. The 70% opacity ping glow is too intense on dark backgrounds. The fix reduces
   it to 45% to match `--ease-glow-primary` and other dark-mode glows

## Submission

`submissions/examples/badges-dark-mode-reduced-motion-9168/`

The demo shows all three issues. A **Simulate Reduce Motion** toggle demonstrates
the broken vs fixed ping behaviour without needing OS settings. Dark mode can be
tested with Chrome DevTools → Rendering → prefers-color-scheme: dark.

## Checklist

- [x] Files added only inside `submissions/examples/badges-dark-mode-reduced-motion-9168/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/`, `components/`, or any other framework file
- [x] Single focused fix, one commit
