### PR TITLE
feat: add CSS-only animated calendar icon component

### DIFF
--- a/submissions/examples/css-only-animated-calendar-icon/README.md
+++ b/submissions/examples/css-only-animated-calendar-icon/README.md
@@ -1,0 +1,26 @@
+# CSS-only Animated Calendar Icon
+
+An interactive, 3D animated calendar icon component built entirely with CSS. No JavaScript required.
+
+## Overview
+This component simulates a daily tear-off or flip calendar. When hovered, the top date page flips down using a smooth 3D CSS transform (`rotateX(-180deg)`), revealing the next date underneath. 
+
+## Features
+- ✨ 100% CSS-only (no JavaScript)
+- 📅 3D flip animation using CSS perspective and transforms
+- 🔗 Realistic 3D styled calendar rings
+- 🎨 Clean, modern aesthetic with soft shadows
+- 🖱️ Interactive hover state
+
+## Files
+- `demo.html`: The HTML structure containing the calendar, header, and pages.
+- `style.css`: The CSS styling and 3D transformation logic.
+
+## Usage
+Simply copy the HTML structure and link the CSS file to use this component. The component uses the `Poppins` font from Google Fonts for a clean, friendly look.
+
+## Customization
+You can customize the calendar by changing the HTML text or modifying the CSS in `style.css`:
+- Header color: Change `background-color: #ef4444;` in `.ease-calendar-header` (Red by default).
+- Dates: Modify the numbers in the `.ease-cal-day` spans within the HTML.
+- Flip speed: Adjust `transition: transform 0.8s` in `.ease-cal-page-top`.

--- a/submissions/examples/css-only-animated-calendar-icon/demo.html
+++ b/submissions/examples/css-only-animated-calendar-icon/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Animated Calendar Icon</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="ease-calendar-wrapper">
+    <div class="ease-calendar-icon">
+      <div class="ease-calendar-header">
+        <span class="ease-cal-month">AUG</span>
+      </div>
+      <div class="ease-calendar-body">
+        <div class="ease-cal-page ease-cal-page-bottom">
+          <span class="ease-cal-day">27</span>
+        </div>
+        <div class="ease-cal-page ease-cal-page-top">
+          <span class="ease-cal-day">26</span>
+        </div>
+      </div>
+      <div class="ease-cal-rings">
+        <div class="ease-cal-ring"></div>
+        <div class="ease-cal-ring"></div>
+      </div>
+    </div>
+    <div class="ease-calendar-text">Hover to flip date</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-only-animated-calendar-icon/style.css
+++ b/submissions/examples/css-only-animated-calendar-icon/style.css
@@ -1,0 +1,134 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  background-color: #f1f5f9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  perspective: 1000px;
+}
+
+.ease-calendar-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.ease-calendar-icon {
+  position: relative;
+  width: 120px;
+  height: 140px;
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1), 0 4px 10px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ease-calendar-icon:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.15), 0 5px 15px rgba(0, 0, 0, 0.1);
+}
+
+.ease-calendar-header {
+  background-color: #ef4444;
+  height: 35%;
+  width: 100%;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-bottom: 2px dashed rgba(255, 255, 255, 0.3);
+  z-index: 2;
+}
+
+.ease-cal-month {
+  color: white;
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 2px;
+}
+
+.ease-calendar-body {
+  position: relative;
+  height: 65%;
+  width: 100%;
+  perspective: 800px;
+}
+
+.ease-cal-page {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: white;
+  border-bottom-left-radius: 16px;
+  border-bottom-right-radius: 16px;
+  transform-origin: top;
+  backface-visibility: hidden;
+}
+
+.ease-cal-day {
+  font-size: 3rem;
+  font-weight: 700;
+  color: #334155;
+}
+
+.ease-cal-page-top {
+  z-index: 2;
+  transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: inset 0 -10px 20px rgba(0, 0, 0, 0.03);
+}
+
+.ease-cal-page-bottom {
+  z-index: 1;
+}
+
+.ease-calendar-icon:hover .ease-cal-page-top {
+  transform: rotateX(-180deg);
+}
+
+.ease-cal-rings {
+  position: absolute;
+  top: 25%;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  padding: 0 15px;
+  z-index: 5;
+}
+
+.ease-cal-ring {
+  width: 12px;
+  height: 25px;
+  background: linear-gradient(to bottom, #d1d5db 0%, #9ca3af 50%, #6b7280 100%);
+  border-radius: 6px;
+  box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.3), inset -1px -1px 2px rgba(255, 255, 255, 0.5);
+  transform: translateY(-50%);
+}
+
+.ease-calendar-text {
+  color: #64748b;
+  font-weight: 600;
+  font-size: 0.9rem;
+  opacity: 0.7;
+  transition: opacity 0.3s ease;
+}
+
+.ease-calendar-icon:hover ~ .ease-calendar-text {
+  opacity: 1;
+}


### PR DESCRIPTION
Fixes #11081

## Description
This PR adds a CSS-only Animated Calendar Icon component located in \submissions/examples/css-only-animated-calendar-icon\.

Features:
- Realistic 3D flip animation using CSS \perspective\ and \otateX\
- Simulated calendar rings
- Soft shadows and modern aesthetic
- 100% CSS-only with no JavaScript

Checklist:
- [x] demo.html added
- [x] style.css added
- [x] README.md added
- [x] Follows CSS-only project constraints