### PR TITLE
feat(submission): add CSS subgrid data table with :has() row highlight

### DIFF
--- a/submissions/examples/subgrid-table-highlight-sk/README.md
+++ b/submissions/examples/subgrid-table-highlight-sk/README.md
@@ -1,0 +1,36 @@
+# CSS Subgrid Data Table with :has() Row Highlight
+
+5-column data table using CSS Subgrid for column alignment and `:has(.cell:hover)` for full-row highlight animation.
+
+## Classes
+
+| Class | Role |
+|---|---|
+| `ease-sg-table` | Grid container: `grid-template-columns: repeat(5, ...)` |
+| `ease-sg-row` | Each row: `grid-template-columns: subgrid` |
+| `ease-sg-cell` | Individual cell |
+| `ease-sg-header` | Header row modifier |
+| `ease-sg-new` | Flash animation for newly added rows |
+
+## Usage
+
+```html
+<div class="ease-sg-table">
+  <div class="ease-sg-row ease-sg-header">
+    <span class="ease-sg-cell">Name</span>
+    <span class="ease-sg-cell">Role</span>
+  </div>
+  <div class="ease-sg-row">
+    <span class="ease-sg-cell">Alice</span>
+    <span class="ease-sg-cell">Engineer</span>
+  </div>
+</div>
+```
+
+## How it works
+
+- `grid-template-columns: subgrid` on each row inherits the parent's column tracks, ensuring perfect alignment regardless of cell content
+- `.ease-sg-row:has(.ease-sg-cell:hover)` selects the row when **any** of its cells are hovered — previously required JS event delegation
+- `@supports not (grid-template-columns: subgrid)` falls back to `display: table`
+
+Closes #9612

--- a/submissions/examples/subgrid-table-highlight-sk/demo.html
+++ b/submissions/examples/subgrid-table-highlight-sk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Subgrid Table Row Highlight</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>CSS Subgrid Data Table</h1>
+
+    <div class="ease-sg-table">
+
+        <div class="ease-sg-row ease-sg-header">
+            <span class="ease-sg-cell">Name</span>
+            <span class="ease-sg-cell">Role</span>
+            <span class="ease-sg-cell">Status</span>
+            <span class="ease-sg-cell">Joined</span>
+            <span class="ease-sg-cell">Score</span>
+        </div>
+
+        <div class="ease-sg-row">
+            <span class="ease-sg-cell">Alice Chen</span>
+            <span class="ease-sg-cell">Engineer</span>
+            <span class="ease-sg-cell"><span class="status-badge status-active">Active</span></span>
+            <span class="ease-sg-cell">2022</span>
+            <span class="ease-sg-cell">94<div class="score-bar" style="width:94%"></div></span>
+        </div>
+
+        <div class="ease-sg-row">
+            <span class="ease-sg-cell">Bob Okafor</span>
+            <span class="ease-sg-cell">Designer</span>
+            <span class="ease-sg-cell"><span class="status-badge status-active">Active</span></span>
+            <span class="ease-sg-cell">2021</span>
+            <span class="ease-sg-cell">88<div class="score-bar" style="width:88%"></div></span>
+        </div>
+
+        <div class="ease-sg-row">
+            <span class="ease-sg-cell">Clara Metz</span>
+            <span class="ease-sg-cell">Product</span>
+            <span class="ease-sg-cell"><span class="status-badge status-pending">Pending</span></span>
+            <span class="ease-sg-cell">2023</span>
+            <span class="ease-sg-cell">72<div class="score-bar" style="width:72%"></div></span>
+        </div>
+
+        <div class="ease-sg-row">
+            <span class="ease-sg-cell">David Kim</span>
+            <span class="ease-sg-cell">DevRel</span>
+            <span class="ease-sg-cell"><span class="status-badge status-inactive">Inactive</span></span>
+            <span class="ease-sg-cell">2020</span>
+            <span class="ease-sg-cell">61<div class="score-bar" style="width:61%"></div></span>
+        </div>
+
+        <div class="ease-sg-row">
+            <span class="ease-sg-cell">Eva Santos</span>
+            <span class="ease-sg-cell">QA</span>
+            <span class="ease-sg-cell"><span class="status-badge status-active">Active</span></span>
+            <span class="ease-sg-cell">2022</span>
+            <span class="ease-sg-cell">97<div class="score-bar" style="width:97%"></div></span>
+        </div>
+
+    </div>
+
+    <p style="font-size:0.78rem;color:#555;margin:0">Hover any row to highlight. Each row is <code>grid-template-columns: subgrid</code> for perfect column alignment.</p>
+
+</body>
+</html>

--- a/submissions/examples/subgrid-table-highlight-sk/style.css
+++ b/submissions/examples/subgrid-table-highlight-sk/style.css
@@ -1,0 +1,141 @@
+:root {
+    --accent: oklch(65% 0.2 250);
+}
+
+@keyframes row-flash {
+    from {
+        background: color-mix(in oklch, var(--accent) 35%, transparent);
+    }
+}
+
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #e8e8e8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 2rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.2rem;
+    margin: 0;
+}
+
+.ease-sg-table {
+    display: grid;
+    grid-template-columns: 1.8fr 1.4fr 1fr 1fr 0.8fr;
+    width: 100%;
+    max-width: 680px;
+    border: 1px solid #2e2e2e;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.ease-sg-row {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+    transition: background 0.18s ease, transform 0.18s ease;
+}
+
+.ease-sg-header {
+    background: #1a1a1a;
+    border-bottom: 1px solid #2e2e2e;
+}
+
+.ease-sg-row:not(.ease-sg-header):has(.ease-sg-cell:hover) {
+    background: color-mix(in oklch, var(--accent) 12%, transparent);
+    transform: translateX(3px);
+}
+
+.ease-sg-cell {
+    padding: 0.75rem 1rem;
+    font-size: 0.85rem;
+    border-right: 1px solid #1e1e1e;
+}
+
+.ease-sg-cell:last-child {
+    border-right: none;
+}
+
+.ease-sg-header .ease-sg-cell {
+    font-weight: 600;
+    font-size: 0.75rem;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    user-select: none;
+}
+
+.ease-sg-header .ease-sg-cell:hover {
+    color: #e8e8e8;
+}
+
+.status-badge {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+    font-size: 0.72rem;
+    font-weight: 600;
+}
+
+.status-active {
+    background: color-mix(in oklch, oklch(60% 0.2 145) 20%, transparent);
+    color: oklch(70% 0.2 145);
+}
+
+.status-inactive {
+    background: color-mix(in oklch, oklch(60% 0.15 20) 20%, transparent);
+    color: oklch(65% 0.18 20);
+}
+
+.status-pending {
+    background: color-mix(in oklch, oklch(65% 0.18 80) 20%, transparent);
+    color: oklch(70% 0.18 80);
+}
+
+.score-bar {
+    height: 4px;
+    border-radius: 2px;
+    background: var(--accent);
+    opacity: 0.7;
+    margin-top: 4px;
+}
+
+/* new row flash */
+.ease-sg-row.ease-sg-new {
+    animation: row-flash 1s ease-out;
+}
+
+@supports not (grid-template-columns: subgrid) {
+    .ease-sg-table {
+        display: table;
+        width: 100%;
+    }
+
+    .ease-sg-row {
+        display: table-row;
+    }
+
+    .ease-sg-cell {
+        display: table-cell;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-sg-row {
+        transition: none;
+    }
+
+    .ease-sg-row.ease-sg-new {
+        animation: none;
+    }
+}


### PR DESCRIPTION
Closes #9612

Adds `submissions/examples/subgrid-table-highlight-sk/` — 5-column data table using `grid-template-columns: subgrid` on each row for perfect column alignment, combined with `:has(.ease-sg-cell:hover)` for CSS-only row-level interaction.

`subgrid` inherits the parent column tracks so all rows align without JS layout calculation. `:has(.cell:hover)` on the row replaces what previously needed JS event delegation — the row gets a `translateX(3px)` nudge and a `color-mix` background tint when any cell is hovered. `@supports not (grid-template-columns: subgrid)` falls back to `display: table`.