### PR TITLE
fix: add dark mode border override to tabs nav separator (issue #9136)

### DIFF
--- a/submissions/examples/tabs-dark-mode-9136/README.md
+++ b/submissions/examples/tabs-dark-mode-9136/README.md
@@ -1,0 +1,65 @@
+# Tabs Dark Mode Fix — Issue #9136
+
+**Fixes:** #9136
+
+## What does this do?
+
+Adds a `@media (prefers-color-scheme: dark)` block to `components/tabs.css` so
+the nav separator border uses a dark-appropriate color instead of staying as a
+bright light-grey line on a dark background.
+
+## The problem
+
+`components/tabs.css` has no dark mode block. The nav separator uses:
+
+```css
+.ease-tabs-nav {
+  border-bottom: 2px solid var(--ease-color-neutral-200);
+}
+```
+
+`--ease-color-neutral-200` is `#e2e8f0` — a light grey. It has no dark mode
+override in `variables.css`. In dark mode, the browser uses the `#0b1121` dark
+background from `--ease-color-bg`, but the nav border stays `#e2e8f0` — a
+bright horizontal stripe clearly visible across a dark page.
+
+## How to reproduce
+
+Chrome DevTools → More Tools → Rendering →
+set **Emulate CSS media feature prefers-color-scheme** to `dark` →
+open any page with `.ease-tabs` markup.
+
+The nav separator is immediately visible as a bright light-grey line.
+
+## The fix
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-tabs-nav {
+    border-bottom-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  .ease-tabs-auto .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(2):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(2),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(4),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6) {
+    border-bottom-color: var(--ease-color-primary-light, #a09af8);
+  }
+}
+```
+
+## What changes
+
+| Element | Light mode | Dark mode (after fix) |
+|---|---|---|
+| `.ease-tabs-nav` border | `#e2e8f0` light grey | `#334155` dark grey |
+| Active underline | `#6c63ff` primary | unchanged — already correct |
+| Inactive label | `#94a3b8` muted | unchanged — already overridden in `variables.css` |
+
+## Demo
+
+Open in Chrome DevTools with `prefers-color-scheme: dark` emulated to see both
+the broken and fixed tabs side by side. The bottom of the page also has a live
+`ease-tabs` instance using the real framework classes with the fix applied.

--- a/submissions/examples/tabs-dark-mode-9136/demo.html
+++ b/submissions/examples/tabs-dark-mode-9136/demo.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tabs Dark Mode Fix — Issue #9136</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+    }
+
+    .page {
+      max-width: 820px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    h1 {
+      font-size: var(--ease-text-2xl, 1.5rem);
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .demo-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    @media (max-width: 600px) {
+      .demo-row { grid-template-columns: 1fr; }
+    }
+
+    .demo-label {
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .tag {
+      font-size: 0.68rem;
+      font-weight: 700;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    /* ── BROKEN tabs — no dark mode override ──────────────── */
+    .tabs-broken {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+    }
+
+    .tabs-broken-nav {
+      display: flex;
+      /* hardcoded light border — broken in dark mode */
+      border-bottom: 2px solid #e2e8f0;
+      position: relative;
+      margin-bottom: 1rem;
+    }
+
+    .tabs-broken-label {
+      flex: 1;
+      text-align: center;
+      padding: 0.75rem;
+      font-weight: 600;
+      font-size: 0.875rem;
+      cursor: pointer;
+      color: var(--ease-color-muted, #64748b);
+    }
+
+    .tabs-broken-active-label {
+      color: var(--ease-color-primary, #6c63ff);
+    }
+
+    .tabs-broken-underline {
+      position: absolute;
+      bottom: -2px;
+      left: 33.333%;
+      height: 2px;
+      width: 33.333%;
+      background-color: var(--ease-color-primary, #6c63ff);
+    }
+
+    .tabs-broken-panel {
+      font-size: 0.875rem;
+      color: var(--ease-color-text, #1e293b);
+      padding: 0.5rem 0;
+    }
+
+    /* ── FIXED tabs — with dark mode override ─────────────── */
+    .tabs-fixed {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+    }
+
+    .tabs-fixed-nav {
+      display: flex;
+      border-bottom: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+      position: relative;
+      margin-bottom: 1rem;
+    }
+
+    /* THE FIX — dark mode override */
+    @media (prefers-color-scheme: dark) {
+      .tabs-fixed-nav {
+        border-bottom-color: var(--ease-color-neutral-700, #334155);
+      }
+    }
+
+    .tabs-fixed-label {
+      flex: 1;
+      text-align: center;
+      padding: 0.75rem;
+      font-weight: 600;
+      font-size: 0.875rem;
+      cursor: pointer;
+      color: var(--ease-color-muted, #64748b);
+    }
+
+    .tabs-fixed-active-label {
+      color: var(--ease-color-primary, #6c63ff);
+    }
+
+    .tabs-fixed-underline {
+      position: absolute;
+      bottom: -2px;
+      left: 33.333%;
+      height: 2px;
+      width: 33.333%;
+      background-color: var(--ease-color-primary, #6c63ff);
+    }
+
+    .tabs-fixed-panel {
+      font-size: 0.875rem;
+      color: var(--ease-color-text, #1e293b);
+      padding: 0.5rem 0;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <h1>Tabs Dark Mode Fix</h1>
+    <p class="sub">Issue #9136 — <code>tabs.css</code> nav border uses <code>--ease-color-neutral-200</code> with no dark override</p>
+
+    <div class="hint">
+      Enable dark mode emulation in Chrome DevTools → More Tools → Rendering →
+      set <strong>Emulate CSS media feature prefers-color-scheme</strong> to
+      <code>dark</code>. The broken tabs show a bright light-grey separator.
+      The fixed tabs use a dark border that matches the dark background.
+    </div>
+
+    <div class="demo-row">
+
+      <!-- BROKEN -->
+      <div>
+        <div class="demo-label">
+          <span class="tag tag-broken">Broken</span>
+          Light-grey border in dark mode
+        </div>
+        <div class="tabs-broken">
+          <div class="tabs-broken-nav">
+            <div class="tabs-broken-label">Tab 1</div>
+            <div class="tabs-broken-label tabs-broken-active-label">Tab 2</div>
+            <div class="tabs-broken-label">Tab 3</div>
+            <div class="tabs-broken-underline"></div>
+          </div>
+          <div class="tabs-broken-panel">
+            The nav border uses <code>#e2e8f0</code> — visible as a bright stripe
+            on a dark background because <code>--ease-color-neutral-200</code>
+            has no dark mode override.
+          </div>
+        </div>
+      </div>
+
+      <!-- FIXED -->
+      <div>
+        <div class="demo-label">
+          <span class="tag tag-fixed">Fixed</span>
+          Dark border with <code>--ease-color-neutral-700</code>
+        </div>
+        <div class="tabs-fixed">
+          <div class="tabs-fixed-nav">
+            <div class="tabs-fixed-label">Tab 1</div>
+            <div class="tabs-fixed-label tabs-fixed-active-label">Tab 2</div>
+            <div class="tabs-fixed-label">Tab 3</div>
+            <div class="tabs-fixed-underline"></div>
+          </div>
+          <div class="tabs-fixed-panel">
+            In dark mode the nav border switches to
+            <code>--ease-color-neutral-700</code> (#334155) — a dark grey
+            that matches dividers in forms, modals, and other components.
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Live framework tabs using real classes + style.css fix -->
+    <p style="font-size:var(--ease-text-sm,0.875rem);font-weight:700;margin-bottom:0.75rem;">
+      Live demo — using real <code>.ease-tabs</code> classes with the fix applied
+    </p>
+
+    <div class="ease-tabs">
+      <input type="radio" name="demo-tabs" class="ease-tab-input" id="t1" checked />
+      <input type="radio" name="demo-tabs" class="ease-tab-input" id="t2" />
+      <input type="radio" name="demo-tabs" class="ease-tab-input" id="t3" />
+
+      <div class="ease-tabs-nav">
+        <label class="ease-tab-label" for="t1">Overview</label>
+        <label class="ease-tab-label" for="t2">Details</label>
+        <label class="ease-tab-label" for="t3">Settings</label>
+        <div class="ease-tab-underline" style="width:33.333%"></div>
+      </div>
+
+      <div class="ease-tabs-content">
+        <div class="ease-tab-panel" style="padding:1rem 0;font-size:var(--ease-text-sm,0.875rem);">
+          Overview content — the nav border above uses a dark-appropriate color in dark mode.
+        </div>
+        <div class="ease-tab-panel" style="padding:1rem 0;font-size:var(--ease-text-sm,0.875rem);">
+          Details content
+        </div>
+        <div class="ease-tab-panel" style="padding:1rem 0;font-size:var(--ease-text-sm,0.875rem);">
+          Settings content
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/tabs-dark-mode-9136/style.css
+++ b/submissions/examples/tabs-dark-mode-9136/style.css
@@ -1,0 +1,29 @@
+/* ============================================================
+   Fix for issue #9136
+   components/tabs.css has no dark mode support.
+
+   The nav separator uses --ease-color-neutral-200 (#e2e8f0)
+   which has no dark mode override in variables.css. In dark mode
+   it stays a bright light-grey line on a #0b1121 background —
+   the most jarring visual defect in the component.
+
+   Every other component that uses neutral-scale tokens for
+   borders has an explicit dark mode block. This adds the same.
+   ============================================================ */
+
+@media (prefers-color-scheme: dark) {
+  /* Nav separator: was #e2e8f0 light grey — now dark border */
+  .ease-tabs-nav {
+    border-bottom-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  /* Auto-width variant active tab indicator */
+  .ease-tabs-auto .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(2):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(2),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(4),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
+  .ease-tabs-auto .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6) {
+    border-bottom-color: var(--ease-color-primary-light, #a09af8);
+  }
+}


### PR DESCRIPTION
# Add dark mode border override to tabs nav separator (issue #9136)

## Summary
components/tabs.css contains zero @media (prefers-color-scheme: dark) rules. The file ends at line 119 with no dark mode block anywhere. The tab navigation border, inactive tab label text, and the .ease-tabs-auto active indicator all use CSS custom property tokens that are either not overridden in dark mode or resolve to light-grey values that look broken against a dark background.

The result is a visually inconsistent tabs component in dark mode: the navigation separator is a bright #e2e8f0 light-grey line cutting across a dark-themed page, and the inactive tab labels appear in a muted grey that can blend into the dark surface.

Fixes #9136

---
