### PR TITLE
feat: add sticky header that shrinks on scroll component

### DIFF
--- a/submissions/examples/sticky-header-shrink/README.md
+++ b/submissions/examples/sticky-header-shrink/README.md
@@ -1,0 +1,15 @@
+# Sticky Header That Shrinks on Scroll
+
+A fixed header that starts with generous padding and a large logo, then compacts to a slimmer size with a subtle box-shadow when the user scrolls past 80px. Includes navigation links and a smooth transition between states.
+
+## EaseMotion CSS classes used
+
+None required — built with plain CSS transitions.
+
+## How to run
+
+Open `demo.html` in a browser and scroll down to see the header shrink.
+
+## Accessibility notes
+
+The fixed header stays accessible at all scroll positions. Reduced motion disables the transition.

--- a/submissions/examples/sticky-header-shrink/demo.html
+++ b/submissions/examples/sticky-header-shrink/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sticky Header That Shrinks on Scroll</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="shrink-header" id="shrinkHeader">
+    <div class="shrink-inner">
+      <span class="shrink-logo">Logo</span>
+      <nav class="shrink-nav">
+        <a href="#">Home</a>
+        <a href="#">About</a>
+        <a href="#">Services</a>
+        <a href="#">Contact</a>
+      </nav>
+    </div>
+  </header>
+  <main class="shrink-content">
+    <h1>Scroll Down</h1>
+    <p>The header shrinks as you scroll past 80px.</p>
+    <div class="shrink-spacer"></div>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/sticky-header-shrink/script.js
+++ b/submissions/examples/sticky-header-shrink/script.js
@@ -1,0 +1,3 @@
+window.addEventListener("scroll", () => {
+  document.getElementById("shrinkHeader").classList.toggle("compact", window.scrollY > 80);
+});

--- a/submissions/examples/sticky-header-shrink/style.css
+++ b/submissions/examples/sticky-header-shrink/style.css
@@ -1,0 +1,91 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}
+
+.shrink-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+  transition: padding 0.3s ease, box-shadow 0.3s ease;
+  padding: 1rem 2rem;
+}
+
+.shrink-header.compact {
+  padding: 0.5rem 2rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.shrink-inner {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.shrink-logo {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #6366f1;
+  transition: font-size 0.3s ease;
+}
+
+.shrink-header.compact .shrink-logo {
+  font-size: 1rem;
+}
+
+.shrink-nav {
+  display: flex;
+  gap: 1.25rem;
+}
+
+.shrink-nav a {
+  font-size: 0.875rem;
+  color: #64748b;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.shrink-nav a:hover {
+  color: #6366f1;
+}
+
+.shrink-content {
+  margin-top: 72px;
+  padding: 2rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.shrink-content h1 {
+  font-size: 1.5rem;
+  color: #1e293b;
+}
+
+.shrink-content p {
+  color: #64748b;
+}
+
+.shrink-spacer {
+  height: 150vh;
+  background: linear-gradient(#f8fafc, #e2e8f0);
+  border-radius: 12px;
+  margin-top: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shrink-header,
+  .shrink-logo {
+    transition: none;
+  }
+}


### PR DESCRIPTION
A fixed header that starts with generous padding and a large logo, then compacts to a slimmer size with box-shadow when scrolling past 80px. Includes navigation links and smooth transition.

Closes #10459