### PR TITLE
feat(submission): add CSS steps() sprite walk cycle demos

### DIFF
--- a/submissions/examples/steps-sprite-walk-cycle-sk/README.md
+++ b/submissions/examples/steps-sprite-walk-cycle-sk/README.md
@@ -1,0 +1,29 @@
+# CSS steps() Sprite Walk Cycle
+
+Three `steps()` timing function demonstrations: digit counter, discrete position walker, and simulated sprite strip cycling.
+
+## Classes
+
+| Class | Demo |
+|---|---|
+| `ease-digit-strip` / `ease-digit-inner` | Digit counter — `steps(10, end)` on `translateY` |
+| `ease-step-walker` | Discrete position jumps — `steps(6, end)` on `translateX` |
+| `ease-sprite-box` | Simulated sprite strip — `steps(8, start)` on `background-position` |
+
+## How it works
+
+`steps(N, direction)` divides the animation timeline into N equal discrete intervals instead of interpolating continuously.
+
+- **Digit counter**: a vertical strip of digits animates `translateY(-100%)` in `steps(10, end)` — each step jumps exactly one digit height
+- **Sprite cycling**: `background-position` advances by one frame width per step — `steps(frameCount, start)` is the standard sprite technique
+- `--walk-speed` custom property controls animation duration on the sprite demo
+
+## Usage
+
+```css
+.my-sprite {
+  animation: sprite-advance var(--walk-speed) steps(8, start) infinite;
+}
+```
+
+Closes #9614

--- a/submissions/examples/steps-sprite-walk-cycle-sk/demo.html
+++ b/submissions/examples/steps-sprite-walk-cycle-sk/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS steps() Sprite Walk Cycle</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>CSS steps() Timing Function</h1>
+
+    <!-- 1. Digit counter -->
+    <div class="demo-block">
+        <div class="label"><code>steps(10, end)</code> — digit counter</div>
+        <div class="digit-counter-wrap">
+            <div class="ease-digit-strip">
+                <div class="ease-digit-inner">
+                    <div class="ease-digit">0</div>
+                    <div class="ease-digit">1</div>
+                    <div class="ease-digit">2</div>
+                    <div class="ease-digit">3</div>
+                    <div class="ease-digit">4</div>
+                    <div class="ease-digit">5</div>
+                    <div class="ease-digit">6</div>
+                    <div class="ease-digit">7</div>
+                    <div class="ease-digit">8</div>
+                    <div class="ease-digit">9</div>
+                </div>
+            </div>
+            <div class="ease-digit-strip" style="--offset: 0.2s">
+                <div class="ease-digit-inner" style="animation-delay:-0.4s">
+                    <div class="ease-digit">0</div>
+                    <div class="ease-digit">1</div>
+                    <div class="ease-digit">2</div>
+                    <div class="ease-digit">3</div>
+                    <div class="ease-digit">4</div>
+                    <div class="ease-digit">5</div>
+                    <div class="ease-digit">6</div>
+                    <div class="ease-digit">7</div>
+                    <div class="ease-digit">8</div>
+                    <div class="ease-digit">9</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 2. Discrete step walker -->
+    <div class="demo-block">
+        <div class="label"><code>steps(6, end)</code> — discrete position jumps</div>
+        <div class="ease-step-track">
+            <div class="ease-step-walker"></div>
+        </div>
+    </div>
+
+    <!-- 3. Simulated sprite strip -->
+    <div class="demo-block">
+        <div class="label"><code>steps(8, start)</code> — sprite strip cycling</div>
+        <div class="ease-sprite-demo">
+            <div>
+                <div class="ease-sprite-box"></div>
+                <div class="ease-sprite-label">Default speed</div>
+            </div>
+            <div>
+                <div class="ease-sprite-box" style="--walk-speed:0.4s"></div>
+                <div class="ease-sprite-label">Fast</div>
+            </div>
+            <div>
+                <div class="ease-sprite-box" style="--walk-speed:1.6s"></div>
+                <div class="ease-sprite-label">Slow</div>
+            </div>
+        </div>
+        <p style="font-size:0.75rem;color:#555;margin:0;text-align:center">
+            Speed controlled by <code>--walk-speed</code> custom property
+        </p>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/steps-sprite-walk-cycle-sk/style.css
+++ b/submissions/examples/steps-sprite-walk-cycle-sk/style.css
@@ -1,0 +1,230 @@
+:root {
+    --walk-speed: 0.8s;
+    --frame-count: 8;
+    --frame-w: 48px;
+}
+
+/* ============================================================
+   Digit counter — 10 frames, translateY steps through digits
+   ============================================================ */
+@keyframes count-up {
+    to { transform: translateY(-100%); }
+}
+
+/* ============================================================
+   Walking dots — steps() gives discrete position jumps
+   ============================================================ */
+@keyframes step-walk {
+    to { transform: translateX(280px); }
+}
+
+@keyframes step-bounce {
+    0%   { transform: translateY(0); }
+    25%  { transform: translateY(-16px); }
+    50%  { transform: translateY(0); }
+    75%  { transform: translateY(-8px); }
+    100% { transform: translateY(0); }
+}
+
+/* ============================================================
+   CSS-only "sprite" using background-position steps
+   Simulated sprite strip via linear-gradient frames
+   ============================================================ */
+@keyframes sprite-advance {
+    to {
+        background-position: calc(var(--frame-w) * var(--frame-count) * -1) 0;
+    }
+}
+
+@keyframes sprite-advance-slow {
+    to {
+        background-position: calc(var(--frame-w) * 6 * -1) 0;
+    }
+}
+
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #e8e8e8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3.5rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 4rem 2rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.2rem;
+    margin: 0;
+    color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.demo-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+.label {
+    font-size: 0.72rem;
+    color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    text-align: center;
+}
+
+code {
+    font-size: 0.8em;
+    background: #1a1a1a;
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+    color: oklch(70% 0.2 260);
+}
+
+/* --- 1. Digit counter --- */
+.ease-digit-strip {
+    width: 32px;
+    height: 44px;
+    overflow: hidden;
+    border: 1px solid #333;
+    border-radius: 6px;
+    background: #111;
+}
+
+.ease-digit-inner {
+    display: flex;
+    flex-direction: column;
+    animation: count-up 2s steps(10, end) infinite;
+}
+
+.ease-digit {
+    width: 32px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: oklch(70% 0.2 260);
+}
+
+.digit-counter-wrap {
+    display: flex;
+    gap: 2px;
+}
+
+/* --- 2. Discrete step walker --- */
+.ease-step-track {
+    width: 320px;
+    height: 50px;
+    position: relative;
+    border-bottom: 2px solid #2e2e2e;
+}
+
+.ease-step-walker {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: oklch(65% 0.22 160);
+    animation:
+        step-walk 3s steps(6, end) infinite,
+        step-bounce 0.5s steps(2, end) infinite;
+}
+
+/* --- 3. CSS simulated sprite strip --- */
+.ease-sprite-demo {
+    display: flex;
+    gap: 2rem;
+    align-items: flex-end;
+}
+
+/* Simulated 8-frame sprite using repeating-linear-gradient */
+.ease-sprite-box {
+    width: var(--frame-w);
+    height: 48px;
+    background: repeating-linear-gradient(
+        to right,
+        oklch(55% 0.2 260)  0,
+        oklch(55% 0.2 260)  calc(var(--frame-w) - 2px),
+        oklch(35% 0.1 260)  calc(var(--frame-w) - 2px),
+        oklch(35% 0.1 260)  var(--frame-w),
+        oklch(55% 0.2 290)  var(--frame-w),
+        oklch(55% 0.2 290)  calc(var(--frame-w) * 2 - 2px),
+        oklch(35% 0.1 290)  calc(var(--frame-w) * 2 - 2px),
+        oklch(35% 0.1 290)  calc(var(--frame-w) * 2),
+        oklch(55% 0.2 320)  calc(var(--frame-w) * 2),
+        oklch(55% 0.2 320)  calc(var(--frame-w) * 3 - 2px),
+        oklch(35% 0.1 320)  calc(var(--frame-w) * 3 - 2px),
+        oklch(35% 0.1 320)  calc(var(--frame-w) * 3),
+        oklch(55% 0.2 350)  calc(var(--frame-w) * 3),
+        oklch(55% 0.2 350)  calc(var(--frame-w) * 4 - 2px),
+        oklch(35% 0.1 350)  calc(var(--frame-w) * 4 - 2px),
+        oklch(35% 0.1 350)  calc(var(--frame-w) * 4),
+        oklch(55% 0.2 20)   calc(var(--frame-w) * 4),
+        oklch(55% 0.2 20)   calc(var(--frame-w) * 5 - 2px),
+        oklch(35% 0.1 20)   calc(var(--frame-w) * 5 - 2px),
+        oklch(35% 0.1 20)   calc(var(--frame-w) * 5),
+        oklch(55% 0.2 50)   calc(var(--frame-w) * 5),
+        oklch(55% 0.2 50)   calc(var(--frame-w) * 6 - 2px),
+        oklch(35% 0.1 50)   calc(var(--frame-w) * 6 - 2px),
+        oklch(35% 0.1 50)   calc(var(--frame-w) * 6),
+        oklch(55% 0.2 80)   calc(var(--frame-w) * 6),
+        oklch(55% 0.2 80)   calc(var(--frame-w) * 7 - 2px),
+        oklch(35% 0.1 80)   calc(var(--frame-w) * 7 - 2px),
+        oklch(35% 0.1 80)   calc(var(--frame-w) * 7),
+        oklch(55% 0.2 110)  calc(var(--frame-w) * 7),
+        oklch(55% 0.2 110)  calc(var(--frame-w) * 8 - 2px),
+        oklch(35% 0.1 110)  calc(var(--frame-w) * 8 - 2px),
+        oklch(35% 0.1 110)  calc(var(--frame-w) * 8)
+    );
+    background-size: calc(var(--frame-w) * var(--frame-count)) 100%;
+    border-radius: 6px;
+    overflow: hidden;
+    animation: sprite-advance var(--walk-speed) steps(var(--frame-count), start) infinite;
+}
+
+.ease-sprite-label {
+    font-size: 0.72rem;
+    color: #666;
+    text-align: center;
+    margin-top: 0.4rem;
+}
+
+.speed-controls {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.speed-btn {
+    padding: 0.3rem 0.7rem;
+    border-radius: 6px;
+    border: 1px solid #333;
+    background: #1a1a1a;
+    color: #aaa;
+    font-size: 0.75rem;
+    cursor: pointer;
+}
+
+.speed-btn:hover {
+    background: #222;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-digit-inner,
+    .ease-step-walker,
+    .ease-sprite-box {
+        animation: none;
+    }
+}


### PR DESCRIPTION
Closes #9614

Adds `submissions/examples/steps-sprite-walk-cycle-sk/` — three `steps()` timing function demonstrations. No external image assets needed.

1. **Digit counter** — `translateY(-100%)` in `steps(10, end)` over a vertical digit strip
2. **Discrete step walker** — `translateX` in `steps(6, end)` for discrete position jumps
3. **Simulated sprite strip** — `background-position` advances per step in `steps(8, start)`, speed controlled by `--walk-speed` custom property

The sprite strip demo shows three speeds side-by-side to make the `--walk-speed` pattern immediately copy-pasteable.