### PR TITLE
feat: Add global documentation search palette component

### DIFF
--- a/submissions/examples/global-doc-search-jt/README.md
+++ b/submissions/examples/global-doc-search-jt/README.md
@@ -1,0 +1,9 @@
+# Global Documentation Search Component
+
+A modern, accessible, dark-themed command palette layout mimicking premium documentation search inputs (like Algolia or Tailwind Docs).
+
+## Features
+
+- **Global Key Bindings:** Accessible instantly across the app using `Ctrl + K` or `Cmd + K`.
+- **Keyboard-First Navigation:** Seamless list tracking using `ArrowUp` and `ArrowDown` keys, and activation on `Enter`.
+- **Fuzzy/Live Matching:** Instant filtering logic built inside a vanilla JavaScript context without layout-heavy dependencies.

--- a/submissions/examples/global-doc-search-jt/demo.html
+++ b/submissions/examples/global-doc-search-jt/demo.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Global Documentation Search Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="nav-logo">⚡ EaseMotion CSS</div>
+      <button class="search-trigger" id="searchTrigger">
+        <span>Search documentation...</span>
+        <kbd>Ctrl K</kbd>
+      </button>
+    </nav>
+
+    <div class="main-content">
+      <h1>Global Documentation Search Palette</h1>
+      <p>
+        Press <kbd>Ctrl</kbd> + <kbd>K</kbd> (or <kbd>Cmd</kbd> +
+        <kbd>K</kbd> on Mac) to launch the command palette.
+      </p>
+    </div>
+
+    <div class="search-overlay" id="searchOverlay" aria-hidden="true">
+      <div class="search-modal">
+        <div class="search-header">
+          <input
+            type="search"
+            id="searchInput"
+            placeholder="Type an animation or component..."
+            autocomplete="off"
+          />
+        </div>
+        <div class="search-results" id="searchResults"></div>
+        <div class="search-footer">
+          <span><kbd>↑↓</kbd> Navigate</span>
+          <span><kbd>↵ Enter</kbd> Select</span>
+          <span><kbd>esc</kbd> Close</span>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      const docItems = [
+        {
+          name: "ease-fade-in",
+          category: "Animations",
+          url: "#fade-in",
+          icon: "✨",
+        },
+        {
+          name: "ease-slide-up",
+          category: "Animations",
+          url: "#slide-up",
+          icon: "🚀",
+        },
+        {
+          name: "ease-zoom-in",
+          category: "Animations",
+          url: "#zoom-in",
+          icon: "🔍",
+        },
+        {
+          name: "ease-hover-grow",
+          category: "Hover Effects",
+          url: "#hover-grow",
+          icon: "📈",
+        },
+        {
+          name: "ease-hover-glow",
+          category: "Hover Effects",
+          url: "#hover-glow",
+          icon: "💡",
+        },
+        {
+          name: "ease-center",
+          category: "Layout Utilities",
+          url: "#center",
+          icon: "🎯",
+        },
+        {
+          name: "ease-btn-primary",
+          category: "Components",
+          url: "#buttons",
+          icon: "🔘",
+        },
+        {
+          name: "ease-card-glass",
+          category: "Components",
+          url: "#cards",
+          icon: "🎴",
+        },
+      ];
+
+      const trigger = document.getElementById("searchTrigger");
+      const overlay = document.getElementById("searchOverlay");
+      const input = document.getElementById("searchInput");
+      const resultsContainer = document.getElementById("searchResults");
+
+      let activeIndex = 0;
+      let filteredItems = [...docItems];
+
+      function openSearch() {
+        overlay.classList.add("open");
+        overlay.setAttribute("aria-hidden", "false");
+        input.value = "";
+        renderResults(docItems);
+        setTimeout(() => input.focus(), 50);
+      }
+
+      function closeSearch() {
+        overlay.classList.remove("open");
+        overlay.setAttribute("aria-hidden", "true");
+      }
+
+      function renderResults(items) {
+        filteredItems = items;
+        if (items.length === 0) {
+          resultsContainer.innerHTML = `<div class="no-results">No results found for "${input.value}"</div>`;
+          return;
+        }
+
+        let html = "";
+        let currentCategory = "";
+        let globalIndex = 0;
+
+        items.forEach((item) => {
+          if (item.category !== currentCategory) {
+            currentCategory = item.category;
+            html += `<div class="search-section-title">${currentCategory}</div>`;
+          }
+
+          const isActive = globalIndex === activeIndex ? "active" : "";
+          html += `
+                    <a href="${item.url}" class="search-item ${isActive}" data-index="${globalIndex}">
+                        <span>${item.icon} &nbsp; ${item.name}</span>
+                        ${globalIndex === activeIndex ? '<kbd class="enter-kbd">Enter</kbd>' : ""}
+                    </a>
+                `;
+          globalIndex++;
+        });
+
+        resultsContainer.innerHTML = html;
+      }
+
+      input.addEventListener("input", (e) => {
+        const query = e.target.value.toLowerCase().trim();
+        const matches = docItems.filter((item) =>
+          item.name.toLowerCase().includes(query)
+        );
+        activeIndex = 0;
+        renderResults(matches);
+      });
+
+      trigger.addEventListener("click", openSearch);
+      overlay.addEventListener("click", (e) => {
+        if (e.target === overlay) closeSearch();
+      });
+
+      window.addEventListener("keydown", (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
+          e.preventDefault();
+          overlay.classList.contains("open") ? closeSearch() : openSearch();
+        }
+
+        if (!overlay.classList.contains("open")) return;
+
+        if (e.key === "Escape") {
+          closeSearch();
+        } else if (e.key === "ArrowDown") {
+          e.preventDefault();
+          if (filteredItems.length > 0) {
+            activeIndex = (activeIndex + 1) % filteredItems.length;
+            renderResults(filteredItems);
+            scrollToActive();
+          }
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          if (filteredItems.length > 0) {
+            activeIndex =
+              (activeIndex - 1 + filteredItems.length) % filteredItems.length;
+            renderResults(filteredItems);
+            scrollToActive();
+          }
+        } else if (e.key === "Enter") {
+          e.preventDefault();
+          if (filteredItems[activeIndex]) {
+            window.location.hash = filteredItems[activeIndex].url;
+            closeSearch();
+            alert(`Navigating to: ${filteredItems[activeIndex].name}`);
+          }
+        }
+      });
+
+      function scrollToActive() {
+        const activeEl = resultsContainer.querySelector(".search-item.active");
+        if (activeEl) {
+          activeEl.scrollIntoView({ block: "nearest" });
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/submissions/examples/global-doc-search-jt/style.css
+++ b/submissions/examples/global-doc-search-jt/style.css
@@ -1,0 +1,176 @@
+:root {
+    --bg-main: #0b0f19;
+    --modal-bg: #161b26;
+    --border-color: rgba(255, 255, 255, 0.08);
+    --accent-color: #7c5cff;
+    --text-muted: #848d9a;
+}
+
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-main);
+    color: #fff;
+}
+
+.navbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+    border-bottom: 1px solid var(--border-color);
+    background: rgba(11, 15, 25, 0.8);
+    backdrop-filter: blur(12px);
+}
+
+.nav-logo {
+    font-weight: 700;
+    font-size: 1.1rem;
+}
+
+.search-trigger {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--border-color);
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    color: var(--text-muted);
+    cursor: pointer;
+    width: 240px;
+    justify-content: space-between;
+    transition: all 0.2s ease;
+}
+
+.search-trigger:hover {
+    border-color: var(--accent-color);
+    background: rgba(255, 255, 255, 0.07);
+}
+
+.main-content {
+    max-width: 600px;
+    margin: 100px auto;
+    text-align: center;
+    padding: 0 1rem;
+}
+
+.main-content h1 {
+    font-size: 2.2rem;
+    margin-bottom: 0.5rem;
+}
+
+.main-content p {
+    color: var(--text-muted);
+}
+
+kbd {
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-size: 0.75rem;
+    font-family: monospace;
+    color: #cbd5e1;
+}
+
+.search-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(5, 7, 13, 0.85);
+    backdrop-filter: blur(6px);
+    display: flex;
+    justify-content: center;
+    padding-top: 12vh;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.18s ease;
+    z-index: 1000;
+    box-sizing: border-box;
+}
+
+.search-overlay.open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.search-modal {
+    background: var(--modal-bg);
+    width: 100%;
+    max-width: 560px;
+    height: max-content;
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.7);
+}
+
+.search-header input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 1.1rem;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--border-color);
+    font-size: 1.1rem;
+    color: #fff;
+    outline: none;
+}
+
+.search-results {
+    max-height: 340px;
+    overflow-y: auto;
+    padding: 0.6rem;
+}
+
+.search-section-title {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    padding: 0.6rem 0.5rem 0.3rem 0.5rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+}
+
+.search-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 0.8rem;
+    color: #cbd5e1;
+    text-decoration: none;
+    border-radius: 8px;
+    margin-bottom: 2px;
+    transition: background 0.1s ease;
+}
+
+.search-item.active {
+    background: var(--accent-color);
+    color: #fff;
+}
+
+.enter-kbd {
+    background: rgba(255, 255, 255, 0.25);
+    color: #fff;
+    border: none;
+}
+
+.no-results {
+    padding: 2rem;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.search-footer {
+    display: flex;
+    gap: 1.2rem;
+    padding: 0.8rem 1.1rem;
+    background: rgba(0, 0, 0, 0.2);
+    border-top: 1px solid var(--border-color);
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements a beautifully designed, dark-themed **Global Documentation Search Command Palette** component. It mimics premium documentation interfaces (like Algolia or Tailwind Docs) and allows users to quickly search and filter through animation modules and component assets.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/global-doc-search-jt/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
It adds an elegant, overlay-driven modal search palette that filters available project classes dynamically as you type.

**How does a developer use it?**
```html
<button class="search-trigger" id="searchTrigger">
    <span>Search documentation...</span>
    <kbd>Ctrl K</kbd>
</button>