### PR TITLE
docs: remove duplicate animation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,21 +439,6 @@ Use the non-minified version for debugging and development:
 | ease-duration-medium | 300ms    |
 | ease-duration-slow   | 600ms    |
 
-<!-- Looping animations -->
-<div class="ease-bounce">Bouncing</div>
-<div class="ease-pulse">Pulsing</div>
-<div class="ease-rotate">Rotating</div>
-<div class="ease-ping">Ping</div>
-
-You can customize the iteration count of looping animations:
-
-```css
-:root {
-  --ease-animation-iterations: 3;
-}
-```
-
-By default, the value is `infinite`, preserving existing behavior.
 
 <!-- Exit animation -->
 <div class="ease-expand-border-exit"></div>


### PR DESCRIPTION
## Description

This PR removes duplicated looping animation documentation from `README.md`.

### Changes Made

* Removed duplicate looping animation examples:

  * `.ease-bounce`
  * `.ease-pulse`
  * `.ease-rotate`
  * `.ease-ping`
* Removed the duplicated `--ease-animation-iterations` explanation from the later Animations section.
* Kept the dedicated **"Controlling looping animations"** section as the single source of reference.

### Issue Fixed

Closes #1870

### Type of Change

* Documentation update

### Checklist

* [x] Removed duplicate content
* [x] Kept one clear reference section
* [x] No unrelated changes made
* [x] README updated successfully
