### PR TITLE
feat: add ease-avatar-group component with animated avatar stack (Closes #10876)

### DIFF
--- a/submissions/core_changes-issue-10876/README.md
+++ b/submissions/core_changes-issue-10876/README.md
@@ -1,0 +1,60 @@
+# ease-avatar-group
+
+## What does this do?
+
+Provides a CSS-only animated avatar group (avatar stack / facepile) component with overlapping circular avatars, configurable overlap via custom property, hover spread effect, border rings, and an overflow count badge.
+
+## How is it used?
+
+Add `ease-avatar-group` as the container and `ease-avatar-group-item` on each avatar. Optionally append a `ease-avatar-group-count` element for the overflow count.
+
+```html
+<div class="ease-avatar-group">
+  <div class="ease-avatar-group-item" style="background: #6366f1;">AW</div>
+  <div class="ease-avatar-group-item" style="background: #a855f7;">BM</div>
+  <div class="ease-avatar-group-item" style="background: #ec4899;">CS</div>
+  <span class="ease-avatar-group-count">+3</span>
+</div>
+```
+
+For image avatars:
+
+```html
+<div class="ease-avatar-group">
+  <img class="ease-avatar-group-item" src="user1.jpg" alt="User 1" />
+  <img class="ease-avatar-group-item" src="user2.jpg" alt="User 2" />
+  <span class="ease-avatar-group-count">+2</span>
+</div>
+```
+
+### Custom overlap
+
+Control the overlap amount via the `--ease-avatar-overlap` custom property:
+
+```html
+<div class="ease-avatar-group" style="--ease-avatar-overlap: -1rem;">
+```
+
+### Size variants
+
+| Class | Size |
+| --- | --- |
+| `ease-avatar-group-item-sm` / `ease-avatar-group-count-sm` | 2rem |
+| Default | 2.5rem |
+| `ease-avatar-group-item-lg` / `ease-avatar-group-count-lg` | 3rem |
+| `ease-avatar-group-item-xl` / `ease-avatar-group-count-xl` | 4rem |
+
+## Why is it useful?
+
+Avatar groups are a common UI pattern in team pages, chat headers, collaboration tools, and social interfaces. This component provides a polished, animated, accessible implementation with zero JavaScript, fitting EaseMotion CSS's animation-first philosophy.
+
+## Features
+
+- Overlapping circular avatars with configurable `--ease-avatar-overlap`
+- Hover spread effect — the group fans out on hover
+- Individual lift on avatar hover (`translateY`)
+- Overflow count badge (`+N`)
+- Support for images and text initials
+- Four size variants (sm, md, lg, xl)
+- Respects `prefers-reduced-motion`
+- Pure CSS, no JavaScript

--- a/submissions/core_changes-issue-10876/demo.html
+++ b/submissions/core_changes-issue-10876/demo.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-avatar-group — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <h1 style="font-size: 1.5rem; font-weight: 700; margin-bottom: 2rem;">
+    ease-avatar-group
+  </h1>
+  <p style="font-size: 0.875rem; color: #64748b; margin-bottom: 2.5rem; max-width: 48rem;">
+    Animated CSS-only avatar stack with configurable overlap, hover spread effect, border rings, and overflow count.
+  </p>
+
+  <div class="demo-section">
+    <h2 class="section-title">Initials</h2>
+    <div class="demo-row">
+      <div class="ease-avatar-group">
+        <div class="ease-avatar-group-item" style="background: #6366f1;">AW</div>
+        <div class="ease-avatar-group-item" style="background: #a855f7;">BM</div>
+        <div class="ease-avatar-group-item" style="background: #ec4899;">CS</div>
+        <div class="ease-avatar-group-item" style="background: #14b8a6;">DK</div>
+        <span class="ease-avatar-group-count">+3</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2 class="section-title">Images</h2>
+    <div class="demo-row">
+      <div class="ease-avatar-group">
+        <img class="ease-avatar-group-item" src="https://i.pravatar.cc/80?img=1" alt="Alice" />
+        <img class="ease-avatar-group-item" src="https://i.pravatar.cc/80?img=2" alt="Bob" />
+        <img class="ease-avatar-group-item" src="https://i.pravatar.cc/80?img=3" alt="Carol" />
+        <img class="ease-avatar-group-item" src="https://i.pravatar.cc/80?img=4" alt="David" />
+        <span class="ease-avatar-group-count">+5</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2 class="section-title">Sizes</h2>
+    <div class="demo-row">
+      <div class="variant-group">
+        <div class="ease-avatar-group">
+          <div class="ease-avatar-group-item ease-avatar-group-item-sm" style="background: #6366f1;">A</div>
+          <div class="ease-avatar-group-item ease-avatar-group-item-sm" style="background: #a855f7;">B</div>
+          <div class="ease-avatar-group-item ease-avatar-group-item-sm" style="background: #ec4899;">C</div>
+          <span class="ease-avatar-group-count ease-avatar-group-count-sm">+2</span>
+        </div>
+        <span class="variant-label">sm</span>
+      </div>
+      <div class="variant-group">
+        <div class="ease-avatar-group">
+          <div class="ease-avatar-group-item" style="background: #6366f1;">A</div>
+          <div class="ease-avatar-group-item" style="background: #a855f7;">B</div>
+          <div class="ease-avatar-group-item" style="background: #ec4899;">C</div>
+          <span class="ease-avatar-group-count">+2</span>
+        </div>
+        <span class="variant-label">md</span>
+      </div>
+      <div class="variant-group">
+        <div class="ease-avatar-group">
+          <div class="ease-avatar-group-item ease-avatar-group-item-lg" style="background: #6366f1;">A</div>
+          <div class="ease-avatar-group-item ease-avatar-group-item-lg" style="background: #a855f7;">B</div>
+          <div class="ease-avatar-group-item ease-avatar-group-item-lg" style="background: #ec4899;">C</div>
+          <span class="ease-avatar-group-count ease-avatar-group-count-lg">+2</span>
+        </div>
+        <span class="variant-label">lg</span>
+      </div>
+      <div class="variant-group">
+        <div class="ease-avatar-group">
+          <div class="ease-avatar-group-item ease-avatar-group-item-xl" style="background: #6366f1;">A</div>
+          <div class="ease-avatar-group-item ease-avatar-group-item-xl" style="background: #a855f7;">B</div>
+          <div class="ease-avatar-group-item ease-avatar-group-item-xl" style="background: #ec4899;">C</div>
+          <span class="ease-avatar-group-count ease-avatar-group-count-xl">+2</span>
+        </div>
+        <span class="variant-label">xl</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2 class="section-title">Custom Overlap via <code>--ease-avatar-overlap</code></h2>
+    <div class="overlap-row">
+      <span class="overlap-label">tight (&#x2212;1rem)</span>
+      <div class="ease-avatar-group" style="--ease-avatar-overlap: -1rem;">
+        <div class="ease-avatar-group-item" style="background: #6366f1;">A</div>
+        <div class="ease-avatar-group-item" style="background: #a855f7;">B</div>
+        <div class="ease-avatar-group-item" style="background: #ec4899;">C</div>
+        <span class="ease-avatar-group-count">+2</span>
+      </div>
+    </div>
+    <div class="overlap-row">
+      <span class="overlap-label">default (&#x2212;0.5rem)</span>
+      <div class="ease-avatar-group">
+        <div class="ease-avatar-group-item" style="background: #6366f1;">A</div>
+        <div class="ease-avatar-group-item" style="background: #a855f7;">B</div>
+        <div class="ease-avatar-group-item" style="background: #ec4899;">C</div>
+        <span class="ease-avatar-group-count">+2</span>
+      </div>
+    </div>
+    <div class="overlap-row">
+      <span class="overlap-label">loose (&#x2212;0.2rem)</span>
+      <div class="ease-avatar-group" style="--ease-avatar-overlap: -0.2rem;">
+        <div class="ease-avatar-group-item" style="background: #6366f1;">A</div>
+        <div class="ease-avatar-group-item" style="background: #a855f7;">B</div>
+        <div class="ease-avatar-group-item" style="background: #ec4899;">C</div>
+        <span class="ease-avatar-group-count">+2</span>
+      </div>
+    </div>
+    <div class="overlap-row">
+      <span class="overlap-label">none (0)</span>
+      <div class="ease-avatar-group" style="--ease-avatar-overlap: 0;">
+        <div class="ease-avatar-group-item" style="background: #6366f1;">A</div>
+        <div class="ease-avatar-group-item" style="background: #a855f7;">B</div>
+        <div class="ease-avatar-group-item" style="background: #ec4899;">C</div>
+        <span class="ease-avatar-group-count">+2</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2 class="section-title">Interaction</h2>
+    <p style="font-size: 0.875rem; color: #64748b; margin: 0 0 1rem;">
+      Hover the group to spread avatars apart. Hover an individual avatar to lift it.
+    </p>
+    <div class="demo-row">
+      <div class="ease-avatar-group">
+        <div class="ease-avatar-group-item" style="background: #6366f1;">AW</div>
+        <div class="ease-avatar-group-item" style="background: #a855f7;">BM</div>
+        <div class="ease-avatar-group-item" style="background: #ec4899;">CS</div>
+        <div class="ease-avatar-group-item" style="background: #14b8a6;">DK</div>
+        <div class="ease-avatar-group-item" style="background: #f59e0b;">ER</div>
+        <div class="ease-avatar-group-item" style="background: #3b82f6;">FG</div>
+        <span class="ease-avatar-group-count">+4</span>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-10876/style.css
+++ b/submissions/core_changes-issue-10876/style.css
@@ -1,0 +1,188 @@
+/* ============================================
+   ease-avatar-group — Animated Avatar Stack — EaseMotion CSS
+   ============================================ */
+
+/* ── Reset & Base ── */
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #1a1a2e;
+  background: #f8f9fa;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3rem 1.5rem;
+}
+
+/* ── Section Styles ── */
+.section-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+  width: 100%;
+  max-width: 48rem;
+}
+
+.demo-section {
+  width: 100%;
+  max-width: 48rem;
+  margin-bottom: 2.5rem;
+}
+
+.demo-row {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.variant-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.variant-label {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.overlap-row {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.overlap-label {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  min-width: 9rem;
+}
+
+/* ── ease-avatar-group ── */
+.ease-avatar-group {
+  display: inline-flex;
+  align-items: center;
+  --ease-avatar-overlap: -0.5rem;
+}
+
+.ease-avatar-group-item {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 2px solid #fff;
+  margin-right: var(--ease-avatar-overlap, -0.5rem);
+  object-fit: cover;
+  transition: transform 0.2s ease, margin-right 0.2s ease;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #fff;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.ease-avatar-group-item:last-child {
+  margin-right: 0;
+}
+
+.ease-avatar-group:hover .ease-avatar-group-item {
+  margin-right: 0.15rem;
+}
+
+.ease-avatar-group-item:hover {
+  transform: translateY(-0.35rem);
+  z-index: 2;
+}
+
+.ease-avatar-group-item img {
+  width: 100%;
+  height: 100%;
+  border-radius: 9999px;
+  object-fit: cover;
+}
+
+.ease-avatar-group-count {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  background: #f1f5f9;
+  border: 2px solid #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #64748b;
+  flex-shrink: 0;
+  margin-right: 0;
+}
+
+/* ── Size Variants ── */
+.ease-avatar-group-item-sm {
+  width: 2rem;
+  height: 2rem;
+  font-size: 0.7rem;
+}
+
+.ease-avatar-group-count-sm {
+  width: 2rem;
+  height: 2rem;
+  font-size: 0.65rem;
+}
+
+.ease-avatar-group-item-lg {
+  width: 3rem;
+  height: 3rem;
+  font-size: 1rem;
+}
+
+.ease-avatar-group-count-lg {
+  width: 3rem;
+  height: 3rem;
+  font-size: 0.9rem;
+}
+
+.ease-avatar-group-item-xl {
+  width: 4rem;
+  height: 4rem;
+  font-size: 1.25rem;
+}
+
+.ease-avatar-group-count-xl {
+  width: 4rem;
+  height: 4rem;
+  font-size: 1rem;
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-avatar-group-item {
+    transition: none;
+  }
+
+  .ease-avatar-group:hover .ease-avatar-group-item {
+    margin-right: var(--ease-avatar-overlap, -0.5rem);
+  }
+
+  .ease-avatar-group-item:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a CSS-only animated avatar group / avatar stack component with the following features:

- `.ease-avatar-group` — flex container with configurable overlap via `--ease-avatar-overlap`
- `.ease-avatar-group-item` — individual avatar with border ring, hover lift (`translateY`)
- `.ease-avatar-group-count` — overflow count badge ("+N")
- Hover spread effect — group fans out on container hover
- Four size variants: sm (2rem), md (2.5rem), lg (3rem), xl (4rem)
- Supports both image and initials-based avatars
- Respects `prefers-reduced-motion`
- Pure CSS, no JavaScript

Closes #10876

## Files

- `submissions/core_changes-issue-10876/demo.html`
- `submissions/core_changes-issue-10876/style.css`
- `submissions/core_changes-issue-10876/README.md`

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist

- [x] All changes are inside `submissions/core_changes-issue-10876/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge