### PR TITLE
feat: add image comparison slider example

### DIFF
--- a/submissions/examples/image-comparison-slider/README.md
+++ b/submissions/examples/image-comparison-slider/README.md
@@ -1,0 +1,16 @@
+# Image Comparison Slider
+
+An interactive before/after image comparison slider. A draggable vertical divider with a circular handle lets users reveal the "before" image underneath the "after" overlay. The handle snaps to a 5%–95% range. Uses gradient backgrounds for the demo.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser. Drag the white handle left and right to compare the two images.
+
+## Accessibility notes
+
+The slider is operated via mouse drag. No keyboard fallback is provided in this demo. Reduced motion has no impact as the slider is interaction-driven.

--- a/submissions/examples/image-comparison-slider/demo.html
+++ b/submissions/examples/image-comparison-slider/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Comparison Slider</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #1e293b;">
+    <div class="compare" id="compare">
+      <div class="compare-after" id="compareAfter">
+        <div class="compare-img compare-img-after"></div>
+      </div>
+      <div class="compare-before" id="compareBefore">
+        <div class="compare-img compare-img-before"></div>
+      </div>
+      <div class="compare-handle" id="compareHandle">
+        <span class="compare-arrow compare-arrow-left">◀</span>
+        <span class="compare-arrow compare-arrow-right">▶</span>
+      </div>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/image-comparison-slider/script.js
+++ b/submissions/examples/image-comparison-slider/script.js
@@ -1,0 +1,15 @@
+const compare = document.getElementById("compare");
+const before = document.getElementById("compareBefore");
+const handle = document.getElementById("compareHandle");
+let dragging = false;
+
+handle.addEventListener("mousedown", () => dragging = true);
+document.addEventListener("mouseup", () => dragging = false);
+document.addEventListener("mousemove", (e) => {
+  if (!dragging) return;
+  const rect = compare.getBoundingClientRect();
+  let x = ((e.clientX - rect.left) / rect.width) * 100;
+  x = Math.max(5, Math.min(95, x));
+  before.style.width = x + "%";
+  handle.style.left = x + "%";
+});

--- a/submissions/examples/image-comparison-slider/style.css
+++ b/submissions/examples/image-comparison-slider/style.css
@@ -1,0 +1,89 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.compare {
+  position: relative;
+  width: 500px;
+  max-width: 90vw;
+  height: 350px;
+  max-height: 60vh;
+  border-radius: 12px;
+  overflow: hidden;
+  user-select: none;
+}
+
+.compare-img {
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+}
+
+.compare-img-before {
+  background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
+}
+
+.compare-img-after {
+  background: linear-gradient(135deg, #22c55e, #14b8a6, #06b6d4);
+}
+
+.compare-before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 50%;
+  overflow: hidden;
+  z-index: 1;
+}
+
+.compare-after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.compare-handle {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 4px;
+  height: 100%;
+  background: #ffffff;
+  z-index: 2;
+  cursor: ew-resize;
+  transform: translateX(-50%);
+}
+
+.compare-handle::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  z-index: -1;
+}
+
+.compare-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.7rem;
+  color: #334155;
+  pointer-events: none;
+}
+
+.compare-arrow-left { left: -16px; }
+.compare-arrow-right { right: -16px; }


### PR DESCRIPTION
An interactive before/after image comparison slider with a draggable vertical divider. Users can click and drag to reveal the image underneath. The handle has a circular control knob with arrow indicators.

Closes #9285