### PR TITLE
feat: add code block with copy to clipboard component

### DIFF
--- a/submissions/examples/code-block-copy/README.md
+++ b/submissions/examples/code-block-copy/README.md
@@ -1,0 +1,16 @@
+# Code Block with Copy to Clipboard
+
+A dark-themed code block with a header showing the language label and a Copy button. Clicking Copy copies the code to clipboard using the Async Clipboard API and shows a "Copied!" confirmation for 2 seconds. The button turns green briefly.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser. Click the Copy button to copy the code.
+
+## Accessibility notes
+
+The Copy button is a `<button>` element with visible text feedback. Code is rendered as plain text inside a `<pre><code>` element.

--- a/submissions/examples/code-block-copy/demo.html
+++ b/submissions/examples/code-block-copy/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Code Block with Copy to Clipboard</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #f8fafc;">
+    <div class="code-block">
+      <div class="code-header">
+        <span class="code-lang">JavaScript</span>
+        <button class="code-copy" id="codeCopy">Copy</button>
+      </div>
+      <pre class="code-pre"><code class="code-content" id="codeContent">function greet(name) {
+  return `Hello, ${name}!`;
+}
+
+console.log(greet("World"));</code></pre>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/code-block-copy/script.js
+++ b/submissions/examples/code-block-copy/script.js
@@ -1,0 +1,12 @@
+const btn = document.getElementById("codeCopy");
+const code = document.getElementById("codeContent");
+
+btn.addEventListener("click", async () => {
+  await navigator.clipboard.writeText(code.textContent);
+  btn.textContent = "Copied!";
+  btn.classList.add("copied");
+  setTimeout(() => {
+    btn.textContent = "Copy";
+    btn.classList.remove("copied");
+  }, 2000);
+});

--- a/submissions/examples/code-block-copy/style.css
+++ b/submissions/examples/code-block-copy/style.css
@@ -1,0 +1,64 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.code-block {
+  width: 420px;
+  max-width: 90vw;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #1e293b;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+
+.code-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: #334155;
+}
+
+.code-lang {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.code-copy {
+  font-size: 0.75rem;
+  color: #e2e8f0;
+  background: none;
+  border: 1px solid #475569;
+  border-radius: 4px;
+  padding: 0.2rem 0.6rem;
+  cursor: pointer;
+}
+
+.code-copy:hover {
+  background: #475569;
+}
+
+.code-copy.copied {
+  background: #22c55e;
+  border-color: #22c55e;
+  color: #ffffff;
+}
+
+.code-pre {
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+.code-content {
+  font-family: "Cascadia Code", "Fira Code", monospace;
+  font-size: 0.825rem;
+  line-height: 1.7;
+  color: #e2e8f0;
+}


### PR DESCRIPTION
A dark-themed code block with a header showing the language label and a Copy button. Clicking Copy copies the code to clipboard using the Async Clipboard API and shows a 'Copied!' confirmation for 2 seconds. The button turns green briefly.

Closes #10471