### PR TITLE
[FEATURE]: Add ease-justify-self-*, ease-justify-items-*, ease-content-*, ease-place-self-*, and ease-place-content-* alignment utility classes

### DIFF
--- a/submissions/core_changes-issue-9861/README.md
+++ b/submissions/core_changes-issue-9861/README.md
@@ -1,0 +1,70 @@
+# Core Changes — Issue #9861: Add Alignment Utility Classes
+
+## Overview
+
+Add utility classes for `justify-self`, `justify-items`, `align-content`, `place-self`, and `place-content` to `core/utilities.css`. These complete the CSS box alignment set alongside the existing `align-items`, `align-self`, `justify-content`, and `place-items` utilities.
+
+## Problem
+
+1. **`justify-self`** — missing inline-axis item alignment (auto, start, end, center, stretch)
+2. **`justify-items`** — missing inline-axis container alignment
+3. **`align-content`** — missing space distribution between wrapped lines
+4. **`place-self`** / **`place-content`** — missing alignment shorthands
+
+## Proposed Changes
+
+### `core/utilities.css` — additions to the existing Alignment section
+
+**Justify Self** (5 classes):
+```
+.ease-justify-self-auto    → justify-self: auto
+.ease-justify-self-start   → justify-self: start
+.ease-justify-self-end     → justify-self: end
+.ease-justify-self-center  → justify-self: center
+.ease-justify-self-stretch → justify-self: stretch
+```
+
+**Justify Items** (4 classes):
+```
+.ease-justify-items-start   → justify-items: start
+.ease-justify-items-end     → justify-items: end
+.ease-justify-items-center  → justify-items: center
+.ease-justify-items-stretch → justify-items: stretch
+```
+
+**Align Content** (7 classes):
+```
+.ease-content-start   → align-content: flex-start
+.ease-content-end     → align-content: flex-end
+.ease-content-center  → align-content: center
+.ease-content-between → align-content: space-between
+.ease-content-around  → align-content: space-around
+.ease-content-evenly  → align-content: space-evenly
+.ease-content-stretch → align-content: stretch
+```
+
+**Place Self** (4 classes):
+```
+.ease-place-self-start   → place-self: start
+.ease-place-self-end     → place-self: end
+.ease-place-self-center  → place-self: center
+.ease-place-self-stretch → place-self: stretch
+```
+
+**Place Content** (4 classes):
+```
+.ease-place-content-start   → place-content: start
+.ease-place-content-end     → place-content: end
+.ease-place-content-center  → place-content: center
+.ease-place-content-between → place-content: space-between
+```
+
+## Affected Files
+
+- `core/utilities.css`
+
+## Labels
+
+- type:feature
+- level:intermediate
+- GSSoC-26

--- a/submissions/core_changes-issue-9861/demo.html
+++ b/submissions/core_changes-issue-9861/demo.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Issue #9861 — Alignment Utility Classes Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: Inter, Arial, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 960px;
+      margin: auto;
+    }
+    h1 { color: #f8fafc; border-bottom: 1px solid #334155; padding-bottom: 0.5rem; }
+    h2 { color: #94a3b8; font-size: 1.1rem; margin-top: 2rem; }
+    section { margin: 2rem 0; padding: 1.5rem; background: #1e293b; border-radius: 8px; }
+    .code { font-family: monospace; color: #38bdf8; font-size: 0.85rem; }
+    table { width: 100%; border-collapse: collapse; margin: 0.5rem 0; }
+    td, th { padding: 0.5rem; border: 1px solid #334155; }
+    th { background: #0f172a; color: #94a3b8; text-align: left; }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+    .card {
+      background: #334155;
+      border-radius: 6px;
+      padding: 1rem;
+      text-align: center;
+    }
+    .card .label { font-size: 0.75rem; color: #94a3b8; margin-top: 0.25rem; }
+    .container {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 4px;
+      background: #0f172a;
+      border-radius: 4px;
+      padding: 4px;
+      min-height: 80px;
+    }
+    .container .item {
+      background: #1e40af;
+      border-radius: 3px;
+      padding: 6px;
+      font-size: 0.7rem;
+      color: #e2e8f0;
+    }
+    .container .item.special { background: #7e22ce; }
+    .content-demo {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      background: #0f172a;
+      border-radius: 4px;
+      padding: 4px;
+      min-height: 100px;
+      align-items: flex-start;
+    }
+    .content-demo .item {
+      background: #1e40af;
+      border-radius: 3px;
+      padding: 8px;
+      font-size: 0.7rem;
+      color: #e2e8f0;
+      width: 100%;
+    }
+  </style>
+</head>
+<body>
+  <h1>Issue #9861 — Alignment Utility Classes</h1>
+  <p>Proposed additions to <code>core/utilities.css</code>: justify-self, justify-items, align-content, place-self, and place-content utilities.</p>
+
+  <section>
+    <h2>Justify Self</h2>
+    <p class="code">.ease-justify-self-{auto, start, end, center, stretch}</p>
+    <p>Each grid cell has the same class on its container; the purple item overrides with a different justify-self.</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-justify-self-auto</code></td><td><div class="container"><div class="item">A</div><div class="item special ease-justify-self-auto">auto</div><div class="item">B</div></div></td></tr>
+      <tr><td><code>ease-justify-self-start</code></td><td><div class="container"><div class="item">A</div><div class="item special ease-justify-self-start">start</div><div class="item">B</div></div></td></tr>
+      <tr><td><code>ease-justify-self-end</code></td><td><div class="container"><div class="item">A</div><div class="item special ease-justify-self-end">end</div><div class="item">B</div></div></td></tr>
+      <tr><td><code>ease-justify-self-center</code></td><td><div class="container"><div class="item">A</div><div class="item special ease-justify-self-center">center</div><div class="item">B</div></div></td></tr>
+      <tr><td><code>ease-justify-self-stretch</code></td><td><div class="container"><div class="item">A</div><div class="item special ease-justify-self-stretch">stretch</div><div class="item">B</div></div></td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Justify Items</h2>
+    <p class="code">.ease-justify-items-{start, end, center, stretch}</p>
+    <p>Applies to the grid container to align all items along the inline axis.</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-justify-items-start</code></td><td><div class="container ease-justify-items-start"><div class="item">A</div><div class="item">B</div><div class="item">C</div><div class="item">D</div><div class="item">E</div><div class="item">F</div></div></td></tr>
+      <tr><td><code>ease-justify-items-end</code></td><td><div class="container ease-justify-items-end"><div class="item">A</div><div class="item">B</div><div class="item">C</div><div class="item">D</div><div class="item">E</div><div class="item">F</div></div></td></tr>
+      <tr><td><code>ease-justify-items-center</code></td><td><div class="container ease-justify-items-center"><div class="item">A</div><div class="item">B</div><div class="item">C</div><div class="item">D</div><div class="item">E</div><div class="item">F</div></div></td></tr>
+      <tr><td><code>ease-justify-items-stretch</code></td><td><div class="container ease-justify-items-stretch"><div class="item">A</div><div class="item">B</div><div class="item">C</div><div class="item">D</div><div class="item">E</div><div class="item">F</div></div></td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Align Content</h2>
+    <p class="code">.ease-content-{start, end, center, between, around, evenly, stretch}</p>
+    <p>Distributes space between wrapped flex lines.</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-content-start</code></td><td><div class="content-demo ease-content-start" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div><div class="item">Line 3</div></div></td></tr>
+      <tr><td><code>ease-content-end</code></td><td><div class="content-demo ease-content-end" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div><div class="item">Line 3</div></div></td></tr>
+      <tr><td><code>ease-content-center</code></td><td><div class="content-demo ease-content-center" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div><div class="item">Line 3</div></div></td></tr>
+      <tr><td><code>ease-content-between</code></td><td><div class="content-demo ease-content-between" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div><div class="item">Line 3</div></div></td></tr>
+      <tr><td><code>ease-content-around</code></td><td><div class="content-demo ease-content-around" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div><div class="item">Line 3</div></div></td></tr>
+      <tr><td><code>ease-content-evenly</code></td><td><div class="content-demo ease-content-evenly" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div><div class="item">Line 3</div></div></td></tr>
+      <tr><td><code>ease-content-stretch</code></td><td><div class="content-demo ease-content-stretch" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div><div class="item">Line 3</div></div></td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Place Self</h2>
+    <p class="code">.ease-place-self-{start, end, center, stretch}</p>
+    <p>Shorthand for <code>align-self</code> + <code>justify-self</code>. Purple items show the override.</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-place-self-start</code></td><td><div class="container"><div class="item">A</div><div class="item special ease-place-self-start">start</div><div class="item">B</div></div></td></tr>
+      <tr><td><code>ease-place-self-end</code></td><td><div class="container"><div class="item">A</div><div class="item special ease-place-self-end">end</div><div class="item">B</div></div></td></tr>
+      <tr><td><code>ease-place-self-center</code></td><td><div class="container"><div class="item">A</div><div class="item special ease-place-self-center">center</div><div class="item">B</div></div></td></tr>
+      <tr><td><code>ease-place-self-stretch</code></td><td><div class="container"><div class="item">A</div><div class="item special ease-place-self-stretch">stretch</div><div class="item">B</div></div></td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Place Content</h2>
+    <p class="code">.ease-place-content-{start, end, center, between}</p>
+    <p>Shorthand for <code>align-content</code> + <code>justify-content</code>.</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-place-content-start</code></td><td><div class="content-demo ease-place-content-start" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div></div></td></tr>
+      <tr><td><code>ease-place-content-end</code></td><td><div class="content-demo ease-place-content-end" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div></div></td></tr>
+      <tr><td><code>ease-place-content-center</code></td><td><div class="content-demo ease-place-content-center" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div></div></td></tr>
+      <tr><td><code>ease-place-content-between</code></td><td><div class="content-demo ease-place-content-between" style="height: 120px;"><div class="item">Line 1</div><div class="item">Line 2</div></div></td></tr>
+    </table>
+  </section>
+</body>
+</html>

--- a/submissions/core_changes-issue-9861/style.css
+++ b/submissions/core_changes-issue-9861/style.css
@@ -1,0 +1,35 @@
+/* Proposed alignment utility classes for core/utilities.css */
+
+/* Justify Self */
+.ease-justify-self-auto    { justify-self: auto !important; }
+.ease-justify-self-start   { justify-self: start !important; }
+.ease-justify-self-end     { justify-self: end !important; }
+.ease-justify-self-center  { justify-self: center !important; }
+.ease-justify-self-stretch { justify-self: stretch !important; }
+
+/* Justify Items */
+.ease-justify-items-start   { justify-items: start !important; }
+.ease-justify-items-end     { justify-items: end !important; }
+.ease-justify-items-center  { justify-items: center !important; }
+.ease-justify-items-stretch { justify-items: stretch !important; }
+
+/* Align Content */
+.ease-content-start   { align-content: flex-start !important; }
+.ease-content-end     { align-content: flex-end !important; }
+.ease-content-center  { align-content: center !important; }
+.ease-content-between { align-content: space-between !important; }
+.ease-content-around  { align-content: space-around !important; }
+.ease-content-evenly  { align-content: space-evenly !important; }
+.ease-content-stretch { align-content: stretch !important; }
+
+/* Place Self */
+.ease-place-self-start   { place-self: start !important; }
+.ease-place-self-end     { place-self: end !important; }
+.ease-place-self-center  { place-self: center !important; }
+.ease-place-self-stretch { place-self: stretch !important; }
+
+/* Place Content */
+.ease-place-content-start   { place-content: start !important; }
+.ease-place-content-end     { place-content: end !important; }
+.ease-place-content-center  { place-content: center !important; }
+.ease-place-content-between { place-content: space-between !important; }


### PR DESCRIPTION
## ✦ Description
Add utility classes for `justify-self`, `justify-items`, `align-content`, `place-self`, and `place-content` to `core/utilities.css`. These complete the CSS box alignment set alongside the existing align-items, align-self, justify-content, and place-items utilities.

Fixes #9861

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## ✦ Checklist
- [x] All changes are inside `submissions/core_changes-issue-9861/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed utility classes
- [x] Includes `README.md` — describes proposed changes
- [x] **No changes to `core/` or `components/`**
- [x] One feature per PR

---

## ⟡ Description

### Root Cause
`core/utilities.css` has align-items, align-self, justify-content, and place-items but is missing justify-self, justify-items, align-content, place-self, and place-content.

### Changes Made
Proposed additions to `core/utilities.css` in `submissions/core_changes-issue-9861/style.css`:
- **5 justify-self** classes: auto, start, end, center, stretch
- **4 justify-items** classes: start, end, center, stretch
- **7 align-content** classes: start, end, center, between, around, evenly, stretch
- **4 place-self** classes: start, end, center, stretch
- **4 place-content** classes: start, end, center, between

### Testing Performed
Open `submissions/core_changes-issue-9861/demo.html` in a browser. Grid cells with a highlighted purple item demonstrate justify-self and place-self overrides. Multi-line flex containers demonstrate align-content and place-content distribution.

---

## Additional Notes
- Naming matches existing convention: `ease-content-*` for align-content (parallels `ease-justify-*` for justify-content)
- No core framework files, components, or docs were modified
- Branch pushed: Pcmhacker-piro/EaseMotion-css:feat/core-changes-alignment-9861