### PR TITLE
fix: replace hardcoded rgba() with glass design token variables in navbar.css

### DIFF
--- a/components/navbar.css
+++ b/components/navbar.css
@@ -15,8 +15,8 @@
     padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem);
     min-height: 4rem;
     width: 100%;
-    background: rgba(255, 255, 255, 0.18);
-    border: 1px solid rgba(255, 255, 255, 0.24);
+    background: var(--ease-glass-bg, rgba(255, 255, 255, 0.18));
+    border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.24));
     border-radius: var(--ease-radius-xl, 1.5rem);
     box-shadow: var(
       --ease-shadow-md,
@@ -85,8 +85,8 @@
 
   .ease-navbar-glass-blur {
     --ease-navbar-glass-blur: 24px;
-    background: rgba(255, 255, 255, 0.14);
-    border-color: rgba(255, 255, 255, 0.2);
+    background: var(--ease-glass-bg, rgba(255, 255, 255, 0.14));
+    border-color: var(--ease-glass-border, rgba(255, 255, 255, 0.2));
     box-shadow: var(
       --ease-shadow-xl,
       0 20px 25px -5px rgba(0, 0, 0, 0.45),


### PR DESCRIPTION
## Description
`.ease-navbar-glass` hardcoded rgba color values instead of using the design token variables defined in `variables.css`:

```css
/* Before */
background: rgba(255, 255, 255, 0.18);
border: 1px solid rgba(255, 255, 255, 0.24);

/* After */
background: var(--ease-glass-bg, rgba(255, 255, 255, 0.18));
border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.24));
```

`--ease-glass-bg` and `--ease-glass-border` automatically adapt to dark mode via `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]`. By hardcoding rgba values, the glass navbar always showed light-mode transparency regardless of theme.

Changes made:
- Replaced hardcoded rgba on `.ease-navbar-glass` with `--ease-glass-bg` and `--ease-glass-border` tokens
- Same fix applied to `.ease-navbar-glass-blur` modifier
- `@supports not (backdrop-filter)` fallback left as hardcoded rgba — intentional opaque fallback for browsers without backdrop-filter support

Fixes #10239

## Type of Change
- [x] Bug fix

## Checklist
- [x] Tested in light and dark mode
- [x] No regressions to existing styles
- [x] Follows existing code conventions