### PR TITLE
fix: expose --ease-card-neu-shadow-dark and --ease-card-neu-shadow-light tokens for neumorphic card shadows

### DIFF
--- a/submissions/examples/fix-cards-neumorphic-shadow-tokens/README.md
+++ b/submissions/examples/fix-cards-neumorphic-shadow-tokens/README.md
@@ -1,0 +1,49 @@
+# Fix: Expose CSS Custom Properties for Neumorphic Shadow Colors in cards.css
+
+## Problem
+
+`.ease-card-neumorphic` hardcoded all rgba shadow values across base, hover, and dark mode states:
+
+```css
+.ease-card-neumorphic {
+  box-shadow:
+    8px 8px 20px rgba(15, 23, 42, 0.12),    /* hardcoded */
+    -8px -8px 20px rgba(255, 255, 255, 0.78); /* hardcoded */
+}
+```
+
+The same values were duplicated in the hover state and dark mode — three separate selectors with hardcoded rgba values. Users who wanted to customise the shadow colors had to override all three.
+
+## Solution
+
+Expose `--ease-card-neu-shadow-dark` and `--ease-card-neu-shadow-light` tokens on `.ease-card-neumorphic` and use them across all shadow declarations:
+
+```css
+.ease-card-neumorphic {
+  --ease-card-neu-shadow-dark:  rgba(15, 23, 42, 0.12);
+  --ease-card-neu-shadow-light: rgba(255, 255, 255, 0.78);
+
+  box-shadow:
+    8px 8px 20px var(--ease-card-neu-shadow-dark),
+    -8px -8px 20px var(--ease-card-neu-shadow-light);
+}
+```
+
+Dark mode overrides the tokens — the hover state adapts automatically with no extra selectors needed.
+
+## Usage
+
+```html
+<!-- Custom shadow colors per card -->
+<div class="ease-card ease-card-neumorphic"
+     style="--ease-card-neu-shadow-dark: rgba(108,99,255,0.2);
+            --ease-card-neu-shadow-light: rgba(255,255,255,0.9);">
+  Purple neumorphic card
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses CSS custom properties so users can customise components without targeting multiple selectors. Exposing shadow color tokens also eliminates the value duplication between base, hover, and dark mode states.
+
+Fixes #10427

--- a/submissions/examples/fix-cards-neumorphic-shadow-tokens/demo.html
+++ b/submissions/examples/fix-cards-neumorphic-shadow-tokens/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Neumorphic Shadow Tokens — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    .controls { display: flex; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+    }
+    .ease-card { padding: var(--ease-space-6); }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted); margin-bottom: 0.75rem; }
+  </style>
+</head>
+<body>
+  <h2>Neumorphic Shadow Token Fix</h2>
+  <p>
+    Shadow colors now use <code>--ease-card-neu-shadow-dark</code> and
+    <code>--ease-card-neu-shadow-light</code> tokens. Override per-instance or globally.
+  </p>
+
+  <div class="controls">
+    <button class="ease-btn ease-btn-primary" onclick="document.documentElement.setAttribute('data-theme','dark')">Dark Mode</button>
+    <button class="ease-btn ease-btn-outline" onclick="document.documentElement.removeAttribute('data-theme')">Light Mode</button>
+  </div>
+
+  <h3>Default (hover to see elevation)</h3>
+  <div class="grid">
+    <div class="ease-card ease-card-neumorphic">Default neumorphic card</div>
+    <div class="ease-card ease-card-neumorphic">Hover me</div>
+  </div>
+
+  <h3>Custom shadow colors via token override</h3>
+  <div class="grid">
+    <div class="ease-card ease-card-neumorphic"
+         style="--ease-card-neu-shadow-dark: rgba(108,99,255,0.2); --ease-card-neu-shadow-light: rgba(255,255,255,0.9);">
+      Purple shadow variant
+    </div>
+    <div class="ease-card ease-card-neumorphic"
+         style="--ease-card-neu-shadow-dark: rgba(34,197,94,0.2); --ease-card-neu-shadow-light: rgba(255,255,255,0.9);">
+      Green shadow variant
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-cards-neumorphic-shadow-tokens/style.css
+++ b/submissions/examples/fix-cards-neumorphic-shadow-tokens/style.css
@@ -1,0 +1,39 @@
+/* Fix: Expose CSS custom properties for neumorphic shadow colors in cards.css
+
+   Problem: .ease-card-neumorphic hardcoded all rgba shadow values across
+   base, hover, and dark mode states — duplicating values and making
+   customisation impossible without overriding multiple selectors.
+
+   Solution: Expose --ease-card-neu-shadow-dark and
+   --ease-card-neu-shadow-light tokens with original values as fallbacks.
+*/
+
+.ease-card-neumorphic {
+  --ease-card-neu-shadow-dark:  rgba(15, 23, 42, 0.12);
+  --ease-card-neu-shadow-light: rgba(255, 255, 255, 0.78);
+
+  box-shadow:
+    8px 8px 20px var(--ease-card-neu-shadow-dark),
+    -8px -8px 20px var(--ease-card-neu-shadow-light);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-card-neumorphic:hover {
+    box-shadow:
+      12px 12px 26px var(--ease-card-neu-shadow-dark),
+      -10px -10px 24px var(--ease-card-neu-shadow-light);
+  }
+}
+
+/* Dark mode overrides — update tokens so hover state adapts automatically */
+@media (prefers-color-scheme: dark) {
+  .ease-card-neumorphic {
+    --ease-card-neu-shadow-dark:  rgba(0, 0, 0, 0.32);
+    --ease-card-neu-shadow-light: rgba(255, 255, 255, 0.04);
+  }
+}
+
+[data-theme="dark"] .ease-card-neumorphic {
+  --ease-card-neu-shadow-dark:  rgba(0, 0, 0, 0.32);
+  --ease-card-neu-shadow-light: rgba(255, 255, 255, 0.04);
+}


### PR DESCRIPTION
## Pull Request Description
`.ease-card-neumorphic` hardcoded rgba shadow values across three separate selectors (base, hover, dark mode) — the same values duplicated in multiple places. Users who wanted to customise the shadow colors had to override all three selectors. Exposing token variables eliminates the duplication and makes customisation a single-line override.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
`--ease-card-neu-shadow-dark` and `--ease-card-neu-shadow-light` tokens on `.ease-card-neumorphic`. Dark mode overrides the tokens — the hover state adapts automatically with no extra selectors needed.

**How does a developer use it?**
```html
<!-- Custom shadow colors per card -->
<div class="ease-card ease-card-neumorphic"
     style="--ease-card-neu-shadow-dark: rgba(108,99,255,0.2);
            --ease-card-neu-shadow-light: rgba(255,255,255,0.9);">
  Purple neumorphic card
</div>
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS uses CSS custom properties so users can customise components without targeting multiple selectors. Exposing shadow tokens also eliminates value duplication across base, hover, and dark mode states.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows default, dark mode, and custom shadow color variants)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Changes to `components/cards.css`: add two token declarations on `.ease-card-neumorphic`, replace hardcoded rgba values in base and hover `box-shadow` with token references, and set dark mode token overrides on `.ease-card-neumorphic` inside the `prefers-color-scheme: dark` block. The hover state box-shadow values also slightly increase (consistent with existing behaviour) and now use the same tokens.

Fixes #10427