### PR TITLE
[FEATURE]: Add ease-mi-s/e, ease-mbs/e, ease-pi-s/e, ease-pbs/e, and ease-inset-* logical/flow-relative property utility classes

### DIFF
--- a/submissions/core_changes-issue-9857/README.md
+++ b/submissions/core_changes-issue-9857/README.md
@@ -1,0 +1,62 @@
+# Core Changes — Issue #9857: Add Logical (Flow-Relative) Property Utility Classes
+
+## Overview
+
+Add utility classes for flow-relative CSS logical properties to `core/utilities.css`. These properties respect `writing-mode` and `direction` (LTR/RTL), enabling layouts that automatically adapt to different scripts.
+
+## Problem
+
+1. **`margin-inline` / `margin-block`** — no flow-relative margin utilities (physical `mt-4`, `ml-4` don't flip in RTL)
+2. **`padding-inline` / `padding-block`** — no flow-relative padding utilities
+3. **`inset-inline` / `inset-block`** — no logical positioning utilities
+
+## Proposed Changes
+
+### `core/utilities.css` — new Logical (Flow-Relative) Spacing section after margin section
+
+**Margin Inline** (19 classes):
+```
+.ease-mi-s, .ease-mi-e                → margin-inline-start/end: var(--ease-space-4)
+.ease-mi-s-{1,2,3,4,6,8,10,12}        → margin-inline-start with size
+.ease-mi-e-{1,2,3,4,6,8,10,12}        → margin-inline-end with size
+.ease-margin-inline-auto               → margin-inline: auto
+```
+
+**Margin Block** (18 classes):
+```
+.ease-mbs, .ease-mbe                   → margin-block-start/end: var(--ease-space-4)
+.ease-mbs-{1,2,3,4,6,8,10,12}         → margin-block-start with size
+.ease-mbe-{1,2,3,4,6,8,10,12}         → margin-block-end with size
+```
+
+**Padding Inline** (18 classes):
+```
+.ease-pi-s, .ease-pi-e                → padding-inline-start/end: var(--ease-space-4)
+.ease-pi-s-{1,2,3,4,6,8,10,12}       → padding-inline-start with size
+.ease-pi-e-{1,2,3,4,6,8,10,12}       → padding-inline-end with size
+```
+
+**Padding Block** (18 classes):
+```
+.ease-pbs, .ease-pbe                  → padding-block-start/end: var(--ease-space-4)
+.ease-pbs-{1,2,3,4,6,8,10,12}        → padding-block-start with size
+.ease-pbe-{1,2,3,4,6,8,10,12}        → padding-block-end with size
+```
+
+**Inset Logical** (4 classes):
+```
+.ease-inset-inline-0  → inset-inline: 0
+.ease-inset-block-0   → inset-block: 0
+.ease-is-0            → inset-inline-start: 0
+.ease-ie-0            → inset-inline-end: 0
+```
+
+## Affected Files
+
+- `core/utilities.css`
+
+## Labels
+
+- type:feature
+- level:intermediate
+- GSSoC-26

--- a/submissions/core_changes-issue-9857/demo.html
+++ b/submissions/core_changes-issue-9857/demo.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Issue #9857 — Logical Property Utility Classes Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body {
+      font-family: Inter, Arial, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 960px;
+      margin: auto;
+    }
+    h1 { color: #f8fafc; border-bottom: 1px solid #334155; padding-bottom: 0.5rem; }
+    h2 { color: #94a3b8; font-size: 1.1rem; margin-top: 2rem; }
+    section { margin: 2rem 0; padding: 1.5rem; background: #1e293b; border-radius: 8px; }
+    .code { font-family: monospace; color: #38bdf8; font-size: 0.85rem; }
+    table { width: 100%; border-collapse: collapse; margin: 0.5rem 0; }
+    td, th { padding: 0.5rem; border: 1px solid #334155; }
+    th { background: #0f172a; color: #94a3b8; text-align: left; }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 1rem;
+    }
+    .card {
+      background: #334155;
+      border-radius: 6px;
+      padding: 1rem;
+    }
+    .card .label { font-size: 0.75rem; color: #94a3b8; margin-top: 0.25rem; }
+    .card p { font-size: 0.85rem; margin: 0 0 0.25rem; }
+    .box {
+      background: #0f172a;
+      border: 1px solid #475569;
+      border-radius: 4px;
+      padding: 0.25rem;
+      min-height: 40px;
+    }
+    .box .inner {
+      background: #1e40af;
+      border-radius: 3px;
+      padding: 0.25rem 0.5rem;
+      font-size: 0.7rem;
+      display: inline-block;
+    }
+    .rtl-box {
+      direction: rtl;
+      text-align: start;
+    }
+    .pill {
+      display: inline-block;
+      background: #1e40af;
+      border-radius: 999px;
+      padding: 0.25rem 0.5rem;
+      font-size: 0.7rem;
+    }
+    .pill.outset {
+      background: transparent;
+      border: 1px dashed #475569;
+    }
+    .inset-demo {
+      position: relative;
+      height: 60px;
+      background: #0f172a;
+      border-radius: 4px;
+      margin: 0.5rem 0;
+    }
+    .inset-demo .overlay {
+      position: absolute;
+      background: rgba(30, 64, 175, 0.5);
+      border: 1px solid #3b82f6;
+      border-radius: 2px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.65rem;
+    }
+    .two-panel {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+    .two-panel > div { min-width: 0; }
+  </style>
+</head>
+<body>
+  <h1>Issue #9857 — Logical (Flow-Relative) Property Utility Classes</h1>
+  <p>Proposed additions to <code>core/utilities.css</code>: margin-inline, margin-block, padding-inline, padding-block, and inset logical utilities that respect <code>writing-mode</code> and <code>direction</code>.</p>
+
+  <section>
+    <h2>How Logical Properties Work</h2>
+    <p>Logical properties respect the document's writing direction. In LTR, <code>inline-start</code> = left; in RTL, it flips to right.</p>
+    <div class="two-panel">
+      <div>
+        <p style="color: #38bdf8;">LTR (left-to-right)</p>
+        <div class="box" style="display: flex;">
+          <span class="inner ease-mi-s-4">mi-s (start margin)</span>
+        </div>
+      </div>
+      <div>
+        <p style="color: #f472b6;">RTL (right-to-left)</p>
+        <div class="box rtl-box" style="display: flex;">
+          <span class="inner ease-mi-s-4">mi-s flips!</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Margin Inline</h2>
+    <p class="code">.ease-mi-s (start) / .ease-mi-e (end) + scale: {1,2,3,4,6,8,10,12}</p>
+    <p><code>ease-margin-inline-auto</code> centers block elements in both LTR and RTL.</p>
+    <table>
+      <tr><th>Class</th><th>LTR Preview</th><th>RTL Preview</th></tr>
+      <tr><td><code>ease-mi-s-4</code></td><td><div class="box" style="display: flex;"><span class="inner ease-mi-s-4">start margin</span></div></td><td><div class="box rtl-box" style="display: flex;"><span class="inner ease-mi-s-4">start margin</span></div></td></tr>
+      <tr><td><code>ease-mi-e-4</code></td><td><div class="box" style="display: flex; justify-content: flex-end;"><span class="inner ease-mi-e-4">end margin</span></div></td><td><div class="box rtl-box" style="display: flex; justify-content: flex-start;"><span class="inner ease-mi-e-4" style="direction: ltr;">end margin</span></div></td></tr>
+      <tr><td><code>ease-margin-inline-auto</code></td><td><div class="box ease-margin-inline-auto" style="width: 60%;"><div class="inner">auto</div></div></td><td><div class="box rtl-box ease-margin-inline-auto" style="width: 60%;"><div class="inner">auto</div></div></td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Margin Block</h2>
+    <p class="code">.ease-mbs (block-start) / .ease-mbe (block-end) + scale: {1,2,3,4,6,8,10,12}</p>
+    <p><code>block-start</code> = top, <code>block-end</code> = bottom (same in both LTR and RTL).</p>
+    <table>
+      <tr><th>Class</th><th>Preview</th></tr>
+      <tr><td><code>ease-mbs-4</code></td><td><div class="box" style="display: flex; flex-direction: column;"><span class="inner ease-mbs-4">block-start margin (top)</span></div></td></tr>
+      <tr><td><code>ease-mbe-4</code></td><td><div class="box" style="display: flex; flex-direction: column;"><span class="inner ease-mbe-4">block-end margin (bottom)</span></div></td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Padding Inline</h2>
+    <p class="code">.ease-pi-s (start) / .ease-pi-e (end) + scale: {1,2,3,4,6,8,10,12}</p>
+    <div class="demo-grid">
+      <div class="card">
+        <div class="box"><span class="inner ease-pi-s-4">pi-s-4 padding start</span></div>
+        <div class="label">LTR: ease-pi-s-4</div>
+      </div>
+      <div class="card">
+        <div class="box rtl-box"><span class="inner ease-pi-s-4">pi-s-4 flips</span></div>
+        <div class="label">RTL: ease-pi-s-4</div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Padding Block</h2>
+    <p class="code">.ease-pbs (block-start) / .ease-pbe (block-end) + scale: {1,2,3,4,6,8,10,12}</p>
+    <div class="demo-grid">
+      <div class="card">
+        <div class="box" style="display: flex; flex-direction: column;"><span class="inner ease-pbs-4">pbs-4 top padding</span></div>
+        <div class="label">ease-pbs-4 (padding-block-start)</div>
+      </div>
+      <div class="card">
+        <div class="box" style="display: flex; flex-direction: column;"><span class="inner ease-pbe-4">pbe-4 bottom padding</span></div>
+        <div class="label">ease-pbe-4 (padding-block-end)</div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Inset Logical</h2>
+    <p class="code">.ease-inset-inline-0 / .ease-inset-block-0 / .ease-is-0 / .ease-ie-0</p>
+    <p>Used for positioning absolutely-positioned elements with logical coordinates.</p>
+    <div class="demo-grid">
+      <div class="card">
+        <div class="inset-demo">
+          <div class="overlay ease-inset-inline-0" style="top: 0; height: 50%;">inset-inline: 0</div>
+        </div>
+        <div class="label">ease-inset-inline-0</div>
+      </div>
+      <div class="card">
+        <div class="inset-demo">
+          <div class="overlay ease-inset-block-0" style="left: 0; width: 50%;">inset-block: 0</div>
+        </div>
+        <div class="label">ease-inset-block-0</div>
+      </div>
+      <div class="card">
+        <div class="inset-demo" style="position: relative;">
+          <div class="overlay ease-is-0" style="top: 0; height: 100%; width: 40%;">is-0</div>
+        </div>
+        <div class="label">ease-is-0 (inline-start:0)</div>
+      </div>
+      <div class="card">
+        <div class="inset-demo" style="position: relative;">
+          <div class="overlay ease-ie-0" style="top: 0; height: 100%; width: 40%;">ie-0</div>
+        </div>
+        <div class="label">ease-ie-0 (inline-end:0)</div>
+      </div>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/core_changes-issue-9857/style.css
+++ b/submissions/core_changes-issue-9857/style.css
@@ -1,0 +1,93 @@
+/* Proposed logical (flow-relative) property utility classes for core/utilities.css */
+
+/* ── Margin Inline ───────────────────────────────────── */
+
+.ease-mi-s { margin-inline-start: var(--ease-space-4) !important; }
+.ease-mi-e { margin-inline-end:   var(--ease-space-4) !important; }
+.ease-mi-s-1  { margin-inline-start: var(--ease-space-1) !important; }
+.ease-mi-e-1  { margin-inline-end:   var(--ease-space-1) !important; }
+.ease-mi-s-2  { margin-inline-start: var(--ease-space-2) !important; }
+.ease-mi-e-2  { margin-inline-end:   var(--ease-space-2) !important; }
+.ease-mi-s-3  { margin-inline-start: var(--ease-space-3) !important; }
+.ease-mi-e-3  { margin-inline-end:   var(--ease-space-3) !important; }
+.ease-mi-s-4  { margin-inline-start: var(--ease-space-4) !important; }
+.ease-mi-e-4  { margin-inline-end:   var(--ease-space-4) !important; }
+.ease-mi-s-6  { margin-inline-start: var(--ease-space-6) !important; }
+.ease-mi-e-6  { margin-inline-end:   var(--ease-space-6) !important; }
+.ease-mi-s-8  { margin-inline-start: var(--ease-space-8) !important; }
+.ease-mi-e-8  { margin-inline-end:   var(--ease-space-8) !important; }
+.ease-mi-s-10 { margin-inline-start: var(--ease-space-10) !important; }
+.ease-mi-e-10 { margin-inline-end:   var(--ease-space-10) !important; }
+.ease-mi-s-12 { margin-inline-start: var(--ease-space-12) !important; }
+.ease-mi-e-12 { margin-inline-end:   var(--ease-space-12) !important; }
+.ease-margin-inline-auto { margin-inline: auto !important; }
+
+/* ── Margin Block ────────────────────────────────────── */
+
+.ease-mbs { margin-block-start: var(--ease-space-4) !important; }
+.ease-mbe { margin-block-end:   var(--ease-space-4) !important; }
+.ease-mbs-1  { margin-block-start: var(--ease-space-1) !important; }
+.ease-mbe-1  { margin-block-end:   var(--ease-space-1) !important; }
+.ease-mbs-2  { margin-block-start: var(--ease-space-2) !important; }
+.ease-mbe-2  { margin-block-end:   var(--ease-space-2) !important; }
+.ease-mbs-3  { margin-block-start: var(--ease-space-3) !important; }
+.ease-mbe-3  { margin-block-end:   var(--ease-space-3) !important; }
+.ease-mbs-4  { margin-block-start: var(--ease-space-4) !important; }
+.ease-mbe-4  { margin-block-end:   var(--ease-space-4) !important; }
+.ease-mbs-6  { margin-block-start: var(--ease-space-6) !important; }
+.ease-mbe-6  { margin-block-end:   var(--ease-space-6) !important; }
+.ease-mbs-8  { margin-block-start: var(--ease-space-8) !important; }
+.ease-mbe-8  { margin-block-end:   var(--ease-space-8) !important; }
+.ease-mbs-10 { margin-block-start: var(--ease-space-10) !important; }
+.ease-mbe-10 { margin-block-end:   var(--ease-space-10) !important; }
+.ease-mbs-12 { margin-block-start: var(--ease-space-12) !important; }
+.ease-mbe-12 { margin-block-end:   var(--ease-space-12) !important; }
+
+/* ── Padding Inline ──────────────────────────────────── */
+
+.ease-pi-s { padding-inline-start: var(--ease-space-4) !important; }
+.ease-pi-e { padding-inline-end:   var(--ease-space-4) !important; }
+.ease-pi-s-1  { padding-inline-start: var(--ease-space-1) !important; }
+.ease-pi-e-1  { padding-inline-end:   var(--ease-space-1) !important; }
+.ease-pi-s-2  { padding-inline-start: var(--ease-space-2) !important; }
+.ease-pi-e-2  { padding-inline-end:   var(--ease-space-2) !important; }
+.ease-pi-s-3  { padding-inline-start: var(--ease-space-3) !important; }
+.ease-pi-e-3  { padding-inline-end:   var(--ease-space-3) !important; }
+.ease-pi-s-4  { padding-inline-start: var(--ease-space-4) !important; }
+.ease-pi-e-4  { padding-inline-end:   var(--ease-space-4) !important; }
+.ease-pi-s-6  { padding-inline-start: var(--ease-space-6) !important; }
+.ease-pi-e-6  { padding-inline-end:   var(--ease-space-6) !important; }
+.ease-pi-s-8  { padding-inline-start: var(--ease-space-8) !important; }
+.ease-pi-e-8  { padding-inline-end:   var(--ease-space-8) !important; }
+.ease-pi-s-10 { padding-inline-start: var(--ease-space-10) !important; }
+.ease-pi-e-10 { padding-inline-end:   var(--ease-space-10) !important; }
+.ease-pi-s-12 { padding-inline-start: var(--ease-space-12) !important; }
+.ease-pi-e-12 { padding-inline-end:   var(--ease-space-12) !important; }
+
+/* ── Padding Block ───────────────────────────────────── */
+
+.ease-pbs { padding-block-start: var(--ease-space-4) !important; }
+.ease-pbe { padding-block-end:   var(--ease-space-4) !important; }
+.ease-pbs-1  { padding-block-start: var(--ease-space-1) !important; }
+.ease-pbe-1  { padding-block-end:   var(--ease-space-1) !important; }
+.ease-pbs-2  { padding-block-start: var(--ease-space-2) !important; }
+.ease-pbe-2  { padding-block-end:   var(--ease-space-2) !important; }
+.ease-pbs-3  { padding-block-start: var(--ease-space-3) !important; }
+.ease-pbe-3  { padding-block-end:   var(--ease-space-3) !important; }
+.ease-pbs-4  { padding-block-start: var(--ease-space-4) !important; }
+.ease-pbe-4  { padding-block-end:   var(--ease-space-4) !important; }
+.ease-pbs-6  { padding-block-start: var(--ease-space-6) !important; }
+.ease-pbe-6  { padding-block-end:   var(--ease-space-6) !important; }
+.ease-pbs-8  { padding-block-start: var(--ease-space-8) !important; }
+.ease-pbe-8  { padding-block-end:   var(--ease-space-8) !important; }
+.ease-pbs-10 { padding-block-start: var(--ease-space-10) !important; }
+.ease-pbe-10 { padding-block-end:   var(--ease-space-10) !important; }
+.ease-pbs-12 { padding-block-start: var(--ease-space-12) !important; }
+.ease-pbe-12 { padding-block-end:   var(--ease-space-12) !important; }
+
+/* ── Inset Logical ───────────────────────────────────── */
+
+.ease-inset-inline-0 { inset-inline: 0 !important; }
+.ease-inset-block-0  { inset-block: 0 !important; }
+.ease-is-0 { inset-inline-start: 0 !important; }
+.ease-ie-0 { inset-inline-end: 0 !important; }


### PR DESCRIPTION
## ✦ Description
Add utility classes for CSS logical (flow-relative) properties to `core/utilities.css`. These properties respect `writing-mode` and `direction`, enabling layouts that automatically adapt to RTL scripts like Arabic/Hebrew and vertical writing modes.

Fixes #9857

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## ✦ Checklist
- [x] All changes are inside `submissions/core_changes-issue-9857/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed utility classes
- [x] Includes `README.md` — describes proposed changes
- [x] **No changes to `core/` or `components/`**
- [x] One feature per PR

---

## ⟡ Description

### Root Cause
`core/utilities.css` only has physical-direction spacing utilities (mt-4, ml-4, etc.) that do not flip in RTL layouts.

### Changes Made
Proposed additions to `core/utilities.css` in `submissions/core_changes-issue-9857/style.css`:
- **19 margin-inline** classes: mi-s/e (base) + 8 scale variants each + margin-inline-auto
- **18 margin-block** classes: mbs/mbe (base) + 8 scale variants each
- **18 padding-inline** classes: pi-s/e (base) + 8 scale variants each
- **18 padding-block** classes: pbs/pbe (base) + 8 scale variants each
- **4 inset logical** classes: inset-inline-0, inset-block-0, is-0, ie-0

All classes use `!important` and `--ease-space-*` design tokens (sizes: 1,2,3,4,6,8,10,12).

### Testing Performed
Open `submissions/core_changes-issue-9857/demo.html` in a browser. Side-by-side LTR/RTL panels show how `mi-s` (inline-start) flips automatically. Inset classes demonstrate logical positioning for absolutely-positioned elements.

---

## Additional Notes
- Naming convention: s=start, e=end, bs=block-start, be=block-end, pi=padding-inline, mi=margin-inline, pbs=padding-block-start, mbe=margin-block-end
- No core framework files, components, or docs were modified
- Branch pushed: Pcmhacker-piro/EaseMotion-css:feat/core-changes-logical-9857