### PR TITLE
[BUG FIX] .ease-footer link hover ignores --ease-color-primary

### DIFF
--- a/submissions/examples/footer-hover-custom-color-fix-ag/README.md
+++ b/submissions/examples/footer-hover-custom-color-fix-ag/README.md
@@ -1,0 +1,15 @@
+# [BUG FIX] .ease-footer link hover ignores --ease-color-primary
+
+## What does this do?
+Fixes footer link hover ignoring primary theme overrides by using CSS custom variables rather than hardcoded visual variables.
+
+## How is it used?
+```html
+a:hover { color: var(--ease-color-primary); }
+```
+
+## Why is it useful?
+Allows users to fully style all component states using standard CSS design variables.
+
+## Fixes
+Fixes #9858

--- a/submissions/examples/footer-hover-custom-color-fix-ag/demo.html
+++ b/submissions/examples/footer-hover-custom-color-fix-ag/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Footer Hover Custom Color Fix</title>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Customized Footer Link Hover</h1>
+    <p>Hover over the footer links below. They adapt to the custom primary color (greenish accent) because we override <code>--ease-color-primary</code>.</p>
+    
+    <footer class="footer">
+      <div class="footer-links">
+        <a href="#" class="footer-link">Documentation</a>
+        <a href="#" class="footer-link">GitHub Repo</a>
+        <a href="#" class="footer-link">Discord Support</a>
+      </div>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/footer-hover-custom-color-fix-ag/style.css
+++ b/submissions/examples/footer-hover-custom-color-fix-ag/style.css
@@ -1,0 +1,68 @@
+/* Bug Fix: Footer link hover custom variable
+   Issue #9858 */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  /* THE FIX: Bind custom primary property */
+  --ease-color-primary: #10b981; /* Green color override */
+}
+
+body {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  background: #090d16;
+  color: #f1f5f9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.demo-container {
+  max-width: 500px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: #fff;
+}
+
+p {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+code {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+}
+
+.footer {
+  background: #0f172a;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 2rem;
+  border-radius: 0.5rem;
+  text-align: center;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.footer-link {
+  color: #64748b;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+/* THE FIX: Hover state reads user CSS variables */
+.footer-link:hover {
+  color: var(--ease-color-primary);
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #9858
Fixes footer link hover ignoring primary theme overrides by using CSS custom variables rather than hardcoded visual variables.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/footer-hover-custom-color-fix-ag/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Binds hover states inside the footer to use the `--ease-color-primary` custom property.

**How does a developer use it?**
```html
a:hover { color: var(--ease-color-primary); }
```

**Why does it fit EaseMotion CSS?**
Allows users to fully style all component states using standard CSS design variables.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission only includes the fixed CSS in `submissions/examples/footer-hover-custom-color-fix-ag/style.css` and a simple demo as per the new contribution guidelines. The original bug is documented in #9858.
