### PR TITLE
feat: add CSS-only cross-document View Transition API demo example

### DIFF
--- a/submissions/examples/ease-view-transitions/README.md
+++ b/submissions/examples/ease-view-transitions/README.md
@@ -1,0 +1,33 @@
+# Cross-document View Transitions Demo
+
+## What does this do?
+A two-page demo showcasing the CSS View Transitions API for cross-document (MPA) navigation. A gallery card "morphs" into the detail page hero using shared `view-transition-name` elements.
+
+## How is it used?
+Open `gallery.html` in a Chromium-based browser (Chrome/Edge 126+) and click any card. The browser captures the old state, transitions to the new page, and animates the shared element.
+
+## How it works
+- `@view-transition { navigation: auto }` enables cross-document transitions
+- Cards in `gallery.html` use `view-transition-name: card-N` on their image
+- `detail.html` sets the matching `view-transition-name` on the hero via JS
+- `::view-transition-old()` and `::view-transition-new()` apply custom fade animations
+- Graceful degradation: unsupported browsers navigate normally with no animation
+
+## Framework features showcased
+- `ease-card`, `ease-card-shadow`, `ease-card-flat` — card components
+- `ease-grid`, `ease-grid-cols-3` — responsive grid layout
+- `ease-text-*`, `ease-font-bold`, `ease-text-muted` — typography
+- `--ease-color-*` tokens — design tokens
+- `prefers-reduced-motion` support
+
+## File structure
+| File | Purpose |
+|------|---------|
+| `gallery.html` | Gallery page with 3 cards, each linking to detail |
+| `detail.html` | Detail page showing card info, sets matching `view-transition-name` |
+| `style.css` | Imports framework, view transition config, custom animations |
+| `README.md` | This file |
+
+## Browser support
+- ✅ Chrome/Edge 126+ (full support for cross-document View Transitions)
+- ❌ Firefox, Safari (no support yet; navigates normally)

--- a/submissions/examples/ease-view-transitions/detail.html
+++ b/submissions/examples/ease-view-transitions/detail.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Detail — View Transitions Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="ease-py-4" style="padding-left: var(--ease-space-4);">
+  <a href="gallery.html" class="ease-text-primary" style="text-decoration: none; font-weight: 500;">&larr; Back to Gallery</a>
+</header>
+
+<main id="detail-main" style="max-width: 800px; margin: 0 auto; padding: 0 var(--ease-space-4);">
+
+  <div id="hero" class="ease-view-hero" style="view-transition-name: none;">
+    <div id="hero-img" class="card-img-hero"></div>
+  </div>
+
+  <div class="ease-card ease-card-flat ease-mt-6 ease-padding-6">
+    <h2 id="detail-title" class="ease-text-2xl ease-font-bold"></h2>
+    <p id="detail-desc" class="ease-text-lg ease-text-muted ease-mt-4"></p>
+    <p id="detail-extra" class="ease-text-sm ease-text-muted ease-mt-4"></p>
+  </div>
+
+</main>
+
+<script>
+(function () {
+  var data = [
+    {
+      title: "Mountain Peak",
+      desc: "A breathtaking view of the alpine summit at sunrise, captured from the northern ridge trail.",
+      extra: "Elevation: 3,847m | Location: Swiss Alps | Best season: Summer",
+      gradient: "linear-gradient(135deg, #667eea, #764ba2)"
+    },
+    {
+      title: "Deep Forest",
+      desc: "Ancient redwoods towering in the misty morning light, with ferns carpeting the forest floor.",
+      extra: "Park: Redwood National Park | Species: Sequoia sempervirens | Canopy: 90m",
+      gradient: "linear-gradient(135deg, #43e97b, #38f9d7)"
+    },
+    {
+      title: "Ocean Sunset",
+      desc: "Golden hour paints the sky in brilliant hues over the vast Pacific horizon at dusk.",
+      extra: "Location: Big Sur, California | Time: 6:47 PM | Conditions: Clear skies",
+      gradient: "linear-gradient(135deg, #f093fb, #f5576c)"
+    }
+  ];
+  var params = new URLSearchParams(location.search);
+  var idx = Math.min(Math.max(parseInt(params.get("card")) || 0, 0), data.length - 1);
+  var item = data[idx];
+  var hero = document.getElementById("hero");
+  var img = document.getElementById("hero-img");
+  document.getElementById("detail-title").textContent = item.title;
+  document.getElementById("detail-desc").textContent = item.desc;
+  document.getElementById("detail-extra").textContent = item.extra;
+  img.style.background = item.gradient;
+  img.textContent = item.title;
+  hero.style.viewTransitionName = "card-" + idx;
+})();
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-view-transitions/gallery.html
+++ b/submissions/examples/ease-view-transitions/gallery.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gallery — View Transitions Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="ease-text-center ease-py-8">
+  <h1 class="ease-text-3xl ease-font-bold">Nature Gallery</h1>
+  <p class="ease-text-muted">Click a card to see the view transition in action</p>
+</header>
+
+<main class="ease-grid ease-grid-cols-3 ease-gap-6" style="max-width: 960px; margin: 0 auto; padding: 0 var(--ease-space-4);">
+
+  <a href="detail.html?card=0" class="ease-card ease-card-shadow ease-view-card ease-view-card-0">
+    <div class="card-img" style="background: linear-gradient(135deg, #667eea, #764ba2);">
+      <span>Mountain</span>
+    </div>
+    <div class="ease-card-body">
+      <h3 class="ease-card-title">Mountain Peak</h3>
+      <p class="ease-card-subtitle">A breathtaking view of the alpine summit at sunrise.</p>
+    </div>
+  </a>
+
+  <a href="detail.html?card=1" class="ease-card ease-card-shadow ease-view-card ease-view-card-1">
+    <div class="card-img" style="background: linear-gradient(135deg, #43e97b, #38f9d7);">
+      <span>Forest</span>
+    </div>
+    <div class="ease-card-body">
+      <h3 class="ease-card-title">Deep Forest</h3>
+      <p class="ease-card-subtitle">Ancient redwoods towering in the misty morning light.</p>
+    </div>
+  </a>
+
+  <a href="detail.html?card=2" class="ease-card ease-card-shadow ease-view-card ease-view-card-2">
+    <div class="card-img" style="background: linear-gradient(135deg, #f093fb, #f5576c);">
+      <span>Sunset</span>
+    </div>
+    <div class="ease-card-body">
+      <h3 class="ease-card-title">Ocean Sunset</h3>
+      <p class="ease-card-subtitle">Golden hour paints the sky over the Pacific horizon.</p>
+    </div>
+  </a>
+
+</main>
+
+</body>
+</html>

--- a/submissions/examples/ease-view-transitions/style.css
+++ b/submissions/examples/ease-view-transitions/style.css
@@ -1,0 +1,87 @@
+@import "../../../core/variables.css";
+@import "../../../core/base.css";
+@import "../../../core/utilities.css";
+@import "../../../components/buttons.css";
+@import "../../../components/cards.css";
+
+@view-transition {
+  navigation: auto;
+}
+
+body {
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  min-height: 100vh;
+}
+
+/* ── Card image ── */
+.ease-view-card .card-img {
+  height: 180px;
+  border-radius: var(--ease-radius-lg) var(--ease-radius-lg) 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--ease-text-xl);
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 2px 8px rgba(0,0,0,0.25);
+}
+
+.ease-view-card-0 .card-img { view-transition-name: card-0; }
+.ease-view-card-1 .card-img { view-transition-name: card-1; }
+.ease-view-card-2 .card-img { view-transition-name: card-2; }
+
+/* ── Detail hero ── */
+.ease-view-hero {
+  border-radius: var(--ease-radius-xl);
+  overflow: hidden;
+}
+
+.card-img-hero {
+  height: 360px;
+  border-radius: var(--ease-radius-xl);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--ease-text-3xl);
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 2px 12px rgba(0,0,0,0.3);
+}
+
+/* ── Card link reset ── */
+a.ease-card {
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+a.ease-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--ease-shadow-xl);
+}
+
+/* ── View transition animations ── */
+::view-transition-old(card-0),
+::view-transition-old(card-1),
+::view-transition-old(card-2) {
+  animation: 0.35s ease-out both ease-kf-fade-out;
+}
+
+::view-transition-new(card-0),
+::view-transition-new(card-1),
+::view-transition-new(card-2) {
+  animation: 0.35s ease-out both ease-kf-fade-in;
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(card-0),
+  ::view-transition-old(card-1),
+  ::view-transition-old(card-2),
+  ::view-transition-new(card-0),
+  ::view-transition-new(card-1),
+  ::view-transition-new(card-2) {
+    animation-duration: 0.01ms;
+  }
+  a.ease-card { transition: none; }
+}


### PR DESCRIPTION
## Description

A two-page (gallery → detail) demo showcasing the CSS View Transitions API for cross-document (MPA) navigation with shared element morphing animations.

Fixes #10877

## Type of Change
- [x] New feature

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] No existing core files were modified

## Changes Made

Created `submissions/examples/ease-view-transitions/` with:

| File | Purpose |
|------|---------|
| `gallery.html` | Gallery grid with 3 cards, each linking to a detail page |
| `detail.html` | Detail page with hero image, sets matching view-transition-name via JS |
| `style.css` | Framework imports, @view-transition rules, custom ::view-transition-old/new animations, prefers-reduced-motion |
| `README.md` | Documentation |

## How it works
- `@view-transition { navigation: auto }` enables cross-document transitions
- Each card image has `view-transition-name: card-N` (0-2)
- Detail page applies the matching name to the hero element
- Custom `::view-transition-old()/new()` animations using `ease-kf-fade-in/out` keyframes
- Graceful degradation: unsupported browsers navigate normally
- Respects `prefers-reduced-motion`