### PR TITLE
feat: add progress ring / circle progress example

### DIFF
--- a/submissions/examples/progress-ring/README.md
+++ b/submissions/examples/progress-ring/README.md
@@ -1,0 +1,16 @@
+# Progress Ring / Circle Progress
+
+An SVG-based circular progress indicator with three color variants (indigo, green, amber). The ring animates from empty to the target percentage on load. The circumference-based stroke-dashoffset technique is used for the animation.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser to see the three progress rings animate on load.
+
+## Accessibility notes
+
+The percentage is displayed as text in the center. The SVG circles are purely decorative. Reduced motion disables the stroke animation.

--- a/submissions/examples/progress-ring/demo.html
+++ b/submissions/examples/progress-ring/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Progress Ring / Circle Progress</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #f8fafc; gap: 2.5rem; flex-wrap: wrap;">
+    <div class="ring-wrapper">
+      <svg viewBox="0 0 128 128" width="128" height="128" class="ring-svg">
+        <circle class="ring-track" cx="64" cy="64" r="56" />
+        <circle class="ring-fill" id="ring1" cx="64" cy="64" r="56" stroke-dasharray="351.86" stroke-dashoffset="351.86" />
+      </svg>
+      <span class="ring-label">72%</span>
+    </div>
+    <div class="ring-wrapper">
+      <svg viewBox="0 0 128 128" width="128" height="128" class="ring-svg">
+        <circle class="ring-track" cx="64" cy="64" r="56" />
+        <circle class="ring-fill ring-fill-success" id="ring2" cx="64" cy="64" r="56" stroke-dasharray="351.86" stroke-dashoffset="351.86" />
+      </svg>
+      <span class="ring-label">45%</span>
+    </div>
+    <div class="ring-wrapper">
+      <svg viewBox="0 0 128 128" width="128" height="128" class="ring-svg">
+        <circle class="ring-track" cx="64" cy="64" r="56" />
+        <circle class="ring-fill ring-fill-warning" id="ring3" cx="64" cy="64" r="56" stroke-dasharray="351.86" stroke-dashoffset="351.86" />
+      </svg>
+      <span class="ring-label">90%</span>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/progress-ring/script.js
+++ b/submissions/examples/progress-ring/script.js
@@ -1,0 +1,8 @@
+const vals = { ring1: 72, ring2: 45, ring3: 90 };
+const circ = 2 * Math.PI * 56;
+
+Object.entries(vals).forEach(([id, pct]) => {
+  const el = document.getElementById(id);
+  const offset = circ - (pct / 100) * circ;
+  requestAnimationFrame(() => el.style.strokeDashoffset = offset);
+});

--- a/submissions/examples/progress-ring/style.css
+++ b/submissions/examples/progress-ring/style.css
@@ -1,0 +1,41 @@
+.ring-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ring-svg {
+  display: block;
+  transform: rotate(-90deg);
+}
+
+.ring-track {
+  fill: none;
+  stroke: #e2e8f0;
+  stroke-width: 10;
+}
+
+.ring-fill {
+  fill: none;
+  stroke: #6366f1;
+  stroke-width: 10;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 1s ease;
+}
+
+.ring-fill-success { stroke: #22c55e; }
+.ring-fill-warning { stroke: #f59e0b; }
+
+.ring-label {
+  position: absolute;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ring-fill {
+    transition: none;
+  }
+}


### PR DESCRIPTION
An SVG-based circular progress indicator with three color variants (indigo, green, amber). The ring animates from empty to the target percentage on load using the stroke-dashoffset technique.

Closes #9289