### PR TITLE
feat(utilities): add .ease-hstack horizontal stack utility (#10066)

### DIFF
--- a/submissions/core_changes-issue-10066/README.md
+++ b/submissions/core_changes-issue-10066/README.md
@@ -1,0 +1,72 @@
+# .ease-hstack Horizontal Stack Utility
+
+Adds `.ease-hstack` inline horizontal stack utility classes (counterpart to `.ease-stack` vertical stack).
+
+## Problem
+
+`.ease-stack{-sm,-lg,-xl}` creates only vertical (column) flex stacks. Layouts need a horizontal inline stack — for icon+text groups, badge clusters, or navigation link rows.
+
+## Proposed CSS to Add to `core/utilities.css`
+
+```css
+.ease-hstack {
+  display: inline-flex !important;
+  flex-direction: row !important;
+  gap: var(--ease-space-4) !important;
+}
+.ease-hstack-sm {
+  display: inline-flex !important;
+  flex-direction: row !important;
+  gap: var(--ease-space-2) !important;
+}
+.ease-hstack-lg {
+  display: inline-flex !important;
+  flex-direction: row !important;
+  gap: var(--ease-space-6) !important;
+}
+.ease-hstack-xl {
+  display: inline-flex !important;
+  flex-direction: row !important;
+  gap: var(--ease-space-8) !important;
+}
+```
+
+## Usage
+
+```html
+<!-- Button + badge group -->
+<div class="ease-hstack-sm">
+  <button class="ease-btn ease-btn-primary">Save</button>
+  <button class="ease-btn ease-btn-outline">Cancel</button>
+  <span class="ease-badge ease-badge-success">Draft</span>
+</div>
+
+<!-- Icon + text (inline with surrounding content) -->
+<p>You can also combine
+  <span class="ease-hstack-sm" style="vertical-align:middle">
+    <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10 18a8 8 0 100-16 8 8 0 000 16z"/>
+    </svg>
+    <span>inline elements</span>
+  </span>
+  without breaking text flow.
+</p>
+
+<!-- Composable with other utilities -->
+<div class="ease-hstack ease-items-center ease-flex-wrap">
+  <span class="ease-badge ease-badge-info">Tag 1</span>
+  <span class="ease-badge ease-badge-info">Tag 2</span>
+  <span class="ease-badge ease-badge-info">Tag 3</span>
+  <span class="ease-badge ease-badge-info">Tag 4</span>
+</div>
+```
+
+## Benefits
+- Mirrors `.ease-stack` API: same naming, same gap scale, same `!important` convention
+- `inline-flex` keeps it inline with surrounding text (unlike block-level `.ease-stack`)
+- Composes with `.ease-items-center`, `.ease-flex-wrap`, etc.
+
+## Files
+- `README.md` — this file
+- `demo.html` — demo page
+- `style.css` — proposed utility CSS

--- a/submissions/core_changes-issue-10066/demo.html
+++ b/submissions/core_changes-issue-10066/demo.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>.ease-hstack — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      color: #1e293b;
+      line-height: 1.6;
+      padding: 2rem;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    header {
+      text-align: center;
+      margin-bottom: 3rem;
+      padding-bottom: 2rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    h1 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; }
+    .subtitle { color: #64748b; font-size: 1rem; }
+    section {
+      margin-bottom: 2.5rem;
+      padding: 1.5rem;
+      background: white;
+      border-radius: 0.75rem;
+      border: 1px solid #e2e8f0;
+    }
+    section h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .pill {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.65rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      background: #e0e7ff;
+      color: #4338ca;
+    }
+    hr { border: none; border-top: 1px dashed #e2e8f0; margin: 1.5rem 0; }
+    code {
+      background: #f1f5f9;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.85rem;
+      font-family: "JetBrains Mono", monospace;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>↔ ease-hstack</h1>
+      <p class="subtitle">Horizontal inline-flex stack utility — Issue #10066</p>
+    </header>
+
+    <section>
+      <h2>Gap Variants</h2>
+
+      <p style="margin-bottom:0.5rem;font-size:0.85rem;color:#64748b;">
+        <code>ease-hstack-sm</code> &mdash; gap: var(--ease-space-2)
+      </p>
+      <div class="ease-hstack-sm">
+        <span class="pill">sm</span>
+        <span class="pill">gap</span>
+        <span class="pill">0.5rem</span>
+      </div>
+      <hr />
+
+      <p style="margin-bottom:0.5rem;font-size:0.85rem;color:#64748b;">
+        <code>ease-hstack</code> &mdash; gap: var(--ease-space-4)
+      </p>
+      <div class="ease-hstack">
+        <span class="pill">default</span>
+        <span class="pill">gap</span>
+        <span class="pill">1rem</span>
+      </div>
+      <hr />
+
+      <p style="margin-bottom:0.5rem;font-size:0.85rem;color:#64748b;">
+        <code>ease-hstack-lg</code> &mdash; gap: var(--ease-space-6)
+      </p>
+      <div class="ease-hstack-lg">
+        <span class="pill">lg</span>
+        <span class="pill">gap</span>
+        <span class="pill">1.5rem</span>
+      </div>
+      <hr />
+
+      <p style="margin-bottom:0.5rem;font-size:0.85rem;color:#64748b;">
+        <code>ease-hstack-xl</code> &mdash; gap: var(--ease-space-8)
+      </p>
+      <div class="ease-hstack-xl">
+        <span class="pill">xl</span>
+        <span class="pill">gap</span>
+        <span class="pill">2rem</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>Button Groups</h2>
+
+      <p style="margin-bottom:0.75rem;font-size:0.85rem;color:#64748b;">Default buttons</p>
+      <div class="ease-hstack-sm">
+        <button class="ease-btn ease-btn-primary">Save</button>
+        <button class="ease-btn ease-btn-outline">Cancel</button>
+        <span class="ease-badge ease-badge-success">Draft</span>
+      </div>
+
+      <hr />
+
+      <p style="margin-bottom:0.75rem;font-size:0.85rem;color:#64748b;">Large buttons (wider gap)</p>
+      <div class="ease-hstack">
+        <button class="ease-btn ease-btn-primary ease-btn-lg">Submit</button>
+        <button class="ease-btn ease-btn-outline ease-btn-lg">Reset</button>
+        <span class="ease-badge ease-badge-info">Pending</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>Badge Clusters (with wrap)</h2>
+      <div class="ease-hstack-sm ease-items-center ease-flex-wrap">
+        <span class="ease-badge ease-badge-info">React</span>
+        <span class="ease-badge ease-badge-info">TypeScript</span>
+        <span class="ease-badge ease-badge-success">Tailwind</span>
+        <span class="ease-badge ease-badge-warning">Node.js</span>
+        <span class="ease-badge ease-badge-info">PostgreSQL</span>
+        <span class="ease-badge ease-badge-danger">Redis</span>
+        <span class="ease-badge ease-badge-success">Docker</span>
+        <span class="ease-badge ease-badge-info">AWS</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>Inline with Text</h2>
+      <p>
+        This is a sentence with an
+        <span class="ease-hstack-sm" style="vertical-align:middle;display:inline-flex!important">
+          <svg width="16" height="16" viewBox="0 0 20 20" fill="#6c63ff">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"/>
+          </svg>
+          <span><strong>icon+text</strong></span>
+        </span>
+        inline horizontal stack that doesn't break the text flow.
+      </p>
+    </section>
+
+    <section>
+      <h2>HTML Structure</h2>
+      <pre style="background:#1e293b;color:#e2e8f0;padding:1.25rem;border-radius:0.75rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;overflow-x:auto;line-height:1.6;margin-top:0.5rem;">&lt;!-- Button group --&gt;
+&lt;div class="ease-hstack-sm"&gt;
+  &lt;button class="ease-btn ease-btn-primary"&gt;Save&lt;/button&gt;
+  &lt;button class="ease-btn ease-btn-outline"&gt;Cancel&lt;/button&gt;
+  &lt;span class="ease-badge"&gt;Draft&lt;/span&gt;
+&lt;/div&gt;
+
+&lt;!-- Inline with text --&gt;
+&lt;p&gt;
+  Some text
+  &lt;span class="ease-hstack-sm" style="vertical-align:middle"&gt;
+    &lt;svg width="16" height="16"&gt;...&lt;/svg&gt;
+    &lt;span&gt;inline content&lt;/span&gt;
+  &lt;/span&gt;
+  continues here.
+&lt;/p&gt;
+
+&lt;!-- Wrapping badge cluster --&gt;
+&lt;div class="ease-hstack ease-items-center ease-flex-wrap"&gt;
+  &lt;span class="ease-badge"&gt;Tag&lt;/span&gt;
+&lt;/div&gt;</pre>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10066/style.css
+++ b/submissions/core_changes-issue-10066/style.css
@@ -1,0 +1,73 @@
+.ease-hstack {
+  display: inline-flex !important;
+  flex-direction: row !important;
+  gap: var(--ease-space-4, 1rem) !important;
+}
+.ease-hstack-sm {
+  display: inline-flex !important;
+  flex-direction: row !important;
+  gap: var(--ease-space-2, 0.5rem) !important;
+}
+.ease-hstack-lg {
+  display: inline-flex !important;
+  flex-direction: row !important;
+  gap: var(--ease-space-6, 1.5rem) !important;
+}
+.ease-hstack-xl {
+  display: inline-flex !important;
+  flex-direction: row !important;
+  gap: var(--ease-space-8, 2rem) !important;
+}
+
+/* Composing utilities */
+.ease-items-center { align-items: center !important; }
+.ease-items-start { align-items: flex-start !important; }
+.ease-flex-wrap   { flex-wrap: wrap !important; }
+.ease-flex-nowrap { flex-wrap: nowrap !important; }
+
+/* Button styles for demo */
+.ease-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+  line-height: 1.25;
+  transition: background 0.15s, box-shadow 0.15s;
+}
+.ease-btn-primary {
+  background: #6c63ff;
+  color: #fff;
+}
+.ease-btn-outline {
+  background: transparent;
+  border-color: #d1d5db;
+  color: #374151;
+}
+.ease-btn-sm {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+}
+.ease-btn-lg {
+  padding: 0.625rem 1.25rem;
+  font-size: 1rem;
+}
+
+/* Badge styles for demo */
+.ease-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+.ease-badge-success { background: #dcfce7; color: #15803d; }
+.ease-badge-info    { background: #dbeafe; color: #1d4ed8; }
+.ease-badge-danger  { background: #fee2e2; color: #b91c1c; }
+.ease-badge-warning { background: #fef3c7; color: #b45309; }


### PR DESCRIPTION
## Description

Adds `.ease-hstack` inline horizontal stack utility classes — the row-direction counterpart to `.ease-stack` (vertical column).

### Features
- `.ease-hstack-sm` — gap: `var(--ease-space-2)`
- `.ease-hstack` — gap: `var(--ease-space-4)`
- `.ease-hstack-lg` — gap: `var(--ease-space-6)`
- `.ease-hstack-xl` — gap: `var(--ease-space-8)`
- Uses `inline-flex` to keep inline with surrounding text
- Composes with `.ease-items-center`, `.ease-flex-wrap`, etc.
- Matches `.ease-stack` API and `!important` convention

### Files
- `submissions/core_changes-issue-10066/README.md`
- `submissions/core_changes-issue-10066/demo.html`
- `submissions/core_changes-issue-10066/style.css`

Fixes #10066
