### PR TITLE
fix: activate scroll reveal elements immediately when reduced motion

### DIFF
--- a/core/reveal.js
+++ b/core/reveal.js
@@ -1,8 +1,8 @@
 (function () {
-  'use strict';
+  "use strict";
 
-  var revealClass = 'ease-reveal';
-  var activeClass = 'ease-reveal-active';
+  var revealClass = "ease-reveal";
+  var activeClass = "ease-reveal-active";
 
   function isCentered(el) {
     var rect = el.getBoundingClientRect();
@@ -11,10 +11,26 @@
   }
 
   // Check if user prefers reduced motion
-  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (prefersReducedMotion) return;
+  const prefersReducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+  if (prefersReducedMotion) {
+    var readyReduced = function () {
+      var els = document.querySelectorAll("." + revealClass);
+      Array.prototype.forEach.call(els, function (el) {
+        el.classList.add(activeClass);
+      });
+    };
 
-  var supportsObserver = 'IntersectionObserver' in window;
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", readyReduced);
+    } else {
+      readyReduced();
+    }
+    return;
+  }
+
+  var supportsObserver = "IntersectionObserver" in window;
 
   if (supportsObserver) {
     var observer = new IntersectionObserver(
@@ -30,7 +46,7 @@
     );
 
     var ready = function () {
-      var els = document.querySelectorAll('.' + revealClass);
+      var els = document.querySelectorAll("." + revealClass);
       Array.prototype.forEach.call(els, function (el) {
         if (isCentered(el)) {
           el.classList.add(activeClass);
@@ -40,21 +56,21 @@
       });
     };
 
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', ready);
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", ready);
     } else {
       ready();
     }
   } else {
     var readyFallback = function () {
-      var els = document.querySelectorAll('.' + revealClass);
+      var els = document.querySelectorAll("." + revealClass);
       Array.prototype.forEach.call(els, function (el) {
         el.classList.add(activeClass);
       });
     };
 
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', readyFallback);
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", readyFallback);
     } else {
       readyFallback();
     }


### PR DESCRIPTION
fixes #10558

I have successfully resolved the issue where prefers-reduced-motion: reduce kept scroll-reveal elements permanently hidden, committed the changes to a new branch, and pushed them to your fork.

Here is a summary of the completed steps:

Reveal Script Fix: Modified 
reveal.js
 so that when prefers-reduced-motion is matched, it immediately queries and appends .ease-reveal-active to all reveal elements instead of exiting early.
Rebuilt & Tested: Run npm run build, npm run lint, and npm test successfully. All 13 smoke tests passed.