### PR TITLE
feat: add CSS-only animated envelope reveal component

### DIFF
--- a/submissions/examples/css-only-animated-envelope/README.md
+++ b/submissions/examples/css-only-animated-envelope/README.md
@@ -1,0 +1,27 @@
+# CSS-only Animated Envelope Reveal
+
+A delightful, interactive CSS-only envelope component that opens and reveals a letter when hovered over. No JavaScript required.
+
+## Overview
+This component simulates a real envelope opening mechanism. Using CSS border hacks to create the envelope flaps, CSS 3D transforms (`rotateX`) to fold back the top flap, and precise `z-index` manipulation to pull the letter out from behind the front flaps.
+
+## Features
+- ✨ 100% CSS-only (no JavaScript)
+- ✉️ Interactive 3D envelope opening animation
+- 📝 Sliding letter reveal effect on hover
+- 🖌️ Beautiful typography using Google Fonts (`Dancing Script` and `Inter`)
+- 📐 Complex shape creation using pure CSS border rendering
+
+## Files
+- `demo.html`: The HTML structure including the envelope back, letter, front flaps, and top flap.
+- `style.css`: The styling, geometry (border hacks), and hover transitions.
+
+## Usage
+Simply copy the HTML structure and link the CSS file. You can replace the text inside the `.ease-letter-content` to display any message, invitation, or card you want.
+
+## Customization
+Adjust the envelope colors by modifying the border colors in `style.css`:
+- Envelope Back: `.ease-envelope-back` (`#f43f5e`)
+- Top Flap: `.ease-envelope-flap` (`#e11d48`)
+- Front Left/Right Flaps: `.ease-envelope-left`, `.ease-envelope-right` (`#fb7185`)
+- Front Bottom Flap: `.ease-envelope-bottom` (`#fda4af`)

--- a/submissions/examples/css-only-animated-envelope/demo.html
+++ b/submissions/examples/css-only-animated-envelope/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Animated Envelope Reveal</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@700&family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="ease-envelope-container">
+    <div class="ease-envelope-wrapper">
+      <div class="ease-envelope">
+        <!-- Back of the envelope -->
+        <div class="ease-envelope-back"></div>
+        
+        <!-- The letter inside -->
+        <div class="ease-letter">
+          <div class="ease-letter-content">
+            <h2 class="ease-letter-title">You're Invited!</h2>
+            <p class="ease-letter-text">Join us for the special celebration event this weekend.</p>
+          </div>
+        </div>
+        
+        <!-- Front parts of the envelope -->
+        <div class="ease-envelope-front ease-envelope-left"></div>
+        <div class="ease-envelope-front ease-envelope-right"></div>
+        <div class="ease-envelope-front ease-envelope-bottom"></div>
+        
+        <!-- Top flap -->
+        <div class="ease-envelope-flap"></div>
+      </div>
+    </div>
+    <div class="ease-helper-text">Hover to open</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-only-animated-envelope/style.css
+++ b/submissions/examples/css-only-animated-envelope/style.css
@@ -1,0 +1,170 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: #fce7f3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.ease-envelope-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.ease-envelope-wrapper {
+  position: relative;
+  width: 300px;
+  height: 200px;
+  cursor: pointer;
+}
+
+.ease-envelope {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  perspective: 1000px;
+  transform-style: preserve-3d;
+  transition: transform 0.4s ease;
+}
+
+.ease-envelope-wrapper:hover .ease-envelope {
+  transform: translateY(-20px);
+}
+
+.ease-envelope-back {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #f43f5e;
+  border-radius: 4px;
+  box-shadow: 0 10px 30px rgba(225, 29, 72, 0.3);
+  z-index: 1;
+}
+
+/* The Letter */
+.ease-letter {
+  position: absolute;
+  top: 5px;
+  left: 5%;
+  width: 90%;
+  height: 90%;
+  background-color: #ffffff;
+  border-radius: 4px;
+  z-index: 2;
+  transition: all 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 1rem;
+}
+
+.ease-envelope-wrapper:hover .ease-letter {
+  transform: translateY(-120px);
+  z-index: 4;
+}
+
+.ease-letter-content {
+  border: 1px dashed #f472b6;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+
+.ease-letter-title {
+  font-family: 'Dancing Script', cursive;
+  color: #be185d;
+  font-size: 1.8rem;
+}
+
+.ease-letter-text {
+  font-size: 0.8rem;
+  color: #475569;
+  line-height: 1.4;
+}
+
+/* Envelope Front Parts */
+.ease-envelope-front {
+  position: absolute;
+  z-index: 3;
+}
+
+.ease-envelope-left {
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  border-top: 100px solid transparent;
+  border-bottom: 100px solid transparent;
+  border-left: 150px solid #fb7185;
+}
+
+.ease-envelope-right {
+  top: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-top: 100px solid transparent;
+  border-bottom: 100px solid transparent;
+  border-right: 150px solid #fb7185;
+}
+
+.ease-envelope-bottom {
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  border-left: 150px solid transparent;
+  border-right: 150px solid transparent;
+  border-bottom: 100px solid #fda4af;
+}
+
+/* Top Flap */
+.ease-envelope-flap {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  border-left: 150px solid transparent;
+  border-right: 150px solid transparent;
+  border-top: 120px solid #e11d48;
+  transform-origin: top;
+  transition: transform 0.5s ease 0.1s, z-index 0.2s;
+  z-index: 5;
+}
+
+.ease-envelope-wrapper:hover .ease-envelope-flap {
+  transform: rotateX(180deg);
+  z-index: 1; /* Drop behind the letter after opening */
+  transition: transform 0.5s ease, z-index 0.1s ease 0.3s;
+}
+
+/* Helper Text */
+.ease-helper-text {
+  color: #be185d;
+  font-weight: 600;
+  opacity: 0.8;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
Fixes #11091

## Description
This PR adds a CSS-only Animated Envelope Reveal component located in \submissions/examples/css-only-animated-envelope\.

Features:
- Interactive 3D envelope opening animation using \otateX\
- Complex envelope geometry built entirely with CSS border hacks
- Sliding letter reveal effect on hover with precise \z-index\ transitions
- Beautiful typography using Google Fonts (Dancing Script)
- 100% CSS-only with no JavaScript

Checklist:
- [x] demo.html added
- [x] style.css added
- [x] README.md added
- [x] Follows CSS-only project constraints