### PR TITLE
Add print-color-adjust utility classes [GSSOC26]

### DIFF
--- a/submissions/examples/ease-print-color-adjust-zx/README.md
+++ b/submissions/examples/ease-print-color-adjust-zx/README.md
@@ -1,0 +1,7 @@
+# Print Color Adjust Utilities
+
+**What does this do?**  
+Demonstrates `print-color-adjust` with classes `print-economy` and `print-exact`.
+
+**Why?**  
+Controls whether the browser can adjust colors for printing. Use `print-exact` to preserve dark backgrounds and brand colors in print output.

--- a/submissions/examples/ease-print-color-adjust-zx/demo.html
+++ b/submissions/examples/ease-print-color-adjust-zx/demo.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Print Color Adjust Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 700px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1e293b;
+      }
+      .label {
+        font-family: monospace;
+        font-size: 0.85rem;
+        color: #6c63ff;
+        font-weight: 600;
+        margin: 1.5rem 0 0.25rem;
+      }
+      .note {
+        background: #f1f5f9;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Print Color Adjust</h1>
+    <p class="note">
+      Controls whether the browser can adjust colors for printing or
+      accessibility. Open print preview (Ctrl+P) to see the difference.
+    </p>
+
+    <div class="label">print-economy (default)</div>
+    <div class="demo-card print-economy">
+      Browser <strong>may</strong> adjust colors to save ink — dark backgrounds
+      may be removed in print.
+    </div>
+
+    <div class="label">print-exact</div>
+    <div class="demo-card print-exact">
+      Browser <strong>must not</strong> adjust colors — preserves the original
+      design in print.
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-print-color-adjust-zx/style.css
+++ b/submissions/examples/ease-print-color-adjust-zx/style.css
@@ -1,0 +1,18 @@
+.print-economy {
+  print-color-adjust: economy;
+}
+.print-exact {
+  print-color-adjust: exact;
+}
+
+.demo-card {
+  padding: 1.5rem;
+  margin: 0.5rem 0;
+  border-radius: 8px;
+  color: #fff;
+  background: linear-gradient(135deg, #1e293b, #334155);
+  font-size: 1.1rem;
+}
+.demo-card strong {
+  color: #fbbf24;
+}


### PR DESCRIPTION
## Summary

Adds utility classes for `print-color-adjust`:
- `print-economy` — `print-color-adjust: economy` (browser may adjust)
- `print-exact` — `print-color-adjust: exact` (preserve original colors)

Closes #9273