### PR TITLE
feat(submission): add content-visibility + scroll-driven stagger reveal

### DIFF
--- a/submissions/examples/content-visibility-stagger-sk/README.md
+++ b/submissions/examples/content-visibility-stagger-sk/README.md
@@ -1,0 +1,29 @@
+# content-visibility Stagger Reveal
+
+Long-page layout where each section uses `content-visibility: auto` for off-screen rendering performance, while items animate in via `animation-timeline: view()`.
+
+## Classes
+
+| Class | Role |
+|---|---|
+| `ease-cv-section` | Section with `content-visibility: auto` + `contain-intrinsic-size` |
+| `ease-cv-item` | Item that stagger-reveals via `view()` timeline and `--i` delay |
+
+## Usage
+
+```html
+<section class="ease-cv-section">
+  <div class="ease-cv-item" style="--i:0">Item A</div>
+  <div class="ease-cv-item" style="--i:1">Item B</div>
+</section>
+```
+
+## Key details
+
+- `contain-intrinsic-size: 0 420px` preserves scroll height so the scrollbar doesn't jump when sections come into view
+- `animation-delay: calc(var(--i, 0) * 60ms)` staggers items within each section
+- `animation-timeline: view()` scoped to each item — fires when it enters the viewport
+- Entire animation block inside `@supports (animation-timeline: scroll())` for compatibility
+- `prefers-reduced-motion` sets items to `opacity: 1; transform: none` immediately
+
+Closes #9604

--- a/submissions/examples/content-visibility-stagger-sk/demo.html
+++ b/submissions/examples/content-visibility-stagger-sk/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>content-visibility Stagger Reveal</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="page-header">
+        <h1>content-visibility + Scroll-Driven Stagger</h1>
+        <p>Scroll down — off-screen sections are skipped by the renderer, items animate in as you reach them</p>
+    </div>
+
+    <section class="ease-cv-section">
+        <h2>Section 1 — Design</h2>
+        <div class="ease-cv-items">
+            <div class="ease-cv-item" style="--i:0"><div class="item-title">Typography</div><div class="item-sub">Variable fonts, optical sizing</div></div>
+            <div class="ease-cv-item" style="--i:1"><div class="item-title">Color</div><div class="item-sub">oklch, P3 wide gamut</div></div>
+            <div class="ease-cv-item" style="--i:2"><div class="item-title">Spacing</div><div class="item-sub">8pt grid, fluid scale</div></div>
+            <div class="ease-cv-item" style="--i:3"><div class="item-title">Motion</div><div class="item-sub">Spring curves, scroll-driven</div></div>
+            <div class="ease-cv-item" style="--i:4"><div class="item-title">Icons</div><div class="item-sub">SVG, variable stroke</div></div>
+            <div class="ease-cv-item" style="--i:5"><div class="item-title">Layout</div><div class="item-sub">Subgrid, container queries</div></div>
+        </div>
+    </section>
+
+    <section class="ease-cv-section">
+        <h2>Section 2 — Development</h2>
+        <div class="ease-cv-items">
+            <div class="ease-cv-item" style="--i:0"><div class="item-title">CSS Houdini</div><div class="item-sub">@property, paint worklet</div></div>
+            <div class="ease-cv-item" style="--i:1"><div class="item-title">View Transitions</div><div class="item-sub">Named morphing</div></div>
+            <div class="ease-cv-item" style="--i:2"><div class="item-title">Scroll-Driven</div><div class="item-sub">view(), scroll() timelines</div></div>
+            <div class="ease-cv-item" style="--i:3"><div class="item-title">Trig Functions</div><div class="item-sub">sin(), cos(), atan2()</div></div>
+            <div class="ease-cv-item" style="--i:4"><div class="item-title">:has()</div><div class="item-sub">Parent selector patterns</div></div>
+            <div class="ease-cv-item" style="--i:5"><div class="item-title">Cascade Layers</div><div class="item-sub">@layer ordering</div></div>
+        </div>
+    </section>
+
+    <section class="ease-cv-section">
+        <h2>Section 3 — Performance</h2>
+        <div class="ease-cv-items">
+            <div class="ease-cv-item" style="--i:0"><div class="item-title">content-visibility</div><div class="item-sub">Skip off-screen rendering</div></div>
+            <div class="ease-cv-item" style="--i:1"><div class="item-title">will-change</div><div class="item-sub">Compositor promotion</div></div>
+            <div class="ease-cv-item" style="--i:2"><div class="item-title">contain</div><div class="item-sub">Layout isolation</div></div>
+            <div class="ease-cv-item" style="--i:3"><div class="item-title">transform</div><div class="item-sub">GPU composited layers</div></div>
+            <div class="ease-cv-item" style="--i:4"><div class="item-title">font-display</div><div class="item-sub">FOUT prevention</div></div>
+            <div class="ease-cv-item" style="--i:5"><div class="item-title">IntersectionObserver</div><div class="item-sub">JS fallback pattern</div></div>
+        </div>
+    </section>
+
+    <section class="ease-cv-section">
+        <h2>Section 4 — Accessibility</h2>
+        <div class="ease-cv-items">
+            <div class="ease-cv-item" style="--i:0"><div class="item-title">prefers-reduced-motion</div><div class="item-sub">Animation opt-out</div></div>
+            <div class="ease-cv-item" style="--i:1"><div class="item-title">Focus management</div><div class="item-sub">Dialog, popover</div></div>
+            <div class="ease-cv-item" style="--i:2"><div class="item-title">Color contrast</div><div class="item-sub">WCAG AA/AAA</div></div>
+            <div class="ease-cv-item" style="--i:3"><div class="item-title">Screen readers</div><div class="item-sub">aria-live, visually-hidden</div></div>
+        </div>
+    </section>
+
+</body>
+</html>

--- a/submissions/examples/content-visibility-stagger-sk/style.css
+++ b/submissions/examples/content-visibility-stagger-sk/style.css
@@ -1,0 +1,102 @@
+@keyframes item-reveal {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #e8e8e8;
+    margin: 0;
+    padding: 0;
+}
+
+.page-header {
+    text-align: center;
+    padding: 4rem 2rem 2rem;
+    position: sticky;
+    top: 0;
+    background: #0f0f0f;
+    z-index: 10;
+    border-bottom: 1px solid #1e1e1e;
+}
+
+.page-header h1 {
+    font-size: 1.3rem;
+    margin: 0 0 0.5rem;
+}
+
+.page-header p {
+    font-size: 0.82rem;
+    color: #666;
+    margin: 0;
+}
+
+.ease-cv-section {
+    content-visibility: auto;
+    contain-intrinsic-size: 0 420px;
+    padding: 3rem 2rem;
+    max-width: 700px;
+    margin: 0 auto;
+    border-bottom: 1px solid #1a1a1a;
+}
+
+.ease-cv-section h2 {
+    font-size: 1rem;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin: 0 0 1.5rem;
+}
+
+.ease-cv-items {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 1rem;
+}
+
+.ease-cv-item {
+    background: #1a1a1a;
+    border: 1px solid #2e2e2e;
+    border-radius: 10px;
+    padding: 1.25rem;
+    font-size: 0.88rem;
+    opacity: 0;
+    transform: translateY(22px);
+}
+
+@supports (animation-timeline: scroll()) {
+    .ease-cv-item {
+        animation: item-reveal linear both;
+        animation-timeline: view();
+        animation-range: entry 0% entry 65%;
+        animation-delay: calc(var(--i, 0) * 60ms);
+    }
+}
+
+@supports not (animation-timeline: scroll()) {
+    .ease-cv-item {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+.ease-cv-item .item-title {
+    font-weight: 600;
+    margin-bottom: 0.3rem;
+}
+
+.ease-cv-item .item-sub {
+    color: #666;
+    font-size: 0.78rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-cv-item {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
+}


### PR DESCRIPTION
Closes #9604

Adds `submissions/examples/content-visibility-stagger-sk/` — long-page layout combining `content-visibility: auto` (rendering performance) with `animation-timeline: view()` stagger reveals.

`contain-intrinsic-size: 0 420px` preserves scroll height so the scrollbar stays stable when off-screen sections aren't rendered. Items stagger via `animation-delay: calc(var(--i) * 60ms)`. The entire scroll-driven block is inside `@supports (animation-timeline: scroll())` so items are immediately visible on unsupported browsers. `prefers-reduced-motion` bypasses animation.