### PR TITLE
feat(submission): add conic-gradient CSS clock with @property angles

### DIFF
--- a/submissions/examples/conic-gradient-clock-sk/README.md
+++ b/submissions/examples/conic-gradient-clock-sk/README.md
@@ -1,0 +1,26 @@
+# Conic Gradient CSS Clock
+
+Analog clock where hands are `conic-gradient()` sectors driven by `@property`-registered angle variables and `steps()` timing.
+
+## Class
+
+`ease-conic-clock` — wraps `.clock-face` with three gradient hand elements.
+
+## How it works
+
+Each hand is a full-size `border-radius: 50%` element whose background is:
+
+```css
+background: conic-gradient(color var(--sec), transparent var(--sec));
+```
+
+A `mask: radial-gradient(...)` ring clips the gradient to an arc at the correct radius from center, making it look like a hand.
+
+Timing:
+- Seconds: `60s steps(60, start)` — one discrete step per second
+- Minutes: `3600s steps(60, start)` — one step per minute
+- Hours: `43200s steps(720, start)` — one step per 1/720th of 12 hours
+
+A small script offsets the `animation-delay` to the current time on load.
+
+Closes #9607

--- a/submissions/examples/conic-gradient-clock-sk/demo.html
+++ b/submissions/examples/conic-gradient-clock-sk/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Conic Gradient CSS Clock</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>Conic Gradient CSS Clock</h1>
+
+    <div class="ease-conic-clock">
+        <div class="clock-face">
+            <span class="clock-12">12</span>
+            <span class="clock-3">3</span>
+            <span class="clock-6">6</span>
+            <span class="clock-9">9</span>
+            <div class="hand-hours"></div>
+            <div class="hand-minutes"></div>
+            <div class="hand-seconds"></div>
+            <div class="clock-center"></div>
+        </div>
+    </div>
+
+    <p class="note">
+        Clock hands are conic-gradient sectors with
+        <code>@property</code>-registered angle variables.
+        seconds: <code>steps(60)</code>,
+        minutes: <code>steps(60)</code>,
+        hours: <code>steps(720)</code>.
+    </p>
+
+    <script>
+        /* Offset animations to current time */
+        const now = new Date();
+        const s = now.getSeconds();
+        const m = now.getMinutes() + s / 60;
+        const h = (now.getHours() % 12) + m / 60;
+
+        const secPct   = -(s / 60) * 100;
+        const minPct   = -(m / 60) * 100;
+        const hourPct  = -(h / 12) * 100;
+
+        document.querySelector('.hand-seconds').style.animationDelay = `${secPct}%`;
+        document.querySelector('.hand-minutes').style.animationDelay = `${minPct}%`;
+        document.querySelector('.hand-hours').style.animationDelay   = `${hourPct}%`;
+    </script>
+
+</body>
+</html>

--- a/submissions/examples/conic-gradient-clock-sk/style.css
+++ b/submissions/examples/conic-gradient-clock-sk/style.css
@@ -1,0 +1,182 @@
+@property --sec {
+    syntax: '<angle>';
+    initial-value: 0deg;
+    inherits: false;
+}
+
+@property --min {
+    syntax: '<angle>';
+    initial-value: 0deg;
+    inherits: false;
+}
+
+@property --hr {
+    syntax: '<angle>';
+    initial-value: 0deg;
+    inherits: false;
+}
+
+@keyframes tick-seconds {
+    to { --sec: 360deg; }
+}
+
+@keyframes tick-minutes {
+    to { --min: 360deg; }
+}
+
+@keyframes tick-hours {
+    to { --hr: 360deg; }
+}
+
+body {
+    font-family: sans-serif;
+    background: #0a0a0a;
+    color: #e8e8e8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 2rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.3rem;
+    margin: 0;
+}
+
+.ease-conic-clock {
+    position: relative;
+    width: 220px;
+    height: 220px;
+}
+
+.clock-face {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: #111;
+    box-shadow: 0 0 0 2px #2e2e2e, 0 0 40px oklch(0% 0 0 / 0.4);
+    overflow: hidden;
+}
+
+/* hour markers */
+.clock-face::before {
+    content: '';
+    position: absolute;
+    inset: 8px;
+    border-radius: 50%;
+    background:
+        repeating-conic-gradient(
+            #333 0deg 1deg,
+            transparent 1deg 30deg
+        );
+    mask: radial-gradient(circle, transparent 85%, black 86%);
+}
+
+.hand-hours {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: conic-gradient(
+        oklch(65% 0.18 260) var(--hr),
+        transparent var(--hr)
+    );
+    animation: tick-hours 43200s steps(720, start) infinite;
+    mask:
+        radial-gradient(circle at 50%, transparent 30%, black 31%, black 46%, transparent 47%);
+}
+
+.hand-minutes {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: conic-gradient(
+        oklch(70% 0.2 160) var(--min),
+        transparent var(--min)
+    );
+    animation: tick-minutes 3600s steps(60, start) infinite;
+    mask:
+        radial-gradient(circle at 50%, transparent 38%, black 39%, black 52%, transparent 53%);
+}
+
+.hand-seconds {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: conic-gradient(
+        oklch(65% 0.25 20) var(--sec),
+        transparent var(--sec)
+    );
+    animation: tick-seconds 60s steps(60, start) infinite;
+    mask:
+        radial-gradient(circle at 50%, transparent 44%, black 45%, black 54%, transparent 55%);
+}
+
+.clock-center {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 10px;
+    height: 10px;
+    background: #e8e8e8;
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 10;
+}
+
+.clock-12 {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.65rem;
+    color: #666;
+}
+
+.clock-3 {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 0.65rem;
+    color: #666;
+}
+
+.clock-6 {
+    position: absolute;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.65rem;
+    color: #666;
+}
+
+.clock-9 {
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 0.65rem;
+    color: #666;
+}
+
+p.note {
+    font-size: 0.78rem;
+    color: #555;
+    text-align: center;
+    max-width: 300px;
+    margin: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hand-hours,
+    .hand-minutes,
+    .hand-seconds {
+        animation: none;
+    }
+}


### PR DESCRIPTION
Closes #9607

Adds `submissions/examples/conic-gradient-clock-sk/` — analog clock where hands are `conic-gradient` sectors, not rotating `<div>` elements.

Each hand is a full-size circle with `conic-gradient(color var(--sec), transparent var(--sec))`. A `mask: radial-gradient(...)` ring clips it to the correct arc position. `@property` registers each angle as `<angle>` so the gradient animates. `steps(60, start)` on seconds and minutes produces realistic discrete ticking. A small script offsets `animation-delay` to the current time on load.