### PR TITLE
Add text-underline-position utility classes [GSSOC26]

### DIFF
--- a/submissions/examples/ease-text-underline-position-zx/README.md
+++ b/submissions/examples/ease-text-underline-position-zx/README.md
@@ -1,0 +1,15 @@
+# Text Underline Position Utilities
+
+**What does this do?**  
+Demonstrates the `text-underline-position` CSS property with three utility classes: `underline-auto`, `underline-under`, and `underline-from-font`.
+
+**How is it used?**
+
+```html
+<p class="underline-auto">Underline on the alphabetic baseline</p>
+<p class="underline-under">Underline below all descenders</p>
+<p class="underline-from-font">Underline at font's preferred position</p>
+```
+
+**Why is it useful?**  
+The `underline-auto` position can cause descenders (g, j, p, q, y) to collide with the underline, harming readability. The `under` value moves the underline below all descenders for cleaner text. The `from-font` value respects the typeface designer's intent. A small but impactful typography utility for EaseMotion.

--- a/submissions/examples/ease-text-underline-position-zx/demo.html
+++ b/submissions/examples/ease-text-underline-position-zx/demo.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text Underline Position Utilities Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        max-width: 700px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1e293b;
+      }
+      .note {
+        background: #f1f5f9;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+        margin: 1rem 0;
+      }
+      .label {
+        font-family: monospace;
+        font-size: 0.85rem;
+        color: #6c63ff;
+        font-weight: 600;
+        margin: 1.5rem 0 0.25rem;
+      }
+      .desc {
+        font-size: 0.85rem;
+        color: #64748b;
+        margin: 0 0 0.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Text Underline Position Utilities</h1>
+    <p class="note">
+      These utilities control where the underline is placed relative to the
+      text. Particularly important for readability with descending characters
+      (g, j, p, q, y).
+    </p>
+
+    <div class="label">underline-auto</div>
+    <div class="desc">
+      Browser chooses position (typically on the alphabetic baseline)
+    </div>
+    <p class="demo-text underline-auto">
+      The quick brown fox jumps over the lazy dog
+    </p>
+
+    <div class="label">underline-under</div>
+    <div class="desc">
+      Underline is drawn below the descenders — more readable
+    </div>
+    <p class="demo-text underline-under">
+      The quick brown fox jumps over the lazy dog
+    </p>
+
+    <div class="label">underline-from-font</div>
+    <div class="desc">
+      Uses the font's preferred underline position if available
+    </div>
+    <p class="demo-text underline-from-font">
+      The quick brown fox jumps over the lazy dog
+    </p>
+
+    <h2>Descender Comparison</h2>
+    <p class="note">
+      Notice how <strong>underline-under</strong> keeps the underline clear of
+      descending letters like <em>g</em>, <em>j</em>, <em>p</em>, <em>q</em>,
+      <em>y</em>.
+    </p>
+
+    <div class="label">auto (descenders may cross the underline)</div>
+    <p class="demo-descender underline-auto">gjpqy gjpqy gjpqy gjpqy</p>
+
+    <div class="label">under (underline stays below descenders)</div>
+    <p class="demo-descender underline-under">gjpqy gjpqy gjpqy gjpqy</p>
+  </body>
+</html>

--- a/submissions/examples/ease-text-underline-position-zx/style.css
+++ b/submissions/examples/ease-text-underline-position-zx/style.css
@@ -1,0 +1,27 @@
+.underline-auto {
+  text-underline-position: auto;
+}
+
+.underline-under {
+  text-underline-position: under;
+}
+
+.underline-from-font {
+  text-underline-position: from-font;
+}
+
+.demo-text {
+  font-size: 1.5rem;
+  text-decoration-line: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-color: #6c63ff;
+  padding: 0.5rem 0;
+}
+
+.demo-descender {
+  font-size: 2rem;
+  text-decoration-line: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-color: #ef4444;
+  padding: 0.5rem 0;
+}


### PR DESCRIPTION
## Summary

Adds utility classes for the `text-underline-position` CSS property:
- `underline-auto` — `text-underline-position: auto`
- `underline-under` — `text-underline-position: under`
- `underline-from-font` — `text-underline-position: from-font`

These classes give developers control over where the underline is placed relative to text. The `under` value is especially useful for preventing descenders (g, j, p, q, y) from crossing the underline.

Part of GSSOC26 contribution.

Closes #9261