### PR TITLE
fix: use --ease-color-surface for .ease-card-flat background in dark mode (issue #10666)

### DIFF
--- a/submissions/examples/card-flat-dark-mode-10666/README.md
+++ b/submissions/examples/card-flat-dark-mode-10666/README.md
@@ -1,0 +1,53 @@
+# Card Flat Dark Mode Fix — Issue #10666
+
+**Fixes:** #10666
+
+## What does this do?
+
+Adds a dark mode override for `.ease-card-flat` so it uses
+`--ease-color-surface` instead of staying near-white in dark mode.
+
+## The problem
+
+`components/cards.css` line 122:
+
+```css
+.ease-card-flat {
+  border-color: transparent;
+  background-color: var(--ease-color-neutral-100, #f1f5f9); /* no dark override */
+}
+```
+
+`--ease-color-neutral-100` is `#f1f5f9` with no dark mode override. In
+dark mode the page background is `#0b1121` but the flat card stays
+`#f1f5f9` — near-white on near-black. The component designed to have
+the most subtle presence becomes the most visually prominent element.
+
+## The fix
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-card-flat {
+    background-color: var(--ease-color-surface, #141e33);
+  }
+}
+```
+
+`--ease-color-surface` (`#141e33`) is slightly lighter than the page
+background (`#0b1121`), recreating the same "subtle elevation above the
+background" relationship that `--ease-color-neutral-100` provides in
+light mode over `--ease-color-bg` (`#f8fafc`).
+
+## Before vs after in dark mode
+
+| Mode | Page bg | Flat card bg | Relationship |
+|---|---|---|---|
+| Light | `#f8fafc` | `#f1f5f9` | Subtly darker — correct ✅ |
+| Dark (broken) | `#0b1121` | `#f1f5f9` | Blazingly lighter — wrong ❌ |
+| Dark (fixed) | `#0b1121` | `#141e33` | Subtly lighter — correct ✅ |
+
+## Demo
+
+Enable dark mode in Chrome DevTools → Rendering →
+prefers-color-scheme: dark. The broken card glows white. The fixed card
+shows as a subtle dark surface matching the design intent.

--- a/submissions/examples/card-flat-dark-mode-10666/demo.html
+++ b/submissions/examples/card-flat-dark-mode-10666/demo.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Flat Dark Mode Fix — Issue #10666</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      background: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      min-height: 100vh;
+      padding: 2rem 1.5rem;
+    }
+
+    .page { max-width: 820px; margin: 0 auto; }
+
+    h1 { font-size: var(--ease-text-2xl, 1.5rem); font-weight: 700; margin-bottom: 0.4rem; }
+
+    .sub {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      margin-bottom: 2rem;
+    }
+
+    .hint {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      border-left: 4px solid var(--ease-color-primary, #6c63ff);
+      border-radius: 0 var(--ease-radius-md, 0.5rem) var(--ease-radius-md, 0.5rem) 0;
+      padding: 0.9rem 1.1rem;
+      font-size: var(--ease-text-sm, 0.875rem);
+      line-height: 1.65;
+      margin-bottom: 2rem;
+    }
+
+    .card-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    @media (max-width: 600px) { .card-row { grid-template-columns: 1fr; } }
+
+    .card-label {
+      font-size: var(--ease-text-sm, 0.875rem);
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .tag {
+      font-size: 0.68rem; font-weight: 700;
+      padding: 0.1rem 0.45rem; border-radius: 999px;
+      text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .tag-broken { background: var(--ease-color-danger, #ef4444); color: #fff; }
+    .tag-fixed  { background: var(--ease-color-success, #22c55e); color: #fff; }
+
+    /* ── BROKEN flat card: hardcoded light bg ────────────────── */
+    .card-broken-flat {
+      border-color: transparent;
+      background-color: #f1f5f9; /* always near-white */
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.25rem;
+    }
+
+    /* ── FIXED flat card: dark surface in dark mode ──────────── */
+    .card-fixed-flat {
+      border-color: transparent;
+      background-color: var(--ease-color-neutral-100, #f1f5f9);
+      border-radius: var(--ease-radius-lg, 1rem);
+      padding: 1.25rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .card-fixed-flat {
+        background-color: var(--ease-color-surface, #141e33);
+      }
+    }
+
+    .card-inner-title {
+      font-weight: 700;
+      font-size: var(--ease-text-base, 1rem);
+      margin-bottom: 0.5rem;
+    }
+
+    .card-inner-body {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #64748b);
+      line-height: 1.6;
+    }
+
+    .bg-note {
+      font-size: 0.72rem;
+      font-family: var(--ease-font-mono, monospace);
+      margin-top: 0.4rem;
+      color: var(--ease-color-muted, #64748b);
+    }
+
+    code {
+      background: var(--ease-color-neutral-100, #f1f5f9);
+      color: var(--ease-color-primary-dark, #4b44cc);
+      padding: 0.1em 0.35em;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1121; }
+      .hint { background: rgba(108,99,255,0.1); }
+      code { background: #1e293b; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+
+    <h1>Card Flat Dark Mode Fix</h1>
+    <p class="sub">
+      Issue #10666 — <code>.ease-card-flat</code> background uses
+      <code>--ease-color-neutral-100</code> with no dark mode override
+    </p>
+
+    <div class="hint">
+      Enable dark mode: Chrome DevTools → More Tools → Rendering →
+      set <strong>Emulate CSS media feature prefers-color-scheme</strong>
+      to <code>dark</code>. The broken flat card appears as a bright
+      near-white block. The fixed one uses a dark surface that recreates
+      the intended subtle elevation.
+    </div>
+
+    <div class="card-row">
+
+      <!-- BROKEN -->
+      <div>
+        <div class="card-label">
+          <span class="tag tag-broken">Broken</span>
+          Near-white <code>#f1f5f9</code> in dark mode
+        </div>
+        <div class="card-broken-flat">
+          <div class="card-inner-title">Flat Card</div>
+          <div class="card-inner-body">
+            Background: <code>#f1f5f9</code> — no dark override.
+            In dark mode this glows as the brightest element on the page.
+          </div>
+        </div>
+        <p class="bg-note">bg: #f1f5f9 — always, never changes in dark mode ❌</p>
+      </div>
+
+      <!-- FIXED -->
+      <div>
+        <div class="card-label">
+          <span class="tag tag-fixed">Fixed</span>
+          Dark surface <code>#141e33</code> in dark mode
+        </div>
+        <div class="card-fixed-flat">
+          <div class="card-inner-title">Flat Card</div>
+          <div class="card-inner-body">
+            Background switches to <code>--ease-color-surface</code>
+            (<code>#141e33</code>) in dark mode — subtly lighter than the page
+            background (<code>#0b1121</code>), recreating the flat card intent.
+          </div>
+        </div>
+        <p class="bg-note">dark bg: #141e33 (--ease-color-surface) — subtle elevation ✅</p>
+      </div>
+
+    </div>
+
+    <!-- Live framework card with fix applied -->
+    <p style="font-size:var(--ease-text-sm,0.875rem);font-weight:700;margin-bottom:0.75rem;">
+      Live — real <code>.ease-card.ease-card-flat</code> with fix applied
+    </p>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
+      <div class="ease-card ease-card-flat">
+        <div class="ease-card-title" style="font-size:var(--ease-text-base,1rem);">Flat Card</div>
+        <div class="ease-card-body">
+          <p>In dark mode, uses <code>--ease-color-surface</code> via
+          the fix in <code>style.css</code>.</p>
+        </div>
+      </div>
+      <div class="ease-card">
+        <div class="ease-card-title" style="font-size:var(--ease-text-base,1rem);">Regular Card</div>
+        <div class="ease-card-body">
+          <p>Regular card for comparison — uses <code>--ease-color-surface</code>
+          directly, already correct.</p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/card-flat-dark-mode-10666/style.css
+++ b/submissions/examples/card-flat-dark-mode-10666/style.css
@@ -1,0 +1,20 @@
+/* ============================================================
+   Fix for issue #10666
+   .ease-card-flat uses --ease-color-neutral-100 (#f1f5f9) for
+   its background with no dark mode override. In dark mode the
+   page background is #0b1121 but the flat card stays #f1f5f9
+   — near-white on near-black. The component designed to have
+   the most subtle presence becomes the most visually prominent.
+
+   The correct dark mode equivalent is --ease-color-surface
+   (#141e33) — slightly lighter than the page bg (#0b1121),
+   recreating the same "subtle elevation above the background"
+   relationship that --ease-color-neutral-100 provides in light
+   mode over --ease-color-bg (#f8fafc).
+   ============================================================ */
+
+@media (prefers-color-scheme: dark) {
+  .ease-card-flat {
+    background-color: var(--ease-color-surface, #141e33);
+  }
+}


### PR DESCRIPTION
Closes #10666

## What

`.ease-card-flat` uses `--ease-color-neutral-100` (`#f1f5f9`) with no
dark mode override. In dark mode the page background is `#0b1121` but
the flat card stays `#f1f5f9` — the component designed to have the most
subtle visual presence becomes the brightest element on the page.

`--ease-color-surface` (`#141e33`) is slightly lighter than
`--ease-color-bg` (`#0b1121`), recreating the same "subtle elevation
above the background" relationship that `--ease-color-neutral-100`
provides in light mode.

## Submission

`submissions/examples/card-flat-dark-mode-10666/`

The demo shows broken vs fixed flat cards side by side. Enable dark mode
in Chrome DevTools → Rendering → prefers-color-scheme: dark to see the
broken card glow white vs the fixed card show as a subtle dark surface.

## Fix

```css
@media (prefers-color-scheme: dark) {
  .ease-card-flat {
    background-color: var(--ease-color-surface, #141e33);
  }
}
