### PR TITLE
feat: add color gradient generator component

### DIFF
--- a/submissions/examples/color-gradient-generator/README.md
+++ b/submissions/examples/color-gradient-generator/README.md
@@ -1,0 +1,16 @@
+# Color Gradient Generator
+
+A live CSS gradient preview tool. Pick two colors and a direction via dropdown — the preview updates instantly and the generated `linear-gradient()` CSS is displayed as copyable text.
+
+## EaseMotion CSS classes used
+
+- `ease-flex` — page-level centering
+- `ease-center` — vertical and horizontal centering
+
+## How to run
+
+Open `demo.html` in a browser. Pick colors and a direction to see the gradient update live.
+
+## Accessibility notes
+
+All inputs have visible labels. The generated CSS is displayed as an `<output>` element. Color inputs are native OS color pickers.

--- a/submissions/examples/color-gradient-generator/demo.html
+++ b/submissions/examples/color-gradient-generator/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Color Gradient Generator</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-flex ease-center" style="min-height: 100vh; background: #f1f5f9;">
+    <div class="grad-card">
+      <h2 class="grad-h2">Gradient Generator</h2>
+      <div class="grad-preview" id="gradPreview"></div>
+      <div class="grad-controls">
+        <div class="grad-field">
+          <label class="grad-label">Color 1</label>
+          <input type="color" id="color1" value="#6366f1" />
+        </div>
+        <div class="grad-field">
+          <label class="grad-label">Color 2</label>
+          <input type="color" id="color2" value="#ec4899" />
+        </div>
+        <div class="grad-field grad-full">
+          <label class="grad-label">Direction</label>
+          <select id="gradDirection">
+            <option value="to right">→ Right</option>
+            <option value="to bottom">↓ Bottom</option>
+            <option value="to bottom right">↘ Diagonal</option>
+            <option value="to left">← Left</option>
+          </select>
+        </div>
+      </div>
+      <output class="grad-output" id="gradOutput">linear-gradient(to right, #6366f1, #ec4899)</output>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/color-gradient-generator/script.js
+++ b/submissions/examples/color-gradient-generator/script.js
@@ -1,0 +1,16 @@
+const color1 = document.getElementById("color1");
+const color2 = document.getElementById("color2");
+const direction = document.getElementById("gradDirection");
+const preview = document.getElementById("gradPreview");
+const output = document.getElementById("gradOutput");
+
+function updateGradient() {
+  const css = `linear-gradient(${direction.value}, ${color1.value}, ${color2.value})`;
+  preview.style.background = css;
+  output.value = css;
+}
+
+color1.addEventListener("input", updateGradient);
+color2.addEventListener("input", updateGradient);
+direction.addEventListener("change", updateGradient);
+updateGradient();

--- a/submissions/examples/color-gradient-generator/style.css
+++ b/submissions/examples/color-gradient-generator/style.css
@@ -1,0 +1,90 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}
+
+.grad-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  width: 320px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+}
+
+.grad-h2 {
+  font-size: 1.1rem;
+  margin: 0 0 1rem;
+  color: #1e293b;
+}
+
+.grad-preview {
+  height: 140px;
+  border-radius: 10px;
+  margin-bottom: 1rem;
+  transition: background 0.2s ease;
+}
+
+.grad-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.grad-field {
+  flex: 1 1 calc(50% - 0.375rem);
+}
+
+.grad-full {
+  flex: 1 1 100%;
+}
+
+.grad-label {
+  display: block;
+  font-size: 0.75rem;
+  color: #64748b;
+  margin-bottom: 0.25rem;
+}
+
+.grad-field input[type="color"] {
+  width: 100%;
+  height: 40px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 2px;
+  cursor: pointer;
+}
+
+.grad-field select {
+  width: 100%;
+  height: 40px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0 0.5rem;
+  font-size: 0.875rem;
+  color: #1e293b;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.grad-output {
+  display: block;
+  margin-top: 1rem;
+  padding: 0.625rem 0.75rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-family: "Cascadia Code", "Fira Code", monospace;
+  font-size: 0.7rem;
+  color: #475569;
+  word-break: break-all;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grad-preview {
+    transition: none;
+  }
+}


### PR DESCRIPTION
A live CSS gradient preview tool. Pick two colors and a direction via dropdown — the preview updates instantly and the generated linear-gradient() CSS is displayed as copyable text.

Closes #10472