### PR TITLE
feat: add markdown-previewer-ak

### DIFF
--- a/submissions/examples/markdown-previewer-ak/README.md
+++ b/submissions/examples/markdown-previewer-ak/README.md
@@ -1,0 +1,10 @@
+# Markdown Previewer
+
+## What
+A live markdown editor with a textarea and rendered HTML preview supporting headings, bold, italic, lists, code, and links.
+
+## How
+A custom JavaScript parser processes markdown line-by-line using regex for inline formatting (bold, italic, code, links) and line-based detection for headings and lists. Updates on every keystroke.
+
+## Why
+Provides instant visual feedback while writing markdown, useful for documentation, note-taking, and content creation.

--- a/submissions/examples/markdown-previewer-ak/demo.html
+++ b/submissions/examples/markdown-previewer-ak/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Markdown Previewer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Markdown Previewer</h1>
+    <div class="split">
+      <textarea id="editor" placeholder="Type markdown here..."># Hello World
+
+## This is a heading
+
+**Bold text** and *italic text*
+
+- List item 1
+- List item 2
+
+`inline code`
+
+[OpenCode](https://opencode.ai)</textarea>
+      <div class="preview" id="preview"></div>
+    </div>
+  </div>
+
+  <script>
+    function render(md) {
+      let lines = md.split('\n');
+      let html = '';
+      let inList = false;
+
+      for (let i = 0; i < lines.length; i++) {
+        let line = lines[i];
+
+        line = line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+        line = line.replace(/\*(.+?)\*/g, '<em>$1</em>');
+        line = line.replace(/`(.+?)`/g, '<code>$1</code>');
+        line = line.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank">$1</a>');
+
+        if (/^### /.test(line)) {
+          if (inList) { html += '</ul>'; inList = false; }
+          html += '<h3>' + line.slice(4) + '</h3>';
+        } else if (/^## /.test(line)) {
+          if (inList) { html += '</ul>'; inList = false; }
+          html += '<h2>' + line.slice(3) + '</h2>';
+        } else if (/^# /.test(line)) {
+          if (inList) { html += '</ul>'; inList = false; }
+          html += '<h1>' + line.slice(2) + '</h1>';
+        } else if (/^- /.test(line)) {
+          if (!inList) { html += '<ul>'; inList = true; }
+          html += '<li>' + line.slice(2) + '</li>';
+        } else if (line.trim() === '') {
+          if (inList) { html += '</ul>'; inList = false; }
+        } else {
+          if (inList) { html += '</ul>'; inList = false; }
+          html += '<p>' + line + '</p>';
+        }
+      }
+
+      if (inList) html += '</ul>';
+      return html;
+    }
+
+    const editor = document.getElementById('editor');
+    const preview = document.getElementById('preview');
+
+    function update() {
+      preview.innerHTML = render(editor.value);
+    }
+
+    editor.addEventListener('input', update);
+    update();
+  </script>
+</body>
+</html>

--- a/submissions/examples/markdown-previewer-ak/style.css
+++ b/submissions/examples/markdown-previewer-ak/style.css
@@ -1,0 +1,88 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #0f0f0f;
+  color: #fff;
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 1000px;
+  padding: 1rem;
+}
+
+h1 {
+  color: #6366f1;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  height: 70vh;
+}
+
+textarea {
+  background: #1a1a1a;
+  border: 1px solid #333;
+  color: #fff;
+  padding: 1rem;
+  border-radius: 12px;
+  font-family: monospace;
+  font-size: 0.95rem;
+  resize: none;
+  outline: none;
+  line-height: 1.6;
+}
+
+textarea:focus {
+  border-color: #6366f1;
+}
+
+.preview {
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 12px;
+  padding: 1rem;
+  overflow-y: auto;
+  line-height: 1.6;
+}
+
+.preview h1 { color: #6366f1; font-size: 1.8rem; margin: 0 0 0.5rem; }
+.preview h2 { color: #818cf8; font-size: 1.4rem; margin: 0 0 0.4rem; }
+.preview h3 { color: #a5b4fc; font-size: 1.2rem; margin: 0 0 0.3rem; }
+.preview p { margin: 0 0 0.75rem; }
+.preview ul { margin: 0 0 0.75rem; padding-left: 1.5rem; }
+.preview li { margin-bottom: 0.25rem; }
+.preview code { background: #262626; padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.9em; }
+.preview a { color: #6366f1; }
+.preview strong { font-weight: 700; }
+.preview em { font-style: italic; }
+
+@media (max-width: 600px) {
+  .split {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+  textarea { height: 200px; }
+  .preview { min-height: 200px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
Adds a live markdown previewer with a textarea editor and rendered HTML preview supporting headings, bold, italic, lists, code blocks, and links. Closes #10531