### PR TITLE
feat: add dark mode toggle switch component

### DIFF
--- a/submissions/examples/dark-mode-toggle/README.md
+++ b/submissions/examples/dark-mode-toggle/README.md
@@ -1,0 +1,15 @@
+# Dark Mode Toggle Switch
+
+A sliding pill toggle switch that switches between light and dark themes using CSS custom properties. The background, text, and muted colors transition smoothly. The toggle itself animates the knob and background color changes.
+
+## EaseMotion CSS classes used
+
+None required — built with plain CSS custom properties and transitions.
+
+## How to run
+
+Open `demo.html` in a browser. Toggle the switch to switch between light and dark mode.
+
+## Accessibility notes
+
+The toggle is a hidden checkbox wrapped in a `<label>` for accessible click targeting. The current mode is displayed as text. Reduced motion disables the transitions.

--- a/submissions/examples/dark-mode-toggle/demo.html
+++ b/submissions/examples/dark-mode-toggle/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dark Mode Toggle Switch</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="dm-body" id="dmBody">
+  <div class="dm-switch-wrap">
+    <label class="dm-switch">
+      <input type="checkbox" id="dmToggle" />
+      <span class="dm-slider"></span>
+    </label>
+    <span class="dm-label" id="dmLabel">Light Mode</span>
+  </div>
+  <main class="dm-main">
+    <h1 class="dm-h1">Dark Mode Demo</h1>
+    <p class="dm-p">Toggle the switch above to switch between light and dark themes.</p>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/dark-mode-toggle/script.js
+++ b/submissions/examples/dark-mode-toggle/script.js
@@ -1,0 +1,8 @@
+const toggle = document.getElementById("dmToggle");
+const body = document.getElementById("dmBody");
+const label = document.getElementById("dmLabel");
+
+toggle.addEventListener("change", () => {
+  body.classList.toggle("dark", toggle.checked);
+  label.textContent = toggle.checked ? "Dark Mode" : "Light Mode";
+});

--- a/submissions/examples/dark-mode-toggle/style.css
+++ b/submissions/examples/dark-mode-toggle/style.css
@@ -1,0 +1,93 @@
+:root {
+  --bg: #ffffff;
+  --text: #1e293b;
+  --muted: #64748b;
+  --card-bg: #f8fafc;
+}
+
+.dm-body.dark {
+  --bg: #0f172a;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --card-bg: #1e293b;
+}
+
+.dm-body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.dm-switch-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.dm-switch {
+  position: relative;
+  width: 48px;
+  height: 26px;
+  cursor: pointer;
+}
+
+.dm-switch input { display: none; }
+
+.dm-slider {
+  position: absolute;
+  inset: 0;
+  background: #e2e8f0;
+  border-radius: 13px;
+  transition: background 0.3s ease;
+}
+
+.dm-slider::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #ffffff;
+  transition: transform 0.3s ease;
+}
+
+.dm-switch input:checked + .dm-slider {
+  background: #6366f1;
+}
+
+.dm-switch input:checked + .dm-slider::after {
+  transform: translateX(22px);
+}
+
+.dm-label {
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.dm-main {
+  padding: 2rem;
+  max-width: 500px;
+}
+
+.dm-h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.dm-p {
+  font-size: 0.9rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dm-body,
+  .dm-slider,
+  .dm-slider::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
A sliding pill toggle switch that switches between light and dark themes using CSS custom properties. The background, text, and muted colors transition smoothly. The toggle itself animates the knob and background color changes.

Closes #10469