### PR TITLE
fix: add dark mode border override for card header and footer dividers

### DIFF
--- a/submissions/examples/card-header-footer-border-dark-mode/README.md
+++ b/submissions/examples/card-header-footer-border-dark-mode/README.md
@@ -1,0 +1,49 @@
+# Card Header/Footer Border Dark Mode Fix
+
+## What does this do?
+
+Adds dark mode overrides for `.ease-card-header` and `.ease-card-footer`
+divider borders so they use a dark-appropriate border color instead of
+staying near-white in dark mode.
+
+## The problem
+
+`components/cards.css`:
+
+```css
+.ease-card-header {
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+.ease-card-footer {
+  border-top: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+```
+
+`--ease-color-neutral-100` is `#f1f5f9` — near-white. It has no dark
+mode override in `variables.css`. In dark mode, the card surface becomes
+dark (`--ease-color-surface` → `#141e33`) but the header and footer
+dividers stay `#f1f5f9` — a bright near-white line visibly cutting
+across the dark card.
+
+## The fix
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-card-header {
+    border-bottom-color: var(--ease-color-neutral-700, #334155);
+  }
+  .ease-card-footer {
+    border-top-color: var(--ease-color-neutral-700, #334155);
+  }
+}
+```
+
+`--ease-color-neutral-700` (`#334155`) is the same dark border value
+used by forms, modals, and tabs in dark mode — consistent with the
+rest of the framework.
+
+## How to verify
+
+Chrome DevTools → More Tools → Rendering →
+set **Emulate CSS media feature prefers-color-scheme** to `dark`.
+The demo shows the broken (bright) and fixed (dark) dividers side by side.

--- a/submissions/examples/card-header-footer-border-dark-mode/demo.html
+++ b/submissions/examples/card-header-footer-border-dark-mode/demo.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Header/Footer Border Dark Mode Fix</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+      padding: 2rem 1.5rem;
+    }
+
+    .page { max-width: 820px; margin: 0 auto; }
+
+    h1 { font-size: var(--ease-text-2xl, 1.5rem); font-weight: 700; margin-bottom: 0.4rem; }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .card-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    @media (max-width: 600px) { .card-row { grid-template-columns: 1fr; } }
+
+    .card-label {
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .tag {
+      font-size: 0.68rem;
+      font-weight: 700;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    /* ── BROKEN card: hardcoded near-white border in dark mode ── */
+    .card-broken-header {
+      padding-bottom: 1rem;
+      margin-bottom: 1rem;
+      /* Bug: --ease-color-neutral-100 = #f1f5f9, no dark override */
+      border-bottom: 1px solid #f1f5f9;
+    }
+    .card-broken-footer {
+      padding-top: 1rem;
+      margin-top: 1rem;
+      border-top: 1px solid #f1f5f9;
+    }
+
+    /* ── FIXED card: dark token applied in dark mode ─────────── */
+    .card-fixed-header {
+      padding-bottom: 1rem;
+      margin-bottom: 1rem;
+      border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+    }
+    .card-fixed-footer {
+      padding-top: 1rem;
+      margin-top: 1rem;
+      border-top: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+    }
+
+    /* The fix — dark mode override for the fixed demo */
+    @media (prefers-color-scheme: dark) {
+      .card-fixed-header { border-bottom-color: var(--ease-color-neutral-700, #334155); }
+      .card-fixed-footer { border-top-color:    var(--ease-color-neutral-700, #334155); }
+    }
+
+    .card-title {
+      font-weight: 700;
+      font-size: var(--ease-text-base, 1rem);
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+
+    <h1>Card Header/Footer Border Dark Mode Fix</h1>
+    <p class="sub">
+      <code>.ease-card-header</code> and <code>.ease-card-footer</code> borders use
+      <code>--ease-color-neutral-100</code> with no dark mode override — dividers appear near-white on dark cards
+    </p>
+
+    <div class="hint">
+      Enable dark mode: Chrome DevTools → More Tools → Rendering →
+      set <strong>Emulate CSS media feature prefers-color-scheme</strong>
+      to <code>dark</code>. The broken card shows a bright near-white
+      divider. The fixed card uses a dark-appropriate border.
+    </div>
+
+    <div class="card-row">
+
+      <!-- BROKEN -->
+      <div>
+        <div class="card-label">
+          <span class="tag tag-broken">Broken</span>
+          Near-white <code>#f1f5f9</code> divider in dark mode
+        </div>
+        <div class="ease-card">
+          <div class="card-broken-header">
+            <div class="card-title">Card Header</div>
+          </div>
+          <div class="ease-card-body">
+            <p style="font-size:var(--ease-text-sm,0.875rem);">
+              The header and footer borders use
+              <code>--ease-color-neutral-100</code> which resolves to
+              <code>#f1f5f9</code> — no dark mode override exists.
+              The dividers are too bright against the dark card surface.
+            </p>
+          </div>
+          <div class="card-broken-footer">
+            <span style="font-size:var(--ease-text-sm,0.875rem);color:var(--ease-color-muted,#64748b);">Footer</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- FIXED -->
+      <div>
+        <div class="card-label">
+          <span class="tag tag-fixed">Fixed</span>
+          Dark border <code>#334155</code> in dark mode
+        </div>
+        <div class="ease-card">
+          <div class="card-fixed-header">
+            <div class="card-title">Card Header</div>
+          </div>
+          <div class="ease-card-body">
+            <p style="font-size:var(--ease-text-sm,0.875rem);">
+              In dark mode the borders switch to
+              <code>--ease-color-neutral-700</code> (<code>#334155</code>) —
+              the same dark border value used by forms, modals,
+              and tabs in dark mode.
+            </p>
+          </div>
+          <div class="card-fixed-footer">
+            <span style="font-size:var(--ease-text-sm,0.875rem);color:var(--ease-color-muted,#64748b);">Footer</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Live framework cards with style.css fix applied -->
+    <p style="font-size:var(--ease-text-sm,0.875rem);font-weight:700;margin-bottom:0.75rem;">
+      Live — real <code>.ease-card</code> with header and footer
+    </p>
+    <div class="ease-card" style="max-width:420px;">
+      <div class="ease-card-header">
+        <h3 class="ease-card-title">Card Title</h3>
+        <p class="ease-card-subtitle">Subtitle text here</p>
+      </div>
+      <div class="ease-card-body">
+        <p>Card body content. The divider above uses <code>--ease-color-neutral-700</code>
+        in dark mode via the fix in <code>style.css</code>.</p>
+      </div>
+      <div class="ease-card-footer">
+        <button class="ease-btn ease-btn-primary ease-btn-sm">Action</button>
+        <button class="ease-btn ease-btn-ghost ease-btn-sm">Cancel</button>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/card-header-footer-border-dark-mode/style.css
+++ b/submissions/examples/card-header-footer-border-dark-mode/style.css
@@ -1,0 +1,21 @@
+/* ============================================================
+   Fix for .ease-card-header and .ease-card-footer borders
+   in dark mode.
+
+   Both elements use --ease-color-neutral-100 (#f1f5f9) for
+   their divider borders. This token has no dark mode override
+   in variables.css, so the dividers stay near-white on a dark
+   card surface — visually too bright and inconsistent with how
+   other components render dividers in dark mode (forms, modals,
+   and tabs all use --ease-color-neutral-700 for dark borders).
+   ============================================================ */
+
+@media (prefers-color-scheme: dark) {
+  .ease-card-header {
+    border-bottom-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  .ease-card-footer {
+    border-top-color: var(--ease-color-neutral-700, #334155);
+  }
+}


### PR DESCRIPTION
## What

`.ease-card-header` and `.ease-card-footer` use `--ease-color-neutral-100`
(`#f1f5f9`) for their divider borders. This token has no dark mode override
in `variables.css`. In dark mode the card surface is dark but the dividers
stay near-white — too bright and inconsistent with how forms, modals, and
tabs render dividers in dark mode.

## Submission

`submissions/examples/card-header-footer-border-dark-mode/`

The demo shows broken vs fixed cards side by side. Enable dark mode in
Chrome DevTools → Rendering → prefers-color-scheme: dark to see the difference.

## Fix

```css
@media (prefers-color-scheme: dark) {
  .ease-card-header {
    border-bottom-color: var(--ease-color-neutral-700, #334155);
  }
  .ease-card-footer {
    border-top-color: var(--ease-color-neutral-700, #334155);
  }
}
