### PR TITLE
feat: add CSS-only animated music equalizer component

### DIFF
--- a/submissions/examples/css-only-music-equalizer/README.md
+++ b/submissions/examples/css-only-music-equalizer/README.md
@@ -1,0 +1,26 @@
+# CSS-only Animated Music Equalizer
+
+A dynamic, animated music equalizer visualizer built entirely with CSS. No JavaScript required.
+
+## Overview
+This component simulates an active audio visualizer by animating vertical bars at pseudo-random intervals using CSS keyframes and `animation-delay`. The card features a glassmorphism aesthetic, and hovering over it intensifies the animation speed.
+
+## Features
+- ✨ 100% CSS-only (no JavaScript)
+- 🎵 Multi-bar animated equalizer effect
+- 🕒 Pseudo-randomized `animation-duration` and `animation-delay`
+- 🎨 Gradient color fills and glassmorphic card design
+- ⚡ Interactive hover state to increase animation speed
+
+## Files
+- `demo.html`: The HTML structure of the equalizer card.
+- `style.css`: The CSS styling and bouncing bar keyframe animations.
+
+## Usage
+Simply copy the HTML structure and link the CSS file to use this component. The equalizer bars `.ease-eq-bar` will automatically animate.
+
+## Customization
+You can customize the colors by changing the CSS in `style.css`:
+- Gradient fill: Modify `linear-gradient(to top, #3b82f6, #06b6d4, #10b981)`
+- Intensity on hover: Adjust the `.ease-equalizer-card:hover .ease-eq-bar` animation duration
+- Number of bars: Add or remove `.ease-eq-bar` elements in the HTML and add matching `:nth-child` pseudo-selectors in the CSS.

--- a/submissions/examples/css-only-music-equalizer/demo.html
+++ b/submissions/examples/css-only-music-equalizer/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Music Equalizer</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="ease-equalizer-card">
+    <div class="ease-eq-info">
+      <div class="ease-eq-title">Now Playing</div>
+      <div class="ease-eq-subtitle">Cyberpunk Synthwave Mix</div>
+    </div>
+    
+    <div class="ease-equalizer-container">
+      <div class="ease-eq-bar"></div>
+      <div class="ease-eq-bar"></div>
+      <div class="ease-eq-bar"></div>
+      <div class="ease-eq-bar"></div>
+      <div class="ease-eq-bar"></div>
+      <div class="ease-eq-bar"></div>
+      <div class="ease-eq-bar"></div>
+      <div class="ease-eq-bar"></div>
+      <div class="ease-eq-bar"></div>
+      <div class="ease-eq-bar"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-only-music-equalizer/style.css
+++ b/submissions/examples/css-only-music-equalizer/style.css
@@ -1,0 +1,87 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: #0f172a;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.ease-equalizer-card {
+  background: rgba(30, 41, 59, 0.7);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 2rem;
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 300px;
+}
+
+.ease-eq-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ease-eq-title {
+  color: #38bdf8;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.ease-eq-subtitle {
+  color: #f8fafc;
+  font-size: 1.1rem;
+  font-weight: 400;
+}
+
+.ease-equalizer-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  height: 60px;
+  width: 100%;
+  gap: 4px;
+}
+
+.ease-eq-bar {
+  flex: 1;
+  background: linear-gradient(to top, #3b82f6, #06b6d4, #10b981);
+  border-radius: 4px;
+  animation: ease-eq-bounce 1s ease-in-out infinite alternate;
+  transform-origin: bottom;
+}
+
+/* Pseudo-random delays for equalizer bars */
+.ease-eq-bar:nth-child(1) { animation-duration: 0.9s; animation-delay: 0.2s; }
+.ease-eq-bar:nth-child(2) { animation-duration: 1.2s; animation-delay: 0.5s; }
+.ease-eq-bar:nth-child(3) { animation-duration: 0.8s; animation-delay: 0.1s; }
+.ease-eq-bar:nth-child(4) { animation-duration: 1.1s; animation-delay: 0.8s; }
+.ease-eq-bar:nth-child(5) { animation-duration: 0.7s; animation-delay: 0.4s; }
+.ease-eq-bar:nth-child(6) { animation-duration: 1.3s; animation-delay: 0.7s; }
+.ease-eq-bar:nth-child(7) { animation-duration: 0.9s; animation-delay: 0.3s; }
+.ease-eq-bar:nth-child(8) { animation-duration: 1.0s; animation-delay: 0.9s; }
+.ease-eq-bar:nth-child(9) { animation-duration: 1.2s; animation-delay: 0.6s; }
+.ease-eq-bar:nth-child(10) { animation-duration: 0.8s; animation-delay: 0.2s; }
+
+@keyframes ease-eq-bounce {
+  0% { height: 10%; }
+  50% { height: 70%; filter: brightness(1.2); }
+  100% { height: 100%; filter: brightness(1.5); box-shadow: 0 0 10px rgba(16, 185, 129, 0.6); }
+}
+
+/* Hover interaction to intensify the visualizer */
+.ease-equalizer-card:hover .ease-eq-bar {
+  animation-duration: 0.5s !important;
+}


### PR DESCRIPTION
Fixes #11073

## Description
This PR adds a CSS-only Animated Music Equalizer component located in \submissions/examples/css-only-music-equalizer\.

Features:
- Multi-bar animated equalizer effect
- Pseudo-randomized \nimation-duration\ and \nimation-delay\ for a realistic effect
- Glassmorphic card design with gradient fills
- Interactive hover state that increases animation speed
- 100% CSS-only with no JavaScript

Checklist:
- [x] demo.html added
- [x] style.css added
- [x] README.md added
- [x] Follows CSS-only project constraints