### PR TITLE
[FEATURE]: Add ease-mask-size, ease-mask-repeat, ease-mask-position, ease-mask-composite, ease-mask-clip, and ease-mask-origin utility classes

### DIFF
--- a/submissions/core_changes-issue-9873/README.md
+++ b/submissions/core_changes-issue-9873/README.md
@@ -1,0 +1,34 @@
+# Core Changes — Issue #9873: Add Mask Property Utility Classes
+
+## Overview
+
+Add utility classes for CSS Mask longhand properties to `core/utilities.css` with `-webkit-` prefix fallback for cross-browser support.
+
+## Problem
+
+`core/utilities.css` has three pre-composed mask-image utilities but no coverage of mask longhand properties:
+
+1. **`mask-size`** — control size of mask images (cover, contain, auto)
+2. **`mask-repeat`** — control mask image repetition (repeat, no-repeat, repeat-x, repeat-y, round, space)
+3. **`mask-position`** — position the mask image (center, top, bottom, left, right)
+4. **`mask-clip`** — determine mask painting area (border-box, padding-box, content-box, fill-box)
+5. **`mask-origin`** — determine mask positioning area (border-box, padding-box, content-box)
+6. **`mask-composite`** — composite multiple mask layers (add, subtract, intersect, exclude)
+
+## Proposed Changes
+
+### `core/utilities.css` — after existing mask image section
+
+**Mask Size** (3 classes) + **Mask Repeat** (6 classes) + **Mask Position** (5 classes) + **Mask Clip** (4 classes) + **Mask Origin** (3 classes) + **Mask Composite** (4 classes) = **25 classes total**
+
+All include both `-webkit-` prefixed and unprefixed declarations for cross-browser compatibility.
+
+## Affected Files
+
+- `core/utilities.css`
+
+## Labels
+
+- type:feature
+- level:intermediate
+- GSSoC-26

--- a/submissions/core_changes-issue-9873/demo.html
+++ b/submissions/core_changes-issue-9873/demo.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Issue #9873 — Mask Property Utility Classes Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: Inter, Arial, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 900px;
+      margin: auto;
+    }
+    h1 { color: #f8fafc; border-bottom: 1px solid #334155; padding-bottom: 0.5rem; }
+    h2 { color: #94a3b8; font-size: 1.1rem; margin-top: 2rem; }
+    section { margin: 2rem 0; padding: 1.5rem; background: #1e293b; border-radius: 8px; }
+    .code { font-family: monospace; color: #38bdf8; font-size: 0.85rem; }
+    table { width: 100%; border-collapse: collapse; margin: 0.5rem 0; }
+    td, th { padding: 0.5rem; border: 1px solid #334155; }
+    th { background: #0f172a; color: #94a3b8; text-align: left; }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 1rem;
+    }
+    .mask-cell {
+      background: #334155;
+      border-radius: 6px;
+      padding: 0.5rem;
+      text-align: center;
+    }
+    .mask-box {
+      width: 100%;
+      height: 80px;
+      background: linear-gradient(135deg, #38bdf8, #8b5cf6, #f43f5e);
+      border-radius: 4px;
+      margin-bottom: 0.25rem;
+    }
+    .mask-box.masked {
+      -webkit-mask-image: linear-gradient(black, transparent);
+      mask-image: linear-gradient(black, transparent);
+    }
+    .mask-box.masked-radial {
+      -webkit-mask-image: radial-gradient(circle, black 50%, transparent 70%);
+      mask-image: radial-gradient(circle, black 50%, transparent 70%);
+    }
+    .mask-cell .label { font-size: 0.75rem; color: #94a3b8; }
+  </style>
+</head>
+<body>
+  <h1>Issue #9873 — Mask Property Utility Classes</h1>
+  <p>Proposed additions to <code>core/utilities.css</code>: mask-size, mask-repeat, mask-position, mask-clip, mask-origin, and mask-composite.</p>
+
+  <section>
+    <h2>Mask Size</h2>
+    <p class="code">.ease-mask-{cover, contain, auto}</p>
+    <div class="demo-grid">
+      <div class="mask-cell"><div class="mask-box masked ease-mask-cover"></div><div class="label">ease-mask-cover</div></div>
+      <div class="mask-cell"><div class="mask-box masked ease-mask-contain"></div><div class="label">ease-mask-contain</div></div>
+      <div class="mask-cell"><div class="mask-box masked ease-mask-auto"></div><div class="label">ease-mask-auto</div></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Mask Repeat</h2>
+    <p class="code">.ease-mask-{repeat, no-repeat, repeat-x, repeat-y, round, space}</p>
+    <div class="demo-grid">
+      <div class="mask-cell"><div class="mask-box masked-radial ease-mask-repeat"></div><div class="label">ease-mask-repeat</div></div>
+      <div class="mask-cell"><div class="mask-box masked-radial ease-mask-no-repeat"></div><div class="label">ease-mask-no-repeat</div></div>
+      <div class="mask-cell"><div class="mask-box masked-radial ease-mask-repeat-x"></div><div class="label">ease-mask-repeat-x</div></div>
+      <div class="mask-cell"><div class="mask-box masked-radial ease-mask-repeat-y"></div><div class="label">ease-mask-repeat-y</div></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Mask Position</h2>
+    <p class="code">.ease-mask-{center, top, bottom, left, right}</p>
+    <div class="demo-grid">
+      <div class="mask-cell"><div class="mask-box masked ease-mask-center"></div><div class="label">ease-mask-center</div></div>
+      <div class="mask-cell"><div class="mask-box masked ease-mask-top"></div><div class="label">ease-mask-top</div></div>
+      <div class="mask-cell"><div class="mask-box masked ease-mask-bottom"></div><div class="label">ease-mask-bottom</div></div>
+      <div class="mask-cell"><div class="mask-box masked ease-mask-left"></div><div class="label">ease-mask-left</div></div>
+      <div class="mask-cell"><div class="mask-box masked ease-mask-right"></div><div class="label">ease-mask-right</div></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Mask Clip &amp; Origin</h2>
+    <p class="code">.ease-mask-clip-{border, padding, content, fill} / .ease-mask-origin-{border, padding, content}</p>
+    <table>
+      <tr><th>Category</th><th>Class</th><th>Value</th></tr>
+      <tr><td>Clip</td><td><code>ease-mask-clip-border</code></td><td>border-box</td></tr>
+      <tr><td>Clip</td><td><code>ease-mask-clip-padding</code></td><td>padding-box</td></tr>
+      <tr><td>Clip</td><td><code>ease-mask-clip-content</code></td><td>content-box</td></tr>
+      <tr><td>Clip</td><td><code>ease-mask-clip-fill</code></td><td>fill-box</td></tr>
+      <tr><td>Origin</td><td><code>ease-mask-origin-border</code></td><td>border-box</td></tr>
+      <tr><td>Origin</td><td><code>ease-mask-origin-padding</code></td><td>padding-box</td></tr>
+      <tr><td>Origin</td><td><code>ease-mask-origin-content</code></td><td>content-box</td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Mask Composite</h2>
+    <p class="code">.ease-mask-composite-{add, subtract, intersect, exclude}</p>
+    <table>
+      <tr><th>Class</th><th>WebKit Value</th><th>Standard Value</th></tr>
+      <tr><td><code>ease-mask-composite-add</code></td><td>source-over</td><td>add</td></tr>
+      <tr><td><code>ease-mask-composite-subtract</code></td><td>source-out</td><td>subtract</td></tr>
+      <tr><td><code>ease-mask-composite-intersect</code></td><td>source-in</td><td>intersect</td></tr>
+      <tr><td><code>ease-mask-composite-exclude</code></td><td>xor</td><td>exclude</td></tr>
+    </table>
+  </section>
+</body>
+</html>

--- a/submissions/core_changes-issue-9873/style.css
+++ b/submissions/core_changes-issue-9873/style.css
@@ -1,0 +1,38 @@
+/* Proposed mask property utility classes for core/utilities.css */
+
+/* Mask Size */
+.ease-mask-cover   { -webkit-mask-size: cover !important; mask-size: cover !important; }
+.ease-mask-contain { -webkit-mask-size: contain !important; mask-size: contain !important; }
+.ease-mask-auto    { -webkit-mask-size: auto !important; mask-size: auto !important; }
+
+/* Mask Repeat */
+.ease-mask-repeat    { -webkit-mask-repeat: repeat !important; mask-repeat: repeat !important; }
+.ease-mask-no-repeat { -webkit-mask-repeat: no-repeat !important; mask-repeat: no-repeat !important; }
+.ease-mask-repeat-x  { -webkit-mask-repeat: repeat-x !important; mask-repeat: repeat-x !important; }
+.ease-mask-repeat-y  { -webkit-mask-repeat: repeat-y !important; mask-repeat: repeat-y !important; }
+.ease-mask-round     { -webkit-mask-repeat: round !important; mask-repeat: round !important; }
+.ease-mask-space     { -webkit-mask-repeat: space !important; mask-repeat: space !important; }
+
+/* Mask Position */
+.ease-mask-center { -webkit-mask-position: center !important; mask-position: center !important; }
+.ease-mask-top    { -webkit-mask-position: top !important; mask-position: top !important; }
+.ease-mask-bottom { -webkit-mask-position: bottom !important; mask-position: bottom !important; }
+.ease-mask-left   { -webkit-mask-position: left !important; mask-position: left !important; }
+.ease-mask-right  { -webkit-mask-position: right !important; mask-position: right !important; }
+
+/* Mask Clip */
+.ease-mask-clip-border  { -webkit-mask-clip: border-box !important; mask-clip: border-box !important; }
+.ease-mask-clip-padding { -webkit-mask-clip: padding-box !important; mask-clip: padding-box !important; }
+.ease-mask-clip-content { -webkit-mask-clip: content-box !important; mask-clip: content-box !important; }
+.ease-mask-clip-fill    { -webkit-mask-clip: fill-box !important; mask-clip: fill-box !important; }
+
+/* Mask Origin */
+.ease-mask-origin-border  { -webkit-mask-origin: border-box !important; mask-origin: border-box !important; }
+.ease-mask-origin-padding { -webkit-mask-origin: padding-box !important; mask-origin: padding-box !important; }
+.ease-mask-origin-content { -webkit-mask-origin: content-box !important; mask-origin: content-box !important; }
+
+/* Mask Composite */
+.ease-mask-composite-add       { -webkit-mask-composite: source-over !important; mask-composite: add !important; }
+.ease-mask-composite-subtract  { -webkit-mask-composite: source-out !important; mask-composite: subtract !important; }
+.ease-mask-composite-intersect { -webkit-mask-composite: source-in !important; mask-composite: intersect !important; }
+.ease-mask-composite-exclude   { -webkit-mask-composite: xor !important; mask-composite: exclude !important; }


### PR DESCRIPTION
## ✦ Description
Add utility classes for CSS Mask longhand properties to `core/utilities.css`. The current utilities have three pre-composed mask-image values but lack fine-grained mask control.

Fixes #9873

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## ✦ Checklist
- [x] All changes are inside `submissions/core_changes-issue-9873/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed utility classes
- [x] Includes `README.md` — describes proposed changes
- [x] **No changes to `core/` or `components/`**
- [x] One feature per PR

---

## ⟡ Description

### Root Cause
`core/utilities.css` has mask-image utilities but no mask-size, mask-repeat, mask-position, mask-clip, mask-origin, or mask-composite classes.

### Changes Made
Proposed additions to `core/utilities.css` in `submissions/core_changes-issue-9873/style.css`:
- **3 mask-size** classes: cover, contain, auto
- **6 mask-repeat** classes: repeat, no-repeat, repeat-x, repeat-y, round, space
- **5 mask-position** classes: center, top, bottom, left, right
- **4 mask-clip** classes: border, padding, content, fill
- **3 mask-origin** classes: border, padding, content
- **4 mask-composite** classes: add, subtract, intersect, exclude

All include `-webkit-` prefix + unprefixed for cross-browser support.

### Testing Performed
Open `submissions/core_changes-issue-9873/demo.html` in a browser.

---

## Additional Notes
- No core framework files, components, or docs were modified
- Branch pushed: Pcmhacker-piro/EaseMotion-css:feat/core-changes-mask-9873