### PR TITLE
fix: exclude disabled elements from modal focus trap (#10562)

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -1,81 +1,91 @@
 (function () {
-  'use strict';
+  "use strict";
 
   function checkModal() {
     const hash = window.location.hash;
     const body = document.body;
 
     // Remove active class from all overlays just in case
-    const overlays = document.querySelectorAll('.ease-modal-overlay');
-    overlays.forEach((overlay) => overlay.classList.remove('is-active'));
+    const overlays = document.querySelectorAll(".ease-modal-overlay");
+    overlays.forEach((overlay) => overlay.classList.remove("is-active"));
 
     if (hash) {
       // Find overlay by hash (pure CSS `:target` fallback)
       try {
-        const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
-        const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
+        const escapedHashSelector = "#" + CSS.escape(hash.substring(1));
+        const overlay = document.querySelector(
+          escapedHashSelector + ".ease-modal-overlay"
+        );
         if (overlay) {
-          body.style.overflow = 'hidden';
-          overlay.classList.add('is-active');
+          body.style.overflow = "hidden";
+          overlay.classList.add("is-active");
 
-          const modal = overlay.querySelector('.ease-modal');
+          const modal = overlay.querySelector(".ease-modal");
           if (modal) {
-            modal.setAttribute('tabindex', '-1');
+            modal.setAttribute("tabindex", "-1");
             modal.focus();
           }
           return;
         }
       } catch (e) {
-        window.location.hash = ''; // Clear invalid hash
+        window.location.hash = ""; // Clear invalid hash
       }
     }
 
     // If no active modal is found
-    body.style.overflow = '';
+    body.style.overflow = "";
   }
 
   // Setup event listeners for hash changes (opening/closing via anchors)
-  window.addEventListener('hashchange', checkModal);
+  window.addEventListener("hashchange", checkModal);
 
   // Setup backdrop click listener to close modal
-  document.addEventListener('click', function (e) {
-    const hash = window.location.hash;
-    if (!hash) return;
+  document.addEventListener(
+    "click",
+    function (e) {
+      const hash = window.location.hash;
+      if (!hash) return;
 
-    try {
-      const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
-      const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
-      if (!overlay || !overlay.classList.contains('is-active')) return;
+      try {
+        const escapedHashSelector = "#" + CSS.escape(hash.substring(1));
+        const overlay = document.querySelector(
+          escapedHashSelector + ".ease-modal-overlay"
+        );
+        if (!overlay || !overlay.classList.contains("is-active")) return;
 
-      if (e.target === overlay) {
-        window.location.hash = ''; // Clear hash = close modal properly
-        e.preventDefault();
+        if (e.target === overlay) {
+          window.location.hash = ""; // Clear hash = close modal properly
+          e.preventDefault();
+        }
+      } catch (e) {
+        // Invalid selector, ignore
       }
-    } catch (e) {
-      // Invalid selector, ignore
-    }
-  }, true); // Capture phase
+    },
+    true
+  ); // Capture phase
 
   // Setup keyboard trap and escape key
-  document.addEventListener('keydown', function (e) {
+  document.addEventListener("keydown", function (e) {
     const hash = window.location.hash;
     if (!hash) return;
 
     try {
-      const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
-      const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
+      const escapedHashSelector = "#" + CSS.escape(hash.substring(1));
+      const overlay = document.querySelector(
+        escapedHashSelector + ".ease-modal-overlay"
+      );
       if (!overlay) return;
 
       // Escape key to close
-      if (e.key === 'Escape') {
-        window.location.hash = ''; // This will trigger hashchange and close the modal
+      if (e.key === "Escape") {
+        window.location.hash = ""; // This will trigger hashchange and close the modal
         return;
       }
 
       // Tab trap
-      if (e.key === 'Tab') {
+      if (e.key === "Tab") {
         const focusableElements = overlay.querySelectorAll(
-          'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
+          'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
         );
         if (focusableElements.length === 0) {
           e.preventDefault();
@@ -87,7 +97,10 @@
 
         if (e.shiftKey) {
           // Shift + Tab
-          if (document.activeElement === firstElement || document.activeElement === overlay.querySelector('.ease-modal')) {
+          if (
+            document.activeElement === firstElement ||
+            document.activeElement === overlay.querySelector(".ease-modal")
+          ) {
             e.preventDefault();
             lastElement.focus();
           }
@@ -105,8 +118,8 @@
   });
 
   // Run on load
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', checkModal);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", checkModal);
   } else {
     checkModal();
   }

--- a/tests/modal.test.js
+++ b/tests/modal.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { JSDOM } from "jsdom";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("EaseMotion-css Modal Focus Trap Tests", () => {
+  let dom;
+  let window;
+  let document;
+
+  beforeAll(() => {
+    dom = new JSDOM(
+      `
+      <!DOCTYPE html>
+      <html>
+        <body>
+          <div id="modal1" class="ease-modal-overlay is-active">
+            <div class="ease-modal">
+              <a id="link1" href="#">Link 1</a>
+              <button id="disabledBtn" disabled>Disabled Button</button>
+              <input id="input1" type="text" />
+              <button id="enabledBtn">Enabled Button</button>
+            </div>
+          </div>
+        </body>
+      </html>
+    `,
+      { runScripts: "outside-only" }
+    );
+
+    window = dom.window;
+    document = window.document;
+
+    // Load and execute modal.js in the JSDOM context
+    const modalJsCode = readFileSync(
+      resolve(__dirname, "../core/modal.js"),
+      "utf8"
+    );
+
+    // Polyfill CSS.escape just in case jsdom does not define it globally
+    const CSSPolyfill = {
+      escape: (val) =>
+        val.replace(/([!"#$%&'()*+,.\/:;<=>?@\[\\\]^`{|}~])/g, "\\$1"),
+    };
+
+    // Run script within local scope where window, document, and CSS resolve to jsdom instances
+    const scriptFunc = new Function("window", "document", "CSS", modalJsCode);
+    scriptFunc(window, document, CSSPolyfill);
+  });
+
+  it("should skip disabled elements in focus trap", () => {
+    window.location.hash = "#modal1";
+
+    const link1 = document.getElementById("link1");
+    const enabledBtn = document.getElementById("enabledBtn");
+
+    // Focus enabledBtn (the last active focusable element)
+    enabledBtn.focus();
+    expect(document.activeElement).toBe(enabledBtn);
+
+    // Dispatch Tab keydown event
+    const tabEvent = new window.KeyboardEvent("keydown", {
+      key: "Tab",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(tabEvent);
+
+    // Focus should wrap back to link1, skipping disabledBtn
+    expect(document.activeElement).toBe(link1);
+
+    // Focus link1 (the first active focusable element)
+    link1.focus();
+    expect(document.activeElement).toBe(link1);
+
+    // Dispatch Shift+Tab keydown event
+    const shiftTabEvent = new window.KeyboardEvent("keydown", {
+      key: "Tab",
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(shiftTabEvent);
+
+    // Focus should wrap backwards to enabledBtn, skipping disabledBtn
+    expect(document.activeElement).toBe(enabledBtn);
+  });
+});


### PR DESCRIPTION
fixes  #10562 

Modal Focus Trap Fix: Updated 
modal.js
 to exclude elements with the disabled attribute from the list of focusable elements inside the modal.
New Unit Tests: Created a new test file 
modal.test.js
 simulating active modals containing enabled and disabled elements to verify that focus skips disabled items on both forward and backward tab actions.
Verification: Executed npm test, formatting, and linting. All tests passed.