### PR TITLE
fix: add dark mode track color override for .ease-loader-spin 

### DIFF
--- a/submissions/examples/loader-spin-track-dark-mode-10807/README.md
+++ b/submissions/examples/loader-spin-track-dark-mode-10807/README.md
@@ -1,0 +1,84 @@
+# Loader Spin Track Dark Mode Fix — Issue #10807
+
+Fixes: #10807
+
+## What does this do?
+
+Adds a `@media (prefers-color-scheme: dark)` block to `components/loaders.css`
+so the `.ease-loader-spin` track ring uses a dark-appropriate border color instead
+of the near-white `--ease-color-neutral-200` in dark mode.
+
+## The problem
+
+`components/loaders.css` line 19:
+
+```css
+.ease-loader-spin {
+    border: 3px solid var(--ease-color-neutral-200); /* full ring — no dark override */
+    border-top-color: var(--ease-color-primary);     /* active arc — primary color */
+    animation: ease-kf-rotate 0.8s var(--ease-ease-linear) infinite;
+}
+```
+
+A CSS spinner works by drawing a full circular border and making one segment
+a different color. The visual effect depends on:
+
+- **Active arc** (`border-top-color`): the focal color — should draw the eye
+- **Inactive track** (`border` color): the ground — should recede into the background
+
+In dark mode:
+
+| | Background | Track | Arc |
+|---|---|---|---|
+| Light mode (correct) | #f8fafc | #e2e8f0 — ~1.1:1 ✅ quiet | #6c63ff — ~4.5:1 ✅ prominent |
+| Dark mode (broken) | #0b1121 | #e2e8f0 — ~13:1 ❌ dominates | #6c63ff — ~4.5:1 — now less visible than track |
+
+The inactive track is ~3× more contrasty than the animated arc it is supposed
+to support. The figure-ground relationship is inverted: users see a bright white
+ring with a slightly different-colored segment, not a clean rotating arc.
+
+## The fix
+
+```css
+@media (prefers-color-scheme: dark) {
+    .ease-loader-spin {
+        border-color: var(--ease-color-neutral-700, #334155);
+    }
+}
+```
+
+`border-color` sets all four sides to `neutral-700`. The existing
+`border-top-color: var(--ease-color-primary)` in the base rule is a more
+specific longhand and continues to apply on top — the active arc color is
+completely unaffected.
+
+## Before vs after in dark mode
+
+| | Track color | Track contrast on #0b1121 | Arc contrast on #0b1121 | Result |
+|---|---|---|---|---|
+| Before | #e2e8f0 (neutral-200) | ≈ 13:1 ❌ | ≈ 4.5:1 | Track dominates arc |
+| After | #334155 (neutral-700) | ≈ 3.5:1 ✅ | ≈ 4.5:1 | Arc is focal point ✅ |
+
+## Why `--ease-color-neutral-700`
+
+`--ease-color-neutral-700` (`#334155`) is the framework's established
+dark-mode border token, used by the sidebar fix (PR #10680), forms, modals,
+tabs, and cards. It gives ~3.5:1 contrast on the `#0b1121` dark background —
+quiet and unobtrusive, appropriate for a track that should recede.
+
+## How to use
+
+No class changes needed. The fix applies automatically via the `@media` block:
+
+```html
+<div class="ease-loader ease-loader-spin" role="status" aria-label="Loading"></div>
+```
+
+## How to test
+
+1. Open `demo.html` directly in a browser — no server required.
+2. The page shows a split light/dark panel side by side.
+3. The dark panel shows the broken spinner (bright white track) and the fixed
+   spinner (subtle dark track) for direct comparison.
+4. To verify via OS preference: Chrome DevTools → More Tools → Rendering →
+   Emulate CSS media feature `prefers-color-scheme: dark`.

--- a/submissions/examples/loader-spin-track-dark-mode-10807/demo.html
+++ b/submissions/examples/loader-spin-track-dark-mode-10807/demo.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline';">
+    <title>Loader Spin Track Dark Mode Fix — Issue #10807</title>
+    <style>
+        /* ── EaseMotion token simulation ───────────────────────── */
+        :root {
+            --ease-color-primary:        #6c63ff;
+            --ease-color-primary-light:  #a5b4fc;
+            --ease-color-neutral-200:    #e2e8f0;
+            --ease-color-neutral-700:    #334155;
+            --ease-color-neutral-400:    #94a3b8;
+            --ease-color-neutral-100:    #f1f5f9;
+            --ease-radius-full:          9999px;
+            --ease-ease-linear:          linear;
+            --ease-space-1:              4px;
+        }
+
+        @keyframes ease-kf-rotate {
+            to { transform: rotate(360deg); }
+        }
+
+        /* ── Base reset ─────────────────────────────────────────── */
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: system-ui, sans-serif;
+            font-size: 14px;
+            line-height: 1.5;
+        }
+
+        /* ── Two-panel layout (light | dark) ────────────────────── */
+        .panels {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            min-height: 100vh;
+        }
+
+        .panel {
+            padding: 2.5rem 2rem;
+        }
+
+        .panel--light {
+            background: #f8fafc;
+            color: #0f172a;
+        }
+
+        .panel--dark {
+            background: #0b1121;
+            color: #e2e8f0;
+        }
+
+        /* ── Section labels ─────────────────────────────────────── */
+        .panel-title {
+            font-size: 1rem;
+            font-weight: 700;
+            margin-bottom: 0.25rem;
+        }
+
+        .panel-subtitle {
+            font-size: 0.78rem;
+            opacity: 0.6;
+            margin-bottom: 2rem;
+        }
+
+        /* ── Spinner row ────────────────────────────────────────── */
+        .spinner-row {
+            display: flex;
+            align-items: center;
+            gap: 1.5rem;
+            margin-bottom: 1.75rem;
+        }
+
+        .spinner-label {
+            font-size: 0.8rem;
+        }
+
+        .spinner-label strong {
+            display: block;
+            font-size: 0.85rem;
+            margin-bottom: 0.15rem;
+        }
+
+        .tag {
+            display: inline-block;
+            font-size: 0.7rem;
+            font-weight: 600;
+            padding: 0.15rem 0.45rem;
+            border-radius: 3px;
+            margin-top: 0.2rem;
+        }
+
+        .tag-broken { background: #fee2e2; color: #991b1b; }
+        .tag-fixed  { background: #dcfce7; color: #166534; }
+        .tag-ok     { background: #dbeafe; color: #1e40af; }
+
+        /* ── Contrast meter ─────────────────────────────────────── */
+        .contrast-bar {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.75rem;
+            padding: 0.4rem 0.65rem;
+            border-radius: 4px;
+            margin-bottom: 2rem;
+        }
+
+        .panel--light .contrast-bar { background: #e2e8f0; color: #334155; }
+        .panel--dark  .contrast-bar { background: #1e293b; color: #94a3b8; }
+
+        .swatch {
+            width: 16px;
+            height: 16px;
+            border-radius: 3px;
+            border: 1px solid rgba(255,255,255,0.15);
+            flex-shrink: 0;
+        }
+
+        /* ── EaseMotion loader component ────────────────────────── */
+        .ease-loader {
+            display: inline-block;
+            width: 36px;
+            height: 36px;
+            border-radius: var(--ease-radius-full);
+            flex-shrink: 0;
+        }
+
+        /* Base spinner — current code */
+        .ease-loader-spin {
+            border: 3px solid var(--ease-color-neutral-200, #e2e8f0);
+            border-top-color: var(--ease-color-primary, #6c63ff);
+            animation: ease-kf-rotate 0.8s linear infinite;
+        }
+
+        /* Fixed variant — override track to neutral-700 */
+        .ease-loader-spin--fixed {
+            border-color: var(--ease-color-neutral-700, #334155);
+            /* border-top-color from .ease-loader-spin continues to apply */
+        }
+
+        /* ── Divider ────────────────────────────────────────────── */
+        .divider {
+            border: none;
+            border-top: 1px solid currentColor;
+            opacity: 0.15;
+            margin: 1.5rem 0;
+        }
+
+        /* ── Note box ───────────────────────────────────────────── */
+        .note {
+            font-size: 0.75rem;
+            opacity: 0.65;
+            line-height: 1.6;
+            margin-top: 0.5rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="panels">
+
+        <!-- ── LIGHT PANEL ──────────────────────────────────────── -->
+        <div class="panel panel--light">
+            <div class="panel-title">Light Mode</div>
+            <div class="panel-subtitle">Background: #f8fafc — both spinners look identical here</div>
+
+            <div class="contrast-bar">
+                <span class="swatch" style="background:#f8fafc;"></span>
+                Page: #f8fafc
+                <span class="swatch" style="background:#e2e8f0;"></span>
+                Track: #e2e8f0 — contrast ≈ 1.1:1 (subtle ✅)
+            </div>
+
+            <div class="spinner-row">
+                <div class="ease-loader ease-loader-spin" role="status" aria-label="Loading"></div>
+                <div class="spinner-label">
+                    <strong>Current (neutral-200 track)</strong>
+                    Track #e2e8f0 on #f8fafc<br>
+                    <span class="tag tag-ok">✅ Fine in light mode</span>
+                </div>
+            </div>
+
+            <div class="spinner-row">
+                <div class="ease-loader ease-loader-spin ease-loader-spin--fixed" role="status" aria-label="Loading"></div>
+                <div class="spinner-label">
+                    <strong>Fixed (neutral-700 track)</strong>
+                    Track #334155 on #f8fafc<br>
+                    <span class="tag tag-ok">✅ Also fine in light mode</span>
+                </div>
+            </div>
+
+            <p class="note">In light mode both spinners are acceptable. The fix only applies
+            inside a <code>@media (prefers-color-scheme: dark)</code> block, so light mode
+            is unaffected when the real component CSS is updated.</p>
+        </div>
+
+        <!-- ── DARK PANEL ───────────────────────────────────────── -->
+        <div class="panel panel--dark">
+            <div class="panel-title">Dark Mode</div>
+            <div class="panel-subtitle">Background: #0b1121 — the bug is visible here</div>
+
+            <div class="contrast-bar">
+                <span class="swatch" style="background:#0b1121; border-color:rgba(255,255,255,0.2);"></span>
+                Page: #0b1121
+                <span class="swatch" style="background:#e2e8f0;"></span>
+                Track (broken): #e2e8f0 — contrast ≈ 13:1
+                <span class="swatch" style="background:#334155;"></span>
+                Track (fixed): #334155 — contrast ≈ 3.5:1
+            </div>
+
+            <!-- Broken -->
+            <div class="spinner-row">
+                <div class="ease-loader ease-loader-spin" role="status" aria-label="Loading"></div>
+                <div class="spinner-label">
+                    <strong>Current (broken)</strong>
+                    Track #e2e8f0 on #0b1121<br>
+                    <span class="tag tag-broken">❌ Track dominates arc — 13:1 contrast</span>
+                </div>
+            </div>
+
+            <!-- Fixed -->
+            <div class="spinner-row">
+                <div class="ease-loader ease-loader-spin ease-loader-spin--fixed" role="status" aria-label="Loading"></div>
+                <div class="spinner-label">
+                    <strong>Fixed</strong>
+                    Track #334155 on #0b1121<br>
+                    <span class="tag tag-fixed">✅ Track recedes — arc is focal point</span>
+                </div>
+            </div>
+
+            <hr class="divider">
+
+            <p class="note">
+                The broken spinner has its figure-ground relationship inverted: the inactive
+                track ring (~13:1) is brighter than the active arc (~4.5:1). The fix restores
+                the correct relationship by lowering the track to ~3.5:1, so the primary-colored
+                arc is again the most prominent element.
+            </p>
+        </div>
+
+    </div>
+</body>
+</html>

--- a/submissions/examples/loader-spin-track-dark-mode-10807/style.css
+++ b/submissions/examples/loader-spin-track-dark-mode-10807/style.css
@@ -1,0 +1,25 @@
+/*
+  Fix: .ease-loader-spin uses --ease-color-neutral-200 (#e2e8f0) for
+  its full circular border (the inactive track ring). This token has
+  no dark mode override, so in dark mode the track stays near-white
+  (#e2e8f0) against a near-black page background (#0b1121).
+
+  Contrast ratio of track on dark background: ~13:1
+  This is higher than the active arc (~4.5:1), inverting the intended
+  figure-ground relationship — the track dominates the arc.
+
+  Fix: dark mode override sets the track to --ease-color-neutral-700
+  (#334155), giving ~3.5:1 contrast — quiet and unobtrusive, letting
+  the primary-colored arc remain the visual focal point.
+
+  Note: border-color sets all four sides. The existing base rule
+  border-top-color: var(--ease-color-primary) is a more specific
+  longhand and continues to apply on top, so the active arc color
+  is unaffected.
+*/
+
+@media (prefers-color-scheme: dark) {
+    .ease-loader-spin {
+        border-color: var(--ease-color-neutral-700, #334155);
+    }
+}


### PR DESCRIPTION
# fix: add dark mode track color override for .ease-loader-spin

## PR Description:

Fixes #10807

### What this submission does
.ease-loader-spin uses --ease-color-neutral-200 (#e2e8f0) for its full circular border (the inactive track ring). This token has no dark mode override, so in dark mode the track stays near-white against the #0b1121 dark page background at ~13:1 contrast — higher than the active primary arc (~4.5:1). The figure-ground relationship inverts: the track dominates the arc, breaking the spinner's visual communication.

This submission proposes a @media (prefers-color-scheme: dark) block overriding border-color to --ease-color-neutral-700 (#334155), giving ~3.5:1 contrast on the dark background — quiet and unobtrusive, restoring the arc as the focal point.

The border-top-color: var(--ease-color-primary) active arc rule is a more specific longhand and continues to apply unchanged.

## Files
style.css
 — the proposed CSS fix
demo.html
 — self-contained split light/dark panel showing broken vs fixed spinner
README.md
 — full explanation with contrast table

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

