### PR TITLE
[FEATURE] Add box-decoration-break: clone utility submission

### DIFF
--- a/submissions/examples/box-decoration-clone-zx/README.md
+++ b/submissions/examples/box-decoration-clone-zx/README.md
@@ -1,0 +1,15 @@
+# Box-Decoration-Break: Clone Utility
+
+**What does this do?**  
+Demonstrates the `box-decoration-break: clone` CSS property, which makes inline elements render their padding, border, and background independently on each line fragment when text wraps.
+
+**How is it used?**
+
+```html
+<span class="box-decoration-clone"
+  >Text that wraps gets full styling on every line</span
+>
+```
+
+**Why is it useful?**  
+By default, inline elements with padding, border, or background use `box-decoration-break: slice`, which clips the styling at line breaks. The `clone` value gives each line its own complete box decoration, which is useful for highlighted inline text, code badges, callouts, and inline tags that span multiple lines.

--- a/submissions/examples/box-decoration-clone-zx/demo.html
+++ b/submissions/examples/box-decoration-clone-zx/demo.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Box-Decoration-Break Clone Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        max-width: 600px;
+        margin: 3rem auto;
+        padding: 0 1rem;
+        color: #1e293b;
+      }
+      h2 {
+        margin-top: 2rem;
+      }
+      .note {
+        background: #f1f5f9;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+        margin: 1rem 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>box-decoration-break: clone</h1>
+    <p class="note">
+      Resize the browser to see how inline elements with
+      padding/border/background behave when text wraps across multiple lines.
+    </p>
+
+    <h2>Without box-decoration-break (default: slice)</h2>
+    <p>
+      <span class="demo-inline-box box-decoration-slice">
+        This is a long inline element with padding, border, and background.
+        Notice how the padding and border get clipped at line breaks.
+      </span>
+    </p>
+
+    <h2>With box-decoration-break: clone</h2>
+    <p>
+      <span class="demo-inline-box box-decoration-clone">
+        This is a long inline element with padding, border, and background. Each
+        line fragment gets its own full padding, border, and background.
+      </span>
+    </p>
+  </body>
+</html>

--- a/submissions/examples/box-decoration-clone-zx/style.css
+++ b/submissions/examples/box-decoration-clone-zx/style.css
@@ -1,0 +1,17 @@
+.box-decoration-clone {
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+.box-decoration-slice {
+  -webkit-box-decoration-break: slice;
+  box-decoration-break: slice;
+}
+
+.demo-inline-box {
+  padding: 0.25em 0.5em;
+  border: 2px solid #6c63ff;
+  background: linear-gradient(135deg, #6c63ff22, #8b5cf622);
+  border-radius: 4px;
+  line-height: 2;
+}


### PR DESCRIPTION
## Description
Add a submission demonstrating the `box-decoration-break: clone` CSS property, which makes inline elements render padding, border, and background on each line fragment independently when text wraps.

### Submission
- `submissions/examples/box-decoration-clone-zx/`
- 3 files: `demo.html`, `style.css`, `README.md`
- Shows inline spans with border/padding/background, with and without box-decoration-break: clone

Closes #9251

Part of GSSOC26