### PR TITLE
feat: add CSS-only Animated Tooltip #9813

### DIFF
--- a/submissions/examples/css-only-animated-tooltip/README.md
+++ b/submissions/examples/css-only-animated-tooltip/README.md
@@ -1,0 +1,11 @@
+# CSS-only Animated Tooltip
+
+A smooth animated tooltip powered entirely by CSS using `data-tooltip` attributes and `::before`/`::after` pseudo-elements.
+
+## Usage
+```html
+<button class="css-tooltip" data-tooltip="Tooltip text here">Hover over me</button>
+```
+
+## Why EaseMotion CSS?
+Pure CSS, animation-first, zero JS dependencies, human-readable class name, composable with any element.

--- a/submissions/examples/css-only-animated-tooltip/demo.html
+++ b/submissions/examples/css-only-animated-tooltip/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>CSS-only Animated Tooltip — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { display:flex; justify-content:center; align-items:center; min-height:100vh; background:#0f172a; font-family:sans-serif; gap:32px; }
+    button { padding:10px 20px; background:#6366f1; color:#fff; border:none; border-radius:8px; cursor:pointer; font-size:1rem; }
+  </style>
+</head>
+<body>
+  <button class="css-tooltip" data-tooltip="This is a pure CSS tooltip!">Hover over me</button>
+  <button class="css-tooltip" data-tooltip="No JavaScript needed!">Hover me too</button>
+</body>
+</html>

--- a/submissions/examples/css-only-animated-tooltip/style.css
+++ b/submissions/examples/css-only-animated-tooltip/style.css
@@ -1,0 +1,42 @@
+.css-tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.css-tooltip::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(6px);
+  background: #1e293b;
+  color: #f8fafc;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  z-index: 10;
+}
+
+.css-tooltip::after {
+  content: "";
+  position: absolute;
+  bottom: calc(100% + 2px);
+  left: 50%;
+  transform: translateX(-50%) translateY(6px);
+  border: 5px solid transparent;
+  border-top-color: #1e293b;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.css-tooltip:hover::before,
+.css-tooltip:hover::after {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}


### PR DESCRIPTION
Closes #9813

## Pull Request Description
Adds a smooth animated tooltip powered entirely by CSS using `data-tooltip` attributes and pseudo-elements with fade and translate animation.

---
## Type of Change
- [x] ✨ New animation / hover effect

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/css-only-animated-tooltip/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---
## Feature Description
**What does this add?**
A CSS-only tooltip that fades and slides in on hover using `data-tooltip` attribute and `::before`/`::after` pseudo-elements.

**How does a developer use it?**
```html
<button class="css-tooltip" data-tooltip="This is a pure CSS tooltip!">Hover over me</button>
```

**Why does it fit EaseMotion CSS?**
Pure CSS, animation-first, zero JS, human-readable class name, composable with any element.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Edge

---
## Notes for Maintainer
Tooltip text is stored in `data-tooltip` attribute and rendered via CSS `content: attr(data-tooltip)`. No JS required.