### PR TITLE
feat(submission): add animation-composition replace/add/accumulate demo

### DIFF
--- a/submissions/examples/animation-composition-accumulate-sk/README.md
+++ b/submissions/examples/animation-composition-accumulate-sk/README.md
@@ -1,0 +1,32 @@
+# animation-composition: accumulate
+
+Three-column comparison of `replace`, `add`, and `accumulate` composition modes showing how they interact with a base floating animation when a hover animation is applied to the same property.
+
+## Classes
+
+| Class | Composition |
+|---|---|
+| `ease-comp-replace` | Default — hover replaces float |
+| `ease-comp-add` | Hover adds to underlying base value |
+| `ease-comp-accumulate` | Hover stacks on current live value |
+
+## Usage
+
+```css
+.my-card {
+  animation: float 3s ease-in-out infinite;
+}
+
+.my-card:hover {
+  animation: hover-lift 0.3s ease forwards;
+  animation-composition: accumulate;
+}
+```
+
+## The problem this solves
+
+When two animations target the same CSS property (`transform`), the default `replace` mode means the hover animation **overwrites** the float. The card snaps to a fixed position when hovered. With `accumulate`, both animations compose — the float continues while the hover lift adds on top.
+
+Requires Chrome 112+ / Safari 16+ / Firefox 119+.
+
+Closes #9615

--- a/submissions/examples/animation-composition-accumulate-sk/demo.html
+++ b/submissions/examples/animation-composition-accumulate-sk/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>animation-composition: accumulate</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>animation-composition</h1>
+
+    <div class="label">Hover each card — all three have a continuous float + a hover lift</div>
+
+    <div class="ease-comp-demo">
+
+        <div class="ease-comp-card ease-comp-replace">
+            Replace
+            <span class="mode-label">float stops on hover</span>
+        </div>
+
+        <div class="ease-comp-card ease-comp-add">
+            Add
+            <span class="mode-label">hover adds to base</span>
+        </div>
+
+        <div class="ease-comp-card ease-comp-accumulate">
+            Accumulate
+            <span class="mode-label">both compose together</span>
+        </div>
+
+    </div>
+
+    <div class="explanation">
+        <dl>
+            <dt>replace</dt>
+            <dd>Hover animation replaces the float — the card jumps to a fixed position and stops floating.</dd>
+
+            <dt>add</dt>
+            <dd>Hover transform is added to the underlying animation's base value (the <code>to</code> keyframe at 0%), not the current live value.</dd>
+
+            <dt>accumulate</dt>
+            <dd>Hover transform is added to the float's <em>current</em> computed value — the float continues, the lift stacks on top. This is the correct fix for "hover breaks my idle animation."</dd>
+        </dl>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/animation-composition-accumulate-sk/style.css
+++ b/submissions/examples/animation-composition-accumulate-sk/style.css
@@ -1,0 +1,134 @@
+@keyframes float {
+    0%, 100% { transform: translateY(0); }
+    50%       { transform: translateY(-14px); }
+}
+
+@keyframes hover-lift {
+    to { transform: translateY(-12px) scale(1.05); }
+}
+
+body {
+    font-family: sans-serif;
+    background: #0f0f0f;
+    color: #e8e8e8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2.5rem;
+    min-height: 100vh;
+    margin: 0;
+    padding: 4rem 1.5rem;
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 1.2rem;
+    margin: 0;
+    color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.label {
+    font-size: 0.72rem;
+    color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    text-align: center;
+}
+
+.ease-comp-demo {
+    display: flex;
+    gap: 2rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.ease-comp-card {
+    width: 160px;
+    background: #1a1a1a;
+    border: 1px solid #2e2e2e;
+    border-radius: 14px;
+    padding: 2rem 1rem 1.5rem;
+    text-align: center;
+    cursor: default;
+    font-size: 0.88rem;
+    font-weight: 500;
+    animation: float 3s ease-in-out infinite;
+}
+
+.ease-comp-card .mode-label {
+    display: block;
+    font-size: 0.7rem;
+    color: #666;
+    margin-top: 0.4rem;
+    font-weight: 400;
+}
+
+/* replace (default) — hover animation replaces the float entirely */
+.ease-comp-replace:hover {
+    animation: hover-lift 0.3s ease forwards;
+    /* animation-composition: replace; — this is the default */
+}
+
+/* add — hover animation adds on top of the float's base value */
+.ease-comp-add:hover {
+    animation: hover-lift 0.3s ease forwards;
+    animation-composition: add;
+}
+
+/* accumulate — hover animation accumulates with the float's current value */
+.ease-comp-accumulate:hover {
+    animation: hover-lift 0.3s ease forwards;
+    animation-composition: accumulate;
+}
+
+/* color coding */
+.ease-comp-replace  { border-color: oklch(50% 0.2 20  / 0.5); }
+.ease-comp-add      { border-color: oklch(50% 0.2 80  / 0.5); }
+.ease-comp-accumulate { border-color: oklch(50% 0.2 145 / 0.5); }
+
+.ease-comp-replace:hover  { border-color: oklch(60% 0.2 20); }
+.ease-comp-add:hover      { border-color: oklch(60% 0.2 80); }
+.ease-comp-accumulate:hover { border-color: oklch(60% 0.2 145); }
+
+.explanation {
+    max-width: 560px;
+    width: 100%;
+    background: #141414;
+    border: 1px solid #2e2e2e;
+    border-radius: 12px;
+    padding: 1.25rem 1.5rem;
+}
+
+.explanation dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem 1rem;
+    font-size: 0.82rem;
+}
+
+.explanation dt {
+    font-weight: 600;
+    color: #888;
+}
+
+.explanation dd {
+    margin: 0;
+    color: #aaa;
+    line-height: 1.5;
+}
+
+@supports not (animation-composition: accumulate) {
+    .ease-comp-add,
+    .ease-comp-accumulate {
+        opacity: 0.5;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-comp-card {
+        animation: none;
+    }
+}


### PR DESCRIPTION
Closes #9615

Adds `submissions/examples/animation-composition-accumulate-sk/` — side-by-side comparison of all three `animation-composition` modes on a card that has both a continuous float and a hover-lift on the same `transform` property.

- `replace` (default) — hover kills the float, card snaps to fixed position
- `add` — hover adds to the base (from-keyframe) value, not the current live position
- `accumulate` — hover stacks on the current live computed value, float continues underneath

`accumulate` is the correct fix for the "adding a hover animation breaks my idle animation" bug that most developers hit and solve wrong (collapsing keyframes or using JS). `@supports not (animation-composition: accumulate)` dims the two non-default cards on unsupported browsers.