### PR TITLE
feat(component): add .ease-breadcrumb navigation component (#10068)

### DIFF
--- a/submissions/core_changes-issue-10068/README.md
+++ b/submissions/core_changes-issue-10068/README.md
@@ -1,0 +1,99 @@
+# .ease-breadcrumb Navigation Component
+
+Adds a breadcrumb navigation component for page hierarchy — documentation sites, dashboards, and multi-step wizards.
+
+## Problem
+
+No breadcrumb component exists in EaseMotion CSS. Users must write custom HTML + CSS for breadcrumb trails.
+
+## Proposed CSS to Add to `components/breadcrumb.css`
+
+```css
+/* Breadcrumb nav wrapper */
+.ease-breadcrumb {
+  font-size: 0.875rem;
+}
+
+/* Ordered list container */
+.ease-breadcrumb-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ease-space-1, 0.25rem);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Each breadcrumb item */
+.ease-breadcrumb-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ease-space-1, 0.25rem);
+}
+
+/* Clickable link */
+.ease-breadcrumb-link {
+  color: var(--ease-color-primary);
+  text-decoration: none;
+  transition: color var(--ease-speed-fast, 150ms);
+}
+
+.ease-breadcrumb-link:hover {
+  text-decoration: underline;
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+/* Separator between items */
+.ease-breadcrumb-separator {
+  color: #9ca3af;
+  margin: 0 var(--ease-space-1, 0.25rem);
+  user-select: none;
+}
+
+/* Current page (no link) */
+.ease-breadcrumb-active {
+  color: #6b7280;
+  font-weight: 500;
+}
+
+/* Size variants */
+.ease-breadcrumb-sm {
+  font-size: 0.75rem;
+}
+
+.ease-breadcrumb-lg {
+  font-size: 1rem;
+}
+```
+
+## Usage
+
+```html
+<nav aria-label="Breadcrumb" class="ease-breadcrumb">
+  <ol class="ease-breadcrumb-list">
+    <li class="ease-breadcrumb-item">
+      <a href="#" class="ease-breadcrumb-link">Home</a>
+      <span class="ease-breadcrumb-separator" aria-hidden="true">›</span>
+    </li>
+    <li class="ease-breadcrumb-item">
+      <a href="#" class="ease-breadcrumb-link">Dashboard</a>
+      <span class="ease-breadcrumb-separator" aria-hidden="true">›</span>
+    </li>
+    <li class="ease-breadcrumb-item ease-breadcrumb-active" aria-current="page">
+      Settings
+    </li>
+  </ol>
+</nav>
+```
+
+## Accessibility
+- `aria-label="Breadcrumb"` on the nav element
+- `aria-current="page"` on the active breadcrumb item
+- `aria-hidden="true"` on separator spans
+- Semantic `<ol>` for ordered hierarchy
+
+## Files
+- `README.md` — this file
+- `demo.html` — breadcrumb demo page
+- `style.css` — breadcrumb component CSS

--- a/submissions/core_changes-issue-10068/demo.html
+++ b/submissions/core_changes-issue-10068/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>.ease-breadcrumb — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>🍞 ease-breadcrumb</h1>
+      <p class="subtitle">Breadcrumb navigation component — Issue #10068</p>
+    </header>
+
+    <section>
+      <h2>Small</h2>
+      <span class="label">ease-breadcrumb-sm</span>
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb ease-breadcrumb-sm" style="margin-top:0.75rem;">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a><span class="ease-breadcrumb-separator" aria-hidden="true">›</span></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Docs</a><span class="ease-breadcrumb-separator" aria-hidden="true">›</span></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Components</a><span class="ease-breadcrumb-separator" aria-hidden="true">›</span></li>
+          <li class="ease-breadcrumb-item ease-breadcrumb-active" aria-current="page">Breadcrumb</li>
+        </ol>
+      </nav>
+    </section>
+
+    <section>
+      <h2>Default</h2>
+      <span class="label">ease-breadcrumb</span>
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb" style="margin-top:0.75rem;">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a><span class="ease-breadcrumb-separator" aria-hidden="true">›</span></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Dashboard</a><span class="ease-breadcrumb-separator" aria-hidden="true">›</span></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Projects</a><span class="ease-breadcrumb-separator" aria-hidden="true">›</span></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Clinical Engine</a><span class="ease-breadcrumb-separator" aria-hidden="true">›</span></li>
+          <li class="ease-breadcrumb-item ease-breadcrumb-active" aria-current="page">Settings</li>
+        </ol>
+      </nav>
+    </section>
+
+    <section>
+      <h2>Large</h2>
+      <span class="label">ease-breadcrumb-lg</span>
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb ease-breadcrumb-lg" style="margin-top:0.75rem;">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a><span class="ease-breadcrumb-separator" aria-hidden="true">/</span></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Products</a><span class="ease-breadcrumb-separator" aria-hidden="true">/</span></li>
+          <li class="ease-breadcrumb-item ease-breadcrumb-active" aria-current="page">EaseMotion CSS</li>
+        </ol>
+      </nav>
+      <p style="font-size:0.8rem;color:#94a3b8;margin-top:0.5rem;">Separator characters are customizable — this example uses <code>/</code></p>
+    </section>
+
+    <section>
+      <h2>Minimal (2 levels)</h2>
+      <span class="label">Edge case</span>
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb" style="margin-top:0.75rem;">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a><span class="ease-breadcrumb-separator" aria-hidden="true">›</span></li>
+          <li class="ease-breadcrumb-item ease-breadcrumb-active" aria-current="page">Current Page</li>
+        </ol>
+      </nav>
+    </section>
+
+    <section class="bg-dark">
+      <h2>Dark Background</h2>
+      <span class="label">On dark bg</span>
+      <nav aria-label="Breadcrumb" class="ease-breadcrumb" style="margin-top:0.75rem;">
+        <ol class="ease-breadcrumb-list">
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Home</a><span class="ease-breadcrumb-separator" aria-hidden="true">›</span></li>
+          <li class="ease-breadcrumb-item"><a href="#" class="ease-breadcrumb-link">Admin</a><span class="ease-breadcrumb-separator" aria-hidden="true">›</span></li>
+          <li class="ease-breadcrumb-item ease-breadcrumb-active" aria-current="page">User Management</li>
+        </ol>
+      </nav>
+    </section>
+
+    <section>
+      <h2>HTML Structure</h2>
+      <pre style="background:#1e293b;color:#e2e8f0;padding:1.25rem;border-radius:0.75rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;overflow-x:auto;line-height:1.6;margin-top:0.5rem;">&lt;nav aria-label="Breadcrumb" class="ease-breadcrumb"&gt;
+  &lt;ol class="ease-breadcrumb-list"&gt;
+    &lt;li class="ease-breadcrumb-item"&gt;
+      &lt;a href="#" class="ease-breadcrumb-link"&gt;Home&lt;/a&gt;
+      &lt;span class="ease-breadcrumb-separator" aria-hidden="true"&gt;›&lt;/span&gt;
+    &lt;/li&gt;
+    &lt;li class="ease-breadcrumb-item ease-breadcrumb-active" aria-current="page"&gt;
+      Current Page
+    &lt;/li&gt;
+  &lt;/ol&gt;
+&lt;/nav&gt;</pre>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10068/style.css
+++ b/submissions/core_changes-issue-10068/style.css
@@ -1,0 +1,124 @@
+:root {
+  --ease-speed-fast: 150ms;
+  --ease-color-primary: #6c63ff;
+  --ease-color-primary-dark: #4b44cc;
+  --ease-space-1: 0.25rem;
+  --ease-space-2: 0.5rem;
+  --ease-space-4: 1rem;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  line-height: 1.6;
+  padding: 2rem;
+}
+
+.container { max-width: 800px; margin: 0 auto; }
+
+header {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 2px solid #e2e8f0;
+}
+
+h1 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; }
+.subtitle { color: #64748b; font-size: 1rem; }
+
+section {
+  margin-bottom: 2.5rem;
+  padding: 1.5rem;
+  background: white;
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+}
+
+section h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.label {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #dbeafe;
+  color: #1d4ed8;
+  margin-bottom: 0.75rem;
+}
+
+/* ---------- Breadcrumb Component ---------- */
+.ease-breadcrumb {
+  font-size: 0.875rem;
+}
+
+.ease-breadcrumb-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ease-space-1, 0.25rem);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ease-breadcrumb-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ease-space-1, 0.25rem);
+}
+
+.ease-breadcrumb-link {
+  color: var(--ease-color-primary, #6c63ff);
+  text-decoration: none;
+  transition: color var(--ease-speed-fast, 150ms);
+}
+
+.ease-breadcrumb-link:hover {
+  text-decoration: underline;
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.ease-breadcrumb-separator {
+  color: #9ca3af;
+  margin: 0 var(--ease-space-1, 0.25rem);
+  user-select: none;
+}
+
+.ease-breadcrumb-active {
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.ease-breadcrumb-sm {
+  font-size: 0.75rem;
+}
+
+.ease-breadcrumb-lg {
+  font-size: 1rem;
+}
+
+/* Dark background demo variant */
+.bg-dark {
+  background: #1e293b;
+}
+
+.bg-dark h2 {
+  color: #e2e8f0;
+  border-bottom-color: #334155;
+}
+
+.bg-dark .ease-breadcrumb-active {
+  color: #9ca3af;
+}


### PR DESCRIPTION
## Description

Adds a `.ease-breadcrumb` navigation component for page hierarchy in documentation sites, dashboards, and multi-step wizards.

### Features
- `.ease-breadcrumb` — nav wrapper with semantic `<ol>` list
- `.ease-breadcrumb-link` — clickable crumb with primary color
- `.ease-breadcrumb-separator` — configurable `›` or `/` divider
- `.ease-breadcrumb-active` — current page marker (muted, bold)
- `.ease-breadcrumb-sm`, `.ease-breadcrumb-lg` — size variants
- Accessible: `aria-label="Breadcrumb"`, `aria-current="page"`, `aria-hidden="true"` on separators

### Files
- `submissions/core_changes-issue-10068/README.md`
- `submissions/core_changes-issue-10068/demo.html`
- `submissions/core_changes-issue-10068/style.css`

Fixes #10068
