### PR TITLE
feat(submission): add scroll-snap + scroll-driven animation gallery

### DIFF
--- a/submissions/examples/scroll-snap-driven-gallery-sk/README.md
+++ b/submissions/examples/scroll-snap-driven-gallery-sk/README.md
@@ -1,0 +1,28 @@
+# Scroll-Snap + Scroll-Driven Gallery
+
+Horizontal `scroll-snap-type: x mandatory` gallery with cards animated via `animation-timeline: view(x)`.
+
+## Classes
+
+| Class | Role |
+|---|---|
+| `ease-snap-gallery` | Scroll container with `scroll-snap-type: x mandatory` |
+| `ease-snap-card` | Snapping card, animated via `view(x)` timeline |
+| `ease-snap-img` | Counter-direction parallax on the same `view(x)` timeline |
+
+## Usage
+
+```html
+<div class="ease-snap-gallery">
+  <article class="ease-snap-card">
+    <img class="ease-snap-img" src="photo.jpg" alt="" />
+    <div class="ease-snap-body">...</div>
+  </article>
+</div>
+```
+
+## Key technique
+
+`animation-timeline: view(x)` scopes the scroll timeline to the **horizontal** axis of the nearest scroll ancestor. `animation-range: entry 10% cover 50%` means the animation runs from when the card enters the viewport to when it reaches center. All effects are inside `@supports (animation-timeline: scroll())` so unsupported browsers get static cards.
+
+Closes #9602

--- a/submissions/examples/scroll-snap-driven-gallery-sk/demo.html
+++ b/submissions/examples/scroll-snap-driven-gallery-sk/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scroll-Snap + Scroll-Driven Gallery</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>Scroll-Snap + Scroll-Driven Animation Gallery</h1>
+
+    <div class="ease-snap-gallery">
+
+        <article class="ease-snap-card">
+            <svg class="ease-snap-img-placeholder ease-snap-img" viewBox="0 0 480 180" xmlns="http://www.w3.org/2000/svg">
+                <rect width="480" height="180" fill="oklch(40% 0.18 260)"/>
+                <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="white" font-size="20" font-family="sans-serif">Slide 1</text>
+            </svg>
+            <div class="ease-snap-body">
+                <h3>Northern Lights</h3>
+                <p>Aurora borealis captured over Iceland</p>
+            </div>
+        </article>
+
+        <article class="ease-snap-card">
+            <svg class="ease-snap-img-placeholder ease-snap-img" viewBox="0 0 480 180" xmlns="http://www.w3.org/2000/svg">
+                <rect width="480" height="180" fill="oklch(40% 0.18 160)"/>
+                <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="white" font-size="20" font-family="sans-serif">Slide 2</text>
+            </svg>
+            <div class="ease-snap-body">
+                <h3>Forest Path</h3>
+                <p>Morning light through ancient redwoods</p>
+            </div>
+        </article>
+
+        <article class="ease-snap-card">
+            <svg class="ease-snap-img-placeholder ease-snap-img" viewBox="0 0 480 180" xmlns="http://www.w3.org/2000/svg">
+                <rect width="480" height="180" fill="oklch(40% 0.18 40)"/>
+                <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="white" font-size="20" font-family="sans-serif">Slide 3</text>
+            </svg>
+            <div class="ease-snap-body">
+                <h3>Desert Dunes</h3>
+                <p>Golden hour across the Sahara</p>
+            </div>
+        </article>
+
+        <article class="ease-snap-card">
+            <svg class="ease-snap-img-placeholder ease-snap-img" viewBox="0 0 480 180" xmlns="http://www.w3.org/2000/svg">
+                <rect width="480" height="180" fill="oklch(40% 0.18 310)"/>
+                <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="white" font-size="20" font-family="sans-serif">Slide 4</text>
+            </svg>
+            <div class="ease-snap-body">
+                <h3>Ocean Cliffs</h3>
+                <p>Dramatic coastline at dusk</p>
+            </div>
+        </article>
+
+        <article class="ease-snap-card">
+            <svg class="ease-snap-img-placeholder ease-snap-img" viewBox="0 0 480 180" xmlns="http://www.w3.org/2000/svg">
+                <rect width="480" height="180" fill="oklch(40% 0.18 200)"/>
+                <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="white" font-size="20" font-family="sans-serif">Slide 5</text>
+            </svg>
+            <div class="ease-snap-body">
+                <h3>Mountain Lake</h3>
+                <p>Glacial reflection in perfect stillness</p>
+            </div>
+        </article>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/scroll-snap-driven-gallery-sk/style.css
+++ b/submissions/examples/scroll-snap-driven-gallery-sk/style.css
@@ -1,0 +1,112 @@
+@keyframes card-enter {
+    from {
+        scale: 0.82;
+        opacity: 0.3;
+        filter: blur(5px);
+    }
+    to {
+        scale: 1;
+        opacity: 1;
+        filter: blur(0);
+    }
+}
+
+@keyframes img-parallax {
+    from { transform: translateX(-18px); }
+    to   { transform: translateX(18px); }
+}
+
+body {
+    font-family: sans-serif;
+    background: #0a0a0a;
+    color: #e8e8e8;
+    margin: 0;
+    padding: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+}
+
+h1 {
+    font-size: 1.2rem;
+    margin: 0;
+    color: #666;
+}
+
+.ease-snap-gallery {
+    display: flex;
+    overflow-x: scroll;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+    gap: 1.25rem;
+    padding: 1.5rem 10vw;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.ease-snap-gallery::-webkit-scrollbar {
+    display: none;
+}
+
+.ease-snap-card {
+    flex: 0 0 72%;
+    max-width: 480px;
+    scroll-snap-align: center;
+    border-radius: 16px;
+    overflow: hidden;
+    background: #1a1a1a;
+    position: relative;
+    min-height: 260px;
+}
+
+@supports (animation-timeline: scroll()) {
+    .ease-snap-card {
+        animation: card-enter linear both;
+        animation-timeline: view(x);
+        animation-range: entry 10% cover 50%;
+    }
+
+    .ease-snap-img {
+        animation: img-parallax linear both;
+        animation-timeline: view(x);
+        animation-range: entry 0% exit 100%;
+    }
+}
+
+.ease-snap-img {
+    width: 100%;
+    height: 180px;
+    object-fit: cover;
+    display: block;
+}
+
+.ease-snap-img-placeholder {
+    width: 100%;
+    height: 180px;
+    display: block;
+}
+
+.ease-snap-body {
+    padding: 1.25rem;
+}
+
+.ease-snap-body h3 {
+    margin: 0 0 0.4rem;
+    font-size: 1rem;
+}
+
+.ease-snap-body p {
+    margin: 0;
+    font-size: 0.82rem;
+    color: #888;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-snap-card,
+    .ease-snap-img {
+        animation: none;
+    }
+}


### PR DESCRIPTION
Closes #9602

Adds `submissions/examples/scroll-snap-driven-gallery-sk/` — horizontal scroll-snap gallery where each card is animated via `animation-timeline: view(x)`.

The `x` axis parameter scopes the timeline to the horizontal scroll container, which is the part most tutorials omit. Cards scale/fade/deblur on `entry 10% cover 50%`. The image inside each card has a counter-direction parallax on `entry 0% exit 100%`. All scroll-driven animations are inside `@supports (animation-timeline: scroll())` so browsers without support get plain static cards.