### PR TITLE
feat: add ease-overflow-wrap utility classes

### DIFF
--- a/submissions/examples/ease-overflow-wrap-zx/README.md
+++ b/submissions/examples/ease-overflow-wrap-zx/README.md
@@ -1,0 +1,7 @@
+# Overflow Wrap Utilities
+
+**What does this do?**
+Demonstrates `overflow-wrap` with normal, break-word, and anywhere classes.
+
+**Why?**
+Controls whether long words can break onto the next line to prevent overflow.

--- a/submissions/examples/ease-overflow-wrap-zx/demo.html
+++ b/submissions/examples/ease-overflow-wrap-zx/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Overflow Wrap Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 700px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1e293b;
+      }
+      .label {
+        font-family: monospace;
+        font-size: 0.85rem;
+        color: #6c63ff;
+        font-weight: 600;
+        margin: 1.5rem 0 0.25rem;
+      }
+      .note {
+        background: #f1f5f9;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Overflow Wrap</h1>
+    <p class="note">
+      Controls whether long words can break onto the next line.
+    </p>
+    <div class="label">ow-normal (no breaking)</div>
+    <div class="demo-ow ow-normal">Supercalifragilisticexpialidocious</div>
+    <div class="label">ow-break (break long words)</div>
+    <div class="demo-ow ow-break">Supercalifragilisticexpialidocious</div>
+  </body>
+</html>

--- a/submissions/examples/ease-overflow-wrap-zx/style.css
+++ b/submissions/examples/ease-overflow-wrap-zx/style.css
@@ -1,0 +1,16 @@
+.ow-normal {
+  overflow-wrap: normal;
+}
+.ow-break {
+  overflow-wrap: break-word;
+}
+.ow-anywhere {
+  overflow-wrap: anywhere;
+}
+.demo-ow {
+  width: 200px;
+  border: 1px solid #cbd5e1;
+  padding: 0.5rem;
+  border-radius: 4px;
+  margin: 0.25rem 0;
+}


### PR DESCRIPTION
## Summary

Controls whether long words can break onto the next line to prevent overflow.

## Classes

- `.ow-normal` — `overflow-wrap: normal`
- `.ow-break` — `overflow-wrap: break-word`
- `.ow-anywhere` — `overflow-wrap: anywhere`

Closes #9431