### PR TITLE
fix: modal size modifiers set --ease-modal-max-width token instead of hardcoding max-width

### DIFF
--- a/submissions/examples/fix-modal-size-modifiers-token/README.md
+++ b/submissions/examples/fix-modal-size-modifiers-token/README.md
@@ -1,0 +1,44 @@
+# Fix: Modal Size Modifiers Should Set --ease-modal-max-width Token
+
+## Problem
+
+`.ease-modal-sm` and `.ease-modal-lg` hardcoded `max-width` directly:
+
+```css
+.ease-modal-sm { max-width: 400px; }
+.ease-modal-lg { max-width: 700px; }
+```
+
+This bypasses `--ease-modal-max-width` — if a user sets `--ease-modal-max-width` on `.ease-modal-sm`, it has no effect because `max-width: 400px` takes precedence. The size modifier classes should set the token, not override the property.
+
+## Solution
+
+Size modifiers set `--ease-modal-max-width` so the base `.ease-modal` token drives the actual dimension:
+
+```css
+.ease-modal-sm { --ease-modal-max-width: 400px; }
+.ease-modal-lg { --ease-modal-max-width: 700px; }
+```
+
+This allows inline overrides to work correctly:
+
+```html
+<!-- Override the sm size to 300px — now works correctly -->
+<div class="ease-modal ease-modal-sm" style="--ease-modal-max-width: 300px;">
+```
+
+## Usage
+
+```html
+<div class="ease-modal ease-modal-sm">Small modal</div>
+<div class="ease-modal ease-modal-lg">Large modal</div>
+
+<!-- Override size modifier -->
+<div class="ease-modal ease-modal-sm" style="--ease-modal-max-width: 300px;">Custom small</div>
+```
+
+## Why it fits EaseMotion CSS
+
+When a component exposes a CSS custom property, all modifiers should set that token rather than hardcoding the underlying property. This keeps the token as the single source of truth and allows inline overrides to work as expected.
+
+Fixes #10430

--- a/submissions/examples/fix-modal-size-modifiers-token/demo.html
+++ b/submissions/examples/fix-modal-size-modifiers-token/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Modal Size Modifiers Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    .row { display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+    .ease-modal { padding: 2rem; }
+  </style>
+</head>
+<body>
+  <h2>Modal Size Modifier Token Fix</h2>
+  <p>
+    <code>.ease-modal-sm</code> and <code>.ease-modal-lg</code> now set
+    <code>--ease-modal-max-width</code> instead of hardcoding <code>max-width</code>.
+    This means <code>.ease-modal</code> drives the actual dimension via its token.
+  </p>
+
+  <div class="row">
+    <button class="ease-btn ease-btn-primary" onclick="document.getElementById('m-default').classList.add('is-active')">Default (500px)</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.getElementById('m-sm').classList.add('is-active')">Small (400px)</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.getElementById('m-lg').classList.add('is-active')">Large (700px)</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.getElementById('m-override').classList.add('is-active')">Override sm to 300px</button>
+  </div>
+
+  <div id="m-default" class="ease-modal-overlay" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal" onclick="event.stopPropagation()">
+      <h3>Default Modal</h3>
+      <p>max-width driven by --ease-modal-max-width default (500px)</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('m-default').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+
+  <div id="m-sm" class="ease-modal-overlay" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal ease-modal-sm" onclick="event.stopPropagation()">
+      <h3>Small Modal</h3>
+      <p>.ease-modal-sm sets --ease-modal-max-width: 400px</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('m-sm').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+
+  <div id="m-lg" class="ease-modal-overlay" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal ease-modal-lg" onclick="event.stopPropagation()">
+      <h3>Large Modal</h3>
+      <p>.ease-modal-lg sets --ease-modal-max-width: 700px</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('m-lg').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+
+  <div id="m-override" class="ease-modal-overlay" onclick="this.classList.remove('is-active')">
+    <div class="ease-modal ease-modal-sm" style="--ease-modal-max-width: 300px;" onclick="event.stopPropagation()">
+      <h3>Overridden Small Modal</h3>
+      <p>.ease-modal-sm with --ease-modal-max-width: 300px inline override</p>
+      <button class="ease-btn ease-btn-primary" onclick="document.getElementById('m-override').classList.remove('is-active')">Close</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-modal-size-modifiers-token/style.css
+++ b/submissions/examples/fix-modal-size-modifiers-token/style.css
@@ -1,0 +1,17 @@
+/* Fix: Modal size modifiers set --ease-modal-max-width token
+   instead of hardcoding max-width directly
+
+   Problem: .ease-modal-sm and .ease-modal-lg hardcoded max-width values
+   bypassing --ease-modal-max-width token, making overrides inconsistent.
+
+   Solution: Size modifiers set --ease-modal-max-width so the base
+   .ease-modal token drives the actual size.
+*/
+
+.ease-modal-sm {
+  --ease-modal-max-width: 400px;
+}
+
+.ease-modal-lg {
+  --ease-modal-max-width: 700px;
+}


### PR DESCRIPTION
## Pull Request Description
`.ease-modal-sm` and `.ease-modal-lg` hardcoded `max-width` directly, bypassing `--ease-modal-max-width`. This meant inline token overrides on size modifier classes had no effect — `style="--ease-modal-max-width: 300px"` on an `.ease-modal-sm` element would be ignored because `max-width: 400px` takes precedence.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Fixes size modifier classes to set `--ease-modal-max-width` instead of hardcoding `max-width`, making the token the single source of truth for modal width.

**How does a developer use it?**
```html
<!-- Size modifiers work as before -->
<div class="ease-modal ease-modal-sm">Small (400px)</div>
<div class="ease-modal ease-modal-lg">Large (700px)</div>

<!-- Inline override now works correctly on modifier classes -->
<div class="ease-modal ease-modal-sm" style="--ease-modal-max-width: 300px;">Custom (300px)</div>
```

**Why does it fit EaseMotion CSS?**
When a component exposes a CSS custom property, all modifier classes should set that token rather than hardcoding the underlying property. This keeps the token as the single source of truth and makes inline overrides work as expected.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — demonstrates default, sm, lg, and inline-overridden sm modals)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Two line changes in `components/modals.css`: `max-width: 400px` becomes `--ease-modal-max-width: 400px` in `.ease-modal-sm`, and `max-width: 700px` becomes `--ease-modal-max-width: 700px` in `.ease-modal-lg`. Requires `--ease-modal-max-width` to be consumed in `.ease-modal` (related to #10411).

Fixes #10430