### PR TITLE
feat: add ease-font-synthesis utility classes

### DIFF
--- a/submissions/examples/ease-font-synthesis-zx/README.md
+++ b/submissions/examples/ease-font-synthesis-zx/README.md
@@ -1,0 +1,7 @@
+# Font Synthesis Utilities
+
+**What does this do?**
+Demonstrates `font-synthesis` with classes for weight, style, and small-caps synthesis.
+
+**Why?**
+Controls whether the browser may synthesize missing font faces.

--- a/submissions/examples/ease-font-synthesis-zx/demo.html
+++ b/submissions/examples/ease-font-synthesis-zx/demo.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Font Synthesis Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 700px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1e293b;
+      }
+      .label {
+        font-family: monospace;
+        font-size: 0.85rem;
+        color: #6c63ff;
+        font-weight: 600;
+        margin: 1.5rem 0 0.25rem;
+      }
+      .note {
+        background: #f1f5f9;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Font Synthesis</h1>
+    <p class="note">
+      Controls whether the browser may synthesize bold, italic, or small-caps
+      faces.
+    </p>
+    <div class="label">synth-weight</div>
+    <div class="demo-synth synth-weight" style="font-weight: 700">
+      Bold weight
+    </div>
+    <div class="label">synth-style</div>
+    <div class="demo-synth synth-style" style="font-style: italic">
+      Italic style
+    </div>
+    <div class="label">synth-none</div>
+    <div
+      class="demo-synth synth-none"
+      style="font-weight: 700; font-style: italic"
+    >
+      No synthesis (may not render bold/italic)
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-font-synthesis-zx/style.css
+++ b/submissions/examples/ease-font-synthesis-zx/style.css
@@ -1,0 +1,28 @@
+.synth-weight {
+  font-synthesis: weight;
+}
+.synth-style {
+  font-synthesis: style;
+}
+.synth-small-caps {
+  font-synthesis: small-caps;
+}
+.synth-weight-style {
+  font-synthesis: weight style;
+}
+.synth-weight-small-caps {
+  font-synthesis: weight small-caps;
+}
+.synth-style-small-caps {
+  font-synthesis: style small-caps;
+}
+.synth-all {
+  font-synthesis: weight style small-caps;
+}
+.synth-none {
+  font-synthesis: none;
+}
+.demo-synth {
+  font-size: 1.8rem;
+  margin: 0.25rem 0;
+}


### PR DESCRIPTION
## Summary

Controls whether the browser may synthesize bold, italic, or small-caps faces.

## Classes

- `.synth-weight` — `font-synthesis: weight`
- `.synth-style` — `font-synthesis: style`
- `.synth-none` — `font-synthesis: none`

Closes #9410