### PR TITLE
feat: add off-canvas drawer slide-in panel component

### DIFF
--- a/submissions/examples/off-canvas-drawer/README.md
+++ b/submissions/examples/off-canvas-drawer/README.md
@@ -1,0 +1,16 @@
+# Off-Canvas Drawer Slide-In Panel
+
+A panel that slides in from the left edge when a toggle button is clicked. Includes a dark backdrop overlay, a header with close button, and navigation links. Clicking the overlay or close button dismisses the drawer.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser. Click "Open Drawer" to slide in the panel. Click ✕ or the overlay to close.
+
+## Accessibility notes
+
+Toggle and close are `<button>` elements. Navigation links are `<a>` elements. Reduced motion disables the slide transition.

--- a/submissions/examples/off-canvas-drawer/demo.html
+++ b/submissions/examples/off-canvas-drawer/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Off-Canvas Drawer Slide-In Panel</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #f8fafc;">
+    <button class="drawer-toggle" id="drawerToggle">☰ Open Drawer</button>
+  </div>
+  <div class="drawer-overlay" id="drawerOverlay"></div>
+  <div class="drawer" id="drawer">
+    <div class="drawer-header">
+      <h3>Menu</h3>
+      <button class="drawer-close" id="drawerClose">✕</button>
+    </div>
+    <nav class="drawer-nav">
+      <a href="#">Dashboard</a>
+      <a href="#">Profile</a>
+      <a href="#">Settings</a>
+      <a href="#">Notifications</a>
+      <a href="#">Logout</a>
+    </nav>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/off-canvas-drawer/script.js
+++ b/submissions/examples/off-canvas-drawer/script.js
@@ -1,0 +1,15 @@
+const drawer = document.getElementById("drawer");
+const overlay = document.getElementById("drawerOverlay");
+
+document.getElementById("drawerToggle").addEventListener("click", () => {
+  drawer.classList.add("open");
+  overlay.classList.add("open");
+});
+
+function closeDrawer() {
+  drawer.classList.remove("open");
+  overlay.classList.remove("open");
+}
+
+document.getElementById("drawerClose").addEventListener("click", closeDrawer);
+overlay.addEventListener("click", closeDrawer);

--- a/submissions/examples/off-canvas-drawer/style.css
+++ b/submissions/examples/off-canvas-drawer/style.css
@@ -1,0 +1,103 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  overflow-x: hidden;
+}
+
+.drawer-toggle {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  background: #6366f1;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.drawer-toggle:hover { background: #4f46e5; }
+
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 300;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.drawer-overlay.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 280px;
+  background: #ffffff;
+  z-index: 301;
+  transform: translateX(-100%);
+  transition: transform 0.35s ease;
+  box-shadow: 2px 0 12px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+}
+
+.drawer.open {
+  transform: translateX(0);
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.drawer-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #1e293b;
+}
+
+.drawer-close {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+  color: #94a3b8;
+}
+
+.drawer-close:hover { color: #475569; }
+
+.drawer-nav {
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem 0;
+}
+
+.drawer-nav a {
+  padding: 0.75rem 1.25rem;
+  font-size: 0.9rem;
+  color: #475569;
+  text-decoration: none;
+}
+
+.drawer-nav a:hover {
+  background: #f8fafc;
+  color: #6366f1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer-overlay,
+  .drawer {
+    transition: none;
+  }
+}


### PR DESCRIPTION
A panel that slides in from the left edge when a toggle button is clicked. Includes a dark backdrop overlay, a header with close button, and navigation links. Clicking the overlay or close dismisses the drawer.

Closes #10465