### PR TITLE
fix: disable transitions on disabled buttons

### DIFF
--- a/components/buttons.css
+++ b/components/buttons.css
@@ -194,6 +194,7 @@
   border-color: var(--ease-color-neutral-200, #e2e8f0) !important;
   cursor: not-allowed;
   box-shadow: none !important;
+  transition: none !important;
 }
 
 .ease-btn:disabled:hover,


### PR DESCRIPTION
## Pull Request Description

This PR fixes a bug where disabled buttons in EaseMotion CSS inappropriately inherit transition effects from the base button styles, leading to unnecessary style recalculations and misleading visual cues.


Closes #10340

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing component
- [ ] Other (describe below)

---

## Current Behavior
The `.ease-btn` component defines transition properties for `background-color`, `transform`, `box-shadow`, etc. Disabled buttons (`:disabled` or `.ease-btn-disabled`) inherit these transitions, meaning the browser still attempts to calculate layout and style interpolation when interacting, even though the visual changes are overridden by `!important` flags.

## Expected Behavior
Disabled buttons should not transition at all, as they are entirely non-interactive. This guarantees a snappy, rigid feel when a user attempts to interact with an inactive UI element and prevents any ghosting or micro-stutters.

## The Fix
Added `transition: none !important;` to the `.ease-btn:disabled, .ease-btn[disabled], .ease-btn-disabled` CSS block inside `components/buttons.css` to completely override the inherited transitions from the parent class.

## Benefits
- Clearer disabled-state behavior.
- Slight reduction in unnecessary style processing and layout thrashing.
- Improved UI consistency.