### PR TITLE
feat: add ease-gap-12 and ease-gap-16 utility classes

### DIFF
--- a/core/utilities.css
+++ b/core/utilities.css
@@ -132,6 +132,8 @@
 .ease-gap-6  { gap: var(--ease-space-6, 1.5rem) !important; }
 .ease-gap-8  { gap: var(--ease-space-8, 2rem) !important; }
 .ease-gap-10 { gap: var(--ease-space-10) !important; }
+.ease-gap-12 { gap: var(--ease-space-12) !important; }
+.ease-gap-16 { gap: var(--ease-space-16) !important; }
 
 /* ────────────────────────────────────────────────────────────
    PADDING


### PR DESCRIPTION
## Summary

Added missing `ease-gap-12` and `ease-gap-16` utility classes to complete the gap scale.

## Changes
- `core/utilities.css`: Added 2 lines after `.ease-gap-10`

Closes #10697

participant: gssoc26