### PR TITLE
feat(component): add .ease-avatar and .ease-avatar-group components (#10104)

### DIFF
--- a/submissions/core_changes-issue-10104/README.md
+++ b/submissions/core_changes-issue-10104/README.md
@@ -1,0 +1,86 @@
+# .ease-avatar and .ease-avatar-group Components
+
+Adds avatar component with initials support and avatar group with overlapping stack.
+
+## Problem
+
+User profiles, comment sections, and team pages display avatars, but each implementation requires custom CSS for sizing, rounding, and fallback initials. Grouped avatars with overlap need negative margins and borders.
+
+## Proposed CSS to Add to `components/avatar.css`
+
+```css
+/* Single avatar */
+.ease-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #e0e7ff;
+  color: #6c63ff;
+  font-weight: 700;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.ease-avatar img { width: 100%; height: 100%; object-fit: cover; }
+
+.ease-avatar-sm { width: 2rem; height: 2rem; font-size: 0.75rem; }
+.ease-avatar-lg { width: 3rem; height: 3rem; font-size: 1.1rem; }
+.ease-avatar-xl { width: 4rem; height: 4rem; font-size: 1.5rem; }
+
+/* Avatar group */
+.ease-avatar-group {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+.ease-avatar-group .ease-avatar {
+  border: 2px solid white;
+  margin-left: -0.5rem;
+}
+
+.ease-avatar-group .ease-avatar:first-child {
+  margin-left: 0;
+}
+
+.ease-avatar-group-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: #e2e8f0;
+  color: #475569;
+  font-size: 0.8rem;
+  font-weight: 700;
+  border: 2px solid white;
+  margin-left: -0.5rem;
+}
+```
+
+## Usage
+
+```html
+<!-- Single avatars -->
+<img class="ease-avatar" src="user1.jpg" alt="User" />
+<div class="ease-avatar">PM</div> <!-- initials fallback -->
+<img class="ease-avatar ease-avatar-lg" src="user2.jpg" alt="User" />
+
+<!-- Avatar group -->
+<div class="ease-avatar-group">
+  <img class="ease-avatar" src="user1.jpg" alt="A" />
+  <img class="ease-avatar" src="user2.jpg" alt="B" />
+  <img class="ease-avatar" src="user3.jpg" alt="C" />
+  <span class="ease-avatar-group-count">+5</span>
+</div>
+```
+
+## Files
+- `README.md` — this file
+- `demo.html` — demo page
+- `style.css` — avatar component CSS

--- a/submissions/core_changes-issue-10104/demo.html
+++ b/submissions/core_changes-issue-10104/demo.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>.ease-avatar — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      color: #1e293b;
+      padding: 2rem;
+    }
+    .container { max-width: 700px; margin: 0 auto; }
+    header {
+      text-align: center;
+      margin-bottom: 3rem;
+      padding-bottom: 2rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    h1 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; }
+    .subtitle { color: #64748b; font-size: 1rem; }
+    section {
+      margin-bottom: 2.5rem;
+      padding: 1.5rem;
+      background: white;
+      border-radius: 0.75rem;
+      border: 1px solid #e2e8f0;
+    }
+    section h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .inline-wrap {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .avatar-card { text-align: center; }
+    .avatar-card p {
+      margin-top: 0.5rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+    .avatar-card code {
+      display: block;
+      font-size: 0.65rem;
+      color: #64748b;
+      margin-top: 0.15rem;
+    }
+    hr { border: none; border-top: 1px dashed #e2e8f0; margin: 1.5rem 0; }
+    code {
+      background: #f1f5f9;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.85rem;
+      font-family: "JetBrains Mono", monospace;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>👤 ease-avatar</h1>
+      <p class="subtitle">Avatar + Avatar Group — Issue #10104</p>
+    </header>
+
+    <section>
+      <h2>Size Variants</h2>
+      <div class="inline-wrap">
+        <div class="avatar-card">
+          <div class="ease-avatar ease-avatar-sm" style="display:inline-flex;">S</div>
+          <p>sm</p>
+          <code>ease-avatar-sm</code>
+        </div>
+        <div class="avatar-card">
+          <div class="ease-avatar" style="display:inline-flex;">M</div>
+          <p>default</p>
+          <code>ease-avatar</code>
+        </div>
+        <div class="avatar-card">
+          <div class="ease-avatar ease-avatar-lg" style="display:inline-flex;">L</div>
+          <p>lg</p>
+          <code>ease-avatar-lg</code>
+        </div>
+        <div class="avatar-card">
+          <div class="ease-avatar ease-avatar-xl" style="display:inline-flex;">XL</div>
+          <p>xl</p>
+          <code>ease-avatar-xl</code>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Image Avatars</h2>
+      <div class="inline-wrap">
+        <div class="avatar-card">
+          <img class="ease-avatar" src="https://placehold.co/100x100/6366f1/ffffff?text=A" alt="A" />
+          <p>Default</p>
+        </div>
+        <div class="avatar-card">
+          <img class="ease-avatar ease-avatar-lg" src="https://placehold.co/100x100/22c55e/ffffff?text=B" alt="B" />
+          <p>Large</p>
+        </div>
+        <div class="avatar-card">
+          <img class="ease-avatar ease-avatar-xl" src="https://placehold.co/100x100/ef4444/ffffff?text=C" alt="C" />
+          <p>XL</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Initials Fallback</h2>
+      <div class="inline-wrap">
+        <div class="avatar-card">
+          <div class="ease-avatar" style="display:inline-flex;">PM</div>
+          <p>PM</p>
+        </div>
+        <div class="avatar-card">
+          <div class="ease-avatar ease-avatar-lg" style="display:inline-flex;">JD</div>
+          <p>JD</p>
+        </div>
+        <div class="avatar-card">
+          <div class="ease-avatar ease-avatar-xl" style="display:inline-flex;">SK</div>
+          <p>SK</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Avatar Group (Overlapping)</h2>
+      <p style="font-size:0.85rem;color:#64748b;margin-bottom:1rem;">
+        Using <code>ease-avatar-group</code> with overlapping avatars and count badge.
+      </p>
+      <div style="display:flex;flex-direction:column;gap:1.5rem;">
+        <div class="ease-avatar-group">
+          <img class="ease-avatar" src="https://placehold.co/100x100/6366f1/ffffff?text=A" alt="A" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/22c55e/ffffff?text=B" alt="B" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/ef4444/ffffff?text=C" alt="C" />
+        </div>
+
+        <div class="ease-avatar-group">
+          <img class="ease-avatar" src="https://placehold.co/100x100/6366f1/ffffff?text=A" alt="A" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/22c55e/ffffff?text=B" alt="B" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/f59e0b/ffffff?text=C" alt="C" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/3b82f6/ffffff?text=D" alt="D" />
+          <span class="ease-avatar-group-count">+3</span>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Use Case: Team Row</h2>
+      <div style="display:flex;align-items:center;gap:1rem;padding:1rem;border:1px solid #e2e8f0;border-radius:0.75rem;background:#f8fafc;">
+        <div class="ease-avatar-group">
+          <img class="ease-avatar" src="https://placehold.co/100x100/6366f1/ffffff?text=A" alt="A" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/22c55e/ffffff?text=B" alt="B" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/f59e0b/ffffff?text=C" alt="C" />
+        </div>
+        <div>
+          <p style="font-weight:700;font-size:0.9rem;">Design Team</p>
+          <p style="font-size:0.8rem;color:#64748b;">Alice, Bob, and Carol</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>HTML Structure</h2>
+      <pre style="background:#1e293b;color:#e2e8f0;padding:1.25rem;border-radius:0.75rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;overflow-x:auto;line-height:1.6;margin-top:0.5rem;">&lt;!-- Single avatar with image --&gt;
+&lt;img class="ease-avatar" src="user.jpg" alt="User" /&gt;
+
+&lt;!-- Single avatar with initials --&gt;
+&lt;div class="ease-avatar"&gt;PM&lt;/div&gt;
+
+&lt;!-- Size variants --&gt;
+&lt;img class="ease-avatar ease-avatar-sm" /&gt;
+&lt;img class="ease-avatar ease-avatar-lg" /&gt;
+&lt;img class="ease-avatar ease-avatar-xl" /&gt;
+
+&lt;!-- Avatar group with overlap --&gt;
+&lt;div class="ease-avatar-group"&gt;
+  &lt;img class="ease-avatar" src="u1.jpg" /&gt;
+  &lt;img class="ease-avatar" src="u2.jpg" /&gt;
+  &lt;img class="ease-avatar" src="u3.jpg" /&gt;
+  &lt;span class="ease-avatar-group-count"&gt;+5&lt;/span&gt;
+&lt;/div&gt;</pre>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10104/style.css
+++ b/submissions/core_changes-issue-10104/style.css
@@ -1,0 +1,54 @@
+.ease-avatar-group {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+.ease-avatar-group .ease-avatar {
+  border: 2px solid white;
+  margin-left: -0.5rem;
+}
+
+.ease-avatar-group .ease-avatar:first-child {
+  margin-left: 0;
+}
+
+.ease-avatar-group-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: #e2e8f0;
+  color: #475569;
+  font-size: 0.8rem;
+  font-weight: 700;
+  border: 2px solid white;
+  margin-left: -0.5rem;
+}
+
+.ease-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #e0e7ff;
+  color: #6c63ff;
+  font-weight: 700;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.ease-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ease-avatar-sm { width: 2rem; height: 2rem; font-size: 0.75rem; }
+.ease-avatar-lg { width: 3rem; height: 3rem; font-size: 1.1rem; }
+.ease-avatar-xl { width: 4rem; height: 4rem; font-size: 1.5rem; }


### PR DESCRIPTION
## Description

Adds `.ease-avatar` single avatar and `.ease-avatar-group` overlapping avatar stack components.

### Features
- `.ease-avatar` — 2.5rem circle, image or initials fallback, `#e0e7ff` bg with `#6c63ff` text, `object-fit: cover`
- `.ease-avatar-sm` (2rem), `.ease-avatar-lg` (3rem), `.ease-avatar-xl` (4rem) — size variants
- `.ease-avatar-group` — `flex-direction: row-reverse` with `-0.5rem` overlap, white 2px border ring
- `.ease-avatar-group-count` — `+N` overflow circle badge

### Files
- `submissions/core_changes-issue-10104/README.md`
- `submissions/core_changes-issue-10104/demo.html`
- `submissions/core_changes-issue-10104/style.css`

Fixes #10104
