### PR TITLE
feat(submission): add ink-spread radial reveal with blob variant

### DIFF
--- a/submissions/examples/ink-spread-radial-reveal-sk/README.md
+++ b/submissions/examples/ink-spread-radial-reveal-sk/README.md
@@ -1,0 +1,30 @@
+# Ink Spread Radial Reveal
+
+CSS-only radial reveal using `clip-path: circle()` transition, triggered by a hidden checkbox and `:has()`.
+
+## Classes
+
+| Class | Effect |
+|---|---|
+| `ease-ink-trigger` | Wrapper label; toggling the checkbox inside drives the reveal |
+| `ease-ink-overlay` | The dark overlay that sweeps in/out via `clip-path: circle()` |
+| `ease-ink-content` | Content fades in after the overlay spreads |
+| `ease-ink-blob` | Modifier on `.ease-ink-card` — adds `filter: blur+contrast` for organic blob edges |
+
+## Usage
+
+```html
+<label class="ease-ink-trigger">
+  <input type="checkbox" hidden />
+  <div class="ease-ink-card">
+    <div class="ease-ink-overlay"></div>
+    <div class="ease-ink-content">Revealed</div>
+  </div>
+</label>
+```
+
+## How it works
+
+`clip-path: circle(0%)` → `circle(150%)` is a radial wipe. On `.ease-ink-blob`, applying `filter: blur(8px)` to the overlay inside a `filter: contrast(20)` parent creates organic blob-edge morphology — the classic CSS goo trick applied to clip-path reveals.
+
+Closes #9598

--- a/submissions/examples/ink-spread-radial-reveal-sk/demo.html
+++ b/submissions/examples/ink-spread-radial-reveal-sk/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ink Spread Radial Reveal</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>Ink Spread Radial Reveal</h1>
+    <p class="hint">Click a card to reveal / hide</p>
+
+    <!-- Clean geometric clip-path wipe -->
+    <label class="ease-ink-trigger">
+        <input type="checkbox" hidden />
+        <div class="ease-ink-card">
+            <span class="ease-ink-label">Click to reveal</span>
+            <div class="ease-ink-overlay"></div>
+            <div class="ease-ink-content">
+                Revealed Content
+                <p>clip-path: circle() radial wipe</p>
+            </div>
+        </div>
+    </label>
+
+    <!-- Blob-edge organic spread -->
+    <label class="ease-ink-trigger">
+        <input type="checkbox" hidden />
+        <div class="ease-ink-card ease-ink-blob">
+            <span class="ease-ink-label">Click for blob variant</span>
+            <div class="ease-ink-overlay"></div>
+            <div class="ease-ink-content">
+                Ink Blob Spread
+                <p>blur + contrast creates organic edges</p>
+            </div>
+        </div>
+    </label>
+
+</body>
+</html>

--- a/submissions/examples/ink-spread-radial-reveal-sk/style.css
+++ b/submissions/examples/ink-spread-radial-reveal-sk/style.css
@@ -1,0 +1,131 @@
+body {
+    font-family: sans-serif;
+    background: #f5f0eb;
+    color: #1a1a1a;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2.5rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 2rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.3rem;
+    margin: 0;
+    color: #333;
+}
+
+p.hint {
+    font-size: 0.85rem;
+    color: #888;
+    margin: 0;
+}
+
+.ease-ink-trigger {
+    position: relative;
+    display: block;
+    cursor: pointer;
+}
+
+.ease-ink-trigger input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.ease-ink-card {
+    position: relative;
+    width: 320px;
+    height: 200px;
+    border-radius: 16px;
+    overflow: hidden;
+    background: #e8e0d5;
+}
+
+.ease-ink-overlay {
+    position: absolute;
+    inset: 0;
+    background: #0d0d0d;
+    clip-path: circle(0% at 50% 50%);
+    transition: clip-path 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-ink-trigger:has(input:checked) .ease-ink-overlay {
+    clip-path: circle(150% at 50% 50%);
+}
+
+.ease-ink-content {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.5rem;
+    color: #f0f0f0;
+    font-weight: 700;
+    font-size: 1.2rem;
+    opacity: 0;
+    transition: opacity 0.4s 0.5s;
+    text-align: center;
+    padding: 1rem;
+}
+
+.ease-ink-trigger:has(input:checked) .ease-ink-content {
+    opacity: 1;
+}
+
+.ease-ink-content p {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 400;
+    color: #aaa;
+}
+
+.ease-ink-label {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    color: #888;
+    pointer-events: none;
+    transition: opacity 0.2s;
+}
+
+.ease-ink-trigger:has(input:checked) .ease-ink-label {
+    opacity: 0;
+}
+
+/* blob edge variant — blur+contrast on parent */
+.ease-ink-blob .ease-ink-overlay {
+    filter: blur(8px);
+}
+
+.ease-ink-blob {
+    filter: contrast(20) blur(0px);
+}
+
+.ease-ink-blob .ease-ink-content,
+.ease-ink-blob .ease-ink-label {
+    filter: contrast(0.05) blur(0);
+}
+
+.ease-ink-trigger:has(input:checked) .ease-ink-blob .ease-ink-content {
+    filter: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-ink-overlay {
+        transition: none;
+    }
+
+    .ease-ink-content {
+        transition: none;
+    }
+}


### PR DESCRIPTION
Closes #9598

Adds `submissions/examples/ink-spread-radial-reveal-sk/` — two reveal patterns, both CSS-only via `:has(input:checked)`.

1. **Clean geometric** — `clip-path: circle(0%)` transitions to `circle(150%)` for a radial wipe
2. **Blob variant** — same clip-path animation but `filter: blur(8px)` on the overlay inside a `filter: contrast(20)` parent creates organic blob edges (the CSS goo trick applied to reveals)

Content fades in 500ms after the overlay spreads. `prefers-reduced-motion` disables transitions.