### PR TITLE
feat: add ease-break-inside utility classes

### DIFF
--- a/submissions/examples/ease-break-inside-zx/README.md
+++ b/submissions/examples/ease-break-inside-zx/README.md
@@ -1,0 +1,7 @@
+# Break Inside Utilities
+
+**What does this do?**
+Demonstrates `break-inside` with classes to control column/page breaking behavior.
+
+**Why?**
+Controls whether elements can break across columns or pages.

--- a/submissions/examples/ease-break-inside-zx/demo.html
+++ b/submissions/examples/ease-break-inside-zx/demo.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Break Inside Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 700px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1e293b;
+      }
+      .label {
+        font-family: monospace;
+        font-size: 0.85rem;
+        color: #6c63ff;
+        font-weight: 600;
+        margin: 1.5rem 0 0.25rem;
+      }
+      .note {
+        background: #f1f5f9;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Break Inside</h1>
+    <p class="note">
+      Controls whether elements can break across columns or pages.
+    </p>
+    <div class="label">break-inside-avoid (elements stay together)</div>
+    <div class="demo-break break-inside-avoid">
+      <p>Paragraph 1 - stays together</p>
+      <p>Paragraph 2 - stays together</p>
+      <p>Paragraph 3 - stays together</p>
+      <p>Paragraph 4 - stays together</p>
+      <p>Paragraph 5 - stays together</p>
+      <p>Paragraph 6 - stays together</p>
+    </div>
+    <div class="label">break-inside-auto (default flow)</div>
+    <div class="demo-break break-inside-auto">
+      <p>Paragraph 1 - may break</p>
+      <p>Paragraph 2 - may break</p>
+      <p>Paragraph 3 - may break</p>
+      <p>Paragraph 4 - may break</p>
+      <p>Paragraph 5 - may break</p>
+      <p>Paragraph 6 - may break</p>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-break-inside-zx/style.css
+++ b/submissions/examples/ease-break-inside-zx/style.css
@@ -1,0 +1,22 @@
+.break-inside-auto {
+  break-inside: auto;
+}
+.break-inside-avoid {
+  break-inside: avoid;
+}
+.break-inside-avoid-page {
+  break-inside: avoid-page;
+}
+.break-inside-avoid-column {
+  break-inside: avoid-column;
+}
+.demo-break {
+  column-count: 3;
+  column-gap: 1.5rem;
+}
+.demo-break p {
+  margin: 0 0 0.5rem;
+  padding: 0.5rem;
+  background: #f1f5f9;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary

Controls whether elements can break across columns or pages.

## Classes

- `.break-inside-auto` — `break-inside: auto`
- `.break-inside-avoid` — `break-inside: avoid`

Closes #9419