### PR TITLE
feat: add overflow-clip-margin utility classes

### DIFF
--- a/submissions/examples/overflow-clip-margin-utility/README.md
+++ b/submissions/examples/overflow-clip-margin-utility/README.md
@@ -1,0 +1,16 @@
+## Overflow-Clip-Margin Utility
+
+**What does this do?**  
+Provides utility classes for the `overflow-clip-margin` CSS property, which controls how far an element's content can extend beyond its bounds when `overflow: clip` is active before being clipped.
+
+**How is it used?**  
+Combine with the `overflow-clip` class (or any `overflow: clip` container):
+
+```html
+<div class="overflow-clip overflow-clip-margin-10">
+  <!-- content can overflow 10px before being clipped -->
+</div>
+```
+
+**Why is it useful?**  
+When using `overflow: clip` to create a clipping container, decorative elements like shadows, glow effects, or absolutely-positioned children often need a small overflow allowance. `overflow-clip-margin` provides exactly that — a controlled overflow budget — without switching to `overflow: hidden` (which also clips shadows and transforms).

--- a/submissions/examples/overflow-clip-margin-utility/demo.html
+++ b/submissions/examples/overflow-clip-margin-utility/demo.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Overflow-Clip-Margin Utility Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 800px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        background: #f8f9fa;
+        color: #1a1a2e;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+      p {
+        margin-bottom: 1.5rem;
+        color: #555;
+      }
+      .demo-group {
+        margin-bottom: 2.5rem;
+      }
+      .demo-group h2 {
+        font-size: 1rem;
+        margin-bottom: 0.75rem;
+        color: #333;
+      }
+      .row {
+        display: flex;
+        gap: 1.5rem;
+        flex-wrap: wrap;
+      }
+      .clip-box {
+        width: 140px;
+        height: 100px;
+        background: #fff;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+        position: relative;
+      }
+      .clip-box .label {
+        font-size: 0.7rem;
+        color: #666;
+        text-align: center;
+        padding-top: 4px;
+      }
+      .clip-box .overflow-content {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 160px;
+        height: 60px;
+        transform: translate(-50%, -50%);
+        background: linear-gradient(135deg, #6366f1, #a855f7);
+        border-radius: 4px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #fff;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-align: center;
+        box-shadow: 0 4px 20px rgba(99, 102, 241, 0.4);
+      }
+      .clip-box .overflow-content.shadow-heavy {
+        box-shadow: 0 8px 40px rgba(99, 102, 241, 0.6);
+      }
+      .badge {
+        display: inline-block;
+        background: #e9ecef;
+        padding: 0.15rem 0.4rem;
+        border-radius: 3px;
+        font-size: 0.65rem;
+        font-weight: 600;
+        font-family: monospace;
+        margin-bottom: 0.5rem;
+      }
+      .comparison-row {
+        display: flex;
+        gap: 2rem;
+        flex-wrap: wrap;
+        align-items: flex-start;
+      }
+      .comparison-item {
+        flex: 1;
+        min-width: 200px;
+      }
+      .clip-visual {
+        position: relative;
+        margin-top: 0.5rem;
+      }
+      .clip-visual .overflow-indicator {
+        position: absolute;
+        border: 2px dashed #ef4444;
+        pointer-events: none;
+      }
+      .note {
+        background: #fffbea;
+        border: 1px solid #fde68a;
+        border-radius: 6px;
+        padding: 0.75rem 1rem;
+        font-size: 0.85rem;
+        color: #92400e;
+        margin-top: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Overflow-Clip-Margin Utility</h1>
+    <p>
+      Controls how far overflowing content extends beyond a
+      <code>overflow: clip</code>
+      container before being clipped. Essential for shadows, glows, and
+      decorative overflows.
+    </p>
+
+    <div class="demo-group">
+      <h2>Without overflow-clip-margin vs. with margin allowance</h2>
+      <div class="comparison-row">
+        <div class="comparison-item">
+          <div class="badge">overflow-clip margin-0</div>
+          <div class="clip-box overflow-clip overflow-clip-margin-0">
+            <div class="label">shadow clipped</div>
+            <div class="overflow-content">Shadow<br />Clipped</div>
+          </div>
+        </div>
+        <div class="comparison-item">
+          <div class="badge">overflow-clip-margin-5</div>
+          <div class="clip-box overflow-clip overflow-clip-margin-5">
+            <div class="label">5px margin</div>
+            <div class="overflow-content">Shadow<br />Visible</div>
+          </div>
+        </div>
+        <div class="comparison-item">
+          <div class="badge">overflow-clip-margin-10</div>
+          <div class="clip-box overflow-clip overflow-clip-margin-10">
+            <div class="label">10px margin</div>
+            <div class="overflow-content shadow-heavy">
+              Shadow<br />Fully Visible
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-group">
+      <h2>Progressive margin values</h2>
+      <div class="row">
+        <div>
+          <div class="badge">margin-0</div>
+          <div class="clip-box overflow-clip overflow-clip-margin-0">
+            <div
+              class="overflow-content"
+              style="background: linear-gradient(135deg, #22c55e, #16a34a)"
+            >
+              0px
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="badge">margin-3</div>
+          <div class="clip-box overflow-clip overflow-clip-margin-3">
+            <div
+              class="overflow-content"
+              style="background: linear-gradient(135deg, #22c55e, #16a34a)"
+            >
+              3px
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="badge">margin-8</div>
+          <div class="clip-box overflow-clip overflow-clip-margin-8">
+            <div
+              class="overflow-content"
+              style="background: linear-gradient(135deg, #22c55e, #16a34a)"
+            >
+              8px
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="badge">margin-15</div>
+          <div class="clip-box overflow-clip overflow-clip-margin-15">
+            <div
+              class="overflow-content"
+              style="background: linear-gradient(135deg, #22c55e, #16a34a)"
+            >
+              15px
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="badge">margin-20</div>
+          <div class="clip-box overflow-clip overflow-clip-margin-20">
+            <div
+              class="overflow-content"
+              style="background: linear-gradient(135deg, #22c55e, #16a34a)"
+            >
+              20px
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <strong>Key difference from <code>overflow: hidden</code>:</strong> With
+      <code>overflow: clip</code>, no scrollbar appears and programmatic
+      scrolling is disabled — but you can still let specific visual overflows
+      show using <code>overflow-clip-margin</code>.
+    </div>
+  </body>
+</html>

--- a/submissions/examples/overflow-clip-margin-utility/style.css
+++ b/submissions/examples/overflow-clip-margin-utility/style.css
@@ -1,0 +1,25 @@
+.overflow-clip-margin-0 {
+  overflow-clip-margin: 0px;
+}
+.overflow-clip-margin-3 {
+  overflow-clip-margin: 3px;
+}
+.overflow-clip-margin-5 {
+  overflow-clip-margin: 5px;
+}
+.overflow-clip-margin-8 {
+  overflow-clip-margin: 8px;
+}
+.overflow-clip-margin-10 {
+  overflow-clip-margin: 10px;
+}
+.overflow-clip-margin-15 {
+  overflow-clip-margin: 15px;
+}
+.overflow-clip-margin-20 {
+  overflow-clip-margin: 20px;
+}
+
+.overflow-clip {
+  overflow: clip;
+}


### PR DESCRIPTION
Adds overflow-clip-margin utility classes for controlled overflow allowance with `overflow: clip`.

Closes #10731

participant: gssoc26