### PR TITLE
[FEATURE]: Enable source map generation in the production minified CSS build process

### DIFF
--- a/submissions/core_changes-issue-9882/README.md
+++ b/submissions/core_changes-issue-9882/README.md
@@ -1,0 +1,71 @@
+# Core Changes — Issue #9882: Enable Source Map Generation in Production Minified CSS Build
+
+## Overview
+
+The current build pipeline produces `easemotion.min.css` without a corresponding source map file, making production CSS debugging difficult.
+
+## Problem
+
+- No `easemotion.min.css.map` is generated during the build
+- Browser DevTools show minified CSS with no source traceability
+- Error stack traces point to line 1 of the minified file
+- Framework contributors cannot identify which source file (`core/animations.css` vs `components/buttons.css`) contains a given rule
+
+## Proposed Changes
+
+### `scripts/build-minified-css.mjs`
+
+- Use `csso` minifier with `sourceMap: true` option
+- Generate `easemotion.min.css.map` alongside the minified CSS
+- Append `/*# sourceMappingURL=easemotion.min.css.map */` comment to the output
+
+**Current behavior:**
+```js
+await writeFile(outputFile, `${minifiedCss}\n`, "utf8");
+```
+
+**Proposed:**
+```js
+import { minify } from "csso";
+
+const result = minify(minifiedCss, {
+  filename: "easemotion.min.css",
+  sourceMap: true,
+});
+
+await writeFile(outputFile, result.css + `\n/*# sourceMappingURL=easemotion.min.css.map */`, "utf8");
+await writeFile(outputFile.replace(".css", ".css.map"), JSON.stringify(result.map), "utf8");
+```
+
+### `scripts/validate-bundle.mjs`
+
+- Verify that the `.map` file exists
+- Validate the source map has `version: 3`
+- Check that `sources` array contains expected paths
+- Ensure `mappings` string is non-empty
+
+### `scripts/validate-pack.mjs`
+
+- Add `easemotion.min.css.map` to the `required` array
+- Ensure it's included in the npm package
+
+## Affected Files
+
+- `scripts/build-minified-css.mjs`
+- `scripts/validate-bundle.mjs`
+- `scripts/validate-pack.mjs`
+- `package.json` (add `csso` dependency)
+
+## Dependencies
+
+Add `csso` to `devDependencies`:
+```json
+"csso": "^5.4.0"
+```
+
+## Labels
+
+- type:feature
+- type:devops
+- level:intermediate
+- GSSoC-26

--- a/submissions/core_changes-issue-9882/demo.html
+++ b/submissions/core_changes-issue-9882/demo.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Issue #9882 — Source Map Generation Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <h1>Issue #9882: Source Map Generation</h1>
+  <p class="subtitle">Enabling CSS source maps in the production build pipeline</p>
+
+  <div class="container">
+    <div class="card">
+      <div class="card-header before">Before</div>
+      <div class="card-body">
+        <div class="file-list">
+          <div class="file">
+            <span class="file-icon">📄</span>
+            <span class="file-name">easemotion.min.css</span>
+            <span class="file-badge present">Present</span>
+          </div>
+          <div class="file">
+            <span class="file-icon">❌</span>
+            <span class="file-name">easemotion.min.css.map</span>
+            <span class="file-badge missing">Missing</span>
+          </div>
+        </div>
+        <div class="issue-list">
+          <div class="issue">❌ Browser DevTools show only minified CSS</div>
+          <div class="issue">❌ No traceability to source files</div>
+          <div class="issue">❌ Error stacks point to line 1</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header after">After</div>
+      <div class="card-body">
+        <div class="file-list">
+          <div class="file">
+            <span class="file-icon">📄</span>
+            <span class="file-name">easemotion.min.css</span>
+            <span class="file-badge present">Present</span>
+          </div>
+          <div class="file">
+            <span class="file-icon">🗺️</span>
+            <span class="file-name">easemotion.min.css.map</span>
+            <span class="file-badge present">Present</span>
+          </div>
+        </div>
+        <div class="issue-list">
+          <div class="issue resolved">✅ DevTools map to original source files</div>
+          <div class="issue resolved">✅ Each rule traces to its source file</div>
+          <div class="issue resolved">✅ Source map comment appended to minified CSS</div>
+        </div>
+        <div class="code-block">
+          <code>
+/*# sourceMappingURL=easemotion.min.css.map */
+          </code>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>How It Works</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-text">Build script uses <code>csso</code> with <code>sourceMap: true</code></div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-text">Generates <code>easemotion.min.css.map</code> alongside minified CSS</div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-text">Source map comment appended to minified output</div>
+      </div>
+      <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-text">Validation scripts verify map integrity and pack inclusion</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Affected Scripts</h2>
+    <ul>
+      <li><code>scripts/build-minified-css.mjs</code> — Enable source map generation via csso</li>
+      <li><code>scripts/validate-bundle.mjs</code> — Validate source map integrity</li>
+      <li><code>scripts/validate-pack.mjs</code> — Include .map file in npm package</li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-9882/style.css
+++ b/submissions/core_changes-issue-9882/style.css
@@ -1,0 +1,1 @@
+/* Issue #9882: Demo-only submission — build script changes, no CSS changes required */


### PR DESCRIPTION
## ✦ Description
Add source map generation to the production CSS build pipeline. The current build produces `easemotion.min.css` without a corresponding `.map` file, making production CSS debugging extremely difficult. This submission proposes the changes needed in `scripts/build-minified-css.mjs`, `scripts/validate-bundle.mjs`, and `scripts/validate-pack.mjs` to generate and validate source maps using `csso`.

Fixes #9882

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## ✦ Checklist
- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [ ] (If applicable) I have run npm run lint and npm run format locally before pushing.

---

## ⟡ Description

### Root Cause
The build script at `scripts/build-minified-css.mjs` uses a custom minification function (`minifyCss`) that strips comments and whitespace but does not generate a source map. The validation scripts likewise have no checks for source map integrity or packaging.

### Proposed Changes
- **`scripts/build-minified-css.mjs`** — Use `csso` with `sourceMap: true` to generate `easemotion.min.css.map`
- **`scripts/validate-bundle.mjs`** — Validate source map existence, version, sources, and mappings
- **`scripts/validate-pack.mjs`** — Add `.map` file to required npm pack files
- **`package.json`** — Add `csso` dev dependency

### Testing Performed
Open `demo.html` in a browser to see the before/after comparison of the build output.

### Result
N/A — submission contains proposed changes for maintainer review

---

## Additional Notes
- Submission placed in `submissions/core_changes-issue-9882/` following existing pattern (see `core_changes-issue-5215`)
- No core framework files, components, or docs were modified
- Proposed changes are for maintainer review and integration
- Branch pushed: Pcmhacker-piro/EaseMotion-css:feat/core-changes-source-map-9882