### PR TITLE
fix: document CSS custom property limitation on breakpoint tokens in variables.css

### DIFF
--- a/core/variables.css
+++ b/core/variables.css
@@ -126,6 +126,20 @@
   --ease-leading-loose:  1.9;
 
   /* ── Responsive Breakpoints ─────────────────────────── */
+  /*
+   * ⚠️  KNOWN LIMITATION — CSS custom properties cannot be used inside
+   * @media query conditions. The following tokens are reference values
+   * only and document the breakpoints used across the framework.
+   *
+   * ✅  Correct usage (copy the raw value):
+   *     @media (min-width: 768px) { ... }
+   *
+   * ❌  Does NOT work in any browser:
+   *     @media (min-width: var(--ease-bp-md)) { ... }
+   *
+   * If you need JavaScript access to breakpoints, read these values
+   * with getComputedStyle(document.documentElement).getPropertyValue('--ease-bp-md')
+   */
   --ease-bp-sm: 640px;
   --ease-bp-md: 768px;
   --ease-bp-lg: 1024px;


### PR DESCRIPTION
## Description
`--ease-bp-sm/md/lg/xl` tokens were defined in `variables.css` with no indication that they **cannot** be used inside `@media` query conditions — a known CSS limitation that applies to all browsers.

This gave users a false impression that they could write:
```css
/* ❌ Does NOT work in any browser */
@media (min-width: var(--ease-bp-md)) { ... }
```

Changes made:
- Added a prominent `⚠️ KNOWN LIMITATION` comment block above the breakpoint tokens explaining:
  - CSS custom properties cannot be used inside `@media` query conditions
  - Correct usage: copy the raw pixel value directly into `@media`
  - Incorrect pattern that silently fails in all browsers
  - How to access the values in JavaScript via `getComputedStyle()`
- No functional CSS changes — token names and values are unchanged

Fixes #10245

## Type of Change
- [x] Bug fix / documentation improvement

## Checklist
- [x] No regressions to existing styles
- [x] Follows existing code conventions
- [x] Improves developer experience by surfacing a non-obvious limitation