### PR TITLE
feat: add ease-text-shadow utility classes

### DIFF
--- a/submissions/examples/ease-text-shadow-zx/README.md
+++ b/submissions/examples/ease-text-shadow-zx/README.md
@@ -1,0 +1,7 @@
+# Text Shadow Utilities
+
+**What does this do?**
+Demonstrates `text-shadow` with sm, md, lg, glow, and neon effects.
+
+**Why?**
+Applies shadow effects to text for visual emphasis.

--- a/submissions/examples/ease-text-shadow-zx/demo.html
+++ b/submissions/examples/ease-text-shadow-zx/demo.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text Shadow Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 700px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1e293b;
+      }
+      .label {
+        font-family: monospace;
+        font-size: 0.85rem;
+        color: #6c63ff;
+        font-weight: 600;
+        margin: 1.5rem 0 0.25rem;
+      }
+      .note {
+        background: #f1f5f9;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Text Shadow</h1>
+    <p class="note">Applies shadow effects to text.</p>
+    <div class="label">shadow-sm</div>
+    <div class="demo-shadow shadow-sm">Small shadow</div>
+    <div class="label">shadow-lg</div>
+    <div class="demo-shadow shadow-lg">Large shadow</div>
+    <div class="label">shadow-glow</div>
+    <div class="demo-shadow shadow-glow" style="color: #6c63ff">
+      Glow effect
+    </div>
+    <div class="label">shadow-neon</div>
+    <div class="demo-shadow shadow-neon" style="color: #ff6b6b">
+      Neon effect
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-text-shadow-zx/style.css
+++ b/submissions/examples/ease-text-shadow-zx/style.css
@@ -1,0 +1,28 @@
+.shadow-sm {
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
+}
+.shadow-md {
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+}
+.shadow-lg {
+  text-shadow: 4px 4px 8px rgba(0, 0, 0, 0.4);
+}
+.shadow-glow {
+  text-shadow:
+    0 0 10px rgba(108, 99, 255, 0.6),
+    0 0 20px rgba(108, 99, 255, 0.3);
+}
+.shadow-neon {
+  text-shadow:
+    0 0 5px #ff6b6b,
+    0 0 10px #ff6b6b,
+    0 0 20px #ff6b6b;
+}
+.shadow-none {
+  text-shadow: none;
+}
+.demo-shadow {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0.75rem 0;
+}


### PR DESCRIPTION
## Summary

Applies shadow effects to text with sm, md, lg, glow, and neon presets.

## Classes

- `.shadow-sm` — `text-shadow: sm preset`
- `.shadow-lg` — `text-shadow: lg preset`
- `.shadow-glow` — `text-shadow: glow preset`
- `.shadow-neon` — `text-shadow: neon preset`

Closes #9425