### PR TITLE
feat(submission): add color-mix() animated palette theme switcher

### DIFF
--- a/submissions/examples/color-mix-animated-theme-sk/README.md
+++ b/submissions/examples/color-mix-animated-theme-sk/README.md
@@ -1,0 +1,34 @@
+# color-mix() Animated Theme Switcher
+
+Animates an entire page palette simultaneously using a single `@property --mix-pct` custom property inside `color-mix(in oklch, ...)`.
+
+## Classes
+
+| Class | Theme |
+|---|---|
+| `ease-theme-sunset` | Orange → Pink (oklch 50deg → 340deg) |
+| `ease-theme-ocean` | Teal → Blue (oklch 200deg → 260deg) |
+| `ease-theme-forest` | Green → Brown (oklch 145deg → 100deg) |
+| `ease-theme-active` | Triggers the blend-in animation |
+
+## Usage
+
+```html
+<div class="ease-theme-card ease-theme-ocean ease-theme-active" id="card">
+  <div class="theme-header">...</div>
+</div>
+```
+
+Switch theme by swapping the `ease-theme-*` class and re-adding `ease-theme-active`.
+
+## How it works
+
+`--mix-pct` animates 0%→100%. Every surface uses:
+
+```css
+background: color-mix(in oklch, var(--from) var(--mix-pct), var(--to));
+```
+
+`oklch` produces perceptually uniform blends with no muddy mid-tones. `@supports not (color: color-mix(in oklch, red, blue))` provides a static fallback.
+
+Closes #9609

--- a/submissions/examples/color-mix-animated-theme-sk/demo.html
+++ b/submissions/examples/color-mix-animated-theme-sk/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>color-mix() Animated Theme Switcher</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>color-mix() Animated Theme Switcher</h1>
+
+    <div class="ease-theme-card ease-theme-ocean ease-theme-active" id="theme-card">
+        <div class="theme-header">
+            <h2 id="theme-name">Ocean</h2>
+            <p>All surfaces derive from a single <code>--mix-pct</code> animation</p>
+        </div>
+        <div class="theme-body">
+            <div>
+                <span class="theme-tag">Design</span>
+                <span class="theme-tag" style="margin-left:0.4rem">Motion</span>
+            </div>
+            <div class="theme-bar" style="width:80%"></div>
+            <div class="theme-bar" style="width:55%"></div>
+            <div class="theme-bar" style="width:35%"></div>
+        </div>
+    </div>
+
+    <div class="theme-switcher">
+        <button class="theme-btn" onclick="switchTheme('sunset', 'Sunset', this)">Sunset</button>
+        <button class="theme-btn active" onclick="switchTheme('ocean', 'Ocean', this)">Ocean</button>
+        <button class="theme-btn" onclick="switchTheme('forest', 'Forest', this)">Forest</button>
+    </div>
+
+    <script>
+        function switchTheme(name, label, btn) {
+            const card = document.getElementById('theme-card');
+            card.classList.remove('ease-theme-sunset', 'ease-theme-ocean', 'ease-theme-forest', 'ease-theme-active');
+            void card.offsetWidth;
+            card.classList.add(`ease-theme-${name}`, 'ease-theme-active');
+            document.getElementById('theme-name').textContent = label;
+            document.querySelectorAll('.theme-btn').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+        }
+    </script>
+
+</body>
+</html>

--- a/submissions/examples/color-mix-animated-theme-sk/style.css
+++ b/submissions/examples/color-mix-animated-theme-sk/style.css
@@ -1,0 +1,139 @@
+@property --mix-pct {
+    syntax: '<percentage>';
+    initial-value: 100%;
+    inherits: true;
+}
+
+@keyframes blend-in {
+    from { --mix-pct: 0%; }
+    to   { --mix-pct: 100%; }
+}
+
+/* Theme palettes — from/to pairs in oklch */
+.ease-theme-sunset {
+    --from: oklch(72% 0.22 50);
+    --to:   oklch(65% 0.22 340);
+}
+
+.ease-theme-ocean {
+    --from: oklch(60% 0.2 200);
+    --to:   oklch(55% 0.2 260);
+}
+
+.ease-theme-forest {
+    --from: oklch(55% 0.18 145);
+    --to:   oklch(48% 0.15 100);
+}
+
+.ease-theme-active {
+    animation: blend-in 0.7s ease forwards;
+}
+
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #e8e8e8;
+    margin: 0;
+    padding: 2rem;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.2rem;
+    margin: 0;
+}
+
+.ease-theme-card {
+    width: 100%;
+    max-width: 480px;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid #2e2e2e;
+}
+
+.theme-header {
+    padding: 2rem 1.5rem 1.5rem;
+    background: color-mix(in oklch, var(--from, oklch(55% 0.2 260)) var(--mix-pct), var(--to, oklch(55% 0.2 260)));
+}
+
+.theme-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: #fff;
+}
+
+.theme-header p {
+    margin: 0.4rem 0 0;
+    font-size: 0.82rem;
+    color: oklch(95% 0 0 / 0.7);
+}
+
+.theme-body {
+    background: #1a1a1a;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.theme-tag {
+    display: inline-block;
+    padding: 0.25rem 0.65rem;
+    border-radius: 20px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #fff;
+    background: color-mix(in oklch, var(--from, oklch(55% 0.2 260)) var(--mix-pct), var(--to, oklch(55% 0.2 260)));
+}
+
+.theme-bar {
+    height: 6px;
+    border-radius: 3px;
+    background: color-mix(in oklch, var(--from, oklch(55% 0.2 260)) var(--mix-pct), var(--to, oklch(55% 0.2 260)));
+}
+
+.theme-switcher {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.theme-btn {
+    padding: 0.4rem 1rem;
+    border-radius: 8px;
+    border: 1px solid #333;
+    background: #1e1e1e;
+    color: #ccc;
+    font-size: 0.82rem;
+    cursor: pointer;
+}
+
+.theme-btn:hover {
+    background: #2a2a2a;
+}
+
+.theme-btn.active {
+    border-color: #888;
+    color: #fff;
+}
+
+@supports not (color: color-mix(in oklch, red, blue)) {
+    .theme-header,
+    .theme-tag,
+    .theme-bar {
+        background: oklch(55% 0.2 260);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-theme-active {
+        animation: none;
+        --mix-pct: 100%;
+    }
+}


### PR DESCRIPTION
Closes #9609

Adds `submissions/examples/color-mix-animated-theme-sk/` — three palette themes (sunset/ocean/forest) where switching animates the entire UI simultaneously via a single `--mix-pct` custom property.

Every surface color is `color-mix(in oklch, var(--from) var(--mix-pct), var(--to))`. Animating `--mix-pct` 0%→100% via `@keyframes` transitions the whole palette at once. `oklch` color space avoids muddy mid-tone blends. `@supports not (color: color-mix(in oklch, red, blue))` provides a static fallback color.