### PR TITLE
feat: Add CSS-only Typing Text Effect Component

### DIFF
--- a/submissions/examples/css-only-typing-effect/README.md
+++ b/submissions/examples/css-only-typing-effect/README.md
@@ -1,0 +1,14 @@
+# CSS-only Typing Text Effect
+
+### 1. What does this do?
+A smooth typewriter animation created entirely with CSS keyframes and `steps()`. It mimics the look of someone typing out a string of text character by character, complete with a blinking cursor at the end.
+
+### 2. How is it used?
+```html
+<div class="typing-container">
+  <h1 class="typing-text">Welcome to the Matrix...</h1>
+</div>
+```
+
+### 3. Why is this useful?
+Typing effects are incredibly popular for hero sections and terminal-themed UI, but they are almost always done using JavaScript. Providing a strictly CSS-only version using the `steps()` function delivers a high-impact, lightweight utility that fits EaseMotion CSS's vision.

--- a/submissions/examples/css-only-typing-effect/demo.html
+++ b/submissions/examples/css-only-typing-effect/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Typing Effect</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="typing-container">
+    <h1 class="typing-text">Welcome to the Matrix...</h1>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-only-typing-effect/style.css
+++ b/submissions/examples/css-only-typing-effect/style.css
@@ -1,0 +1,40 @@
+body {
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: #0d0d0d;
+  font-family: 'Courier New', Courier, monospace;
+}
+
+.typing-container {
+  display: inline-block;
+}
+
+.typing-text {
+  color: #0f0;
+  font-size: 2.5rem;
+  font-weight: normal;
+  border-right: 2px solid #0f0;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0;
+  /* 
+   * The number of steps (25) should equal the number of characters in the string:
+   * "Welcome to the Matrix..." has exactly 25 characters.
+   */
+  animation: typing 3.5s steps(25, end), blink-caret 0.75s step-end infinite;
+}
+
+/* Typing effect */
+@keyframes typing {
+  from { width: 0; }
+  to { width: 100%; }
+}
+
+/* Blinking cursor effect */
+@keyframes blink-caret {
+  from, to { border-color: transparent; }
+  50% { border-color: #0f0; }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a smooth typewriter animation created entirely with CSS keyframes and `steps()`. It mimics the look of someone typing out a string of text character by character, complete with a blinking cursor at the end. This resolves issue #9620.

Resolves #9620

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-only-typing-effect/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A smooth typewriter animation created entirely with CSS keyframes and `steps()`. It mimics the look of someone typing out a string of text character by character, complete with a blinking cursor at the end.

**How does a developer use it?**

```html
<div class="typing-container">
  <h1 class="typing-text">Welcome to the Matrix...</h1>
</div>
```

**Why does it fit EaseMotion CSS?**

Typing effects are incredibly popular for hero sections and terminal-themed UI, but they are almost always done using JavaScript. Providing a strictly CSS-only version using the `steps()` function delivers a high-impact, lightweight utility that fits EaseMotion CSS's vision.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*
