### PR TITLE
feat(utilities): add aspect-ratio utility classes (#10063)

### DIFF
--- a/submissions/core_changes-issue-10063/README.md
+++ b/submissions/core_changes-issue-10063/README.md
@@ -1,0 +1,47 @@
+# .ease-aspect-{auto,square,video,4-3,3-2,21-9} Utility Classes
+
+Adds standalone `aspect-ratio` utility classes for images, videos, and media containers — no more custom CSS needed for common ratios.
+
+## Problem
+
+The card component uses `aspect-ratio: 16/9` internally for images, but there are no standalone `.ease-aspect-*` utilities. Users must write custom CSS for common ratios like 1:1, 4:3, 3:2, or 21:9.
+
+## Proposed CSS to Add to `core/utilities.css`
+
+```css
+.ease-aspect-auto   { aspect-ratio: auto !important; }
+.ease-aspect-square { aspect-ratio: 1 / 1 !important; }
+.ease-aspect-video  { aspect-ratio: 16 / 9 !important; }
+.ease-aspect-4-3    { aspect-ratio: 4 / 3 !important; }
+.ease-aspect-3-2    { aspect-ratio: 3 / 2 !important; }
+.ease-aspect-21-9   { aspect-ratio: 21 / 9 !important; }
+```
+
+## Usage
+
+```html
+<!-- Video thumbnail -->
+<img class="ease-aspect-video" src="thumbnail.jpg" alt="Video">
+
+<!-- Square profile photo -->
+<img class="ease-aspect-square" src="avatar.jpg" alt="Avatar">
+
+<!-- Cinematic 21:9 banner -->
+<div class="ease-aspect-21-9 ease-bg-primary ease-center">
+  Ultra-wide banner content
+</div>
+
+<!-- Classic 4:3 photo -->
+<img class="ease-aspect-4-3" src="photo.jpg" alt="Photo">
+```
+
+## Benefits
+- covers the most common web ratios (1:1, 16:9, 4:3, 3:2, 21:9)
+- `auto` restores intrinsic sizing
+- composes with `.ease-object-cover`, `.ease-w-full`, etc.
+- uses `!important` to match EaseMotion utility convention
+
+## Files
+- `README.md` — this file
+- `demo.html` — demo page
+- `style.css` — proposed CSS

--- a/submissions/core_changes-issue-10063/demo.html
+++ b/submissions/core_changes-issue-10063/demo.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>aspect-ratio Utilities — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      color: #1e293b;
+      padding: 2rem;
+    }
+    .container { max-width: 900px; margin: 0 auto; }
+    header {
+      text-align: center;
+      margin-bottom: 3rem;
+      padding-bottom: 2rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    h1 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; }
+    .subtitle { color: #64748b; font-size: 1rem; }
+    section {
+      margin-bottom: 2.5rem;
+      padding: 1.5rem;
+      background: white;
+      border-radius: 0.75rem;
+      border: 1px solid #e2e8f0;
+    }
+    section h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1.5rem;
+    }
+    .card {
+      text-align: center;
+    }
+    .card p {
+      margin-top: 0.5rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+    }
+    .card code {
+      display: block;
+      font-size: 0.7rem;
+      color: #64748b;
+      margin-top: 0.25rem;
+    }
+    .ratio-box {
+      width: 100%;
+      border-radius: 0.5rem;
+      overflow: hidden;
+      background: #eef2ff;
+      border: 2px solid #c7d2fe;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.75rem;
+      font-weight: 700;
+      color: #4338ca;
+    }
+    .ratio-box img {
+      width: 100%;
+      height: 100%;
+    }
+    hr { border: none; border-top: 1px dashed #e2e8f0; margin: 1.5rem 0; }
+    code {
+      background: #f1f5f9;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.85rem;
+      font-family: "JetBrains Mono", monospace;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>▭ aspect-ratio Utilities</h1>
+      <p class="subtitle">Common aspect ratios as reusable classes — Issue #10063</p>
+    </header>
+
+    <section>
+      <h2>Ratio Variants</h2>
+      <div class="grid">
+        <div class="card">
+          <div class="ratio-box ease-aspect-square">
+            <div style="text-align:center;line-height:1.4;">1:1<br/>square</div>
+          </div>
+          <p>square <code>ease-aspect-square</code></p>
+        </div>
+        <div class="card">
+          <div class="ratio-box ease-aspect-video">
+            <div>16:9 video</div>
+          </div>
+          <p>video <code>ease-aspect-video</code></p>
+        </div>
+        <div class="card">
+          <div class="ratio-box ease-aspect-4-3">
+            <div>4:3</div>
+          </div>
+          <p>4:3 <code>ease-aspect-4-3</code></p>
+        </div>
+        <div class="card">
+          <div class="ratio-box ease-aspect-3-2">
+            <div>3:2</div>
+          </div>
+          <p>3:2 <code>ease-aspect-3-2</code></p>
+        </div>
+        <div class="card">
+          <div class="ratio-box ease-aspect-21-9">
+            <div>21:9</div>
+          </div>
+          <p>21:9 <code>ease-aspect-21-9</code></p>
+        </div>
+        <div class="card">
+          <div class="ratio-box ease-aspect-auto" style="height:120px;">
+            <div>auto<br/>(intrinsic)</div>
+          </div>
+          <p>auto <code>ease-aspect-auto</code></p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>With Images</h2>
+      <p style="font-size:0.85rem;color:#64748b;margin-bottom:1rem;">
+        Each image uses its respective aspect ratio + <code>ease-object-cover</code> to fill the container.
+      </p>
+      <div class="grid">
+        <div class="card">
+          <div class="ratio-box ease-aspect-square" style="padding:0;">
+            <img src="https://placehold.co/400x300/6366f1/ffffff?text=400x300" alt="square" />
+          </div>
+          <p>square + object-cover</p>
+        </div>
+        <div class="card">
+          <div class="ratio-box ease-aspect-video" style="padding:0;">
+            <img src="https://placehold.co/400x300/6366f1/ffffff?text=400x300" alt="video" />
+          </div>
+          <p>video + object-cover</p>
+        </div>
+        <div class="card">
+          <div class="ratio-box ease-aspect-4-3" style="padding:0;">
+            <img src="https://placehold.co/400x300/6366f1/ffffff?text=400x300" alt="4-3" />
+          </div>
+          <p>4:3 + object-cover</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Use Cases</h2>
+      <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:1.5rem;">
+        <div>
+          <p style="font-weight:700;margin-bottom:0.5rem;">🎬 Video Gallery</p>
+          <div class="ratio-box ease-aspect-video" style="padding:0;margin-bottom:0.5rem;">
+            <img src="https://placehold.co/800x450/6366f1/ffffff?text=Video+Thumbnail" alt="video" />
+          </div>
+          <code>ease-aspect-video</code>
+        </div>
+        <div>
+          <p style="font-weight:700;margin-bottom:0.5rem;">👤 Avatar Grid</p>
+          <div style="display:flex;gap:0.5rem;">
+            <div class="ratio-box ease-aspect-square" style="width:80px;padding:0;">
+              <img src="https://placehold.co/200x200/6366f1/ffffff?text=A" alt="avatar" />
+            </div>
+            <div class="ratio-box ease-aspect-square" style="width:80px;padding:0;">
+              <img src="https://placehold.co/200x200/6366f1/ffffff?text=B" alt="avatar" />
+            </div>
+            <div class="ratio-box ease-aspect-square" style="width:80px;padding:0;">
+              <img src="https://placehold.co/200x200/6366f1/ffffff?text=C" alt="avatar" />
+            </div>
+          </div>
+          <code>ease-aspect-square</code>
+        </div>
+        <div>
+          <p style="font-weight:700;margin-bottom:0.5rem;">🖼️ Photo Album</p>
+          <div class="ratio-box ease-aspect-4-3" style="padding:0;margin-bottom:0.5rem;">
+            <img src="https://placehold.co/800x600/6366f1/ffffff?text=4:3+Photo" alt="photo" />
+          </div>
+          <code>ease-aspect-4-3</code>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>HTML Structure</h2>
+      <pre style="background:#1e293b;color:#e2e8f0;padding:1.25rem;border-radius:0.75rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;overflow-x:auto;line-height:1.6;margin-top:0.5rem;">&lt;!-- Video thumbnail --&gt;
+&lt;img class="ease-aspect-video" src="thumbnail.jpg" alt="Video" /&gt;
+
+&lt;!-- Square avatar --&gt;
+&lt;img class="ease-aspect-square" src="avatar.jpg" alt="Avatar" /&gt;
+
+&lt;!-- Cinematic banner --&gt;
+&lt;div class="ease-aspect-21-9 ease-bg-primary ease-center"&gt;
+  Cinematic content
+&lt;/div&gt;
+
+&lt;!-- Classic photo --&gt;
+&lt;img class="ease-aspect-4-3" src="photo.jpg" alt="Photo" /&gt;
+
+&lt;!-- Intrinsic reset --&gt;
+&lt;img class="ease-aspect-auto" src="natural.png" alt="Natural" /&gt;</pre>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10063/style.css
+++ b/submissions/core_changes-issue-10063/style.css
@@ -1,0 +1,6 @@
+.ease-aspect-auto   { aspect-ratio: auto !important; }
+.ease-aspect-square { aspect-ratio: 1 / 1 !important; }
+.ease-aspect-video  { aspect-ratio: 16 / 9 !important; }
+.ease-aspect-4-3    { aspect-ratio: 4 / 3 !important; }
+.ease-aspect-3-2    { aspect-ratio: 3 / 2 !important; }
+.ease-aspect-21-9   { aspect-ratio: 21 / 9 !important; }


### PR DESCRIPTION
## Description

Adds standalone `aspect-ratio` utility classes for images, videos, and media containers — no more custom CSS for common ratios.

### Features
- `.ease-aspect-auto` — `aspect-ratio: auto` (intrinsic)
- `.ease-aspect-square` — `1 / 1`
- `.ease-aspect-video` — `16 / 9`
- `.ease-aspect-4-3` — `4 / 3`
- `.ease-aspect-3-2` — `3 / 2`
- `.ease-aspect-21-9` — `21 / 9`
- Uses `!important` to match all other EaseMotion utilities

### Files
- `submissions/core_changes-issue-10063/README.md`
- `submissions/core_changes-issue-10063/demo.html`
- `submissions/core_changes-issue-10063/style.css`

Fixes #10063
