### PR TITLE
feat: add CSS-only morphing skeleton loader grid to content reveal (#11022)

### DIFF
--- a/submissions/examples/morphing-skeleton-grid-pp/README.md
+++ b/submissions/examples/morphing-skeleton-grid-pp/README.md
@@ -1,0 +1,64 @@
+# CSS-Only Morphing Skeleton Grid to Content Reveal
+
+## What does this do?
+
+This component implements a responsive, highly polished dashboard grid of cards that smoothly morph from animated skeleton shimmers into rich loaded content cards (containing images, user profiles, interactive buttons, metrics, and media players) when triggered. The entire interaction and transition logic is implemented strictly in pure CSS.
+
+## How is it used?
+
+Structure your markup inside a `.morph-card` container holding a `.skeleton-layer` and a `.content-layer`. Use a checkbox toggle (e.g. at the top of the grid or inside the card) or card hover/focus states to trigger the active reveal state:
+
+```html
+<div class="morph-card">
+  <!-- Sibling Trigger (for standalone card triggers) -->
+  <input type="checkbox" id="card-trigger" class="card-trigger-checkbox" />
+
+  <!-- Skeleton Layer (Displayed by default) -->
+  <div class="skeleton-layer">
+    <div class="skeleton-media shimmer-block"></div>
+    <div class="skeleton-row-meta">
+      <div class="skeleton-circle shimmer-block"></div>
+      <div class="skeleton-meta-lines">
+        <div class="skeleton-line shimmer-block"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Content Layer (Revealed on active state) -->
+  <div class="content-layer">
+    <div class="content-media">
+      <img src="..." alt="Media" />
+    </div>
+    <div class="content-meta">
+      <img class="content-avatar" src="..." alt="Avatar" />
+      <h3 class="content-title">Loaded Content</h3>
+    </div>
+  </div>
+</div>
+```
+
+## Why is it useful?
+
+Typical page loading indicators or skeleton loaders switch content instantly using JavaScript `display: none` / `display: block` or direct DOM injection. This results in visual stuttering and reflow layout shifts as components snap into place.
+
+Key architectural advantages of this pure CSS approach:
+
+- **Morphing Shape Coordinate Alignment**: By matching the size, positioning, and borders of the skeleton placeholders to their rich counterparts, we trigger synchronized scaling and opacity transitions that simulate actual shapes morphing (e.g. skeleton circle shrinking into the profile image, text bars collapsing as text fades and slides up).
+- **Background-Position Shimmer**: Creates a subtle left-to-right pulse shimmer using a moving linear gradient background, animated smoothly via CSS keyframes.
+- **Staggered Content Reveals**: Employs staggered `transition-delay` sequences on sibling children in the content layer, allowing images to render first, followed by headings, description lines, and interactive buttons for a premium "cascading load" effect.
+- **Dual Trigger Mechanics**: Combines a global `:has()` selector trigger (for simulation control checkboxes) with individual `:hover` triggers, allowing developers to test loading states both dashboard-wide and card-by-card.
+- **A11y & Reduced Motion Friendly**: Detects user preferences via `@media (prefers-reduced-motion: reduce)` to disable the shimmer animation and layout transforms, performing an instant flat opacity crossfade transition instead.
+
+## Tech Stack
+
+- HTML5
+- CSS3 (CSS Grids, `:has()` Selectors, Shimmer animations, Staggered transitions, Custom bezier curves)
+
+## Preview
+
+Open `demo.html` directly in any modern web browser to view and interact with the Morphing Skeleton Grid.
+
+## Contribution Notes
+
+- Class naming was handled by the contributor (`pp`).
+- Maintainer will rename classes to standard `ease-*` conventions (e.g. `.ease-morph-card`, `.ease-shimmer-block`) and map colors to the framework's theme variables upon merge.

--- a/submissions/examples/morphing-skeleton-grid-pp/demo.html
+++ b/submissions/examples/morphing-skeleton-grid-pp/demo.html
@@ -1,0 +1,587 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS-Only Morphing Skeleton Loader Grid to Content Reveal</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Dashboard Main Header -->
+    <header class="dashboard-header">
+      <h1>Morphing Skeleton Grid</h1>
+      <p>
+        A pure CSS implementation showcasing card grids that smoothly morph from
+        animated skeleton shimmers to rich interactive modules. Hover over cards
+        to preview individual loaded states, or toggle the global simulation
+        below.
+      </p>
+    </header>
+
+    <!-- Global Switch Simulation Controls -->
+    <div class="controls-panel">
+      <span class="control-label">Simulation Control:</span>
+      <label class="toggle-switch">
+        <input type="checkbox" id="global-reveal-checkbox" />
+        <span class="toggle-slider">
+          <span class="toggle-text left">Skeleton</span>
+          <span class="toggle-text right">Live</span>
+        </span>
+      </label>
+    </div>
+
+    <!-- Cards Grid Layout -->
+    <main class="cards-grid">
+      <!-- Card 1: Blog Post Card -->
+      <div class="morph-card">
+        <!-- Skeleton State Layer -->
+        <div class="skeleton-layer">
+          <div class="skeleton-media shimmer-block"></div>
+          <div class="skeleton-row-meta">
+            <div class="skeleton-circle shimmer-block"></div>
+            <div class="skeleton-meta-lines">
+              <div class="skeleton-line shimmer-block"></div>
+              <div class="skeleton-line short shimmer-block"></div>
+            </div>
+          </div>
+          <div class="skeleton-desc">
+            <div class="skeleton-line shimmer-block"></div>
+            <div class="skeleton-line shimmer-block"></div>
+            <div class="skeleton-line short shimmer-block"></div>
+          </div>
+          <div class="skeleton-actions">
+            <div class="skeleton-badge shimmer-block"></div>
+            <div class="skeleton-btn shimmer-block"></div>
+          </div>
+        </div>
+
+        <!-- Rich Loaded Content Layer -->
+        <div class="content-layer">
+          <div class="content-media">
+            <svg
+              width="100%"
+              height="100%"
+              viewBox="0 0 400 200"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#00f2fe" stop-opacity="0.1" />
+                  <stop offset="100%" stop-color="#4facfe" stop-opacity="0.2" />
+                </linearGradient>
+              </defs>
+              <rect width="100%" height="100%" fill="url(#grad1)" />
+              <circle
+                cx="200"
+                cy="100"
+                r="45"
+                fill="none"
+                stroke="#00f2fe"
+                stroke-width="2"
+                stroke-dasharray="8 4"
+                opacity="0.6"
+              />
+              <path
+                d="M 120 120 Q 200 40 280 120"
+                stroke="#4facfe"
+                stroke-width="3"
+                fill="none"
+                opacity="0.8"
+              />
+              <circle cx="200" cy="80" r="6" fill="#00f2fe" />
+            </svg>
+            <div class="content-overlay">
+              <span class="media-tag">Engineering</span>
+            </div>
+          </div>
+          <div class="content-meta">
+            <img
+              class="content-avatar"
+              src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' fill='%2300f2fe'><circle cx='50' cy='50' r='50'/><text x='50%25' y='55%25' dominant-baseline='middle' text-anchor='middle' fill='%230b0b0f' font-family='sans-serif' font-weight='bold' font-size='40'>AD</text></svg>"
+              alt="Avatar"
+            />
+            <div class="content-meta-text">
+              <span class="content-meta-name">Alex Dev</span>
+              <span class="content-meta-sub">Posted 2 hours ago</span>
+            </div>
+          </div>
+          <h3 class="content-title">Next-Gen CSS Easing Architecture</h3>
+          <p class="content-desc">
+            Explore the performance impact of fluid cubic-bezier curves vs
+            linear spring simulations for zero-dependency web animations.
+          </p>
+          <div class="content-footer">
+            <span class="content-badge">5 min read</span>
+            <button class="content-btn">Read Article</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Card 2: E-Commerce / Showcase Card -->
+      <div class="morph-card card-variant-2">
+        <!-- Skeleton State Layer -->
+        <div class="skeleton-layer">
+          <div class="skeleton-media shimmer-block"></div>
+          <div class="skeleton-row-meta">
+            <div class="skeleton-circle shimmer-block"></div>
+            <div class="skeleton-meta-lines">
+              <div class="skeleton-line shimmer-block"></div>
+              <div class="skeleton-line short shimmer-block"></div>
+            </div>
+          </div>
+          <div class="skeleton-desc">
+            <div class="skeleton-line shimmer-block"></div>
+            <div class="skeleton-line shimmer-block"></div>
+            <div class="skeleton-line short shimmer-block"></div>
+          </div>
+          <div class="skeleton-actions">
+            <div class="skeleton-badge shimmer-block"></div>
+            <div class="skeleton-btn shimmer-block"></div>
+          </div>
+        </div>
+
+        <!-- Rich Loaded Content Layer -->
+        <div class="content-layer">
+          <div class="content-media">
+            <svg
+              width="100%"
+              height="100%"
+              viewBox="0 0 400 200"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <linearGradient id="grad2" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#7f00ff" stop-opacity="0.1" />
+                  <stop offset="100%" stop-color="#e100ff" stop-opacity="0.2" />
+                </linearGradient>
+              </defs>
+              <rect width="100%" height="100%" fill="url(#grad2)" />
+              <rect
+                x="150"
+                y="50"
+                width="100"
+                height="100"
+                rx="15"
+                fill="none"
+                stroke="#e100ff"
+                stroke-width="2"
+                opacity="0.7"
+              />
+              <circle
+                cx="200"
+                cy="100"
+                r="20"
+                fill="none"
+                stroke="#7f00ff"
+                stroke-width="2"
+              />
+            </svg>
+            <div class="content-overlay">
+              <span class="media-tag">Hardware</span>
+            </div>
+          </div>
+          <div class="content-meta">
+            <img
+              class="content-avatar"
+              src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' fill='%23e100ff'><circle cx='50' cy='50' r='50'/><text x='50%25' y='55%25' dominant-baseline='middle' text-anchor='middle' fill='%230b0b0f' font-family='sans-serif' font-weight='bold' font-size='40'>X</text></svg>"
+              alt="Avatar"
+            />
+            <div class="content-meta-text">
+              <span class="content-meta-name">X-Wearables</span>
+              <span class="content-meta-sub">In stock</span>
+            </div>
+          </div>
+          <h3 class="content-title">AeroWatch Series X</h3>
+          <p class="content-desc">
+            Always-on retina display with custom haptic feedback animations,
+            health index tracking, and modular titanium straps.
+          </p>
+          <div class="content-footer">
+            <span class="content-badge">$299.00</span>
+            <button class="content-btn">Pre-order</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Card 3: Profile Card Variant -->
+      <div class="morph-card card-variant-3">
+        <!-- Skeleton State Layer -->
+        <div class="skeleton-layer">
+          <div class="profile-card-media shimmer-block">
+            <div class="profile-card-avatar-container">
+              <div class="skeleton-circle shimmer-block"></div>
+            </div>
+          </div>
+          <div class="skeleton-profile-header skeleton-meta-lines">
+            <div class="skeleton-line short shimmer-block"></div>
+            <div class="skeleton-line x-short shimmer-block"></div>
+          </div>
+          <div class="skeleton-desc">
+            <div class="skeleton-line shimmer-block"></div>
+            <div class="skeleton-line short shimmer-block"></div>
+          </div>
+          <div class="skeleton-actions">
+            <div class="skeleton-badge shimmer-block"></div>
+            <div class="skeleton-btn shimmer-block"></div>
+          </div>
+        </div>
+
+        <!-- Rich Loaded Content Layer -->
+        <div class="content-layer">
+          <div class="profile-card-media">
+            <svg
+              width="100%"
+              height="120px"
+              viewBox="0 0 400 120"
+              xmlns="http://www.w3.org/2000/svg"
+              style="border-radius: 16px"
+            >
+              <defs>
+                <linearGradient id="grad3" x1="0%" y1="0%" x2="100%" y2="0%">
+                  <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.2" />
+                  <stop offset="100%" stop-color="#1d4ed8" stop-opacity="0.2" />
+                </linearGradient>
+              </defs>
+              <rect width="100%" height="100%" fill="url(#grad3)" />
+              <path
+                d="M 0 80 Q 100 40 200 80 T 400 80 L 400 120 L 0 120 Z"
+                fill="#1e1e28"
+                opacity="0.3"
+              />
+            </svg>
+            <div class="profile-card-avatar-container">
+              <img
+                class="content-avatar"
+                src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' fill='%233b82f6'><circle cx='50' cy='50' r='50'/><text x='50%25' y='55%25' dominant-baseline='middle' text-anchor='middle' fill='%23f3f4f6' font-family='sans-serif' font-weight='bold' font-size='40'>EV</text></svg>"
+                alt="Avatar"
+              />
+            </div>
+          </div>
+          <div class="content-meta-text">
+            <span class="content-meta-name" style="font-size: 1.25rem"
+              >Eleanor Vance</span
+            >
+            <span class="content-meta-sub">Principal Motion Architect</span>
+          </div>
+          <p class="content-desc">
+            Specializing in fluid micro-interactions, responsive kinetics, and
+            interactive SVG illustrations for high-end web applications.
+          </p>
+          <div class="content-footer">
+            <span class="content-badge">London, UK</span>
+            <button
+              class="content-btn"
+              style="
+                background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+                color: white;
+                box-shadow: 0 4px 10px rgba(59, 130, 246, 0.2);
+              "
+            >
+              Hire Me
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Card 4: Metrics / Dashboard Indicator Card -->
+      <div class="morph-card">
+        <!-- Skeleton State Layer -->
+        <div class="skeleton-layer">
+          <div class="skeleton-media shimmer-block" style="height: 120px"></div>
+          <div class="skeleton-desc" style="margin-top: 1rem">
+            <div
+              class="skeleton-line short shimmer-block"
+              style="height: 20px"
+            ></div>
+            <div
+              class="skeleton-line x-short shimmer-block"
+              style="height: 40px; margin-top: 0.5rem"
+            ></div>
+            <div class="skeleton-line shimmer-block"></div>
+            <div class="skeleton-line short shimmer-block"></div>
+          </div>
+          <div class="skeleton-actions" style="margin-top: auto">
+            <div class="skeleton-badge shimmer-block"></div>
+            <div class="skeleton-btn shimmer-block"></div>
+          </div>
+        </div>
+
+        <!-- Rich Loaded Content Layer -->
+        <div class="content-layer">
+          <div class="content-media" style="height: 120px">
+            <svg
+              width="100%"
+              height="100%"
+              viewBox="0 0 400 120"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <linearGradient id="grad4" x1="0%" y1="100%" x2="0%" y2="0%">
+                  <stop offset="0%" stop-color="#10b981" stop-opacity="0.05" />
+                  <stop offset="100%" stop-color="#10b981" stop-opacity="0.2" />
+                </linearGradient>
+              </defs>
+              <rect width="100%" height="100%" fill="url(#grad4)" />
+              <path
+                d="M 0 100 Q 80 40 160 80 T 320 30 L 400 60"
+                fill="none"
+                stroke="#10b981"
+                stroke-width="3"
+                stroke-linecap="round"
+              />
+              <circle cx="320" cy="30" r="5" fill="#10b981" />
+            </svg>
+            <div class="content-overlay">
+              <span
+                class="media-tag"
+                style="
+                  background: rgba(16, 185, 129, 0.15);
+                  border-color: rgba(16, 185, 129, 0.3);
+                  color: #10b981;
+                "
+                >Analytics</span
+              >
+            </div>
+          </div>
+          <h3
+            class="content-title"
+            style="
+              margin-top: 0.5rem;
+              font-size: 1rem;
+              color: var(--text-secondary);
+            "
+          >
+            Active Subscriptions
+          </h3>
+          <div class="metrics-display">
+            <span class="metrics-number">24,890</span>
+            <span class="metrics-trend">+12.4%</span>
+          </div>
+          <p class="content-desc">
+            Weekly conversion metrics showing accelerated user onboarding and
+            retention optimization across active tiers.
+          </p>
+          <div class="content-footer">
+            <span class="content-badge">Updated 10m ago</span>
+            <button
+              class="content-btn"
+              style="
+                background: linear-gradient(135deg, #10b981, #059669);
+                color: white;
+                box-shadow: 0 4px 10px rgba(16, 185, 129, 0.2);
+              "
+            >
+              View Report
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Card 5: Media / Music Player Card -->
+      <div class="morph-card card-variant-2">
+        <!-- Skeleton State Layer -->
+        <div class="skeleton-layer">
+          <div class="skeleton-media shimmer-block"></div>
+          <div class="skeleton-row-meta">
+            <div class="skeleton-circle shimmer-block"></div>
+            <div class="skeleton-meta-lines">
+              <div class="skeleton-line shimmer-block"></div>
+              <div class="skeleton-line short shimmer-block"></div>
+            </div>
+          </div>
+          <div class="skeleton-desc">
+            <div class="skeleton-line shimmer-block"></div>
+            <div class="skeleton-line short shimmer-block"></div>
+          </div>
+          <div class="skeleton-actions">
+            <div class="skeleton-badge shimmer-block"></div>
+            <div class="skeleton-btn shimmer-block"></div>
+          </div>
+        </div>
+
+        <!-- Rich Loaded Content Layer -->
+        <div class="content-layer">
+          <div class="content-media">
+            <svg
+              width="100%"
+              height="100%"
+              viewBox="0 0 400 200"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <linearGradient id="grad5" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#ec4899" stop-opacity="0.1" />
+                  <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0.2" />
+                </linearGradient>
+              </defs>
+              <rect width="100%" height="100%" fill="url(#grad5)" />
+              <polygon
+                points="175,70 235,100 175,130"
+                fill="none"
+                stroke="#ec4899"
+                stroke-width="3"
+                stroke-linejoin="round"
+              />
+              <circle
+                cx="200"
+                cy="100"
+                r="50"
+                fill="none"
+                stroke="#8b5cf6"
+                stroke-width="2"
+                opacity="0.5"
+              />
+            </svg>
+            <div class="content-overlay">
+              <span
+                class="media-tag"
+                style="
+                  background: rgba(236, 72, 153, 0.15);
+                  border-color: rgba(236, 72, 153, 0.3);
+                  color: #ec4899;
+                "
+                >Audio</span
+              >
+            </div>
+          </div>
+          <div class="song-info">
+            <h3 class="content-title" style="margin-bottom: 0.25rem">
+              Synthetic Dreams
+            </h3>
+            <span style="font-size: 0.8rem; color: var(--text-secondary)"
+              >Retrowave Syndicate</span
+            >
+          </div>
+          <div class="progress-track">
+            <div class="progress-fill"></div>
+          </div>
+          <div class="player-controls">
+            <button class="player-btn">&#x23ee;</button>
+            <button class="player-btn play">&#x25b6;</button>
+            <button class="player-btn">&#x23ed;</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Card 6: Standalone Click Toggle Card -->
+      <label class="toggle-card-label" for="card-6-checkbox">
+        <div class="morph-card">
+          <!-- Standalone Trigger -->
+          <input
+            type="checkbox"
+            id="card-6-checkbox"
+            class="card-trigger-checkbox"
+          />
+
+          <span class="toggle-indicator">Click to test</span>
+
+          <!-- Skeleton State Layer -->
+          <div class="skeleton-layer">
+            <div class="skeleton-media shimmer-block"></div>
+            <div class="skeleton-row-meta">
+              <div class="skeleton-circle shimmer-block"></div>
+              <div class="skeleton-meta-lines">
+                <div class="skeleton-line shimmer-block"></div>
+                <div class="skeleton-line short shimmer-block"></div>
+              </div>
+            </div>
+            <div class="skeleton-desc">
+              <div class="skeleton-line shimmer-block"></div>
+              <div class="skeleton-line shimmer-block"></div>
+              <div class="skeleton-line short shimmer-block"></div>
+            </div>
+            <div class="skeleton-actions">
+              <div class="skeleton-badge shimmer-block"></div>
+              <div class="skeleton-btn shimmer-block"></div>
+            </div>
+          </div>
+
+          <!-- Rich Loaded Content Layer -->
+          <div class="content-layer">
+            <div class="content-media">
+              <svg
+                width="100%"
+                height="100%"
+                viewBox="0 0 400 200"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <defs>
+                  <linearGradient
+                    id="grad6"
+                    x1="0%"
+                    y1="0%"
+                    x2="100%"
+                    y2="100%"
+                  >
+                    <stop offset="0%" stop-color="#eab308" stop-opacity="0.1" />
+                    <stop
+                      offset="100%"
+                      stop-color="#3b82f6"
+                      stop-opacity="0.2"
+                    />
+                  </linearGradient>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#grad6)" />
+                <path
+                  d="M 150 70 L 250 70 L 200 140 Z"
+                  fill="none"
+                  stroke="#eab308"
+                  stroke-width="2"
+                />
+                <circle
+                  cx="200"
+                  cy="90"
+                  r="15"
+                  fill="none"
+                  stroke="#3b82f6"
+                  stroke-width="2"
+                />
+              </svg>
+              <div class="content-overlay">
+                <span
+                  class="media-tag"
+                  style="
+                    background: rgba(234, 179, 8, 0.15);
+                    border-color: rgba(234, 179, 8, 0.3);
+                    color: #eab308;
+                  "
+                  >Interactive</span
+                >
+              </div>
+            </div>
+            <div class="content-meta">
+              <img
+                class="content-avatar"
+                src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' fill='%23eab308'><circle cx='50' cy='50' r='50'/><text x='50%25' y='55%25' dominant-baseline='middle' text-anchor='middle' fill='%230b0b0f' font-family='sans-serif' font-weight='bold' font-size='40'>SL</text></svg>"
+                alt="Avatar"
+              />
+              <div class="content-meta-text">
+                <span class="content-meta-name">Self-Loader</span>
+                <span class="content-meta-sub">Active State</span>
+              </div>
+            </div>
+            <h3 class="content-title">Standalone Trigger Mode</h3>
+            <p class="content-desc">
+              Clicking this card toggles its state independently. Uses a hidden
+              sibling checkbox hack to capture standard user click states in
+              pure CSS.
+            </p>
+            <div class="content-footer">
+              <span class="content-badge">Hacked checkbox</span>
+              <button
+                class="content-btn"
+                style="
+                  background: linear-gradient(135deg, #eab308, #ca8a04);
+                  color: #0b0b0f;
+                  box-shadow: 0 4px 10px rgba(234, 179, 8, 0.2);
+                "
+              >
+                Reset
+              </button>
+            </div>
+          </div>
+        </div>
+      </label>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/morphing-skeleton-grid-pp/style.css
+++ b/submissions/examples/morphing-skeleton-grid-pp/style.css
@@ -1,0 +1,803 @@
+/* Morphing Skeleton Loader Grid Stylesheet */
+
+/* Import Outfit Font */
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap");
+
+:root {
+  --bg-color: #0b0b0f;
+  --card-bg: rgba(22, 22, 30, 0.7);
+  --card-border: rgba(255, 255, 255, 0.05);
+  --text-primary: #f3f4f6;
+  --text-secondary: #9ca3af;
+  --accent-cyan: #00f2fe;
+  --accent-blue: #4facfe;
+  --accent-purple: #7f00ff;
+  --accent-magenta: #e100ff;
+
+  /* Skeleton Variables */
+  --skeleton-base: rgba(255, 255, 255, 0.04);
+  --skeleton-highlight: rgba(255, 255, 255, 0.1);
+  --shimmer-duration: 1.8s;
+
+  /* Custom easing curves */
+  --ease-out-back: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-in-out-quint: cubic-bezier(0.83, 0, 0.17, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Outfit", sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+  overflow-x: hidden;
+  background-image:
+    radial-gradient(
+      circle at 10% 20%,
+      rgba(0, 242, 254, 0.03) 0%,
+      transparent 40%
+    ),
+    radial-gradient(
+      circle at 90% 80%,
+      rgba(127, 0, 255, 0.04) 0%,
+      transparent 40%
+    );
+}
+
+/* Header Styles */
+.dashboard-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+  max-width: 800px;
+}
+
+.dashboard-header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(
+    135deg,
+    var(--text-primary) 30%,
+    var(--text-secondary)
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.03em;
+}
+
+.dashboard-header p {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  font-weight: 300;
+}
+
+/* Global Simulation Switch */
+.controls-panel {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--card-border);
+  padding: 1rem 2rem;
+  border-radius: 50px;
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-bottom: 3rem;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.3);
+}
+
+.control-label {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 140px;
+  height: 40px;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: 0.4s var(--ease-in-out-quint);
+  border-radius: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem;
+}
+
+.toggle-slider::before {
+  content: "";
+  position: absolute;
+  height: 32px;
+  width: 66px;
+  left: 3px;
+  bottom: 3px;
+  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-blue));
+  transition: 0.4s var(--ease-in-out-quint);
+  border-radius: 20px;
+  box-shadow: 0 4px 15px rgba(0, 242, 254, 0.4);
+  z-index: 1;
+}
+
+.toggle-text {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  z-index: 2;
+  transition: color 0.3s;
+}
+
+.toggle-text.left {
+  color: #0b0b0f;
+}
+
+.toggle-text.right {
+  color: var(--text-secondary);
+}
+
+/* Toggle Interactions */
+input:checked + .toggle-slider::before {
+  transform: translateX(66px);
+  background: linear-gradient(
+    135deg,
+    var(--accent-purple),
+    var(--accent-magenta)
+  );
+  box-shadow: 0 4px 15px rgba(127, 0, 255, 0.4);
+}
+
+input:checked + .toggle-slider .toggle-text.left {
+  color: var(--text-secondary);
+}
+
+input:checked + .toggle-slider .toggle-text.right {
+  color: #0b0b0f;
+}
+
+/* Grid Container */
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 2rem;
+  width: 100%;
+  max-width: 1100px;
+  margin-bottom: 2rem;
+}
+
+/* Card Container Styles */
+.morph-card {
+  position: relative;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  overflow: hidden;
+  height: 400px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(16px);
+  transition:
+    transform 0.4s var(--ease-out-back),
+    border-color 0.4s ease,
+    box-shadow 0.4s ease;
+  transform-style: preserve-3d;
+  perspective: 1000px;
+}
+
+.morph-card:hover {
+  transform: translateY(-8px);
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 12px 40px rgba(0, 242, 254, 0.08);
+}
+
+/* Individual Card Checkbox for Card-Level Toggle */
+.card-trigger-checkbox {
+  display: none;
+}
+
+/* Layers: Skeleton vs Content */
+.skeleton-layer,
+.content-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  transition:
+    opacity 0.5s var(--ease-in-out-quint),
+    transform 0.5s var(--ease-in-out-quint),
+    visibility 0.5s;
+  pointer-events: none;
+}
+
+.skeleton-layer {
+  opacity: 1;
+  visibility: visible;
+  z-index: 2;
+  transform: scale(1);
+}
+
+.content-layer {
+  opacity: 0;
+  visibility: hidden;
+  z-index: 1;
+  transform: scale(0.95) translateY(10px);
+}
+
+/* Global Switch Trigger logic */
+body:has(#global-reveal-checkbox:checked) .content-layer {
+  opacity: 1;
+  visibility: visible;
+  z-index: 2;
+  transform: scale(1) translateY(0);
+  pointer-events: auto;
+}
+
+body:has(#global-reveal-checkbox:checked) .skeleton-layer {
+  opacity: 0;
+  visibility: hidden;
+  z-index: 1;
+  transform: scale(1.05) translateY(-10px);
+}
+
+/* Individual Hover Trigger logic (only active when global loader is NOT checked) */
+body:not(:has(#global-reveal-checkbox:checked))
+  .morph-card:hover
+  .content-layer {
+  opacity: 1;
+  visibility: visible;
+  z-index: 2;
+  transform: scale(1) translateY(0);
+  pointer-events: auto;
+}
+
+body:not(:has(#global-reveal-checkbox:checked))
+  .morph-card:hover
+  .skeleton-layer {
+  opacity: 0;
+  visibility: hidden;
+  z-index: 1;
+  transform: scale(1.05) translateY(-10px);
+}
+
+/* Sibling check logic for alternative standalone triggers */
+.card-trigger-checkbox:checked ~ .content-layer {
+  opacity: 1;
+  visibility: visible;
+  z-index: 2;
+  transform: scale(1) translateY(0);
+  pointer-events: auto;
+}
+
+.card-trigger-checkbox:checked ~ .skeleton-layer {
+  opacity: 0;
+  visibility: hidden;
+  z-index: 1;
+  transform: scale(1.05) translateY(-10px);
+}
+
+/* Shimmer Animation */
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.shimmer-block {
+  background: linear-gradient(
+    90deg,
+    var(--skeleton-base) 25%,
+    var(--skeleton-highlight) 37%,
+    var(--skeleton-base) 50%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer var(--shimmer-duration) infinite linear;
+  border-radius: 4px;
+  transition:
+    transform 0.4s var(--ease-out-back),
+    border-radius 0.4s ease,
+    opacity 0.3s ease;
+}
+
+/* Skeleton Layout Structures */
+.skeleton-media {
+  width: 100%;
+  height: 180px;
+  border-radius: 16px;
+  margin-bottom: 1.25rem;
+}
+
+.skeleton-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.skeleton-circle {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skeleton-meta-lines {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 6px;
+  width: 100%;
+}
+
+.skeleton-line.short {
+  width: 60%;
+}
+
+.skeleton-line.x-short {
+  width: 40%;
+}
+
+.skeleton-desc {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  flex-grow: 1;
+}
+
+.skeleton-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.skeleton-btn {
+  height: 36px;
+  width: 90px;
+  border-radius: 18px;
+}
+
+.skeleton-badge {
+  height: 24px;
+  width: 60px;
+  border-radius: 12px;
+}
+
+/* Content Layout Components */
+.content-media {
+  width: 100%;
+  height: 180px;
+  border-radius: 16px;
+  margin-bottom: 1.25rem;
+  overflow: hidden;
+  position: relative;
+  background: #1e1e28;
+}
+
+.content-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.6s var(--ease-out-back);
+}
+
+.morph-card:hover .content-media img {
+  transform: scale(1.08);
+}
+
+.content-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    to bottom,
+    transparent 40%,
+    rgba(15, 15, 20, 0.9)
+  );
+  display: flex;
+  align-items: flex-end;
+  padding: 1rem;
+}
+
+.media-tag {
+  background: rgba(0, 242, 254, 0.15);
+  border: 1px solid rgba(0, 242, 254, 0.3);
+  color: var(--accent-cyan);
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.content-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.content-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  transition: transform 0.4s var(--ease-out-back);
+}
+
+.morph-card:hover .content-avatar {
+  transform: rotate(5deg) scale(1.1);
+}
+
+.content-meta-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.content-meta-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.content-meta-sub {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.content-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+
+.content-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 1.5rem;
+  flex-grow: 1;
+  font-weight: 300;
+}
+
+.content-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+}
+
+.content-btn {
+  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-blue));
+  border: none;
+  color: #0b0b0f;
+  padding: 0.5rem 1.25rem;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 10px rgba(0, 242, 254, 0.2);
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
+}
+
+.content-btn:hover {
+  transform: scale(1.05);
+  box-shadow: 0 6px 15px rgba(0, 242, 254, 0.35);
+}
+
+.content-badge {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+/* Card Variance Examples Styling */
+
+/* Card 2 Accent (Orange/Purple) */
+.card-variant-2 .media-tag {
+  background: rgba(127, 0, 255, 0.15);
+  border: 1px solid rgba(127, 0, 255, 0.3);
+  color: #a855f7;
+}
+
+.card-variant-2 .content-btn {
+  background: linear-gradient(
+    135deg,
+    var(--accent-purple),
+    var(--accent-magenta)
+  );
+  color: var(--text-primary);
+  box-shadow: 0 4px 10px rgba(127, 0, 255, 0.2);
+}
+
+.card-variant-2 .content-btn:hover {
+  box-shadow: 0 6px 15px rgba(127, 0, 255, 0.35);
+}
+
+/* Card 3 Profile Card Variant */
+.profile-card-media {
+  height: 120px;
+  background: linear-gradient(135deg, #1f2937, #111827);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  margin-bottom: 3.5rem;
+  position: relative;
+}
+
+.profile-card-avatar-container {
+  position: absolute;
+  bottom: -30px;
+  left: 1.5rem;
+}
+
+.profile-card-avatar-container .content-avatar {
+  width: 70px;
+  height: 70px;
+  border: 4px solid var(--bg-color);
+}
+
+.profile-card-avatar-container .skeleton-circle {
+  width: 70px;
+  height: 70px;
+  border: 4px solid var(--bg-color);
+}
+
+.skeleton-profile-header {
+  margin-bottom: 4rem;
+}
+
+.card-variant-3 .content-desc {
+  margin-top: 1rem;
+}
+
+/* Card 4 Metrics Variant */
+.metrics-display {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.metrics-number {
+  font-size: 2.5rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--text-primary), var(--accent-cyan));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.metrics-trend {
+  color: #10b981;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.metrics-trend.negative {
+  color: #ef4444;
+}
+
+/* Card 5 Music Player Variant */
+.player-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: auto;
+}
+
+.player-btn {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    transform 0.2s;
+}
+
+.player-btn:hover {
+  color: var(--accent-cyan);
+  transform: scale(1.15);
+}
+
+.player-btn.play {
+  font-size: 2.2rem;
+  color: var(--accent-cyan);
+}
+
+.progress-track {
+  width: 100%;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  margin: 1.5rem 0 1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.progress-fill {
+  width: 65%;
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent-cyan), var(--accent-blue));
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.song-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+/* Card 6 Interactive Toggle Card (Card triggers itself on click) */
+.toggle-card-label {
+  cursor: pointer;
+}
+
+.toggle-card-label:hover .morph-card {
+  border-color: rgba(0, 242, 254, 0.25);
+  box-shadow: 0 12px 40px rgba(0, 242, 254, 0.12);
+}
+
+.toggle-indicator {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.25rem 0.5rem;
+  border-radius: 12px;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  border: 1px solid var(--card-border);
+  z-index: 10;
+}
+
+/* Morph transition delays to staggered lines */
+.content-layer > * {
+  transition:
+    transform 0.5s var(--ease-out-back),
+    opacity 0.5s ease;
+}
+
+/* Apply staggered fade-in animations to content details when loaded */
+body:has(#global-reveal-checkbox:checked) .content-layer > *:nth-child(1) {
+  transition-delay: 0.05s;
+}
+body:has(#global-reveal-checkbox:checked) .content-layer > *:nth-child(2) {
+  transition-delay: 0.15s;
+}
+body:has(#global-reveal-checkbox:checked) .content-layer > *:nth-child(3) {
+  transition-delay: 0.25s;
+}
+body:has(#global-reveal-checkbox:checked) .content-layer > *:nth-child(4) {
+  transition-delay: 0.35s;
+}
+
+body:not(:has(#global-reveal-checkbox:checked))
+  .morph-card:hover
+  .content-layer
+  > *:nth-child(1) {
+  transition-delay: 0.05s;
+}
+body:not(:has(#global-reveal-checkbox:checked))
+  .morph-card:hover
+  .content-layer
+  > *:nth-child(2) {
+  transition-delay: 0.15s;
+}
+body:not(:has(#global-reveal-checkbox:checked))
+  .morph-card:hover
+  .content-layer
+  > *:nth-child(3) {
+  transition-delay: 0.25s;
+}
+body:not(:has(#global-reveal-checkbox:checked))
+  .morph-card:hover
+  .content-layer
+  > *:nth-child(4) {
+  transition-delay: 0.35s;
+}
+
+.card-trigger-checkbox:checked ~ .content-layer > *:nth-child(1) {
+  transition-delay: 0.05s;
+}
+.card-trigger-checkbox:checked ~ .content-layer > *:nth-child(2) {
+  transition-delay: 0.15s;
+}
+.card-trigger-checkbox:checked ~ .content-layer > *:nth-child(3) {
+  transition-delay: 0.25s;
+}
+.card-trigger-checkbox:checked ~ .content-layer > *:nth-child(4) {
+  transition-delay: 0.35s;
+}
+
+/* Accessibility Support for Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .shimmer-block {
+    animation: none !important;
+    background: rgba(255, 255, 255, 0.06) !important;
+  }
+
+  .morph-card:hover {
+    transform: none !important;
+  }
+
+  .skeleton-layer,
+  .content-layer,
+  .content-layer > *,
+  .content-media img,
+  .content-avatar {
+    transition: opacity 0.2s ease !important;
+    transform: none !important;
+    transition-delay: 0s !important;
+  }
+
+  .toggle-slider::before {
+    transition: transform 0.1s !important;
+  }
+}
+
+/* Responsive Grid styling details */
+@media (max-width: 768px) {
+  .cards-grid {
+    grid-template-columns: 1fr;
+  }
+  .dashboard-header h1 {
+    font-size: 2rem;
+  }
+}


### PR DESCRIPTION
Closes #11022

### Description
This PR implements the feature request for a CSS-only morphing skeleton loader grid that smoothly reveals rich content card elements when triggered. The implementation is located inside `submissions/examples/morphing-skeleton-grid-pp/`.

### Features Implemented
- **Dynamic Shimmer Pulse:** Uses raw CSS animation on a semi-transparent linear-gradient to create a smooth moving glow effect across skeleton shapes.
- **Morphing Coordinate Alignment:** Skeletons match layout structures (image block, circle avatar, text lines, pill badges) of their rich content counterpart, shrinking, transforming, and fading out as content fades in and shifts/scales up.
- **Dual Interaction Trigger:** Built purely in CSS, supporting both global simulated toggling via a high-tech dashboard switch, and card-by-card focus/hover reveals.
- **Staggered Content Cascade:** Animates content details with progressive `transition-delay` parameters to create a premium visual load.
- **A11y/Reduced Motion Fallback:** Leverages `@media (prefers-reduced-motion: reduce)` to disable shimmering and scaling transitions, defaulting to an instant opacity crossfade.