### PR TITLE
feat: add CSS-only typing speed test demo component

### DIFF
--- a/submissions/examples/ease-typing-speed-test/README.md
+++ b/submissions/examples/ease-typing-speed-test/README.md
@@ -1,0 +1,30 @@
+# Typing Speed Test Demo
+
+## What does this do?
+An interactive typing speed test that measures WPM, accuracy, and characters typed over a 60-second countdown. Demonstrates combining multiple EaseMotion CSS features into a single interactive demo.
+
+## How is it used?
+Open `demo.html` in a browser and click **Start Test**. Type the displayed prompt as quickly and accurately as possible. Stats update in real time: WPM (count-up animation), accuracy percentage, and a circular progress timer. Results panel animates in on completion.
+
+## Framework features showcased
+- `ease-card`, `ease-card-shadow` — card component
+- `ease-btn`, `ease-btn-primary`, `ease-btn-lg`, `ease-btn-pill` — button variants
+- `ease-fade-in` — entrance animation
+- `ease-flex`, `ease-grid`, `ease-grid-cols-3` — layout utilities
+- `ease-text-*`, `ease-font-bold`, `ease-text-muted` — typography
+- `ease-input` — form input styling
+- `--ease-color-*` tokens — design token usage
+- `prefers-reduced-motion` support
+
+## File structure
+| File | Purpose |
+|------|---------|
+| `demo.html` | Main page with stats bar, prompt, input, start button, results panel |
+| `style.css` | Imports framework, custom styles for prompt highlighting, timer ring, results animation |
+| `script.js` | Timer, input matching, WPM/accuracy calculation, count-up display |
+| `README.md` | This file |
+
+## Accessibility
+- Respects `prefers-reduced-motion` (disables animations)
+- Works on touch devices
+- Proper focus management on start

--- a/submissions/examples/ease-typing-speed-test/demo.html
+++ b/submissions/examples/ease-typing-speed-test/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Typing Speed Test — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-center" style="min-height: 100vh; background: var(--ease-color-bg); padding: var(--ease-space-4);">
+
+<main class="ease-card ease-card-shadow" style="max-width: 680px; width: 100%;">
+
+  <h2 class="ease-fade-in ease-text-2xl ease-font-bold ease-mb-4">
+    Typing Speed Test
+  </h2>
+
+  <div class="ease-flex ease-justify-between ease-items-center ease-mb-4 ease-gap-4">
+    <div class="ease-flex ease-items-center ease-gap-2">
+      <span class="ease-text-sm ease-text-muted">WPM</span>
+      <span id="wpm" class="ease-font-bold ease-text-xl">0</span>
+    </div>
+    <div class="ease-flex ease-items-center ease-gap-2">
+      <span class="ease-text-sm ease-text-muted">Accuracy</span>
+      <span id="accuracy" class="ease-font-bold ease-text-xl">100%</span>
+    </div>
+    <div class="ease-flex ease-items-center ease-gap-2">
+      <span class="ease-text-sm ease-text-muted">Time</span>
+      <svg width="44" height="44" viewBox="0 0 44 44" aria-hidden="true">
+        <circle cx="22" cy="22" r="18" fill="none" stroke="var(--ease-color-neutral-200)" stroke-width="4"/>
+        <circle id="timer-ring" cx="22" cy="22" r="18" fill="none" stroke="var(--ease-color-primary)" stroke-width="4"
+          stroke-linecap="round" stroke-dasharray="113.1" stroke-dashoffset="0" transform="rotate(-90 22 22)"/>
+      </svg>
+      <span id="timer" class="ease-font-bold ease-text-lg">60</span>
+    </div>
+  </div>
+
+  <div id="prompt" class="ease-mb-4 ease-text-lg ease-leading-relaxed" style="font-family: var(--ease-font-sans); line-height: 1.8;"></div>
+
+  <textarea id="input" class="ease-input" rows="3" placeholder="Start typing here..." disabled autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+
+  <button id="action-btn" class="ease-btn ease-btn-primary ease-btn-lg ease-btn-pill ease-mt-4 ease-w-full">
+    Start Test
+  </button>
+
+  <div id="results" class="ease-mt-6 ease-hidden">
+    <hr class="ease-mb-6" style="border-color: var(--ease-color-neutral-200);">
+    <div class="ease-grid ease-grid-cols-3 ease-gap-4 ease-text-center">
+      <div>
+        <div id="final-wpm" class="ease-text-3xl ease-font-bold ease-text-primary">0</div>
+        <div class="ease-text-sm ease-text-muted">WPM</div>
+      </div>
+      <div>
+        <div id="final-accuracy" class="ease-text-3xl ease-font-bold ease-text-success">0%</div>
+        <div class="ease-text-sm ease-text-muted">Accuracy</div>
+      </div>
+      <div>
+        <div id="final-chars" class="ease-text-3xl ease-font-bold">0</div>
+        <div class="ease-text-sm ease-text-muted">Chars</div>
+      </div>
+    </div>
+    <div class="ease-text-center ease-mt-4">
+      <div id="final-raw" class="ease-text-sm ease-text-muted">Raw WPM: 0</div>
+    </div>
+  </div>
+
+</main>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/ease-typing-speed-test/script.js
+++ b/submissions/examples/ease-typing-speed-test/script.js
@@ -1,0 +1,190 @@
+(function () {
+  "use strict";
+
+  var prompts = [
+    "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. How vexingly quick daft zebras jump.",
+    "The five boxing wizards jump quickly. Sphinx of black quartz, judge my vow. Waltz, bad nymph, for quick jigs vex.",
+    "Two driven jocks help fax my big quiz. Quick, zephyrs blow, vexing daft Jim. Sex-charged fop blew my junk TV quiz.",
+    "When zombies arrive, quickly fax Judge Pat. A mad boxer shot a quick, gloved jab to the jaw of his dizzy opponent.",
+    "Jaded zombies acted quaintly but kept driving their oxen forward. A quick movement of the enemy will jeopardize six gunboats."
+  ];
+
+  var els = {
+    prompt: document.getElementById("prompt"),
+    input: document.getElementById("input"),
+    timer: document.getElementById("timer"),
+    timerRing: document.getElementById("timer-ring"),
+    wpm: document.getElementById("wpm"),
+    accuracy: document.getElementById("accuracy"),
+    actionBtn: document.getElementById("action-btn"),
+    results: document.getElementById("results"),
+    finalWpm: document.getElementById("final-wpm"),
+    finalAccuracy: document.getElementById("final-accuracy"),
+    finalChars: document.getElementById("final-chars"),
+    finalRaw: document.getElementById("final-raw")
+  };
+
+  var state = {
+    running: false,
+    finished: false,
+    timeLeft: 60,
+    totalTime: 60,
+    timerId: null,
+    promptText: "",
+    correctChars: 0,
+    totalTyped: 0,
+    startTime: 0
+  };
+
+  var CIRCUMFERENCE = 2 * Math.PI * 18;
+
+  function pickPrompt() {
+    return prompts[Math.floor(Math.random() * prompts.length)];
+  }
+
+  function displayPrompt(text) {
+    state.promptText = text;
+    els.prompt.innerHTML = "";
+    for (var i = 0; i < text.length; i++) {
+      var span = document.createElement("span");
+      span.className = "pending";
+      span.textContent = text[i] === " " ? "\u00A0" : text[i];
+      if (i > 0 && text[i] === " ") span.style.marginRight = "0.15em";
+      els.prompt.appendChild(span);
+    }
+  }
+
+  function updateStats() {
+    var elapsed = Math.max(1, (Date.now() - state.startTime) / 1000 / 60);
+    var wpm = Math.round((state.correctChars / 5) / elapsed);
+    var accuracy = state.totalTyped > 0 ? Math.round((state.correctChars / state.totalTyped) * 100) : 100;
+    els.wpm.textContent = wpm;
+    els.accuracy.textContent = accuracy + "%";
+  }
+
+  function updateTimer() {
+    els.timer.textContent = Math.ceil(state.timeLeft);
+    var offset = CIRCUMFERENCE * (1 - state.timeLeft / state.totalTime);
+    els.timerRing.setAttribute("stroke-dashoffset", Math.max(0, offset));
+    if (state.timeLeft <= 10) {
+      els.timerRing.setAttribute("stroke", "var(--ease-color-danger)");
+    } else if (state.timeLeft <= 30) {
+      els.timerRing.setAttribute("stroke", "var(--ease-color-warning)");
+    }
+  }
+
+  function endTest() {
+    state.running = false;
+    state.finished = true;
+    clearInterval(state.timerId);
+    els.input.disabled = true;
+    els.actionBtn.textContent = "Try Again";
+
+    var elapsed = Math.max(1, (Date.now() - state.startTime) / 1000 / 60);
+    var rawWpm = Math.round((state.totalTyped / 5) / elapsed);
+    var wpm = Math.round((state.correctChars / 5) / elapsed);
+    var accuracy = state.totalTyped > 0 ? Math.round((state.correctChars / state.totalTyped) * 100) : 100;
+
+    els.finalWpm.textContent = wpm;
+    els.finalAccuracy.textContent = accuracy + "%";
+    els.finalChars.textContent = state.correctChars;
+    els.finalRaw.textContent = "Raw WPM: " + rawWpm;
+    els.results.classList.remove("ease-hidden");
+  }
+
+  function checkInput() {
+    var val = els.input.value;
+    var chars = els.prompt.querySelectorAll("span");
+    state.correctChars = 0;
+    state.totalTyped = 0;
+
+    for (var i = 0; i < chars.length; i++) {
+      if (i < val.length) {
+        state.totalTyped++;
+        var expected = state.promptText[i];
+        var typed = val[i];
+        if (typed === expected) {
+          chars[i].className = "correct";
+          state.correctChars++;
+        } else {
+          chars[i].className = "incorrect";
+        }
+      } else if (i === val.length) {
+        chars[i].className = "current";
+      } else {
+        chars[i].className = "pending";
+      }
+    }
+
+    updateStats();
+
+    if (val.length >= state.promptText.length) {
+      endTest();
+    }
+  }
+
+  function countdown() {
+    state.timeLeft--;
+    updateTimer();
+    if (state.timeLeft <= 0) {
+      endTest();
+    }
+  }
+
+  function startTest() {
+    state.running = true;
+    state.finished = false;
+    state.timeLeft = 60;
+    state.correctChars = 0;
+    state.totalTyped = 0;
+    state.startTime = Date.now();
+
+    els.results.classList.add("ease-hidden");
+    els.prompt.classList.remove("ease-hidden");
+    els.timerRing.setAttribute("stroke", "var(--ease-color-primary)");
+
+    displayPrompt(pickPrompt());
+    els.input.value = "";
+    els.input.disabled = false;
+    els.input.focus();
+    els.actionBtn.textContent = "Testing\u2026";
+    els.actionBtn.disabled = true;
+    els.wpm.textContent = "0";
+    els.accuracy.textContent = "100%";
+    updateTimer();
+
+    checkInput();
+    state.timerId = setInterval(countdown, 1000);
+  }
+
+  function resetTest() {
+    clearInterval(state.timerId);
+    state.running = false;
+    state.finished = false;
+    state.timeLeft = 60;
+    state.correctChars = 0;
+    state.totalTyped = 0;
+
+    els.results.classList.add("ease-hidden");
+    els.input.disabled = true;
+    els.actionBtn.textContent = "Start Test";
+    els.actionBtn.disabled = false;
+    els.wpm.textContent = "0";
+    els.accuracy.textContent = "100%";
+    els.timer.textContent = "60";
+    els.timerRing.setAttribute("stroke-dashoffset", "0");
+    els.timerRing.setAttribute("stroke", "var(--ease-color-primary)");
+    displayPrompt(pickPrompt());
+    els.input.value = "";
+  }
+
+  els.actionBtn.addEventListener("click", function () {
+    if (state.running) return;
+    if (state.finished) resetTest();
+    setTimeout(startTest, 100);
+  });
+
+  els.input.addEventListener("input", checkInput);
+
+  displayPrompt(pickPrompt());
+})();

--- a/submissions/examples/ease-typing-speed-test/style.css
+++ b/submissions/examples/ease-typing-speed-test/style.css
@@ -1,0 +1,48 @@
+@import "../../../core/variables.css";
+@import "../../../core/base.css";
+@import "../../../core/animations.css";
+@import "../../../core/utilities.css";
+@import "../../../components/buttons.css";
+@import "../../../components/cards.css";
+@import "../../../components/forms.css";
+
+#prompt span {
+  transition: color 0.1s ease;
+}
+#prompt .correct {
+  color: var(--ease-color-success);
+}
+#prompt .incorrect {
+  color: var(--ease-color-danger);
+  background: var(--ease-color-danger-alpha);
+  border-radius: 2px;
+}
+#prompt .current {
+  border-left: 2px solid var(--ease-color-primary);
+  animation: blink-caret 0.8s step-end infinite;
+}
+@keyframes blink-caret {
+  50% { border-color: transparent; }
+}
+#prompt .pending {
+  color: var(--ease-color-neutral-400);
+}
+
+#timer-ring {
+  transition: stroke-dashoffset 0.3s linear;
+}
+
+#results {
+  animation: ease-fade-in 0.4s ease-out;
+}
+
+#results .ease-text-3xl {
+  animation: ease-count-up 0.6s ease-out forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #prompt span { transition: none; }
+  #timer-ring { transition: none; }
+  #results { animation: none; }
+  #results .ease-text-3xl { animation: none; }
+}


### PR DESCRIPTION
## Description

Adds an interactive typing speed test demo that measures WPM, accuracy, and characters typed over a 60-second countdown with an animated SVG circular progress ring.

Fixes #10878

## Type of Change
- [x] New feature

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] No existing core files were modified

## Changes Made

Created `submissions/examples/ease-typing-speed-test/` with:

| File | Purpose |
|------|---------|
| `demo.html` | Main page with stats bar, prompt, input, start button, results panel |
| `style.css` | Imports framework, custom styles for prompt highlighting, timer ring, results animation |
| `script.js` | Timer, input matching, WPM/accuracy calculation, count-up display |
| `README.md` | Documentation |

## Framework classes used
- `ease-card`, `ease-card-shadow`, `ease-btn`, `ease-btn-primary`, `ease-btn-lg`, `ease-btn-pill`
- `ease-fade-in`, `ease-flex`, `ease-grid`, `ease-grid-cols-3`, `ease-input`
- `ease-text-*`, `ease-font-bold`, `ease-text-muted`
- `--ease-color-*` design tokens
- `prefers-reduced-motion` support