### PR TITLE
fix: named masonry variants set --ease-masonry-columns token instead of hardcoding columns property

### DIFF
--- a/submissions/examples/fix-masonry-columns-token/README.md
+++ b/submissions/examples/fix-masonry-columns-token/README.md
@@ -1,0 +1,57 @@
+# Fix: Named Masonry Variants Set --ease-masonry-columns Token
+
+## Problem
+
+`.ease-masonry-2`, `.ease-masonry-3`, and `.ease-masonry-4` hardcoded the `columns` property directly:
+
+```css
+.ease-masonry-2 { columns: 2; }
+.ease-masonry-3 { columns: 3; }
+.ease-masonry-4 { columns: 4; }
+```
+
+The base `.ease-masonry` class correctly uses `var(--ease-masonry-columns, 2)` — but named variants bypassed the token entirely. If a user set `--ease-masonry-columns` on a named variant it had no effect because `columns: 2` (a direct property) takes precedence over the token.
+
+## Solution
+
+Named variants set `--ease-masonry-columns` to their respective values, then consume the token via `columns: var(--ease-masonry-columns)`:
+
+```css
+.ease-masonry-2 {
+  --ease-masonry-columns: 2;
+  columns: var(--ease-masonry-columns, 2);
+}
+```
+
+Responsive breakpoint overrides also set the token:
+
+```css
+@media (max-width: 639px) {
+  .ease-masonry-2 { --ease-masonry-columns: 1; }
+}
+```
+
+## Usage
+
+Override column count on a named variant via inline token:
+
+```html
+<!-- Use .ease-masonry-2 layout but override to 3 columns -->
+<div class="ease-masonry-2" style="--ease-masonry-columns: 3;">
+  ...
+</div>
+```
+
+Global override:
+
+```css
+:root {
+  --ease-masonry-columns: 2; /* affects base .ease-masonry */
+}
+```
+
+## Why it fits EaseMotion CSS
+
+When a component exposes a CSS custom property, all modifier classes should set that token rather than hardcoding the underlying property — keeping the token as the single source of truth and making inline overrides work as expected.
+
+Fixes #10423

--- a/submissions/examples/fix-masonry-columns-token/demo.html
+++ b/submissions/examples/fix-masonry-columns-token/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Masonry Columns Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 600px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted); margin-bottom: 0.75rem; }
+    .card {
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      margin-bottom: var(--ease-space-4);
+      font-size: 0.875rem;
+    }
+    .section { margin-bottom: 2rem; }
+  </style>
+</head>
+<body>
+  <h2>Masonry Columns Token Fix</h2>
+  <p>
+    Named variants now set <code>--ease-masonry-columns</code> so users can
+    override column count via the token. Resize the window to see responsive behaviour.
+  </p>
+
+  <div class="section">
+    <h3>.ease-masonry-2 (default 2 cols — override to 3 via token)</h3>
+    <div class="ease-masonry-2" style="--ease-masonry-columns: 3;">
+      <div class="card">Card 1 — token overridden to 3 cols</div>
+      <div class="card">Card 2</div>
+      <div class="card">Card 3</div>
+      <div class="card">Card 4</div>
+      <div class="card">Card 5</div>
+      <div class="card">Card 6</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>.ease-masonry-3 (3 cols desktop, 2 tablet, 1 mobile)</h3>
+    <div class="ease-masonry-3">
+      <div class="card">Card 1</div>
+      <div class="card">Card 2</div>
+      <div class="card">Card 3</div>
+      <div class="card">Card 4</div>
+      <div class="card">Card 5</div>
+      <div class="card">Card 6</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>.ease-masonry-4 (4 → 3 → 2 → 1 cols responsive)</h3>
+    <div class="ease-masonry-4">
+      <div class="card">Card 1</div>
+      <div class="card">Card 2</div>
+      <div class="card">Card 3</div>
+      <div class="card">Card 4</div>
+      <div class="card">Card 5</div>
+      <div class="card">Card 6</div>
+      <div class="card">Card 7</div>
+      <div class="card">Card 8</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-masonry-columns-token/style.css
+++ b/submissions/examples/fix-masonry-columns-token/style.css
@@ -1,0 +1,53 @@
+/* Fix: Named masonry variants set --ease-masonry-columns token
+   instead of hardcoding the columns property directly
+
+   Problem: .ease-masonry-2, .ease-masonry-3, .ease-masonry-4 hardcoded
+   the columns property, bypassing --ease-masonry-columns token.
+   Users who override --ease-masonry-columns on a named variant had no effect.
+
+   Solution: Named variants set --ease-masonry-columns so the base
+   .ease-masonry token drives the actual column count — consistent
+   with how modifier classes work elsewhere in the framework.
+*/
+
+/* 2-column variant */
+.ease-masonry-2 {
+  --ease-masonry-columns: 2;
+  columns: var(--ease-masonry-columns, 2);
+}
+
+@media (max-width: 639px) {
+  .ease-masonry-2 { --ease-masonry-columns: 1; }
+}
+
+/* 3-column variant */
+.ease-masonry-3 {
+  --ease-masonry-columns: 3;
+  columns: var(--ease-masonry-columns, 3);
+}
+
+@media (max-width: 639px) {
+  .ease-masonry-3 { --ease-masonry-columns: 1; }
+}
+
+@media (min-width: 640px) and (max-width: 1023px) {
+  .ease-masonry-3 { --ease-masonry-columns: 2; }
+}
+
+/* 4-column variant */
+.ease-masonry-4 {
+  --ease-masonry-columns: 4;
+  columns: var(--ease-masonry-columns, 4);
+}
+
+@media (max-width: 639px) {
+  .ease-masonry-4 { --ease-masonry-columns: 1; }
+}
+
+@media (min-width: 640px) and (max-width: 1023px) {
+  .ease-masonry-4 { --ease-masonry-columns: 2; }
+}
+
+@media (min-width: 1024px) and (max-width: 1279px) {
+  .ease-masonry-4 { --ease-masonry-columns: 3; }
+}


### PR DESCRIPTION
## Pull Request Description
`.ease-masonry-2`, `.ease-masonry-3`, and `.ease-masonry-4` hardcoded the `columns` property directly, bypassing `--ease-masonry-columns`. The base `.ease-masonry` correctly uses the token — named variants should follow the same pattern so inline token overrides work as expected.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Fixes named masonry variants to set `--ease-masonry-columns` so the token is the single source of truth for column count — consistent with the base `.ease-masonry` class.

**How does a developer use it?**
```html
<!-- Override .ease-masonry-2 to 3 columns via token -->
<div class="ease-masonry-2" style="--ease-masonry-columns: 3;">
  ...
</div>
```

**Why does it fit EaseMotion CSS?**
When a component exposes a CSS custom property, all modifier classes should set that token rather than hardcoding the underlying property — keeping the token as the single source of truth and making inline overrides work as expected.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows token override on `.ease-masonry-2` and responsive behaviour of `.ease-masonry-3` and `.ease-masonry-4`)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Changes needed in `components/masonry.css`: replace `columns: 2/3/4` in each named variant with `--ease-masonry-columns: 2/3/4` plus `columns: var(--ease-masonry-columns)`. Responsive breakpoint overrides should also set the token rather than the property directly.

Fixes #10423