### PR TITLE
fix(modal): restore focus to trigger element on close

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -1,13 +1,21 @@
 (function () {
   'use strict';
 
+  let lastFocusedElement = null;
+
   function checkModal() {
     const hash = window.location.hash;
     const body = document.body;
 
-    // Remove active class from all overlays just in case
+    // Remove active class from all overlays just in case, tracking if any were active
+    let wasModalActive = false;
     const overlays = document.querySelectorAll('.ease-modal-overlay');
-    overlays.forEach((overlay) => overlay.classList.remove('is-active'));
+    overlays.forEach((overlay) => {
+      if (overlay.classList.contains('is-active')) {
+        wasModalActive = true;
+      }
+      overlay.classList.remove('is-active');
+    });
 
     if (hash) {
       // Find overlay by hash (pure CSS `:target` fallback)
@@ -20,6 +28,9 @@
 
           const modal = overlay.querySelector('.ease-modal');
           if (modal) {
+            if (!wasModalActive && document.activeElement) {
+              lastFocusedElement = document.activeElement;
+            }
             modal.setAttribute('tabindex', '-1');
             modal.focus();
           }
@@ -32,6 +43,16 @@
 
     // If no active modal is found
     body.style.overflow = '';
+
+    // Restore focus when closing
+    if (wasModalActive && lastFocusedElement) {
+      setTimeout(() => {
+        if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+          lastFocusedElement.focus();
+        }
+        lastFocusedElement = null;
+      }, 0);
+    }
   }
 
   // Setup event listeners for hash changes (opening/closing via anchors)


### PR DESCRIPTION
## Pull Request Description

Fixes a major accessibility issue where keyboard and screen reader focus is lost when closing an `.ease-modal`. When the modal closes, focus now correctly returns to the element that triggered it (e.g., the original link or button).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  - Core Bug Fix (Accessibility)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Restores accessibility focus logic to modals so users aren't stranded at the top of the page when dismissing a modal.

**How does a developer use it?**

```html
<!-- Developers don't need to change anything! The core modal.js script now automatically remembers what triggered the modal and returns focus to it on close. -->
