### PR TITLE
fix: expose --ease-loader-size custom property in loaders.css

### DIFF
--- a/components/loaders.css
+++ b/components/loaders.css
@@ -10,8 +10,8 @@
 @layer easemotion-components {
   .ease-loader {
     display: inline-block;
-    width: 32px;
-    height: 32px;
+    width: var(--ease-loader-size, 32px);
+    height: var(--ease-loader-size, 32px);
     border-radius: var(--ease-radius-full);
   }
 


### PR DESCRIPTION
## Description
`.ease-loader` hardcoded `width` and `height` at `32px` with no CSS custom property for size customisation:

```css
/* Before */
.ease-loader {
  width: 32px;
  height: 32px;
}

/* After */
.ease-loader {
  width: var(--ease-loader-size, 32px);
  height: var(--ease-loader-size, 32px);
}
```

Unlike other components (navbar exposes `--ease-navbar-glass-blur`, sidebar exposes `--ease-sidebar-width`), loaders had no exposed size token. Users who needed a different loader size had to override `.ease-loader` directly, requiring higher specificity.

Changes made:
- Replaced hardcoded `32px` with `var(--ease-loader-size, 32px)` on both `width` and `height`
- Default behaviour is unchanged — `32px` is the fallback value
- Users can now customise size via `--ease-loader-size` on any ancestor element or in their own `:root`

Fixes #10247

## Type of Change
- [x] Bug fix / enhancement

## Checklist
- [x] Default loader size unchanged at 32px
- [x] No regressions to existing styles
- [x] Follows existing code conventions