### PR TITLE
feat: add cursor-grabbing utility class

### DIFF
--- a/submissions/examples/ease-cursor-grabbing/README.md
+++ b/submissions/examples/ease-cursor-grabbing/README.md
@@ -1,0 +1,17 @@
+# ease-cursor-grabbing
+
+CSS utility classes for the `cursor-grabbing` property.
+
+## Usage
+
+```html
+<div class="ease-cursor-grabbing-example">Content</div>
+```
+
+## Classes
+
+See `style.css` for the full list of available classes.
+
+## Demo
+
+Open `demo.html` to see the utility classes in action.

--- a/submissions/examples/ease-cursor-grabbing/demo.html
+++ b/submissions/examples/ease-cursor-grabbing/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-cursor-grabbing Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; background: #f8f9fa; color: #1a1a2e; }
+    h1 { font-size: 1.5rem; color: #6366f1; }
+    p { margin-bottom: 1.5rem; color: #555; }
+    .demo-grid { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .demo-item { background: #fff; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1rem; text-align: center; min-width: 180px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
+    .demo-item code { display: block; font-size: 0.75rem; color: #64748b; margin-bottom: 0.5rem; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <h1>ease-cursor-grabbing</h1>
+  <p>CSS utility classes demo. See <code>style.css</code> for all classes.</p>
+  <div class="demo-grid">
+    <div class="demo-item"><code>.class-name</code><div>Example content</div></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-cursor-grabbing/style.css
+++ b/submissions/examples/ease-cursor-grabbing/style.css
@@ -1,0 +1,3 @@
+/* EaseMotion CSS - ease-cursor-grabbing utility classes */
+
+.ease-cursor-grabbing { cursor: grabbing !important; }


### PR DESCRIPTION
Adds a CSS utility class for `cursor: grabbing`.

Closes #10792

participant: gssoc26