### PR TITLE
fix: .ease-navbar mobile menu does not close on outside click #9878

### DIFF
--- a/submissions/examples/ease-navbar-outside-click-fix/README.md
+++ b/submissions/examples/ease-navbar-outside-click-fix/README.md
@@ -1,0 +1,17 @@
+# .ease-navbar — Outside Click Fix
+
+Fixes #9878: the `.ease-navbar` mobile menu previously only closed when the hamburger icon was clicked again. This demo shows the corrected behavior.
+
+## What changed
+CSS alone (checkbox-hack toggle) cannot detect a click outside the element, so this adds one small, documented vanilla JS snippet (~15 lines, no dependencies) that:
+- Closes the menu when the user clicks anywhere outside `.ease-navbar`
+- Closes the menu on `Escape`
+- Closes the menu when a nav link is clicked
+
+This also resolves the WCAG 2.1 SC 1.4.13 concern noted in the issue — the revealed menu is now dismissible without forcing a second hamburger click.
+
+## Usage
+Open `demo.html` directly in a browser — no server needed. Resize to under 768px (or use DevTools device mode) to see the mobile menu.
+
+## Why EaseMotion CSS?
+Keeps the existing pure-CSS checkbox-hack toggle and slide-down animation intact; the JS only adds the dismissal behavior CSS can't provide on its own.

--- a/submissions/examples/ease-navbar-outside-click-fix/demo.html
+++ b/submissions/examples/ease-navbar-outside-click-fix/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>.ease-navbar — Outside Click Fix — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="ease-navbar">
+    <div class="ease-navbar-brand">EaseMotion</div>
+    <input type="checkbox" id="ease-navbar-toggle" class="ease-navbar-checkbox" />
+    <label for="ease-navbar-toggle" class="ease-navbar-hamburger" aria-label="Toggle navigation" aria-controls="easeNavbarMenu">
+      <span></span><span></span><span></span>
+    </label>
+    <nav class="ease-navbar-menu" id="easeNavbarMenu">
+      <a href="#" class="ease-navbar-link">Home</a>
+      <a href="#" class="ease-navbar-link">Features</a>
+      <a href="#" class="ease-navbar-link">Docs</a>
+      <a href="#" class="ease-navbar-link">Contact</a>
+    </nav>
+  </header>
+
+  <main class="demo-content">
+    <p>Resize below 768px (or open DevTools device mode), open the menu, then click anywhere here, press Escape, or click a nav link — the menu should close in all three cases.</p>
+  </main>
+
+  <script>
+    // Minimal vanilla JS — CSS alone cannot detect clicks outside an element.
+    (function () {
+      var toggle = document.getElementById('ease-navbar-toggle');
+      var navbar = document.querySelector('.ease-navbar');
+      var menu = document.getElementById('easeNavbarMenu');
+
+      function closeMenu() {
+        toggle.checked = false;
+      }
+
+      // 1. Click outside the navbar closes the menu
+      document.addEventListener('click', function (e) {
+        if (toggle.checked && !navbar.contains(e.target)) {
+          closeMenu();
+        }
+      });
+
+      // 2. Escape key closes the menu
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && toggle.checked) {
+          closeMenu();
+        }
+      });
+
+      // 3. Clicking a nav link closes the menu
+      menu.querySelectorAll('.ease-navbar-link').forEach(function (link) {
+        link.addEventListener('click', closeMenu);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-navbar-outside-click-fix/style.css
+++ b/submissions/examples/ease-navbar-outside-click-fix/style.css
@@ -1,0 +1,103 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0b0d12;
+  color: #e2e8f0;
+  min-height: 100vh;
+}
+
+.ease-navbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #11141a;
+  border-bottom: 1px solid #2d3340;
+  padding: 14px 20px;
+}
+
+.ease-navbar-brand {
+  font-weight: 700;
+  color: #38bdf8;
+  font-size: 1.05rem;
+}
+
+.ease-navbar-checkbox { display: none; }
+
+.ease-navbar-hamburger {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  cursor: pointer;
+  z-index: 20;
+}
+
+.ease-navbar-hamburger span {
+  width: 24px;
+  height: 2px;
+  background: #e2e8f0;
+  border-radius: 2px;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.ease-navbar-checkbox:checked ~ .ease-navbar-hamburger span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+.ease-navbar-checkbox:checked ~ .ease-navbar-hamburger span:nth-child(2) {
+  opacity: 0;
+}
+.ease-navbar-checkbox:checked ~ .ease-navbar-hamburger span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+.ease-navbar-menu {
+  display: flex;
+  gap: 24px;
+}
+
+.ease-navbar-link {
+  color: #94a3b8;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s ease;
+}
+
+.ease-navbar-link:hover { color: #38bdf8; }
+
+.demo-content {
+  padding: 60px 24px;
+  color: #64748b;
+  font-size: 0.9rem;
+  line-height: 1.7;
+  max-width: 600px;
+}
+
+@media (max-width: 768px) {
+  .ease-navbar-hamburger { display: flex; }
+
+  .ease-navbar-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    gap: 0;
+    background: #11141a;
+    border-bottom: 1px solid #2d3340;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: max-height 0.3s ease, opacity 0.25s ease;
+  }
+
+  .ease-navbar-checkbox:checked ~ .ease-navbar-menu {
+    max-height: 280px;
+    opacity: 1;
+  }
+
+  .ease-navbar-link {
+    padding: 14px 20px;
+    border-top: 1px solid #1e2430;
+  }
+}


### PR DESCRIPTION
Closes #9878

## Pull Request Description
Adds a self-contained demo showing the .ease-navbar mobile menu correctly closing on outside click, Escape key, and nav-link click — addressing the missing click-outside handler and the WCAG 2.1 SC 1.4.13 concern raised in the issue.

---
## Type of Change
- [x] 🐛 Bug fix

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-navbar-outside-click-fix/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — CSS for the navbar and mobile menu
- [x] Includes `README.md` — what it fixes, how it works, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One fix per PR

---
## Feature Description
**What does this fix?**
The mobile nav menu previously stayed open after an outside click — users had to hit the hamburger icon again. This demo adds a minimal (~15 line) vanilla JS snippet, documented in the README, that closes the menu on outside click, Escape, or nav-link click, while keeping the existing CSS-only toggle and animation.

**How does a developer use it?**
```html
<input type="checkbox" id="ease-navbar-toggle" class="ease-navbar-checkbox" />
<label for="ease-navbar-toggle" class="ease-navbar-hamburger">...</label>
<nav class="ease-navbar-menu" id="easeNavbarMenu">...</nav>
```

**Why does it fit EaseMotion CSS?**
Preserves the pure-CSS checkbox-hack toggle and slide-down transition; JS is limited strictly to the dismissal logic CSS cannot express.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome (opened directly, tested outside-click/Escape/link-click)
- [ ] Edge

---
## Notes for Maintainer
No core or components/ files modified, per validator rules. JS is intentionally minimal and isolated to the demo's own `<script>` block.