### PR TITLE
feat(submission): add offset-path card entrance animation

### DIFF
--- a/submissions/examples/offset-path-card-entrance-sk/README.md
+++ b/submissions/examples/offset-path-card-entrance-sk/README.md
@@ -1,0 +1,24 @@
+# offset-path Card Entrance
+
+Cards enter along a custom cubic bezier SVG path using `offset-path` and `offset-distance`, with `nth-child` stagger delays.
+
+## Class
+
+`ease-path-card` — animates `offset-distance` 0%→100% along `path('M -220 0 C -80 -150 80 150 220 0')` with `offset-rotate: auto`.
+
+## Usage
+
+```html
+<div class="card-stage">
+  <div class="ease-path-card">Card 1</div>
+  <div class="ease-path-card">Card 2</div>
+  <div class="ease-path-card">Card 3</div>
+</div>
+```
+
+## Notes
+
+- `offset-rotate: auto 0deg` keeps cards upright while following the path tangent direction
+- `prefers-reduced-motion` falls back to a simple fade-up with `offset-path: none`
+
+Closes #9597

--- a/submissions/examples/offset-path-card-entrance-sk/demo.html
+++ b/submissions/examples/offset-path-card-entrance-sk/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>offset-path Card Entrance</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>offset-path Card Entrance</h1>
+
+    <div class="card-stage" id="stage">
+        <div class="ease-path-card">Card 1</div>
+        <div class="ease-path-card">Card 2</div>
+        <div class="ease-path-card">Card 3</div>
+        <div class="ease-path-card">Card 4</div>
+    </div>
+
+    <button class="replay-btn" onclick="replay()">Replay</button>
+
+    <script>
+        function replay() {
+            const stage = document.getElementById('stage');
+            const cards = stage.querySelectorAll('.ease-path-card');
+            cards.forEach(c => {
+                c.style.animation = 'none';
+                void c.offsetWidth;
+                c.style.animation = '';
+            });
+        }
+    </script>
+
+</body>
+</html>

--- a/submissions/examples/offset-path-card-entrance-sk/style.css
+++ b/submissions/examples/offset-path-card-entrance-sk/style.css
@@ -1,0 +1,100 @@
+@keyframes deal-card {
+    from {
+        offset-distance: 0%;
+        opacity: 0;
+    }
+    to {
+        offset-distance: 100%;
+        opacity: 1;
+    }
+}
+
+@keyframes fade-in-simple {
+    from { opacity: 0; transform: translateY(20px); }
+    to   { opacity: 1; transform: none; }
+}
+
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 2rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.3rem;
+    margin: 0;
+}
+
+.card-stage {
+    position: relative;
+    width: 500px;
+    height: 220px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ease-path-card {
+    position: absolute;
+    width: 140px;
+    height: 90px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 1rem;
+    offset-path: path('M -220 0 C -80 -150 80 150 220 0');
+    offset-rotate: auto 0deg;
+    animation: deal-card 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.ease-path-card:nth-child(1) {
+    background: oklch(55% 0.22 260);
+    animation-delay: 0s;
+}
+
+.ease-path-card:nth-child(2) {
+    background: oklch(55% 0.22 160);
+    animation-delay: 0.12s;
+}
+
+.ease-path-card:nth-child(3) {
+    background: oklch(55% 0.22 30);
+    animation-delay: 0.24s;
+}
+
+.ease-path-card:nth-child(4) {
+    background: oklch(55% 0.22 310);
+    animation-delay: 0.36s;
+}
+
+.replay-btn {
+    padding: 0.5rem 1.25rem;
+    border-radius: 8px;
+    border: 1px solid #444;
+    background: #1e1e1e;
+    color: #ccc;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.replay-btn:hover {
+    background: #2a2a2a;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-path-card {
+        offset-path: none;
+        animation-name: fade-in-simple;
+    }
+}


### PR DESCRIPTION
Closes #9597

Adds `submissions/examples/offset-path-card-entrance-sk/` — cards entering by traveling along a custom cubic bezier path via `offset-path` + `offset-distance`.

The path `M -220 0 C -80 -150 80 150 220 0` creates an S-curve "deal from deck" entrance. `offset-rotate: auto 0deg` keeps cards visually upright while following the path tangent. nth-child stagger delays give 120ms between each card. `prefers-reduced-motion` sets `offset-path: none` and falls back to a plain fade-up.