### PR TITLE
feat(submission): add linear() spring easing presets

### DIFF
--- a/submissions/examples/linear-spring-easing-sk/README.md
+++ b/submissions/examples/linear-spring-easing-sk/README.md
@@ -1,0 +1,27 @@
+# linear() Spring Easing
+
+Three spring easing presets using CSS `linear()` timing function with N-stop value encoding.
+
+## Classes / Custom Properties
+
+| Property | Description |
+|---|---|
+| `--spring-snappy` | Quick overshoot, fast settle |
+| `--spring-wobbly` | More oscillation, bouncy feel |
+| `--spring-stiff` | Minimal overshoot, controlled |
+
+## Usage
+
+```css
+.my-element {
+  animation: pop-in 0.6s var(--spring-snappy) both;
+}
+```
+
+## How it works
+
+`linear()` accepts N value stops that encode any arbitrary easing curve. Unlike `cubic-bezier()` (4 control points max), a spring curve with overshoot can be encoded precisely. Each stop is a progress value at an optional percentage of the animation timeline.
+
+`@supports not (animation-timing-function: linear(0, 1))` provides a `cubic-bezier` fallback for older browsers.
+
+Closes #9586

--- a/submissions/examples/linear-spring-easing-sk/demo.html
+++ b/submissions/examples/linear-spring-easing-sk/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>linear() Spring Easing</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>linear() Spring Easing Presets</h1>
+
+    <div class="demo-grid">
+
+        <div class="spring-card ease-spring-snappy" id="c1">
+            Snappy
+            <span>ease-spring-snappy</span>
+        </div>
+
+        <div class="spring-card ease-spring-wobbly" id="c2">
+            Wobbly
+            <span>ease-spring-wobbly</span>
+        </div>
+
+        <div class="spring-card ease-spring-stiff" id="c3">
+            Stiff
+            <span>ease-spring-stiff</span>
+        </div>
+
+        <div class="spring-card ease-spring-baseline" id="c4">
+            ease-out
+            <span>baseline comparison</span>
+        </div>
+
+    </div>
+
+    <p style="color:#666;font-size:0.8rem">Click any card to replay</p>
+
+    <script>
+        document.querySelectorAll('.spring-card').forEach(card => {
+            card.addEventListener('click', () => {
+                card.classList.add('replaying');
+                void card.offsetWidth;
+                card.classList.remove('replaying');
+            });
+        });
+    </script>
+
+</body>
+</html>

--- a/submissions/examples/linear-spring-easing-sk/style.css
+++ b/submissions/examples/linear-spring-easing-sk/style.css
@@ -1,0 +1,122 @@
+:root {
+    --spring-snappy: linear(
+        0, 0.009, 0.035 6.1%, 0.141, 0.281 18.4%,
+        0.723 30.7%, 0.875, 0.969, 1.02, 1.048 44.1%,
+        1.062, 1.063, 1.047, 1.018 59.6%,
+        0.999, 0.996, 0.998 72.5%, 1
+    );
+    --spring-wobbly: linear(
+        0, 0.007, 0.029 4.7%, 0.118, 0.245 16%,
+        0.692 28.8%, 0.882, 1.01, 1.075, 1.107 44.5%,
+        1.115, 1.105, 1.078 53.7%, 1.014, 0.966 60.7%,
+        0.937, 0.929 68.3%, 0.935, 0.955 77.3%,
+        0.983, 1.001 89.1%, 1.007, 1
+    );
+    --spring-stiff: linear(
+        0, 0.014, 0.057 5.5%, 0.214, 0.401 18.2%,
+        0.788 29.3%, 0.934, 0.997, 1.024 42.7%,
+        1.031, 1.024, 1.007 56.2%, 0.998, 0.997 68.3%, 1
+    );
+    --ease-out: cubic-bezier(0, 0, 0.2, 1);
+}
+
+@supports not (animation-timing-function: linear(0, 1)) {
+    :root {
+        --spring-snappy: cubic-bezier(0.34, 1.56, 0.64, 1);
+        --spring-wobbly: cubic-bezier(0.34, 1.9, 0.64, 1);
+        --spring-stiff:  cubic-bezier(0.34, 1.2, 0.64, 1);
+    }
+}
+
+@keyframes pop-in {
+    from {
+        transform: scale(0.75);
+        opacity: 0;
+    }
+    to {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+@keyframes slide-up {
+    from { transform: translateY(40px); opacity: 0; }
+    to   { transform: translateY(0);    opacity: 1; }
+}
+
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2.5rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 3rem 1.5rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.3rem;
+    margin: 0;
+    text-align: center;
+}
+
+.demo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1.5rem;
+    width: 100%;
+    max-width: 800px;
+}
+
+.spring-card {
+    background: #1e1e1e;
+    border: 1px solid #333;
+    border-radius: 12px;
+    padding: 2rem 1.25rem;
+    text-align: center;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+}
+
+.spring-card span {
+    display: block;
+    margin-top: 0.4rem;
+    font-weight: 400;
+    font-size: 0.75rem;
+    color: #888;
+}
+
+.ease-spring-snappy {
+    animation: pop-in 0.6s var(--spring-snappy) both;
+}
+
+.ease-spring-wobbly {
+    animation: pop-in 0.8s var(--spring-wobbly) both;
+}
+
+.ease-spring-stiff {
+    animation: pop-in 0.5s var(--spring-stiff) both;
+}
+
+.ease-spring-baseline {
+    animation: pop-in 0.6s var(--ease-out) both;
+}
+
+.replaying {
+    animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-spring-snappy,
+    .ease-spring-wobbly,
+    .ease-spring-stiff,
+    .ease-spring-baseline {
+        animation: none;
+    }
+}


### PR DESCRIPTION
Closes #9586

Adds `submissions/examples/linear-spring-easing-sk/` with three spring easing presets encoded using `linear()` timing function.

## What

- `--spring-snappy`, `--spring-wobbly`, `--spring-stiff` custom properties storing `linear()` curves
- Each preset is a multi-stop encoding of the spring response including overshoot
- Click-to-replay interaction in the demo
- `@supports not (animation-timing-function: linear(0, 1))` fallback to `cubic-bezier`
- `prefers-reduced-motion` guard

`linear()` is the correct solution for spring easing — it encodes the actual curve rather than approximating it with 4 cubic-bezier control points.