### PR TITLE
feat(animation): add .ease-reveal-* convenience classes for scroll-triggered animations (#10070)

### DIFF
--- a/submissions/core_changes-issue-10070/README.md
+++ b/submissions/core_changes-issue-10070/README.md
@@ -1,0 +1,89 @@
+# .ease-reveal-* Convenience Classes
+
+Adds single-class scroll-reveal convenience classes that bundle `.ease-reveal` with a built-in animation direction, reducing the common two-class pattern to one.
+
+## Problem
+
+Currently, users must write two classes for any scroll-reveal effect:
+```html
+<div class="ease-reveal ease-slide-up">Content</div>
+```
+
+This confuses new contributors: "Do I need both? What does each one do?"
+
+## Solution
+
+New single-class convenience variants:
+```html
+<div class="ease-reveal-slide-up">Content</div>
+```
+
+### Proposed CSS to Add to `core/animations.css`
+
+After the existing `.ease-reveal` block:
+
+```css
+/* Convenience single-class reveal variants */
+.ease-reveal-fade { animation-name: ease-kf-fade-in; }
+.ease-reveal-slide-up { animation-name: ease-kf-slide-up; transform: translateY(2rem); }
+.ease-reveal-slide-down { animation-name: ease-kf-slide-down; transform: translateY(-2rem); }
+.ease-reveal-slide-left { animation-name: ease-kf-slide-in-left; transform: translateX(2rem); }
+.ease-reveal-slide-right { animation-name: ease-kf-slide-in-right; transform: translateX(-2rem); }
+.ease-reveal-zoom { animation-name: ease-kf-zoom-in; transform: scale(0.9); }
+.ease-reveal-blur { animation-name: ease-kf-blur-to-focus; filter: blur(6px); }
+```
+
+Add the convenience classes to the base inactive state selector:
+```css
+.ease-reveal,
+.ease-reveal-fade, .ease-reveal-slide-up, .ease-reveal-slide-down,
+.ease-reveal-slide-left, .ease-reveal-slide-right,
+.ease-reveal-zoom, .ease-reveal-blur {
+  opacity: 0;
+  will-change: transform, opacity, filter;
+  transition:
+    opacity 0.7s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    transform 0.7s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    filter 0.7s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+```
+
+Add convenience classes to the active state selector:
+```css
+.ease-reveal.ease-reveal-active,
+.ease-reveal-fade.ease-reveal-active,
+.ease-reveal-slide-up.ease-reveal-active,
+.ease-reveal-slide-down.ease-reveal-active,
+.ease-reveal-slide-left.ease-reveal-active,
+.ease-reveal-slide-right.ease-reveal-active,
+.ease-reveal-zoom.ease-reveal-active,
+.ease-reveal-blur.ease-reveal-active {
+  opacity: 1;
+  transform: translateY(0) translateX(0) scale(1);
+  filter: blur(0);
+}
+```
+
+### Usage
+
+```html
+<!-- Before: two classes -->
+<div class="ease-reveal ease-slide-up" data-delay="200">Hello</div>
+
+<!-- After: one class -->
+<div class="ease-reveal-slide-up">Hello</div>
+<div class="ease-reveal-fade">Fade in</div>
+<div class="ease-reveal-zoom">Zoom in</div>
+<div class="ease-reveal-blur">Blur to focus</div>
+<div class="ease-reveal-slide-left">Slide from left</div>
+```
+
+Composition is preserved — users can still write:
+```html
+<div class="ease-reveal ease-slide-up ease-delay-200">Hello</div>
+```
+
+## Files
+- `README.md` — this file
+- `demo.html` — interactive demo page
+- `style.css` — CSS for reveal convenience classes

--- a/submissions/core_changes-issue-10070/demo.html
+++ b/submissions/core_changes-issue-10070/demo.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>.ease-reveal-* Convenience Classes — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>👁️ ease-reveal-* Convenience Classes</h1>
+      <p class="subtitle">Single-class scroll-reveal variants — Issue #10070</p>
+    </header>
+
+    <section>
+      <h2>Before vs After</h2>
+      <div class="compare">
+        <div class="compare-old">
+          <h4>Before (two classes)</h4>
+          <pre>&lt;div class="ease-reveal ease-slide-up"&gt;
+  Content
+&lt;/div&gt;</pre>
+        </div>
+        <div class="compare-new">
+          <h4>After (one class)</h4>
+          <pre>&lt;div class="ease-reveal-slide-up"&gt;
+  Content
+&lt;/div&gt;</pre>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>All Variants</h2>
+      <div class="demo-grid">
+        <div class="demo-card ease-reveal-slide-up">
+          <span class="tag">New</span>
+          <h3>ease-reveal-slide-up</h3>
+          <p>↑</p>
+        </div>
+        <div class="demo-card ease-reveal-slide-down">
+          <span class="tag">New</span>
+          <h3>ease-reveal-slide-down</h3>
+          <p>↓</p>
+        </div>
+        <div class="demo-card ease-reveal-slide-left">
+          <span class="tag">New</span>
+          <h3>ease-reveal-slide-left</h3>
+          <p>←</p>
+        </div>
+        <div class="demo-card ease-reveal-slide-right">
+          <span class="tag">New</span>
+          <h3>ease-reveal-slide-right</h3>
+          <p>→</p>
+        </div>
+        <div class="demo-card ease-reveal-fade">
+          <span class="tag">New</span>
+          <h3>ease-reveal-fade</h3>
+          <p>✦</p>
+        </div>
+        <div class="demo-card ease-reveal-zoom">
+          <span class="tag">New</span>
+          <h3>ease-reveal-zoom</h3>
+          <p>🔍</p>
+        </div>
+        <div class="demo-card ease-reveal-blur">
+          <span class="tag">New</span>
+          <h3>ease-reveal-blur</h3>
+          <p>◎</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>CSS Added to core/animations.css</h2>
+      <pre>/* Convenience single-class reveal variants */
+.ease-reveal-fade { animation-name: ease-kf-fade-in; }
+.ease-reveal-slide-up { animation-name: ease-kf-slide-up; transform: translateY(2rem); }
+.ease-reveal-slide-down { animation-name: ease-kf-slide-down; transform: translateY(-2rem); }
+.ease-reveal-slide-left { animation-name: ease-kf-slide-in-left; transform: translateX(2rem); }
+.ease-reveal-slide-right { animation-name: ease-kf-slide-in-right; transform: translateX(-2rem); }
+.ease-reveal-zoom { animation-name: ease-kf-zoom-in; transform: scale(0.9); }
+.ease-reveal-blur { animation-name: ease-kf-blur-to-focus; filter: blur(6px); }
+
+/* Add to base inactive state selector */
+.ease-reveal,
+.ease-reveal-fade, .ease-reveal-slide-up,
+.ease-reveal-slide-down, .ease-reveal-slide-left,
+.ease-reveal-slide-right, .ease-reveal-zoom,
+.ease-reveal-blur {
+  opacity: 0;
+  transition: opacity 0.7s ease, transform 0.7s ease, filter 0.7s ease;
+}
+
+/* Add to .ease-reveal-active selector */
+.ease-reveal.ease-reveal-active,
+.ease-reveal-fade.ease-reveal-active,
+.ease-reveal-slide-up.ease-reveal-active,
+.ease-reveal-slide-down.ease-reveal-active,
+.ease-reveal-slide-left.ease-reveal-active,
+.ease-reveal-slide-right.ease-reveal-active,
+.ease-reveal-zoom.ease-reveal-active,
+.ease-reveal-blur.ease-reveal-active {
+  opacity: 1;
+  transform: translateY(0) translateX(0) scale(1);
+  filter: blur(0);
+}</pre>
+    </section>
+
+    <section>
+      <h2>Usage Examples</h2>
+      <pre>&lt;!-- Convenience (single class) --&gt;
+&lt;div class="ease-reveal-slide-up"&gt;Slides up&lt;/div&gt;
+&lt;div class="ease-reveal-fade"&gt;Fades in&lt;/div&gt;
+&lt;div class="ease-reveal-zoom"&gt;Zooms in&lt;/div&gt;
+&lt;div class="ease-reveal-blur"&gt;Unblurs&lt;/div&gt;
+
+&lt;!-- Original composition still works --&gt;
+&lt;div class="ease-reveal ease-slide-up ease-delay-200"&gt;
+  Staggered with custom delay
+&lt;/div&gt;</pre>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10070/style.css
+++ b/submissions/core_changes-issue-10070/style.css
@@ -1,0 +1,192 @@
+:root {
+  --ease-speed-medium: 300ms;
+  --ease-speed-slow: 600ms;
+  --ease-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-color-primary: #6c63ff;
+  --ease-color-primary-dark: #4b44cc;
+  --ease-radius: 0.75rem;
+  --ease-shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --ease-shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  line-height: 1.6;
+  padding: 2rem;
+}
+
+.container { max-width: 800px; margin: 0 auto; }
+
+header {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 2px solid #e2e8f0;
+}
+
+h1 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; }
+.subtitle { color: #64748b; font-size: 1rem; }
+h2 { font-size: 1.15rem; font-weight: 700; margin-bottom: 1.5rem; padding-bottom: 0.5rem; border-bottom: 2px solid #e2e8f0; }
+section { margin-bottom: 3rem; }
+
+/* ---------- Reveal convenience classes ---------- */
+@keyframes ease-kf-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes ease-kf-slide-up {
+  from { opacity: 0; transform: translateY(2rem); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-kf-slide-down {
+  from { opacity: 0; transform: translateY(-2rem); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-kf-slide-in-left {
+  from { opacity: 0; transform: translateX(2rem); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-kf-slide-in-right {
+  from { opacity: 0; transform: translateX(-2rem); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-kf-zoom-in {
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes ease-kf-blur-to-focus {
+  from { opacity: 0; filter: blur(6px); }
+  to { opacity: 1; filter: blur(0); }
+}
+
+/* Convenience single-class reveal variants */
+.ease-reveal-fade { animation-name: ease-kf-fade-in; }
+.ease-reveal-slide-up { animation-name: ease-kf-slide-up; transform: translateY(2rem); }
+.ease-reveal-slide-down { animation-name: ease-kf-slide-down; transform: translateY(-2rem); }
+.ease-reveal-slide-left { animation-name: ease-kf-slide-in-left; transform: translateX(2rem); }
+.ease-reveal-slide-right { animation-name: ease-kf-slide-in-right; transform: translateX(-2rem); }
+.ease-reveal-zoom { animation-name: ease-kf-zoom-in; transform: scale(0.9); }
+.ease-reveal-blur { animation-name: ease-kf-blur-to-focus; filter: blur(6px); }
+
+/* Base inactive state */
+.ease-reveal,
+.ease-reveal-fade, .ease-reveal-slide-up, .ease-reveal-slide-down,
+.ease-reveal-slide-left, .ease-reveal-slide-right,
+.ease-reveal-zoom, .ease-reveal-blur {
+  opacity: 0;
+  will-change: transform, opacity, filter;
+  transition:
+    opacity 0.7s var(--ease-ease),
+    transform 0.7s var(--ease-ease),
+    filter 0.7s var(--ease-ease);
+}
+
+/* Active state (triggered by reveal.js IntersectionObserver) */
+.ease-reveal.ease-reveal-active,
+.ease-reveal-fade.ease-reveal-active,
+.ease-reveal-slide-up.ease-reveal-active,
+.ease-reveal-slide-down.ease-reveal-active,
+.ease-reveal-slide-left.ease-reveal-active,
+.ease-reveal-slide-right.ease-reveal-active,
+.ease-reveal-zoom.ease-reveal-active,
+.ease-reveal-blur.ease-reveal-active {
+  opacity: 1;
+  transform: translateY(0) translateX(0) scale(1);
+  filter: blur(0);
+}
+
+/* Demo styling */
+.demo-card {
+  background: white;
+  border-radius: 1rem;
+  padding: 2rem;
+  text-align: center;
+  border: 1px solid #e2e8f0;
+  box-shadow: var(--ease-shadow-sm);
+  margin-bottom: 1rem;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.demo-card h3 {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #64748b;
+  margin-bottom: 0.5rem;
+}
+
+.demo-card p {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--ease-color-primary);
+}
+
+.tag {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #dbeafe;
+  color: #1d4ed8;
+  margin-bottom: 0.75rem;
+}
+
+pre {
+  background: #1e293b;
+  color: #e2e8f0;
+  padding: 1.25rem;
+  border-radius: 0.75rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  overflow-x: auto;
+  line-height: 1.6;
+  margin-top: 1rem;
+}
+
+.compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.compare-old {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.compare-new {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.compare-old h4 { color: #dc2626; font-size: 0.75rem; text-transform: uppercase; margin-bottom: 0.5rem; }
+.compare-new h4 { color: #16a34a; font-size: 0.75rem; text-transform: uppercase; margin-bottom: 0.5rem; }
+
+@media (max-width: 600px) {
+  .compare { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Description

Adds single-class `.ease-reveal-*` convenience variants that bundle `.ease-reveal` with a built-in animation direction, reducing the common two-class pattern to one.

### What's Added
- `.ease-reveal-fade` — reveal + fade-in
- `.ease-reveal-slide-up` — reveal + slide up
- `.ease-reveal-slide-down` — reveal + slide down
- `.ease-reveal-slide-left` — reveal + slide from left
- `.ease-reveal-slide-right` — reveal + slide from right
- `.ease-reveal-zoom` — reveal + zoom in
- `.ease-reveal-blur` — reveal + blur to focus

Original composition `.ease-reveal.ease-slide-up` still works.

### Files
- `submissions/core_changes-issue-10070/README.md`
- `submissions/core_changes-issue-10070/demo.html`
- `submissions/core_changes-issue-10070/style.css`

Fixes #10070
