### PR TITLE
feat(utilities): add responsive padding/margin breakpoint variants (#10065)

### DIFF
--- a/submissions/core_changes-issue-10065/README.md
+++ b/submissions/core_changes-issue-10065/README.md
@@ -1,0 +1,65 @@
+# Responsive Padding/Margin Breakpoint Variants
+
+Adds responsive breakpoint variants for all padding and margin utilities — enabling spacing changes at sm (640px), md (768px), lg (1024px), and xl (1280px) breakpoints.
+
+## Problem
+
+The framework defines responsive breakpoints for `display`, `flex`, and `grid` (e.g., `ease-md-flex`, `ease-lg-grid-cols-2`) but not for `padding` or `margin`. Users wanting `ease-md-padding-8` on tablets have no corresponding class and must write custom `@media` CSS.
+
+## Proposed CSS to Add to `core/utilities.css`
+
+Insert these blocks inside the existing `@media (min-width: ...)` sections:
+
+### sm (≥640px) — inside `@media (min-width: 640px)`
+
+| Class | CSS |
+|-------|-----|
+| `.ease-sm-padding-{1,2,3,4,6,8,10,12}` | `padding: var(--ease-space-N) !important` |
+| `.ease-sm-pt-4`, `.ease-sm-pr-4`, `.ease-sm-pb-4`, `.ease-sm-pl-4` | directional padding |
+| `.ease-sm-px-4`, `.ease-sm-py-4`, `.ease-sm-px-8`, `.ease-sm-py-8` | axis padding |
+| `.ease-sm-margin-{1,2,3,4,6,8}`, `.ease-sm-margin-auto` | margin |
+| `.ease-sm-mx-auto`, `.ease-sm-my-{4,8}` | axis margin |
+| `.ease-sm-mt-4`, `.ease-sm-mr-4`, `.ease-sm-mb-4`, `.ease-sm-ml-4` | directional margin |
+
+### md (≥768px) — inside `@media (min-width: 768px)`
+
+Same set prefixed `ease-md-` (e.g., `.ease-md-padding-8`, `.ease-md-mx-auto`).
+
+### lg (≥1024px) — inside `@media (min-width: 1024px)`
+
+Same set prefixed `ease-lg-` (e.g., `.ease-lg-padding-12`, `.ease-lg-margin-4`).
+
+### xl (≥1280px) — inside `@media (min-width: 1280px)`
+
+Same set prefixed `ease-xl-` (e.g., `.ease-xl-padding-6`, `.ease-xl-my-8`).
+
+## Usage
+
+```html
+<!-- Responsive padding: tight on mobile, spacious on desktop -->
+<div class="ease-padding-4 ease-md-padding-8 ease-lg-padding-12">
+  <h2>Responsive Section</h2>
+  <p>Padding grows at each breakpoint.</p>
+</div>
+
+<!-- Responsive margin: centered on md+ -->
+<div class="ease-margin-4 ease-md-mx-auto ease-md-margin-8">
+  Centered card on tablet+
+</div>
+
+<!-- Responsive axis: horizontal padding on md+ -->
+<div class="ease-padding-4 ease-md-px-8 ease-lg-px-12">
+  Content with responsive horizontal padding
+</div>
+```
+
+## Benefits
+- Mirrors existing responsive naming pattern: `ease-{bp}-{utility}-{value}`
+- Uses same `!important` convention as all other EaseMotion utilities
+- No duplication of breakpoint values (uses `--ease-bp-sm: 640px` etc.)
+- Gaps in the current spacing API (e.g., no `ease-pt-8` base class) are not extended — only existing base classes get responsive variants
+
+## Files
+- `README.md` — this file
+- `demo.html` — demo page showing responsive behavior
+- `style.css` — proposed CSS additions to `core/utilities.css`

--- a/submissions/core_changes-issue-10065/demo.html
+++ b/submissions/core_changes-issue-10065/demo.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Responsive Padding/Margin — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    :root {
+      --ease-space-1: 0.25rem;
+      --ease-space-2: 0.5rem;
+      --ease-space-3: 0.75rem;
+      --ease-space-4: 1rem;
+      --ease-space-6: 1.5rem;
+      --ease-space-8: 2rem;
+      --ease-space-10: 2.5rem;
+      --ease-space-12: 3rem;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      color: #1e293b;
+      line-height: 1.6;
+      padding: 2rem;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    header {
+      text-align: center;
+      margin-bottom: 3rem;
+      padding-bottom: 2rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    h1 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; }
+    .subtitle { color: #64748b; font-size: 1rem; }
+    section {
+      margin-bottom: 2.5rem;
+      padding: 1.5rem;
+      background: white;
+      border-radius: 0.75rem;
+      border: 1px solid #e2e8f0;
+    }
+    section h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    code {
+      background: #f1f5f9;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.85rem;
+      font-family: "JetBrains Mono", monospace;
+    }
+    .label {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.65rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      background: #e0e7ff;
+      color: #4338ca;
+      margin-bottom: 0.75rem;
+    }
+    .demo-box {
+      background: #eef2ff;
+      border: 2px dashed #6366f1;
+      border-radius: 0.5rem;
+    }
+    .demo-box-inner {
+      background: #c7d2fe;
+      border-radius: 0.25rem;
+      padding: 0.5rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #3730a3;
+      text-align: center;
+    }
+    .bp-indicator {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .bp-tag {
+      padding: 0.2rem 0.6rem;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      font-weight: 600;
+    }
+    .bp-tag.base  { background: #e2e8f0; color: #475569; }
+    .bp-tag.sm    { background: #dbeafe; color: #1d4ed8; }
+    .bp-tag.md    { background: #dcfce7; color: #15803d; }
+    .bp-tag.lg    { background: #fef3c7; color: #b45309; }
+    .bp-tag.xl    { background: #fee2e2; color: #b91c1c; }
+    hr { border: none; border-top: 1px dashed #e2e8f0; margin: 1.5rem 0; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>📐 Responsive Spacing</h1>
+      <p class="subtitle">Padding / margin breakpoint variants — Issue #10065</p>
+    </header>
+
+    <section>
+      <h2>How It Works</h2>
+      <div class="bp-indicator">
+        <span class="bp-tag base">Base (no prefix)</span>
+        <span class="bp-tag sm">.ease-sm-*  ≥640px</span>
+        <span class="bp-tag md">.ease-md-*  ≥768px</span>
+        <span class="bp-tag lg">.ease-lg-*  ≥1024px</span>
+        <span class="bp-tag xl">.ease-xl-*  ≥1280px</span>
+      </div>
+      <p style="font-size:0.85rem;color:#475569;">
+        Resize your browser to see the padding/margin change at each breakpoint.
+        The examples below use <code>padding-4 → md:padding-8 → lg:padding-12</code>
+        and <code>margin-4 → md:margin-8 → lg:mx-auto</code>.
+      </p>
+    </section>
+
+    <section>
+      <h2>Responsive Padding</h2>
+      <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.75rem;">
+        Classes: <code>ease-padding-4 ease-md-padding-8 ease-lg-padding-12</code>
+      </p>
+      <div class="demo-box ease-padding-4 ease-md-padding-8 ease-lg-padding-12">
+        <div class="demo-box-inner">
+          padding: 4 → md:8 → lg:12
+        </div>
+      </div>
+      <hr />
+      <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.75rem;">
+        Directional: <code>ease-pt-4 ease-md-pr-8 ease-lg-pb-12 ease-xl-pl-4</code>
+      </p>
+      <div class="demo-box ease-pt-4 ease-md-pr-8 ease-lg-pb-12 ease-xl-pl-4">
+        <div class="demo-box-inner">
+          pt:4 → md:pr:8 → lg:pb:12 → xl:pl:4
+        </div>
+      </div>
+      <hr />
+      <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.75rem;">
+        Axis: <code>ease-px-4 ease-md-px-8 ease-lg-px-12</code>
+      </p>
+      <div class="demo-box ease-px-4 ease-md-px-8 ease-lg-px-12">
+        <div class="demo-box-inner">
+          px:4 → md:px:8 → lg:px:12
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Responsive Margin</h2>
+      <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.75rem;">
+        <code>ease-margin-4 ease-md-margin-8 ease-lg-mx-auto</code>
+        (outer bg shows margin effect)
+      </p>
+      <div class="demo-box ease-margin-4 ease-md-margin-8 ease-lg-mx-auto" style="border-style:solid;border-color:#93c5fd;background:#eff6ff;">
+        <div class="demo-box-inner">
+          margin:4 → md:8 → lg:mx-auto
+        </div>
+      </div>
+      <hr />
+      <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.75rem;">
+        Bottom margin only: <code>ease-mb-4 ease-md-mb-8 ease-lg-mb-12</code>
+      </p>
+      <div class="demo-box ease-mb-4 ease-md-mb-8 ease-lg-mb-12" style="border-style:solid;border-color:#93c5fd;background:#eff6ff;">
+        <div class="demo-box-inner">mb:4 → md:mb:8 → lg:mb:12</div>
+      </div>
+    </section>
+
+    <section>
+      <h2>All Breakpoint Variants (Generated Pattern)</h2>
+      <p style="font-size:0.85rem;color:#64748b;margin-bottom:1rem;">
+        Each of the 4 breakpoints generates the following classes (shown for md here):
+      </p>
+      <pre style="background:#1e293b;color:#e2e8f0;padding:1.25rem;border-radius:0.75rem;font-family:'JetBrains Mono',monospace;font-size:0.8rem;overflow-x:auto;line-height:1.5;margin-top:0.5rem;">/* Padding generics */
+.ease-md-padding-{1,2,3,4,6,8,10,12}
+/* Padding directional */
+.ease-md-pt-4  .ease-md-pr-4
+.ease-md-pb-4  .ease-md-pl-4
+/* Padding axis */
+.ease-md-px-4  .ease-md-py-4
+.ease-md-px-8  .ease-md-py-8
+/* Margin generics */
+.ease-md-margin-{1,2,3,4,6,8}
+.ease-md-margin-auto
+/* Margin axis + directional */
+.ease-md-mx-auto  .ease-md-my-{4,8}
+.ease-md-mt-4  .ease-md-mr-4
+.ease-md-mb-4  .ease-md-ml-4
+
+Replace md → sm / lg / xl for other breakpoints.</pre>
+    </section>
+
+    <section>
+      <h2>HTML Structure</h2>
+      <pre style="background:#1e293b;color:#e2e8f0;padding:1.25rem;border-radius:0.75rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;overflow-x:auto;line-height:1.6;margin-top:0.5rem;">&lt;!-- Responsive padding --&gt;
+&lt;div class="ease-padding-4 ease-md-padding-8 ease-lg-padding-12"&gt;
+  Padding scales up at each breakpoint.
+&lt;/div&gt;
+
+&lt;!-- Responsive margin + centering --&gt;
+&lt;div class="ease-margin-4 ease-md-mx-auto ease-md-margin-8"&gt;
+  Centered card on tablet+.
+&lt;/div&gt;
+
+&lt;!-- Responsive axis padding --&gt;
+&lt;div class="ease-padding-4 ease-md-px-8 ease-lg-px-12"&gt;
+  Horizontal padding scales, vertical stays.
+&lt;/div&gt;</pre>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10065/style.css
+++ b/submissions/core_changes-issue-10065/style.css
@@ -1,0 +1,155 @@
+/* ============================================================
+   Responsive Padding / Margin Breakpoint Variants
+   Issue: #10065
+   ============================================================
+   Add these blocks inside the existing @media (min-width: ...)
+   sections in core/utilities.css.
+   ============================================================ */
+
+/* ---- SM (≥640px) ---- */
+@media (min-width: 640px) {
+  .ease-sm-padding-1  { padding: var(--ease-space-1) !important; }
+  .ease-sm-padding-2  { padding: var(--ease-space-2) !important; }
+  .ease-sm-padding-3  { padding: var(--ease-space-3) !important; }
+  .ease-sm-padding-4  { padding: var(--ease-space-4) !important; }
+  .ease-sm-padding-6  { padding: var(--ease-space-6) !important; }
+  .ease-sm-padding-8  { padding: var(--ease-space-8) !important; }
+  .ease-sm-padding-10 { padding: var(--ease-space-10) !important; }
+  .ease-sm-padding-12 { padding: var(--ease-space-12) !important; }
+
+  .ease-sm-pt-4 { padding-top:    var(--ease-space-4) !important; }
+  .ease-sm-pr-4 { padding-right:  var(--ease-space-4) !important; }
+  .ease-sm-pb-4 { padding-bottom: var(--ease-space-4) !important; }
+  .ease-sm-pl-4 { padding-left:   var(--ease-space-4) !important; }
+  .ease-sm-px-4 { padding-left: var(--ease-space-4) !important; padding-right:  var(--ease-space-4) !important; }
+  .ease-sm-py-4 { padding-top:  var(--ease-space-4) !important; padding-bottom: var(--ease-space-4) !important; }
+  .ease-sm-px-8 { padding-left: var(--ease-space-8) !important; padding-right:  var(--ease-space-8) !important; }
+  .ease-sm-py-8 { padding-top:  var(--ease-space-8) !important; padding-bottom: var(--ease-space-8) !important; }
+
+  .ease-sm-margin-1   { margin: var(--ease-space-1) !important; }
+  .ease-sm-margin-2   { margin: var(--ease-space-2) !important; }
+  .ease-sm-margin-3   { margin: var(--ease-space-3) !important; }
+  .ease-sm-margin-4   { margin: var(--ease-space-4) !important; }
+  .ease-sm-margin-6   { margin: var(--ease-space-6) !important; }
+  .ease-sm-margin-8   { margin: var(--ease-space-8) !important; }
+  .ease-sm-margin-auto { margin: auto !important; }
+
+  .ease-sm-mx-auto { margin-left: auto !important; margin-right: auto !important; }
+  .ease-sm-my-4    { margin-top: var(--ease-space-4) !important; margin-bottom: var(--ease-space-4) !important; }
+  .ease-sm-my-8    { margin-top: var(--ease-space-8) !important; margin-bottom: var(--ease-space-8) !important; }
+  .ease-sm-mt-4  { margin-top:    var(--ease-space-4) !important; }
+  .ease-sm-mr-4  { margin-right:  var(--ease-space-4) !important; }
+  .ease-sm-mb-4  { margin-bottom: var(--ease-space-4) !important; }
+  .ease-sm-ml-4  { margin-left:   var(--ease-space-4) !important; }
+}
+
+/* ---- MD (≥768px) ---- */
+@media (min-width: 768px) {
+  .ease-md-padding-1  { padding: var(--ease-space-1) !important; }
+  .ease-md-padding-2  { padding: var(--ease-space-2) !important; }
+  .ease-md-padding-3  { padding: var(--ease-space-3) !important; }
+  .ease-md-padding-4  { padding: var(--ease-space-4) !important; }
+  .ease-md-padding-6  { padding: var(--ease-space-6) !important; }
+  .ease-md-padding-8  { padding: var(--ease-space-8) !important; }
+  .ease-md-padding-10 { padding: var(--ease-space-10) !important; }
+  .ease-md-padding-12 { padding: var(--ease-space-12) !important; }
+
+  .ease-md-pt-4 { padding-top:    var(--ease-space-4) !important; }
+  .ease-md-pr-4 { padding-right:  var(--ease-space-4) !important; }
+  .ease-md-pb-4 { padding-bottom: var(--ease-space-4) !important; }
+  .ease-md-pl-4 { padding-left:   var(--ease-space-4) !important; }
+  .ease-md-px-4 { padding-left: var(--ease-space-4) !important; padding-right:  var(--ease-space-4) !important; }
+  .ease-md-py-4 { padding-top:  var(--ease-space-4) !important; padding-bottom: var(--ease-space-4) !important; }
+  .ease-md-px-8 { padding-left: var(--ease-space-8) !important; padding-right:  var(--ease-space-8) !important; }
+  .ease-md-py-8 { padding-top:  var(--ease-space-8) !important; padding-bottom: var(--ease-space-8) !important; }
+
+  .ease-md-margin-1   { margin: var(--ease-space-1) !important; }
+  .ease-md-margin-2   { margin: var(--ease-space-2) !important; }
+  .ease-md-margin-3   { margin: var(--ease-space-3) !important; }
+  .ease-md-margin-4   { margin: var(--ease-space-4) !important; }
+  .ease-md-margin-6   { margin: var(--ease-space-6) !important; }
+  .ease-md-margin-8   { margin: var(--ease-space-8) !important; }
+  .ease-md-margin-auto { margin: auto !important; }
+
+  .ease-md-mx-auto { margin-left: auto !important; margin-right: auto !important; }
+  .ease-md-my-4    { margin-top: var(--ease-space-4) !important; margin-bottom: var(--ease-space-4) !important; }
+  .ease-md-my-8    { margin-top: var(--ease-space-8) !important; margin-bottom: var(--ease-space-8) !important; }
+  .ease-md-mt-4  { margin-top:    var(--ease-space-4) !important; }
+  .ease-md-mr-4  { margin-right:  var(--ease-space-4) !important; }
+  .ease-md-mb-4  { margin-bottom: var(--ease-space-4) !important; }
+  .ease-md-ml-4  { margin-left:   var(--ease-space-4) !important; }
+}
+
+/* ---- LG (≥1024px) ---- */
+@media (min-width: 1024px) {
+  .ease-lg-padding-1  { padding: var(--ease-space-1) !important; }
+  .ease-lg-padding-2  { padding: var(--ease-space-2) !important; }
+  .ease-lg-padding-3  { padding: var(--ease-space-3) !important; }
+  .ease-lg-padding-4  { padding: var(--ease-space-4) !important; }
+  .ease-lg-padding-6  { padding: var(--ease-space-6) !important; }
+  .ease-lg-padding-8  { padding: var(--ease-space-8) !important; }
+  .ease-lg-padding-10 { padding: var(--ease-space-10) !important; }
+  .ease-lg-padding-12 { padding: var(--ease-space-12) !important; }
+
+  .ease-lg-pt-4 { padding-top:    var(--ease-space-4) !important; }
+  .ease-lg-pr-4 { padding-right:  var(--ease-space-4) !important; }
+  .ease-lg-pb-4 { padding-bottom: var(--ease-space-4) !important; }
+  .ease-lg-pl-4 { padding-left:   var(--ease-space-4) !important; }
+  .ease-lg-px-4 { padding-left: var(--ease-space-4) !important; padding-right:  var(--ease-space-4) !important; }
+  .ease-lg-py-4 { padding-top:  var(--ease-space-4) !important; padding-bottom: var(--ease-space-4) !important; }
+  .ease-lg-px-8 { padding-left: var(--ease-space-8) !important; padding-right:  var(--ease-space-8) !important; }
+  .ease-lg-py-8 { padding-top:  var(--ease-space-8) !important; padding-bottom: var(--ease-space-8) !important; }
+
+  .ease-lg-margin-1   { margin: var(--ease-space-1) !important; }
+  .ease-lg-margin-2   { margin: var(--ease-space-2) !important; }
+  .ease-lg-margin-3   { margin: var(--ease-space-3) !important; }
+  .ease-lg-margin-4   { margin: var(--ease-space-4) !important; }
+  .ease-lg-margin-6   { margin: var(--ease-space-6) !important; }
+  .ease-lg-margin-8   { margin: var(--ease-space-8) !important; }
+  .ease-lg-margin-auto { margin: auto !important; }
+
+  .ease-lg-mx-auto { margin-left: auto !important; margin-right: auto !important; }
+  .ease-lg-my-4    { margin-top: var(--ease-space-4) !important; margin-bottom: var(--ease-space-4) !important; }
+  .ease-lg-my-8    { margin-top: var(--ease-space-8) !important; margin-bottom: var(--ease-space-8) !important; }
+  .ease-lg-mt-4  { margin-top:    var(--ease-space-4) !important; }
+  .ease-lg-mr-4  { margin-right:  var(--ease-space-4) !important; }
+  .ease-lg-mb-4  { margin-bottom: var(--ease-space-4) !important; }
+  .ease-lg-ml-4  { margin-left:   var(--ease-space-4) !important; }
+}
+
+/* ---- XL (≥1280px) ---- */
+@media (min-width: 1280px) {
+  .ease-xl-padding-1  { padding: var(--ease-space-1) !important; }
+  .ease-xl-padding-2  { padding: var(--ease-space-2) !important; }
+  .ease-xl-padding-3  { padding: var(--ease-space-3) !important; }
+  .ease-xl-padding-4  { padding: var(--ease-space-4) !important; }
+  .ease-xl-padding-6  { padding: var(--ease-space-6) !important; }
+  .ease-xl-padding-8  { padding: var(--ease-space-8) !important; }
+  .ease-xl-padding-10 { padding: var(--ease-space-10) !important; }
+  .ease-xl-padding-12 { padding: var(--ease-space-12) !important; }
+
+  .ease-xl-pt-4 { padding-top:    var(--ease-space-4) !important; }
+  .ease-xl-pr-4 { padding-right:  var(--ease-space-4) !important; }
+  .ease-xl-pb-4 { padding-bottom: var(--ease-space-4) !important; }
+  .ease-xl-pl-4 { padding-left:   var(--ease-space-4) !important; }
+  .ease-xl-px-4 { padding-left: var(--ease-space-4) !important; padding-right:  var(--ease-space-4) !important; }
+  .ease-xl-py-4 { padding-top:  var(--ease-space-4) !important; padding-bottom: var(--ease-space-4) !important; }
+  .ease-xl-px-8 { padding-left: var(--ease-space-8) !important; padding-right:  var(--ease-space-8) !important; }
+  .ease-xl-py-8 { padding-top:  var(--ease-space-8) !important; padding-bottom: var(--ease-space-8) !important; }
+
+  .ease-xl-margin-1   { margin: var(--ease-space-1) !important; }
+  .ease-xl-margin-2   { margin: var(--ease-space-2) !important; }
+  .ease-xl-margin-3   { margin: var(--ease-space-3) !important; }
+  .ease-xl-margin-4   { margin: var(--ease-space-4) !important; }
+  .ease-xl-margin-6   { margin: var(--ease-space-6) !important; }
+  .ease-xl-margin-8   { margin: var(--ease-space-8) !important; }
+  .ease-xl-margin-auto { margin: auto !important; }
+
+  .ease-xl-mx-auto { margin-left: auto !important; margin-right: auto !important; }
+  .ease-xl-my-4    { margin-top: var(--ease-space-4) !important; margin-bottom: var(--ease-space-4) !important; }
+  .ease-xl-my-8    { margin-top: var(--ease-space-8) !important; margin-bottom: var(--ease-space-8) !important; }
+  .ease-xl-mt-4  { margin-top:    var(--ease-space-4) !important; }
+  .ease-xl-mr-4  { margin-right:  var(--ease-space-4) !important; }
+  .ease-xl-mb-4  { margin-bottom: var(--ease-space-4) !important; }
+  .ease-xl-ml-4  { margin-left:   var(--ease-space-4) !important; }
+}


### PR DESCRIPTION
## Description

Adds responsive breakpoint variants for all padding and margin utilities — enabling spacing changes at sm (640px), md (768px), lg (1024px), and xl (1280px) breakpoints, matching the existing responsive pattern used for `display`, `flex`, and `grid`.

### Features
- **Padding generics:** `ease-{sm,md,lg,xl}-padding-{1,2,3,4,6,8,10,12}`
- **Directional padding:** `ease-{sm,md,lg,xl}-{pt,pr,pb,pl}-4`, `{px,py}-{4,8}`
- **Margin generics:** `ease-{sm,md,lg,xl}-margin-{1,2,3,4,6,8}`, `-margin-auto`
- **Directional + axis margin:** `ease-{sm,md,lg,xl}-{mt,mr,mb,ml}-4`, `{mx,my}-{auto,4,8}`
- Uses `!important` to match all other EaseMotion utilities
- Mirrors existing naming: `ease-{bp}-{utility}-{value}`

### Files
- `submissions/core_changes-issue-10065/README.md`
- `submissions/core_changes-issue-10065/demo.html`
- `submissions/core_changes-issue-10065/style.css`

Fixes #10065
