### PR TITLE
resolve #9783: Centered Text Label Section Divider Line

### DIFF
--- a/submissions/examples/new-divider-centered-label-sn50/README.md
+++ b/submissions/examples/new-divider-centered-label-sn50/README.md
@@ -1,0 +1,7 @@
+# Centered Text Label Section Divider Line
+
+Layout line dividers housing centered styled tags.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-divider-centered-label-sn50/demo.html
+++ b/submissions/examples/new-divider-centered-label-sn50/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: Centered Text Label Section Divider Line</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-divider-wrap">
+  <span class="divider-label">OR CONTINUE WITH</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/new-divider-centered-label-sn50/style.css
+++ b/submissions/examples/new-divider-centered-label-sn50/style.css
@@ -1,0 +1,9 @@
+/* ==========================================================================
+   EaseMotion CSS: Centered Text Label Section Divider Line
+   ========================================================================== */
+
+@layer components {
+.ease-divider-wrap { position: relative; text-align: center; margin: 2rem 0; width: 300px; }
+.ease-divider-wrap::before { content: ''; position: absolute; left: 0; top: 50%; width: 100%; height: 1px; background: #222; z-index: 1; }
+.divider-label { position: relative; background: #000; padding: 0 12px; color: #555; font-size: 0.75rem; font-weight: bold; z-index: 2; letter-spacing: 1px; }
+}


### PR DESCRIPTION
Closes #9783

## What this does
Layout line dividers housing centered styled tags.

## Files
- `submissions/examples/new-divider-centered-label-sn50/style.css`
- `submissions/examples/new-divider-centered-label-sn50/demo.html`
- `submissions/examples/new-divider-centered-label-sn50/README.md`
