### PR TITLE
fix: document .em-badge as deprecated alias for .ease-badge in badges.css

### DIFF
--- a/components/badges.css
+++ b/components/badges.css
@@ -1,6 +1,11 @@
 @layer easemotion-components {
-  .em-badge,
-  .ease-badge {
+  /* ── Badge Component ─────────────────────────────────────────
+     Use .ease-badge and .ease-badge-* classes.
+     The .em-* prefix is a legacy alias kept for backward
+     compatibility. It will be removed in v2.0.
+     ────────────────────────────────────────────────────────── */
+  .ease-badge,
+  .em-badge /* @deprecated: use .ease-badge */ {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -14,42 +19,36 @@
     border-radius: var(--ease-radius-full);
     box-shadow: var(--ease-shadow-sm);
   }
-
-  .em-badge-danger,
-  .ease-badge-danger {
+  .ease-badge-danger,
+  .em-badge-danger /* @deprecated */ {
     background-color: var(--ease-color-danger);
   }
-
-  .em-badge-success,
-  .ease-badge-success {
+  .ease-badge-success,
+  .em-badge-success /* @deprecated */ {
     background-color: var(--ease-color-success);
   }
-
   /* Size Variants */
-  .em-badge-sm,
-  .ease-badge-sm {
+  .ease-badge-sm,
+  .em-badge-sm /* @deprecated */ {
     height: 16px;
     min-width: 16px;
     padding: 0 var(--ease-space-1, 0.25rem);
     font-size: 0.625rem;
   }
-
-  .em-badge-lg,
-  .ease-badge-lg {
+  .ease-badge-lg,
+  .em-badge-lg /* @deprecated */ {
     height: 24px;
     min-width: 24px;
     padding: 0 var(--ease-space-3, 0.75rem);
     font-size: var(--ease-text-sm, 0.875rem);
   }
-
   /* Pulsing glow variant */
-  .em-badge-pulse,
-  .ease-badge-pulse {
+  .ease-badge-pulse,
+  .em-badge-pulse /* @deprecated */ {
     position: relative;
   }
-
-  .em-badge-pulse::after,
-  .ease-badge-pulse::after {
+  .ease-badge-pulse::after,
+  .em-badge-pulse::after {
     content: "";
     position: absolute;
     top: 0;
@@ -61,14 +60,12 @@
     animation: ease-kf-ping 1.5s var(--ease-ease-out) infinite;
     z-index: -1;
   }
-
-  .em-badge-danger.em-badge-pulse::after,
-  .ease-badge-danger.ease-badge-pulse::after {
+  .ease-badge-danger.ease-badge-pulse::after,
+  .em-badge-danger.em-badge-pulse::after {
     box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
   }
-
-  .em-badge-success.em-badge-pulse::after,
-  .ease-badge-success.ease-badge-pulse::after {
+  .ease-badge-success.ease-badge-pulse::after,
+  .em-badge-success.em-badge-pulse::after {
     box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
   }
 }


### PR DESCRIPTION
## Description
`badges.css` exported both `.em-badge` and `.ease-badge` prefixes for every badge variant with no indication that `.em-*` is a legacy naming convention. This caused confusion about which class name to use — the entire rest of the framework uses `.ease-*` prefixes exclusively.

Changes made:
- Added a deprecation notice comment block at the top of the badge component explaining `.em-*` aliases are kept for backward compatibility and will be removed in v2.0
- Added `/* @deprecated */` inline comments on each `.em-*` selector so editors with CSS linting can surface the deprecation at usage sites
- Reordered selectors to put `.ease-*` first (canonical) followed by `.em-*` (deprecated alias) consistently across all rules
- No functional CSS changes — all existing `.em-*` and `.ease-*` classes continue to work identically

Fixes #10244

## Type of Change
- [x] Bug fix / documentation improvement

## Checklist
- [x] No regressions to existing styles
- [x] Follows existing code conventions
- [x] Backward compatible — existing `.em-*` users are unaffected