### PR TITLE
fix(modal): restore focus to triggering element on close

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -1,6 +1,8 @@
 (function () {
   'use strict';
 
+  let previousFocusedElement = null;
+
   function checkModal() {
     const hash = window.location.hash;
     const body = document.body;
@@ -16,10 +18,17 @@
         const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
         if (overlay) {
           body.style.overflow = 'hidden';
+
+          previousFocusedElement = document.activeElement;
+
           overlay.classList.add('is-active');
 
           const modal = overlay.querySelector('.ease-modal');
           if (modal) {
+            if (!overlay.classList.contains('is-active')) {
+              previousFocusedElement = document.activeElement;
+            }
+
             modal.setAttribute('tabindex', '-1');
             modal.focus();
           }
@@ -32,6 +41,14 @@
 
     // If no active modal is found
     body.style.overflow = '';
+
+    if (
+      previousFocusedElement &&
+      typeof previousFocusedElement.focus === 'function'
+    ) {
+      previousFocusedElement.focus();
+      previousFocusedElement = null;
+    }
   }
 
   // Setup event listeners for hash changes (opening/closing via anchors)


### PR DESCRIPTION
## Pull Request Description

Fixes an accessibility issue in the modal component where keyboard focus is moved into the modal when opened but is not restored to the triggering element when the modal is closed.

The update stores the previously focused element before opening the modal and restores focus when the modal closes, improving keyboard navigation and accessibility.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Restores keyboard focus to the element that opened a modal after the modal is closed.

**How does a developer use it?**

No API changes are required. The behavior works automatically for existing modal implementations.

**Why does it fit EaseMotion CSS?**

This improves accessibility and keyboard navigation while preserving the existing modal API and user experience.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---
Fixes #10334 

## Notes for Maintainer

This is a small accessibility improvement for the existing modal implementation.

The change stores `document.activeElement` before modal activation and restores focus when the modal is closed via hash removal, backdrop click, or Escape key.

No visual behavior or API changes were introduced.