### PR TITLE
feat: add notification badge / count bubble example

### DIFF
--- a/submissions/examples/notification-badge-count-bubble/README.md
+++ b/submissions/examples/notification-badge-count-bubble/README.md
@@ -1,0 +1,16 @@
+# Notification Badge / Count Bubble
+
+A circular notification badge with a count number, available in three sizes (small, medium, large) and three color variants (danger red, warning amber, success green). Includes a pulsing dot variant for live notifications.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser to see the badge variants.
+
+## Accessibility notes
+
+Badge text is rendered as visible content for screen reader compatibility. The pulse animation is purely decorative. Reduced motion disables the pulse.

--- a/submissions/examples/notification-badge-count-bubble/demo.html
+++ b/submissions/examples/notification-badge-count-bubble/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Notification Badge / Count Bubble</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #f8fafc; gap: 2.5rem;">
+    <div class="badge-wrapper">
+      <span class="badge badge-sm badge-danger">3</span>
+      <span class="badge-label">Small</span>
+    </div>
+    <div class="badge-wrapper">
+      <span class="badge badge-md badge-warning">12</span>
+      <span class="badge-label">Medium</span>
+    </div>
+    <div class="badge-wrapper">
+      <span class="badge badge-lg badge-success">99+</span>
+      <span class="badge-label">Large</span>
+    </div>
+    <div class="badge-wrapper">
+      <span class="badge badge-md badge-danger badge-pulse">●</span>
+      <span class="badge-label">Pulse</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/notification-badge-count-bubble/style.css
+++ b/submissions/examples/notification-badge-count-bubble/style.css
@@ -1,0 +1,61 @@
+.badge-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-weight: 700;
+  color: #ffffff;
+  line-height: 1;
+}
+
+.badge-sm {
+  min-width: 20px;
+  height: 20px;
+  font-size: 0.65rem;
+  padding: 0 4px;
+}
+
+.badge-md {
+  min-width: 28px;
+  height: 28px;
+  font-size: 0.8rem;
+  padding: 0 6px;
+}
+
+.badge-lg {
+  min-width: 36px;
+  height: 36px;
+  font-size: 0.95rem;
+  padding: 0 8px;
+}
+
+.badge-danger { background: #ef4444; }
+.badge-warning { background: #f59e0b; }
+.badge-success { background: #22c55e; }
+
+.badge-pulse {
+  animation: pulse 1.5s ease infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.5); }
+  50% { box-shadow: 0 0 0 10px rgba(239, 68, 68, 0); }
+}
+
+.badge-label {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .badge-pulse {
+    animation: none;
+  }
+}


### PR DESCRIPTION
A circular notification badge with count number available in three sizes (sm/md/lg) and three color variants (danger, warning, success). Also includes a pulsing dot variant for live notifications.

Closes #9284