### PR TITLE
fix: replace :focus with :focus-visible on form input styles

### DIFF
--- a/components/forms.css
+++ b/components/forms.css
@@ -75,10 +75,11 @@
     opacity: 0.7;
   }
 
-  /* Focus Animation */
-  .ease-input:focus,
-  .ease-textarea:focus,
-  .ease-select:focus {
+  /* Focus Animation — use :focus-visible so the ring appears only on
+     keyboard navigation, not on mouse click, consistent with buttons.css */
+  .ease-input:focus-visible,
+  .ease-textarea:focus-visible,
+  .ease-select:focus-visible {
     border-color: var(--ease-color-primary, #6c63ff);
     box-shadow: 0 0 0 3px var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.18));
   }
@@ -102,7 +103,7 @@
 
   /* State Variants (Success) */
   .ease-input-success,
-  .ease-input-success:focus {
+  .ease-input-success:focus-visible {
     border-color: var(--ease-color-success, #22c55e) !important;
     box-shadow: 0 0 0 3px var(--ease-color-success-alpha, rgba(34, 197, 94, 0.15)) !important;
   }
@@ -112,7 +113,7 @@
 
   /* State Variants (Danger/Error) */
   .ease-input-danger,
-  .ease-input-danger:focus {
+  .ease-input-danger:focus-visible {
     border-color: var(--ease-color-danger, #ef4444) !important;
     box-shadow: 0 0 0 3px var(--ease-color-danger-alpha, rgba(239, 68, 68, 0.15)) !important;
   }
@@ -122,7 +123,7 @@
 
   /* State Variants (Warning) */
   .ease-input-warning,
-  .ease-input-warning:focus {
+  .ease-input-warning:focus-visible {
     border-color: var(--ease-color-warning, #f59e0b) !important;
     box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15) !important;
   }


### PR DESCRIPTION
## Description
`forms.css` used `:focus` for input, textarea, and select focus ring styles:

```css
.ease-input:focus,
.ease-textarea:focus,
.ease-select:focus {
  border-color: var(--ease-color-primary);
  box-shadow: 0 0 0 3px var(--ease-color-primary-alpha);
}
```

`:focus` shows the focus ring on **all** focus events including mouse clicks. The rest of the framework (`buttons.css`, `chip.css`, `tabs.css`) correctly uses `:focus-visible` which only shows the ring during keyboard navigation.

Changes made:
- Replaced `:focus` with `:focus-visible` on the base input/textarea/select focus selector
- Replaced `:focus` with `:focus-visible` on success, danger, and warning validation state selectors
- `:focus-within` on `.ease-field-label` is intentional and unchanged
- Added a comment explaining the `:focus-visible` choice

Fixes #10235

## Type of Change
- [x] Bug fix

## Checklist
- [x] Tested in Chrome, Firefox, Safari
- [x] No regressions to existing styles
- [x] Follows existing code conventions