### PR TITLE
fix: replace undefined --ease-color-text-dark with --ease-color-text in glass card (issue #10240)

### DIFF
--- a/submissions/examples/card-glass-text-dark-token-10240/README.md
+++ b/submissions/examples/card-glass-text-dark-token-10240/README.md
@@ -1,0 +1,57 @@
+# Glass Card Text Token Fix — Issue #10240
+
+**Fixes:** #10240
+
+## What does this do?
+
+Replaces the undefined `--ease-color-text-dark` token in the
+`.ease-card-glass` dark mode block with `--ease-color-text` — the
+correct existing token that is properly overridden in dark mode.
+
+## The problem
+
+`components/cards.css` line 182:
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-card-glass {
+    color: var(--ease-color-text-dark, #f8fafc); /* undefined token */
+  }
+}
+```
+
+`--ease-color-text-dark` does not exist in `variables.css` — not in
+`:root`, not in the dark mode block, not anywhere. The browser always
+falls through to the hardcoded fallback `#f8fafc`. Any developer who
+tries to override this color by setting `--ease-color-text-dark` in
+their own CSS gets no effect — the token was never defined.
+
+## The fix
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-card-glass {
+    color: var(--ease-color-text, #e2e8f0); /* correct existing token */
+  }
+}
+```
+
+`--ease-color-text` is defined in `variables.css` and overridden to
+`#e2e8f0` in dark mode. It is the same token used by every other
+dark-mode text in the framework. No new tokens needed.
+
+## Why not Option B (declare the missing token)?
+
+The issue proposed two options. Option A (used here) is preferred
+because `--ease-color-text` already carries the correct dark value.
+Introducing `--ease-color-text-dark` as a new token would create two
+tokens with the same purpose and no clear distinction, increasing
+cognitive overhead for users of the framework.
+
+## Demo
+
+The demo shows a side-by-side comparison on a dark background — the
+broken card always shows `#f8fafc` regardless of token overrides; the
+fixed card correctly uses `--ease-color-text`. Enable dark mode in
+Chrome DevTools → Rendering to also see the real `.ease-card-glass`
+class updated by `style.css`.

--- a/submissions/examples/card-glass-text-dark-token-10240/demo.html
+++ b/submissions/examples/card-glass-text-dark-token-10240/demo.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glass Card Text Token Fix — Issue #10240</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+      padding: 2rem 1.5rem;
+    }
+
+    .page {
+      max-width: 820px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      font-size: var(--ease-text-2xl, 1.5rem);
+      font-weight: 700;
+      margin-bottom: 0.4rem;
+    }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .card-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    @media (max-width: 600px) {
+      .card-row { grid-template-columns: 1fr; }
+    }
+
+    .card-label {
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .tag {
+      font-size: 0.68rem;
+      font-weight: 700;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    /* ── Dark page wrapper to make the bug visible ── */
+    .dark-bg {
+      background: #0b1121;
+      padding: 1.5rem;
+      border-radius: var(--ease-radius-lg, 1rem);
+      margin-bottom: 2rem;
+    }
+
+    /* ── BROKEN card: uses undefined token ────────── */
+    .card-broken {
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.25rem;
+      /* Broken: undefined token → always #f8fafc (near-white) */
+      color: var(--ease-color-text-dark, #f8fafc);
+    }
+
+    /* ── FIXED card: uses correct existing token ──── */
+    .card-fixed {
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.25rem;
+      /* Fixed: uses --ease-color-text → #e2e8f0 in dark mode */
+      color: var(--ease-color-text, #e2e8f0);
+    }
+
+    .card-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      font-size: var(--ease-text-base, 1rem);
+    }
+
+    .card-body {
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.6;
+      opacity: 0.85;
+    }
+
+    .computed-color {
+      margin-top: 0.75rem;
+      font-size: 0.72rem;
+      font-family: var(--ease-font-mono, monospace);
+      padding: 0.35rem 0.6rem;
+      border-radius: 4px;
+      background: rgba(0,0,0,0.3);
+      display: inline-block;
+    }
+
+    /* ── Live framework card ──────────────────────── */
+    .glass-wrapper {
+      background: linear-gradient(135deg, #6c63ff 0%, #a09af8 100%);
+      padding: 2rem;
+      border-radius: var(--ease-radius-lg, 1rem);
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+
+    <h1>Glass Card Text Token Fix</h1>
+    <p class="sub">Issue #10240 — <code>--ease-color-text-dark</code> is undefined, glass card text always falls to hardcoded <code>#f8fafc</code></p>
+
+    <div class="hint">
+      Enable dark mode: Chrome DevTools → More Tools → Rendering →
+      set <strong>Emulate CSS media feature prefers-color-scheme</strong>
+      to <code>dark</code>. In the dark background panels below, hover
+      each card and inspect its computed <code>color</code> in the
+      Elements panel to see the token difference.
+    </div>
+
+    <!-- Side-by-side on dark background (always dark, bug visible without DevTools) -->
+    <div class="dark-bg">
+      <div class="card-row">
+
+        <div>
+          <div class="card-label" style="color:#e2e8f0;">
+            <span class="tag tag-broken">Broken</span>
+            <code style="background:#1e293b;color:#a09af8;">--ease-color-text-dark</code>
+          </div>
+          <div class="card-broken">
+            <div class="card-title">Glass Card</div>
+            <div class="card-body">
+              Text color uses <code style="background:rgba(0,0,0,0.3);color:#a09af8;">--ease-color-text-dark</code>
+              which is undefined. Always falls to <code style="background:rgba(0,0,0,0.3);color:#fca5a5;">#f8fafc</code>.
+              Setting this token in your CSS has no effect.
+            </div>
+            <div class="computed-color" style="color:#f8fafc;">
+              computed: #f8fafc (hardcoded fallback)
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div class="card-label" style="color:#e2e8f0;">
+            <span class="tag tag-fixed">Fixed</span>
+            <code style="background:#1e293b;color:#a09af8;">--ease-color-text</code>
+          </div>
+          <div class="card-fixed">
+            <div class="card-title">Glass Card</div>
+            <div class="card-body">
+              Text color uses <code style="background:rgba(0,0,0,0.3);color:#86efac;">--ease-color-text</code>
+              which is correctly defined and overridden to
+              <code style="background:rgba(0,0,0,0.3);color:#86efac;">#e2e8f0</code>
+              in dark mode. Fully overridable via the token.
+            </div>
+            <div class="computed-color" style="color:#e2e8f0;">
+              computed: #e2e8f0 (from --ease-color-text dark override)
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Live .ease-card-glass with style.css fix applied -->
+    <p style="font-size:var(--ease-text-sm,0.875rem);font-weight:700;margin-bottom:0.75rem;">
+      Live — real <code>.ease-card.ease-card-glass</code> with fix applied
+    </p>
+    <div class="glass-wrapper">
+      <div class="ease-card ease-card-glass">
+        <div class="ease-card-title">Glass Card (Fixed)</div>
+        <div class="ease-card-body">
+          <p>
+            In dark mode, this card's text now resolves from
+            <code>--ease-color-text</code> — the same token
+            used by every other dark-mode text in the framework.
+            Enable dark mode emulation in DevTools to verify.
+          </p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/card-glass-text-dark-token-10240/style.css
+++ b/submissions/examples/card-glass-text-dark-token-10240/style.css
@@ -1,0 +1,20 @@
+/* ============================================================
+   Fix for issue #10240
+   components/cards.css references --ease-color-text-dark in
+   the .ease-card-glass dark mode block, but this token is
+   never defined in variables.css. The browser always falls
+   through to the hardcoded fallback #f8fafc.
+
+   The fix uses --ease-color-text which is the correct existing
+   token — overridden to #e2e8f0 in dark mode in variables.css
+   and used by every other dark-mode text in the framework.
+   ============================================================ */
+
+@media (prefers-color-scheme: dark) {
+  .ease-card-glass {
+    /* Replace the undefined --ease-color-text-dark with the
+       existing correct token. --ease-color-text is overridden
+       to #e2e8f0 in dark mode via variables.css. */
+    color: var(--ease-color-text, #e2e8f0);
+  }
+}


### PR DESCRIPTION
Fixes #10240

## What

`cards.css` dark mode block for `.ease-card-glass` uses
`--ease-color-text-dark` which is never defined in `variables.css`. The
browser always falls to the hardcoded fallback `#f8fafc`, bypassing the
token system. Developers cannot override this color because the token has
no cascade entry anywhere in the framework.

The fix replaces it with `--ease-color-text` — correctly defined and
overridden to `#e2e8f0` in dark mode, the same token used by every other
dark-mode text in the framework.

## Submission

`submissions/examples/card-glass-text-dark-token-10240/`

The demo shows a side-by-side comparison on a dark background. The broken
card always shows `#f8fafc` (hardcoded fallback). The fixed card resolves
from `--ease-color-text`. Enable dark mode emulation in Chrome DevTools →
Rendering to also see the real `.ease-card-glass` class updated by
`style.css`.

## Checklist

- [x] Files added only inside `submissions/examples/card-glass-text-dark-token-10240/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/`, `components/`, or any other framework file
- [x] Single focused fix, one commit
