### PR TITLE
feat(submission): add CSS 3D preserve-3d ambient parallax

### DIFF
--- a/submissions/examples/preserve-3d-parallax-sk/README.md
+++ b/submissions/examples/preserve-3d-parallax-sk/README.md
@@ -1,0 +1,32 @@
+# CSS 3D preserve-3d Parallax
+
+Idle ambient parallax using `transform-style: preserve-3d` and `perspective`. No JS, no scroll, no mouse events required.
+
+## Classes
+
+| Class | Role |
+|---|---|
+| `ease-parallax-viewport` | Sets `perspective: 700px` |
+| `ease-parallax-scene` | `transform-style: preserve-3d`, animated with `idle-rock` tilt |
+| `ease-parallax-layer` | Each layer at a different `translateZ()` depth |
+| `layer-bg` | Far layer: `translateZ(-80px) scale(1.18)` |
+| `layer-mid` | Content at `translateZ(0)` |
+| `layer-fg` | Near layer: `translateZ(50px) scale(0.9)` |
+
+## Usage
+
+```html
+<div class="ease-parallax-viewport">
+  <div class="ease-parallax-scene">
+    <div class="ease-parallax-layer layer-bg"></div>
+    <div class="ease-parallax-layer layer-mid"><h2>Content</h2></div>
+    <div class="ease-parallax-layer layer-fg"></div>
+  </div>
+</div>
+```
+
+## How it works
+
+Tilting the parent scene container with `rotateX/rotateY` creates depth-differential movement between layers — far layers appear to move less than near layers due to perspective foreshortening. The `scale()` compensation on the bg layer (`scale(1.18)`) prevents gaps at the edges during tilt.
+
+Closes #9610

--- a/submissions/examples/preserve-3d-parallax-sk/demo.html
+++ b/submissions/examples/preserve-3d-parallax-sk/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D preserve-3d Parallax</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>CSS 3D preserve-3d Parallax</h1>
+
+    <div class="ease-parallax-viewport">
+        <div class="ease-parallax-scene">
+            <div class="ease-parallax-layer layer-bg"></div>
+            <div class="ease-parallax-layer layer-mid">
+                <h2>Deep Motion</h2>
+                <p>Pure CSS parallax</p>
+            </div>
+            <div class="ease-parallax-layer layer-fg"></div>
+        </div>
+    </div>
+
+    <p class="note">
+        Layers at different <code>translateZ()</code> depths inside a
+        <code>transform-style: preserve-3d</code> parent. The idle tilt
+        animation creates parallax depth with no JS or scroll.
+    </p>
+
+</body>
+</html>

--- a/submissions/examples/preserve-3d-parallax-sk/style.css
+++ b/submissions/examples/preserve-3d-parallax-sk/style.css
@@ -1,0 +1,161 @@
+@keyframes idle-rock {
+    0%   { transform: rotateX(4deg)  rotateY(-3deg); }
+    25%  { transform: rotateX(-2deg) rotateY(4deg); }
+    50%  { transform: rotateX(3deg)  rotateY(2deg); }
+    75%  { transform: rotateX(-3deg) rotateY(-4deg); }
+    100% { transform: rotateX(4deg)  rotateY(-3deg); }
+}
+
+@keyframes float-scene {
+    0%, 100% { transform: translateY(0px); }
+    50%       { transform: translateY(-8px); }
+}
+
+body {
+    font-family: sans-serif;
+    background: #080810;
+    color: #e8e8e8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 2rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.2rem;
+    margin: 0;
+    color: #555;
+}
+
+.ease-parallax-viewport {
+    perspective: 700px;
+    width: 340px;
+    height: 260px;
+    position: relative;
+}
+
+.ease-parallax-scene {
+    width: 100%;
+    height: 100%;
+    transform-style: preserve-3d;
+    position: relative;
+    animation:
+        idle-rock 10s ease-in-out infinite,
+        float-scene 6s ease-in-out infinite;
+}
+
+.ease-parallax-layer {
+    position: absolute;
+    inset: 0;
+    border-radius: 14px;
+    overflow: hidden;
+}
+
+/* Far layer — background */
+.layer-bg {
+    transform: translateZ(-80px) scale(1.18);
+    background: linear-gradient(
+        135deg,
+        oklch(25% 0.15 260),
+        oklch(20% 0.1 300)
+    );
+}
+
+.layer-bg::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+        ellipse at 30% 40%,
+        oklch(40% 0.2 280 / 0.4),
+        transparent 60%
+    );
+}
+
+/* Stars in bg layer */
+.layer-bg::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image:
+        radial-gradient(1px 1px at 20% 30%, white 0%, transparent 100%),
+        radial-gradient(1px 1px at 60% 20%, white 0%, transparent 100%),
+        radial-gradient(1px 1px at 80% 50%, white 0%, transparent 100%),
+        radial-gradient(1px 1px at 10% 70%, white 0%, transparent 100%),
+        radial-gradient(1px 1px at 50% 80%, white 0%, transparent 100%),
+        radial-gradient(1px 1px at 90% 15%, white 0%, transparent 100%),
+        radial-gradient(1px 1px at 35% 60%, white 0%, transparent 100%),
+        radial-gradient(1.5px 1.5px at 70% 75%, white 0%, transparent 100%);
+    opacity: 0.7;
+}
+
+/* Mid layer — content */
+.layer-mid {
+    transform: translateZ(0px);
+    background: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.layer-mid h2 {
+    font-size: 2rem;
+    font-weight: 800;
+    margin: 0;
+    letter-spacing: -0.02em;
+    background: linear-gradient(135deg, #fff 40%, oklch(75% 0.2 280));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.layer-mid p {
+    font-size: 0.78rem;
+    color: oklch(65% 0.1 280);
+    margin: 0;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+/* Foreground layer — floating orb */
+.layer-fg {
+    transform: translateZ(50px) scale(0.9);
+    background: transparent;
+    pointer-events: none;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+    padding: 1rem;
+}
+
+.layer-fg::before {
+    content: '';
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 35%, oklch(80% 0.22 280), oklch(50% 0.25 260));
+    box-shadow: 0 0 20px oklch(60% 0.2 280 / 0.5);
+}
+
+.note {
+    font-size: 0.78rem;
+    color: #444;
+    text-align: center;
+    max-width: 340px;
+    margin: 0;
+    line-height: 1.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-parallax-scene {
+        animation: none;
+        transform: rotateX(0) rotateY(0);
+    }
+}


### PR DESCRIPTION
Closes #9610

Adds `submissions/examples/preserve-3d-parallax-sk/` — ambient idle parallax using `transform-style: preserve-3d` and `perspective`. No JS, no scroll, no mouse events.

Three layers: bg at `translateZ(-80px) scale(1.18)`, mid at `translateZ(0)`, fg at `translateZ(50px) scale(0.9)`. An `idle-rock` keyframe tilts the parent scene — because of perspective, far layers appear to move less than near layers, creating the depth illusion. The `scale()` compensation on the bg layer prevents gap edges during tilt.