### PR TITLE
feat: add CSS-only modal window component

### DIFF
--- a/submissions/examples/css-only-modal/README.md
+++ b/submissions/examples/css-only-modal/README.md
@@ -1,0 +1,23 @@
+# CSS-Only Modal Window
+
+A sleek, fully animated modal (lightbox) component that operates without any JavaScript, using the CSS `:target` pseudo-class.
+
+## How it works
+
+This modal leverages the **`:target` CSS pseudo-class** hack.
+
+1.  **The Trigger:** The "Open Modal" button is a standard anchor link pointing to an ID on the page (e.g., `<a href="#demo-modal">`).
+2.  **The State:** When the user clicks the link, the browser's URL updates to include the hash `#demo-modal`. The element with `id="demo-modal"` becomes the "target" element.
+3.  **The CSS:** We set the modal wrapper to be visually hidden by default (`visibility: hidden; opacity: 0;`). We then write a CSS rule `modal:target { visibility: visible; opacity: 1; }` which applies only when the modal is the active target in the URL.
+4.  **Closing:** To close the modal, the user clicks the close button "X" or the darkened backdrop. Both of these are simply links pointing to `#` (e.g., `<a href="#">`), which changes the URL fragment, removing the target state from the modal and causing it to hide again.
+
+## Features
+
+*   **Zero JS Dependency**: Relies purely on URL fragments and CSS state.
+*   **Animated Entrance**: The modal scales up and fades in smoothly.
+*   **Backdrop Dismiss**: Clicking outside the modal content dismisses it, just like a JS modal.
+*   **Back Button Support**: Because it uses URL hashes, the browser's "Back" button automatically closes the modal.
+
+## Usage
+
+Open `demo.html` in your browser. All presentation and state logic is contained in `style.css`.

--- a/submissions/examples/css-only-modal/demo.html
+++ b/submissions/examples/css-only-modal/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS-only Modal Window</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="page-content">
+        <h1>Welcome to the Page</h1>
+        <p>This page features a fully functional modal window that opens and closes without any JavaScript.</p>
+        
+        <!-- The trigger button (link) -->
+        <a href="#demo-modal" class="btn open-modal-btn">Open Modal</a>
+    </div>
+
+    <!-- The Modal Structure -->
+    <div id="demo-modal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2>Important Information</h2>
+                <!-- The close button (link to #, which clears the target) -->
+                <a href="#" class="close-btn" title="Close">&times;</a>
+            </div>
+            
+            <div class="modal-body">
+                <p>This modal is rendered completely using HTML and CSS!</p>
+                <p>By using the <code>:target</code> pseudo-class, the browser applies styles when the URL fragment matches the modal's ID.</p>
+                <p>Clicking the background or the close button clears the target, hiding the modal again.</p>
+            </div>
+            
+            <div class="modal-footer">
+                <a href="#" class="btn btn-secondary">Cancel</a>
+                <a href="#" class="btn btn-primary">Accept</a>
+            </div>
+        </div>
+        
+        <!-- The backdrop overlay (clicking it closes the modal) -->
+        <a href="#" class="modal-backdrop" tabindex="-1"></a>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-only-modal/style.css
+++ b/submissions/examples/css-only-modal/style.css
@@ -1,0 +1,169 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    background: #f8fafc;
+    font-family: 'Inter', sans-serif;
+    color: #334155;
+    margin: 0;
+    min-height: 100vh;
+}
+
+.page-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 20px;
+    text-align: center;
+}
+
+h1 {
+    color: #0f172a;
+}
+
+/* Button Styles */
+.btn {
+    display: inline-block;
+    padding: 12px 24px;
+    font-size: 16px;
+    font-weight: 500;
+    text-decoration: none;
+    border-radius: 8px;
+    transition: all 0.2s;
+    cursor: pointer;
+    border: none;
+}
+
+.open-modal-btn, .btn-primary {
+    background: #3b82f6;
+    color: white;
+    box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.4);
+}
+
+.open-modal-btn:hover, .btn-primary:hover {
+    background: #2563eb;
+    transform: translateY(-1px);
+}
+
+.btn-secondary {
+    background: #e2e8f0;
+    color: #475569;
+}
+
+.btn-secondary:hover {
+    background: #cbd5e1;
+}
+
+/* --- Modal Styles --- */
+
+.modal {
+    /* Initially hidden */
+    visibility: hidden;
+    opacity: 0;
+    
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* The magic: when the URL has #demo-modal */
+.modal:target {
+    visibility: visible;
+    opacity: 1;
+}
+
+/* Modal Content Box */
+.modal-content {
+    background: white;
+    width: 90%;
+    max-width: 500px;
+    border-radius: 16px;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    position: relative;
+    z-index: 1001; /* Above backdrop */
+    
+    /* Animation initial state */
+    transform: scale(0.95) translateY(20px);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.modal:target .modal-content {
+    /* Animation final state */
+    transform: scale(1) translateY(0);
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px;
+    border-bottom: 1px solid #f1f5f9;
+}
+
+.modal-header h2 {
+    margin: 0;
+    font-size: 20px;
+    color: #0f172a;
+}
+
+.close-btn {
+    text-decoration: none;
+    color: #94a3b8;
+    font-size: 28px;
+    line-height: 1;
+    font-weight: 600;
+    transition: color 0.2s;
+}
+
+.close-btn:hover {
+    color: #ef4444;
+}
+
+.modal-body {
+    padding: 24px;
+    color: #475569;
+    line-height: 1.6;
+}
+
+.modal-body p {
+    margin-top: 0;
+}
+
+.modal-body code {
+    background: #f1f5f9;
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: #ec4899;
+}
+
+.modal-footer {
+    padding: 16px 24px;
+    border-top: 1px solid #f1f5f9;
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+/* The dark background overlay */
+.modal-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(15, 23, 42, 0.6);
+    backdrop-filter: blur(4px);
+    cursor: default;
+}


### PR DESCRIPTION
Resolves #10373

This PR adds a fully functional modal/lightbox component using purely HTML and CSS.

### Changes:
- Created \css-only-modal\ component directory
- Implemented \demo.html\ using the \:target\ pseudo-class hack
- Styled the component with \style.css\ incorporating animated entrance and a functional backdrop
- Included \README.md\ explaining the \:target\ state management mechanism

This aligns with the library's goal of providing high-quality, Javascript-free components.