### PR TITLE
fix: add dark mode border correction for .ease-footer and .ease-footer-bottom

### DIFF
--- a/submissions/examples/footer-border-dark-mode-10810/README.md
+++ b/submissions/examples/footer-border-dark-mode-10810/README.md
@@ -1,0 +1,88 @@
+# Footer Border Dark Mode Fix — Issue #10810
+
+Fixes: #10810
+
+## What does this do?
+
+Adds a `@media (prefers-color-scheme: dark)` override to `components/footer.css`
+so the `border-top` on `.ease-footer` and `.ease-footer-bottom` uses a dark-appropriate
+token instead of the near-white `--ease-color-neutral-200`.
+
+## The problem
+
+`components/footer.css` has two rules using `--ease-color-neutral-200` (`#e5e7eb`)
+for `border-top`:
+
+```css
+/* Line ~11 */
+.ease-footer {
+    background: var(--ease-color-neutral-900, #111);
+    border-top: 1px solid var(--ease-color-neutral-200, #e5e7eb); /* ← near-white */
+}
+
+/* Line ~144 */
+.ease-footer-bottom {
+    border-top: 1px solid var(--ease-color-neutral-200, #e5e7eb); /* ← near-white */
+}
+```
+
+The footer background is intentionally dark (`#111`) in **both** light and dark mode.
+`--ease-color-neutral-200` has no dark mode override in `core/variables.css`, so the
+border stays `#e5e7eb` regardless of color scheme.
+
+Contrast ratio of `#e5e7eb` on `#111`: **≈ 14:1** — the same contrast as black text
+on white. A 1px border at this contrast is the most visible horizontal line on the page,
+which defeats the intent of a subtle section separator.
+
+This is the same structural issue as `sidebar.css` (fixed in PR #10680): a dark-background
+component using a light-mode border token with no dark mode correction block.
+
+## The fix
+
+```css
+@media (prefers-color-scheme: dark) {
+    .ease-footer {
+        border-top-color: var(--ease-color-neutral-700, #334155);
+    }
+
+    .ease-footer-bottom {
+        border-top-color: var(--ease-color-neutral-700, #334155);
+    }
+}
+```
+
+`--ease-color-neutral-700` (`#334155`) against the `#111` footer background gives
+**≈ 3.5:1** contrast — subtle and appropriate for a section divider.
+
+## Before vs after
+
+| Rule | Before | After |
+|---|---|---|
+| `.ease-footer` border-top | `#e5e7eb` — 14:1 on dark footer ❌ | `#334155` — 3.5:1 on dark footer ✅ |
+| `.ease-footer-bottom` border-top | `#e5e7eb` — 14:1 on dark footer ❌ | `#334155` — 3.5:1 on dark footer ✅ |
+
+## Why `--ease-color-neutral-700`
+
+The same token is used for dark-mode borders in the sidebar fix (PR #10680),
+forms, modals, tabs, and cards — it is the established dark-surface border
+convention across the framework.
+
+## How to use
+
+```html
+<!-- No class changes needed — the fix is applied via @media in the component CSS -->
+<footer class="ease-footer">
+    <div class="ease-footer-grid"><!-- columns --></div>
+    <div class="ease-footer-bottom">
+        <span>© 2026 Company</span>
+    </div>
+</footer>
+```
+
+## How to test
+
+1. Open `demo.html` directly in a browser — no server required.
+2. The **Broken** footer shows a near-white `#e5e7eb` border against the dark background.
+3. The **Fixed** footer shows a subtle dark `#334155` border.
+4. To test the `@media` path: Chrome DevTools → More Tools → Rendering →
+   Emulate CSS media feature `prefers-color-scheme: dark`.

--- a/submissions/examples/footer-border-dark-mode-10810/demo.html
+++ b/submissions/examples/footer-border-dark-mode-10810/demo.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline';">
+    <title>Footer Border Dark Mode Fix — Issue #10810</title>
+    <style>
+        /* ── Simulate EaseMotion CSS tokens ──────────────────── */
+        :root {
+            --ease-color-neutral-900: #111;
+            --ease-color-neutral-800: #1f2937;
+            --ease-color-neutral-700: #334155;
+            --ease-color-neutral-500: #6b7280;
+            --ease-color-neutral-400: #9ca3af;
+            --ease-color-neutral-300: #d1d5db;
+            --ease-color-neutral-200: #e5e7eb;
+            --ease-color-neutral-100: #f3f4f6;
+            --ease-color-primary:     #6366f1;
+            --ease-speed-fast:        150ms;
+            --ease-ease:              cubic-bezier(0.4, 0, 0.2, 1);
+            --ease-ease-bounce:       cubic-bezier(0.34, 1.56, 0.64, 1);
+            --ease-footer-padding:    3rem 2rem 2rem;
+        }
+
+        /* ── Base reset ───────────────────────────────────────── */
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: system-ui, sans-serif;
+            background: #f8fafc;
+            color: #0f172a;
+        }
+
+        /* ── Demo page layout ─────────────────────────────────── */
+        .demo-wrapper {
+            max-width: 900px;
+            margin: 2rem auto;
+            padding: 0 1rem;
+        }
+
+        h1 {
+            font-size: 1.25rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .demo-label {
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            padding: 0.4rem 0.75rem;
+            border-radius: 4px;
+            margin-bottom: 0.5rem;
+            display: inline-block;
+        }
+
+        .label-broken  { background: #fee2e2; color: #991b1b; }
+        .label-fixed   { background: #dcfce7; color: #166534; }
+
+        .demo-section  { margin-bottom: 3rem; }
+
+        /* ── Contrast annotation bar ──────────────────────────── */
+        .contrast-bar {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            font-size: 0.78rem;
+            padding: 0.5rem 0.75rem;
+            border-radius: 4px;
+            margin-bottom: 0.75rem;
+            background: #f1f5f9;
+            border: 1px solid #e2e8f0;
+        }
+
+        .swatch {
+            width: 20px;
+            height: 20px;
+            border-radius: 3px;
+            border: 1px solid rgba(0,0,0,0.15);
+            flex-shrink: 0;
+        }
+
+        /* ── EaseMotion footer component (copied from components/footer.css) */
+        .ease-footer {
+            background: var(--ease-color-neutral-900, #111);
+            border-top: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+            padding: var(--ease-footer-padding, 3rem 2rem 2rem);
+            color: var(--ease-color-neutral-400, #9ca3af);
+            font-size: 0.875rem;
+        }
+
+        .ease-footer-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 2rem;
+            margin-bottom: 2.5rem;
+        }
+
+        .ease-footer-col-title {
+            font-weight: 600;
+            color: var(--ease-color-neutral-100, #f3f4f6);
+            margin-bottom: 1rem;
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .ease-footer-links {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .ease-footer-links a {
+            color: var(--ease-color-neutral-400, #9ca3af);
+            text-decoration: none;
+            transition: color var(--ease-speed-fast, 150ms) var(--ease-ease);
+        }
+
+        .ease-footer-links a:hover {
+            color: var(--ease-color-primary, #6366f1);
+        }
+
+        .ease-footer-bottom {
+            border-top: 1px solid var(--ease-color-neutral-200, #e5e7eb);
+            padding-top: 1.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1rem;
+            font-size: 0.8rem;
+            color: var(--ease-color-neutral-500, #6b7280);
+        }
+
+        /* ── Fixed variant overrides ──────────────────────────── */
+        .ease-footer--fixed {
+            border-top-color: var(--ease-color-neutral-700, #334155);
+        }
+
+        .ease-footer--fixed .ease-footer-bottom {
+            border-top-color: var(--ease-color-neutral-700, #334155);
+        }
+    </style>
+</head>
+<body>
+    <div class="demo-wrapper">
+        <h1>Footer Border Dark Mode Fix — Issue #10810</h1>
+        <p style="margin-bottom:2rem;font-size:0.875rem;color:#475569;">
+            Both footers below use a <code>--ease-color-neutral-900</code> (#111) background.
+            Toggle your OS/browser dark mode to see how each behaves, or inspect the
+            border colours directly.
+        </p>
+
+        <!-- ── BROKEN ─────────────────────────────────────────── -->
+        <div class="demo-section">
+            <span class="demo-label label-broken">❌ Current (broken)</span>
+            <div class="contrast-bar">
+                <span class="swatch" style="background:#111;"></span>
+                Footer background: #111 (--ease-color-neutral-900)
+                <span class="swatch" style="background:#e5e7eb;"></span>
+                border-top: #e5e7eb (--ease-color-neutral-200) — contrast ≈ 14:1
+            </div>
+            <footer class="ease-footer">
+                <div class="ease-footer-grid">
+                    <div>
+                        <div class="ease-footer-col-title">Product</div>
+                        <ul class="ease-footer-links">
+                            <li><a href="#">Features</a></li>
+                            <li><a href="#">Pricing</a></li>
+                            <li><a href="#">Changelog</a></li>
+                        </ul>
+                    </div>
+                    <div>
+                        <div class="ease-footer-col-title">Company</div>
+                        <ul class="ease-footer-links">
+                            <li><a href="#">About</a></li>
+                            <li><a href="#">Blog</a></li>
+                            <li><a href="#">Careers</a></li>
+                        </ul>
+                    </div>
+                    <div>
+                        <div class="ease-footer-col-title">Support</div>
+                        <ul class="ease-footer-links">
+                            <li><a href="#">Docs</a></li>
+                            <li><a href="#">GitHub</a></li>
+                            <li><a href="#">Discord</a></li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="ease-footer-bottom">
+                    <span>© 2026 EaseMotion CSS</span>
+                    <span>MIT License</span>
+                </div>
+            </footer>
+        </div>
+
+        <!-- ── FIXED ──────────────────────────────────────────── -->
+        <div class="demo-section">
+            <span class="demo-label label-fixed">✅ Fixed</span>
+            <div class="contrast-bar">
+                <span class="swatch" style="background:#111;"></span>
+                Footer background: #111 (--ease-color-neutral-900)
+                <span class="swatch" style="background:#334155;"></span>
+                border-top: #334155 (--ease-color-neutral-700) — contrast ≈ 3.5:1
+            </div>
+            <footer class="ease-footer ease-footer--fixed">
+                <div class="ease-footer-grid">
+                    <div>
+                        <div class="ease-footer-col-title">Product</div>
+                        <ul class="ease-footer-links">
+                            <li><a href="#">Features</a></li>
+                            <li><a href="#">Pricing</a></li>
+                            <li><a href="#">Changelog</a></li>
+                        </ul>
+                    </div>
+                    <div>
+                        <div class="ease-footer-col-title">Company</div>
+                        <ul class="ease-footer-links">
+                            <li><a href="#">About</a></li>
+                            <li><a href="#">Blog</a></li>
+                            <li><a href="#">Careers</a></li>
+                        </ul>
+                    </div>
+                    <div>
+                        <div class="ease-footer-col-title">Support</div>
+                        <ul class="ease-footer-links">
+                            <li><a href="#">Docs</a></li>
+                            <li><a href="#">GitHub</a></li>
+                            <li><a href="#">Discord</a></li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="ease-footer-bottom">
+                    <span>© 2026 EaseMotion CSS</span>
+                    <span>MIT License</span>
+                </div>
+            </footer>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/footer-border-dark-mode-10810/style.css
+++ b/submissions/examples/footer-border-dark-mode-10810/style.css
@@ -1,0 +1,23 @@
+/*
+  Fix: footer.css border-top uses --ease-color-neutral-200 (#e5e7eb)
+  against a --ease-color-neutral-900 (#111) background.
+  Contrast ratio ~14:1 — a near-white line on a near-black footer.
+  Visible in both light mode (footer is always dark) and dark mode.
+
+  Proposed correction: dark mode override sets border-top-color to
+  --ease-color-neutral-700 (#334155), giving ~3.5:1 contrast — subtle
+  and appropriate for a section divider on a dark surface.
+*/
+
+/* ── Dark mode border correction for .ease-footer ──────────── */
+@media (prefers-color-scheme: dark) {
+    /* Top border of the main footer container */
+    .ease-footer {
+        border-top-color: var(--ease-color-neutral-700, #334155);
+    }
+
+    /* Internal divider above the bottom bar (copyright / secondary links) */
+    .ease-footer-bottom {
+        border-top-color: var(--ease-color-neutral-700, #334155);
+    }
+}


### PR DESCRIPTION
# fix: add dark mode border correction for .ease-footer and .ease-footer-bottom

Fixes #10810

## What this submission does
footer.css
 uses --ease-color-neutral-200 (#e5e7eb) for border-top on both .ease-footer and .ease-footer-bottom. The footer background is intentionally --ease-color-neutral-900 (#111) in all color schemes. This produces a ~14:1 contrast ratio — a near-white line on a near-black background — visible in both light and dark mode.

This submission proposes a @media (prefers-color-scheme: dark) override using --ease-color-neutral-700 (#334155), reducing the contrast to ~3.5:1 — subtle and appropriate for a section divider.

## Files
style.css
 — the proposed CSS fix
demo.html
 — self-contained demo showing broken vs fixed side by side
README.md
 — full explanation with before/after contrast table