### PR TITLE
feat(submission): add animated ::selection styling patterns

### DIFF
--- a/submissions/examples/selection-animation-sk/README.md
+++ b/submissions/examples/selection-animation-sk/README.md
@@ -1,0 +1,23 @@
+# Animated ::selection Styles
+
+Three `::selection` pseudo-element styling patterns using CSS custom properties and focus-state transitions.
+
+## Classes
+
+| Class | Effect |
+|---|---|
+| `ease-selection-ink` | Ink-spread `text-shadow` on `::selection`, activated by `:focus` |
+| `ease-selection-themed` | Selection color driven by `data-theme` attribute on any ancestor |
+| `ease-selection-redact` | High-contrast inverted "redacted document" look |
+
+## Usage
+
+```html
+<p class="ease-selection-ink" tabindex="0">Select this text.</p>
+
+<div data-theme="ocean">
+  <p class="ease-selection-themed">Theme-aware selection.</p>
+</div>
+```
+
+Closes #9596

--- a/submissions/examples/selection-animation-sk/demo.html
+++ b/submissions/examples/selection-animation-sk/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated ::selection Styles</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>Animated ::selection Styles</h1>
+
+    <div class="demo-block">
+        <h3>ease-selection-ink — ink-spread text-shadow</h3>
+        <p class="ease-selection-ink" tabindex="0">
+            Select this text to see the ink-spread shadow effect on the selection highlight.
+            The text-shadow on <code>::selection</code> transitions when the element has focus.
+        </p>
+    </div>
+
+    <div class="demo-block" id="themed-block">
+        <h3>ease-selection-themed — theme-aware selection color</h3>
+        <p class="ease-selection-themed">
+            Select this text. Use the buttons below to switch the selection color theme.
+            The color is driven by the <code>data-theme</code> attribute on the container.
+        </p>
+        <div class="theme-btns">
+            <button class="theme-btn" onclick="setTheme('default')">Default</button>
+            <button class="theme-btn" onclick="setTheme('ocean')">Ocean</button>
+            <button class="theme-btn" onclick="setTheme('forest')">Forest</button>
+            <button class="theme-btn" onclick="setTheme('sunset')">Sunset</button>
+        </div>
+    </div>
+
+    <div class="demo-block">
+        <h3>ease-selection-redact — inverted redact style</h3>
+        <p class="ease-selection-redact">
+            Select this text to see the high-contrast inverted "redacted document" selection style.
+        </p>
+    </div>
+
+    <script>
+        function setTheme(name) {
+            const block = document.getElementById('themed-block');
+            if (name === 'default') {
+                block.removeAttribute('data-theme');
+            } else {
+                block.dataset.theme = name;
+            }
+        }
+    </script>
+
+</body>
+</html>

--- a/submissions/examples/selection-animation-sk/style.css
+++ b/submissions/examples/selection-animation-sk/style.css
@@ -1,0 +1,109 @@
+:root {
+    --selection-default: oklch(70% 0.25 300);
+    --selection-ocean:   oklch(65% 0.2 220);
+    --selection-forest:  oklch(60% 0.2 145);
+    --selection-sunset:  oklch(68% 0.22 40);
+}
+
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #e8e8e8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2.5rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 3rem 1.5rem;
+    box-sizing: border-box;
+    line-height: 1.7;
+}
+
+h1 {
+    font-size: 1.3rem;
+    margin: 0;
+}
+
+.demo-block {
+    background: #1a1a1a;
+    border: 1px solid #2e2e2e;
+    border-radius: 12px;
+    padding: 1.5rem 2rem;
+    max-width: 560px;
+    width: 100%;
+}
+
+.demo-block h3 {
+    margin: 0 0 0.6rem;
+    font-size: 0.85rem;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+/* --- ink spread via text-shadow on ::selection --- */
+.ease-selection-ink::selection {
+    background: var(--selection-default);
+    color: #fff;
+    text-shadow: 0 0 0px oklch(40% 0.3 300);
+}
+
+.ease-selection-ink:focus-within::selection,
+.ease-selection-ink:focus::selection {
+    background: var(--selection-default);
+    text-shadow: 0 0 14px oklch(40% 0.3 300);
+}
+
+/* --- themed selection via data-theme attribute --- */
+[data-theme="ocean"] .ease-selection-themed::selection,
+[data-theme="ocean"].ease-selection-themed::selection {
+    background: var(--selection-ocean);
+    color: #fff;
+}
+
+[data-theme="forest"] .ease-selection-themed::selection,
+[data-theme="forest"].ease-selection-themed::selection {
+    background: var(--selection-forest);
+    color: #fff;
+}
+
+[data-theme="sunset"] .ease-selection-themed::selection,
+[data-theme="sunset"].ease-selection-themed::selection {
+    background: var(--selection-sunset);
+    color: #fff;
+}
+
+.ease-selection-themed::selection {
+    background: var(--selection-default);
+    color: #fff;
+}
+
+/* --- redact / reveal highlight style --- */
+.ease-selection-redact::selection {
+    background: #e8e8e8;
+    color: #0f0f0f;
+    text-shadow: none;
+}
+
+/* theme switcher UI */
+.theme-btns {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.75rem;
+}
+
+.theme-btn {
+    padding: 0.3rem 0.75rem;
+    border-radius: 6px;
+    border: 1px solid #444;
+    background: #222;
+    color: #ccc;
+    font-size: 0.78rem;
+    cursor: pointer;
+}
+
+.theme-btn:hover {
+    background: #333;
+}


### PR DESCRIPTION
Closes #9596

Adds `submissions/examples/selection-animation-sk/` with three `::selection` patterns.

- `ease-selection-ink` — `text-shadow` on `::selection` shifts when the element gains `:focus`, simulating an ink-spread effect
- `ease-selection-themed` — selection color is derived from a `--selection-*` custom property resolved by `data-theme` on any ancestor (ocean, forest, sunset)
- `ease-selection-redact` — high-contrast inverted selection for a "classified document" look

All colors use `oklch` for perceptual uniformity. No JS required for the CSS effects; the theme demo uses a tiny `dataset.theme` setter for the switcher buttons.