### PR TITLE
feat: add paint-order utility classes

### DIFF
--- a/submissions/examples/paint-order-utility/README.md
+++ b/submissions/examples/paint-order-utility/README.md
@@ -1,0 +1,15 @@
+## Paint-Order Utility
+
+**What does this do?**  
+Provides utility classes for the CSS `paint-order` property, which controls the order in which fill, stroke, and markers are painted for SVG elements and text. By default, fill is drawn first, then stroke. Reversing this creates outlined text effects.
+
+**How is it used?**  
+Add a class to any text or SVG element to control paint ordering:
+
+```html
+<h1 class="paint-order-stroke">Outlined Text Effect</h1>
+<svg><text class="paint-order-stroke">SVG Text</text></svg>
+```
+
+**Why is it useful?**  
+Creating outlined (stroke-first) text typically requires SVG or complex workarounds. The `paint-order` property makes it trivial with a single CSS declaration — ideal for headings, logos, badges, and decorative typography.

--- a/submissions/examples/paint-order-utility/demo.html
+++ b/submissions/examples/paint-order-utility/demo.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Paint-Order Utility Demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 700px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        background: #f8f9fa;
+        color: #1a1a2e;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+      p {
+        margin-bottom: 1.5rem;
+        color: #555;
+      }
+      .demo-group {
+        margin-bottom: 2rem;
+      }
+      .demo-group h2 {
+        font-size: 1rem;
+        margin-bottom: 0.75rem;
+        color: #333;
+      }
+      .demo-row {
+        display: flex;
+        gap: 1.5rem;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .demo-card {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: 1rem 1.5rem;
+        text-align: center;
+        flex: 1;
+        min-width: 160px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+      }
+      .demo-card .badge {
+        display: block;
+        font-size: 0.7rem;
+        font-family: monospace;
+        color: #64748b;
+        margin-bottom: 0.5rem;
+      }
+      .demo-card .sample-text {
+        font-size: 1.8rem;
+        font-weight: 800;
+        -webkit-text-stroke: 1.5px #6366f1;
+        text-stroke: 1.5px #6366f1;
+        color: #fff;
+        letter-spacing: -0.02em;
+      }
+      .demo-card .sample-text.fill-only {
+        -webkit-text-stroke: 0;
+        text-stroke: 0;
+        color: #6366f1;
+      }
+      .info-box {
+        background: #f0f9ff;
+        border: 1px solid #bae6fd;
+        border-radius: 6px;
+        padding: 0.75rem 1rem;
+        font-size: 0.85rem;
+        color: #0369a1;
+        margin: 1.5rem 0;
+      }
+      .svg-demo {
+        background: #1e1e2e;
+        border-radius: 8px;
+        padding: 1rem;
+        text-align: center;
+      }
+      .svg-demo svg {
+        max-width: 100%;
+        height: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Paint-Order Utility</h1>
+    <p>
+      Controls whether fill or stroke is painted first on text and SVG elements.
+      Use <code>paint-order-stroke</code> to create outlined text where the
+      stroke appears behind the fill.
+    </p>
+
+    <div class="demo-group">
+      <h2>Text with stroke: paint order comparison</h2>
+      <div class="demo-row">
+        <div class="demo-card">
+          <div class="badge">paint-order-normal</div>
+          <div class="sample-text paint-order-normal">Hello</div>
+          <div style="font-size: 0.75rem; color: #999; margin-top: 0.5rem">
+            Stroke drawn <em>on top</em> of fill
+          </div>
+        </div>
+        <div class="demo-card">
+          <div class="badge">paint-order-stroke</div>
+          <div class="sample-text paint-order-stroke">Hello</div>
+          <div style="font-size: 0.75rem; color: #999; margin-top: 0.5rem">
+            Stroke drawn <em>behind</em> fill
+          </div>
+        </div>
+        <div class="demo-card">
+          <div class="badge">paint-order-stroke-fill</div>
+          <div class="sample-text paint-order-stroke-fill">Hello</div>
+          <div style="font-size: 0.75rem; color: #999; margin-top: 0.5rem">
+            Explicit: stroke then fill
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-group">
+      <h2>With thicker stroke (3px)</h2>
+      <div class="demo-row" style="gap: 1rem">
+        <div class="demo-card" style="flex: 1">
+          <div class="badge">paint-order-normal</div>
+          <div
+            class="sample-text paint-order-normal"
+            style="
+              -webkit-text-stroke: 3px #ef4444;
+              text-stroke: 3px #ef4444;
+              font-size: 2rem;
+            "
+          >
+            Oops
+          </div>
+          <div style="font-size: 0.75rem; color: #999; margin-top: 0.5rem">
+            Stroke bleeds into fill area
+          </div>
+        </div>
+        <div class="demo-card" style="flex: 1">
+          <div class="badge">paint-order-stroke</div>
+          <div
+            class="sample-text paint-order-stroke"
+            style="
+              -webkit-text-stroke: 3px #ef4444;
+              text-stroke: 3px #ef4444;
+              font-size: 2rem;
+            "
+          >
+            Nice
+          </div>
+          <div style="font-size: 0.75rem; color: #999; margin-top: 0.5rem">
+            Crisp fill with outline behind
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-group">
+      <h2>Without stroke (fill only)</h2>
+      <div class="demo-row">
+        <div class="demo-card">
+          <div class="badge">paint-order-fill</div>
+          <div class="sample-text fill-only paint-order-fill">Fill</div>
+        </div>
+        <div class="demo-card">
+          <div class="badge">paint-order-normal (no stroke)</div>
+          <div class="sample-text fill-only paint-order-normal">Fill</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-group">
+      <h2>SVG elements</h2>
+      <div class="svg-demo">
+        <svg width="300" height="100" viewBox="0 0 300 100">
+          <text
+            x="20"
+            y="40"
+            font-size="24"
+            font-weight="bold"
+            fill="#22c55e"
+            stroke="#166534"
+            stroke-width="2"
+            class="paint-order-normal"
+          >
+            normal
+          </text>
+          <text
+            x="20"
+            y="80"
+            font-size="24"
+            font-weight="bold"
+            fill="#22c55e"
+            stroke="#166534"
+            stroke-width="2"
+            class="paint-order-stroke"
+          >
+            paint-order: stroke
+          </text>
+        </svg>
+      </div>
+    </div>
+
+    <div class="info-box">
+      <strong>Tip:</strong> <code>paint-order: stroke</code> is especially
+      useful for logo marks, hero headings, and badge text where you want a
+      clean outline behind filled text without the stroke bleeding inward.
+    </div>
+  </body>
+</html>

--- a/submissions/examples/paint-order-utility/style.css
+++ b/submissions/examples/paint-order-utility/style.css
@@ -1,0 +1,18 @@
+.paint-order-normal {
+  paint-order: normal;
+}
+.paint-order-fill {
+  paint-order: fill;
+}
+.paint-order-stroke {
+  paint-order: stroke;
+}
+.paint-order-markers {
+  paint-order: markers;
+}
+.paint-order-stroke-fill {
+  paint-order: stroke fill;
+}
+.paint-order-markers-stroke-fill {
+  paint-order: markers stroke fill;
+}


### PR DESCRIPTION
Adds paint-order utility classes for controlling fill/stroke paint ordering on text and SVG elements.

Closes #10739

participant: gssoc26