### PR TITLE
feat(submission): add @starting-style dialog and popover animation

### DIFF
--- a/submissions/examples/starting-style-dialog-sk/README.md
+++ b/submissions/examples/starting-style-dialog-sk/README.md
@@ -1,0 +1,34 @@
+# @starting-style Dialog and Popover Animation
+
+Full open/close animation on `<dialog>` and the native Popover API using `@starting-style` + `transition: display allow-discrete`.
+
+## Classes
+
+| Selector | Effect |
+|---|---|
+| `dialog.ease-dialog` | Animated `<dialog>` — fade + slide entry, reverse on close |
+| `#ease-popover[popover]` | Animated native popover via `:popover-open` + `@starting-style` |
+
+## Usage
+
+```html
+<button onclick="document.querySelector('dialog.ease-dialog').showModal()">Open</button>
+
+<dialog class="ease-dialog">
+  <p>Content</p>
+  <button onclick="this.closest('dialog').close()">Close</button>
+</dialog>
+
+<div id="my-popover" popover>Popover content</div>
+<button popovertarget="my-popover">Toggle</button>
+```
+
+## How it works
+
+- Entry: `@starting-style` defines the *from* state for the first paint after `display: none` → `display: block`
+- Exit: `transition: display 0.3s allow-discrete` lets the element stay rendered for 300ms after losing `[open]`/`:popover-open` so the reverse transition plays before removal
+- `::backdrop` gets its own `@starting-style` block for the overlay fade
+
+Requires Chrome 117+ / Firefox 129+ / Safari 17.2+.
+
+Closes #9603

--- a/submissions/examples/starting-style-dialog-sk/demo.html
+++ b/submissions/examples/starting-style-dialog-sk/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@starting-style Dialog and Popover</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>@starting-style Dialog &amp; Popover</h1>
+
+    <div class="buttons">
+
+        <button class="open-btn" onclick="document.querySelector('dialog.ease-dialog').showModal()">
+            Open Dialog
+        </button>
+
+        <button class="popover-btn" popovertarget="ease-popover">
+            Toggle Popover
+        </button>
+
+    </div>
+
+    <!-- Dialog -->
+    <dialog class="ease-dialog">
+        <h2>Animated Dialog</h2>
+        <p>
+            This dialog animates open and closed using <code>@starting-style</code> for the entry
+            and <code>transition: display allow-discrete</code> for the exit. No JS animation code.
+        </p>
+        <button class="close-btn" onclick="this.closest('dialog').close()">Close</button>
+    </dialog>
+
+    <!-- Popover -->
+    <div id="ease-popover" popover>
+        <strong>Native Popover API</strong>
+        <p style="margin:0.5rem 0 0;font-size:0.82rem;color:#aaa">
+            Animated with <code>@starting-style</code> and <code>:popover-open</code>.
+            Click anywhere outside to dismiss.
+        </p>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/starting-style-dialog-sk/style.css
+++ b/submissions/examples/starting-style-dialog-sk/style.css
@@ -1,0 +1,139 @@
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #e8e8e8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 2rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.3rem;
+    margin: 0;
+}
+
+.open-btn,
+.popover-btn,
+.close-btn {
+    padding: 0.55rem 1.2rem;
+    border-radius: 8px;
+    border: 1px solid #444;
+    background: #1e1e1e;
+    color: #e8e8e8;
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+
+.open-btn:hover,
+.popover-btn:hover {
+    background: #2a2a2a;
+}
+
+/* === Dialog === */
+dialog.ease-dialog {
+    background: #1a1a1a;
+    border: 1px solid #333;
+    border-radius: 14px;
+    padding: 2rem;
+    color: #e8e8e8;
+    max-width: 380px;
+    width: 90%;
+
+    /* closed state */
+    opacity: 0;
+    transform: translateY(-16px) scale(0.96);
+    transition:
+        opacity 0.3s ease,
+        transform 0.3s ease,
+        overlay 0.3s allow-discrete,
+        display 0.3s allow-discrete;
+}
+
+dialog.ease-dialog[open] {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+@starting-style {
+    dialog.ease-dialog[open] {
+        opacity: 0;
+        transform: translateY(-16px) scale(0.96);
+    }
+}
+
+dialog.ease-dialog::backdrop {
+    background: oklch(0% 0 0 / 0);
+    transition:
+        background 0.3s ease,
+        overlay 0.3s allow-discrete,
+        display 0.3s allow-discrete;
+}
+
+dialog.ease-dialog[open]::backdrop {
+    background: oklch(0% 0 0 / 0.6);
+}
+
+@starting-style {
+    dialog.ease-dialog[open]::backdrop {
+        background: oklch(0% 0 0 / 0);
+    }
+}
+
+dialog.ease-dialog h2 {
+    margin: 0 0 0.75rem;
+    font-size: 1.1rem;
+}
+
+dialog.ease-dialog p {
+    margin: 0 0 1.25rem;
+    font-size: 0.88rem;
+    color: #aaa;
+}
+
+/* === Popover === */
+#ease-popover {
+    position: fixed;
+    bottom: auto;
+    top: auto;
+    inset-block-start: 40%;
+    background: #222;
+    border: 1px solid #444;
+    border-radius: 10px;
+    padding: 1.25rem 1.5rem;
+    color: #e8e8e8;
+    font-size: 0.9rem;
+    max-width: 280px;
+
+    opacity: 0;
+    transform: scale(0.92) translateY(8px);
+    transition:
+        opacity 0.25s ease,
+        transform 0.25s ease,
+        overlay 0.25s allow-discrete,
+        display 0.25s allow-discrete;
+}
+
+#ease-popover:popover-open {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+}
+
+@starting-style {
+    #ease-popover:popover-open {
+        opacity: 0;
+        transform: scale(0.92) translateY(8px);
+    }
+}
+
+.buttons {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}


### PR DESCRIPTION
Closes #9603

Adds `submissions/examples/starting-style-dialog-sk/` — animated `<dialog>` and native Popover API using `@starting-style` + `transition: display allow-discrete`.

- `@starting-style` defines the initial from-state for the first paint after `display: none` → visible, enabling entry animation
- `transition: display 0.3s allow-discrete` keeps the element rendered during the exit transition before it returns to `display: none`
- `::backdrop` has its own `@starting-style` block for the overlay fade
- `:popover-open` pseudo-class used for the Popover API variant

No JS animation code. `showModal()` / `close()` are the only JS calls.