### PR TITLE
fix: demonstrate modal.js overflow restore bug and fix

### DIFF
--- a/submissions/examples/modal-js-overflow-restore/README.md
+++ b/submissions/examples/modal-js-overflow-restore/README.md
@@ -1,0 +1,82 @@
+# modal.js Overflow Restore Fix
+
+## What does this do?
+
+Demonstrates the bug in `core/modal.js` where closing a modal runs
+`body.style.overflow = ''`, which erases any inline overflow value that was
+already on `<body>` before the modal opened.
+
+## The problem
+
+In `core/modal.js`:
+
+```js
+// Opening a modal — line 17
+body.style.overflow = 'hidden';
+
+// Closing a modal — line 33
+body.style.overflow = '';  // ← always resets to empty string
+```
+
+Setting `overflow` to an empty string removes the inline style entirely,
+regardless of what it was before. If anything else had already set
+`body.style.overflow` (e.g. a sidebar toggle that locks scroll), closing
+the modal silently clears it — breaking the sidebar behaviour with no
+error or warning.
+
+## Scenario that breaks
+
+1. Sidebar opens → sets `body.style.overflow = 'hidden'` (locks page scroll)
+2. User opens a modal → modal.js also sets `body.style.overflow = 'hidden'`
+3. User closes the modal → modal.js runs `body.style.overflow = ''`
+4. The sidebar's scroll lock is gone — page scrolls again even though the
+   sidebar is still open
+
+## The fix
+
+Save the current `body.style.overflow` value before locking it, then restore
+that saved value when closing instead of always resetting to `''`:
+
+```js
+function checkModal() {
+  const hash = window.location.hash;
+  const body = document.body;
+
+  const overlays = document.querySelectorAll('.ease-modal-overlay');
+  overlays.forEach((overlay) => overlay.classList.remove('is-active'));
+
+  if (hash) {
+    try {
+      const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
+      const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
+      if (overlay) {
+        // Save the current value before overwriting it
+        if (typeof checkModal._savedOverflow === 'undefined') {
+          checkModal._savedOverflow = body.style.overflow;
+        }
+        body.style.overflow = 'hidden';
+        overlay.classList.add('is-active');
+        const modal = overlay.querySelector('.ease-modal');
+        if (modal) {
+          modal.setAttribute('tabindex', '-1');
+          modal.focus();
+        }
+        return;
+      }
+    } catch (e) {}
+  }
+
+  // Restore the saved value instead of always resetting to ''
+  body.style.overflow = (typeof checkModal._savedOverflow !== 'undefined')
+    ? checkModal._savedOverflow
+    : '';
+  delete checkModal._savedOverflow;
+}
+```
+
+## Demo
+
+The demo shows the broken and fixed behaviour side by side with step-by-step
+buttons. Click through Steps 1, 2, and 3 in each panel to see what
+`body.style.overflow` holds at each stage and whether it survives the modal
+closing.

--- a/submissions/examples/modal-js-overflow-restore/demo.html
+++ b/submissions/examples/modal-js-overflow-restore/demo.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>modal.js Overflow Restore Fix</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+    }
+
+    .page {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    h1 {
+      font-size: var(--ease-text-2xl, 1.5rem);
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .hint strong { display: block; margin-bottom: 0.3rem; }
+
+    .section {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .section-title {
+      font-size: var(--ease-text-base, 1rem);
+      font-weight: 700;
+      margin-bottom: 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .tag {
+      font-size: 0.68rem;
+      font-weight: 700;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+
+    .demo-btn {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.45rem 0.9rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 600;
+      border: none;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      cursor: pointer;
+      transition: background 150ms ease;
+    }
+
+    .btn-primary {
+      background: var(--ease-color-primary, #6c63ff);
+      color: #fff;
+    }
+    .btn-primary:hover { background: var(--ease-color-primary-dark, #4b44cc); }
+
+    .btn-success {
+      background: var(--ease-color-success, #22c55e);
+      color: #fff;
+    }
+    .btn-success:hover { background: var(--ease-color-success-dark, #15803d); }
+
+    .btn-danger {
+      background: var(--ease-color-danger, #ef4444);
+      color: #fff;
+    }
+    .btn-danger:hover { background: var(--ease-color-danger-dark, #b91c1c); }
+
+    .btn-ghost {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-text, #1e293b);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+    }
+    .btn-ghost:hover { background: var(--ease-color-neutral-200, #e2e8f0); }
+
+    .state-display {
+      font-family: var(--ease-font-mono, monospace);
+      font-size: 0.78rem;
+      padding: 0.75rem 1rem;
+      background: var(--ease-color-neutral-900, #0f172a);
+      color: #e2e8f0;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      margin-top: 0.75rem;
+      line-height: 1.7;
+    }
+
+    .state-display .ok    { color: #86efac; }
+    .state-display .warn  { color: #fca5a5; }
+    .state-display .dim   { color: #64748b; }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .section {
+        background: var(--ease-color-surface, #141e33);
+        border-color: var(--ease-color-neutral-700, #334155);
+      }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+
+    <h1>modal.js Overflow Restore Fix</h1>
+    <p class="sub">
+      <code>body.style.overflow = ''</code> on modal close erases any
+      pre-existing inline overflow value
+    </p>
+
+    <div class="hint">
+      <strong>How to use this demo:</strong>
+      Each section simulates the scenario step by step.
+      Click through the steps in order to see what <code>body.style.overflow</code>
+      holds at each stage — and whether it survives the modal closing.
+    </div>
+
+    <!-- ── BROKEN ─────────────────────────────────────────── -->
+    <div class="section">
+      <div class="section-title">
+        <span class="tag tag-broken">Broken</span>
+        Current behaviour — <code>overflow = ''</code> erases the sidebar value
+      </div>
+
+      <p style="font-size:var(--ease-text-sm,0.875rem);color:var(--ease-color-muted,#64748b);margin-bottom:1rem;line-height:1.6;">
+        Scenario: a sidebar toggle sets <code>body.style.overflow = 'hidden'</code>
+        to lock scroll. Then a modal opens (also sets <code>overflow = 'hidden'</code>).
+        When the modal closes, the current code runs
+        <code>body.style.overflow = ''</code> — clearing the sidebar's lock too.
+      </p>
+
+      <div class="btn-row">
+        <button class="demo-btn btn-success" onclick="brokenStep1()">
+          Step 1 — Open Sidebar
+        </button>
+        <button class="demo-btn btn-primary" onclick="brokenStep2()">
+          Step 2 — Open Modal
+        </button>
+        <button class="demo-btn btn-danger" onclick="brokenStep3()">
+          Step 3 — Close Modal
+        </button>
+        <button class="demo-btn btn-ghost" onclick="brokenReset()">
+          Reset
+        </button>
+      </div>
+
+      <div class="state-display" id="broken-log">
+        <span class="dim">Click Step 1 to begin...</span>
+      </div>
+    </div>
+
+    <!-- ── FIXED ──────────────────────────────────────────── -->
+    <div class="section">
+      <div class="section-title">
+        <span class="tag tag-fixed">Fixed</span>
+        Proposed fix — saves and restores the previous overflow value
+      </div>
+
+      <p style="font-size:var(--ease-text-sm,0.875rem);color:var(--ease-color-muted,#64748b);margin-bottom:1rem;line-height:1.6;">
+        Same scenario. The fix saves <code>body.style.overflow</code> before
+        locking it, and restores that saved value when the modal closes — instead
+        of always resetting to <code>''</code>.
+      </p>
+
+      <div class="btn-row">
+        <button class="demo-btn btn-success" onclick="fixedStep1()">
+          Step 1 — Open Sidebar
+        </button>
+        <button class="demo-btn btn-primary" onclick="fixedStep2()">
+          Step 2 — Open Modal
+        </button>
+        <button class="demo-btn btn-danger" onclick="fixedStep3()">
+          Step 3 — Close Modal
+        </button>
+        <button class="demo-btn btn-ghost" onclick="fixedReset()">
+          Reset
+        </button>
+      </div>
+
+      <div class="state-display" id="fixed-log">
+        <span class="dim">Click Step 1 to begin...</span>
+      </div>
+    </div>
+
+    <!-- ── The fix ────────────────────────────────────────── -->
+    <div class="section">
+      <div class="section-title">The fix for <code>core/modal.js</code></div>
+      <pre style="background:var(--ease-color-neutral-900,#0f172a);color:#e2e8f0;padding:1.1rem 1.25rem;border-radius:var(--ease-radius-md,0.5rem);font-size:0.78rem;line-height:1.75;overflow-x:auto;"><span style="color:#64748b;">// Save the overflow value BEFORE locking — add this near the top of checkModal()</span>
+<span style="color:#fca5a5;">- body.style.overflow = 'hidden';</span>
+<span style="color:#86efac;">+ var previousOverflow = body.style.overflow;
++ body.style.overflow = 'hidden';</span>
+
+<span style="color:#64748b;">// Restore the saved value on close — replace the reset line</span>
+<span style="color:#fca5a5;">- body.style.overflow = '';</span>
+<span style="color:#86efac;">+ body.style.overflow = (typeof previousOverflow !== 'undefined') ? previousOverflow : '';</span></pre>
+    </div>
+
+  </div>
+
+  <script>
+    // ── BROKEN behaviour simulation ───────────────────────────
+    var brokenBodyOverflow = ''; // represents body.style.overflow
+
+    function updateBrokenLog() {
+      var log = document.getElementById('broken-log');
+      var display = brokenBodyOverflow === '' ? '""  (empty string — scroll unlocked)' : '"' + brokenBodyOverflow + '"';
+      var cls = brokenBodyOverflow === 'hidden' ? 'ok' : (brokenBodyOverflow === '' ? 'warn' : 'ok');
+      log.innerHTML =
+        '<span class="dim">body.style.overflow = </span>' +
+        '<span class="' + cls + '">' + display + '</span>';
+    }
+
+    function brokenStep1() {
+      // Sidebar opens — sets overflow: hidden
+      brokenBodyOverflow = 'hidden';
+      var log = document.getElementById('broken-log');
+      log.innerHTML =
+        '<span class="ok">body.style.overflow = "hidden"</span>\n' +
+        '<span class="dim">↑ Sidebar set this to lock scroll</span>';
+    }
+
+    function brokenStep2() {
+      // Modal opens — also sets overflow: hidden (same value, no problem yet)
+      brokenBodyOverflow = 'hidden';
+      var log = document.getElementById('broken-log');
+      log.innerHTML =
+        '<span class="ok">body.style.overflow = "hidden"</span>\n' +
+        '<span class="dim">↑ Modal also set this (sidebar value preserved for now)</span>';
+    }
+
+    function brokenStep3() {
+      // Modal closes — current code runs: body.style.overflow = ''
+      brokenBodyOverflow = '';
+      var log = document.getElementById('broken-log');
+      log.innerHTML =
+        '<span class="warn">body.style.overflow = ""  ← ERASED!</span>\n' +
+        '<span class="warn">↑ Modal close set this to empty string</span>\n' +
+        '<span class="warn">↑ Sidebar\'s "hidden" lock is gone — page scrolls again</span>';
+    }
+
+    function brokenReset() {
+      brokenBodyOverflow = '';
+      document.getElementById('broken-log').innerHTML =
+        '<span class="dim">Reset. Click Step 1 to begin...</span>';
+    }
+
+    // ── FIXED behaviour simulation ────────────────────────────
+    var fixedBodyOverflow = '';
+    var fixedSavedOverflow; // undefined until modal opens
+
+    function fixedStep1() {
+      // Sidebar opens
+      fixedBodyOverflow = 'hidden';
+      fixedSavedOverflow = undefined;
+      document.getElementById('fixed-log').innerHTML =
+        '<span class="ok">body.style.overflow = "hidden"</span>\n' +
+        '<span class="dim">↑ Sidebar set this to lock scroll</span>';
+    }
+
+    function fixedStep2() {
+      // Modal opens — saves the current value before locking
+      fixedSavedOverflow = fixedBodyOverflow; // save "hidden"
+      fixedBodyOverflow = 'hidden';
+      document.getElementById('fixed-log').innerHTML =
+        '<span class="ok">body.style.overflow = "hidden"</span>\n' +
+        '<span class="ok">savedOverflow = "' + fixedSavedOverflow + '"  ← saved before modal locked it</span>';
+    }
+
+    function fixedStep3() {
+      // Modal closes — restores the saved value instead of resetting to ''
+      fixedBodyOverflow = (typeof fixedSavedOverflow !== 'undefined') ? fixedSavedOverflow : '';
+      fixedSavedOverflow = undefined;
+      var display = fixedBodyOverflow === '' ? '""' : '"' + fixedBodyOverflow + '"';
+      document.getElementById('fixed-log').innerHTML =
+        '<span class="ok">body.style.overflow = ' + display + '  ← restored!</span>\n' +
+        '<span class="ok">↑ Sidebar\'s "hidden" lock is preserved</span>\n' +
+        '<span class="ok">↑ Page scroll stays locked as the sidebar intended</span>';
+    }
+
+    function fixedReset() {
+      fixedBodyOverflow = '';
+      fixedSavedOverflow = undefined;
+      document.getElementById('fixed-log').innerHTML =
+        '<span class="dim">Reset. Click Step 1 to begin...</span>';
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/modal-js-overflow-restore/style.css
+++ b/submissions/examples/modal-js-overflow-restore/style.css
@@ -1,0 +1,64 @@
+/* ============================================================
+   Demo styles for the modal.js overflow restore fix.
+   The actual fix is demonstrated in demo.html via JavaScript.
+
+   This file provides layout styles for the side-by-side
+   comparison and the simulated sidebar/modal interaction.
+   ============================================================ */
+
+/* ── Demo page layout ───────────────────────────────────────── */
+.demo-layout {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.demo-col {
+  flex: 1;
+  min-width: 280px;
+}
+
+/* ── Simulated sidebar that sets overflow on body ───────────── */
+.demo-sidebar-trigger {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 50;
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ── Status bar showing current body.style.overflow value ───── */
+.overflow-status {
+  padding: 0.5rem 0.875rem;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-family: var(--ease-font-mono, monospace);
+  font-weight: 600;
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  color: var(--ease-color-text, #1e293b);
+  margin-top: 0.5rem;
+  min-height: 2.25rem;
+  display: flex;
+  align-items: center;
+}
+
+.overflow-status.has-value {
+  background: rgba(34, 197, 94, 0.1);
+  border-color: rgba(34, 197, 94, 0.3);
+  color: var(--ease-color-success, #22c55e);
+}
+
+.overflow-status.erased {
+  background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: var(--ease-color-danger, #ef4444);
+}
+
+@media (prefers-color-scheme: dark) {
+  .overflow-status {
+    background: var(--ease-color-neutral-800, #1e293b);
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+}


### PR DESCRIPTION
# Demonstrate modal.js overflow restore bug and fix
## Summary
core/modal.js always runs body.style.overflow = '' when a modal closes. Setting overflow to an empty string removes the inline style entirely, erasing any value that was already set before the modal opened.

If a sidebar toggle or other component had set body.style.overflow = 'hidden' to lock scroll, closing a modal silently removes that lock. The page becomes scrollable even though the sidebar is still open.

The fix saves body.style.overflow before locking it and restores the saved value on close instead of always resetting to empty string.

The demo shows the broken and fixed behaviour step by step with interactive buttons — no issue number assigned yet, raising PR for maintainer review.


---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- One-sentence description -->

**How does a developer use it?**

```html
<!-- Show the class usage in HTML -->
```

**Why does it fit EaseMotion CSS?**

<!-- Explain how this fits the human-readable, animation-first philosophy -->

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

