### PR TITLE
Add text-combine-upright utility classes [GSSOC26]

### DIFF
--- a/submissions/examples/ease-text-combine-upright-zx/README.md
+++ b/submissions/examples/ease-text-combine-upright-zx/README.md
@@ -1,0 +1,7 @@
+# Text Combine Upright Utilities
+
+**What does this do?**  
+Demonstrates `text-combine-upright` with classes `combine-none`, `combine-all`, `combine-digits`.
+
+**Why?**  
+Combines multiple characters into one character space in vertical writing modes. Essential for CJK typography (dates, numbers, abbreviations).

--- a/submissions/examples/ease-text-combine-upright-zx/demo.html
+++ b/submissions/examples/ease-text-combine-upright-zx/demo.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text Combine Upright Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 700px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1e293b;
+      }
+      .label {
+        font-family: monospace;
+        font-size: 0.85rem;
+        color: #6c63ff;
+        font-weight: 600;
+        margin: 1.5rem 0 0.25rem;
+      }
+      .row {
+        display: flex;
+        gap: 2rem;
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Text Combine Upright</h1>
+    <p>
+      Combines multiple characters into one character space in vertical writing
+      — useful for dates, numbers, and abbreviations.
+    </p>
+    <div class="row">
+      <div>
+        <div class="label">combine-none (default)</div>
+        <div class="demo-vert combine-none">令和5年4月1日</div>
+      </div>
+      <div>
+        <div class="label">combine-all</div>
+        <div class="demo-vert combine-all">令和5年4月1日</div>
+      </div>
+      <div>
+        <div class="label">combine-digits (2 digits)</div>
+        <div class="demo-vert combine-digits">令和5年4月1日</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-text-combine-upright-zx/style.css
+++ b/submissions/examples/ease-text-combine-upright-zx/style.css
@@ -1,0 +1,19 @@
+.combine-none {
+  text-combine-upright: none;
+}
+.combine-all {
+  text-combine-upright: all;
+}
+.combine-digits {
+  text-combine-upright: digits;
+}
+
+.demo-vert {
+  writing-mode: vertical-rl;
+  font-size: 1.5rem;
+  line-height: 2;
+  padding: 1rem;
+  margin: 0.5rem 0;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}


### PR DESCRIPTION
## Summary

Adds utility classes for `text-combine-upright`:
- `combine-none` — `text-combine-upright: none`
- `combine-all` — `text-combine-upright: all`
- `combine-digits` — `text-combine-upright: digits`

Combines characters into one space in vertical text.

Closes #9277