### PR TITLE
feat: add CSS-only cyberpunk glitch button component

### DIFF
--- a/submissions/examples/css-only-cyberpunk-button/README.md
+++ b/submissions/examples/css-only-cyberpunk-button/README.md
@@ -1,0 +1,26 @@
+# CSS-only Cyberpunk Glitch Button
+
+A high-tech, neon-styled cyberpunk button built entirely with CSS. No JavaScript required.
+
+## Overview
+This component provides a futuristic, sci-fi aesthetic using CSS `clip-path` for geometric cutouts. When hovered, the button inverts colors and triggers a glitch animation with scanning lines and pseudo-element offsets.
+
+## Features
+- ✨ 100% CSS-only (no JavaScript)
+- 📐 Advanced geometric cutouts using `clip-path`
+- 🎨 Neon color scheme with cyan (`#0ff`) and magenta (`#f0f`) offsets
+- 📺 Glitch keyframe animations and scanning line effects
+- ⌨️ Fully interactive hover and active states
+
+## Files
+- `demo.html`: The HTML structure of the cyberpunk button.
+- `style.css`: The CSS styling, clip-paths, and keyframe animations.
+
+## Usage
+Copy the HTML structure and link the CSS file to use this component. The font `Orbitron` from Google Fonts is recommended for the best cyberpunk look, but it can be swapped out for any monospace or tech-focused font.
+
+## Customization
+Adjust the neon colors by modifying the CSS values in `style.css`:
+- Main border and glow: `#0ff` (Cyan)
+- Secondary glitch offset: `#f0f` (Magenta)
+- Background color: `#050505` (Dark Gray/Black)

--- a/submissions/examples/css-only-cyberpunk-button/demo.html
+++ b/submissions/examples/css-only-cyberpunk-button/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Cyberpunk Glitch Button</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700;900&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="ease-cyber-container">
+    <button class="ease-cyber-btn">
+      <span class="ease-cyber-btn-content">INITIALIZE</span>
+      <span class="ease-cyber-btn-glitch"></span>
+      <span class="ease-cyber-btn-label">R25</span>
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-only-cyberpunk-button/style.css
+++ b/submissions/examples/css-only-cyberpunk-button/style.css
@@ -1,0 +1,148 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Orbitron', sans-serif;
+  background-color: #050505;
+  background-image: 
+    linear-gradient(rgba(0, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 20px 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.ease-cyber-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.ease-cyber-btn {
+  position: relative;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  outline: none;
+  font-family: 'Orbitron', sans-serif;
+}
+
+.ease-cyber-btn-content {
+  display: block;
+  position: relative;
+  padding: 1.5rem 3rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  background: #050505;
+  border: 2px solid #0ff;
+  letter-spacing: 4px;
+  clip-path: polygon(10% 0, 100% 0, 100% 70%, 90% 100%, 0 100%, 0 30%);
+  transition: all 0.3s ease;
+  z-index: 2;
+  box-shadow: inset 0 0 15px rgba(0, 255, 255, 0.2);
+}
+
+.ease-cyber-btn::before,
+.ease-cyber-btn::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #0ff;
+  z-index: 1;
+  clip-path: polygon(10% 0, 100% 0, 100% 70%, 90% 100%, 0 100%, 0 30%);
+  transition: transform 0.3s ease;
+}
+
+.ease-cyber-btn::before {
+  background: #f0f;
+  transform: translate(-4px, 4px);
+  z-index: 0;
+}
+
+.ease-cyber-btn::after {
+  background: #0ff;
+  transform: translate(4px, -4px);
+  z-index: 0;
+}
+
+.ease-cyber-btn-label {
+  position: absolute;
+  bottom: -5px;
+  right: 10%;
+  background: #0ff;
+  color: #050505;
+  font-size: 0.6rem;
+  font-weight: 900;
+  padding: 2px 6px;
+  z-index: 3;
+  letter-spacing: 1px;
+}
+
+.ease-cyber-btn:hover .ease-cyber-btn-content {
+  background: #0ff;
+  color: #050505;
+  text-shadow: 0 0 5px #fff;
+}
+
+.ease-cyber-btn:hover::before {
+  transform: translate(-6px, 6px);
+  animation: ease-cyber-glitch-anim 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) both infinite;
+}
+
+.ease-cyber-btn:hover::after {
+  transform: translate(6px, -6px);
+  animation: ease-cyber-glitch-anim 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) reverse both infinite;
+}
+
+.ease-cyber-btn-glitch {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.ease-cyber-btn:hover .ease-cyber-btn-glitch::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.8);
+  animation: ease-cyber-scanline 2s linear infinite;
+}
+
+@keyframes ease-cyber-glitch-anim {
+  0% { transform: translate(0); }
+  20% { transform: translate(-2px, 2px); }
+  40% { transform: translate(-2px, -2px); }
+  60% { transform: translate(2px, 2px); }
+  80% { transform: translate(2px, -2px); }
+  100% { transform: translate(0); }
+}
+
+@keyframes ease-cyber-scanline {
+  0% { top: 0; opacity: 0; }
+  10% { opacity: 1; }
+  90% { opacity: 1; }
+  100% { top: 100%; opacity: 0; }
+}
+
+.ease-cyber-btn:active .ease-cyber-btn-content {
+  transform: scale(0.95);
+}


### PR DESCRIPTION
Fixes #11060

## Description
This PR adds a high-tech CSS-only Cyberpunk Glitch Button component located in \submissions/examples/css-only-cyberpunk-button\.

Features:
- Geometric cutouts using clip-path
- Hover state glitch animation with scanning lines
- Neon aesthetic with cyan and magenta offsets
- 100% CSS-only with no JavaScript

Checklist:
- [x] demo.html added
- [x] style.css added
- [x] README.md added
- [x] Follows CSS-only project constraints