### PR TITLE
feat(component): add .ease-avatar-group overlapping avatar stack (#10100)

### DIFF
--- a/submissions/core_changes-issue-10100/README.md
+++ b/submissions/core_changes-issue-10100/README.md
@@ -1,0 +1,58 @@
+# .ease-avatar-group Overlapping Avatar Stack
+
+Adds an overlapping avatar group component for displaying team members, contributors, or participants with a stacked layout.
+
+## Problem
+
+Team pages, contributor lists, and participant displays often show multiple avatars overlapping or listed together, but EaseMotion has no utility for this common pattern. Manual implementation requires flexbox with negative margins and custom borders.
+
+## Proposed CSS to Add to `components/avatar-group.css`
+
+```css
+.ease-avatar-group {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+.ease-avatar-group .ease-avatar {
+  border: 2px solid white;
+  margin-left: -0.5rem;
+}
+
+.ease-avatar-group .ease-avatar:first-child {
+  margin-left: 0;
+}
+
+.ease-avatar-group-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: #e2e8f0;
+  color: #475569;
+  font-size: 0.8rem;
+  font-weight: 700;
+  border: 2px solid white;
+  margin-left: -0.5rem;
+}
+```
+
+## Usage
+
+```html
+<div class="ease-avatar-group">
+  <img class="ease-avatar" src="user1.jpg" alt="User 1" />
+  <img class="ease-avatar" src="user2.jpg" alt="User 2" />
+  <img class="ease-avatar" src="user3.jpg" alt="User 3" />
+  <img class="ease-avatar" src="user4.jpg" alt="User 4" />
+  <span class="ease-avatar-group-count">+3</span>
+</div>
+```
+
+## Files
+- `README.md` — this file
+- `demo.html` — demo page
+- `style.css` — proposed CSS (includes basic .ease-avatar for demo purposes)

--- a/submissions/core_changes-issue-10100/demo.html
+++ b/submissions/core_changes-issue-10100/demo.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>.ease-avatar-group — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      color: #1e293b;
+      padding: 2rem;
+    }
+    .container { max-width: 700px; margin: 0 auto; }
+    header {
+      text-align: center;
+      margin-bottom: 3rem;
+      padding-bottom: 2rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    h1 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; }
+    .subtitle { color: #64748b; font-size: 1rem; }
+    section {
+      margin-bottom: 2.5rem;
+      padding: 1.5rem;
+      background: white;
+      border-radius: 0.75rem;
+      border: 1px solid #e2e8f0;
+    }
+    section h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .avatar-group-demo {
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+      flex-wrap: wrap;
+    }
+    .avatar-group-demo div {
+      text-align: center;
+    }
+    .avatar-group-demo p {
+      margin-top: 0.5rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+    }
+    .avatar-group-demo code {
+      display: block;
+      font-size: 0.7rem;
+      color: #64748b;
+      margin-top: 0.25rem;
+    }
+    hr { border: none; border-top: 1px dashed #e2e8f0; margin: 1.5rem 0; }
+    code {
+      background: #f1f5f9;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.85rem;
+      font-family: "JetBrains Mono", monospace;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>👥 ease-avatar-group</h1>
+      <p class="subtitle">Overlapping avatar stack component — Issue #10100</p>
+    </header>
+
+    <section>
+      <h2>Basic Usage</h2>
+      <div class="avatar-group-demo">
+        <div>
+          <div class="ease-avatar-group">
+            <img class="ease-avatar" src="https://placehold.co/100x100/6366f1/ffffff?text=A" alt="User A" />
+            <img class="ease-avatar" src="https://placehold.co/100x100/22c55e/ffffff?text=B" alt="User B" />
+            <img class="ease-avatar" src="https://placehold.co/100x100/ef4444/ffffff?text=C" alt="User C" />
+          </div>
+          <p>3 avatars</p>
+          <code>&lt;div class="ease-avatar-group"&gt;
+  &lt;img class="ease-avatar" src="..." /&gt;
+  &lt;img class="ease-avatar" src="..." /&gt;
+  &lt;img class="ease-avatar" src="..." /&gt;
+&lt;/div&gt;</code>
+        </div>
+        
+        <div>
+          <div class="ease-avatar-group">
+            <img class="ease-avatar" src="https://placehold.co/100x100/6366f1/ffffff?text=A" alt="User A" />
+            <img class="ease-avatar" src="https://placehold.co/100x100/22c55e/ffffff?text=B" alt="User B" />
+            <img class="ease-avatar" src="https://placehold.co/100x100/ef4444/ffffff?text=C" alt="User C" />
+            <img class="ease-avatar" src="https://placehold.co/100x100/f59e0b/ffffff?text=D" alt="User D" />
+            <img class="ease-avatar" src="https://placehold.co/100x100/3b82f6/ffffff?text=E" alt="User E" />
+            <span class="ease-avatar-group-count">+2</span>
+          </div>
+          <p>5 avatars + 2 more</p>
+          <code>&lt;div class="ease-avatar-group"&gt;
+  &lt;!-- 5 avatars --&gt;
+  &lt;span class="ease-avatar-group-count"&gt;+2&lt;/span&gt;
+&lt;/div&gt;</code>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>With Initials Fallback</h2>
+      <div class="avatar-group-demo">
+        <div>
+          <div class="ease-avatar-group">
+            <div class="ease-avatar">PM</div>
+            <div class="ease-avatar">JD</div>
+            <div class="ease-avatar">SK</div>
+          </div>
+          <p>Initials only</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Use Case: Team Row</h2>
+      <div style="background:#f8fafc;padding:1.5rem;border-radius:0.75rem;">
+        <div class="ease-avatar-group">
+          <img class="ease-avatar" src="https://placehold.co/100x100/6366f1/ffffff?text=A" alt="Alice" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/22c55e/ffffff?text=B" alt="Bob" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/f59e0b/ffffff?text=C" alt="Carol" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/3b82f6/ffffff?text=D" alt="David" />
+          <img class="ease-avatar" src="https://placehold.co/100x100/8b5cf6/ffffff?text=E" alt="Eve" />
+          <span class="ease-avatar-group-count">+3</span>
+        </div>
+        <div style="margin-left:2rem;">
+          <p style="font-weight:700;font-size:0.9rem;">Engineering Team</p>
+          <p style="font-size:0.8rem;color:#64748b;">Alice, Bob, Carol, David, Eve + 3 more</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>HTML Structure</h2>
+      <pre style="background:#1e293b;color:#e2e8f0;padding:1.25rem;border-radius:0.75rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;overflow-x:auto;line-height:1.6;margin-top:0.5rem;">&lt;!-- Basic overlapping avatars --&gt;
+&lt;div class="ease-avatar-group"&gt;
+  &lt;img class="ease-avatar" src="u1.jpg" alt="User 1" /&gt;
+  &lt;img class="ease-avatar" src="u2.jpg" alt="User 2" /&gt;
+  &lt;img class="ease-avatar" src="u3.jpg" alt="User 3" /&gt;
+  &lt;img class="ease-avatar" src="u4.jpg" alt="User 4" /&gt;
+  &lt;span class="ease-avatar-group-count"&gt;+2&lt;/span&gt;
+&lt;/div&gt;
+
+&lt;!-- With initials fallback --&gt;
+&lt;div class="ease-avatar-group"&gt;
+  &lt;div class="ease-avatar"&gt;AL&lt;/div&gt;
+  &lt;div class="ease-avatar"&gt;BO&lt;/div&gt;
+  &lt;div class="ease-avatar"&gt;CH&lt;/div&gt;
+&lt;/div&gt;
+</pre>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-10100/style.css
+++ b/submissions/core_changes-issue-10100/style.css
@@ -1,0 +1,51 @@
+.ease-avatar-group {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+.ease-avatar-group .ease-avatar {
+  border: 2px solid white;
+  margin-left: -0.5rem;
+}
+
+.ease-avatar-group .ease-avatar:first-child {
+  margin-left: 0;
+}
+
+.ease-avatar-group-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: #e2e8f0;
+  color: #475569;
+  font-size: 0.8rem;
+  font-weight: 700;
+  border: 2px solid white;
+  margin-left: -0.5rem;
+}
+
+/* Basic avatar styles for demo - in practice these would come from .ease-avatar component */
+.ease-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #e0e7ff;
+  color: #6c63ff;
+  font-weight: 700;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.ease-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Description

Adds `.ease-avatar-group` overlapping avatar stack component for displaying team members, contributors, or participants with a stacked layout.

### Features
- `.ease-avatar-group` — `display: inline-flex`, `flex-direction: row-reverse`, `justify-content: flex-end`
- Each child avatar gets `border: 2px solid white` and `margin-left: -0.5rem` (except first child)
- `.ease-avatar-group-count` — `+N` overflow badge as circled number
- Works with image avatars or initials-only avatars

### Files
- `submissions/core_changes-issue-10100/README.md`
- `submissions/core_changes-issue-10100/demo.html`
- `submissions/core_changes-issue-10100/style.css`

Fixes #10100
