### PR TITLE
fix: suppress card hover lift when child button is hovered #9867

### DIFF
--- a/components/cards.css
+++ b/components/cards.css
@@ -82,7 +82,7 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .ease-card-hover:hover {
+  .ease-card-hover:not(:has(.ease-btn:hover)):hover {
     transform: translateY(-6px);
     box-shadow: var(--ease-shadow-xl, 0 20px 25px -5px rgba(0, 0, 0, 0.45),
                        0 10px 10px -5px rgba(0, 0, 0, 0.30));

--- a/submissions/examples/ease-card-hover-double-lift-fix/README.md
+++ b/submissions/examples/ease-card-hover-double-lift-fix/README.md
@@ -1,0 +1,17 @@
+# Fix: .ease-card-hover double lift conflict with .ease-btn-hover
+
+Fixes the double lift effect when `.ease-btn-hover` is nested inside `.ease-card-hover`.
+
+## Root Cause
+`.ease-card-hover:hover` fires on any descendant hover including child buttons, causing both card and button to lift simultaneously.
+
+## Fix Applied
+Added `:not(:has(.ease-btn:hover))` guard to `components/cards.css`:
+
+```css
+.ease-card-hover:not(:has(.ease-btn:hover)):hover {
+  transform: translateY(-6px);
+}
+```
+
+Closes #9867


### PR DESCRIPTION
Closes #9867

## Pull Request Description
Fixes the double lift effect when `.ease-btn-hover` is nested inside `.ease-card-hover`. Hovering the button was triggering both the card lift and button lift simultaneously due to CSS hover bubbling.

---
## Type of Change
- [x] 🐛 Bug fix in an existing submission

---
## Submission Checklist
- [x] Includes `README.md` in `submissions/examples/ease-card-hover-double-lift-fix/`
- [x] **No changes to `core/`**
- [x] One feature per PR

---
## Feature Description
**What does this fix?**
Added `:not(:has(.ease-btn:hover))` guard to `.ease-card-hover:hover` in `components/cards.css` so the card lift is suppressed when a child button is being hovered.

**How does a developer use it?**
```html
<div class="ease-card ease-card-hover">
  <p>Card content</p>
  <button class="ease-btn ease-btn-primary ease-btn-hover">Click Me</button>
</div>
```

**Why does it fit EaseMotion CSS?**
Clean, composable CSS fix using modern `:has()` pseudo-class — no JS, no breaking changes.

---
## Browser Testing
- [x] Chrome
- [x] Edge

---
## Notes for Maintainer
Fix applied in `components/cards.css` line 85 — changed `.ease-card-hover:hover` to `.ease-card-hover:not(:has(.ease-btn:hover)):hover`. `:has()` is supported in all modern browsers (Chrome 105+, Firefox 121+, Safari 15.4+).