### PR TITLE
fix: remove unnecessary !important from validation state styles in forms.css

### DIFF
--- a/components/forms.css
+++ b/components/forms.css
@@ -103,31 +103,31 @@
   /* State Variants (Success) */
   .ease-input-success,
   .ease-input-success:focus {
-    border-color: var(--ease-color-success, #22c55e) !important;
-    box-shadow: 0 0 0 3px var(--ease-color-success-alpha, rgba(34, 197, 94, 0.15)) !important;
+    border-color: var(--ease-color-success, #22c55e);
+    box-shadow: 0 0 0 3px var(--ease-color-success-alpha, rgba(34, 197, 94, 0.15));
   }
   .ease-field-success .ease-field-label {
-    color: var(--ease-color-success, #22c55e) !important;
+    color: var(--ease-color-success, #22c55e);
   }
 
   /* State Variants (Danger/Error) */
   .ease-input-danger,
   .ease-input-danger:focus {
-    border-color: var(--ease-color-danger, #ef4444) !important;
-    box-shadow: 0 0 0 3px var(--ease-color-danger-alpha, rgba(239, 68, 68, 0.15)) !important;
+    border-color: var(--ease-color-danger, #ef4444);
+    box-shadow: 0 0 0 3px var(--ease-color-danger-alpha, rgba(239, 68, 68, 0.15));
   }
   .ease-field-danger .ease-field-label {
-    color: var(--ease-color-danger, #ef4444) !important;
+    color: var(--ease-color-danger, #ef4444);
   }
 
   /* State Variants (Warning) */
   .ease-input-warning,
   .ease-input-warning:focus {
-    border-color: var(--ease-color-warning, #f59e0b) !important;
-    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15) !important;
+    border-color: var(--ease-color-warning, #f59e0b);
+    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15);
   }
   .ease-field-warning .ease-field-label {
-    color: var(--ease-color-warning, #f59e0b) !important;
+    color: var(--ease-color-warning, #f59e0b);
   }
 
   /* Disabled State */


### PR DESCRIPTION
## Description
Validation state styles in `forms.css` used `!important` on `border-color`, `box-shadow`, and `color` for success, danger, and warning states:

```css
.ease-input-success,
.ease-input-success:focus-visible {
  border-color: var(--ease-color-success) !important;  /* ← unnecessary */
  box-shadow: 0 0 0 3px var(--ease-color-success-alpha) !important;  /* ← unnecessary */
}
```

Using `!important` in component CSS prevents users from overriding validation styles without also using `!important` — breaking the cascade for legitimate customisations. The `@layer easemotion-components` system already provides lower specificity than unlayered user styles, making `!important` unnecessary.

Changes made:
- Removed `!important` from all 9 validation state declarations across `.ease-input-success`, `.ease-input-danger`, `.ease-input-warning` and their corresponding `.ease-field-*` label color rules
- `transition: none !important` inside `prefers-reduced-motion` is intentional and unchanged — it must override animated component transitions

Fixes #10246

## Type of Change
- [x] Bug fix

## Checklist
- [x] Verified validation state styles still apply correctly without !important
- [x] No regressions to existing styles
- [x] Follows existing code conventions