### PR TITLE
[FEATURE]: Add ease-grid-flow-*, ease-auto-rows-*, and ease-auto-cols-* grid auto utility classes

### DIFF
--- a/submissions/core_changes-issue-9860/README.md
+++ b/submissions/core_changes-issue-9860/README.md
@@ -1,0 +1,49 @@
+# Core Changes — Issue #9860: Add Grid Auto Utility Classes
+
+## Overview
+
+Add utility classes for `grid-auto-flow`, `grid-auto-rows`, and `grid-auto-columns` to `core/utilities.css`. The current Grid section provides `grid-template-columns` utilities but no implicit grid controls.
+
+## Problem
+
+1. **`grid-auto-flow`** — no utilities for row/column/dense auto-placement
+2. **`grid-auto-rows`** — no utilities for implicit row sizing
+3. **`grid-auto-columns`** — no utilities for implicit column sizing
+
+## Proposed Changes
+
+### `core/utilities.css` — additions after existing grid-column section
+
+**Grid Auto Flow** (5 classes):
+```
+.ease-grid-flow-row       → grid-auto-flow: row
+.ease-grid-flow-col       → grid-auto-flow: column
+.ease-grid-flow-dense     → grid-auto-flow: dense
+.ease-grid-flow-row-dense → grid-auto-flow: row dense
+.ease-grid-flow-col-dense → grid-auto-flow: column dense
+```
+
+**Grid Auto Rows** (4 classes):
+```
+.ease-auto-rows-min  → grid-auto-rows: min-content
+.ease-auto-rows-max  → grid-auto-rows: max-content
+.ease-auto-rows-fr   → grid-auto-rows: minmax(0, 1fr)
+.ease-auto-rows-auto → grid-auto-rows: auto
+```
+
+**Grid Auto Columns** (3 classes):
+```
+.ease-auto-cols-min  → grid-auto-columns: min-content
+.ease-auto-cols-max  → grid-auto-columns: max-content
+.ease-auto-cols-fr   → grid-auto-columns: minmax(0, 1fr)
+```
+
+## Affected Files
+
+- `core/utilities.css`
+
+## Labels
+
+- type:feature
+- level:intermediate
+- GSSoC-26

--- a/submissions/core_changes-issue-9860/demo.html
+++ b/submissions/core_changes-issue-9860/demo.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Issue #9860 — Grid Auto Utility Classes Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: Inter, Arial, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 960px;
+      margin: auto;
+    }
+    h1 { color: #f8fafc; border-bottom: 1px solid #334155; padding-bottom: 0.5rem; }
+    h2 { color: #94a3b8; font-size: 1.1rem; margin-top: 2rem; }
+    section { margin: 2rem 0; padding: 1.5rem; background: #1e293b; border-radius: 8px; }
+    .code { font-family: monospace; color: #38bdf8; font-size: 0.85rem; }
+    table { width: 100%; border-collapse: collapse; margin: 0.5rem 0; }
+    td, th { padding: 0.5rem; border: 1px solid #334155; }
+    th { background: #0f172a; color: #94a3b8; text-align: left; }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 1rem;
+    }
+    .card {
+      background: #334155;
+      border-radius: 6px;
+      padding: 1rem;
+    }
+    .card .label { font-size: 0.75rem; color: #94a3b8; margin-top: 0.25rem; }
+    .grid-demo {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 4px;
+      background: #0f172a;
+      border-radius: 4px;
+      padding: 4px;
+      min-height: 120px;
+    }
+    .grid-demo .item {
+      background: #1e40af;
+      border-radius: 3px;
+      padding: 8px;
+      font-size: 0.75rem;
+      text-align: center;
+      color: #e2e8f0;
+    }
+    .grid-demo .item.tall { background: #7e22ce; grid-row: span 2; }
+    .grid-demo .item.wide { background: #047857; grid-column: span 2; }
+    .grid-demo.cols-demo {
+      grid-template-columns: repeat(2, 1fr);
+      grid-template-rows: repeat(3, 60px);
+    }
+    .grid-demo.rows-demo {
+      grid-template-columns: repeat(3, 1fr);
+      grid-template-rows: 40px 40px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Issue #9860 — Grid Auto Utility Classes</h1>
+  <p>Proposed additions to <code>core/utilities.css</code>: grid-auto-flow, grid-auto-rows, and grid-auto-columns utilities.</p>
+
+  <section>
+    <h2>Grid Auto Flow</h2>
+    <p class="code">.ease-grid-flow-{row, col, dense, row-dense, col-dense}</p>
+    <p>Controls how auto-placed items fill the grid. Tall items span 2 rows; colored items show placement differences.</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-grid-flow-row</code></td><td><div class="grid-demo ease-grid-flow-row"><div class="item">1</div><div class="item tall">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div></div></td></tr>
+      <tr><td><code>ease-grid-flow-col</code></td><td><div class="grid-demo ease-grid-flow-col"><div class="item">1</div><div class="item tall">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div></div></td></tr>
+      <tr><td><code>ease-grid-flow-dense</code></td><td><div class="grid-demo ease-grid-flow-dense"><div class="item">1</div><div class="item tall">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div></div></td></tr>
+      <tr><td><code>ease-grid-flow-row-dense</code></td><td><div class="grid-demo ease-grid-flow-row-dense"><div class="item">1</div><div class="item tall">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div></div></td></tr>
+      <tr><td><code>ease-grid-flow-col-dense</code></td><td><div class="grid-demo ease-grid-flow-col-dense"><div class="item">1</div><div class="item tall">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div></div></td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Grid Auto Rows</h2>
+    <p class="code">.ease-auto-rows-{min, max, fr, auto}</p>
+    <p>Sets the size of implicitly-created rows (items placed beyond the defined grid template).</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-auto-rows-min</code></td><td><div class="grid-demo rows-demo ease-auto-rows-min"><div class="item">1</div><div class="item">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div><div class="item">7</div><div class="item">8</div></div></td></tr>
+      <tr><td><code>ease-auto-rows-max</code></td><td><div class="grid-demo rows-demo ease-auto-rows-max"><div class="item" style="height: 60px;">A</div><div class="item">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div><div class="item">7</div><div class="item">8</div></div></td></tr>
+      <tr><td><code>ease-auto-rows-fr</code></td><td><div class="grid-demo rows-demo ease-auto-rows-fr"><div class="item">1</div><div class="item">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div><div class="item">7</div><div class="item">8</div></div></td></tr>
+      <tr><td><code>ease-auto-rows-auto</code></td><td><div class="grid-demo rows-demo ease-auto-rows-auto"><div class="item">1</div><div class="item">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div><div class="item">7</div><div class="item">8</div></div></td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Grid Auto Columns</h2>
+    <p class="code">.ease-auto-cols-{min, max, fr}</p>
+    <p>Sets the size of implicitly-created columns (used with <code>grid-auto-flow: column</code>).</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-auto-cols-min</code></td><td><div class="grid-demo cols-demo ease-grid-flow-col ease-auto-cols-min"><div class="item">1</div><div class="item">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div></div></td></tr>
+      <tr><td><code>ease-auto-cols-max</code></td><td><div class="grid-demo cols-demo ease-grid-flow-col ease-auto-cols-max"><div class="item" style="width: 80px;">1</div><div class="item">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div></div></td></tr>
+      <tr><td><code>ease-auto-cols-fr</code></td><td><div class="grid-demo cols-demo ease-grid-flow-col ease-auto-cols-fr"><div class="item">1</div><div class="item">2</div><div class="item">3</div><div class="item">4</div><div class="item">5</div><div class="item">6</div></div></td></tr>
+    </table>
+  </section>
+</body>
+</html>

--- a/submissions/core_changes-issue-9860/style.css
+++ b/submissions/core_changes-issue-9860/style.css
@@ -1,0 +1,19 @@
+/* Proposed grid auto utility classes for core/utilities.css */
+
+/* Grid Auto Flow */
+.ease-grid-flow-row       { grid-auto-flow: row !important; }
+.ease-grid-flow-col       { grid-auto-flow: column !important; }
+.ease-grid-flow-dense     { grid-auto-flow: dense !important; }
+.ease-grid-flow-row-dense { grid-auto-flow: row dense !important; }
+.ease-grid-flow-col-dense { grid-auto-flow: column dense !important; }
+
+/* Grid Auto Rows */
+.ease-auto-rows-min  { grid-auto-rows: min-content !important; }
+.ease-auto-rows-max  { grid-auto-rows: max-content !important; }
+.ease-auto-rows-fr   { grid-auto-rows: minmax(0, 1fr) !important; }
+.ease-auto-rows-auto { grid-auto-rows: auto !important; }
+
+/* Grid Auto Columns */
+.ease-auto-cols-min  { grid-auto-columns: min-content !important; }
+.ease-auto-cols-max  { grid-auto-columns: max-content !important; }
+.ease-auto-cols-fr   { grid-auto-columns: minmax(0, 1fr) !important; }


### PR DESCRIPTION
## ✦ Description
Add utility classes for grid-auto-flow, grid-auto-rows, and grid-auto-columns to `core/utilities.css`. The current Grid section has grid-template-columns utilities but no implicit grid controls for auto-placement and sizing.

Fixes #9860

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## ✦ Checklist
- [x] All changes are inside `submissions/core_changes-issue-9860/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed utility classes
- [x] Includes `README.md` — describes proposed changes
- [x] **No changes to `core/` or `components/`**
- [x] One feature per PR

---

## ⟡ Description

### Root Cause
`core/utilities.css` has grid-template-columns utilities but no grid-auto-flow, grid-auto-rows, or grid-auto-columns.

### Changes Made
Proposed additions to `core/utilities.css` in `submissions/core_changes-issue-9860/style.css`:
- **5 grid-auto-flow** classes: row, col, dense, row-dense, col-dense
- **4 grid-auto-rows** classes: min, max, fr, auto
- **3 grid-auto-columns** classes: min, max, fr

### Testing Performed
Open `submissions/core_changes-issue-9860/demo.html` in a browser. Grid cells with tall/wide items show flow behavior differences. Extra items beyond the template demonstrate auto-rows and auto-columns sizing.

---

## Additional Notes
- Dense mode fills gaps left by items spanning multiple tracks
- `ease-auto-rows-fr` and `ease-auto-cols-fr` use `minmax(0, 1fr)` for equal distribution
- No core framework files, components, or docs were modified
- Branch pushed: Pcmhacker-piro/EaseMotion-css:feat/core-changes-grid-auto-9860