### PR TITLE
fix: point main and style fields to easemotion.min.css for bundler compatibility #9874

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "easemotion-css",
   "version": "1.0.0",
   "description": "Human-readable, animation-first CSS framework. Zero dependencies. No build step required.",
-  "main": "easemotion.css",
-  "style": "easemotion.css",
+  "main": "easemotion.min.css",
+  "style": "easemotion.min.css",
   "files": [
     "easemotion.css",
     "easemotion.min.css",


### PR DESCRIPTION
Closes #9874

## Pull Request Description
Fixes package.json so bundlers (Vite, webpack, Parcel) use the pre-built flat file `easemotion.min.css` instead of resolving 15+ @import chains individually, preventing silent style failures.

---
## Type of Change
- [x] 🐛 Bug fix in an existing submission

---
## Submission Checklist
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---
## Feature Description
**What does this add?**
Fixes `package.json` by pointing `"main"` and `"style"` fields to `easemotion.min.css` instead of `easemotion.css`.

**Why does it fit EaseMotion CSS?**
Ensures the package works correctly in all Node.js bundler environments without silent style failures.

---
## Browser Testing
- [x] Chrome
- [x] Edge

---
## Notes for Maintainer
Only `package.json` was modified — `"main"` and `"style"` now point to `easemotion.min.css`. The `"files"` array already includes it so no further changes needed.