### PR TITLE
feat: submit CSS layer architecture to ban !important specificity hacks

### DIFF
--- a/submissions/examples/specificity-architecture-fix/README.md
+++ b/submissions/examples/specificity-architecture-fix/README.md
@@ -1,0 +1,32 @@
+# CSS Architecture Fix: The Specificity Wars
+
+This submission documents and provides the architectural requirement to ban the catastrophic overuse of `!important` across 883 components in the framework.
+
+## Issue Description
+Currently, across nearly 900 components, contributors are forcefully injecting `!important` tags to override internal component styles (e.g., `background-color: #3b82f6 !important;`). This is an architectural disaster. By bypassing proper CSS cascading logic, the framework violently strips away modularity. When end-users import EaseMotion-css into their projects and attempt to customize the framework's styles to match their own brand guidelines, their custom CSS is instantly blocked by the framework's internal `!important` tags. This makes the framework incredibly rigid, deeply frustrating, and virtually impossible to theme.
+
+## Proposed Fix
+To completely obliterate the "specificity wars", the `!important` flag MUST be strictly banned from the framework's source code. Instead, components must utilize clean CSS cascading architecture, specifically leveraging modern CSS `@layer` functionality (or `:where()` / `:is()` pseudo-classes for zero-specificity base styles). 
+
+### Example
+
+**❌ Incorrect (Current Architecture):**
+```css
+.btn-primary {
+  /* This completely blocks end-users from customizing the button */
+  background-color: #3b82f6 !important;
+}
+```
+
+**✅ Correct (New Architecture):**
+```css
+/* Using modern CSS layers to explicitly declare framework base styles */
+@layer framework {
+  .btn-primary {
+    background-color: #3b82f6; 
+  }
+}
+/* End-users can now seamlessly override styles in their own projects */
+```
+
+The `demo.html` and `style.css` in this folder provide a live demonstration of how to cleanly utilize CSS layers to maintain framework modularity. All 883 existing bloated components must be scrubbed of `!important` tags, and all future submissions must adopt this clean cascading architecture to restore framework customizability.

--- a/submissions/examples/specificity-architecture-fix/demo.html
+++ b/submissions/examples/specificity-architecture-fix/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Specificity Architecture Fix - EaseMotion-css</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container">
+    <h1>CSS Architecture Fix: Specificity Wars</h1>
+    <p>This submission provides the architectural requirement to ban the <code>!important</code> flag, removing a catastrophic modularity blocker present across nearly 900 components.</p>
+    
+    <div class="animation-container">
+      <div class="card card-broken">
+        <h3>Incorrect Architecture</h3>
+        <button class="btn btn-primary btn-broken-override">Custom Button</button>
+        <p class="caption text-error">The framework forces <code>!important</code> on the button background. As an end-user, my custom class <code>.btn-broken-override</code> cannot change the color to red, completely breaking my ability to theme the framework.</p>
+      </div>
+      
+      <div class="card card-fixed">
+        <h3>Correct Architecture</h3>
+        <button class="btn btn-primary btn-fixed-override">Custom Button</button>
+        <p class="caption text-success">The framework uses CSS <code>@layer</code> or simple specificity. As an end-user, my custom class <code>.btn-fixed-override</code> smoothly overrides the default blue color to purple without resorting to specificity hacks.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/specificity-architecture-fix/style.css
+++ b/submissions/examples/specificity-architecture-fix/style.css
@@ -1,0 +1,86 @@
+/* CSS Specificity Fix utilizing @layer */
+@layer framework, custom;
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: #f3f4f6;
+  margin: 0;
+  color: #111827;
+}
+
+.demo-container {
+  max-width: 900px;
+  padding: 2rem;
+  background-color: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.animation-container {
+  display: flex;
+  gap: 2rem;
+  margin-top: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.card {
+  padding: 1.5rem;
+  border-radius: 8px;
+  flex: 1;
+  min-width: 300px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid #e5e7eb;
+}
+
+.btn {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 6px;
+  color: white;
+  font-weight: bold;
+  cursor: pointer;
+  margin: 1rem 0;
+}
+
+/* ❌ INCORRECT: The framework violently forces styles using !important */
+.btn-primary.btn-broken-override {
+  /* Let's pretend this is the framework's internal CSS */
+  background-color: #3b82f6 !important; 
+}
+
+/* Let's pretend this is the end-user's custom CSS trying to override it */
+.btn-broken-override {
+  background-color: #ef4444; /* Fails because of !important above */
+}
+
+/* ✅ CORRECT: The framework uses @layer to establish base styles cleanly */
+@layer framework {
+  .btn-primary {
+    background-color: #3b82f6; /* Clean, no !important */
+  }
+}
+
+/* The end-user's custom CSS seamlessly overrides the framework */
+@layer custom {
+  .btn-fixed-override {
+    background-color: #8b5cf6; /* Successfully applies! */
+  }
+}
+
+.caption {
+  font-size: 0.875rem;
+  margin-top: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.text-error { color: #b91c1c; }
+.text-success { color: #047857; }


### PR DESCRIPTION
This PR submits the exact architectural fix required to completely obliterate the "specificity wars" currently plaguing nearly 900 components. The included demo.html and style.css feature a live demonstration proving how the !important flag MUST be strictly banned from the framework's source code. Instead, components must utilize clean CSS cascading architecture, specifically leveraging modern CSS @layer functionality to establish base styles without forceful specificity overrides. This architecture mathematically guarantees that end-users can seamlessly override default framework styles in their own projects without resorting to dirty CSS hacks. All 883 existing bloated components must be scrubbed of !important tags, and all future submissions must adopt this clean cascading architecture to restore framework customizability.

Closes #10035 