### PR TITLE
[FEATURE]: Add ease-font-size-adjust and ease-font-stretch font variation utility classes

### DIFF
--- a/submissions/core_changes-issue-9880/README.md
+++ b/submissions/core_changes-issue-9880/README.md
@@ -1,0 +1,54 @@
+# Core Changes — Issue #9880: Add Font Variation Utility Classes (font-size-adjust, font-stretch)
+
+## Overview
+
+Add font variation utility classes for `font-size-adjust` and `font-stretch` to `core/utilities.css`.
+
+## Problem
+
+The current typography utilities cover font-size, weight, text alignment, and transform but miss two important font-level properties:
+
+1. **`font-size-adjust`** — adjusts the aspect ratio so fallback fonts maintain the same visual size as the primary font, preventing layout shifts when a custom font fails to load
+2. **`font-stretch`** — selects condensed or expanded faces from a font family (important for variable fonts and OpenType families)
+
+## Proposed Changes
+
+### `core/utilities.css` — Typography section
+
+**Font Size Adjust** (5 classes):
+```
+.ease-font-size-adjust-none      → font-size-adjust: none
+.ease-font-size-adjust-from-font → font-size-adjust: from-font
+.ease-font-size-adjust-05        → font-size-adjust: 0.5
+.ease-font-size-adjust-06        → font-size-adjust: 0.6
+.ease-font-size-adjust-07        → font-size-adjust: 0.7
+```
+
+**Font Stretch** (15 classes):
+```
+.ease-font-stretch-normal          → font-stretch: normal
+.ease-font-stretch-condensed       → font-stretch: condensed
+.ease-font-stretch-expanded        → font-stretch: expanded
+.ease-font-stretch-extra-condensed → font-stretch: extra-condensed
+.ease-font-stretch-extra-expanded  → font-stretch: extra-expanded
+.ease-font-stretch-semi-condensed  → font-stretch: semi-condensed
+.ease-font-stretch-semi-expanded   → font-stretch: semi-expanded
+.ease-font-stretch-ultra-condensed → font-stretch: ultra-condensed
+.ease-font-stretch-ultra-expanded  → font-stretch: ultra-expanded
+.ease-font-stretch-pct-50         → font-stretch: 50%
+.ease-font-stretch-pct-75         → font-stretch: 75%
+.ease-font-stretch-pct-100        → font-stretch: 100%
+.ease-font-stretch-pct-125        → font-stretch: 125%
+.ease-font-stretch-pct-150        → font-stretch: 150%
+.ease-font-stretch-pct-200        → font-stretch: 200%
+```
+
+## Affected Files
+
+- `core/utilities.css`
+
+## Labels
+
+- type:feature
+- level:intermediate
+- GSSoC-26

--- a/submissions/core_changes-issue-9880/demo.html
+++ b/submissions/core_changes-issue-9880/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Issue #9880 — Font Variation Utility Classes Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: Inter, Arial, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 900px;
+      margin: auto;
+    }
+    h1 { color: #f8fafc; border-bottom: 1px solid #334155; padding-bottom: 0.5rem; }
+    h2 { color: #94a3b8; font-size: 1.1rem; margin-top: 2rem; }
+    section { margin: 2rem 0; padding: 1.5rem; background: #1e293b; border-radius: 8px; }
+    .demo-box { background: #334155; padding: 1rem; border-radius: 6px; margin: 0.5rem 0; }
+    .demo-label { font-size: 0.8rem; color: #64748b; margin-bottom: 0.25rem; }
+    .code { font-family: monospace; color: #38bdf8; font-size: 0.85rem; }
+    table { width: 100%; border-collapse: collapse; margin: 0.5rem 0; }
+    td, th { padding: 0.5rem; border: 1px solid #334155; }
+    th { background: #0f172a; color: #94a3b8; text-align: left; }
+    td { text-align: left; }
+    .sample { font-size: 1.5rem; }
+    .fallback-demo { font-family: Georgia, "Times New Roman", serif; }
+  </style>
+</head>
+<body>
+  <h1>Issue #9880 — Font Variation Utility Classes</h1>
+  <p>Proposed additions to <code>core/utilities.css</code>: <code>font-size-adjust</code> and <code>font-stretch</code> utilities.</p>
+
+  <section>
+    <h2>Font Size Adjust</h2>
+    <p class="code">.ease-font-size-adjust-{none, from-font, 05, 06, 07}</p>
+    <p>Normalizes the visual size of fallback fonts when the primary font fails to load, preventing layout shifts.</p>
+    <table>
+      <tr><th>Class</th><th>Preview (Georgia fallback)</th></tr>
+      <tr><td><code>ease-font-size-adjust-none</code></td><td class="sample fallback-demo ease-font-size-adjust-none">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-size-adjust-from-font</code></td><td class="sample fallback-demo ease-font-size-adjust-from-font">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-size-adjust-05</code></td><td class="sample fallback-demo ease-font-size-adjust-05">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-size-adjust-06</code></td><td class="sample fallback-demo ease-font-size-adjust-06">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-size-adjust-07</code></td><td class="sample fallback-demo ease-font-size-adjust-07">The quick brown fox</td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Font Stretch</h2>
+    <p class="code">.ease-font-stretch-{normal, condensed, expanded, ...}</p>
+    <p>Selects condensed or expanded faces from a font family. Useful with variable fonts.</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-font-stretch-ultra-condensed</code></td><td class="sample ease-font-stretch-ultra-condensed">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-extra-condensed</code></td><td class="sample ease-font-stretch-extra-condensed">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-condensed</code></td><td class="sample ease-font-stretch-condensed">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-semi-condensed</code></td><td class="sample ease-font-stretch-semi-condensed">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-normal</code></td><td class="sample ease-font-stretch-normal">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-semi-expanded</code></td><td class="sample ease-font-stretch-semi-expanded">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-expanded</code></td><td class="sample ease-font-stretch-expanded">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-extra-expanded</code></td><td class="sample ease-font-stretch-extra-expanded">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-ultra-expanded</code></td><td class="sample ease-font-stretch-ultra-expanded">The quick brown fox</td></tr>
+    </table>
+
+    <h3>Percentage Values</h3>
+    <table>
+      <tr><th>Class</th><th>Value</th><th>Preview</th></tr>
+      <tr><td><code>ease-font-stretch-pct-50</code></td><td>50%</td><td class="sample ease-font-stretch-pct-50">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-pct-75</code></td><td>75%</td><td class="sample ease-font-stretch-pct-75">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-pct-100</code></td><td>100%</td><td class="sample ease-font-stretch-pct-100">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-pct-125</code></td><td>125%</td><td class="sample ease-font-stretch-pct-125">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-pct-150</code></td><td>150%</td><td class="sample ease-font-stretch-pct-150">The quick brown fox</td></tr>
+      <tr><td><code>ease-font-stretch-pct-200</code></td><td>200%</td><td class="sample ease-font-stretch-pct-200">The quick brown fox</td></tr>
+    </table>
+  </section>
+</body>
+</html>

--- a/submissions/core_changes-issue-9880/style.css
+++ b/submissions/core_changes-issue-9880/style.css
@@ -1,0 +1,25 @@
+/* Proposed font variation utility classes for core/utilities.css */
+
+/* Font Size Adjust */
+.ease-font-size-adjust-none      { font-size-adjust: none !important; }
+.ease-font-size-adjust-from-font { font-size-adjust: from-font !important; }
+.ease-font-size-adjust-05        { font-size-adjust: 0.5 !important; }
+.ease-font-size-adjust-06        { font-size-adjust: 0.6 !important; }
+.ease-font-size-adjust-07        { font-size-adjust: 0.7 !important; }
+
+/* Font Stretch */
+.ease-font-stretch-normal          { font-stretch: normal !important; }
+.ease-font-stretch-condensed       { font-stretch: condensed !important; }
+.ease-font-stretch-expanded        { font-stretch: expanded !important; }
+.ease-font-stretch-extra-condensed { font-stretch: extra-condensed !important; }
+.ease-font-stretch-extra-expanded  { font-stretch: extra-expanded !important; }
+.ease-font-stretch-semi-condensed  { font-stretch: semi-condensed !important; }
+.ease-font-stretch-semi-expanded   { font-stretch: semi-expanded !important; }
+.ease-font-stretch-ultra-condensed { font-stretch: ultra-condensed !important; }
+.ease-font-stretch-ultra-expanded  { font-stretch: ultra-expanded !important; }
+.ease-font-stretch-pct-50  { font-stretch: 50% !important; }
+.ease-font-stretch-pct-75  { font-stretch: 75% !important; }
+.ease-font-stretch-pct-100 { font-stretch: 100% !important; }
+.ease-font-stretch-pct-125 { font-stretch: 125% !important; }
+.ease-font-stretch-pct-150 { font-stretch: 150% !important; }
+.ease-font-stretch-pct-200 { font-stretch: 200% !important; }


### PR DESCRIPTION
## ✦ Description
Add font variation utility classes for `font-size-adjust` and `font-stretch` to `core/utilities.css`. The current typography utilities cover font-size, weight, text alignment, and transform but miss these two important font-level properties.

Fixes #9880

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## ✦ Checklist
- [x] All changes are inside `submissions/core_changes-issue-9880/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed utility classes
- [x] Includes `README.md` — describes proposed changes
- [x] **No changes to `core/` or `components/`**
- [x] One feature per PR

---

## ⟡ Description

### Root Cause
`core/utilities.css` has font-size, weight, and text alignment utilities but is missing:
- **font-size-adjust** — normalizes visual size of fallback fonts, preventing layout shifts
- **font-stretch** — selects condensed/expanded faces (important for variable fonts)

### Changes Made
Proposed additions to `core/utilities.css` in `submissions/core_changes-issue-9880/style.css`:
- **5 font-size-adjust classes**: `ease-font-size-adjust-{none, from-font, 05, 06, 07}`
- **15 font-stretch classes**: keyword variants (normal to ultra-expanded) + percentage variants (50% to 200%)

### Testing Performed
Open `submissions/core_changes-issue-9880/demo.html` in a browser to see all proposed classes in action.

---

## Additional Notes
- No core framework files, components, or docs were modified
- Class naming follows existing EaseMotion CSS conventions (ease- prefix, !important flag)
- Branch pushed: Pcmhacker-piro/EaseMotion-css:feat/core-changes-font-variation-9880