### PR TITLE
fix: move will-change to :hover state in ease-hover-morph-card — avoid permanent GPU layer promotion

### DIFF
--- a/submissions/examples/fix-animations-will-change/README.md
+++ b/submissions/examples/fix-animations-will-change/README.md
@@ -1,0 +1,44 @@
+# Fix: Move will-change to :hover State in ease-hover-morph-card
+
+## Problem
+
+`core/animations.css` applied `will-change: border-radius, transform` statically on `.ease-hover-morph-card`:
+
+```css
+.ease-hover-morph-card {
+  will-change: border-radius, transform; /* always on — wastes GPU memory */
+}
+```
+
+`will-change` hints the browser to promote an element to a GPU compositing layer permanently. Applying it statically means every `.ease-hover-morph-card` on the page is GPU-promoted even at rest.
+
+## Solution
+
+Move `will-change` to the `:hover` state so GPU promotion only happens just before the animation:
+
+```css
+.ease-hover-morph-card {
+  /* No will-change here */
+  transition: border-radius ..., transform ...;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-hover-morph-card:hover {
+    will-change: border-radius, transform;
+  }
+}
+```
+
+## Usage
+
+No class changes needed:
+
+```html
+<div class="ease-hover-morph-card">Hover me</div>
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS prioritises performance. Static `will-change` on component selectors causes unnecessary GPU overhead on every page that uses the framework. Moving it to `:hover` follows the recommended browser guidance: set `will-change` just before the animation, let the browser clean up after.
+
+Fixes #10250

--- a/submissions/examples/fix-animations-will-change/demo.html
+++ b/submissions/examples/fix-animations-will-change/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: will-change Overuse — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+    .ease-hover-morph-card {
+      padding: var(--ease-space-6);
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-neutral-200);
+      cursor: pointer;
+      text-align: center;
+    }
+    .ease-hover-morph-card:hover {
+      border-radius: var(--ease-radius-xl);
+      transform: scale(1.04);
+      box-shadow: var(--ease-shadow-lg);
+    }
+    .info {
+      background: var(--ease-color-primary-alpha);
+      border: 1px solid var(--ease-color-primary);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.875rem;
+      margin-bottom: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+  <h2>will-change Overuse Fix</h2>
+  <div class="info">
+    <strong>Before:</strong> All cards had <code>will-change: border-radius, transform</code> statically — permanent GPU layers even at rest.<br/>
+    <strong>After:</strong> <code>will-change</code> only set on <code>:hover</code> — GPU promotion happens just-in-time.
+  </div>
+  <p>Hover the cards. Open DevTools Layers panel to verify GPU layers only appear on hover.</p>
+  <div class="grid">
+    <div class="ease-hover-morph-card ease-card">Card 1</div>
+    <div class="ease-hover-morph-card ease-card">Card 2</div>
+    <div class="ease-hover-morph-card ease-card">Card 3</div>
+    <div class="ease-hover-morph-card ease-card">Card 4</div>
+    <div class="ease-hover-morph-card ease-card">Card 5</div>
+    <div class="ease-hover-morph-card ease-card">Card 6</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-animations-will-change/style.css
+++ b/submissions/examples/fix-animations-will-change/style.css
@@ -1,0 +1,24 @@
+/* Fix: Move will-change to :hover state in .ease-hover-morph-card
+
+   Problem: will-change: border-radius, transform was set statically on
+   .ease-hover-morph-card — promoting every instance to a GPU compositing
+   layer permanently, even when not animating.
+
+   Solution: Move will-change to the :hover state so GPU promotion only
+   happens when the animation is about to occur.
+*/
+
+.ease-hover-morph-card {
+  border-radius: var(--ease-radius-md);
+  transition:
+    border-radius var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    transform var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+  /* No will-change here — avoids permanent GPU layer promotion */
+}
+
+/* Promote to GPU layer only on hover — browser prepares just in time */
+@media (hover: hover) and (pointer: fine) {
+  .ease-hover-morph-card:hover {
+    will-change: border-radius, transform;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
`.ease-hover-morph-card` had `will-change: border-radius, transform` set statically — permanently promoting every card instance to a GPU compositing layer even at rest. This wastes GPU memory on any page with multiple morph cards. Moving `will-change` to the `:hover` state follows browser recommendations: promote just before animation, let the browser clean up after.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Moves `will-change` from the static `.ease-hover-morph-card` selector to a `@media (hover: hover)` `:hover` rule so GPU layer promotion only occurs just before the animation.

**How does a developer use it?**
```html
<!-- No class changes needed -->
<div class="ease-hover-morph-card">Hover me</div>
```

Apply the fix in your own CSS:
```css
@media (hover: hover) and (pointer: fine) {
  .ease-hover-morph-card:hover {
    will-change: border-radius, transform;
  }
}
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS prioritises performance. Static `will-change` on component selectors causes unnecessary GPU overhead on every page that uses the framework. Moving it to `:hover` follows the recommended browser guidance.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser — open DevTools Layers panel to verify GPU layers only appear on hover)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The fix for `core/animations.css` moves `will-change: border-radius, transform` from the static `.ease-hover-morph-card` selector to a `@media (hover: hover) and (pointer: fine) .ease-hover-morph-card:hover` rule. The `will-change` on `.ease-reveal` is already correct (set on hidden state, reset to `auto` on active) and is unchanged.

Fixes #10250