### PR TITLE
feat: add parallax hero section component

### DIFF
--- a/submissions/examples/parallax-hero-section/README.md
+++ b/submissions/examples/parallax-hero-section/README.md
@@ -1,0 +1,15 @@
+# Parallax Hero Section
+
+A full-viewport hero section with a scenic background that scrolls at a slower rate (30%) than the foreground content. Below the hero are regular text sections for reading. The parallax is implemented via a `translateY` transform updated on scroll.
+
+## EaseMotion CSS classes used
+
+None required — built with plain CSS and scroll event.
+
+## How to run
+
+Open `demo.html` in a browser. Scroll down to see the background move slower than the foreground.
+
+## Accessibility notes
+
+The scroll effect is purely decorative. Reduced motion disables the parallax transform.

--- a/submissions/examples/parallax-hero-section/demo.html
+++ b/submissions/examples/parallax-hero-section/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Parallax Hero Section</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="parallax-hero">
+    <div class="parallax-bg" id="parallaxBg"></div>
+    <div class="parallax-content">
+      <h1 class="parallax-title">Explore the Mountains</h1>
+      <p class="parallax-sub">Scroll down to see the parallax effect in action.</p>
+    </div>
+  </div>
+  <div class="parallax-section">
+    <h2>About the Range</h2>
+    <p>Mountain ranges are formed by tectonic forces or volcanism. The highest mountain on Earth is Mount Everest at 8,848 meters above sea level.</p>
+    <p>Parallax scrolling is a technique where background content moves at a different speed than foreground content while scrolling.</p>
+  </div>
+  <div class="parallax-section">
+    <h2>Getting Started</h2>
+    <p>Plan your route, pack the essentials, and always check the weather before heading out. A good guide can make all the difference.</p>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/parallax-hero-section/script.js
+++ b/submissions/examples/parallax-hero-section/script.js
@@ -1,0 +1,6 @@
+const bg = document.getElementById("parallaxBg");
+
+window.addEventListener("scroll", () => {
+  const offset = window.pageYOffset;
+  bg.style.transform = `translateY(${offset * 0.3}px)`;
+});

--- a/submissions/examples/parallax-hero-section/style.css
+++ b/submissions/examples/parallax-hero-section/style.css
@@ -1,0 +1,75 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}
+
+.parallax-hero {
+  position: relative;
+  height: 80vh;
+  overflow: hidden;
+}
+
+.parallax-bg {
+  position: absolute;
+  inset: -20% 0 0;
+  background: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="800" height="600"%3E%3Cdefs%3E%3ClinearGradient id="g" x2="0%%" y2="100%%"%3E%3Cstop offset="0%%" stop-color="%231e3a5f"/%3E%3Cstop offset="100%%" stop-color="%234a6fa5"/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect fill="url(%23g)" width="800" height="600"/%3E%3Cpolygon points="0,400 100,320 200,380 350,280 500,360 650,250 800,340 800,600 0,600" fill="%232d5a3d"/%3E%3Cpolygon points="200,380 300,340 400,390 550,310 700,370 800,340 800,600 200,600" fill="%233b6b4a"/%3E%3Ccircle cx="650" cy="80" r="35" fill="%23fbbf24" opacity="0.9"/%3E%3C/svg%3E') center / cover no-repeat;
+  transform: translateY(0);
+  will-change: transform;
+  z-index: 0;
+}
+
+.parallax-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  text-align: center;
+  color: #ffffff;
+  padding: 2rem;
+}
+
+.parallax-title {
+  font-size: 2.2rem;
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.parallax-sub {
+  font-size: 1rem;
+  color: #e2e8f0;
+  margin: 0;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.parallax-section {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+  color: #1e293b;
+  line-height: 1.7;
+}
+
+.parallax-section h2 {
+  font-size: 1.2rem;
+  margin: 0 0 0.75rem;
+}
+
+.parallax-section p {
+  font-size: 0.9rem;
+  color: #475569;
+  margin: 0 0 0.75rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .parallax-bg {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
A full-viewport hero section with a scenic background that scrolls at a slower rate (30%) than the foreground content. Below the hero are regular text sections for reading. The parallax is implemented via a translateY transform updated on scroll.

Closes #10477