### PR TITLE
feat(utilities): add 6-column and 12-column grid utilities (#10071)

### DIFF
--- a/submissions/core_changes-issue-10071/README.md
+++ b/submissions/core_changes-issue-10071/README.md
@@ -1,0 +1,68 @@
+# 6-Column and 12-Column Grid Utilities
+
+Adds `.ease-grid-cols-6`, `.ease-grid-cols-12`, and `.ease-col-span-{5-11}` to the existing grid system, enabling standard design system layouts (sidebar + content, dashboards, form grids).
+
+## Problem
+
+Current grid only goes up to 4 columns:
+- `.ease-grid-cols-{1,2,3,4}` 
+- `.ease-col-span-{1,2,3,4}`
+
+Most real-world layouts need finer control. A sidebar + content layout using `.ease-grid-cols-2` gives each column 50%, which is too wide for a sidebar.
+
+## Proposed CSS to Add to `core/utilities.css`
+
+### Base grid classes (add after `.ease-grid-cols-4`):
+```css
+.ease-grid-cols-6  { grid-template-columns: repeat(6, minmax(0, 1fr)) !important; }
+.ease-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)) !important; }
+```
+
+### Span classes (add after `.ease-col-span-4`):
+```css
+.ease-col-span-5  { grid-column: span 5 / span 5 !important; }
+.ease-col-span-6  { grid-column: span 6 / span 6 !important; }
+.ease-col-span-7  { grid-column: span 7 / span 7 !important; }
+.ease-col-span-8  { grid-column: span 8 / span 8 !important; }
+.ease-col-span-9  { grid-column: span 9 / span 9 !important; }
+.ease-col-span-10 { grid-column: span 10 / span 10 !important; }
+.ease-col-span-11 { grid-column: span 11 / span 11 !important; }
+```
+
+### Responsive variants
+Add within each `@media` block (sm, md, lg, xl):
+```css
+.ease-sm-grid-cols-6  { grid-template-columns: repeat(6, minmax(0, 1fr)) !important; }
+.ease-sm-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)) !important; }
+/* ... same for .ease-md-, .ease-lg-, .ease-xl- */
+```
+
+### Mobile collapse (add to the 480px override):
+```css
+.ease-grid-cols-6,
+.ease-grid-cols-12 {
+  grid-template-columns: minmax(0, 1fr) !important;
+}
+```
+
+## Usage
+
+```html
+<!-- 12-column dashboard layout -->
+<div class="ease-grid ease-grid-cols-12 ease-gap-4">
+  <aside class="ease-col-span-3 ease-card">Sidebar</aside>
+  <main class="ease-col-span-9 ease-card">Main content</main>
+</div>
+
+<!-- 6-column stat cards -->
+<div class="ease-grid ease-grid-cols-6 ease-gap-4">
+  <div class="ease-col-span-2 ease-card">Stat 1</div>
+  <div class="ease-col-span-2 ease-card">Stat 2</div>
+  <div class="ease-col-span-2 ease-card">Stat 3</div>
+</div>
+```
+
+## Files
+- `README.md` — this file
+- `demo.html` — interactive demo page
+- `style.css` — CSS for the grid utilities

--- a/submissions/core_changes-issue-10071/demo.html
+++ b/submissions/core_changes-issue-10071/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>6 & 12 Column Grid Utilities — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>📐 Grid Utilities: 6 & 12 Columns</h1>
+      <p class="subtitle">Adding .ease-grid-cols-6, .ease-grid-cols-12, and .ease-col-span-{5-11} — Issue #10071</p>
+    </header>
+
+    <section>
+      <h2>12-Column Dashboard Layout</h2>
+      <div class="ease-grid ease-grid-cols-12 ease-gap-3" style="margin-bottom:0.75rem;">
+        <div class="grid-demo grid-demo-primary ease-col-span-12">Header (span 12)</div>
+        <div class="grid-demo grid-demo-secondary ease-col-span-3">Sidebar (span 3)</div>
+        <div class="grid-demo grid-demo-accent ease-col-span-9">Main Content (span 9)</div>
+        <div class="grid-demo grid-demo-primary ease-col-span-12">Footer (span 12)</div>
+      </div>
+      <pre>&lt;div class="ease-grid ease-grid-cols-12 ease-gap-4"&gt;
+  &lt;aside class="ease-col-span-3"&gt;Sidebar&lt;/aside&gt;
+  &lt;main class="ease-col-span-9"&gt;Main content&lt;/main&gt;
+&lt;/div&gt;</pre>
+    </section>
+
+    <section>
+      <h2>6-Column Stat Cards</h2>
+      <div class="ease-grid ease-grid-cols-6 ease-gap-3" style="margin-bottom:0.75rem;">
+        <div class="grid-demo grid-demo-muted ease-col-span-2">Users<br/>1,234</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-2">Revenue<br/>$12K</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-2">Orders<br/>456</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-3">Conversion<br/>3.2%</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-3">Bounce<br/>24%</div>
+      </div>
+      <pre>&lt;div class="ease-grid ease-grid-cols-6 ease-gap-4"&gt;
+  &lt;div class="ease-col-span-2"&gt;Stat 1&lt;/div&gt;
+  &lt;div class="ease-col-span-2"&gt;Stat 2&lt;/div&gt;
+  &lt;div class="ease-col-span-2"&gt;Stat 3&lt;/div&gt;
+&lt;/div&gt;</pre>
+    </section>
+
+    <section>
+      <h2>Mixed Span Layouts</h2>
+      <div class="ease-grid ease-grid-cols-12 ease-gap-2" style="margin-bottom:0.75rem;">
+        <div class="grid-demo grid-demo-secondary ease-col-span-4">span 4</div>
+        <div class="grid-demo grid-demo-secondary ease-col-span-4">span 4</div>
+        <div class="grid-demo grid-demo-secondary ease-col-span-4">span 4</div>
+        <div class="grid-demo grid-demo-accent ease-col-span-5">span 5</div>
+        <div class="grid-demo grid-demo-accent ease-col-span-7">span 7</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+        <div class="grid-demo grid-demo-muted ease-col-span-1">1</div>
+      </div>
+      <pre>&lt;div class="ease-grid ease-grid-cols-12"&gt;
+  &lt;div class="ease-col-span-5"&gt;span 5&lt;/div&gt;
+  &lt;div class="ease-col-span-7"&gt;span 7&lt;/div&gt;
+&lt;/div&gt;</pre>
+    </section>
+
+    <section>
+      <h2>What's Being Added</h2>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;">
+        <div>
+          <span class="tag">New</span>
+          <h3 style="font-size:1rem;margin-bottom:0.5rem;">Grid Columns</h3>
+          <pre>.ease-grid-cols-6
+.ease-grid-cols-12
+.ease-sm-grid-cols-6
+.ease-sm-grid-cols-12
+.ease-md-grid-cols-6
+.ease-md-grid-cols-12
+.ease-lg-grid-cols-6
+.ease-lg-grid-cols-12
+.ease-xl-grid-cols-6
+.ease-xl-grid-cols-12</pre>
+        </div>
+        <div>
+          <span class="tag">New</span>
+          <h3 style="font-size:1rem;margin-bottom:0.5rem;">Column Spans</h3>
+          <pre>.ease-col-span-5
+.ease-col-span-6
+.ease-col-span-7
+.ease-col-span-8
+.ease-col-span-9
+.ease-col-span-10
+.ease-col-span-11</pre>
+        </div>
+      </div>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10071/style.css
+++ b/submissions/core_changes-issue-10071/style.css
@@ -1,0 +1,148 @@
+:root {
+  --ease-space-1: 0.25rem;
+  --ease-space-2: 0.5rem;
+  --ease-space-3: 0.75rem;
+  --ease-space-4: 1rem;
+  --ease-space-6: 1.5rem;
+  --ease-space-8: 2rem;
+  --ease-gap: 1rem;
+  --ease-radius: 0.75rem;
+  --ease-shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --ease-shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+  --ease-bp-sm: 640px;
+  --ease-bp-md: 768px;
+  --ease-bp-lg: 1024px;
+  --ease-bp-xl: 1280px;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  line-height: 1.6;
+  padding: 2rem;
+}
+
+.container { max-width: 1100px; margin: 0 auto; }
+
+header {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 2px solid #e2e8f0;
+}
+
+h1 { font-size: 2rem; font-weight: 800; margin-bottom: 0.5rem; }
+.subtitle { color: #64748b; font-size: 1rem; }
+h2 { font-size: 1.25rem; font-weight: 700; margin-bottom: 1.5rem; padding-bottom: 0.5rem; border-bottom: 2px solid #e2e8f0; }
+section { margin-bottom: 3rem; }
+
+/* ---------- Grid Utilities (proposed) ---------- */
+.ease-grid { display: grid !important; }
+.ease-gap-2 { gap: 0.5rem !important; }
+.ease-gap-3 { gap: 0.75rem !important; }
+.ease-gap-4 { gap: 1rem !important; }
+
+.ease-grid-cols-1  { grid-template-columns: repeat(1, minmax(0, 1fr)) !important; }
+.ease-grid-cols-2  { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }
+.ease-grid-cols-3  { grid-template-columns: repeat(3, minmax(0, 1fr)) !important; }
+.ease-grid-cols-4  { grid-template-columns: repeat(4, minmax(0, 1fr)) !important; }
+
+/* NEW: 6 and 12 column grids */
+.ease-grid-cols-6  { grid-template-columns: repeat(6, minmax(0, 1fr)) !important; }
+.ease-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)) !important; }
+
+/* Span classes */
+.ease-col-span-1  { grid-column: span 1 / span 1 !important; }
+.ease-col-span-2  { grid-column: span 2 / span 2 !important; }
+.ease-col-span-3  { grid-column: span 3 / span 3 !important; }
+.ease-col-span-4  { grid-column: span 4 / span 4 !important; }
+
+/* NEW: span 5-11 */
+.ease-col-span-5  { grid-column: span 5 / span 5 !important; }
+.ease-col-span-6  { grid-column: span 6 / span 6 !important; }
+.ease-col-span-7  { grid-column: span 7 / span 7 !important; }
+.ease-col-span-8  { grid-column: span 8 / span 8 !important; }
+.ease-col-span-9  { grid-column: span 9 / span 9 !important; }
+.ease-col-span-10 { grid-column: span 10 / span 10 !important; }
+.ease-col-span-11 { grid-column: span 11 / span 11 !important; }
+.ease-col-full    { grid-column: 1 / -1 !important; }
+
+/* ---------- Demo card styles ---------- */
+.grid-demo {
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  text-align: center;
+  font-size: 0.8rem;
+  font-weight: 600;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.grid-demo-primary {
+  background: #6c63ff;
+  color: white;
+}
+
+.grid-demo-secondary {
+  background: #e8e5ff;
+  color: #4b44cc;
+}
+
+.grid-demo-accent {
+  background: #f0fdf4;
+  color: #16a34a;
+  border: 1px solid #bbf7d0;
+}
+
+.grid-demo-muted {
+  background: #f1f5f9;
+  color: #64748b;
+  border: 1px solid #e2e8f0;
+}
+
+.desc {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  margin-top: 0.75rem;
+}
+
+pre {
+  background: #1e293b;
+  color: #e2e8f0;
+  padding: 1.25rem;
+  border-radius: 0.75rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  overflow-x: auto;
+  line-height: 1.6;
+  margin-top: 1rem;
+}
+
+.tag {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #dbeafe;
+  color: #1d4ed8;
+  margin-bottom: 0.75rem;
+}
+
+/* Mobile collapse simulation */
+@media (max-width: 640px) {
+  .ease-grid-cols-2,
+  .ease-grid-cols-3,
+  .ease-grid-cols-4,
+  .ease-grid-cols-6,
+  .ease-grid-cols-12 {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+}


### PR DESCRIPTION
## Description

Adds 6-column and 12-column grid utilities to the existing grid system, enabling standard design system layouts like sidebar + content dashboards.

### What's Added
- `.ease-grid-cols-6` and `.ease-grid-cols-12` — 6 and 12 column grids
- `.ease-col-span-{5,6,7,8,9,10,11}` — span classes for fine-grained control
- Responsive variants: `.ease-{sm,md,lg,xl}-grid-cols-{6,12}`
- Mobile collapse at 480px for new grid classes

### Files
- `submissions/core_changes-issue-10071/README.md`
- `submissions/core_changes-issue-10071/demo.html`
- `submissions/core_changes-issue-10071/style.css`

### Checklist
- [x] Changes in `submissions/core_changes-issue-10071/` only
- [x] Includes README.md, demo.html, style.css
- [x] No changes to core/ or components/

Fixes #10071
