### PR TITLE
fix: add dark mode border override for .ease-card-outlined and base .ease-card (issue #10672)

### DIFF
--- a/submissions/examples/card-outlined-border-dark-mode-10672/README.md
+++ b/submissions/examples/card-outlined-border-dark-mode-10672/README.md
@@ -1,0 +1,62 @@
+# Card Outlined Border Dark Mode Fix — Issue #10672
+
+**Fixes:** #10672
+
+## What does this do?
+
+Adds dark mode border overrides for `.ease-card-outlined` and the base
+`.ease-card` so they use a dark-appropriate border color in dark mode
+instead of staying near-white.
+
+## The problem
+
+`components/cards.css`:
+
+```css
+/* Base card — line 11 */
+.ease-card {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0); /* no dark override */
+}
+
+/* Outlined card — line 127 */
+.ease-card-outlined {
+  background-color: transparent;
+  border: 2px solid var(--ease-color-neutral-200, #e2e8f0); /* no dark override */
+}
+```
+
+`--ease-color-neutral-200` is `#e2e8f0` with no dark mode override in
+`variables.css`. In dark mode the page background is `#0b1121` but the
+border stays `#e2e8f0` — a bright near-white line. For the outlined card
+this is the most damaging: the entire component's visual identity depends
+on its border, and that border becomes an overly harsh frame.
+
+## The fix
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-card {
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+  .ease-card-outlined {
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+}
+```
+
+`--ease-color-neutral-700` (`#334155`) is the same dark border used by
+forms, modals, tabs, and sidebar in dark mode.
+
+## Why both classes are included
+
+The base `.ease-card` fix covers all cards inheriting its border. The
+`.ease-card-outlined` fix is restated explicitly because it uses the
+`border` shorthand (which sets width and style alongside color), meaning
+the base-class border-color override might not take precedence without
+an explicit restatement.
+
+## Demo
+
+Enable dark mode in Chrome DevTools → Rendering → prefers-color-scheme:
+dark. The demo shows broken vs fixed for both the outlined variant and
+the base card.

--- a/submissions/examples/card-outlined-border-dark-mode-10672/demo.html
+++ b/submissions/examples/card-outlined-border-dark-mode-10672/demo.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Outlined Border Dark Mode Fix — Issue #10672</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+      padding: 2rem 1.5rem;
+    }
+
+    .page { max-width: 820px; margin: 0 auto; }
+
+    h1 { font-size: var(--ease-text-2xl, 1.5rem); font-weight: 700; margin-bottom: 0.4rem; }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .section-title {
+      font-size: var(--ease-text-base, 1rem);
+      font-weight: 700;
+      margin-bottom: 1rem;
+    }
+
+    .card-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    @media (max-width: 600px) { .card-row { grid-template-columns: 1fr; } }
+
+    .card-label {
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .tag {
+      font-size: 0.68rem; font-weight: 700;
+      padding: 0.1rem 0.45rem; border-radius: 999px;
+      text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    /* ── BROKEN outlined: hardcoded light border ─────────────── */
+    .card-broken-outlined {
+      background-color: transparent;
+      border: 2px solid #e2e8f0; /* always light — no dark override */
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.25rem;
+    }
+
+    /* ── FIXED outlined: dark border in dark mode ────────────── */
+    .card-fixed-outlined {
+      background-color: transparent;
+      border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.25rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .card-fixed-outlined {
+        border-color: var(--ease-color-neutral-700, #334155);
+      }
+    }
+
+    .card-inner-title {
+      font-weight: 700;
+      font-size: var(--ease-text-base, 1rem);
+      margin-bottom: 0.5rem;
+    }
+
+    .card-inner-body {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      line-height: 1.6;
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+
+    <h1>Card Outlined Border Dark Mode Fix</h1>
+    <p class="sub">
+      Issue #10672 — <code>.ease-card-outlined</code> border uses
+      <code>--ease-color-neutral-200</code> with no dark mode override
+    </p>
+
+    <div class="hint">
+      Enable dark mode: Chrome DevTools → More Tools → Rendering →
+      set <strong>Emulate CSS media feature prefers-color-scheme</strong>
+      to <code>dark</code>. The broken card shows a bright near-white
+      <code>2px</code> border. The fixed card uses a dark-appropriate border.
+    </div>
+
+    <!-- Outlined card comparison -->
+    <div class="section-title">Outlined card (<code>.ease-card-outlined</code>)</div>
+    <div class="card-row">
+
+      <div>
+        <div class="card-label">
+          <span class="tag tag-broken">Broken</span>
+          Near-white border — harsh contrast in dark mode
+        </div>
+        <div class="card-broken-outlined">
+          <div class="card-inner-title">Outlined Card</div>
+          <div class="card-inner-body">
+            Border: <code>#e2e8f0</code> — no dark override.
+            In dark mode this is a bright white frame on a near-black page.
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="card-label">
+          <span class="tag tag-fixed">Fixed</span>
+          Dark border <code>#334155</code> in dark mode
+        </div>
+        <div class="card-fixed-outlined">
+          <div class="card-inner-title">Outlined Card</div>
+          <div class="card-inner-body">
+            Border switches to <code>--ease-color-neutral-700</code>
+            (<code>#334155</code>) in dark mode — subtle, appropriate contrast.
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Base card comparison -->
+    <div class="section-title">Base card (<code>.ease-card</code>) border</div>
+    <div class="card-row">
+
+      <div>
+        <div class="card-label">
+          <span class="tag tag-broken">Broken</span>
+          Base 1px border also near-white in dark mode
+        </div>
+        <div class="ease-card" style="border-color:#e2e8f0 !important;">
+          <div class="ease-card-title" style="font-size:var(--ease-text-base,1rem);">Base Card</div>
+          <div class="ease-card-body">
+            <p>The base <code>.ease-card</code> uses the same
+            <code>--ease-color-neutral-200</code> border — bright in dark mode.</p>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="card-label">
+          <span class="tag tag-fixed">Fixed</span>
+          Base border corrected by the same dark mode block
+        </div>
+        <div class="ease-card">
+          <div class="ease-card-title" style="font-size:var(--ease-text-base,1rem);">Base Card</div>
+          <div class="ease-card-body">
+            <p>With <code>style.css</code> fix applied, the base card border
+            also switches to <code>--ease-color-neutral-700</code> in dark mode.</p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/card-outlined-border-dark-mode-10672/style.css
+++ b/submissions/examples/card-outlined-border-dark-mode-10672/style.css
@@ -1,0 +1,28 @@
+/* ============================================================
+   Fix for issue #10672
+   .ease-card-outlined uses --ease-color-neutral-200 (#e2e8f0)
+   for its border with no dark mode override. In dark mode the
+   page background is #0b1121 but the border stays #e2e8f0 —
+   near-white on near-black — extremely high contrast for a
+   component designed to have minimal visual presence.
+
+   The base .ease-card also uses --ease-color-neutral-200 for
+   its 1px border, which is also bright in dark mode.
+
+   Fix: add a dark mode block overriding both with
+   --ease-color-neutral-700 (#334155) — the same dark border
+   used by forms, modals, and tabs in dark mode.
+   ============================================================ */
+
+@media (prefers-color-scheme: dark) {
+  /* Base card border — affects all cards that inherit it */
+  .ease-card {
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  /* Outlined card — restated explicitly because it uses border shorthand
+     which redeclares border-width and border-style alongside border-color */
+  .ease-card-outlined {
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+}


### PR DESCRIPTION
Closes #10672

## What

`.ease-card-outlined` uses `--ease-color-neutral-200` (`#e2e8f0`) for its
`2px` border with no dark mode override. In dark mode the page background
is `#0b1121` but the border stays `#e2e8f0` — near-white on near-black,
extremely high contrast for a card designed to have minimal visual presence.

The base `.ease-card` also uses the same token for its `1px` border, so
all default card borders are also near-white in dark mode.

## Submission

`submissions/examples/card-outlined-border-dark-mode-10672/`

The demo shows broken vs fixed for both the outlined variant and the base
card. Enable dark mode in Chrome DevTools → Rendering →
prefers-color-scheme: dark.

## Fix

```css
@media (prefers-color-scheme: dark) {
  .ease-card {
    border-color: var(--ease-color-neutral-700, #334155);
  }
  .ease-card-outlined {
    border-color: var(--ease-color-neutral-700, #334155);
  }
}
