### PR TITLE
feat(form): add .ease-toggle toggle/switch component (#10060)

### DIFF
--- a/submissions/core_changes-issue-10060/README.md
+++ b/submissions/core_changes-issue-10060/README.md
@@ -1,0 +1,123 @@
+# .ease-toggle Toggle/Switch Component
+
+Adds a custom toggle switch component with animated thumb, color variants, and keyboard accessibility.
+
+## Problem
+
+No toggle/switch component exists in EaseMotion CSS. Adding a visual switch requires 15+ lines of custom CSS per instance.
+
+## Proposed CSS to Add to `components/toggle.css`
+
+```css
+/* Toggle wrapper */
+.ease-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* Visually hidden native checkbox */
+.ease-toggle input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Track */
+.ease-toggle-track {
+  position: relative;
+  width: 2.75rem;
+  height: 1.5rem;
+  background: #d1d5db;
+  border-radius: 9999px;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+/* Checked track */
+.ease-toggle input:checked + .ease-toggle-track {
+  background: var(--ease-color-primary, #6c63ff);
+}
+
+/* Thumb */
+.ease-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1.25rem;
+  height: 1.25rem;
+  background: white;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Checked thumb */
+.ease-toggle input:checked + .ease-toggle-track .ease-toggle-thumb {
+  transform: translateX(1.25rem);
+}
+
+/* Focus-visible */
+.ease-toggle input:focus-visible + .ease-toggle-track {
+  box-shadow: 0 0 0 3px var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.25));
+  outline: none;
+}
+
+/* Size variants */
+.ease-toggle-sm .ease-toggle-track { width: 2rem; height: 1.125rem; }
+.ease-toggle-sm .ease-toggle-thumb { width: 0.85rem; height: 0.85rem; top: 2px; left: 2px; }
+.ease-toggle-sm input:checked + .ease-toggle-track .ease-toggle-thumb { transform: translateX(0.875rem); }
+
+.ease-toggle-lg .ease-toggle-track { width: 3.5rem; height: 1.875rem; }
+.ease-toggle-lg .ease-toggle-thumb { width: 1.5rem; height: 1.5rem; top: 3px; left: 3px; }
+.ease-toggle-lg input:checked + .ease-toggle-track .ease-toggle-thumb { transform: translateX(1.625rem); }
+
+/* Color variants */
+.ease-toggle-primary input:checked + .ease-toggle-track { background: var(--ease-color-primary, #6c63ff); }
+.ease-toggle-success input:checked + .ease-toggle-track { background: var(--ease-color-success, #22c55e); }
+.ease-toggle-danger  input:checked + .ease-toggle-track { background: var(--ease-color-danger, #ef4444); }
+
+/* Disabled */
+.ease-toggle input:disabled ~ * { opacity: 0.5; cursor: not-allowed; }
+```
+
+## Usage
+
+```html
+<label class="ease-toggle ease-toggle-primary">
+  <input type="checkbox" checked />
+  <span class="ease-toggle-track">
+    <span class="ease-toggle-thumb"></span>
+  </span>
+  <span>Enable notifications</span>
+</label>
+
+<label class="ease-toggle ease-toggle-success ease-toggle-sm">
+  <input type="checkbox" />
+  <span class="ease-toggle-track">
+    <span class="ease-toggle-thumb"></span>
+  </span>
+  <span>Small toggle</span>
+</label>
+```
+
+## Accessibility
+- Native `<input type="checkbox">` hidden visually but accessible to screen readers
+- Keyboard: Tab to focus, Space to toggle
+- `focus-visible` ring for keyboard users
+- Disabled state with reduced opacity
+
+## Files
+- `README.md` — this file
+- `demo.html` — demo page
+- `style.css` — toggle component CSS

--- a/submissions/core_changes-issue-10060/demo.html
+++ b/submissions/core_changes-issue-10060/demo.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>.ease-toggle — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      color: #1e293b;
+      padding: 2rem;
+    }
+    .container { max-width: 650px; margin: 0 auto; }
+    header {
+      text-align: center;
+      margin-bottom: 3rem;
+      padding-bottom: 2rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    h1 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; }
+    .subtitle { color: #64748b; font-size: 1rem; }
+    section {
+      margin-bottom: 2.5rem;
+      padding: 1.5rem;
+      background: white;
+      border-radius: 0.75rem;
+      border: 1px solid #e2e8f0;
+    }
+    section h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .toggle-row {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    hr { border: none; border-top: 1px dashed #e2e8f0; margin: 1.5rem 0; }
+    code {
+      background: #f1f5f9;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.85rem;
+      font-family: "JetBrains Mono", monospace;
+    }
+    .label {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.65rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      background: #e0e7ff;
+      color: #4338ca;
+      margin-bottom: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>🔘 ease-toggle</h1>
+      <p class="subtitle">Toggle/switch component — Issue #10060</p>
+    </header>
+
+    <section>
+      <h2>Default Toggle</h2>
+      <div class="toggle-row">
+        <label class="ease-toggle">
+          <input type="checkbox" checked />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Enable notifications</span>
+        </label>
+        <label class="ease-toggle">
+          <input type="checkbox" />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Dark mode</span>
+        </label>
+        <label class="ease-toggle">
+          <input type="checkbox" />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Auto-save edits</span>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h2>Color Variants</h2>
+      <div class="toggle-row">
+        <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.25rem;">
+          <span class="label">Primary</span> (default)
+        </p>
+        <label class="ease-toggle ease-toggle-primary">
+          <input type="checkbox" checked />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Wi-Fi</span>
+        </label>
+      </div>
+      <hr />
+      <div class="toggle-row">
+        <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.25rem;">
+          <span class="label" style="background:#dcfce7;color:#15803d;">Success</span>
+        </p>
+        <label class="ease-toggle ease-toggle-success">
+          <input type="checkbox" checked />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Backup completed</span>
+        </label>
+        <label class="ease-toggle ease-toggle-success">
+          <input type="checkbox" />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Auto-backup</span>
+        </label>
+      </div>
+      <hr />
+      <div class="toggle-row">
+        <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.25rem;">
+          <span class="label" style="background:#fee2e2;color:#b91c1c;">Danger</span>
+        </p>
+        <label class="ease-toggle ease-toggle-danger">
+          <input type="checkbox" />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Delete confirmed</span>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h2>Size Variants</h2>
+      <div class="toggle-row">
+        <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.25rem;">
+          <span class="label">Sm</span>
+        </p>
+        <label class="ease-toggle ease-toggle-primary ease-toggle-sm">
+          <input type="checkbox" checked />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Small toggle</span>
+        </label>
+      </div>
+      <hr />
+      <div class="toggle-row">
+        <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.25rem;">
+          <span class="label">Default</span>
+        </p>
+        <label class="ease-toggle ease-toggle-primary">
+          <input type="checkbox" checked />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Default toggle</span>
+        </label>
+      </div>
+      <hr />
+      <div class="toggle-row">
+        <p style="font-size:0.85rem;color:#64748b;margin-bottom:0.25rem;">
+          <span class="label">Lg</span>
+        </p>
+        <label class="ease-toggle ease-toggle-primary ease-toggle-lg">
+          <input type="checkbox" checked />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Large toggle</span>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h2>Disabled State</h2>
+      <div class="toggle-row">
+        <label class="ease-toggle">
+          <input type="checkbox" checked disabled />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Enabled (disabled)</span>
+        </label>
+        <label class="ease-toggle">
+          <input type="checkbox" disabled />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Disabled toggle</span>
+        </label>
+        <label class="ease-toggle ease-toggle-danger">
+          <input type="checkbox" checked disabled />
+          <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+          <span>Disabled danger</span>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h2>HTML Structure</h2>
+      <pre style="background:#1e293b;color:#e2e8f0;padding:1.25rem;border-radius:0.75rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;overflow-x:auto;line-height:1.6;margin-top:0.5rem;">&lt;!-- Basic toggle --&gt;
+&lt;label class="ease-toggle ease-toggle-primary"&gt;
+  &lt;input type="checkbox" checked /&gt;
+  &lt;span class="ease-toggle-track"&gt;
+    &lt;span class="ease-toggle-thumb"&gt;&lt;/span&gt;
+  &lt;/span&gt;
+  &lt;span&gt;Label text&lt;/span&gt;
+&lt;/label&gt;
+
+&lt;!-- Small success toggle --&gt;
+&lt;label class="ease-toggle ease-toggle-success ease-toggle-sm"&gt;
+  &lt;input type="checkbox" /&gt;
+  &lt;span class="ease-toggle-track"&gt;
+    &lt;span class="ease-toggle-thumb"&gt;&lt;/span&gt;
+  &lt;/span&gt;
+  &lt;span&gt;Small&lt;/span&gt;
+&lt;/label&gt;
+
+&lt;!-- Disabled --&gt;
+&lt;label class="ease-toggle"&gt;
+  &lt;input type="checkbox" disabled /&gt;
+  ...
+&lt;/label&gt;</pre>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10060/style.css
+++ b/submissions/core_changes-issue-10060/style.css
@@ -1,0 +1,74 @@
+.ease-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.ease-toggle:focus-within {
+  outline: none;
+}
+
+.ease-toggle input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-toggle-track {
+  position: relative;
+  width: 2.75rem;
+  height: 1.5rem;
+  background: #d1d5db;
+  border-radius: 9999px;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.ease-toggle input:checked + .ease-toggle-track {
+  background: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1.25rem;
+  height: 1.25rem;
+  background: white;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-toggle input:checked + .ease-toggle-track .ease-toggle-thumb {
+  transform: translateX(1.25rem);
+}
+
+.ease-toggle input:focus-visible + .ease-toggle-track {
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.25);
+  outline: none;
+}
+
+.ease-toggle-sm .ease-toggle-track { width: 2rem; height: 1.125rem; }
+.ease-toggle-sm .ease-toggle-thumb { width: 0.85rem; height: 0.85rem; top: 2px; left: 2px; }
+.ease-toggle-sm input:checked + .ease-toggle-track .ease-toggle-thumb { transform: translateX(0.875rem); }
+
+.ease-toggle-lg .ease-toggle-track { width: 3.5rem; height: 1.875rem; }
+.ease-toggle-lg .ease-toggle-thumb { width: 1.5rem; height: 1.5rem; top: 3px; left: 3px; }
+.ease-toggle-lg input:checked + .ease-toggle-track .ease-toggle-thumb { transform: translateX(1.625rem); }
+
+.ease-toggle-primary input:checked + .ease-toggle-track { background: var(--ease-color-primary, #6c63ff); }
+.ease-toggle-success input:checked + .ease-toggle-track { background: var(--ease-color-success, #22c55e); }
+.ease-toggle-danger  input:checked + .ease-toggle-track { background: var(--ease-color-danger, #ef4444); }
+
+.ease-toggle input:disabled ~ * { opacity: 0.5; cursor: not-allowed; }


### PR DESCRIPTION
## Description

Adds a `.ease-toggle` toggle/switch component with animated thumb, color variants, size variants, and keyboard accessibility.

### Features
- `.ease-toggle` — label wrapper (hidden checkbox + track + thumb + label)
- `.ease-toggle-track` — rounded pill background (transitions on check)
- `.ease-toggle-thumb` — circular knob with spring-like cubic-bezier transform
- `.ease-toggle-sm`, `.ease-toggle-lg` — size variants
- `.ease-toggle-primary`, `.ease-toggle-success`, `.ease-toggle-danger` — color variants
- `input:focus-visible` ring on track for keyboard users
- `input:disabled` dims the entire toggle
- Native `<input type="checkbox">` hidden visually but screen-reader accessible

### Files
- `submissions/core_changes-issue-10060/README.md`
- `submissions/core_changes-issue-10060/demo.html`
- `submissions/core_changes-issue-10060/style.css`

Fixes #10060
