### PR TITLE
[FEATURE]: Add ease-outline-style, ease-outline-width, ease-outline-offset, and ease-outline-color utility classes

### DIFF
--- a/submissions/core_changes-issue-9872/README.md
+++ b/submissions/core_changes-issue-9872/README.md
@@ -1,0 +1,62 @@
+# Core Changes — Issue #9872: Add Outline Utility Classes
+
+## Overview
+
+Add utility classes for `outline` longhand properties to `core/utilities.css`. The outline property is distinct from border — it does not take up space and is critical for focus indicators and accessibility.
+
+## Problem
+
+The current Border & Radius section has border utilities but no outline classes:
+
+1. **`outline-style`** — no utilities for focus ring styles (solid, dashed, dotted, double, none)
+2. **`outline-width`** — no size utilities (0, 1px, 2px, 4px)
+3. **`outline-offset`** — no offset utilities for spacing outline from element
+4. **`outline-color`** — no color utilities using theme tokens
+
+## Proposed Changes
+
+### `core/utilities.css` — new Outline section after border section
+
+**Outline Style** (5 classes):
+```
+.ease-outline-none   → outline: none
+.ease-outline-solid  → outline-style: solid
+.ease-outline-dashed → outline-style: dashed
+.ease-outline-dotted → outline-style: dotted
+.ease-outline-double → outline-style: double
+```
+
+**Outline Width** (4 classes):
+```
+.ease-outline-0 → outline-width: 0
+.ease-outline-1 → outline-width: 1px
+.ease-outline-2 → outline-width: 2px
+.ease-outline-4 → outline-width: 4px
+```
+
+**Outline Offset** (4 classes):
+```
+.ease-outline-offset-0 → outline-offset: 0
+.ease-outline-offset-1 → outline-offset: 1px
+.ease-outline-offset-2 → outline-offset: 2px
+.ease-outline-offset-4 → outline-offset: 4px
+```
+
+**Outline Color** (5 classes):
+```
+.ease-outline-primary   → outline-color: var(--ease-color-primary)
+.ease-outline-success   → outline-color: var(--ease-color-success)
+.ease-outline-danger    → outline-color: var(--ease-color-danger)
+.ease-outline-current   → outline-color: currentColor
+.ease-outline-transparent → outline-color: transparent
+```
+
+## Affected Files
+
+- `core/utilities.css`
+
+## Labels
+
+- type:feature
+- level:beginner
+- GSSoC-26

--- a/submissions/core_changes-issue-9872/demo.html
+++ b/submissions/core_changes-issue-9872/demo.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Issue #9872 — Outline Utility Classes Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: Inter, Arial, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 900px;
+      margin: auto;
+    }
+    h1 { color: #f8fafc; border-bottom: 1px solid #334155; padding-bottom: 0.5rem; }
+    h2 { color: #94a3b8; font-size: 1.1rem; margin-top: 2rem; }
+    section { margin: 2rem 0; padding: 1.5rem; background: #1e293b; border-radius: 8px; }
+    .code { font-family: monospace; color: #38bdf8; font-size: 0.85rem; }
+    table { width: 100%; border-collapse: collapse; margin: 0.5rem 0; }
+    td, th { padding: 0.5rem; border: 1px solid #334155; }
+    th { background: #0f172a; color: #94a3b8; text-align: left; }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      gap: 1rem;
+    }
+    .outline-cell {
+      background: #334155;
+      border-radius: 6px;
+      padding: 1rem;
+      text-align: center;
+    }
+    .outline-box {
+      padding: 1rem;
+      background: #0f172a;
+      border-radius: 4px;
+      margin-bottom: 0.25rem;
+      font-size: 0.85rem;
+    }
+    .outline-cell .label { font-size: 0.75rem; color: #94a3b8; }
+    .focus-demo {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .focus-btn {
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 6px;
+      background: #334155;
+      color: #e2e8f0;
+      font-size: 0.85rem;
+      cursor: pointer;
+    }
+    .focus-btn:focus-visible {
+      outline-width: 2px;
+      outline-style: solid;
+    }
+  </style>
+</head>
+<body>
+  <h1>Issue #9872 — Outline Utility Classes</h1>
+  <p>Proposed additions to <code>core/utilities.css</code>: outline-style, outline-width, outline-offset, and outline-color utilities.</p>
+
+  <section>
+    <h2>Outline Style</h2>
+    <p class="code">.ease-outline-{none, solid, dashed, dotted, double}</p>
+    <div class="demo-grid">
+      <div class="outline-cell"><div class="outline-box ease-outline-solid ease-outline-2">solid</div><div class="label">ease-outline-solid</div></div>
+      <div class="outline-cell"><div class="outline-box ease-outline-dashed ease-outline-2">dashed</div><div class="label">ease-outline-dashed</div></div>
+      <div class="outline-cell"><div class="outline-box ease-outline-dotted ease-outline-2">dotted</div><div class="label">ease-outline-dotted</div></div>
+      <div class="outline-cell"><div class="outline-box ease-outline-double ease-outline-2">double</div><div class="label">ease-outline-double</div></div>
+      <div class="outline-cell"><div class="outline-box ease-outline-none">none</div><div class="label">ease-outline-none</div></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Outline Width</h2>
+    <p class="code">.ease-outline-{0, 1, 2, 4}</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-outline-0</code></td><td><span class="outline-box ease-outline-solid ease-outline-0">width 0</span></td></tr>
+      <tr><td><code>ease-outline-1</code></td><td><span class="outline-box ease-outline-solid ease-outline-1">width 1px</span></td></tr>
+      <tr><td><code>ease-outline-2</code></td><td><span class="outline-box ease-outline-solid ease-outline-2">width 2px</span></td></tr>
+      <tr><td><code>ease-outline-4</code></td><td><span class="outline-box ease-outline-solid ease-outline-4">width 4px</span></td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Outline Offset</h2>
+    <p class="code">.ease-outline-offset-{0, 1, 2, 4}</p>
+    <p>Controls the space between the element and its outline — useful for focus rings.</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-outline-offset-0</code></td><td><span class="outline-box ease-outline-solid ease-outline-2 ease-outline-offset-0">offset 0</span></td></tr>
+      <tr><td><code>ease-outline-offset-1</code></td><td><span class="outline-box ease-outline-solid ease-outline-2 ease-outline-offset-1">offset 1px</span></td></tr>
+      <tr><td><code>ease-outline-offset-2</code></td><td><span class="outline-box ease-outline-solid ease-outline-2 ease-outline-offset-2">offset 2px</span></td></tr>
+      <tr><td><code>ease-outline-offset-4</code></td><td><span class="outline-box ease-outline-solid ease-outline-2 ease-outline-offset-4">offset 4px</span></td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Outline Color</h2>
+    <p class="code">.ease-outline-{primary, success, danger, current, transparent}</p>
+    <div class="demo-grid">
+      <div class="outline-cell"><div class="outline-box ease-outline-solid ease-outline-2 ease-outline-primary">primary</div><div class="label">ease-outline-primary</div></div>
+      <div class="outline-cell"><div class="outline-box ease-outline-solid ease-outline-2 ease-outline-success">success</div><div class="label">ease-outline-success</div></div>
+      <div class="outline-cell"><div class="outline-box ease-outline-solid ease-outline-2 ease-outline-danger">danger</div><div class="label">ease-outline-danger</div></div>
+      <div class="outline-cell"><div class="outline-box ease-outline-solid ease-outline-2 ease-outline-current">current</div><div class="label">ease-outline-current</div></div>
+      <div class="outline-cell"><div class="outline-box ease-outline-solid ease-outline-2 ease-outline-transparent">transparent</div><div class="label">ease-outline-transparent</div></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Accessibility — Focus Ring Example</h2>
+    <p>Combining outline utilities for custom focus indicators:</p>
+    <div class="focus-demo">
+      <button class="focus-btn ease-outline-2 ease-outline-primary ease-outline-offset-2" tabindex="0">Focus me (Tab)</button>
+      <button class="focus-btn ease-outline-2 ease-outline-dashed ease-outline-offset-2" tabindex="0">Dashed focus</button>
+      <button class="focus-btn ease-outline-2 ease-outline-dotted ease-outline-offset-2" tabindex="0">Dotted focus</button>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/core_changes-issue-9872/style.css
+++ b/submissions/core_changes-issue-9872/style.css
@@ -1,0 +1,27 @@
+/* Proposed outline utility classes for core/utilities.css */
+
+/* Outline Style */
+.ease-outline-none   { outline: none !important; }
+.ease-outline-solid  { outline-style: solid !important; }
+.ease-outline-dashed { outline-style: dashed !important; }
+.ease-outline-dotted { outline-style: dotted !important; }
+.ease-outline-double { outline-style: double !important; }
+
+/* Outline Width */
+.ease-outline-0 { outline-width: 0 !important; }
+.ease-outline-1 { outline-width: 1px !important; }
+.ease-outline-2 { outline-width: 2px !important; }
+.ease-outline-4 { outline-width: 4px !important; }
+
+/* Outline Offset */
+.ease-outline-offset-0 { outline-offset: 0 !important; }
+.ease-outline-offset-1 { outline-offset: 1px !important; }
+.ease-outline-offset-2 { outline-offset: 2px !important; }
+.ease-outline-offset-4 { outline-offset: 4px !important; }
+
+/* Outline Color */
+.ease-outline-primary   { outline-color: var(--ease-color-primary) !important; }
+.ease-outline-success   { outline-color: var(--ease-color-success) !important; }
+.ease-outline-danger    { outline-color: var(--ease-color-danger) !important; }
+.ease-outline-current   { outline-color: currentColor !important; }
+.ease-outline-transparent { outline-color: transparent !important; }


### PR DESCRIPTION
## ✦ Description
Add utility classes for outline longhand properties to `core/utilities.css`. The outline property is distinct from border — it does not take up space and is critical for focus indicators and accessibility.

Fixes #9872

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## ✦ Checklist
- [x] All changes are inside `submissions/core_changes-issue-9872/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed utility classes
- [x] Includes `README.md` — describes proposed changes
- [x] **No changes to `core/` or `components/`**
- [x] One feature per PR

---

## ⟡ Description

### Root Cause
`core/utilities.css` has border utilities but no outline-style, outline-width, outline-offset, or outline-color classes.

### Changes Made
Proposed additions to `core/utilities.css` in `submissions/core_changes-issue-9872/style.css`:
- **5 outline-style** classes: none, solid, dashed, dotted, double
- **4 outline-width** classes: 0, 1px, 2px, 4px
- **4 outline-offset** classes: 0, 1px, 2px, 4px
- **5 outline-color** classes: primary, success, danger, current, transparent

### Testing Performed
Open `submissions/core_changes-issue-9872/demo.html` in a browser. Tab through focus ring examples.

---

## Additional Notes
- No core framework files, components, or docs were modified
- Branch pushed: Pcmhacker-piro/EaseMotion-css:feat/core-changes-outline-9872