### PR TITLE
fix: use --ease-glass-border token for .ease-card-glass border instead of hardcoded rgba

### DIFF
--- a/submissions/examples/fix-cards-glass-tokens/README.md
+++ b/submissions/examples/fix-cards-glass-tokens/README.md
@@ -1,0 +1,47 @@
+# Fix: Use --ease-glass-border Token in .ease-card-glass
+
+## Problem
+
+`.ease-card-glass` hardcoded the border color instead of using the `--ease-glass-border` token:
+
+```css
+.ease-card-glass {
+  border: 1px solid rgba(255, 255, 255, 0.3); /* hardcoded */
+}
+```
+
+`variables.css` defines `--ease-glass-border` which automatically adapts to dark mode via `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]`. By hardcoding the rgba value, the glass card border always uses light-mode transparency regardless of theme.
+
+## Solution
+
+Use the design token variable with the original rgba as fallback:
+
+```css
+.ease-card-glass {
+  border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.3));
+}
+```
+
+## Usage
+
+No class changes needed:
+
+```html
+<div class="ease-card ease-card-glass">
+  Glass card content
+</div>
+```
+
+The border now adapts automatically to dark mode and responds to custom theme overrides:
+
+```css
+:root {
+  --ease-glass-border: rgba(255, 255, 255, 0.15); /* custom border opacity */
+}
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses design tokens as the single source of truth. Glass components should consume `--ease-glass-bg` and `--ease-glass-border` tokens so dark mode and theme overrides work automatically — consistent with the navbar glass fix.
+
+Fixes #10413

--- a/submissions/examples/fix-cards-glass-tokens/demo.html
+++ b/submissions/examples/fix-cards-glass-tokens/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Glass Card Border Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    .controls { display: flex; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap; }
+    .gradient-bg {
+      background: linear-gradient(135deg, #6c63ff 0%, #3b82f6 100%);
+      padding: 2rem;
+      border-radius: var(--ease-radius-lg);
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+    }
+    .ease-card-glass { padding: var(--ease-space-6); }
+  </style>
+</head>
+<body>
+  <h2>Glass Card Border Token Fix</h2>
+  <p>
+    Toggle dark mode — the glass card border now adapts automatically using
+    <code>--ease-glass-border</code> token instead of a hardcoded rgba value.
+  </p>
+
+  <div class="controls">
+    <button class="ease-btn ease-btn-primary" onclick="document.documentElement.setAttribute('data-theme','dark')">Dark Mode</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.documentElement.removeAttribute('data-theme')">Light Mode</button>
+  </div>
+
+  <div class="gradient-bg">
+    <div class="ease-card ease-card-glass">
+      <h3 style="margin-bottom:0.5rem;">Glass Card</h3>
+      <p style="margin:0;">Border uses <code>--ease-glass-border</code> token — adapts to dark mode automatically.</p>
+    </div>
+    <div class="ease-card ease-card-glass">
+      <h3 style="margin-bottom:0.5rem;">Another Card</h3>
+      <p style="margin:0;">Both cards share the same token-driven border color.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-cards-glass-tokens/style.css
+++ b/submissions/examples/fix-cards-glass-tokens/style.css
@@ -1,0 +1,16 @@
+/* Fix: Use --ease-glass-border token in .ease-card-glass
+
+   Problem: .ease-card-glass hardcoded border: 1px solid rgba(255,255,255,0.3)
+   instead of using --ease-glass-border token from variables.css.
+   The --ease-glass-border token automatically adapts to dark mode via
+   prefers-color-scheme and [data-theme="dark"].
+
+   Note: --ease-glass-bg is already being set locally on .ease-card-glass
+   to a slightly more opaque value (0.35) than the default (0.12) for
+   better card readability — this local override is intentional.
+   Only the border needs to reference the token.
+*/
+
+.ease-card-glass {
+  border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.3));
+}


### PR DESCRIPTION
## Pull Request Description
`.ease-card-glass` hardcoded `border: 1px solid rgba(255, 255, 255, 0.3)` instead of using the `--ease-glass-border` token defined in `variables.css`. The token automatically adapts to dark mode via `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]` — the hardcoded value ignored both.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Replaces the hardcoded `rgba(255, 255, 255, 0.3)` border with `var(--ease-glass-border, rgba(255, 255, 255, 0.3))` so the glass card border adapts to dark mode and custom theme overrides automatically.

**How does a developer use it?**
```html
<!-- No class changes needed -->
<div class="ease-card ease-card-glass">Glass card</div>
```

```css
/* Custom glass border */
:root {
  --ease-glass-border: rgba(255, 255, 255, 0.15);
}
```

**Why does it fit EaseMotion CSS?**
Glass components should consume `--ease-glass-bg` and `--ease-glass-border` tokens so dark mode and theme overrides work automatically — consistent with the navbar glass token fix.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — includes light/dark mode toggle to verify border adapts via token)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
One line change in `components/cards.css`: `border: 1px solid rgba(255, 255, 255, 0.3)` in `.ease-card-glass` becomes `border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.3))`. The local `--ease-glass-bg` override on `.ease-card-glass` is intentional (0.35 opacity for better card readability) and is unchanged.

Fixes #10413