### PR TITLE
fix: use neutral-900 and reset opacity for disabled inputs in dark mode (issue #10687)

### DIFF
--- a/submissions/examples/forms-disabled-dark-mode-10687/README.md
+++ b/submissions/examples/forms-disabled-dark-mode-10687/README.md
@@ -1,0 +1,72 @@
+# Form Disabled Dark Mode Fix — Issue #10687
+
+**Fixes:** #10687
+
+## What does this do?
+
+Fixes the dark mode visual hierarchy for disabled form inputs. The current
+dark mode override uses a background token that is lighter than the enabled
+input background, making disabled fields look more prominent than enabled
+ones. This fix uses a darker token and resets the inherited opacity.
+
+## The problem
+
+`components/forms.css` dark mode block:
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-input:disabled,
+  .ease-textarea:disabled,
+  .ease-select:disabled {
+    background-color: var(--ease-color-neutral-800, #1e293b); /* lighter than surface */
+    border-color: var(--ease-color-neutral-700, #334155);
+    /* opacity: 0.8 inherited from base disabled rule */
+  }
+}
+```
+
+In dark mode:
+- Enabled input background: `--ease-color-surface` = `#141e33`
+- Disabled input background: `--ease-color-neutral-800` = `#1e293b`
+
+`#1e293b` is lighter than `#141e33`. Disabled looks more prominent than
+enabled — the opposite of what "disabled" should communicate.
+
+The `opacity: 0.8` inherited from the base rule makes the disabled field
+even lighter by blending the `#1e293b` background with the dark page.
+
+## The fix
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-input:disabled,
+  .ease-textarea:disabled,
+  .ease-select:disabled {
+    background-color: var(--ease-color-neutral-900, #0f172a);
+    border-color: var(--ease-color-neutral-700, #334155);
+    opacity: 1;
+  }
+}
+```
+
+`--ease-color-neutral-900` (`#0f172a`) is darker than `--ease-color-surface`
+(`#141e33`) — disabled is correctly more muted than enabled.
+
+`opacity: 1` resets the inherited `opacity: 0.8`. On a light background
+the opacity fade communicates "muted", but on an already-dark surface it
+only makes the element appear lighter (by blending with the dark page
+background behind it), which is the wrong direction.
+
+## Before vs after in dark mode
+
+| | Enabled | Disabled | Relationship |
+|---|---|---|---|
+| Before | `#141e33` | `#1e293b` at 80% | Disabled is lighter ❌ |
+| After | `#141e33` | `#0f172a` at 100% | Disabled is darker ✅ |
+
+## Demo
+
+Enable dark mode in Chrome DevTools → More Tools → Rendering →
+prefers-color-scheme: dark. The Broken section shows the disabled input
+appearing brighter than the enabled one. The Fixed section shows the
+correct darker/more-muted appearance.

--- a/submissions/examples/forms-disabled-dark-mode-10687/demo.html
+++ b/submissions/examples/forms-disabled-dark-mode-10687/demo.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Form Disabled Dark Mode Fix — Issue #10687</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+      padding: 2rem 1.5rem;
+    }
+
+    .page { max-width: 820px; margin: 0 auto; }
+
+    h1 { font-size: var(--ease-text-2xl, 1.5rem); font-weight: 700; margin-bottom: 0.4rem; }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .section {
+      background: var(--ease-color-surface, #fff);
+      border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .section-title {
+      font-size: var(--ease-text-base, 1rem);
+      font-weight: 700;
+      margin-bottom: 1.25rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .tag {
+      font-size: 0.68rem;
+      font-weight: 700;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    .field-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .field-row {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .field-tag {
+      font-size: 0.72rem;
+      font-family: var(--ease-font-mono, monospace);
+      padding: 0.15rem 0.4rem;
+      border-radius: 4px;
+      min-width: 70px;
+      text-align: center;
+    }
+    .enabled-tag  { background: rgba(34,197,94,0.12); color: var(--ease-color-success,#22c55e); }
+    .disabled-tag { background: rgba(239,68,68,0.1);  color: var(--ease-color-danger,#ef4444); }
+
+    /* ── BROKEN disabled: lighter than enabled in dark mode ── */
+    .input-broken-enabled {
+      display: block;
+      width: 100%;
+      padding: 0.625rem 0.875rem;
+      font-size: var(--ease-text-base, 1rem);
+      color: var(--ease-color-text, #1e293b);
+      border: 1.5px solid var(--ease-color-neutral-300, #cbd5e1);
+      border-radius: var(--ease-radius-md, 0.5rem);
+      outline: none;
+    }
+
+    .input-broken-disabled {
+      display: block;
+      width: 100%;
+      padding: 0.625rem 0.875rem;
+      font-size: var(--ease-text-base, 1rem);
+      cursor: not-allowed;
+      border: 1.5px solid;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      outline: none;
+      /* Broken dark mode values */
+      background-color: #141e33; /* enabled surface */
+      color: #94a3b8;
+      border-color: #334155;
+    }
+
+    /* In dark: broken disabled uses #1e293b (lighter) + opacity:0.8 */
+    @media (prefers-color-scheme: dark) {
+      .input-broken-enabled  { background: #141e33; color: #e2e8f0; border-color: #334155; }
+      .input-broken-disabled { background: #1e293b; color: #94a3b8; border-color: #334155; opacity: 0.8; }
+    }
+
+    /* ── FIXED disabled: darker than enabled in dark mode ─── */
+    .input-fixed-enabled {
+      display: block;
+      width: 100%;
+      padding: 0.625rem 0.875rem;
+      font-size: var(--ease-text-base, 1rem);
+      color: var(--ease-color-text, #1e293b);
+      border: 1.5px solid var(--ease-color-neutral-300, #cbd5e1);
+      border-radius: var(--ease-radius-md, 0.5rem);
+      outline: none;
+    }
+
+    .input-fixed-disabled {
+      display: block;
+      width: 100%;
+      padding: 0.625rem 0.875rem;
+      font-size: var(--ease-text-base, 1rem);
+      cursor: not-allowed;
+      border: 1.5px solid;
+      border-radius: var(--ease-radius-md, 0.5rem);
+      outline: none;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .input-fixed-enabled  { background: #141e33; color: #e2e8f0; border-color: #334155; }
+      .input-fixed-disabled { background: #0f172a; color: #94a3b8; border-color: #334155; opacity: 1; }
+    }
+
+    .bg-note {
+      font-size: 0.72rem;
+      font-family: var(--ease-font-mono, monospace);
+      margin-top: 0.25rem;
+      color: var(--ease-color-muted, #64748b);
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .section { background: var(--ease-color-surface, #141e33); border-color: var(--ease-color-neutral-700, #334155); }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+
+    <h1>Form Disabled Dark Mode Fix</h1>
+    <p class="sub">
+      Issue #10687 — disabled input is lighter than enabled input in dark mode
+    </p>
+
+    <div class="hint">
+      Enable dark mode: Chrome DevTools → More Tools → Rendering →
+      set <strong>Emulate CSS media feature prefers-color-scheme</strong>
+      to <code>dark</code>. In dark mode, compare the Enabled vs Disabled
+      inputs in each section — in the Broken section the disabled input
+      is brighter than the enabled one.
+    </div>
+
+    <!-- BROKEN -->
+    <div class="section">
+      <div class="section-title">
+        <span class="tag tag-broken">Broken</span>
+        Disabled input lighter than enabled in dark mode
+      </div>
+
+      <div class="field-group">
+        <div>
+          <div class="field-row">
+            <span class="field-tag enabled-tag">Enabled</span>
+            <input class="input-broken-enabled" type="text" value="Enabled input" readonly />
+          </div>
+          <p class="bg-note">Dark bg: #141e33 (--ease-color-surface) at opacity: 1</p>
+        </div>
+        <div>
+          <div class="field-row">
+            <span class="field-tag disabled-tag">Disabled</span>
+            <input class="input-broken-disabled" type="text" value="Disabled input" disabled readonly />
+          </div>
+          <p class="bg-note">Dark bg: #1e293b (--ease-color-neutral-800) at opacity: 0.8 — lighter than enabled ❌</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- FIXED -->
+    <div class="section">
+      <div class="section-title">
+        <span class="tag tag-fixed">Fixed</span>
+        Disabled input darker than enabled — correct visual hierarchy
+      </div>
+
+      <div class="field-group">
+        <div>
+          <div class="field-row">
+            <span class="field-tag enabled-tag">Enabled</span>
+            <input class="input-fixed-enabled" type="text" value="Enabled input" readonly />
+          </div>
+          <p class="bg-note">Dark bg: #141e33 (--ease-color-surface) at opacity: 1</p>
+        </div>
+        <div>
+          <div class="field-row">
+            <span class="field-tag disabled-tag">Disabled</span>
+            <input class="input-fixed-disabled" type="text" value="Disabled input" disabled readonly />
+          </div>
+          <p class="bg-note">Dark bg: #0f172a (--ease-color-neutral-900) at opacity: 1 — darker than enabled ✅</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Live framework fields with fix applied -->
+    <div class="section">
+      <div class="section-title">
+        Live — real <code>.ease-input</code> classes with fix applied
+      </div>
+      <div class="field-group">
+        <div class="ease-field">
+          <label class="ease-field-label">Enabled input</label>
+          <input class="ease-input" type="text" placeholder="Type here..." />
+        </div>
+        <div class="ease-field">
+          <label class="ease-field-label">Disabled input</label>
+          <input class="ease-input" type="text" value="Cannot edit this" disabled />
+        </div>
+        <div class="ease-field">
+          <label class="ease-field-label">Disabled select</label>
+          <select class="ease-select" disabled>
+            <option>Cannot select</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/forms-disabled-dark-mode-10687/style.css
+++ b/submissions/examples/forms-disabled-dark-mode-10687/style.css
@@ -1,0 +1,29 @@
+/* ============================================================
+   Fix for issue #10687
+   .ease-input:disabled dark mode background is lighter than
+   the enabled input background, inverting the visual hierarchy.
+
+   Current dark mode:
+     Enabled bg:  --ease-color-surface  = #141e33
+     Disabled bg: --ease-color-neutral-800 = #1e293b  ← lighter
+
+   #1e293b is lighter than #141e33 — disabled looks more
+   prominent than enabled. The opacity: 0.8 inherited from the
+   base disabled rule makes the disabled field even lighter by
+   blending with the dark page background.
+
+   Fix:
+   - Use --ease-color-neutral-900 (#0f172a) — darker than surface
+   - Reset opacity to 1 — opacity: 0.8 fades a light bg in light
+     mode but has no useful role on a dark surface
+   ============================================================ */
+
+@media (prefers-color-scheme: dark) {
+  .ease-input:disabled,
+  .ease-textarea:disabled,
+  .ease-select:disabled {
+    background-color: var(--ease-color-neutral-900, #0f172a);
+    border-color: var(--ease-color-neutral-700, #334155);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Fixes #10687

## What

The dark mode disabled input uses `--ease-color-neutral-800` (`#1e293b`)
which is lighter than the enabled surface (`#141e33`). Combined with
the inherited `opacity: 0.8`, disabled inputs appear brighter than
enabled ones in dark mode — the visual hierarchy is inverted.

The fix uses `--ease-color-neutral-900` (`#0f172a`) which is darker than
the enabled surface, and resets `opacity: 1` so the dark background is
not made lighter by blending with the dark page background.

## Submission

`submissions/examples/forms-disabled-dark-mode-10687/`

The demo shows a side-by-side comparison. Enable dark mode in Chrome
DevTools → Rendering → prefers-color-scheme: dark to see the broken
(lighter disabled) vs fixed (darker disabled) appearance.

## Checklist

- [x] Files added only inside `submissions/examples/forms-disabled-dark-mode-10687/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/`, `components/`, or any other framework file
- [x] Single focused fix, one commit
