### PR TITLE
feat(component): add .ease-kbd keyboard key component (#10103)

### DIFF
--- a/submissions/core_changes-issue-10103/README.md
+++ b/submissions/core_changes-issue-10103/README.md
@@ -1,0 +1,63 @@
+# .ease-kbd Keyboard Key Component
+
+Adds a keyboard key component for displaying keyboard shortcuts in documentation, shortcut guides, and help modals.
+
+## Problem
+
+`<kbd>` tags render in browser default monospace with no visual distinction. No `.ease-kbd` class exists to style them as physical keys.
+
+## Proposed CSS to Add to `components/kbd.css`
+
+```css
+.ease-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.5rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #374151;
+  background: #f1f5f9;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  box-shadow: 0 1px 0 #cbd5e1;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.ease-kbd-sm { font-size: 0.65rem; padding: 0.1rem 0.35rem; }
+.ease-kbd-lg { font-size: 0.9rem; padding: 0.25rem 0.65rem; }
+
+.ease-kbd-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+```
+
+## Usage
+
+```html
+<p>Press <kbd class="ease-kbd">Ctrl</kbd> + <kbd class="ease-kbd">K</kbd> to search</p>
+
+<span class="ease-kbd-group">
+  <kbd class="ease-kbd">⌘</kbd>
+  <kbd class="ease-kbd">⇧</kbd>
+  <kbd class="ease-kbd">P</kbd>
+</span>
+
+<!-- Size variants -->
+<kbd class="ease-kbd ease-kbd-sm">Esc</kbd>
+<kbd class="ease-kbd ease-kbd-lg">Enter</kbd>
+```
+
+## Benefits
+- Physical key appearance: light bg, subtle border, rounded corners, shadow
+- Group container for key combinations with proper spacing
+- sm / lg size variants
+
+## Files
+- `README.md` — this file
+- `demo.html` — demo page
+- `style.css` — kbd component CSS

--- a/submissions/core_changes-issue-10103/demo.html
+++ b/submissions/core_changes-issue-10103/demo.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>.ease-kbd — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      color: #1e293b;
+      padding: 2rem;
+    }
+    .container { max-width: 650px; margin: 0 auto; }
+    header {
+      text-align: center;
+      margin-bottom: 3rem;
+      padding-bottom: 2rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    h1 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; }
+    .subtitle { color: #64748b; font-size: 1rem; }
+    section {
+      margin-bottom: 2.5rem;
+      padding: 1.5rem;
+      background: white;
+      border-radius: 0.75rem;
+      border: 1px solid #e2e8f0;
+    }
+    section h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .examples { display: flex; flex-direction: column; gap: 1.25rem; }
+    hr { border: none; border-top: 1px dashed #e2e8f0; margin: 1.5rem 0; }
+    code {
+      background: #f1f5f9;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.85rem;
+      font-family: "JetBrains Mono", monospace;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>⌨️ ease-kbd</h1>
+      <p class="subtitle">Keyboard key component — Issue #10103</p>
+    </header>
+
+    <section>
+      <h2>Single Keys</h2>
+      <div class="examples">
+        <p>Press <kbd class="ease-kbd">Esc</kbd> to close the dialog.</p>
+        <p>Press <kbd class="ease-kbd">Enter</kbd> to submit the form.</p>
+        <p>Press <kbd class="ease-kbd">Tab</kbd> to move to the next field.</p>
+        <p>Press <kbd class="ease-kbd">Space</kbd> to toggle the checkbox.</p>
+        <p>Press <kbd class="ease-kbd">Delete</kbd> to remove the selected item.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>Key Combinations</h2>
+      <div class="examples">
+        <p>
+          Search:
+          <kbd class="ease-kbd">Ctrl</kbd> + <kbd class="ease-kbd">K</kbd>
+        </p>
+        <p>
+          Save:
+          <kbd class="ease-kbd">Ctrl</kbd> + <kbd class="ease-kbd">S</kbd>
+        </p>
+        <p>
+          DevTools:
+          <kbd class="ease-kbd">Ctrl</kbd> + <kbd class="ease-kbd">Shift</kbd> + <kbd class="ease-kbd">I</kbd>
+        </p>
+        <p>
+          Mac screenshot:
+          <kbd class="ease-kbd">⌘</kbd> + <kbd class="ease-kbd">⇧</kbd> + <kbd class="ease-kbd">3</kbd>
+        </p>
+      </div>
+    </section>
+
+    <section>
+      <h2>Group Container</h2>
+      <p>Using <code>ease-kbd-group</code> for natural spacing:</p>
+      <div style="margin-top:1rem;">
+        <span class="ease-kbd-group">
+          <kbd class="ease-kbd">⌘</kbd>
+          <kbd class="ease-kbd">⇧</kbd>
+          <kbd class="ease-kbd">P</kbd>
+        </span>
+        <span style="margin-left:1rem;color:#64748b;font-size:0.85rem;">— Command Palette</span>
+      </div>
+      <div style="margin-top:0.75rem;">
+        <span class="ease-kbd-group">
+          <kbd class="ease-kbd">Ctrl</kbd>
+          <kbd class="ease-kbd">Alt</kbd>
+          <kbd class="ease-kbd">Del</kbd>
+        </span>
+      </div>
+    </section>
+
+    <section>
+      <h2>Size Variants</h2>
+      <div class="examples">
+        <p>
+          Small: <kbd class="ease-kbd ease-kbd-sm">F1</kbd>
+          <code>ease-kbd-sm</code>
+        </p>
+        <p>
+          Default: <kbd class="ease-kbd">F1</kbd>
+        </p>
+        <p>
+          Large: <kbd class="ease-kbd ease-kbd-lg">F1</kbd>
+          <code>ease-kbd-lg</code>
+        </p>
+      </div>
+    </section>
+
+    <section>
+      <h2>HTML Structure</h2>
+      <pre style="background:#1e293b;color:#e2e8f0;padding:1.25rem;border-radius:0.75rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;overflow-x:auto;line-height:1.6;margin-top:0.5rem;">&lt;!-- Single key --&gt;
+&lt;kbd class="ease-kbd"&gt;Esc&lt;/kbd&gt;
+
+&lt;!-- Key combination --&gt;
+&lt;kbd class="ease-kbd"&gt;Ctrl&lt;/kbd&gt; + &lt;kbd class="ease-kbd"&gt;K&lt;/kbd&gt;
+
+&lt;!-- Group --&gt;
+&lt;span class="ease-kbd-group"&gt;
+  &lt;kbd class="ease-kbd"&gt;⌘&lt;/kbd&gt;
+  &lt;kbd class="ease-kbd"&gt;⇧&lt;/kbd&gt;
+  &lt;kbd class="ease-kbd"&gt;P&lt;/kbd&gt;
+&lt;/span&gt;
+
+&lt;!-- Size variants --&gt;
+&lt;kbd class="ease-kbd ease-kbd-sm"&gt;F1&lt;/kbd&gt;
+&lt;kbd class="ease-kbd ease-kbd-lg"&gt;Enter&lt;/kbd&gt;</pre>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10103/style.css
+++ b/submissions/core_changes-issue-10103/style.css
@@ -1,0 +1,25 @@
+.ease-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.5rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #374151;
+  background: #f1f5f9;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  box-shadow: 0 1px 0 #cbd5e1;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.ease-kbd-sm { font-size: 0.65rem; padding: 0.1rem 0.35rem; }
+.ease-kbd-lg { font-size: 0.9rem; padding: 0.25rem 0.65rem; }
+
+.ease-kbd-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}


### PR DESCRIPTION
## Description

Adds a `.ease-kbd` keyboard key component for displaying keyboard shortcuts in documentation, shortcut guides, and help modals.

### Features
- `.ease-kbd` — physical key appearance: light bg, subtle border, rounded corners, bottom shadow
- `.ease-kbd-sm`, `.ease-kbd-lg` — size variants
- `.ease-kbd-group` — inline-flex container with proper gap for key combinations

### Files
- `submissions/core_changes-issue-10103/README.md`
- `submissions/core_changes-issue-10103/demo.html`
- `submissions/core_changes-issue-10103/style.css`

Fixes #10103
