### PR TITLE
feat: add ease-column-gap utility classes

### DIFF
--- a/submissions/examples/ease-column-gap-zx/README.md
+++ b/submissions/examples/ease-column-gap-zx/README.md
@@ -1,0 +1,7 @@
+# Column Gap Utilities
+
+**What does this do?**
+Demonstrates `column-gap` with sizing classes from sm to xl.
+
+**Why?**
+Controls the gap between CSS columns for better layout control.

--- a/submissions/examples/ease-column-gap-zx/demo.html
+++ b/submissions/examples/ease-column-gap-zx/demo.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Column Gap Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 700px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1e293b;
+      }
+      .label {
+        font-family: monospace;
+        font-size: 0.85rem;
+        color: #6c63ff;
+        font-weight: 600;
+        margin: 1.5rem 0 0.25rem;
+      }
+      .note {
+        background: #f1f5f9;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Column Gap</h1>
+    <p class="note">Controls the gap between CSS columns.</p>
+    <div class="label">gap-sm (0.5rem)</div>
+    <div class="demo-gap gap-sm">
+      Column 1: Lorem ipsum dolor sit amet. Column 2: Consectetur adipiscing
+      elit. Column 3: Sed do eiusmod tempor incididunt.
+    </div>
+    <div class="label">gap-lg (2rem)</div>
+    <div class="demo-gap gap-lg">
+      Column 1: Lorem ipsum dolor sit amet. Column 2: Consectetur adipiscing
+      elit. Column 3: Sed do eiusmod tempor incididunt.
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-column-gap-zx/style.css
+++ b/submissions/examples/ease-column-gap-zx/style.css
@@ -1,0 +1,18 @@
+.gap-normal {
+  column-gap: normal;
+}
+.gap-sm {
+  column-gap: 0.5rem;
+}
+.gap-md {
+  column-gap: 1rem;
+}
+.gap-lg {
+  column-gap: 2rem;
+}
+.gap-xl {
+  column-gap: 3rem;
+}
+.demo-gap {
+  column-count: 3;
+}


### PR DESCRIPTION
## Summary

Controls the gap between CSS columns.

## Classes

- `.gap-normal` — `column-gap: normal`
- `.gap-sm` — `column-gap: 0.5rem`
- `.gap-md` — `column-gap: 1rem`
- `.gap-lg` — `column-gap: 2rem`

Closes #9417