### PR TITLE
feat: add floating underline reveal text effect

### DIFF
--- a/submissions/examples/floating-underline-text-reveal/README.md
+++ b/submissions/examples/floating-underline-text-reveal/README.md
@@ -1,0 +1,40 @@
+# Floating Underline Reveal Text
+
+A hover effect where an underline slides in from left to right while the text floats upward slightly. Zero JavaScript — pure CSS.
+
+## Usage
+
+```html
+<a href="#" class="ease-underline-reveal">Explore More</a>
+```
+
+## Variants
+
+```html
+<!-- Color variants -->
+<a href="#" class="ease-underline-reveal accent">Accent</a>
+<a href="#" class="ease-underline-reveal success">Success</a>
+<a href="#" class="ease-underline-reveal danger">Danger</a>
+
+<!-- Thickness -->
+<a href="#" class="ease-underline-reveal thick">Thick</a>
+
+<!-- Direction -->
+<a href="#" class="ease-underline-reveal rtl">Right to Left</a>
+<a href="#" class="ease-underline-reveal center">Center Expand</a>
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Full working demo, opens directly in browser |
+| `style.css` | All underline reveal styles and variants |
+| `README.md` | This file |
+
+## Why it fits EaseMotion CSS
+
+- **Human-readable** — class name describes the effect instantly
+- **Animation-first** — motion is the core feature, not decoration
+- **Composable** — modifier classes stack naturally on the base class
+- **Zero dependencies** — pure CSS, no JavaScript

--- a/submissions/examples/floating-underline-text-reveal/demo.html
+++ b/submissions/examples/floating-underline-text-reveal/demo.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Floating Underline Reveal — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #0f172a;
+      color: #f8fafc;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 56px;
+      padding: 60px 24px;
+    }
+
+    h1 { margin-bottom: 4px; text-align: center; }
+    p { color: #94a3b8; margin: 0; text-align: center; }
+
+    .section {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .section h3 {
+      color: #64748b;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin: 0 0 8px;
+    }
+
+    .row {
+      display: flex;
+      gap: 40px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    a {
+      font-size: 1.1rem;
+      font-weight: 500;
+    }
+
+    nav {
+      display: flex;
+      gap: 32px;
+    }
+
+    nav a {
+      font-size: 1rem;
+      color: #f8fafc;
+    }
+  </style>
+</head>
+<body>
+
+  <div>
+    <h1>Floating Underline Reveal</h1>
+    <p>Hover over any link to see the effect.</p>
+  </div>
+
+  <div class="section">
+    <h3>Default (left → right + float)</h3>
+    <div class="row">
+      <a href="#" class="ease-underline-reveal">Explore More</a>
+      <a href="#" class="ease-underline-reveal">Get Started</a>
+      <a href="#" class="ease-underline-reveal">Learn More</a>
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>Color Variants</h3>
+    <div class="row">
+      <a href="#" class="ease-underline-reveal accent">Accent Purple</a>
+      <a href="#" class="ease-underline-reveal success">Success Green</a>
+      <a href="#" class="ease-underline-reveal danger">Danger Red</a>
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>Thick Underline</h3>
+    <div class="row">
+      <a href="#" class="ease-underline-reveal thick">Bold Underline</a>
+      <a href="#" class="ease-underline-reveal thick accent">Bold Accent</a>
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>Direction Variants</h3>
+    <div class="row">
+      <a href="#" class="ease-underline-reveal rtl">Right to Left</a>
+      <a href="#" class="ease-underline-reveal center">Center Expand</a>
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>Nav Example</h3>
+    <nav>
+      <a href="#" class="ease-underline-reveal">Home</a>
+      <a href="#" class="ease-underline-reveal">About</a>
+      <a href="#" class="ease-underline-reveal">Work</a>
+      <a href="#" class="ease-underline-reveal">Contact</a>
+    </nav>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/floating-underline-text-reveal/style.css
+++ b/submissions/examples/floating-underline-text-reveal/style.css
@@ -1,0 +1,60 @@
+.ease-underline-reveal {
+  position: relative;
+  display: inline-block;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.3s ease;
+}
+
+.ease-underline-reveal::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -3px;
+  width: 0;
+  height: 2px;
+  background: currentColor;
+  transition: width 0.3s ease;
+}
+
+.ease-underline-reveal:hover {
+  transform: translateY(-3px);
+}
+
+.ease-underline-reveal:hover::after {
+  width: 100%;
+}
+
+/* Thickness variants */
+.ease-underline-reveal.thick::after {
+  height: 4px;
+}
+
+/* Color variants */
+.ease-underline-reveal.accent::after {
+  background: #7c3aed;
+}
+
+.ease-underline-reveal.success::after {
+  background: #16a34a;
+}
+
+.ease-underline-reveal.danger::after {
+  background: #dc2626;
+}
+
+/* Right to left */
+.ease-underline-reveal.rtl::after {
+  left: unset;
+  right: 0;
+}
+
+/* Center expand */
+.ease-underline-reveal.center::after {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.ease-underline-reveal.center:hover::after {
+  width: 100%;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS-only floating underline reveal effect for text and links. On hover, an underline slides in from left to right while the text floats upward slightly. Includes color variants, thickness variant, and direction variants (RTL, center-expand). Zero JavaScript.

---

## Closes #9984

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/floating-underline-text-reveal/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A hover effect where an underline smoothly slides in from left to right while the text lifts upward — pure CSS, no JavaScript.

**How does a developer use it?**

```html
<a href="#" class="ease-underline-reveal">Explore More</a>

<!-- With variants -->
<a href="#" class="ease-underline-reveal accent">Accent</a>
<a href="#" class="ease-underline-reveal thick rtl">Thick RTL</a>
<a href="#" class="ease-underline-reveal center">Center Expand</a>
```

**Why does it fit EaseMotion CSS?**

The class name reads like plain English, motion is the core feature, modifier classes compose naturally, and it needs zero JavaScript — all four EaseMotion principles in one effect.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Includes 6 variants out of the box: default (left→right), RTL (right→left), center-expand, accent/success/danger colors, and thick underline. Feel free to trim variants or adjust the float distance to match the core design system.