### PR TITLE
feat: add search bar expand on click example

### DIFF
--- a/submissions/examples/search-bar-expand/README.md
+++ b/submissions/examples/search-bar-expand/README.md
@@ -1,0 +1,16 @@
+# Search Bar Expand on Click
+
+A compact search bar that starts as a small circular icon button and expands to a full-width input field on click. The expansion animates smoothly using a width transition. Clicking the input area or icon opens the bar; blurring closes it when empty.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser. Click the search icon to expand the bar. Click outside to collapse.
+
+## Accessibility notes
+
+The search icon is a `<button>` element. The input has no label — add an `aria-label` in production. Reduced motion disables the width transition.

--- a/submissions/examples/search-bar-expand/demo.html
+++ b/submissions/examples/search-bar-expand/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Search Bar Expand on Click</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #f8fafc;">
+    <div class="search-box" id="searchBox">
+      <input type="text" class="search-input" id="searchInput" placeholder="Search..." />
+      <button class="search-btn" id="searchBtn">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" width="18" height="18"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      </button>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/search-bar-expand/script.js
+++ b/submissions/examples/search-bar-expand/script.js
@@ -1,0 +1,11 @@
+const box = document.getElementById("searchBox");
+const input = document.getElementById("searchInput");
+
+box.addEventListener("click", () => {
+  box.classList.add("open");
+  input.focus();
+});
+
+input.addEventListener("blur", () => {
+  if (!input.value) box.classList.remove("open");
+});

--- a/submissions/examples/search-bar-expand/style.css
+++ b/submissions/examples/search-bar-expand/style.css
@@ -1,0 +1,63 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  background: #ffffff;
+  border-radius: 28px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  width: 48px;
+  transition: width 0.35s ease, box-shadow 0.35s ease;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.search-box.open {
+  width: 280px;
+  box-shadow: 0 2px 12px rgba(99, 102, 241, 0.2);
+}
+
+.search-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 0.9rem;
+  padding: 0 0 0 1rem;
+  background: transparent;
+  color: #334155;
+  min-width: 0;
+}
+
+.search-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border: none;
+  background: #6366f1;
+  border-radius: 50%;
+  color: #ffffff;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.2s ease;
+}
+
+.search-btn:hover {
+  background: #4f46e5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-box {
+    transition: none;
+  }
+  .search-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
A compact search bar that starts as a circular icon button and smoothly expands to a full-width input on click. Clicking outside or tabbing away collapses the bar when empty. The indigo accent button stays visible throughout.

Closes #9291