### PR TITLE
feat: add ease-star-rating accessible CSS-only radio star picker (iss…

### DIFF
--- a/submissions/examples/ease-star-rating-gn/README.md
+++ b/submissions/examples/ease-star-rating-gn/README.md
@@ -1,0 +1,28 @@
+# ease-star-rating — CSS-only Interactive Star Rating
+
+1. **What does this add?** A fully accessible, CSS-only interactive star rating picker built with radio inputs and sibling selectors — no JavaScript. Includes hover-fill animation, size variants (`-sm`/default/`-lg`), color variants (`-gold`/`-primary`/custom via `--ease-star-color`), keyboard focus support, and `prefers-reduced-motion` fallback.
+2. **How is it used?**
+```html
+<fieldset class="ease-star-rating" aria-label="Rate this product">
+  <input type="radio" name="rating" id="r5" value="5" />
+  <label for="r5" aria-label="5 stars"></label>
+  <input type="radio" name="rating" id="r4" value="4" />
+  <label for="r4" aria-label="4 stars"></label>
+  <input type="radio" name="rating" id="r3" value="3" checked />
+  <label for="r3" aria-label="3 stars"></label>
+  <input type="radio" name="rating" id="r2" value="2" />
+  <label for="r2" aria-label="2 stars"></label>
+  <input type="radio" name="rating" id="r1" value="1" />
+  <label for="r1" aria-label="1 star"></label>
+</fieldset>
+
+<!-- Variants -->
+<fieldset class="ease-star-rating ease-star-rating-sm">...</fieldset>
+<fieldset class="ease-star-rating ease-star-rating-lg ease-star-rating-primary">...</fieldset>
+
+<!-- Custom color override -->
+<fieldset class="ease-star-rating" style="--ease-star-color: #22c55e;">...</fieldset>
+```
+3. **Why is it useful?** The markup is reverse-ordered (`flex-direction: row-reverse`) so the 5-star input comes first in the DOM, letting the `~` general sibling selector light up "this star and everything after it in DOM order" on hover — the standard CSS-only star-rating trick. Using real `<input type="radio">` elements (visually hidden, but keyboard-focusable) means the component is natively accessible: screen readers announce it as a radio group, `Tab`/arrow keys work out of the box, and `:focus-visible` provides a clear keyboard focus ring — all without JavaScript, aligned with EaseMotion CSS's zero-dependency philosophy.
+
+**Note:** This is the accessible radio-input/click-to-rate variant, complementing the static display component (`ease-rating-stars-gn`, #8123) and the simpler hover-preview variant (`ease-rating-gn`, #283) already in this repo — together covering the full spectrum of star-rating use cases (display-only, hover-preview, and accessible interactive picker).

--- a/submissions/examples/ease-star-rating-gn/demo.html
+++ b/submissions/examples/ease-star-rating-gn/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-star-rating – EaseMotion CSS</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2.5rem;
+      background: #1e1e2e;
+      color: #f5f5f5;
+      padding: 3rem 2rem;
+    }
+    h1 { font-size: 1.3rem; margin: 0; }
+    h3 { font-size: 0.75rem; color: #999; text-transform: uppercase; letter-spacing: 0.5px; margin: 0 0 0.5rem; }
+    .col { display: flex; flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+    .row { display: flex; gap: 3rem; flex-wrap: wrap; }
+    fieldset { border: none; padding: 0; margin: 0; }
+  </style>
+</head>
+<body>
+
+  <h1>ease-star-rating — CSS-only Interactive Rating</h1>
+
+  <div class="row">
+    <div class="col">
+      <h3>Default (gold, medium)</h3>
+      <fieldset class="ease-star-rating" aria-label="Rate this product">
+        <input type="radio" name="rating1" id="r1-5" value="5" />
+        <label for="r1-5" aria-label="5 stars"></label>
+        <input type="radio" name="rating1" id="r1-4" value="4" />
+        <label for="r1-4" aria-label="4 stars"></label>
+        <input type="radio" name="rating1" id="r1-3" value="3" checked />
+        <label for="r1-3" aria-label="3 stars"></label>
+        <input type="radio" name="rating1" id="r1-2" value="2" />
+        <label for="r1-2" aria-label="2 stars"></label>
+        <input type="radio" name="rating1" id="r1-1" value="1" />
+        <label for="r1-1" aria-label="1 star"></label>
+      </fieldset>
+    </div>
+
+    <div class="col">
+      <h3>Small</h3>
+      <fieldset class="ease-star-rating ease-star-rating-sm" aria-label="Rate this product">
+        <input type="radio" name="rating2" id="r2-5" value="5" />
+        <label for="r2-5" aria-label="5 stars"></label>
+        <input type="radio" name="rating2" id="r2-4" value="4" />
+        <label for="r2-4" aria-label="4 stars"></label>
+        <input type="radio" name="rating2" id="r2-3" value="3" />
+        <label for="r2-3" aria-label="3 stars"></label>
+        <input type="radio" name="rating2" id="r2-2" value="2" />
+        <label for="r2-2" aria-label="2 stars"></label>
+        <input type="radio" name="rating2" id="r2-1" value="1" />
+        <label for="r2-1" aria-label="1 star"></label>
+      </fieldset>
+    </div>
+
+    <div class="col">
+      <h3>Large + Primary color</h3>
+      <fieldset class="ease-star-rating ease-star-rating-lg ease-star-rating-primary" aria-label="Rate this product">
+        <input type="radio" name="rating3" id="r3-5" value="5" />
+        <label for="r3-5" aria-label="5 stars"></label>
+        <input type="radio" name="rating3" id="r3-4" value="4" checked />
+        <label for="r3-4" aria-label="4 stars"></label>
+        <input type="radio" name="rating3" id="r3-3" value="3" />
+        <label for="r3-3" aria-label="3 stars"></label>
+        <input type="radio" name="rating3" id="r3-2" value="2" />
+        <label for="r3-2" aria-label="2 stars"></label>
+        <input type="radio" name="rating3" id="r3-1" value="1" />
+        <label for="r3-1" aria-label="1 star"></label>
+      </fieldset>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-star-rating-gn/style.css
+++ b/submissions/examples/ease-star-rating-gn/style.css
@@ -1,0 +1,77 @@
+/* ============================================
+   EaseMotion CSS — ease-star-rating
+   CSS-only radio-input star rating picker
+   Issue #3851
+   ============================================ */
+
+.ease-star-rating {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  gap: 0.15rem;
+}
+
+.ease-star-rating input {
+  display: none;
+}
+
+.ease-star-rating label {
+  font-size: var(--ease-star-size, 1.75rem);
+  color: var(--ease-color-neutral-300, #d1d5db);
+  cursor: pointer;
+  transition: color var(--ease-speed-fast, 0.2s) var(--ease-ease, ease),
+              transform var(--ease-speed-fast, 0.2s) var(--ease-ease, ease);
+  line-height: 1;
+}
+
+.ease-star-rating label::before {
+  content: '★';
+}
+
+/* Hover fill: light up this star and all stars after it
+   (row-reverse means "after" in DOM = stars to the left visually) */
+.ease-star-rating label:hover,
+.ease-star-rating label:hover ~ label {
+  color: var(--ease-star-color, #fbbf24);
+  transform: scale(1.15);
+}
+
+/* Checked state: keep filled stars colored even without hover */
+.ease-star-rating input:checked ~ label {
+  color: var(--ease-star-color, #fbbf24);
+}
+
+/* Focus ring for keyboard accessibility */
+.ease-star-rating input:focus-visible + label {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ── Size variants ──────────────────────────────────── */
+.ease-star-rating-sm {
+  --ease-star-size: 1.1rem;
+}
+
+.ease-star-rating-lg {
+  --ease-star-size: 2.5rem;
+}
+
+/* ── Color variants ─────────────────────────────────── */
+.ease-star-rating-primary {
+  --ease-star-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-star-rating-gold {
+  --ease-star-color: #fbbf24;
+}
+
+/* ── Reduced motion ─────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-star-rating label {
+    transition: none;
+  }
+  .ease-star-rating label:hover,
+  .ease-star-rating label:hover ~ label {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-star-rating` — a fully accessible, CSS-only interactive star rating picker built with radio inputs and sibling selectors (no JavaScript). Includes hover-fill animation, size variants, color variants, keyboard focus support, and reduced-motion fallback. Closes #3851

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-star-rating-gn/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A `.ease-star-rating` fieldset of radio inputs + labels with hover-fill via the `~` sibling selector, plus `.ease-star-rating-sm`/`-lg` size variants and `.ease-star-rating-gold`/`-primary` color variants (also overridable via `--ease-star-color`).

**How does a developer use it?**
```html
<fieldset class="ease-star-rating" aria-label="Rate this product">
  <input type="radio" name="rating" id="r5" value="5" />
  <label for="r5" aria-label="5 stars"></label>
  <input type="radio" name="rating" id="r4" value="4" />
  <label for="r4" aria-label="4 stars"></label>
  <input type="radio" name="rating" id="r3" value="3" checked />
  <label for="r3" aria-label="3 stars"></label>
  <input type="radio" name="rating" id="r2" value="2" />
  <label for="r2" aria-label="2 stars"></label>
  <input type="radio" name="rating" id="r1" value="1" />
  <label for="r1" aria-label="1 star"></label>
</fieldset>

<fieldset class="ease-star-rating ease-star-rating-lg ease-star-rating-primary">...</fieldset>
```

**Why does it fit EaseMotion CSS?**
Uses real `<input type="radio">` elements (visually hidden but keyboard-focusable) so the component is natively accessible — screen readers announce it as a radio group, keyboard navigation and `:focus-visible` work out of the box — all pure CSS, zero JavaScript, matching the library's accessibility-first, composable philosophy.

---
## Demo
- [x] Demo added (`demo.html` shows default, small, and large+primary variants, each as an accessible `<fieldset>` with `aria-label`s)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
This is the accessible radio-input/click-to-rate variant, complementing the static display component (`ease-rating-stars-gn`, #8123) and the simpler hover-preview variant (`ease-rating-gn`, #283) already in the repo — together covering display-only, hover-preview, and interactive-picker use cases. Markup uses `flex-direction: row-reverse` so the DOM order (5★ first) lets the `~` sibling selector light up "this star and everything after it" on hover, the standard CSS-only star-rating technique.