### PR TITLE
fix: expose --ease-modal-backdrop token for modal overlay backdrop customisation

### DIFF
--- a/submissions/examples/fix-modal-backdrop-token/README.md
+++ b/submissions/examples/fix-modal-backdrop-token/README.md
@@ -1,0 +1,47 @@
+# Fix: Expose --ease-modal-backdrop Token in modals.css
+
+## Problem
+
+`.ease-modal-overlay` hardcoded the backdrop background with no CSS custom property:
+
+```css
+.ease-modal-overlay {
+  background: rgba(15, 23, 42, 0.6); /* no token */
+}
+```
+
+Users who want to adjust the overlay opacity or color must override `.ease-modal-overlay` directly with higher specificity.
+
+## Solution
+
+Expose `--ease-modal-backdrop` with the original value as fallback:
+
+```css
+.ease-modal-overlay {
+  background: var(--ease-modal-backdrop, rgba(15, 23, 42, 0.6));
+}
+```
+
+## Usage
+
+```html
+<!-- Default backdrop -->
+<div class="ease-modal-overlay" id="modal">...</div>
+
+<!-- Custom backdrop per modal -->
+<div class="ease-modal-overlay" id="modal" style="--ease-modal-backdrop: rgba(108, 99, 255, 0.5);">...</div>
+```
+
+Global override:
+
+```css
+:root {
+  --ease-modal-backdrop: rgba(0, 0, 0, 0.8);
+}
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses CSS custom properties so users can customise components without specificity battles. Other components already expose their key values as tokens. The modal backdrop should follow the same pattern.
+
+Fixes #10410

--- a/submissions/examples/fix-modal-backdrop-token/demo.html
+++ b/submissions/examples/fix-modal-backdrop-token/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Modal Backdrop Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    .row { display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+    .light-backdrop { --ease-modal-backdrop: rgba(255, 255, 255, 0.7); }
+    .heavy-backdrop { --ease-modal-backdrop: rgba(15, 23, 42, 0.9); }
+    .tinted-backdrop { --ease-modal-backdrop: rgba(108, 99, 255, 0.5); }
+  </style>
+</head>
+<body>
+  <h2>Modal Backdrop Token Fix</h2>
+  <p>The modal backdrop now uses <code>--ease-modal-backdrop</code>. Override it per modal or globally.</p>
+
+  <div class="row">
+    <button class="ease-btn ease-btn-primary" onclick="document.getElementById('modal-default').classList.add('is-active')">Default Backdrop</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.getElementById('modal-light').classList.add('is-active')">Light Backdrop</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.getElementById('modal-heavy').classList.add('is-active')">Heavy Backdrop</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.getElementById('modal-tinted').classList.add('is-active')">Tinted Backdrop</button>
+  </div>
+
+  <!-- Default -->
+  <div id="modal-default" class="ease-modal-overlay" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal" style="padding:2rem;" onclick="event.stopPropagation()">
+      <h3>Default Backdrop</h3>
+      <p>rgba(15, 23, 42, 0.6) — the default value via fallback</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('modal-default').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+
+  <!-- Light -->
+  <div id="modal-light" class="ease-modal-overlay light-backdrop" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal" style="padding:2rem;" onclick="event.stopPropagation()">
+      <h3>Light Backdrop</h3>
+      <p>--ease-modal-backdrop: rgba(255, 255, 255, 0.7)</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('modal-light').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+
+  <!-- Heavy -->
+  <div id="modal-heavy" class="ease-modal-overlay heavy-backdrop" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal" style="padding:2rem;" onclick="event.stopPropagation()">
+      <h3>Heavy Backdrop</h3>
+      <p>--ease-modal-backdrop: rgba(15, 23, 42, 0.9)</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('modal-heavy').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+
+  <!-- Tinted -->
+  <div id="modal-tinted" class="ease-modal-overlay tinted-backdrop" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal" style="padding:2rem;" onclick="event.stopPropagation()">
+      <h3>Tinted Backdrop</h3>
+      <p>--ease-modal-backdrop: rgba(108, 99, 255, 0.5)</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('modal-tinted').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-modal-backdrop-token/style.css
+++ b/submissions/examples/fix-modal-backdrop-token/style.css
@@ -1,0 +1,22 @@
+/* Fix: Expose --ease-modal-backdrop token in modals.css
+
+   Problem: .ease-modal-overlay hardcoded rgba(15, 23, 42, 0.6) for the
+   backdrop background with no CSS custom property for customisation.
+
+   Solution: Expose --ease-modal-backdrop token with the original value
+   as fallback so users can override per-instance or globally.
+*/
+
+.ease-modal-overlay {
+  background: var(--ease-modal-backdrop, rgba(15, 23, 42, 0.6));
+}
+
+/* Usage example — custom backdrop per modal */
+.my-light-modal-overlay {
+  --ease-modal-backdrop: rgba(255, 255, 255, 0.6);
+}
+
+/* Usage example — more opaque backdrop */
+.my-opaque-modal-overlay {
+  --ease-modal-backdrop: rgba(15, 23, 42, 0.85);
+}


### PR DESCRIPTION
## Pull Request Description
`.ease-modal-overlay` hardcoded `rgba(15, 23, 42, 0.6)` for the backdrop background with no CSS custom property. Users who wanted to adjust the overlay opacity or color had to override `.ease-modal-overlay` directly with higher specificity.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A `--ease-modal-backdrop` CSS custom property on `.ease-modal-overlay` with `rgba(15, 23, 42, 0.6)` as the default fallback — making the backdrop customisable per-instance or globally.

**How does a developer use it?**
```html
<!-- Custom backdrop per modal -->
<div class="ease-modal-overlay" style="--ease-modal-backdrop: rgba(108, 99, 255, 0.5);">
  ...
</div>
```

```css
/* Global override */
:root {
  --ease-modal-backdrop: rgba(0, 0, 0, 0.8);
}
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS uses CSS custom properties so users can customise components without specificity battles. The modal backdrop should follow the same pattern as other component tokens in the framework.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows default, light, heavy, and tinted backdrop variants)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
One line change in `components/modals.css`: `background: rgba(15, 23, 42, 0.6)` becomes `background: var(--ease-modal-backdrop, rgba(15, 23, 42, 0.6))`. Default behaviour is completely unchanged.

Fixes #10410