### PR TITLE
feat: add 3D perspective photo stack with fan-out (issue #10991)

### DIFF
--- a/submissions/examples/perspective-photo-stack-pp/README.md
+++ b/submissions/examples/perspective-photo-stack-pp/README.md
@@ -1,0 +1,44 @@
+# 3D Perspective Photo Stack with Fan-Out
+
+## What does this do?
+
+This component creates an interactive, CSS-only stacked photo gallery that fans out in a 3D arc on stack hover, and lifts/aligns individual cards to face the viewer on item hover or keyboard focus.
+
+## How is it used?
+
+Apply the `.perspective-container`, `.photo-stack`, and `.photo-card` classes to your gallery markup structure:
+
+```html
+<div class="perspective-container">
+  <div class="photo-stack">
+    <div class="photo-card" tabindex="0">
+      <div class="image-wrapper">
+        <img src="your-image.jpg" alt="Description" />
+      </div>
+      <div class="caption">
+        <span class="title">Photo Title</span>
+        <span class="meta">Location • Iso/Specs</span>
+      </div>
+    </div>
+    <!-- Additional photo cards -->
+  </div>
+</div>
+```
+
+## Why is it useful?
+
+It provides a physical-deck sensation to image collections, making galleries feel tangible and responsive. It uses pure hardware-accelerated CSS 3D transforms (`preserve-3d`, `perspective`, `translate3d`, `rotate3d`) to ensure highly optimized rendering, zero JavaScript execution overhead, and native accessibility via keyboard tab-navigation and focus-visible state handlers.
+
+## Tech Stack
+
+- HTML5
+- CSS3 (no external frameworks, no JavaScript)
+
+## Preview
+
+Open `demo.html` directly in any modern web browser to view and interact with the component.
+
+## Contribution Notes
+
+- Class naming was handled by the contributor (`pp`).
+- Maintainer will rename classes to the standard `ease-*` convention (e.g. `.ease-perspective-stack`, `.ease-photo-card`) and substitute hardcoded colors or transition metrics with project-wide design tokens upon integration.

--- a/submissions/examples/perspective-photo-stack-pp/demo.html
+++ b/submissions/examples/perspective-photo-stack-pp/demo.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>3D Perspective Photo Stack with Fan-Out - EaseMotion CSS</title>
+
+    <!-- Link to EaseMotion CSS core animations (for global consistency if integrated) -->
+    <link rel="stylesheet" href="../../../core/animations.css" />
+
+    <!-- Link to our specific feature stylesheet -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="demo-wrapper">
+      <!-- Header Section -->
+      <header class="demo-header">
+        <h1>3D Perspective Photo Stack</h1>
+        <p>
+          An interactive, CSS-only photo gallery deck utilizing 3D perspective
+          transforms, fanning out on stack hover and popping individual photos
+          forward on focus or card hover.
+        </p>
+        <div class="interaction-hint">
+          <span class="hint-icon" aria-hidden="true">✨</span> Hover Stack to
+          Fan Out • Hover/Tab Card to Inspect
+        </div>
+      </header>
+
+      <!-- Main 3D Perspective Photo Stack Container -->
+      <main class="perspective-container">
+        <div
+          class="photo-stack"
+          aria-label="Interactive 3D Photo Gallery Stack"
+        >
+          <!-- Photo Card 1: Sunset Beach -->
+          <div
+            class="photo-card"
+            tabindex="0"
+            role="button"
+            aria-haspopup="dialog"
+            aria-label="Photo 1: Golden Hour Beach, Hawaii"
+          >
+            <div class="image-wrapper">
+              <img
+                src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&q=80&w=600&h=800"
+                alt="Sandy beach with golden sunset and rolling waves"
+              />
+            </div>
+            <div class="caption">
+              <span class="title">Golden Hour Beach</span>
+              <span class="meta">Hawaii • ISO 100</span>
+            </div>
+          </div>
+
+          <!-- Photo Card 2: Starry Mountains -->
+          <div
+            class="photo-card"
+            tabindex="0"
+            role="button"
+            aria-haspopup="dialog"
+            aria-label="Photo 2: Starry Night over Matterhorn, Switzerland"
+          >
+            <div class="image-wrapper">
+              <img
+                src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&q=80&w=600&h=800"
+                alt="Milky Way starry night sky above snow-capped steep mountain peak"
+              />
+            </div>
+            <div class="caption">
+              <span class="title">Starry Peaks</span>
+              <span class="meta">Alps • ISO 1600</span>
+            </div>
+          </div>
+
+          <!-- Photo Card 3: Autumn Path -->
+          <div
+            class="photo-card"
+            tabindex="0"
+            role="button"
+            aria-haspopup="dialog"
+            aria-label="Photo 3: Autumn Trail, Oregon"
+          >
+            <div class="image-wrapper">
+              <img
+                src="https://images.unsplash.com/photo-1501854140801-50d01698950b?auto=format&fit=crop&q=80&w=600&h=800"
+                alt="Forest path surrounded by bright orange and yellow autumn foliage"
+              />
+            </div>
+            <div class="caption">
+              <span class="title">Autumn Trail</span>
+              <span class="meta">Oregon • ISO 200</span>
+            </div>
+          </div>
+
+          <!-- Photo Card 4: Serene Lake -->
+          <div
+            class="photo-card"
+            tabindex="0"
+            role="button"
+            aria-haspopup="dialog"
+            aria-label="Photo 4: Sunset Reflection on Lake, New Zealand"
+          >
+            <div class="image-wrapper">
+              <img
+                src="https://images.unsplash.com/photo-1472214222555-d404758b1c42?auto=format&fit=crop&q=80&w=600&h=800"
+                alt="Calm lake surface reflecting soft pink sunrise colors and green hills"
+              />
+            </div>
+            <div class="caption">
+              <span class="title">Alpine Sunrise</span>
+              <span class="meta">Wakatipu • ISO 50</span>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <!-- Info details panel explaining technical structure -->
+      <section class="demo-info" aria-label="Technical Details">
+        <h2 class="info-title">How it works</h2>
+        <ul>
+          <li>
+            <strong>3D Environment:</strong> Set up using
+            <code>perspective: 1400px</code> and
+            <code>transform-style: preserve-3d</code>.
+          </li>
+          <li>
+            <strong>Physical Overlap:</strong> In the resting state, cards are
+            stacked with offset <code>translateZ</code> and subtle rotations on
+            the Z-axis.
+          </li>
+          <li>
+            <strong>3D Fan Out:</strong> Hovering the stack translates and
+            rotates each card outward along a 3D arc, spreading them flat and
+            readable.
+          </li>
+          <li>
+            <strong>Inspection Elevate:</strong> Hovering/focusing an individual
+            card triggers a reset of Y/Z angles and lifts it forward via
+            <code>translate3d(..., ..., 140px)</code> with a `z-index` override.
+          </li>
+          <li>
+            <strong>Accessibility:</strong> Full keyboard support is included
+            using <code>tabindex="0"</code> and CSS
+            <code>:focus-visible</code> rules.
+          </li>
+        </ul>
+      </section>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/perspective-photo-stack-pp/style.css
+++ b/submissions/examples/perspective-photo-stack-pp/style.css
@@ -1,0 +1,533 @@
+/* ==========================================================================
+   EASEMOTION CSS — 3D PERSPECTIVE PHOTO STACK WITH FAN-OUT
+   Contributor: Pratyush-Panda-2006 (PP)
+   ========================================================================== */
+
+/* Importing Google Font for premium typography */
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800&family=Plus+Jakarta+Sans:wght@300;400;500;600&display=swap");
+
+:root {
+  --bg-dark: #09090b;
+  --panel-bg: rgba(24, 24, 27, 0.6);
+  --border-glass: rgba(255, 255, 255, 0.08);
+  --accent-color: #6366f1;
+  --accent-glow: rgba(99, 102, 241, 0.4);
+  --card-shadow: 0 15px 35px rgba(0, 0, 0, 0.4), 0 5px 15px rgba(0, 0, 0, 0.2);
+  --card-shadow-hover:
+    0 30px 60px rgba(0, 0, 0, 0.6), 0 10px 25px rgba(99, 102, 241, 0.15);
+  --font-display: "Outfit", sans-serif;
+  --font-sans: "Plus Jakarta Sans", sans-serif;
+}
+
+/* Base resets & layout */
+body {
+  font-family: var(--font-sans);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  background: radial-gradient(
+    circle at center,
+    #181824 0%,
+    var(--bg-dark) 100%
+  );
+  color: #f4f4f5;
+  overflow-x: hidden;
+  padding: 2rem;
+}
+
+.demo-wrapper {
+  max-width: 1200px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+/* Header typography and styling */
+.demo-header {
+  text-align: center;
+  max-width: 700px;
+  animation: fadeInDown 1s ease-out;
+}
+
+.demo-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2.2rem, 5vw, 3.5rem);
+  font-weight: 800;
+  line-height: 1.1;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, #ffffff 30%, #a5b4fc 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.03em;
+}
+
+.demo-header p {
+  font-size: clamp(0.95rem, 2vw, 1.15rem);
+  color: #a1a1aa;
+  font-weight: 300;
+  line-height: 1.6;
+}
+
+/* Interactive Hint Badge */
+.interaction-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: rgba(99, 102, 241, 0.1);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  color: #c7d2fe;
+  margin-top: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  animation: pulseHint 2s infinite ease-in-out;
+}
+
+/* ==========================================================================
+   3D PERSPECTIVE PHOTO STACK SYSTEM
+   ========================================================================== */
+
+/* Outer container to establish 3D space */
+.perspective-container {
+  perspective: 1400px;
+  perspective-origin: 50% 30%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 60px 0 100px 0;
+}
+
+/* Wrapper stack that coordinates children in 3D */
+.photo-stack {
+  position: relative;
+  width: 280px;
+  height: 370px;
+  transform-style: preserve-3d;
+  /* Slight initial tilt for depth, transition for resetting or hover */
+  transform: rotateX(12deg) rotateY(-10deg) rotateZ(0deg);
+  transition: transform 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* Smooth tilt adjust on hover over the container */
+.perspective-container:hover .photo-stack {
+  transform: rotateX(8deg) rotateY(-4deg) rotateZ(0deg);
+}
+
+/* Core photo card styling - resembles physical premium printed photo */
+.photo-card {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #ffffff;
+  padding: 10px 10px 45px 10px; /* Thicker bottom border for polaroid style */
+  box-sizing: border-box;
+  border-radius: 6px;
+  box-shadow: var(--card-shadow);
+  transform-style: preserve-3d;
+  cursor: pointer;
+  outline: none;
+
+  /* Smooth transition for fanning out, Z lifting, and Z-index ordering */
+  transition:
+    transform 0.6s cubic-bezier(0.25, 1, 0.5, 1),
+    box-shadow 0.5s ease,
+    background-color 0.5s ease;
+}
+
+/* Inner image container */
+.photo-card .image-wrapper {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: 4px;
+  background-color: #1e1e24;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  position: relative;
+}
+
+.photo-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition:
+    transform 0.6s cubic-bezier(0.25, 1, 0.5, 1),
+    filter 0.5s ease;
+  filter: grayscale(15%) contrast(105%);
+}
+
+/* Hovering photo details (Polaroid-style caption) */
+.photo-card .caption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 45px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-family: var(--font-sans);
+  color: #18181b;
+  box-sizing: border-box;
+  padding: 0 10px;
+}
+
+.photo-card .caption .title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.photo-card .caption .meta {
+  font-size: 0.65rem;
+  color: #71717a;
+  margin-top: 2px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Default state: Overlapping cards with rotation & translation for physical depth */
+.photo-card:nth-child(1) {
+  transform: translateZ(0px) rotateZ(-3deg) translateY(0px) translateX(0px);
+  z-index: 4;
+}
+
+.photo-card:nth-child(2) {
+  transform: translateZ(-25px) rotateZ(2deg) translateY(2px) translateX(4px);
+  z-index: 3;
+}
+
+.photo-card:nth-child(3) {
+  transform: translateZ(-50px) rotateZ(-1deg) translateY(4px) translateX(-4px);
+  z-index: 2;
+}
+
+.photo-card:nth-child(4) {
+  transform: translateZ(-75px) rotateZ(4deg) translateY(6px) translateX(6px);
+  z-index: 1;
+}
+
+/* ==========================================================================
+   HOVER ON STACK: FAN-OUT EFFECT (3D perspektive arc)
+   ========================================================================== */
+
+.perspective-container:hover .photo-card {
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+/* Spread cards horizontally, rotate outward (Y-axis), and bend outward (Z-axis) */
+.perspective-container:hover .photo-card:nth-child(1) {
+  transform: translate3d(-190px, -15px, 20px) rotateY(-18deg) rotateZ(-8deg);
+  z-index: 4;
+}
+
+.perspective-container:hover .photo-card:nth-child(2) {
+  transform: translate3d(-65px, 0px, 0px) rotateY(-6deg) rotateZ(-2deg);
+  z-index: 3;
+}
+
+.perspective-container:hover .photo-card:nth-child(3) {
+  transform: translate3d(65px, 0px, 0px) rotateY(6deg) rotateZ(2deg);
+  z-index: 2;
+}
+
+.perspective-container:hover .photo-card:nth-child(4) {
+  transform: translate3d(190px, -15px, 20px) rotateY(18deg) rotateZ(8deg);
+  z-index: 1;
+}
+
+/* ==========================================================================
+   HOVER ON INDIVIDUAL CARD: POP-OUT, FACE-VIEWER, & TOP ORDERING
+   ========================================================================== */
+
+/* Lift card forward, remove skew/tilt angles, and trigger maximum shadow */
+.perspective-container:hover .photo-card:hover {
+  z-index: 10 !important; /* Forces current hovered card on top of all others */
+  box-shadow: var(--card-shadow-hover);
+  background-color: #ffffff;
+}
+
+.perspective-container:hover .photo-card:hover img {
+  transform: scale(1.06);
+  filter: grayscale(0%) contrast(100%);
+}
+
+.perspective-container:hover .photo-card:nth-child(1):hover {
+  transform: translate3d(-190px, -45px, 140px) rotateY(0deg) rotateZ(0deg)
+    scale(1.08);
+}
+
+.perspective-container:hover .photo-card:nth-child(2):hover {
+  transform: translate3d(-65px, -35px, 140px) rotateY(0deg) rotateZ(0deg)
+    scale(1.08);
+}
+
+.perspective-container:hover .photo-card:nth-child(3):hover {
+  transform: translate3d(65px, -35px, 140px) rotateY(0deg) rotateZ(0deg)
+    scale(1.08);
+}
+
+.perspective-container:hover .photo-card:nth-child(4):hover {
+  transform: translate3d(190px, -45px, 140px) rotateY(0deg) rotateZ(0deg)
+    scale(1.08);
+}
+
+/* ==========================================================================
+   ACCESSIBILITY: KEYBOARD NAVIGATION (FOCUS-VISIBLE SUPPORT)
+   ========================================================================== */
+
+/* When focused, elevate card forward out of the stack, even if stack is not hovered */
+.photo-card:focus-visible {
+  z-index: 12 !important;
+  box-shadow: var(--card-shadow-hover);
+  background-color: #ffffff;
+  outline: 4px solid var(--accent-color);
+  outline-offset: 8px;
+}
+
+.photo-card:focus-visible img {
+  transform: scale(1.06);
+  filter: grayscale(0%) contrast(100%);
+}
+
+/* Focus transform details based on card position */
+.photo-card:nth-child(1):focus-visible {
+  transform: translate3d(-190px, -45px, 140px) rotateY(0deg) rotateZ(0deg)
+    scale(1.08);
+}
+
+.photo-card:nth-child(2):focus-visible {
+  transform: translate3d(-65px, -35px, 140px) rotateY(0deg) rotateZ(0deg)
+    scale(1.08);
+}
+
+.photo-card:nth-child(3):focus-visible {
+  transform: translate3d(65px, -35px, 140px) rotateY(0deg) rotateZ(0deg)
+    scale(1.08);
+}
+
+.photo-card:nth-child(4):focus-visible {
+  transform: translate3d(190px, -45px, 140px) rotateY(0deg) rotateZ(0deg)
+    scale(1.08);
+}
+
+/* ==========================================================================
+   INFO/CONTROLLER FOOTER PANEL
+   ========================================================================== */
+
+.demo-info {
+  background: var(--panel-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--border-glass);
+  padding: 1.5rem 2.5rem;
+  border-radius: 16px;
+  max-width: 600px;
+  text-align: left;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+  animation: fadeInUp 1s ease-out;
+}
+
+.info-title {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: #e2e8f0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.info-title::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background-color: var(--accent-color);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--accent-color);
+}
+
+.demo-info ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #a1a1aa;
+  font-size: 0.9rem;
+  line-height: 1.7;
+}
+
+.demo-info li {
+  margin-bottom: 0.5rem;
+}
+
+.demo-info strong {
+  color: #f4f4f5;
+  font-weight: 500;
+}
+
+/* ==========================================================================
+   ANIMATIONS & MEDIA QUERIES
+   ========================================================================== */
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulseHint {
+  0%,
+  100% {
+    opacity: 0.8;
+    transform: scale(1);
+    box-shadow: 0 0 0 rgba(99, 102, 241, 0);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.02);
+    box-shadow: 0 0 15px var(--accent-glow);
+  }
+}
+
+/* Responsive design adjustments */
+@media (max-width: 768px) {
+  body {
+    padding: 1rem;
+  }
+
+  .perspective-container {
+    padding: 20px 0 60px 0;
+    perspective: 1000px;
+  }
+
+  .photo-stack {
+    width: 200px;
+    height: 260px;
+    transform: rotateX(10deg) rotateY(-8deg);
+  }
+
+  .photo-card {
+    padding: 6px 6px 30px 6px;
+    border-radius: 4px;
+  }
+
+  .photo-card .caption {
+    height: 30px;
+  }
+
+  .photo-card .caption .title {
+    font-size: 0.7rem;
+  }
+
+  .photo-card .caption .meta {
+    font-size: 0.5rem;
+    margin-top: 0;
+  }
+
+  /* Compact fanning for smaller viewports */
+  .perspective-container:hover .photo-card:nth-child(1) {
+    transform: translate3d(-110px, -10px, 10px) rotateY(-14deg) rotateZ(-6deg);
+  }
+
+  .perspective-container:hover .photo-card:nth-child(2) {
+    transform: translate3d(-35px, 0px, 0px) rotateY(-4deg) rotateZ(-1deg);
+  }
+
+  .perspective-container:hover .photo-card:nth-child(3) {
+    transform: translate3d(35px, 0px, 0px) rotateY(4deg) rotateZ(1deg);
+  }
+
+  .perspective-container:hover .photo-card:nth-child(4) {
+    transform: translate3d(110px, -10px, 10px) rotateY(14deg) rotateZ(6deg);
+  }
+
+  /* Compact hover transforms */
+  .perspective-container:hover .photo-card:nth-child(1):hover {
+    transform: translate3d(-110px, -30px, 90px) rotateY(0deg) rotateZ(0deg)
+      scale(1.08);
+  }
+
+  .perspective-container:hover .photo-card:nth-child(2):hover {
+    transform: translate3d(-35px, -20px, 90px) rotateY(0deg) rotateZ(0deg)
+      scale(1.08);
+  }
+
+  .perspective-container:hover .photo-card:nth-child(3):hover {
+    transform: translate3d(35px, -20px, 90px) rotateY(0deg) rotateZ(0deg)
+      scale(1.08);
+  }
+
+  .perspective-container:hover .photo-card:nth-child(4):hover {
+    transform: translate3d(110px, -30px, 90px) rotateY(0deg) rotateZ(0deg)
+      scale(1.08);
+  }
+}
+
+/* Respect user preferences for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .photo-stack,
+  .photo-card,
+  .photo-card img,
+  .interaction-hint {
+    transition: none !important;
+    animation: none !important;
+  }
+
+  .perspective-container {
+    perspective: none !important;
+  }
+
+  .photo-stack {
+    transform: none !important;
+  }
+
+  /* Simplify state changes to simple shifts without angles */
+  .perspective-container:hover .photo-card:nth-child(1) {
+    transform: translateX(-120px) !important;
+  }
+
+  .perspective-container:hover .photo-card:nth-child(2) {
+    transform: translateX(-40px) !important;
+  }
+
+  .perspective-container:hover .photo-card:nth-child(3) {
+    transform: translateX(40px) !important;
+  }
+
+  .perspective-container:hover .photo-card:nth-child(4) {
+    transform: translateX(120px) !important;
+  }
+
+  .perspective-container:hover .photo-card:hover {
+    transform: translateZ(0) scale(1.05) !important;
+  }
+}


### PR DESCRIPTION
Closes #10991

### Description
This PR implements a pure CSS-only interactive 3D Perspective Photo Stack component with a premium physical Polaroid deck design. On stack hover, the cards fan out in a 3D perspective arc, and on individual card hover/focus-visible, they rotate flat to face the viewer, pop out using translateZ, and lift to the top of the stack.

### Features Implemented
- **3D Perspective & Layout:** Utilizes `perspective` and `transform-style: preserve-3d` to create a realistic physical card deck.
- **Subtle Offset & Tilt:** Cards have default rotation and Z-axis offset to show depth.
- **3D Fan-out Arc:** Spreads cards horizontally and rotates them on hover.
- **Individual Hover/Focus Pop:** Resets angles, translates closer in Z, and brings the card to front.
- **Keyboard Accessibility:** Fully focusable with `:focus-visible` support.
- **Responsive Design:** Adapts to small screens and handles reduced motion preferences.