### PR TITLE
feat: add CSS-only morphing password eye visibility toggle (#11026)

### DIFF
--- a/submissions/examples/password-eye-toggle-pp/README.md
+++ b/submissions/examples/password-eye-toggle-pp/README.md
@@ -1,0 +1,77 @@
+# CSS-Only Morphing Password Toggle Eye Icon
+
+A micro-interaction password visibility toggle component. It features an interactive inline SVG eye icon that morphs fluidly between a closed eye with eyelashes (masked/hidden state) and an open eye with a center pupil (visible/unmasked state) using pure CSS.
+
+## What does this do?
+
+- **Masking Transition:** Uses the `-webkit-text-security` CSS property to mask text characters as discs by default, and switches to `none` to reveal the text when the visibility toggle is checked.
+- **Pure CSS Morphing Icon:** Animates outline components (top/bottom eyelids, lashes, and pupil) inside the inline SVG using CSS transforms and opacity transitions.
+- **Accessibility Friendly:** Combines a native checkbox input overlay with the visual SVG container. Users can tab directly to the checkbox and toggle visibility using standard native keyboard triggers (Space key), complete with distinct focus ring overlays.
+
+## How is it used?
+
+Add the structural markup to your HTML form:
+
+```html
+<div class="input-field-wrapper">
+  <!-- Checkbox hack overlay -->
+  <input type="checkbox" id="toggle-visibility" class="toggle-checkbox" />
+
+  <!-- Visual SVG trigger container -->
+  <div class="toggle-trigger" aria-hidden="true">
+    <svg class="eye-icon" viewBox="0 0 20 20">
+      <path class="eye-open-contour" d="..." />
+      <circle class="eye-pupil" cx="10" cy="10" r="2.5" />
+      <path class="eye-closed-contour" d="..." />
+      <path class="eye-lashes" d="..." />
+    </svg>
+  </div>
+
+  <!-- Main password input -->
+  <input type="text" class="text-input password-input" placeholder=" " />
+  <label class="input-label">Password</label>
+</div>
+```
+
+Style states in your stylesheet:
+
+```css
+/* Mask text by default */
+.password-input {
+  -webkit-text-security: disc;
+}
+
+/* Unmask when checkbox is checked */
+.toggle-checkbox:checked ~ .password-input {
+  -webkit-text-security: none;
+}
+
+/* Eyelashes folding back / fading out */
+.toggle-checkbox:checked ~ .toggle-trigger .eye-lashes {
+  opacity: 0;
+  transform: scaleY(0) translateY(-3px);
+}
+
+/* Pupil scaling in */
+.toggle-checkbox:checked ~ .toggle-trigger .eye-pupil {
+  opacity: 1;
+  transform: scale(1);
+}
+```
+
+## Tech Stack
+
+- HTML5
+- CSS3 (transitions, `-webkit-text-security`, sibling selectors)
+- Inline SVGs (scalable vector graphics)
+
+## Accessibility Features
+
+- Focus indicator ring: styled using `.toggle-checkbox:focus-visible ~ .toggle-trigger`.
+- Screen reader friendly: hides decorative eye outline using `aria-hidden="true"` while maintaining the standard checkbox attributes.
+- Natively focusable and triggerable via keyboard standard navigation controls.
+
+## Browser Support Note
+
+- The `-webkit-text-security` property is fully supported in Chromium browsers (Chrome, Edge, Opera, Samsung Internet) and WebKit browsers (Safari on macOS and iOS).
+- In Firefox, text is displayed in standard unmasked format by default. Firefox users still experience the full SVG eye morphing transition when toggling visibility.

--- a/submissions/examples/password-eye-toggle-pp/demo.html
+++ b/submissions/examples/password-eye-toggle-pp/demo.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>CSS-Only Morphing Password Toggle - EaseMotion CSS</title>
+
+    <!-- Link to EaseMotion CSS core -->
+    <link rel="stylesheet" href="../../../core/animations.css" />
+    <!-- Link to your CSS file -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Branding header -->
+    <header class="header-links">
+      <span class="logo-text">EaseMotion CSS</span>
+      <span class="badge-text">Morphing Password Toggle</span>
+    </header>
+
+    <!-- Background decorative grid -->
+    <div class="page-grid"></div>
+
+    <!-- Sign In Form Card -->
+    <main class="form-card">
+      <div class="card-header">
+        <h1 class="card-title">Secured Form</h1>
+        <p class="card-desc">Experience the pure CSS morphing toggle</p>
+      </div>
+
+      <form onsubmit="event.preventDefault()">
+        <div class="form-group">
+          <!-- Email Input -->
+          <div class="input-field-wrapper">
+            <input
+              type="email"
+              id="email-field"
+              class="text-input"
+              placeholder=" "
+              required
+            />
+            <label for="email-field" class="input-label">Email Address</label>
+          </div>
+
+          <!-- Password Input with Toggle visibility elements -->
+          <div class="input-field-wrapper">
+            <!-- The hidden checkbox hack for toggle status -->
+            <input
+              type="checkbox"
+              id="toggle-visibility"
+              class="toggle-checkbox"
+              title="Toggle password visibility"
+            />
+
+            <!-- Labeled trigger button overlay (aligned behind the invisible checkbox) -->
+            <div class="toggle-trigger" aria-hidden="true">
+              <svg
+                class="eye-icon"
+                viewBox="0 0 20 20"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <!-- Open eye outline -->
+                <path
+                  class="eye-open-contour"
+                  d="M2 10c2.5-4.5 13.5-4.5 16 0c-2.5 4.5-13.5 4.5-16 0z"
+                />
+                <!-- Pupil circle -->
+                <circle
+                  class="eye-pupil"
+                  cx="10"
+                  cy="10"
+                  r="2.5"
+                  fill="currentColor"
+                />
+                <!-- Closed eye curve -->
+                <path
+                  class="eye-closed-contour"
+                  d="M2 10c2.5 4.5 13.5 4.5 16 0"
+                />
+                <!-- Eyelashes -->
+                <path
+                  class="eye-lashes"
+                  d="M6 13l-1.5 2 M10 14.5v2.5 M14 13l1.5 2"
+                />
+              </svg>
+            </div>
+
+            <!-- Password input field -->
+            <input
+              type="text"
+              id="password-field"
+              class="text-input password-input"
+              placeholder=" "
+              required
+              autocomplete="current-password"
+            />
+            <label for="password-field" class="input-label">Password</label>
+          </div>
+        </div>
+
+        <!-- Action Button -->
+        <button type="submit" class="submit-btn">Continue</button>
+      </form>
+    </main>
+
+    <footer class="browser-note">
+      Supports keyboard tab navigation & Space key action natively.
+    </footer>
+  </body>
+</html>

--- a/submissions/examples/password-eye-toggle-pp/style.css
+++ b/submissions/examples/password-eye-toggle-pp/style.css
@@ -1,0 +1,368 @@
+@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap");
+
+:root {
+  --bg-color: #040308;
+  --card-bg: rgba(255, 255, 255, 0.02);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.6);
+  --accent-color: #6366f1;
+  --accent-glow: rgba(99, 102, 241, 0.25);
+  --focus-ring: rgba(99, 102, 241, 0.4);
+  --input-bg: rgba(255, 255, 255, 0.03);
+  --input-border: rgba(255, 255, 255, 0.1);
+  --input-focus: rgba(99, 102, 241, 0.3);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Plus Jakarta Sans", sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  /* Ambient backdrop gradients */
+  background-image:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(99, 102, 241, 0.1) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      circle at 80% 80%,
+      rgba(168, 85, 247, 0.1) 0%,
+      transparent 50%
+    );
+}
+
+/* Background grid details */
+.page-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.01) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.01) 1px, transparent 1px);
+  background-size: 50px 50px;
+  background-position: center;
+  mask-image: radial-gradient(circle at center, black, transparent 80%);
+  -webkit-mask-image: radial-gradient(circle at center, black, transparent 80%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Premium Card Container */
+.form-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-radius: 24px;
+  width: 420px;
+  max-width: 90%;
+  padding: 3rem 2.5rem;
+  box-shadow:
+    0 30px 60px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  z-index: 1;
+  position: relative;
+}
+
+.card-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.card-title {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(180deg, #ffffff 0%, #a5b4fc 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.card-desc {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+/* Inputs & Form Groups */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.input-field-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+/* Base input styling */
+.text-input {
+  width: 100%;
+  padding: 1.2rem 1rem 0.6rem 1rem;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 12px;
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-family: inherit;
+  outline: none;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.text-input:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.text-input:focus {
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 4px var(--focus-ring);
+  background: rgba(99, 102, 241, 0.02);
+}
+
+/* Floating Label setup */
+.input-label {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  pointer-events: none;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Move label up on focus or populated states */
+.text-input:focus ~ .input-label,
+.text-input:not(:placeholder-shown) ~ .input-label {
+  top: 0.85rem;
+  font-size: 0.75rem;
+  color: var(--accent-color);
+}
+
+/* Default password field using text security masking */
+.password-input {
+  -webkit-text-security: disc;
+  font-family: monospace; /* aligns dots nicely */
+  letter-spacing: 0.1em;
+}
+
+/* ==========================================================================
+   PASSWORD TOGGLE INTERACTIVE HACK & ACCESSBILITY RING
+   ========================================================================== */
+
+/* The checkbox is positioned over the eye icon, but invisible to clicks */
+.toggle-checkbox {
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 10;
+}
+
+/* Trigger icon container positioned behind the checkbox */
+.toggle-trigger {
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--text-secondary);
+  pointer-events: none; /* allows clicks to pass through to the checkbox */
+  transition:
+    color 0.25s ease,
+    border-radius 0.2s;
+  border-radius: 6px;
+  z-index: 9;
+}
+
+.toggle-checkbox:hover ~ .toggle-trigger {
+  color: var(--text-primary);
+}
+
+/* Accessible focus ring indicators using focus-visible */
+.toggle-checkbox:focus-visible ~ .toggle-trigger {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 4px;
+  color: var(--accent-color);
+}
+
+/* Toggle visibility by disabling text masking when checkbox is checked */
+.toggle-checkbox:checked ~ .password-input {
+  -webkit-text-security: none;
+  font-family: inherit;
+  letter-spacing: normal;
+}
+
+/* Change icon color active state */
+.toggle-checkbox:checked ~ .toggle-trigger {
+  color: var(--accent-color);
+}
+
+/* ==========================================================================
+   MORPHING EYE ICON TRANSITIONS
+   ========================================================================== */
+
+.eye-icon {
+  width: 20px;
+  height: 20px;
+}
+
+/* Eyelid curves, pupil and lashes */
+.eye-open-contour,
+.eye-pupil,
+.eye-closed-contour,
+.eye-lashes {
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  transform-origin: 10px 10px; /* SVG center coordinates */
+}
+
+/* Default State (Masked, Closed Eye) */
+.eye-open-contour {
+  opacity: 0;
+  transform: scale(0.75);
+}
+
+.eye-pupil {
+  opacity: 0;
+  transform: scale(0);
+}
+
+.eye-closed-contour {
+  opacity: 1;
+  transform: scaleY(1);
+}
+
+.eye-lashes {
+  opacity: 1;
+  transform: scaleY(1) translateY(0);
+}
+
+/* Active State (Visible, Open Eye) */
+.toggle-checkbox:checked ~ .toggle-trigger .eye-open-contour {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.toggle-checkbox:checked ~ .toggle-trigger .eye-pupil {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.toggle-checkbox:checked ~ .toggle-trigger .eye-closed-contour {
+  opacity: 0;
+  transform: scaleY(0);
+}
+
+.toggle-checkbox:checked ~ .toggle-trigger .eye-lashes {
+  opacity: 0;
+  transform: scaleY(0) translateY(-3px);
+}
+
+/* ==========================================================================
+   FORM CONTROLS (Submit & Styling)
+   ========================================================================== */
+
+.submit-btn {
+  background: var(--accent-color);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  padding: 1rem;
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 100%;
+  box-shadow: 0 4px 15px rgba(99, 102, 241, 0.3);
+}
+
+.submit-btn:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 6px 20px rgba(99, 102, 241, 0.4),
+    0 0 30px var(--accent-glow);
+}
+
+.submit-btn:active {
+  transform: translateY(0);
+}
+
+.submit-btn:focus-visible {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
+/* Header link styles */
+.header-links {
+  position: absolute;
+  top: 2rem;
+  left: 2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.logo-text {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.badge-text {
+  font-size: 0.75rem;
+  padding: 4px 8px;
+  background: rgba(99, 102, 241, 0.1);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: 100px;
+  color: #a5b4fc;
+}
+
+/* Compatibility disclaimer */
+.browser-note {
+  position: absolute;
+  bottom: 1.5rem;
+  text-align: center;
+  width: 100%;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+/* ==========================================================================
+   A11y / prefers-reduced-motion Fallback
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .text-input,
+  .submit-btn,
+  .input-label,
+  .eye-open-contour,
+  .eye-pupil,
+  .eye-closed-contour,
+  .eye-lashes {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #11026

### Description
This PR implements the feature request for a CSS-Only Morphing Password Toggle Eye Icon under `submissions/examples/password-eye-toggle-pp/`.

### Features Implemented
- **Pure CSS Masking Toggle:** Utilizes a checkbox sibling state selector combined with `-webkit-text-security: disc` to mask and unmask input characters natively, requiring zero JavaScript logic.
- **Morphing eye outline SVG:** Animates eyelids, pupil scaling, and eyelash folding transformations (`translateY`, `scaleY`) dynamically during state transitions.
- **Accessibility & Focus Ring:** Features a tab-focusable native checkbox overlay positioned directly over the toggle area so screen readers and keyboard users can toggle visibility using standard native keys (Space key), featuring a focus-visible outline indicator.
- **Graceful Fallbacks:** Supports browsers lacking `-webkit-text-security` by styling text cleanly, and supports `@media (prefers-reduced-motion: reduce)` by bypassing all component transforms.