### PR TITLE
fix: rename --marquee-* tokens to --ease-marquee-* namespace in ease-marquee.css

### DIFF
--- a/submissions/examples/fix-marquee-token-namespace/README.md
+++ b/submissions/examples/fix-marquee-token-namespace/README.md
@@ -1,0 +1,63 @@
+# Fix: Rename --marquee-* Tokens to --ease-marquee-* Namespace
+
+## Problem
+
+`components/ease-marquee.css` used CSS custom properties without the `--ease-*` prefix:
+
+```css
+.ease-marquee {
+  --marquee-speed: 20s;
+  --marquee-gap: 2rem;
+  --marquee-pause-on-hover: paused;
+  --marquee-direction: normal;
+}
+```
+
+The entire framework uses `--ease-*` prefixed tokens. Non-prefixed tokens break the naming convention and risk collision with user-defined or third-party CSS variables named `--marquee-*`.
+
+## Solution
+
+Rename all tokens to use the `--ease-marquee-*` prefix:
+
+```css
+.ease-marquee {
+  --ease-marquee-speed: 20s;
+  --ease-marquee-gap: 2rem;
+  --ease-marquee-pause-on-hover: paused;
+  --ease-marquee-direction: normal;
+}
+```
+
+## Usage
+
+```html
+<!-- Custom speed via namespaced token -->
+<div class="ease-marquee" style="--ease-marquee-speed: 5s;">
+  <div class="ease-marquee-track">...</div>
+</div>
+```
+
+```css
+/* Global override */
+:root {
+  --ease-marquee-speed: 30s;
+  --ease-marquee-gap: 3rem;
+}
+```
+
+## Migration
+
+If you were using `--marquee-*` tokens in your own CSS, rename them:
+
+| Old | New |
+|-----|-----|
+| `--marquee-speed` | `--ease-marquee-speed` |
+| `--marquee-gap` | `--ease-marquee-gap` |
+| `--marquee-pause-on-hover` | `--ease-marquee-pause-on-hover` |
+| `--marquee-direction` | `--ease-marquee-direction` |
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses `--ease-*` as a namespace for all tokens to prevent collisions and maintain consistency. The marquee component should follow the same convention.
+
+Fixes #10428

--- a/submissions/examples/fix-marquee-token-namespace/demo.html
+++ b/submissions/examples/fix-marquee-token-namespace/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Marquee Token Namespace — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted); margin-bottom: 0.75rem; }
+    .ease-marquee { margin-bottom: 1.5rem; }
+    .item {
+      background: var(--ease-color-primary-alpha);
+      border: 1px solid var(--ease-color-primary);
+      border-radius: var(--ease-radius-md);
+      padding: 0.5rem 1rem;
+      font-size: 0.875rem;
+      color: var(--ease-color-primary);
+      white-space: nowrap;
+    }
+  </style>
+</head>
+<body>
+  <h2>Marquee Token Namespace Fix</h2>
+  <p>
+    All <code>--marquee-*</code> tokens renamed to <code>--ease-marquee-*</code>.
+    Hover to pause. Customise via the namespaced tokens.
+  </p>
+
+  <h3>Default (--ease-marquee-speed: 20s)</h3>
+  <div class="ease-marquee">
+    <div class="ease-marquee-track">
+      <span class="item">EaseMotion CSS</span>
+      <span class="item">Animation First</span>
+      <span class="item">Zero Dependencies</span>
+      <span class="item">Design Tokens</span>
+      <span class="item">Dark Mode Ready</span>
+      <span class="item">EaseMotion CSS</span>
+      <span class="item">Animation First</span>
+      <span class="item">Zero Dependencies</span>
+      <span class="item">Design Tokens</span>
+      <span class="item">Dark Mode Ready</span>
+    </div>
+  </div>
+
+  <h3>Fast (--ease-marquee-speed: 5s via inline token)</h3>
+  <div class="ease-marquee" style="--ease-marquee-speed: 5s;">
+    <div class="ease-marquee-track">
+      <span class="item">Fast Scroll</span>
+      <span class="item">Token Driven</span>
+      <span class="item">--ease-marquee-speed</span>
+      <span class="item">Fast Scroll</span>
+      <span class="item">Token Driven</span>
+      <span class="item">--ease-marquee-speed</span>
+    </div>
+  </div>
+
+  <h3>Reverse direction (--ease-marquee-direction: reverse)</h3>
+  <div class="ease-marquee ease-marquee-reverse">
+    <div class="ease-marquee-track">
+      <span class="item">Going Right</span>
+      <span class="item">Token Namespaced</span>
+      <span class="item">--ease-marquee-direction</span>
+      <span class="item">Going Right</span>
+      <span class="item">Token Namespaced</span>
+      <span class="item">--ease-marquee-direction</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-marquee-token-namespace/style.css
+++ b/submissions/examples/fix-marquee-token-namespace/style.css
@@ -1,0 +1,45 @@
+/* Fix: Rename --marquee-* tokens to --ease-marquee-* namespace
+
+   Problem: ease-marquee.css used --marquee-* custom properties without
+   the --ease-* prefix — inconsistent with the framework naming convention
+   and risks collision with user-defined or third-party CSS variables.
+
+   Solution: Rename all tokens to --ease-marquee-* prefix.
+*/
+
+.ease-marquee {
+  --ease-marquee-speed: 20s;
+  --ease-marquee-gap: 2rem;
+  --ease-marquee-pause-on-hover: paused;
+  --ease-marquee-direction: normal;
+}
+
+.ease-marquee-track {
+  gap: var(--ease-marquee-gap);
+  animation: ease-marquee-scroll var(--ease-marquee-speed) linear infinite;
+  animation-direction: var(--ease-marquee-direction);
+}
+
+.ease-marquee:hover .ease-marquee-track {
+  animation-play-state: var(--ease-marquee-pause-on-hover);
+}
+
+/* Speed variants */
+.ease-marquee-slow   { --ease-marquee-speed: 40s; }
+.ease-marquee-fast   { --ease-marquee-speed: 10s; }
+.ease-marquee-normal { --ease-marquee-speed: 20s; }
+.ease-marquee-xfast  { --ease-marquee-speed: 5s; }
+.ease-marquee-xslow  { --ease-marquee-speed: 60s; }
+
+/* Direction variants */
+.ease-marquee-reverse { --ease-marquee-direction: reverse; }
+
+/* Gap variants */
+.ease-marquee-gap-sm  { --ease-marquee-gap: 1rem; }
+.ease-marquee-gap-md  { --ease-marquee-gap: 2rem; }
+.ease-marquee-gap-lg  { --ease-marquee-gap: 3rem; }
+.ease-marquee-gap-xl  { --ease-marquee-gap: 5rem; }
+
+/* Pause control */
+.ease-marquee-pause      { --ease-marquee-pause-on-hover: paused; }
+.ease-marquee-no-pause   { --ease-marquee-pause-on-hover: running; }


### PR DESCRIPTION
## Pull Request Description
`ease-marquee.css` defined `--marquee-speed`, `--marquee-gap`, `--marquee-pause-on-hover`, and `--marquee-direction` without the `--ease-*` prefix. The entire framework uses `--ease-*` namespaced tokens. Non-prefixed tokens break the naming convention and risk collision with user-defined or third-party CSS variables.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Renames all `--marquee-*` tokens to `--ease-marquee-*` across the base class, all speed variants, direction variants, gap variants, and pause modifiers — making the marquee component consistent with the `--ease-*` naming convention.

**How does a developer use it?**
```html
<div class="ease-marquee" style="--ease-marquee-speed: 5s;">
  <div class="ease-marquee-track">...</div>
</div>
```

```css
:root {
  --ease-marquee-speed: 30s;
  --ease-marquee-gap: 3rem;
}
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS uses `--ease-*` as a namespace for all tokens to prevent collisions and maintain discoverability. The marquee component should follow the same convention as every other component in the framework.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows default, fast, and reverse marquee variants using namespaced tokens)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is a breaking change for users who were using `--marquee-*` tokens directly in their CSS. A migration table is included in `README.md`. All 4 base tokens and all variant modifiers are updated consistently.

Fixes #10428