### PR TITLE
feat(submission): add CSS trig Lissajous loader

### DIFF
--- a/submissions/examples/trig-lissajous-loader-sk/README.md
+++ b/submissions/examples/trig-lissajous-loader-sk/README.md
@@ -1,0 +1,36 @@
+# CSS Trigonometric Lissajous Loader
+
+Loader dots positioned using CSS `sin()` and `cos()` trig functions with varying frequency ratios.
+
+## Classes
+
+| Class | Ratio | Shape |
+|---|---|---|
+| `lissajous-2-1` | 2:1 | Figure-8 |
+| `lissajous-3-2` | 3:2 | Pretzel |
+| `lissajous-1-1` | 1:1 | Circle |
+
+## Usage
+
+```html
+<div class="lissajous-loader lissajous-2-1">
+  <div class="dot" style="--i:0"></div>
+  <div class="dot" style="--i:1"></div>
+  <div class="dot" style="--i:2"></div>
+</div>
+```
+
+## How it works
+
+A `@property --t` typed as `<angle>` animates from `0turn` to `1turn`. Each dot's position is:
+
+```css
+transform: translate(
+  calc(sin(var(--t)) * 55px),
+  calc(cos(calc(var(--t) * 2)) * 35px)
+);
+```
+
+The frequency ratio between X and Y axes determines the Lissajous figure shape.
+
+Closes #9594

--- a/submissions/examples/trig-lissajous-loader-sk/demo.html
+++ b/submissions/examples/trig-lissajous-loader-sk/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Trig Lissajous Loader</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>CSS Trigonometric Lissajous Loaders</h1>
+
+    <div class="loaders">
+
+        <div class="loader-wrap">
+            <div class="lissajous-loader lissajous-2-1">
+                <div class="dot" style="--i:0"></div>
+                <div class="dot" style="--i:1"></div>
+                <div class="dot" style="--i:2"></div>
+            </div>
+            <span>2:1 ratio (figure-8)</span>
+        </div>
+
+        <div class="loader-wrap">
+            <div class="lissajous-loader lissajous-3-2">
+                <div class="dot" style="--i:0"></div>
+                <div class="dot" style="--i:1"></div>
+                <div class="dot" style="--i:2"></div>
+            </div>
+            <span>3:2 ratio (pretzel)</span>
+        </div>
+
+        <div class="loader-wrap">
+            <div class="lissajous-loader lissajous-1-1">
+                <div class="dot" style="--i:0"></div>
+                <div class="dot" style="--i:1"></div>
+                <div class="dot" style="--i:2"></div>
+            </div>
+            <span>1:1 ratio (circle)</span>
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/trig-lissajous-loader-sk/style.css
+++ b/submissions/examples/trig-lissajous-loader-sk/style.css
@@ -1,0 +1,113 @@
+@property --t {
+    syntax: '<angle>';
+    initial-value: 0turn;
+    inherits: false;
+}
+
+@keyframes lissajous {
+    to { --t: 1turn; }
+}
+
+@keyframes fallback-orbit {
+    to { transform: rotate(1turn) translateX(50px) rotate(-1turn); }
+}
+
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 2rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.3rem;
+    margin: 0;
+}
+
+.loaders {
+    display: flex;
+    gap: 4rem;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.loader-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+.loader-wrap span {
+    font-size: 0.75rem;
+    color: #888;
+}
+
+.lissajous-loader {
+    position: relative;
+    width: 140px;
+    height: 100px;
+}
+
+.lissajous-loader .dot {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    margin: -7px 0 0 -7px;
+    animation: lissajous 2s linear infinite;
+    animation-delay: calc(var(--i) * -0.18s);
+}
+
+/* 2:1 ratio — figure-8 */
+.lissajous-2-1 .dot {
+    transform: translate(
+        calc(sin(var(--t)) * 55px),
+        calc(cos(calc(var(--t) * 2)) * 35px)
+    );
+    background: oklch(70% 0.22 calc(var(--i) * 120deg));
+}
+
+/* 3:2 ratio — pretzel */
+.lissajous-3-2 .dot {
+    transform: translate(
+        calc(sin(calc(var(--t) * 2)) * 50px),
+        calc(cos(calc(var(--t) * 3)) * 35px)
+    );
+    background: oklch(70% 0.22 calc(var(--i) * 120deg + 40deg));
+    animation-duration: 3s;
+}
+
+/* 1:1 ratio — circle */
+.lissajous-1-1 .dot {
+    transform: translate(
+        calc(sin(var(--t)) * 45px),
+        calc(cos(var(--t)) * 45px)
+    );
+    background: oklch(70% 0.22 calc(var(--i) * 120deg + 80deg));
+}
+
+@supports not (transform: translateX(calc(sin(1deg) * 1px))) {
+    .lissajous-loader .dot {
+        animation-name: fallback-orbit;
+        transform: none;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .lissajous-loader .dot {
+        animation: none;
+        transform: translate(0, 0);
+    }
+}


### PR DESCRIPTION
Closes #9594

Adds `submissions/examples/trig-lissajous-loader-sk/` with three loader variants using CSS `sin()` / `cos()` trig functions for dot path computation — no JS, no SVG.

A `@property --t` (`<angle>`) animates 0→1turn. Each dot transforms via `translate(calc(sin(--t) * r), calc(cos(--t * freq) * r))`. Changing the frequency ratio between X and Y produces different Lissajous figures (2:1 figure-8, 3:2 pretzel, 1:1 circle).

Includes `@supports not (transform: translateX(calc(sin(1deg) * 1px)))` fallback and `prefers-reduced-motion` guard.