### PR TITLE
[FEATURE]: Add ease-select-*, ease-resize-*, and ease-appearance-* interaction utility classes

### DIFF
--- a/submissions/core_changes-issue-9866/README.md
+++ b/submissions/core_changes-issue-9866/README.md
@@ -1,0 +1,47 @@
+# Core Changes — Issue #9866: Add Interaction Utility Classes
+
+## Overview
+
+Add utility classes for `user-select`, `resize`, and `appearance` to `core/utilities.css`. These properties control user interaction with elements — text selection, element resizing, and native form control styling.
+
+## Problem
+
+1. **`user-select`** — no utilities for text selection behavior (critical for UI elements, drag-and-drop)
+2. **`resize`** — no utilities for element resizing (critical for textareas and custom handles)
+3. **`appearance`** — no utilities for resetting native OS form styling (critical for cross-browser consistency)
+
+## Proposed Changes
+
+### `core/utilities.css` — new Interaction section after existing pointer-events section
+
+**User Select** (4 classes):
+```
+.ease-select-none → user-select: none
+.ease-select-text → user-select: text
+.ease-select-all  → user-select: all
+.ease-select-auto → user-select: auto
+```
+
+**Resize** (4 classes):
+```
+.ease-resize-none       → resize: none
+.ease-resize-both       → resize: both
+.ease-resize-horizontal → resize: horizontal
+.ease-resize-vertical   → resize: vertical
+```
+
+**Appearance** (2 classes):
+```
+.ease-appearance-none → appearance: none
+.ease-appearance-auto → appearance: auto
+```
+
+## Affected Files
+
+- `core/utilities.css`
+
+## Labels
+
+- type:feature
+- level:beginner
+- GSSoC-26

--- a/submissions/core_changes-issue-9866/demo.html
+++ b/submissions/core_changes-issue-9866/demo.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Issue #9866 — Interaction Utility Classes Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: Inter, Arial, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 960px;
+      margin: auto;
+    }
+    h1 { color: #f8fafc; border-bottom: 1px solid #334155; padding-bottom: 0.5rem; }
+    h2 { color: #94a3b8; font-size: 1.1rem; margin-top: 2rem; }
+    section { margin: 2rem 0; padding: 1.5rem; background: #1e293b; border-radius: 8px; }
+    .code { font-family: monospace; color: #38bdf8; font-size: 0.85rem; }
+    table { width: 100%; border-collapse: collapse; margin: 0.5rem 0; }
+    td, th { padding: 0.5rem; border: 1px solid #334155; }
+    th { background: #0f172a; color: #94a3b8; text-align: left; }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+    .demo-card {
+      background: #334155;
+      border-radius: 6px;
+      padding: 1rem;
+      text-align: center;
+    }
+    .demo-card .label { font-size: 0.75rem; color: #94a3b8; margin-top: 0.25rem; }
+    .demo-card p { font-size: 0.85rem; margin: 0.25rem 0; }
+    .try-select {
+      padding: 0.75rem;
+      background: #0f172a;
+      border-radius: 4px;
+      cursor: default;
+    }
+    .resize-box {
+      width: 100%;
+      height: 80px;
+      background: #0f172a;
+      border: 1px solid #475569;
+      border-radius: 4px;
+      overflow: auto;
+      padding: 0.5rem;
+      font-size: 0.75rem;
+      box-sizing: border-box;
+    }
+    .appearance-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: center;
+    }
+    .appearance-row select,
+    .appearance-row input {
+      padding: 0.4rem 0.75rem;
+      border-radius: 4px;
+      border: 1px solid #475569;
+      background: #0f172a;
+      color: #e2e8f0;
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>Issue #9866 — Interaction Utility Classes</h1>
+  <p>Proposed additions to <code>core/utilities.css</code>: user-select, resize, and appearance utilities.</p>
+
+  <section>
+    <h2>User Select</h2>
+    <p class="code">.ease-select-{none, text, all, auto}</p>
+    <p>Try selecting the text inside each card:</p>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <div class="try-select ease-select-none">This text cannot be selected</div>
+        <div class="label">ease-select-none</div>
+      </div>
+      <div class="demo-card">
+        <div class="try-select ease-select-text">This text is selectable</div>
+        <div class="label">ease-select-text</div>
+      </div>
+      <div class="demo-card">
+        <div class="try-select ease-select-all"><strong>Click anywhere</strong> in this box — all text selects</div>
+        <div class="label">ease-select-all</div>
+      </div>
+      <div class="demo-card">
+        <div class="try-select ease-select-auto">Browser default selection behavior</div>
+        <div class="label">ease-select-auto</div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Resize</h2>
+    <p class="code">.ease-resize-{none, both, horizontal, vertical}</p>
+    <p>Grab the bottom-right corner of each box to resize:</p>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <div class="resize-box ease-resize-none">Not resizable</div>
+        <div class="label">ease-resize-none</div>
+      </div>
+      <div class="demo-card">
+        <textarea class="resize-box ease-resize-both" readonly>Resize both directions</textarea>
+        <div class="label">ease-resize-both</div>
+      </div>
+      <div class="demo-card">
+        <textarea class="resize-box ease-resize-horizontal" readonly>Resize horizontally only</textarea>
+        <div class="label">ease-resize-horizontal</div>
+      </div>
+      <div class="demo-card">
+        <textarea class="resize-box ease-resize-vertical" readonly>Resize vertically only</textarea>
+        <div class="label">ease-resize-vertical</div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Appearance</h2>
+    <p class="code">.ease-appearance-none / .ease-appearance-auto</p>
+    <table>
+      <tr><th>Class</th><th>Select</th><th>Text Input</th></tr>
+      <tr>
+        <td>Default (no class)</td>
+        <td><select><option>Option 1</option><option>Option 2</option></select></td>
+        <td><input type="text" value="default style" /></td>
+      </tr>
+      <tr>
+        <td><code>ease-appearance-none</code></td>
+        <td><select class="ease-appearance-none"><option>Option 1</option><option>Option 2</option></select></td>
+        <td><input type="text" class="ease-appearance-none" value="native reset" /></td>
+      </tr>
+      <tr>
+        <td><code>ease-appearance-auto</code></td>
+        <td><select class="ease-appearance-auto"><option>Option 1</option><option>Option 2</option></select></td>
+        <td><input type="text" class="ease-appearance-auto" value="native style" /></td>
+      </tr>
+    </table>
+  </section>
+</body>
+</html>

--- a/submissions/core_changes-issue-9866/style.css
+++ b/submissions/core_changes-issue-9866/style.css
@@ -1,0 +1,17 @@
+/* Proposed interaction utility classes for core/utilities.css */
+
+/* User Select */
+.ease-select-none { user-select: none !important; }
+.ease-select-text { user-select: text !important; }
+.ease-select-all  { user-select: all !important; }
+.ease-select-auto { user-select: auto !important; }
+
+/* Resize */
+.ease-resize-none       { resize: none !important; }
+.ease-resize-both       { resize: both !important; }
+.ease-resize-horizontal { resize: horizontal !important; }
+.ease-resize-vertical   { resize: vertical !important; }
+
+/* Appearance */
+.ease-appearance-none { appearance: none !important; }
+.ease-appearance-auto { appearance: auto !important; }


### PR DESCRIPTION
## ✦ Description
Add utility classes for `user-select`, `resize`, and `appearance` to `core/utilities.css`. These properties control how users interact with elements — text selection, element resizing, and native form control appearance.

Fixes #9866

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## ✦ Checklist
- [x] All changes are inside `submissions/core_changes-issue-9866/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed utility classes
- [x] Includes `README.md` — describes proposed changes
- [x] **No changes to `core/` or `components/`**
- [x] One feature per PR

---

## ⟡ Description

### Root Cause
`core/utilities.css` has a small pointer-events section and cursor utilities but is missing `user-select`, `resize`, and `appearance` classes.

### Changes Made
Proposed additions to `core/utilities.css` in `submissions/core_changes-issue-9866/style.css`:
- **4 user-select** classes: none, text, all, auto
- **4 resize** classes: none, both, horizontal, vertical
- **2 appearance** classes: none, auto

### Testing Performed
Open `submissions/core_changes-issue-9866/demo.html` in a browser. Sections show:
- User-select — try selecting text in each card (none disabled, all selects whole on click)
- Resize — grab the corner of each textarea box
- Appearance — side-by-side comparison of native vs reset form elements

---

## Additional Notes
- No core framework files, components, or docs were modified
- Branch pushed: Pcmhacker-piro/EaseMotion-css:feat/core-changes-interaction-9866