### PR TITLE
fix: expose --ease-modal-max-width and --ease-modal-width tokens in modals.css

### DIFF
--- a/submissions/examples/fix-modal-width-token/README.md
+++ b/submissions/examples/fix-modal-width-token/README.md
@@ -1,0 +1,49 @@
+# Fix: Expose --ease-modal-max-width and --ease-modal-width Tokens
+
+## Problem
+
+`.ease-modal` hardcoded `max-width` and `width` with no CSS custom properties:
+
+```css
+.ease-modal {
+  max-width: 500px;
+  width: 90%;
+}
+```
+
+Users who needed different modal sizes had to override `.ease-modal` directly with higher specificity.
+
+## Solution
+
+Expose `--ease-modal-max-width` and `--ease-modal-width` tokens:
+
+```css
+.ease-modal {
+  max-width: var(--ease-modal-max-width, 500px);
+  width: var(--ease-modal-width, 90%);
+}
+```
+
+## Usage
+
+```html
+<!-- Custom width per modal -->
+<div class="ease-modal" style="--ease-modal-max-width: 800px;">...</div>
+```
+
+```css
+/* Global override */
+:root {
+  --ease-modal-max-width: 600px;
+}
+
+/* Size modifiers */
+.ease-modal-sm { --ease-modal-max-width: 400px; }
+.ease-modal-lg { --ease-modal-max-width: 700px; }
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses CSS custom properties so users can customise components without specificity battles. Modal width is a key dimension that should follow the same token-driven pattern as sidebar width and loader size.
+
+Fixes #10411

--- a/submissions/examples/fix-modal-width-token/demo.html
+++ b/submissions/examples/fix-modal-width-token/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Modal Width Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    .row { display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+  </style>
+</head>
+<body>
+  <h2>Modal Width Token Fix</h2>
+  <p>Modal width is now customisable via <code>--ease-modal-max-width</code> and <code>--ease-modal-width</code>.</p>
+
+  <div class="row">
+    <button class="ease-btn ease-btn-primary" onclick="document.getElementById('modal-default').classList.add('is-active')">Default (500px)</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.getElementById('modal-sm').classList.add('is-active')">Small (400px)</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.getElementById('modal-lg').classList.add('is-active')">Large (700px)</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.getElementById('modal-custom').classList.add('is-active')">Custom (800px)</button>
+  </div>
+
+  <div id="modal-default" class="ease-modal-overlay" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal" style="padding:2rem;" onclick="event.stopPropagation()">
+      <h3>Default Modal</h3>
+      <p>max-width: 500px (default via --ease-modal-max-width fallback)</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('modal-default').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+
+  <div id="modal-sm" class="ease-modal-overlay" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal ease-modal-sm" style="padding:2rem;" onclick="event.stopPropagation()">
+      <h3>Small Modal</h3>
+      <p>--ease-modal-max-width: 400px</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('modal-sm').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+
+  <div id="modal-lg" class="ease-modal-overlay" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal ease-modal-lg" style="padding:2rem;" onclick="event.stopPropagation()">
+      <h3>Large Modal</h3>
+      <p>--ease-modal-max-width: 700px</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('modal-lg').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+
+  <div id="modal-custom" class="ease-modal-overlay" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal" style="padding:2rem; --ease-modal-max-width: 800px;" onclick="event.stopPropagation()">
+      <h3>Custom Modal</h3>
+      <p>--ease-modal-max-width: 800px (inline override)</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('modal-custom').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-modal-width-token/style.css
+++ b/submissions/examples/fix-modal-width-token/style.css
@@ -1,0 +1,22 @@
+/* Fix: Expose --ease-modal-max-width and --ease-modal-width tokens
+
+   Problem: .ease-modal hardcoded max-width: 500px and width: 90%
+   with no CSS custom properties for customisation.
+
+   Solution: Expose tokens with original values as fallbacks.
+*/
+
+.ease-modal {
+  max-width: var(--ease-modal-max-width, 500px);
+  width: var(--ease-modal-width, 90%);
+}
+
+/* Size modifier example — sm */
+.ease-modal-sm {
+  --ease-modal-max-width: 400px;
+}
+
+/* Size modifier example — lg */
+.ease-modal-lg {
+  --ease-modal-max-width: 700px;
+}


### PR DESCRIPTION
## Pull Request Description
`.ease-modal` hardcoded `max-width: 500px` and `width: 90%` with no CSS custom properties. Users who needed different modal sizes had to override `.ease-modal` directly with higher specificity — inconsistent with other components that expose their key dimensions as tokens (`--ease-sidebar-width`, `--ease-loader-size`).

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
`--ease-modal-max-width` (default `500px`) and `--ease-modal-width` (default `90%`) tokens on `.ease-modal` making modal dimensions customisable per-instance or globally.

**How does a developer use it?**
```html
<!-- Custom width inline -->
<div class="ease-modal" style="--ease-modal-max-width: 800px;">...</div>
```

```css
/* Size modifier classes */
.ease-modal-sm { --ease-modal-max-width: 400px; }
.ease-modal-lg { --ease-modal-max-width: 700px; }

/* Global override */
:root { --ease-modal-max-width: 600px; }
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS uses CSS custom properties so users can customise components without specificity battles. Modal width is a key dimension that should follow the same token-driven pattern as `--ease-sidebar-width` and `--ease-loader-size`.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows default 500px, small 400px, large 700px, and custom 800px modal widths)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Two line changes in `components/modals.css`: `max-width: 500px` becomes `max-width: var(--ease-modal-max-width, 500px)` and `width: 90%` becomes `width: var(--ease-modal-width, 90%)`. Default behaviour is completely unchanged.

Fixes #10411