### PR TITLE
feat(form): add .ease-radio custom radio button component (#10061)

### DIFF
--- a/submissions/core_changes-issue-10061/README.md
+++ b/submissions/core_changes-issue-10061/README.md
@@ -1,0 +1,133 @@
+# .ease-radio Custom Radio Button Component
+
+Adds a custom radio button component with animated indicator, color variants, and keyboard accessibility.
+
+## Problem
+
+No framework-level radio button styling exists. Native browser defaults are shown. No group wrapper aligns radio items.
+
+## Proposed CSS to Add to `components/radio.css`
+
+```css
+/* Group wrapper */
+.ease-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.ease-radio-horizontal {
+  flex-direction: row;
+}
+
+/* Label item */
+.ease-radio-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* Visually hidden native input */
+.ease-radio-item input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Custom indicator circle */
+.ease-radio-indicator {
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2px solid #9ca3af;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  flex-shrink: 0;
+}
+
+/* Checked state — border color */
+.ease-radio-item input:checked + .ease-radio-indicator {
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+/* Checked state — inner dot */
+.ease-radio-item input:checked + .ease-radio-indicator::after {
+  content: '';
+  width: 0.65rem;
+  height: 0.65rem;
+  background: var(--ease-color-primary, #6c63ff);
+  border-radius: 50%;
+  animation: ease-kf-radio-fill 0.2s ease-out both;
+}
+
+@keyframes ease-kf-radio-fill {
+  from { transform: scale(0); }
+  to   { transform: scale(1); }
+}
+
+/* Focus-visible ring */
+.ease-radio-item input:focus-visible + .ease-radio-indicator {
+  box-shadow: 0 0 0 3px var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.25));
+  outline: none;
+}
+
+/* Color variants */
+.ease-radio-primary input:checked + .ease-radio-indicator { border-color: var(--ease-color-primary, #6c63ff); }
+.ease-radio-primary input:checked + .ease-radio-indicator::after { background: var(--ease-color-primary, #6c63ff); }
+
+.ease-radio-success input:checked + .ease-radio-indicator { border-color: var(--ease-color-success, #22c55e); }
+.ease-radio-success input:checked + .ease-radio-indicator::after { background: var(--ease-color-success, #22c55e); }
+
+.ease-radio-danger input:checked + .ease-radio-indicator { border-color: var(--ease-color-danger, #ef4444); }
+.ease-radio-danger input:checked + .ease-radio-indicator::after { background: var(--ease-color-danger, #ef4444); }
+
+/* Disabled state */
+.ease-radio-item input:disabled ~ * {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+```
+
+## Usage
+
+```html
+<div class="ease-radio-group">
+  <label class="ease-radio-item">
+    <input type="radio" name="plan" checked />
+    <span class="ease-radio-indicator"></span>
+    <span>Free Plan</span>
+  </label>
+  <label class="ease-radio-item">
+    <input type="radio" name="plan" />
+    <span class="ease-radio-indicator"></span>
+    <span>Pro Plan — $19/mo</span>
+  </label>
+  <label class="ease-radio-item ease-radio-danger">
+    <input type="radio" name="plan" disabled />
+    <span class="ease-radio-indicator"></span>
+    <span>Enterprise (unavailable)</span>
+  </label>
+</div>
+```
+
+## Accessibility
+- Native `<input type="radio">` hidden visually but accessible to screen readers
+- Keyboard: Tab to focus, Arrow keys to navigate, Space to select
+- `focus-visible` ring for keyboard users
+- Disabled state with reduced opacity
+
+## Files
+- `README.md` — this file
+- `demo.html` — radio button demo
+- `style.css` — radio component CSS

--- a/submissions/core_changes-issue-10061/demo.html
+++ b/submissions/core_changes-issue-10061/demo.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>.ease-radio — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      color: #1e293b;
+      padding: 2rem;
+    }
+    .container { max-width: 650px; margin: 0 auto; }
+    header {
+      text-align: center;
+      margin-bottom: 3rem;
+      padding-bottom: 2rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    h1 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; }
+    .subtitle { color: #64748b; font-size: 1rem; }
+    section {
+      margin-bottom: 2.5rem;
+      padding: 1.5rem;
+      background: white;
+      border-radius: 0.75rem;
+      border: 1px solid #e2e8f0;
+    }
+    section h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    hr { border: none; border-top: 1px dashed #e2e8f0; margin: 1.5rem 0; }
+    code {
+      background: #f1f5f9;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.85rem;
+      font-family: "JetBrains Mono", monospace;
+    }
+    .label {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.65rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      background: #e0e7ff;
+      color: #4338ca;
+      margin-bottom: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>🔘 ease-radio</h1>
+      <p class="subtitle">Custom radio button component — Issue #10061</p>
+    </header>
+
+    <section>
+      <h2>Default (Vertical)</h2>
+      <div class="ease-radio-group">
+        <label class="ease-radio-item">
+          <input type="radio" name="plan" checked />
+          <span class="ease-radio-indicator"></span>
+          <span>Free Plan — $0/mo</span>
+        </label>
+        <label class="ease-radio-item">
+          <input type="radio" name="plan" />
+          <span class="ease-radio-indicator"></span>
+          <span>Pro Plan — $19/mo</span>
+        </label>
+        <label class="ease-radio-item">
+          <input type="radio" name="plan" />
+          <span class="ease-radio-indicator"></span>
+          <span>Team Plan — $49/mo</span>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h2>Horizontal Layout</h2>
+      <div class="ease-radio-group ease-radio-horizontal">
+        <label class="ease-radio-item">
+          <input type="radio" name="size" checked />
+          <span class="ease-radio-indicator"></span>
+          <span>Small</span>
+        </label>
+        <label class="ease-radio-item">
+          <input type="radio" name="size" />
+          <span class="ease-radio-indicator"></span>
+          <span>Medium</span>
+        </label>
+        <label class="ease-radio-item">
+          <input type="radio" name="size" />
+          <span class="ease-radio-indicator"></span>
+          <span>Large</span>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h2>Color Variants</h2>
+      <div class="ease-radio-group">
+        <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.25rem;">
+          <span class="label">Primary</span> (default)
+        </p>
+        <div class="ease-radio-group" style="margin-bottom:1rem;">
+          <label class="ease-radio-item ease-radio-primary">
+            <input type="radio" name="primary" checked />
+            <span class="ease-radio-indicator"></span>
+            <span>Primary option A</span>
+          </label>
+          <label class="ease-radio-item ease-radio-primary">
+            <input type="radio" name="primary" />
+            <span class="ease-radio-indicator"></span>
+            <span>Primary option B</span>
+          </label>
+        </div>
+
+        <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.25rem;">
+          <span class="label" style="background:#dcfce7;color:#15803d;">Success</span>
+        </p>
+        <div class="ease-radio-group" style="margin-bottom:1rem;">
+          <label class="ease-radio-item ease-radio-success">
+            <input type="radio" name="success" checked />
+            <span class="ease-radio-indicator"></span>
+            <span>Success option A</span>
+          </label>
+          <label class="ease-radio-item ease-radio-success">
+            <input type="radio" name="success" />
+            <span class="ease-radio-indicator"></span>
+            <span>Success option B</span>
+          </label>
+        </div>
+
+        <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.25rem;">
+          <span class="label" style="background:#fee2e2;color:#b91c1c;">Danger</span>
+        </p>
+        <div class="ease-radio-group">
+          <label class="ease-radio-item ease-radio-danger">
+            <input type="radio" name="danger" checked />
+            <span class="ease-radio-indicator"></span>
+            <span>Danger option A</span>
+          </label>
+          <label class="ease-radio-item ease-radio-danger">
+            <input type="radio" name="danger" />
+            <span class="ease-radio-indicator"></span>
+            <span>Danger option B</span>
+          </label>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Disabled State</h2>
+      <div class="ease-radio-group">
+        <label class="ease-radio-item">
+          <input type="radio" name="disabled" checked />
+          <span class="ease-radio-indicator"></span>
+          <span>Enabled option</span>
+        </label>
+        <label class="ease-radio-item">
+          <input type="radio" name="disabled" disabled />
+          <span class="ease-radio-indicator"></span>
+          <span>Disabled option</span>
+        </label>
+        <label class="ease-radio-item ease-radio-danger">
+          <input type="radio" name="disabled" disabled />
+          <span class="ease-radio-indicator"></span>
+          <span>Disabled danger option</span>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h2>HTML Structure</h2>
+      <pre style="background:#1e293b;color:#e2e8f0;padding:1.25rem;border-radius:0.75rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;overflow-x:auto;line-height:1.6;margin-top:0.5rem;">&lt;div class="ease-radio-group"&gt;
+  &lt;label class="ease-radio-item"&gt;
+    &lt;input type="radio" name="plan" checked /&gt;
+    &lt;span class="ease-radio-indicator"&gt;&lt;/span&gt;
+    &lt;span&gt;Free Plan&lt;/span&gt;
+  &lt;/label&gt;
+  &lt;label class="ease-radio-item"&gt;
+    &lt;input type="radio" name="plan" /&gt;
+    &lt;span class="ease-radio-indicator"&gt;&lt;/span&gt;
+    &lt;span&gt;Pro Plan&lt;/span&gt;
+  &lt;/label&gt;
+&lt;/div&gt;
+
+&lt;!-- Horizontal + color variant --&gt;
+&lt;div class="ease-radio-group ease-radio-horizontal"&gt;
+  &lt;label class="ease-radio-item ease-radio-success"&gt;
+    &lt;input type="radio" name="status" checked /&gt;
+    &lt;span class="ease-radio-indicator"&gt;&lt;/span&gt;
+    &lt;span&gt;Active&lt;/span&gt;
+  &lt;/label&gt;
+&lt;/div&gt;
+
+&lt;!-- Disabled --&gt;
+&lt;label class="ease-radio-item"&gt;
+  &lt;input type="radio" name="x" disabled /&gt;
+  &lt;span class="ease-radio-indicator"&gt;&lt;/span&gt;
+  &lt;span&gt;Unavailable&lt;/span&gt;
+&lt;/label&gt;</pre>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10061/style.css
+++ b/submissions/core_changes-issue-10061/style.css
@@ -1,0 +1,95 @@
+.ease-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.ease-radio-horizontal {
+  flex-direction: row;
+}
+
+.ease-radio-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.ease-radio-item input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-radio-indicator {
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2px solid #9ca3af;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  flex-shrink: 0;
+}
+
+.ease-radio-item input:checked + .ease-radio-indicator {
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-radio-item input:checked + .ease-radio-indicator::after {
+  content: '';
+  width: 0.65rem;
+  height: 0.65rem;
+  background: var(--ease-color-primary, #6c63ff);
+  border-radius: 50%;
+  animation: ease-kf-radio-fill 0.2s ease-out both;
+}
+
+@keyframes ease-kf-radio-fill {
+  from { transform: scale(0); }
+  to   { transform: scale(1); }
+}
+
+.ease-radio-item input:focus-visible + .ease-radio-indicator {
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.25);
+  outline: none;
+}
+
+.ease-radio-primary input:checked + .ease-radio-indicator,
+.ease-radio-primary input:checked + .ease-radio-indicator::after {
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-radio-primary input:checked + .ease-radio-indicator::after {
+  background: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-radio-success input:checked + .ease-radio-indicator {
+  border-color: var(--ease-color-success, #22c55e);
+}
+
+.ease-radio-success input:checked + .ease-radio-indicator::after {
+  background: var(--ease-color-success, #22c55e);
+}
+
+.ease-radio-danger input:checked + .ease-radio-indicator {
+  border-color: var(--ease-color-danger, #ef4444);
+}
+
+.ease-radio-danger input:checked + .ease-radio-indicator::after {
+  background: var(--ease-color-danger, #ef4444);
+}
+
+.ease-radio-item input:disabled ~ * {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Description

Adds a `.ease-radio` custom radio button component with animated indicator, color variants, and keyboard accessibility.

### Features
- `.ease-radio-group` — vertical flex container for radio items
- `.ease-radio-horizontal` — row-direction modifier
- `.ease-radio-item` — label wrapping hidden input + custom indicator
- `.ease-radio-indicator` — custom circle with animated dot fill on check
- `.ease-radio-primary`, `.ease-radio-success`, `.ease-radio-danger` — color variants
- `input:focus-visible` ring for keyboard users
- `input:disabled` dims the entire item
- Native `<input>` hidden visually but screen-reader accessible
- Animation: `ease-kf-radio-fill` scales the inner dot from 0→1

### Files
- `submissions/core_changes-issue-10061/README.md`
- `submissions/core_changes-issue-10061/demo.html`
- `submissions/core_changes-issue-10061/style.css`

Fixes #10061
