### PR TITLE
docs: fix README file structure diagram and roadmap accuracy (#10073)

### DIFF
--- a/submissions/examples/readme-file-structure-fix/README.md
+++ b/submissions/examples/readme-file-structure-fix/README.md
@@ -1,0 +1,101 @@
+# README File Structure & Roadmap Fix
+
+Corrects the outdated file structure diagram and roadmap table in the project README.
+
+## Problem
+
+| Section | Current | Actual |
+|---------|---------|--------|
+| `components/` | 2 files listed | 15 CSS files + chip-demo.html |
+| `submissions/examples/` | 4 hardcoded entries | 3,754+ submissions |
+| `docs/` | 2 files listed | 10+ files including guides |
+| Roadmap | 6 shipped features marked as "Planned" | Already implemented |
+| Project Stats | "Buttons (6 variants), Cards (13 variants)" | 15 component files |
+
+## Changes to README.md
+
+### File Structure — `components/` section
+
+Replace:
+```
+├── components/                 ← MAINTAINER-ONLY
+│   ├── buttons.css             ← 6 variants, 4 sizes, pill, icon
+│   └── cards.css               ← 13 card variants
+```
+
+With:
+```
+├── components/                 ← MAINTAINER-ONLY
+│   ├── badges.css              ← Badge component (pill, icon, dot, status)
+│   ├── buttons.css             ← 6 variants, 4 sizes, pill, icon, group
+│   ├── cards.css               ← 13 card variants
+│   ├── chip.css                ← Multi-select chip group
+│   ├── ease-marquee.css        ← Marquee animation component
+│   ├── footer.css              ← Grid footer with social icons
+│   ├── forms.css               ← Input, checkbox, toggle form components
+│   ├── loaders.css             ← Spinner, pulse, ping, dots loaders
+│   ├── masonry.css             ← 2/3/4 column masonry layouts
+│   ├── modals.css              ← Modal via :target pseudo-class
+│   ├── navbar.css              ← Glass navbar (sticky, blur variants)
+│   ├── scroll-progress.css     ← Scroll-driven progress bar
+│   ├── sidebar.css             ← Collapsible sidebar layout
+│   ├── tabs.css                ← CSS-only tabs (radio button pattern)
+│   ├── tooltips.css            ← Pure CSS tooltip (data-position)
+│   └── chip-demo.html          ← Chip component demo page
+```
+
+### File Structure — `submissions/examples/` section
+
+Replace the 4 hardcoded entries with a count:
+```
+│   └── examples/               ← 3,754+ submissions
+```
+
+### File Structure — `docs/` section
+
+Expand to show key documentation files:
+```
+├── docs/
+│   ├── accessibility-guide.md  ← WCAG compliance & reduced motion
+│   ├── animation-combination-guide.md  ← Animation pairing reference
+│   ├── bootstrap-migration-guide.md    ← Bootstrap migration guide
+│   ├── class-naming-conventions.md     ← Naming conventions
+│   ├── css-variable-theming.md ← Design token theming
+│   ├── masonry-layout-guide.md ← Masonry grid documentation
+│   ├── scroll-snap-utilities.md ← Scroll snap utilities
+│   ├── index.html              ← Deployed documentation site
+│   ├── demo.html               ← Live demo page
+│   └── assets/                 ← Logo, images, icons
+```
+
+### Roadmap
+
+| Feature | Status |
+|---------|--------|
+| ✅ Human-readable core utilities (80+) | **Shipped — v1.0** |
+| ✅ Animation-first motion library (20+) | **Shipped — v1.0** |
+| ✅ Curated contribution pipeline | **Shipped — v1.0** |
+| ✅ Component library (15 CSS components) | **Shipped — v1.0** |
+| ✅ npm package + jsDelivr CDN | **Shipped — v1.0** |
+| ✅ Full documentation site | **Shipped — v1.0** |
+| ✅ Modal components | **Shipped — v1.2** |
+| ✅ Tooltip components | **Shipped — v1.2** |
+| ✅ Navigation components (navbar, sidebar) | **Shipped — v1.3** |
+| ✅ CSS-only tabs | **Shipped — v1.3** |
+| ✅ Badge components | **Shipped — v1.3** |
+| ✅ Form components (inputs, checkboxes, toggles) | **Shipped — v1.4** |
+| 🔜 Dark mode token layer | **Planned — v1.4** |
+| 🔜 Scroll-triggered animations | **Planned — v1.4** |
+| 🔜 Avatar & progress bar components | **Planned — v1.5** |
+| 🔜 Accordion component | **Planned — v1.5** |
+| 🔜 Theming CLI | **Exploring** |
+
+### Project Statistics
+
+Update component count:
+```
+| 🎨 **Components**    | 15 component files (badges, buttons, cards, chip, forms, footer, loaders, masonry, modals, navbar, scroll-progress, sidebar, tabs, tooltips, marquee) |
+```
+
+## Files
+- `README.md` — this file (explanation of proposed changes)


### PR DESCRIPTION
## Description

The README.md file structure section and roadmap table are significantly outdated compared to the actual codebase. This submission documents the corrections needed.

### File Structure — components/
Currently lists only `buttons.css` and `cards.css`. Updated to show all 15 CSS files + chip-demo.html with descriptions.

### File Structure — submissions/examples/
Shows 4 hardcoded entries while 3,754+ exist. Replaced with count.

### File Structure — docs/
Expanded to show accessibility-guide.md, css-variable-theming.md, masonry-layout-guide.md, and other docs.

### Roadmap
Fixed 6 features incorrectly marked as Planned that are already shipped: modals, tooltips, navbar, sidebar, tabs, badges, form components.

### Project Statistics
Updated component count from "2" to "15 component files".

Fixes #10073

---

**Submission:** `submissions/examples/readme-file-structure-fix/README.md`