### PR TITLE
fix(animated-toast-stack): cleanup toast listeners and timers

### DIFF
--- a/submissions/examples/animated-toast-stack-v1/demo.html
+++ b/submissions/examples/animated-toast-stack-v1/demo.html
@@ -90,7 +90,6 @@
       closeBtn.className = 'toast-close-btn';
       closeBtn.setAttribute('aria-label', 'Close Notification');
       closeBtn.textContent = '✕';
-      closeBtn.addEventListener('click', () => dismissToast(toast));
 
       const progressBar = document.createElement('div');
       progressBar.className = 'toast-progress-bar';
@@ -101,13 +100,20 @@
       toast.appendChild(progressBar);
 
       // Keep track of timeout state for hover pause
-      let duration = 5000; // 5 seconds
+      const duration = 5000; // 5 seconds
       let startTime = Date.now();
       let timeLeft = duration;
       let timeoutId = null;
-      let progressEl = toast.querySelector('.toast-progress-bar');
+
+      function clearTimer() {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+      }
 
       function startTimer() {
+        clearTimer();
         startTime = Date.now();
         timeoutId = setTimeout(() => {
           dismissToast(toast);
@@ -115,37 +121,73 @@
       }
 
       function pauseTimer() {
-        clearTimeout(timeoutId);
+        clearTimer();
         timeLeft -= Date.now() - startTime;
         if (timeLeft < 0) timeLeft = 0;
       }
 
+      function handleCloseClick() {
+        dismissToast(toast);
+      }
+
+      function handleMouseEnter() {
+        if (toast.classList.contains('is-dismissing')) return;
+        pauseTimer();
+        toast.classList.add('is-paused');
+      }
+
+      function handleMouseLeave() {
+        if (toast.classList.contains('is-dismissing')) return;
+        toast.classList.remove('is-paused');
+        startTimer();
+      }
+
+      toast.cleanupToastListeners = () => {
+        clearTimer();
+        closeBtn.removeEventListener('click', handleCloseClick);
+        toast.removeEventListener('mouseenter', handleMouseEnter);
+        toast.removeEventListener('mouseleave', handleMouseLeave);
+      };
+
+      closeBtn.addEventListener('click', handleCloseClick);
+      toast.addEventListener('mouseenter', handleMouseEnter);
+      toast.addEventListener('mouseleave', handleMouseLeave);
+
       // Add to stack
       stack.appendChild(toast);
       startTimer();
-
-      // Hover Pause events
-      toast.addEventListener('mouseenter', () => {
-        pauseTimer();
-        toast.classList.add('is-paused');
-      });
-
-      toast.addEventListener('mouseleave', () => {
-        startTime = Date.now();
-        toast.classList.remove('is-paused');
-        startTimer();
-      });
     }
 
     function dismissToast(toast) {
       if (toast.classList.contains('is-dismissing')) return;
       toast.classList.add('is-dismissing');
+      toast.classList.remove('is-paused');
 
-      toast.addEventListener('animationend', (e) => {
-        if (e.animationName === 'ease-kf-toast-exit') {
-          toast.remove();
+      if (typeof toast.cleanupToastListeners === 'function') {
+        toast.cleanupToastListeners();
+      }
+
+      const fallbackTimer = setTimeout(removeToast, 450);
+
+      function handleAnimationEnd(e) {
+        if (e.target === toast && e.animationName === 'ease-kf-toast-exit') {
+          removeToast();
         }
-      });
+      }
+
+      function removeToast() {
+        clearTimeout(fallbackTimer);
+        toast.removeEventListener('animationend', handleAnimationEnd);
+
+        if (typeof toast.cleanupToastListeners === 'function') {
+          toast.cleanupToastListeners();
+          delete toast.cleanupToastListeners;
+        }
+
+        toast.remove();
+      }
+
+      toast.addEventListener('animationend', handleAnimationEnd);
     }
 
     document.querySelectorAll('.trigger-btn[data-type]').forEach(btn => {


### PR DESCRIPTION
## Pull Request Description

Fixes event listener and timer cleanup in the Animated Toast Stack demo to prevent stale listeners and ensure toast elements are always removed from the DOM.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside submissions/examples/animated-toast-stack-v1/
- [x] Includes demo.html — self-contained, opens in browser with no server
- [x] Includes style.css — raw CSS for the proposed feature
- [x] Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to core/
- [x] No changes to components/
- [x] One feature per PR (no bundled unrelated changes)
- [x ] closes #9224  

---

## Feature Description

What does this add?

Improves cleanup of dynamically created toast notifications by removing event listeners, clearing timers, and ensuring proper DOM removal after dismissal.

How does a developer use it?

No API or usage changes. Existing implementation continues to work as before.

html <button class="trigger-btn btn-success">   Trigger Success Toast </button> 

Why does it fit EaseMotion CSS?

This improves the reliability and maintainability of an existing EaseMotion CSS example while preserving the animation-first experience and keeping the demo lightweight.

---

## Demo

- [x] Demo added (demo.html works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari (optional but appreciated)

---

## Notes for Maintainer

### Changes made
- Replaced removable anonymous handlers with named handlers.
- Added cleanupToastListeners() to centralize listener and timer cleanup.
- Removed click, mouseenter, and mouseleave listeners during dismissal.
- Cleared active auto-dismiss timers before DOM removal.
- Removed the animationend listener after exit animation completion.
- Added a fallback cleanup timer to handle reduced-motion or interrupted-animation scenarios where animationend may not fire.

### Verification
- Verified toast creation and dismissal behavior manually.
- Verified hover pause/resume functionality.
- Verified manual close button dismissal.
- Confirmed fallback cleanup path removes the toast even when animation completion is interrupted.
- JavaScript syntax validation passed.

This PR is scoped only to the Animated Toast Stack example and introduces no changes to core framework files.