### PR TITLE
feat: Add CSS-only Glitch Text Effect Component

### DIFF
--- a/submissions/examples/css-only-glitch-text-effect/README.md
+++ b/submissions/examples/css-only-glitch-text-effect/README.md
@@ -1,0 +1,13 @@
+# CSS-only Glitch Text Effect
+
+### 1. What does this do?
+A futuristic CSS-only text glitch effect utilizing `clip-path` and keyframe animations to create a cyberpunk digital distortion.
+
+### 2. How is it used?
+```html
+<h1 class="glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
+```
+Note: The `data-text` attribute must precisely match the inner text of the element.
+
+### 3. Why is it useful?
+It provides a high-end typography animation without JavaScript, directly aligning with EaseMotion CSS's vision. It offers excellent visual flair for hero sections or loading sequences.

--- a/submissions/examples/css-only-glitch-text-effect/demo.html
+++ b/submissions/examples/css-only-glitch-text-effect/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Glitch Text Effect</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="glitch-container">
+    <h1 class="glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
+    <p class="subtitle">HOVER FOR MORE CHAOS</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-only-glitch-text-effect/style.css
+++ b/submissions/examples/css-only-glitch-text-effect/style.css
@@ -1,0 +1,90 @@
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  background-color: #000;
+  font-family: 'Inter', -apple-system, sans-serif;
+  overflow: hidden;
+}
+
+.glitch-container {
+  text-align: center;
+}
+
+.glitch-text {
+  position: relative;
+  font-size: 6rem;
+  font-weight: 900;
+  color: #fff;
+  letter-spacing: 5px;
+  margin: 0;
+  text-transform: uppercase;
+  z-index: 1;
+}
+
+.glitch-text::before,
+.glitch-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #000;
+}
+
+.glitch-text::before {
+  left: 3px;
+  text-shadow: -2px 0 #ff00c1;
+  clip-path: polygon(0 0, 100% 0, 100% 45%, 0 45%);
+  animation: glitch-anim-1 2.5s infinite linear alternate-reverse;
+}
+
+.glitch-text::after {
+  left: -3px;
+  text-shadow: -2px 0 #00fff9, 2px 2px #ff00c1;
+  clip-path: polygon(0 55%, 100% 55%, 100% 100%, 0 100%);
+  animation: glitch-anim-2 3s infinite linear alternate-reverse;
+}
+
+.glitch-text:hover::before {
+  animation: glitch-anim-1 0.5s infinite linear alternate-reverse;
+}
+
+.glitch-text:hover::after {
+  animation: glitch-anim-2 0.5s infinite linear alternate-reverse;
+}
+
+.subtitle {
+  color: #666;
+  font-size: 1rem;
+  letter-spacing: 8px;
+  margin-top: 10px;
+  text-transform: uppercase;
+  animation: pulse 4s infinite;
+}
+
+@keyframes glitch-anim-1 {
+  0% { clip-path: polygon(0 2%, 100% 2%, 100% 5%, 0 5%); }
+  20% { clip-path: polygon(0 15%, 100% 15%, 100% 15%, 0 15%); }
+  40% { clip-path: polygon(0 10%, 100% 10%, 100% 20%, 0 20%); }
+  60% { clip-path: polygon(0 1%, 100% 1%, 100% 2%, 0 2%); }
+  80% { clip-path: polygon(0 33%, 100% 33%, 100% 33%, 0 33%); }
+  100% { clip-path: polygon(0 44%, 100% 44%, 100% 44%, 0 44%); }
+}
+
+@keyframes glitch-anim-2 {
+  0% { clip-path: polygon(0 65%, 100% 65%, 100% 70%, 0 70%); }
+  20% { clip-path: polygon(0 75%, 100% 75%, 100% 75%, 0 75%); }
+  40% { clip-path: polygon(0 80%, 100% 80%, 100% 90%, 0 90%); }
+  60% { clip-path: polygon(0 60%, 100% 60%, 100% 60%, 0 60%); }
+  80% { clip-path: polygon(0 85%, 100% 85%, 100% 85%, 0 85%); }
+  100% { clip-path: polygon(0 95%, 100% 95%, 100% 95%, 0 95%); }
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a CSS-only glitch effect for text that mimics a distorted, cyberpunk-style digital glitch using keyframe animations and pseudo-elements. This resolves issue #9568.

Resolves #9568

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-only-glitch-text-effect/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only glitch effect for text that mimics a distorted, cyberpunk-style digital glitch using keyframe animations and pseudo-elements.

**How does a developer use it?**

```html
<h1 class="glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
```

**Why does it fit EaseMotion CSS?**

It provides an advanced typography animation without requiring any JavaScript. This aligns perfectly with the framework's animation-first philosophy and adds a highly sought-after cyberpunk aesthetic to the utility class collection.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*
