### PR TITLE
fix: derive scroll progress shadow color from semantic color tokens via color-mix() instead of hardcoded rgba

### DIFF
--- a/submissions/examples/fix-scroll-progress-shadow-token/README.md
+++ b/submissions/examples/fix-scroll-progress-shadow-token/README.md
@@ -1,0 +1,41 @@
+# Fix: Use Color Tokens for Scroll Progress Shadow Instead of Hardcoded rgba
+
+## Problem
+
+`--ease-scroll-progress-shadow` hardcoded rgba color values that duplicate the same colors already available via `--ease-color-primary`, `--ease-color-success` etc.:
+
+```css
+--ease-scroll-progress-shadow: 0 2px 10px rgba(108, 99, 255, 0.45);
+```
+
+If a user customises `--ease-color-primary`, the scroll progress shadow does not update to match — it always uses the hardcoded purple regardless of theme.
+
+## Solution
+
+Derive the shadow color from semantic color tokens using `color-mix()`:
+
+```css
+.ease-scroll-progress {
+  --ease-scroll-progress-shadow: 0 2px 10px
+    color-mix(in srgb, var(--ease-color-primary, #6c63ff) 45%, transparent);
+}
+```
+
+A `@supports` fallback preserves the original hardcoded values for browsers without `color-mix()` support.
+
+## Usage
+
+No class changes needed. The shadow now follows `--ease-color-primary` automatically:
+
+```css
+/* Shadow updates automatically when primary color changes */
+:root {
+  --ease-color-primary: #ff6b6b;
+}
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses semantic color tokens so theme changes propagate automatically. Hardcoded rgba values that duplicate token colors break this propagation and require manual updates in multiple places.
+
+Fixes #10424

--- a/submissions/examples/fix-scroll-progress-shadow-token/demo.html
+++ b/submissions/examples/fix-scroll-progress-shadow-token/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Scroll Progress Shadow Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); min-height: 300vh; }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 600px; }
+    .demo-bar {
+      position: relative;
+      height: 8px;
+      border-radius: var(--ease-radius-full);
+      margin-bottom: 1.5rem;
+      overflow: hidden;
+    }
+    .bar-fill {
+      height: 100%;
+      border-radius: var(--ease-radius-full);
+    }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted); margin-bottom: 0.5rem; }
+  </style>
+</head>
+<body>
+  <!-- Actual scroll progress bar at top -->
+  <div class="ease-scroll-progress"></div>
+
+  <h2>Scroll Progress Shadow Token Fix</h2>
+  <p>
+    Shadow colors now derived from semantic color tokens via <code>color-mix()</code>
+    instead of hardcoded rgba values. Scroll down to see the progress bar.
+  </p>
+  <p>
+    If you override <code>--ease-color-primary</code>, the scroll progress
+    shadow will automatically update to match.
+  </p>
+
+  <h3>Theme variants (static preview)</h3>
+  <p>Primary:</p>
+  <div class="demo-bar">
+    <div class="bar-fill" style="width:60%;background:var(--ease-color-primary);box-shadow: 0 2px 10px color-mix(in srgb, var(--ease-color-primary) 45%, transparent);"></div>
+  </div>
+  <p>Success:</p>
+  <div class="demo-bar">
+    <div class="bar-fill" style="width:60%;background:var(--ease-color-success);box-shadow: 0 2px 10px color-mix(in srgb, var(--ease-color-success) 45%, transparent);"></div>
+  </div>
+  <p>Danger:</p>
+  <div class="demo-bar">
+    <div class="bar-fill" style="width:60%;background:var(--ease-color-danger);box-shadow: 0 2px 10px color-mix(in srgb, var(--ease-color-danger) 45%, transparent);"></div>
+  </div>
+  <p>Warning:</p>
+  <div class="demo-bar">
+    <div class="bar-fill" style="width:60%;background:var(--ease-color-warning);box-shadow: 0 2px 10px color-mix(in srgb, var(--ease-color-warning) 45%, transparent);"></div>
+  </div>
+
+  <p style="margin-top:2rem;">Keep scrolling to see the live progress bar update...</p>
+</body>
+</html>

--- a/submissions/examples/fix-scroll-progress-shadow-token/style.css
+++ b/submissions/examples/fix-scroll-progress-shadow-token/style.css
@@ -1,0 +1,52 @@
+/* Fix: Use CSS color tokens for --ease-scroll-progress-shadow
+   instead of hardcoded rgba values
+
+   Problem: --ease-scroll-progress-shadow hardcoded rgba color values
+   that duplicate the same colors already defined in --ease-color-primary,
+   --ease-color-success, --ease-color-danger, --ease-color-warning.
+
+   Note: --ease-glow-* tokens use 0 0 16px offset which differs from
+   the scroll progress 0 2px 10px offset, so we cannot use them as
+   direct replacements. Instead we use color-mix() to derive the
+   shadow color from the semantic color tokens.
+*/
+
+/* Primary theme — uses --ease-color-primary */
+.ease-scroll-progress {
+  --ease-scroll-progress-shadow: 0 2px 10px
+    color-mix(in srgb, var(--ease-color-primary, #6c63ff) 45%, transparent);
+}
+
+/* Success theme */
+.ease-scroll-progress.ease-scroll-progress-success {
+  --ease-scroll-progress-shadow: 0 2px 10px
+    color-mix(in srgb, var(--ease-color-success, #22c55e) 45%, transparent);
+}
+
+/* Danger theme */
+.ease-scroll-progress.ease-scroll-progress-danger {
+  --ease-scroll-progress-shadow: 0 2px 10px
+    color-mix(in srgb, var(--ease-color-danger, #ef4444) 45%, transparent);
+}
+
+/* Warning theme */
+.ease-scroll-progress.ease-scroll-progress-warning {
+  --ease-scroll-progress-shadow: 0 2px 10px
+    color-mix(in srgb, var(--ease-color-warning, #f59e0b) 45%, transparent);
+}
+
+/* Fallback for browsers without color-mix() support */
+@supports not (color: color-mix(in srgb, red 45%, transparent)) {
+  .ease-scroll-progress {
+    --ease-scroll-progress-shadow: 0 2px 10px rgba(108, 99, 255, 0.45);
+  }
+  .ease-scroll-progress.ease-scroll-progress-success {
+    --ease-scroll-progress-shadow: 0 2px 10px rgba(34, 197, 94, 0.45);
+  }
+  .ease-scroll-progress.ease-scroll-progress-danger {
+    --ease-scroll-progress-shadow: 0 2px 10px rgba(239, 68, 68, 0.45);
+  }
+  .ease-scroll-progress.ease-scroll-progress-warning {
+    --ease-scroll-progress-shadow: 0 2px 10px rgba(245, 158, 11, 0.45);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
`--ease-scroll-progress-shadow` hardcoded rgba values that duplicate `--ease-color-primary`, `--ease-color-success`, `--ease-color-danger`, and `--ease-color-warning`. If a user customises `--ease-color-primary`, the scroll progress shadow does not update — it always shows the hardcoded purple regardless of theme.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Replaces hardcoded rgba shadow values with `color-mix(in srgb, var(--ease-color-*) 45%, transparent)` so the shadow color follows semantic color tokens automatically. A `@supports` fallback preserves the original rgba values for browsers without `color-mix()` support.

**How does a developer use it?**
```css
/* Shadow updates automatically when primary color changes */
:root {
  --ease-color-primary: #ff6b6b;
}
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS uses semantic color tokens so theme changes propagate automatically. Shadow colors that duplicate token values should reference those tokens so customisation requires a single override.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows live scroll progress bar plus static previews of all four theme variants)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The `--ease-glow-*` tokens could not be used as direct replacements because they use `0 0 16px` offsets while the scroll progress bar uses `0 2px 10px` — different visual effect. `color-mix()` is the correct approach as it derives the color from the semantic token while preserving the intended shadow geometry. `@supports` fallback is included for full browser compatibility.

Fixes #10424