### PR TITLE
feat: add CSS-only ticket stub component

### DIFF
--- a/submissions/examples/ease-ticket-stub-mk/README.md
+++ b/submissions/examples/ease-ticket-stub-mk/README.md
@@ -1,0 +1,20 @@
+# CSS-Only Ticket Stub Component
+
+### What does this do?
+This adds a stylized event/movie ticket component with perforated cutout edges created entirely using CSS `mask-image`, along with a subtle tactile hover animation.
+
+### How is it used?
+```html
+<div class="ticket-stub">
+  <div class="ticket-content">
+    <h3>Event Name</h3>
+    <p>Details</p>
+  </div>
+  <div class="ticket-tear-section">
+    <span>#123</span>
+  </div>
+</div>
+```
+
+### Why is it useful?
+It provides a physical-world, skeuomorphic UI component to the framework without needing inline SVGs, pseudo-element masking hacks, or extra HTML nodes. By leveraging advanced CSS masking, it remains lightweight, composable, and fits the animation-first philosophy with its playful hover state.

--- a/submissions/examples/ease-ticket-stub-mk/demo.html
+++ b/submissions/examples/ease-ticket-stub-mk/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Ticket Stub Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ticket-wrapper">
+    <div class="ticket-stub">
+      <div class="ticket-content">
+        <h3 class="ticket-title">EaseMotion Conf</h3>
+        <p class="ticket-subtitle">General Admission</p>
+        <div class="ticket-details">
+          <span>Date: Oct 24</span>
+          <span>Time: 10:00 AM</span>
+        </div>
+      </div>
+      <div class="ticket-tear-section">
+        <span class="ticket-number">#001</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-ticket-stub-mk/style.css
+++ b/submissions/examples/ease-ticket-stub-mk/style.css
@@ -1,0 +1,107 @@
+/* Container for centering the demo */
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f3f4f6;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ticket-wrapper {
+  padding: 2rem;
+}
+
+/* Core Ticket Stub Styles */
+.ticket-stub {
+  position: relative;
+  display: flex;
+  width: 350px;
+  height: 150px;
+  background: linear-gradient(135deg, #6c63ff 0%, #8b5cf6 100%);
+  color: #ffffff;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 10px 25px -5px rgba(108, 99, 255, 0.4);
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.4s ease;
+  
+  /* Creates the semi-circle cutouts on the top and bottom at 75% width */
+  mask-image: 
+    radial-gradient(circle at 75% 0, transparent 15px, black 16px),
+    radial-gradient(circle at 75% 100%, transparent 15px, black 16px);
+  mask-size: 100% 51%;
+  mask-repeat: no-repeat;
+  mask-position: top, bottom;
+  
+  /* Webkit support for masks */
+  -webkit-mask-image: 
+    radial-gradient(circle at 75% 0, transparent 15px, black 16px),
+    radial-gradient(circle at 75% 100%, transparent 15px, black 16px);
+  -webkit-mask-size: 100% 51%;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: top, bottom;
+}
+
+/* The perforated line */
+.ticket-stub::after {
+  content: '';
+  position: absolute;
+  top: 15px;
+  bottom: 15px;
+  left: 75%;
+  border-left: 2px dashed rgba(255, 255, 255, 0.5);
+}
+
+.ticket-content {
+  flex: 1;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.ticket-title {
+  margin: 0 0 4px 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.ticket-subtitle {
+  margin: 0 0 16px 0;
+  font-size: 0.875rem;
+  opacity: 0.9;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.ticket-details {
+  display: flex;
+  gap: 16px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  opacity: 0.8;
+}
+
+.ticket-tear-section {
+  width: 25%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.ticket-number {
+  font-weight: 700;
+  font-size: 1.125rem;
+  transform: rotate(90deg);
+  letter-spacing: 2px;
+}
+
+/* Tactile interaction on hover */
+.ticket-stub:hover {
+  transform: translateY(-8px) rotate(2deg);
+  box-shadow: 0 20px 30px -10px rgba(108, 99, 255, 0.5);
+  cursor: pointer;
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces a CSS-only ticket stub component featuring perforated cutout edges and a playful tilt/lift animation on hover. It uses advanced CSS masking techniques (`mask-image: radial-gradient`) to achieve the cutouts without relying on pseudo-element color hacks, ensuring it works seamlessly over any background.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A stylized event/movie ticket component built entirely with CSS `mask-image` and linear gradients, complete with a tactile hover interaction.

**How does a developer use it?**

```html
<div class="ticket-stub">
  <div class="ticket-content">
    <h3>EaseMotion Conf</h3>
    <p>General Admission</p>
    <div class="ticket-details">
      <span>Date: Oct 24</span>
      <span>Time: 10:00 AM</span>
    </div>
  </div>
  <div class="ticket-tear-section">
    <span class="ticket-number">#001</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

It adds a highly sought-after, physical-world UI component (skeuomorphic) to the framework. By leveraging advanced CSS masking, it remains lightweight and composable. It fits the animation-first philosophy perfectly by integrating a playful, physical hover state (`translateY` and `rotate`).

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

I used `mask-image` with intersecting radial gradients to achieve the cutouts cleanly, along with the `-webkit-mask-image` prefixes for broader support. The hover animation currently lifts by 8px and rotates 2 degrees. Feel free to adjust the `transition` timings or `cubic-bezier` values during your standardization process!

---

