### PR TITLE
feat: add ease-announce-bar component with CSS-only dismiss (Closes #10875)

### DIFF
--- a/submissions/core_changes-issue-10875/README.md
+++ b/submissions/core_changes-issue-10875/README.md
@@ -1,0 +1,50 @@
+# ease-announce-bar
+
+## What does this do?
+
+Provides a CSS-only dismissable announcement bar / top banner component with slide-down entrance animation, color variants, and dismiss via the checkbox hack — no JavaScript required.
+
+## How is it used?
+
+Add a hidden checkbox followed by the announcement bar. The dismiss button is a `<label>` that toggles the checkbox, hiding the bar when checked.
+
+```html
+<input type="checkbox" id="dismiss-demo" class="ease-announce-bar-dismiss" />
+<div class="ease-announce-bar is-success">
+  <span class="ease-announce-bar-content">
+    <strong>Success!</strong> Your changes have been saved.
+  </span>
+  <label for="dismiss-demo" class="ease-announce-bar-close" tabindex="0">&#x2715;</label>
+</div>
+```
+
+### Color variants
+
+| Class | Color | Use case |
+| --- | --- | --- |
+| `is-info` (default) | Indigo | General announcements |
+| `is-success` | Green | Success confirmations |
+| `is-warning` | Amber | Warnings / expiring sessions |
+| `is-danger` | Red | Errors / critical alerts |
+
+### Fixed position
+
+Add `.is-fixed` to pin the bar to the top of the viewport:
+
+```html
+<div class="ease-announce-bar is-danger is-fixed">
+```
+
+## Why is it useful?
+
+Announcement banners are a common pattern for promotions, alerts, maintenance notices, and system messages. This component provides a polished, accessible, zero-JavaScript implementation that fits EaseMotion CSS's lightweight philosophy.
+
+## Features
+
+- Slide-down entrance animation (`ease-slide-down`)
+- CSS-only dismiss via checkbox hack (no JS)
+- Four color variants: info, success, warning, danger
+- Fixed position variant (`.is-fixed`)
+- Dismiss button with hover effect
+- Respects `prefers-reduced-motion`
+- Pure CSS, no JavaScript

--- a/submissions/core_changes-issue-10875/demo.html
+++ b/submissions/core_changes-issue-10875/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-announce-bar — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- Fixed banner at the very top -->
+  <input type="checkbox" id="dismiss-fixed" class="ease-announce-bar-dismiss" />
+  <div class="ease-announce-bar is-info is-fixed">
+    <span class="ease-announce-bar-content">
+      We just launched v2.0! <a href="#">Check it out</a>
+    </span>
+    <label for="dismiss-fixed" class="ease-announce-bar-close" tabindex="0">&#x2715;</label>
+  </div>
+
+  <div class="page-content">
+    <h1>ease-announce-bar</h1>
+    <p>
+      CSS-only dismissable announcement bar with slide-down animation, color variants,
+      and dismiss via the checkbox hack — no JavaScript required.
+    </p>
+  </div>
+
+  <div class="page-content">
+    <div class="demo-section">
+      <h2 class="section-title">Color Variants</h2>
+      <div class="stacked-demos">
+
+        <input type="checkbox" id="dismiss-info" class="ease-announce-bar-dismiss" />
+        <div class="ease-announce-bar is-info">
+          <span class="ease-announce-bar-content">
+            This is an <strong>info</strong> announcement. <a href="#">Learn more</a>
+          </span>
+          <label for="dismiss-info" class="ease-announce-bar-close" tabindex="0">&#x2715;</label>
+        </div>
+
+        <input type="checkbox" id="dismiss-success" class="ease-announce-bar-dismiss" />
+        <div class="ease-announce-bar is-success">
+          <span class="ease-announce-bar-content">
+            <strong>Success!</strong> Your changes have been saved.
+          </span>
+          <label for="dismiss-success" class="ease-announce-bar-close" tabindex="0">&#x2715;</label>
+        </div>
+
+        <input type="checkbox" id="dismiss-warning" class="ease-announce-bar-dismiss" />
+        <div class="ease-announce-bar is-warning">
+          <span class="ease-announce-bar-content">
+            <strong>Warning:</strong> Your session will expire in 5 minutes.
+          </span>
+          <label for="dismiss-warning" class="ease-announce-bar-close" tabindex="0">&#x2715;</label>
+        </div>
+
+        <input type="checkbox" id="dismiss-danger" class="ease-announce-bar-dismiss" />
+        <div class="ease-announce-bar is-danger">
+          <span class="ease-announce-bar-content">
+            <strong>Error:</strong> Unable to save changes. Please try again.
+          </span>
+          <label for="dismiss-danger" class="ease-announce-bar-close" tabindex="0">&#x2715;</label>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2 class="section-title">Usage Example</h2>
+      <pre style="background: #1e293b; color: #e2e8f0; padding: 1rem; border-radius: 0.5rem; font-size: 0.8rem; overflow-x: auto; white-space: pre-wrap;">
+&lt;input type="checkbox" id="dismiss-demo" class="ease-announce-bar-dismiss" /&gt;
+&lt;div class="ease-announce-bar is-success"&gt;
+  &lt;span class="ease-announce-bar-content"&gt;
+    &lt;strong&gt;Success!&lt;/strong&gt; Your changes have been saved.
+  &lt;/span&gt;
+  &lt;label for="dismiss-demo" class="ease-announce-bar-close" tabindex="0"&gt;&amp;#x2715;&lt;/label&gt;
+&lt;/div&gt;</pre>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-10875/style.css
+++ b/submissions/core_changes-issue-10875/style.css
@@ -1,0 +1,156 @@
+/* ============================================
+   ease-announce-bar — Dismissable Announcement Bar — EaseMotion CSS
+   ============================================ */
+
+/* ── Reset & Base ── */
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #1a1a2e;
+  background: #f8f9fa;
+}
+
+body {
+  min-height: 100vh;
+  padding-top: 1rem;
+}
+
+.page-content {
+  max-width: 48rem;
+  margin: 3rem auto;
+  padding: 0 1.5rem;
+}
+
+.page-content h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.page-content p {
+  line-height: 1.6;
+  color: #475569;
+}
+
+/* ── Demo section styles ── */
+.section-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+}
+
+.demo-section {
+  margin-bottom: 2rem;
+}
+
+.stacked-demos > * + * {
+  margin-top: 0.5rem;
+}
+
+/* ── ease-announce-bar ── */
+.ease-announce-bar {
+  position: relative;
+  padding: 0.75rem 1rem;
+  background: #6c63ff;
+  color: #fff;
+  text-align: center;
+  font-size: 0.875rem;
+  animation: ease-slide-down 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.ease-announce-bar.is-info {
+  background: #6c63ff;
+}
+
+.ease-announce-bar.is-success {
+  background: #10b981;
+}
+
+.ease-announce-bar.is-warning {
+  background: #f59e0b;
+}
+
+.ease-announce-bar.is-danger {
+  background: #ef4444;
+}
+
+.ease-announce-bar-content {
+  flex: 1;
+  text-align: center;
+}
+
+.ease-announce-bar-content a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.ease-announce-bar-content a:hover {
+  opacity: 0.9;
+}
+
+.ease-announce-bar-close {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.8;
+  padding: 0.25rem;
+  line-height: 1;
+  font-size: 1.1rem;
+  transition: opacity 0.2s;
+  flex-shrink: 0;
+}
+
+.ease-announce-bar-close:hover {
+  opacity: 1;
+}
+
+/* ── CSS-only dismiss via checkbox hack ── */
+.ease-announce-bar-dismiss {
+  display: none;
+}
+
+.ease-announce-bar-dismiss:checked ~ .ease-announce-bar {
+  display: none;
+}
+
+/* ── Fixed variant ── */
+.ease-announce-bar.is-fixed {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+}
+
+/* ── Slide-down animation ── */
+@keyframes ease-slide-down {
+  from {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-announce-bar {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a CSS-only dismissable announcement bar / top banner component with the following features:

- `.ease-announce-bar` — banner container with slide-down entrance animation
- `.ease-announce-bar-content` — text content area
- `.ease-announce-bar-close` — dismiss button (X icon)
- CSS-only dismiss via checkbox hack — no JavaScript required
- Color variants: `.is-info` (default), `.is-success`, `.is-warning`, `.is-danger`
- `.is-fixed` variant for fixed positioning at the top of the viewport
- Respects `prefers-reduced-motion`

Closes #10875

## Files

- `submissions/core_changes-issue-10875/demo.html`
- `submissions/core_changes-issue-10875/style.css`
- `submissions/core_changes-issue-10875/README.md`

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist

- [x] All changes are inside `submissions/core_changes-issue-10875/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge