### PR TITLE
fix: replace hardcoded font-size values with design token variables in footer.css

### DIFF
--- a/submissions/examples/fix-footer-font-size-tokens/README.md
+++ b/submissions/examples/fix-footer-font-size-tokens/README.md
@@ -1,0 +1,48 @@
+# Fix: Replace Hardcoded Font Sizes with Design Token Variables in footer.css
+
+## Problem
+
+`components/footer.css` used font size values outside the `--ease-text-*` token scale:
+
+```css
+.ease-footer-col-title {
+  font-size: 0.9rem; /* not a token value */
+}
+
+.ease-footer-bottom {
+  font-size: 0.8rem; /* not a token value */
+}
+```
+
+The framework defines `--ease-text-sm: 0.875rem` and `--ease-text-xs: 0.75rem`. Using `0.9rem` and `0.8rem` creates values outside the design scale, making footer typography impossible to adjust via the token system.
+
+## Solution
+
+Replace with the nearest design token values:
+
+```css
+.ease-footer-col-title {
+  font-size: var(--ease-text-sm, 0.875rem); /* was 0.9rem */
+}
+
+.ease-footer-bottom {
+  font-size: var(--ease-text-xs, 0.75rem); /* was 0.8rem */
+}
+```
+
+## Usage
+
+Override globally via tokens:
+
+```css
+:root {
+  --ease-text-sm: 1rem;   /* affects footer column titles and other sm text */
+  --ease-text-xs: 0.8rem; /* affects footer bottom bar and other xs text */
+}
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses a defined typography scale via `--ease-text-*` tokens. All component font sizes should reference these tokens so typography can be adjusted globally without targeting individual component selectors.
+
+Fixes #10416

--- a/submissions/examples/fix-footer-font-size-tokens/demo.html
+++ b/submissions/examples/fix-footer-font-size-tokens/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Footer Font Size Tokens — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main style="padding: 2rem; font-family: var(--ease-font-sans);">
+    <h2 style="margin-bottom:0.5rem;">Footer Font Size Token Fix</h2>
+    <p style="color:var(--ease-color-muted);margin-bottom:1.5rem;">
+      Column titles now use <code>--ease-text-sm</code> (0.875rem) and
+      the bottom bar uses <code>--ease-text-xs</code> (0.75rem) instead
+      of off-scale values 0.9rem and 0.8rem.
+    </p>
+  </main>
+
+  <footer class="ease-footer">
+    <div class="ease-footer-grid">
+      <div>
+        <p class="ease-footer-col-title">Product</p>
+        <ul class="ease-footer-links">
+          <li><a href="#">Features</a></li>
+          <li><a href="#">Pricing</a></li>
+          <li><a href="#">Changelog</a></li>
+        </ul>
+      </div>
+      <div>
+        <p class="ease-footer-col-title">Developers</p>
+        <ul class="ease-footer-links">
+          <li><a href="#">Docs</a></li>
+          <li><a href="#">GitHub</a></li>
+          <li><a href="#">NPM</a></li>
+        </ul>
+      </div>
+      <div>
+        <p class="ease-footer-col-title">Company</p>
+        <ul class="ease-footer-links">
+          <li><a href="#">About</a></li>
+          <li><a href="#">Blog</a></li>
+          <li><a href="#">Contact</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="ease-footer-bottom">
+      <span>© 2026 EaseMotion CSS. MIT License.</span>
+      <span>Font size now uses --ease-text-xs token.</span>
+    </div>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/fix-footer-font-size-tokens/style.css
+++ b/submissions/examples/fix-footer-font-size-tokens/style.css
@@ -1,0 +1,19 @@
+/* Fix: Replace hardcoded font-size values with design token variables in footer.css
+
+   Problem: footer.css used 0.9rem and 0.8rem — values not in the
+   --ease-text-* token scale. Closest tokens are:
+     0.9rem  -> --ease-text-sm: 0.875rem
+     0.8rem  -> --ease-text-xs: 0.75rem
+
+   Solution: Use design token variables consistently.
+*/
+
+/* .ease-footer-col-title: 0.9rem -> var(--ease-text-sm) */
+.ease-footer-col-title {
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+/* .ease-footer-bottom: 0.8rem -> var(--ease-text-xs) */
+.ease-footer-bottom {
+  font-size: var(--ease-text-xs, 0.75rem);
+}


### PR DESCRIPTION
## Pull Request Description
`footer.css` used `font-size: 0.9rem` and `font-size: 0.8rem` — values not in the `--ease-text-*` design token scale. The nearest defined tokens are `--ease-text-sm: 0.875rem` and `--ease-text-xs: 0.75rem`. Using off-scale values means footer typography cannot be adjusted via the token system.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Replaces two off-scale `font-size` values with the nearest `--ease-text-*` tokens so footer typography participates in the global type scale.

**How does a developer use it?**
```css
/* Adjust all sm text including footer column titles */
:root { --ease-text-sm: 1rem; }

/* Adjust all xs text including footer bottom bar */
:root { --ease-text-xs: 0.8rem; }
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS uses a defined typography scale via `--ease-text-*` tokens. All component font sizes should reference these tokens so typography can be adjusted globally.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows full footer with column titles and bottom bar using token-driven font sizes)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Two line changes in `components/footer.css`: `font-size: 0.9rem` in `.ease-footer-col-title` becomes `font-size: var(--ease-text-sm, 0.875rem)`, and `font-size: 0.8rem` in `.ease-footer-bottom` becomes `font-size: var(--ease-text-xs, 0.75rem)`.

Fixes #10416