### PR TITLE
fix: expose --ease-btn-spinner-duration token for button loading spinner animation

### DIFF
--- a/submissions/examples/fix-buttons-spinner-duration-token/README.md
+++ b/submissions/examples/fix-buttons-spinner-duration-token/README.md
@@ -1,0 +1,57 @@
+# Fix: Expose --ease-btn-spinner-duration Token for Button Loading Spinner
+
+## Problem
+
+`.ease-btn-loading::after` hardcoded the spinner animation duration:
+
+```css
+animation: ease-kf-btn-spin 0.7s linear infinite;
+```
+
+The `0.7s` value bypasses the `--ease-speed-*` token system and ignores `prefers-reduced-motion` — users who prefer reduced motion still see a spinning animation.
+
+## Solution
+
+Expose `--ease-btn-spinner-duration` with a `0.7s` default and add a `prefers-reduced-motion` override:
+
+```css
+.ease-btn-loading {
+  --ease-btn-spinner-duration: 0.7s;
+}
+
+.ease-btn-loading::after {
+  animation: ease-kf-btn-spin var(--ease-btn-spinner-duration, 0.7s) linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn-loading::after {
+    animation: none;
+    border-top-color: currentColor;
+    opacity: 0.5;
+  }
+}
+```
+
+## Usage
+
+```html
+<!-- Default spinner -->
+<button class="ease-btn ease-btn-primary ease-btn-loading">Loading</button>
+
+<!-- Fast spinner -->
+<button class="ease-btn ease-btn-primary ease-btn-loading"
+        style="--ease-btn-spinner-duration: 0.3s;">Loading</button>
+```
+
+```css
+/* Global override */
+:root {
+  --ease-btn-spinner-duration: 1s;
+}
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS exposes animation parameters as CSS custom properties so users can customise behaviour without overriding component selectors. The spinner duration should follow the same token-driven approach as other animated components.
+
+Fixes #10425

--- a/submissions/examples/fix-buttons-spinner-duration-token/demo.html
+++ b/submissions/examples/fix-buttons-spinner-duration-token/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Button Spinner Duration Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    .row { display: flex; gap: 1rem; flex-wrap: wrap; align-items: center; margin-bottom: 1.5rem; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted); margin-bottom: 0.75rem; }
+  </style>
+</head>
+<body>
+  <h2>Button Spinner Duration Token Fix</h2>
+  <p>
+    Spinner duration is now customisable via <code>--ease-btn-spinner-duration</code>.
+    Default is <code>0.7s</code>.
+  </p>
+
+  <h3>Default (0.7s)</h3>
+  <div class="row">
+    <button class="ease-btn ease-btn-primary ease-btn-loading">Loading</button>
+    <button class="ease-btn ease-btn-outline ease-btn-loading">Loading</button>
+  </div>
+
+  <h3>Fast (0.3s via inline token)</h3>
+  <div class="row">
+    <button class="ease-btn ease-btn-primary ease-btn-loading"
+            style="--ease-btn-spinner-duration: 0.3s;">Loading</button>
+  </div>
+
+  <h3>Slow (1.5s via inline token)</h3>
+  <div class="row">
+    <button class="ease-btn ease-btn-primary ease-btn-loading"
+            style="--ease-btn-spinner-duration: 1.5s;">Loading</button>
+  </div>
+
+  <h3>Global override via :root</h3>
+  <p>Set <code>--ease-btn-spinner-duration</code> on <code>:root</code> to change all spinners globally.</p>
+  <pre style="background:var(--ease-color-neutral-100);padding:1rem;border-radius:var(--ease-radius-md);font-size:0.875rem;font-family:var(--ease-font-mono);">:root {
+  --ease-btn-spinner-duration: 1s;
+}</pre>
+</body>
+</html>

--- a/submissions/examples/fix-buttons-spinner-duration-token/style.css
+++ b/submissions/examples/fix-buttons-spinner-duration-token/style.css
@@ -1,0 +1,24 @@
+/* Fix: Expose --ease-btn-spinner-duration token for button loading spinner
+
+   Problem: .ease-btn-loading::after used hardcoded 0.7s animation duration
+   bypassing --ease-speed-* tokens and prefers-reduced-motion override.
+
+   Solution: Expose --ease-btn-spinner-duration with 0.7s default.
+*/
+
+.ease-btn-loading {
+  --ease-btn-spinner-duration: 0.7s;
+}
+
+.ease-btn-loading::after {
+  animation: ease-kf-btn-spin var(--ease-btn-spinner-duration, 0.7s) linear infinite;
+}
+
+/* Reduced motion — spinner stops */
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn-loading::after {
+    animation: none;
+    border-top-color: currentColor;
+    opacity: 0.5;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
`.ease-btn-loading::after` hardcoded `0.7s` as the spinner animation duration — bypassing the `--ease-speed-*` token system and ignoring `prefers-reduced-motion`. Users who prefer reduced motion still saw a spinning animation, and the duration could not be customised without overriding the component selector directly.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
`--ease-btn-spinner-duration` token (default `0.7s`) on `.ease-btn-loading`, plus a `prefers-reduced-motion` override that stops the spinner animation for users who prefer reduced motion.

**How does a developer use it?**
```html
<!-- Fast spinner -->
<button class="ease-btn ease-btn-primary ease-btn-loading"
        style="--ease-btn-spinner-duration: 0.3s;">Loading</button>
```

```css
/* Global override */
:root { --ease-btn-spinner-duration: 1s; }
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS exposes animation parameters as CSS custom properties and respects `prefers-reduced-motion`. The spinner duration should follow the same token-driven approach as other animated components.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows default 0.7s, fast 0.3s, and slow 1.5s spinner variants)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Two changes in `components/buttons.css`: set `--ease-btn-spinner-duration: 0.7s` on `.ease-btn-loading` and replace the hardcoded `0.7s` in the animation declaration with `var(--ease-btn-spinner-duration, 0.7s)`. Also add a `prefers-reduced-motion` block that disables the spinner animation.

Fixes #10425