### PR TITLE
fix: add aria-label, role, aria-live guidance for .ease-marquee (issue #9470)

### DIFF
--- a/submissions/examples/marquee-aria-guidance-9470/README.md
+++ b/submissions/examples/marquee-aria-guidance-9470/README.md
@@ -1,0 +1,89 @@
+# Marquee Accessibility Guidance — Issue #9470
+
+**Fixes:** #9470
+
+## What does this do?
+
+Provides three working accessible marquee patterns covering every common
+use case, with the correct ARIA attributes for each.
+
+`ease-marquee.css` has an Accessibility section but it only addresses
+focus styling. There is no guidance on the HTML attributes that screen
+reader users require. This submission demonstrates the correct patterns
+so the maintainer can integrate the guidance into the component docs and
+CSS comments.
+
+## The three patterns
+
+### Pattern A — Decorative (logos, brand strips)
+
+Use when the scrolling content is purely decorative or duplicated elsewhere:
+
+```html
+<div class="ease-marquee" aria-hidden="true">
+  <div class="ease-marquee-track">
+    <img src="react.svg" alt="" />
+  </div>
+</div>
+```
+
+`aria-hidden="true"` removes the element from the accessibility tree.
+Screen readers skip it entirely.
+
+### Pattern B — Informational (partner logos, feature highlights)
+
+Use when the content is informational but not a live feed:
+
+```html
+<section
+  class="ease-marquee"
+  aria-label="Our technology partners"
+  aria-roledescription="scrolling banner"
+>
+  <div class="ease-marquee-track" aria-live="off">
+    <img src="react.svg" alt="React" />
+  </div>
+</section>
+```
+
+Screen readers announce the content once on page load and ignore
+scroll updates.
+
+### Pattern C — Live ticker (news, announcements)
+
+Use when content is a live feed that must be communicated to all users:
+
+```html
+<section
+  class="ease-marquee"
+  aria-label="Live announcements"
+  aria-roledescription="scrolling ticker"
+>
+  <div
+    class="ease-marquee-track"
+    role="log"
+    aria-live="polite"
+    aria-atomic="false"
+  >
+    <span>Breaking news item</span>
+  </div>
+</section>
+```
+
+Screen readers announce each new item politely when the user is idle.
+
+## Why this matters
+
+Without these attributes:
+- Screen readers announce the marquee as a generic unlabelled `div`
+- Live tickers may read every item on every scroll cycle (noise) or
+  nothing at all (silent failure)
+- The content is indistinguishable from any other `div` in the page
+  accessibility tree
+
+## Demo
+
+The demo shows all three patterns working with real `.ease-marquee`
+markup. Verify with a screen reader (NVDA, VoiceOver, JAWS) or the
+browser Accessibility Tree in DevTools to confirm how each pattern
+is announced.

--- a/submissions/examples/marquee-aria-guidance-9470/demo.html
+++ b/submissions/examples/marquee-aria-guidance-9470/demo.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Marquee Accessibility Guidance — Issue #9470</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+    }
+
+    .page {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    h1 {
+      font-size: var(--ease-text-2xl, 1.5rem);
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .section {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .section-title {
+      font-size: var(--ease-text-base, 1rem);
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+
+    .section-desc {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      line-height: 1.6;
+      margin-bottom: 1.25rem;
+    }
+
+    .code-block {
+      background: var(--ease-color-neutral-900, #0f172a);
+      color: #e2e8f0;
+      padding: 1rem 1.25rem;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      font-size: 0.78rem;
+      font-family: var(--ease-font-mono, monospace);
+      line-height: 1.7;
+      overflow-x: auto;
+      margin-top: 1rem;
+    }
+
+    .code-block .attr  { color: #93c5fd; }
+    .code-block .val   { color: #86efac; }
+    .code-block .tag   { color: #fca5a5; }
+    .code-block .cmt   { color: #64748b; }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .section {
+        background: var(--ease-color-surface, #141e33);
+        border-color: var(--ease-color-neutral-700, #334155);
+      }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+
+    <h1>Marquee Accessibility Guidance</h1>
+    <p class="sub">Issue #9470 — three accessible patterns for <code>.ease-marquee</code></p>
+
+    <div class="hint">
+      Each pattern below shows a working marquee with the correct ARIA attributes
+      for its use case, plus the HTML markup to copy. Use a screen reader
+      (NVDA, JAWS, VoiceOver) or the browser's Accessibility Tree in DevTools
+      to verify how each pattern is announced.
+    </div>
+
+    <!-- ── Pattern A: Decorative ──────────────────────────────── -->
+    <div class="section">
+      <div class="pattern-label pattern-a">Pattern A — Decorative</div>
+      <div class="section-title">Logo strip / brand strip (content repeated elsewhere)</div>
+      <div class="section-desc">
+        Use <code>aria-hidden="true"</code> when the logos are purely decorative
+        or the same information appears in a visible list elsewhere on the page.
+        The marquee is removed from the accessibility tree entirely — screen
+        readers skip it and there is no duplicate announcement.
+      </div>
+
+      <!-- CORRECT: aria-hidden removes it from AT entirely -->
+      <div
+        class="ease-marquee"
+        aria-hidden="true"
+      >
+        <div class="ease-marquee-track">
+          <span class="marquee-logo">React</span>
+          <span class="marquee-logo">TypeScript</span>
+          <span class="marquee-logo">Node.js</span>
+          <span class="marquee-logo">Vite</span>
+          <span class="marquee-logo">Tailwind</span>
+          <span class="marquee-logo">Vitest</span>
+          <span class="marquee-logo">React</span>
+          <span class="marquee-logo">TypeScript</span>
+          <span class="marquee-logo">Node.js</span>
+          <span class="marquee-logo">Vite</span>
+          <span class="marquee-logo">Tailwind</span>
+          <span class="marquee-logo">Vitest</span>
+        </div>
+      </div>
+
+      <div class="code-block">
+<span class="cmt">&lt;!-- Pattern A: decorative — hidden from screen readers --&gt;</span>
+<span class="tag">&lt;div</span> <span class="attr">class</span>=<span class="val">"ease-marquee"</span>
+     <span class="attr">aria-hidden</span>=<span class="val">"true"</span><span class="tag">&gt;</span>
+  <span class="tag">&lt;div</span> <span class="attr">class</span>=<span class="val">"ease-marquee-track"</span><span class="tag">&gt;</span>
+    <span class="tag">&lt;img</span> <span class="attr">src</span>=<span class="val">"react.svg"</span> <span class="attr">alt</span>=<span class="val">""</span> <span class="tag">/&gt;</span>
+    <span class="tag">&lt;img</span> <span class="attr">src</span>=<span class="val">"node.svg"</span>  <span class="attr">alt</span>=<span class="val">""</span> <span class="tag">/&gt;</span>
+  <span class="tag">&lt;/div&gt;</span>
+<span class="tag">&lt;/div&gt;</span></div>
+    </div>
+
+    <!-- ── Pattern B: Informational ───────────────────────────── -->
+    <div class="section">
+      <div class="pattern-label pattern-b">Pattern B — Informational</div>
+      <div class="section-title">Partner logos / feature highlights (content not elsewhere)</div>
+      <div class="section-desc">
+        Use <code>aria-label</code> and <code>aria-roledescription</code> when the
+        content is informational but not live or urgent.
+        <code>aria-live="off"</code> on the track means the screen reader reads
+        it once on page load and ignores scroll updates — no repeated
+        announcements.
+      </div>
+
+      <section
+        class="ease-marquee"
+        aria-label="Our technology partners"
+        aria-roledescription="scrolling banner"
+      >
+        <div class="ease-marquee-track" aria-live="off">
+          <span class="marquee-logo">EaseMotion CSS</span>
+          <span class="marquee-logo">Zero dependencies</span>
+          <span class="marquee-logo">Animation first</span>
+          <span class="marquee-logo">No build step</span>
+          <span class="marquee-logo">MIT license</span>
+          <span class="marquee-logo">Open source</span>
+          <span class="marquee-logo">EaseMotion CSS</span>
+          <span class="marquee-logo">Zero dependencies</span>
+          <span class="marquee-logo">Animation first</span>
+          <span class="marquee-logo">No build step</span>
+          <span class="marquee-logo">MIT license</span>
+          <span class="marquee-logo">Open source</span>
+        </div>
+      </section>
+
+      <div class="code-block">
+<span class="cmt">&lt;!-- Pattern B: informational — labelled, no live updates --&gt;</span>
+<span class="tag">&lt;section</span>
+  <span class="attr">class</span>=<span class="val">"ease-marquee"</span>
+  <span class="attr">aria-label</span>=<span class="val">"Our technology partners"</span>
+  <span class="attr">aria-roledescription</span>=<span class="val">"scrolling banner"</span>
+<span class="tag">&gt;</span>
+  <span class="tag">&lt;div</span> <span class="attr">class</span>=<span class="val">"ease-marquee-track"</span> <span class="attr">aria-live</span>=<span class="val">"off"</span><span class="tag">&gt;</span>
+    <span class="tag">&lt;img</span> <span class="attr">src</span>=<span class="val">"react.svg"</span> <span class="attr">alt</span>=<span class="val">"React"</span> <span class="tag">/&gt;</span>
+    <span class="tag">&lt;img</span> <span class="attr">src</span>=<span class="val">"node.svg"</span>  <span class="attr">alt</span>=<span class="val">"Node.js"</span> <span class="tag">/&gt;</span>
+  <span class="tag">&lt;/div&gt;</span>
+<span class="tag">&lt;/section&gt;</span></div>
+    </div>
+
+    <!-- ── Pattern C: Live ticker ─────────────────────────────── -->
+    <div class="section">
+      <div class="pattern-label pattern-c">Pattern C — Live ticker</div>
+      <div class="section-title">News ticker / live announcements / real-time updates</div>
+      <div class="section-desc">
+        Use <code>role="log"</code> and <code>aria-live="polite"</code> when
+        the content is a live feed that must be communicated to all users.
+        <code>aria-atomic="false"</code> announces only each new item as it
+        appears — not the entire region. The screen reader waits for idle
+        time before announcing, so it does not interrupt the user.
+      </div>
+
+      <section
+        class="ease-marquee ease-marquee-slow"
+        aria-label="Live announcements"
+        aria-roledescription="scrolling ticker"
+      >
+        <div
+          class="ease-marquee-track"
+          role="log"
+          aria-live="polite"
+          aria-atomic="false"
+        >
+          <span class="marquee-ticker-item"><span class="dot-live"></span>GSSoC 2026 is open for contributions</span>
+          <span class="marquee-ticker-item"><span class="dot-live"></span>New: ease-marquee component added</span>
+          <span class="marquee-ticker-item"><span class="dot-live"></span>300+ contributors and growing</span>
+          <span class="marquee-ticker-item"><span class="dot-live"></span>v1.0.0 stable release</span>
+          <span class="marquee-ticker-item"><span class="dot-live"></span>GSSoC 2026 is open for contributions</span>
+          <span class="marquee-ticker-item"><span class="dot-live"></span>New: ease-marquee component added</span>
+          <span class="marquee-ticker-item"><span class="dot-live"></span>300+ contributors and growing</span>
+          <span class="marquee-ticker-item"><span class="dot-live"></span>v1.0.0 stable release</span>
+        </div>
+      </section>
+
+      <div class="code-block">
+<span class="cmt">&lt;!-- Pattern C: live ticker — announced politely as items scroll --&gt;</span>
+<span class="tag">&lt;section</span>
+  <span class="attr">class</span>=<span class="val">"ease-marquee"</span>
+  <span class="attr">aria-label</span>=<span class="val">"Live announcements"</span>
+  <span class="attr">aria-roledescription</span>=<span class="val">"scrolling ticker"</span>
+<span class="tag">&gt;</span>
+  <span class="tag">&lt;div</span>
+    <span class="attr">class</span>=<span class="val">"ease-marquee-track"</span>
+    <span class="attr">role</span>=<span class="val">"log"</span>
+    <span class="attr">aria-live</span>=<span class="val">"polite"</span>
+    <span class="attr">aria-atomic</span>=<span class="val">"false"</span>
+  <span class="tag">&gt;</span>
+    <span class="tag">&lt;span&gt;</span>Breaking news item one<span class="tag">&lt;/span&gt;</span>
+    <span class="tag">&lt;span&gt;</span>Breaking news item two<span class="tag">&lt;/span&gt;</span>
+  <span class="tag">&lt;/div&gt;</span>
+<span class="tag">&lt;/section&gt;</span></div>
+    </div>
+
+    <!-- ── Quick reference ────────────────────────────────────── -->
+    <div class="section">
+      <div class="section-title">Quick reference</div>
+      <table style="width:100%;font-size:var(--ease-text-sm,0.875rem);border-collapse:collapse;">
+        <thead>
+          <tr style="border-bottom:2px solid var(--ease-color-neutral-200,#e2e8f0);">
+            <th style="text-align:left;padding:0.5rem 0.75rem;font-weight:700;">Use case</th>
+            <th style="text-align:left;padding:0.5rem 0.75rem;font-weight:700;">Pattern</th>
+            <th style="text-align:left;padding:0.5rem 0.75rem;font-weight:700;">Key attribute</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr style="border-bottom:1px solid var(--ease-color-neutral-100,#f1f5f9);">
+            <td style="padding:0.5rem 0.75rem;">Logo strip (decorative)</td>
+            <td style="padding:0.5rem 0.75rem;"><code>A</code></td>
+            <td style="padding:0.5rem 0.75rem;"><code>aria-hidden="true"</code></td>
+          </tr>
+          <tr style="border-bottom:1px solid var(--ease-color-neutral-100,#f1f5f9);">
+            <td style="padding:0.5rem 0.75rem;">Partner logos / features</td>
+            <td style="padding:0.5rem 0.75rem;"><code>B</code></td>
+            <td style="padding:0.5rem 0.75rem;"><code>aria-label</code> + <code>aria-live="off"</code></td>
+          </tr>
+          <tr>
+            <td style="padding:0.5rem 0.75rem;">News ticker / live feed</td>
+            <td style="padding:0.5rem 0.75rem;"><code>C</code></td>
+            <td style="padding:0.5rem 0.75rem;"><code>role="log"</code> + <code>aria-live="polite"</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/marquee-aria-guidance-9470/style.css
+++ b/submissions/examples/marquee-aria-guidance-9470/style.css
@@ -1,0 +1,75 @@
+/* ============================================================
+   Demo styles for issue #9470
+   .ease-marquee accessibility guidance — aria-label, role,
+   aria-live patterns for screen reader users.
+
+   This file provides layout and visual styles for the demo
+   showing all three accessible marquee patterns.
+   ============================================================ */
+
+/* ── Marquee item styles ────────────────────────────────────── */
+.marquee-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1.25rem;
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--ease-color-text, #1e293b);
+  white-space: nowrap;
+}
+
+.marquee-ticker-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 1rem;
+  background: var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.1));
+  border-radius: var(--ease-radius-full, 9999px);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.dot-live {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ease-color-danger, #ef4444);
+  animation: ease-kf-pulse 1.5s ease-in-out infinite;
+}
+
+/* ── Pattern label badges ───────────────────────────────────── */
+.pattern-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.5rem;
+}
+
+.pattern-a { background: var(--ease-color-neutral-200, #e2e8f0); color: var(--ease-color-neutral-700, #334155); }
+.pattern-b { background: rgba(34, 197, 94, 0.15); color: var(--ease-color-success, #22c55e); }
+.pattern-c { background: rgba(239, 68, 68, 0.12); color: var(--ease-color-danger, #ef4444); }
+
+@media (prefers-color-scheme: dark) {
+  .marquee-logo {
+    background: var(--ease-color-surface, #141e33);
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  .pattern-a {
+    background: var(--ease-color-neutral-700, #334155);
+    color: var(--ease-color-neutral-200, #e2e8f0);
+  }
+}


### PR DESCRIPTION
Fixes #9470

## What

`ease-marquee.css` has no guidance on the HTML attributes required for
screen reader accessibility. The Accessibility section only covers
`focus-visible` styling. Without `aria-label`, `role`, and `aria-live`,
screen readers announce the marquee as an unlabelled `div`, live tickers
may read every scroll cycle or nothing at all, and the content cannot be
navigated by landmark.

## Submission

`submissions/examples/marquee-aria-guidance-9470/`

The demo shows three working patterns with correct ARIA markup for every
common marquee use case:

- **Pattern A** — `aria-hidden="true"` for decorative logo strips
- **Pattern B** — `aria-label` + `aria-live="off"` for informational banners  
- **Pattern C** — `role="log"` + `aria-live="polite"` for live tickers

Verify with a screen reader (NVDA, VoiceOver, JAWS) or the browser
Accessibility Tree in DevTools to confirm each pattern behaves correctly.

## Checklist

- [x] Files added only inside `submissions/examples/marquee-aria-guidance-9470/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/`, `components/`, or any other framework file
- [x] Single focused fix, one commit
