### PR TITLE
feat: add marquee speed variants

### DIFF
--- a/submissions/examples/marquee-speed-variants/README.md
+++ b/submissions/examples/marquee-speed-variants/README.md
@@ -1,0 +1,21 @@
+# Marquee Speed Variants
+
+Three marquee speed presets demonstrating scroll-text animation with configurable duration:
+
+| Class | Duration | Speed |
+|-------|----------|-------|
+| `.marquee-half` | 20s | Half speed |
+| `.marquee-normal` | 10s | Default |
+| `.marquee-fast` | 3.33s | 3x speed |
+
+## Usage
+
+```html
+<div class="marquee marquee-half">
+  <span>Your scrolling text here</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+Extends the existing marquee pattern with explicit speed utility classes, making it easy to switch between slow, normal, and fast scroll rates using just a class swap.

--- a/submissions/examples/marquee-speed-variants/demo.html
+++ b/submissions/examples/marquee-speed-variants/demo.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Marquee Speed Variants</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Marquee Speed Variants</h1>
+    <p class="subtitle">Three speed presets: half, normal, and 3x</p>
+
+    <div class="marquee-group">
+      <label>Half Speed</label>
+      <div class="marquee marquee-half">
+        <span>Slow &amp; steady — EaseMotion CSS &nbsp;—&nbsp; </span>
+      </div>
+    </div>
+
+    <div class="marquee-group">
+      <label>Normal Speed</label>
+      <div class="marquee marquee-normal">
+        <span>Default marquee — EaseMotion CSS &nbsp;—&nbsp; </span>
+      </div>
+    </div>
+
+    <div class="marquee-group">
+      <label>3x Speed</label>
+      <div class="marquee marquee-fast">
+        <span>Fast lane — EaseMotion CSS &nbsp;—&nbsp; </span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/marquee-speed-variants/style.css
+++ b/submissions/examples/marquee-speed-variants/style.css
@@ -1,0 +1,82 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 600px;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  margin-bottom: 2.5rem;
+}
+
+.marquee-group {
+  margin-bottom: 2rem;
+}
+
+.marquee-group label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #64748b;
+  margin-bottom: 0.5rem;
+}
+
+.marquee {
+  overflow: hidden;
+  white-space: nowrap;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 12px 16px;
+  background: #1e293b;
+}
+
+.marquee span {
+  display: inline-block;
+  padding-left: 100%;
+  animation: scroll-text linear infinite;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.marquee-normal span {
+  animation-duration: 10s;
+}
+
+.marquee-half span {
+  animation-duration: 20s;
+}
+
+.marquee-fast span {
+  animation-duration: 3.33s;
+}
+
+@keyframes scroll-text {
+  to {
+    transform: translateX(-100%);
+  }
+}


### PR DESCRIPTION
Closes #6195\n\nThree marquee speed presets: half (20s), normal (10s), and fast/3x (3.33s).\n\n### Files\n- `submissions/examples/marquee-speed-variants/demo.html`\n- `submissions/examples/marquee-speed-variants/style.css`\n- `submissions/examples/marquee-speed-variants/README.md`