### PR TITLE
feat: add OKLCH color animation examples

### DIFF
--- a/submissions/examples/oklch-color-animations-ss/demo.html
+++ b/submissions/examples/oklch-color-animations-ss/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OKLCH Color Animation Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <h1>OKLCH Color Animation Examples</h1>
+    <p>Demonstrating perceptually uniform color transitions using the OKLCH color space.</p>
+
+    <section>
+        <h2>1. Animated Color Card</h2>
+        <div class="color-card"></div>
+    </section>
+
+    <section>
+        <h2>2. Animated Gradient Background</h2>
+        <div class="gradient-demo"></div>
+    </section>
+
+    <section>
+        <h2>3. Hover Color Shift Button</h2>
+        <button class="oklch-btn">
+            Hover Me
+        </button>
+    </section>
+
+</body>
+</html>

--- a/submissions/examples/oklch-color-animations-ss/style.css
+++ b/submissions/examples/oklch-color-animations-ss/style.css
@@ -1,0 +1,119 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    min-height:100vh;
+    font-family:Arial,sans-serif;
+    background:#f5f5f5;
+    padding:40px;
+}
+
+h1{
+    margin-bottom:10px;
+}
+
+p{
+    margin-bottom:40px;
+    color:#555;
+}
+
+section{
+    margin-bottom:50px;
+}
+
+/* Example 1 */
+
+.color-card{
+    width:250px;
+    height:250px;
+    border-radius:20px;
+
+    background:oklch(70% 0.18 30);
+
+    animation:hueCycle 5s infinite alternate ease-in-out;
+}
+
+@keyframes hueCycle{
+
+    0%{
+        background:oklch(70% 0.18 30);
+    }
+
+    25%{
+        background:oklch(70% 0.18 120);
+    }
+
+    50%{
+        background:oklch(70% 0.18 210);
+    }
+
+    75%{
+        background:oklch(70% 0.18 300);
+    }
+
+    100%{
+        background:oklch(70% 0.18 30);
+    }
+}
+
+/* Example 2 */
+
+.gradient-demo{
+    width:100%;
+    max-width:700px;
+    height:220px;
+    border-radius:20px;
+
+    background:linear-gradient(
+        90deg,
+        oklch(75% 0.18 20),
+        oklch(75% 0.18 240)
+    );
+
+    animation:gradientShift 6s infinite alternate;
+}
+
+@keyframes gradientShift{
+
+    0%{
+        background:linear-gradient(
+            90deg,
+            oklch(75% 0.18 20),
+            oklch(75% 0.18 240)
+        );
+    }
+
+    100%{
+        background:linear-gradient(
+            90deg,
+            oklch(75% 0.18 120),
+            oklch(75% 0.18 330)
+        );
+    }
+}
+
+/* Example 3 */
+
+.oklch-btn{
+    padding:14px 28px;
+    border:none;
+    border-radius:12px;
+    cursor:pointer;
+
+    color:white;
+
+    background:oklch(62% 0.18 260);
+
+    transition:background .5s ease,
+               transform .3s ease;
+}
+
+.oklch-btn:hover{
+
+    background:oklch(62% 0.18 20);
+
+    transform:translateY(-3px);
+}


### PR DESCRIPTION
Closes #9145

Summary

Added a self-contained example demonstrating OKLCH colour space animations with perceptually uniform color transitions.

 Included Examples

* Animated OKLCH colour card
* Animated OKLCH gradient background
* OKLCH hover colour shift button

 Files Added

submissions/examples/oklch-color-animations-ss/

 demo.html
style.css
README.md

 Notes
* No modifications were made outside the submissions/examples directory.
* The demo works as a standalone HTML file with no external dependencies.
* All examples showcase perceptually uniform colour transitions using OKLCH.
