### PR TITLE
fix: expose --ease-loader-stagger token for dot loader animation delays

### DIFF
--- a/submissions/examples/fix-loaders-stagger-token/README.md
+++ b/submissions/examples/fix-loaders-stagger-token/README.md
@@ -1,0 +1,54 @@
+# Fix: Expose --ease-loader-stagger Token for Dot Loader
+
+## Problem
+
+The staggered dots loader hardcoded `animation-delay` values with no CSS custom property:
+
+```css
+.ease-loader-dot:nth-child(2) { animation-delay: 0.2s; }
+.ease-loader-dot:nth-child(3) { animation-delay: 0.4s; }
+```
+
+Users who wanted different stagger timing had to override these selectors directly.
+
+## Solution
+
+Expose `--ease-loader-stagger` on `.ease-loader-dots` and use it for delay calculations:
+
+```css
+.ease-loader-dots {
+  --ease-loader-stagger: 0.2s;
+}
+
+.ease-loader-dot:nth-child(2) {
+  animation-delay: var(--ease-loader-stagger, 0.2s);
+}
+
+.ease-loader-dot:nth-child(3) {
+  animation-delay: calc(var(--ease-loader-stagger, 0.2s) * 2);
+}
+```
+
+## Usage
+
+```html
+<!-- Default stagger -->
+<div class="ease-loader-dots">
+  <div class="ease-loader-dot"></div>
+  <div class="ease-loader-dot"></div>
+  <div class="ease-loader-dot"></div>
+</div>
+
+<!-- Fast stagger -->
+<div class="ease-loader-dots" style="--ease-loader-stagger: 0.1s;">
+  <div class="ease-loader-dot"></div>
+  <div class="ease-loader-dot"></div>
+  <div class="ease-loader-dot"></div>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS exposes key values as CSS custom properties for customisation without specificity battles. The dot loader stagger is a key animation parameter that should follow the same token-driven approach as `--ease-loader-size`.
+
+Fixes #10426

--- a/submissions/examples/fix-loaders-stagger-token/demo.html
+++ b/submissions/examples/fix-loaders-stagger-token/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Loader Stagger Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    .row {
+      display: flex;
+      align-items: center;
+      gap: 3rem;
+      margin-bottom: 2rem;
+      flex-wrap: wrap;
+    }
+    .item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .item span {
+      font-size: 0.75rem;
+      color: var(--ease-color-muted);
+      font-family: var(--ease-font-mono);
+    }
+    h3 {
+      font-size: 0.875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--ease-color-muted);
+      margin-bottom: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <h2>Loader Stagger Token Fix</h2>
+  <p>Dot loader stagger is now customisable via <code>--ease-loader-stagger</code>. Default is <code>0.2s</code>.</p>
+
+  <h3>Default (0.2s stagger)</h3>
+  <div class="row">
+    <div class="item">
+      <div class="ease-loader-dots">
+        <div class="ease-loader-dot"></div>
+        <div class="ease-loader-dot"></div>
+        <div class="ease-loader-dot"></div>
+      </div>
+      <span>--ease-loader-stagger: 0.2s</span>
+    </div>
+  </div>
+
+  <h3>Fast stagger (0.1s)</h3>
+  <div class="row">
+    <div class="item">
+      <div class="ease-loader-dots" style="--ease-loader-stagger: 0.1s;">
+        <div class="ease-loader-dot"></div>
+        <div class="ease-loader-dot"></div>
+        <div class="ease-loader-dot"></div>
+      </div>
+      <span>--ease-loader-stagger: 0.1s</span>
+    </div>
+  </div>
+
+  <h3>Slow stagger (0.4s)</h3>
+  <div class="row">
+    <div class="item">
+      <div class="ease-loader-dots" style="--ease-loader-stagger: 0.4s;">
+        <div class="ease-loader-dot"></div>
+        <div class="ease-loader-dot"></div>
+        <div class="ease-loader-dot"></div>
+      </div>
+      <span>--ease-loader-stagger: 0.4s</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-loaders-stagger-token/style.css
+++ b/submissions/examples/fix-loaders-stagger-token/style.css
@@ -1,0 +1,20 @@
+/* Fix: Expose --ease-loader-stagger token for dot loader animation delays
+
+   Problem: .ease-loader-dot nth-child delays were hardcoded at 0.2s and
+   0.4s with no CSS custom property for customisation.
+
+   Solution: Expose --ease-loader-stagger token with 0.2s default so
+   users can adjust stagger timing per-instance or globally.
+*/
+
+.ease-loader-dots {
+  --ease-loader-stagger: 0.2s;
+}
+
+.ease-loader-dot:nth-child(2) {
+  animation-delay: var(--ease-loader-stagger, 0.2s);
+}
+
+.ease-loader-dot:nth-child(3) {
+  animation-delay: calc(var(--ease-loader-stagger, 0.2s) * 2);
+}


### PR DESCRIPTION
## Pull Request Description
The staggered dots loader hardcoded `animation-delay: 0.2s` and `animation-delay: 0.4s` with no CSS custom property. Users who wanted different stagger timing had to override the nth-child selectors directly — inconsistent with other loader tokens already exposed (`--ease-loader-size`).

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A `--ease-loader-stagger` token (default `0.2s`) on `.ease-loader-dots`. The second dot uses `var(--ease-loader-stagger)` and the third uses `calc(var(--ease-loader-stagger) * 2)` — preserving the proportional stagger relationship at any speed.

**How does a developer use it?**
```html
<!-- Fast stagger -->
<div class="ease-loader-dots" style="--ease-loader-stagger: 0.1s;">
  <div class="ease-loader-dot"></div>
  <div class="ease-loader-dot"></div>
  <div class="ease-loader-dot"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS exposes key animation parameters as CSS custom properties. The dot loader stagger is a key timing value that should follow the same token-driven approach as `--ease-loader-size`.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows default 0.2s, fast 0.1s, and slow 0.4s stagger variants)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Two line changes in `components/loaders.css` plus adding `--ease-loader-stagger: 0.2s` on `.ease-loader-dots`. The `calc()` approach for the third dot ensures the stagger ratio stays proportional at any custom speed. Default behaviour is completely unchanged.

Fixes #10426