### PR TITLE
feat(submission): add :has() selector-driven sibling motion

### DIFF
--- a/submissions/examples/has-sibling-motion-sk/README.md
+++ b/submissions/examples/has-sibling-motion-sk/README.md
@@ -1,0 +1,22 @@
+# :has() Sibling Motion
+
+Three patterns demonstrating CSS `:has()` driving animation on ancestor and sibling elements.
+
+## Demos
+
+| Class | Selector used | Effect |
+|---|---|---|
+| `ease-has-spotlight` | `:has(.card:hover) .card:not(:hover)` | Dims non-hovered cards |
+| `ease-has-form` | `:has(input:not(:placeholder-shown):invalid)` | Shakes submit button when any input is invalid |
+| `ease-has-layout` | `:has(input:checked)` | Pushes sidebar and main content via checkbox toggle |
+
+## Usage
+
+```html
+<div class="ease-has-spotlight">
+  <div class="card">Alpha</div>
+  <div class="card">Beta</div>
+</div>
+```
+
+Closes #9601

--- a/submissions/examples/has-sibling-motion-sk/demo.html
+++ b/submissions/examples/has-sibling-motion-sk/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>:has() Sibling Motion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>:has() Selector-Driven Sibling Motion</h1>
+
+    <!-- 1. Card spotlight -->
+    <div>
+        <div class="section-label">Card Spotlight — hover any card</div>
+        <div class="ease-has-spotlight">
+            <div class="card">Alpha</div>
+            <div class="card">Beta</div>
+            <div class="card">Gamma</div>
+            <div class="card">Delta</div>
+        </div>
+    </div>
+
+    <!-- 2. Form validation shake -->
+    <div>
+        <div class="section-label">Form Shake — type invalid email then blur</div>
+        <form class="ease-has-form" onsubmit="return false">
+            <input type="email" required placeholder="Email address" />
+            <input type="text" required placeholder="Name" />
+            <button class="submit-btn" type="submit">Submit</button>
+        </form>
+    </div>
+
+    <!-- 3. Sidebar push -->
+    <div>
+        <div class="section-label">Sidebar Push — click the button</div>
+        <div class="ease-has-layout">
+            <input type="checkbox" id="sidebar-toggle" />
+            <div class="has-sidebar">Sidebar</div>
+            <div class="has-main">
+                <span style="font-size:0.85rem;color:#666">Main content</span>
+                <label class="has-toggle-btn" for="sidebar-toggle">Toggle Sidebar</label>
+            </div>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/has-sibling-motion-sk/style.css
+++ b/submissions/examples/has-sibling-motion-sk/style.css
@@ -1,0 +1,186 @@
+@keyframes shake {
+    0%, 100% { transform: translateX(0); }
+    20%       { transform: translateX(-8px); }
+    40%       { transform: translateX(8px); }
+    60%       { transform: translateX(-5px); }
+    80%       { transform: translateX(5px); }
+}
+
+@keyframes sidebar-push {
+    from { transform: translateX(0); }
+    to   { transform: translateX(240px); }
+}
+
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #e8e8e8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 3rem 1.5rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.3rem;
+    margin: 0;
+}
+
+.section-label {
+    font-size: 0.72rem;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 0.75rem;
+}
+
+/* === 1. Card spotlight === */
+.ease-has-spotlight {
+    display: flex;
+    gap: 1rem;
+}
+
+.ease-has-spotlight .card {
+    background: #1e1e1e;
+    border: 1px solid #333;
+    border-radius: 10px;
+    padding: 1.5rem 1rem;
+    width: 110px;
+    text-align: center;
+    font-size: 0.85rem;
+    cursor: default;
+    transition: transform 0.3s, filter 0.3s, opacity 0.3s;
+}
+
+.ease-has-spotlight:has(.card:hover) .card:not(:hover) {
+    transform: scale(0.9);
+    filter: blur(1px);
+    opacity: 0.45;
+}
+
+/* === 2. Form validation shake === */
+.ease-has-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 280px;
+}
+
+.ease-has-form input {
+    padding: 0.6rem 0.8rem;
+    border-radius: 8px;
+    border: 1px solid #333;
+    background: #1a1a1a;
+    color: #e8e8e8;
+    font-size: 0.9rem;
+    outline: none;
+}
+
+.ease-has-form input:focus {
+    border-color: #555;
+}
+
+.ease-has-form .submit-btn {
+    padding: 0.6rem;
+    border-radius: 8px;
+    border: none;
+    background: oklch(50% 0.18 260);
+    color: #fff;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.ease-has-form:has(input:not(:placeholder-shown):invalid) .submit-btn {
+    animation: shake 0.4s ease;
+    background: oklch(50% 0.2 20);
+}
+
+/* === 3. Sidebar toggle push === */
+.ease-has-layout {
+    position: relative;
+    width: 360px;
+    height: 160px;
+    overflow: hidden;
+    border-radius: 12px;
+    border: 1px solid #2e2e2e;
+}
+
+.ease-has-layout input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.has-sidebar {
+    position: absolute;
+    left: -240px;
+    top: 0;
+    bottom: 0;
+    width: 240px;
+    background: #1e1e1e;
+    border-right: 1px solid #333;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    color: #888;
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.has-main {
+    position: absolute;
+    inset: 0;
+    background: #151515;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.75rem;
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.has-toggle-btn {
+    padding: 0.4rem 0.8rem;
+    border-radius: 6px;
+    border: 1px solid #444;
+    background: #222;
+    color: #ccc;
+    font-size: 0.78rem;
+    cursor: pointer;
+}
+
+.ease-has-layout:has(input:checked) .has-sidebar {
+    transform: translateX(240px);
+}
+
+.ease-has-layout:has(input:checked) .has-main {
+    transform: translateX(240px);
+}
+
+@supports not selector(:has(*)) {
+    .ease-has-spotlight:hover .card {
+        transform: none;
+        filter: none;
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-has-form:has(input:not(:placeholder-shown):invalid) .submit-btn {
+        animation: none;
+    }
+
+    .has-sidebar,
+    .has-main {
+        transition: none;
+    }
+
+    .ease-has-spotlight .card {
+        transition: none;
+    }
+}


### PR DESCRIPTION
Closes #9601

Adds `submissions/examples/has-sibling-motion-sk/` with three `:has()`-driven animation patterns.

1. **Card spotlight** — `:has(.card:hover) .card:not(:hover)` dims and blurs non-hovered siblings
2. **Form shake** — `:has(input:not(:placeholder-shown):invalid) .submit-btn` plays a shake keyframe and turns the button red when any input has an invalid value
3. **Sidebar push** — `:has(input:checked)` drives a CSS-only sidebar slide that also pushes the main content

`@supports not selector(:has(*))` fallback included. `prefers-reduced-motion` guard removes animations.