### PR TITLE
feat: add searchable list with highlight matching

### DIFF
--- a/submissions/examples/searchable-highlight-list/README.md
+++ b/submissions/examples/searchable-highlight-list/README.md
@@ -1,0 +1,17 @@
+# Searchable List with Highlight Matching
+
+A searchable list that filters items and highlights the matching portion of text using `<mark>`. Non-matching items are hidden.
+
+## Usage
+
+```html
+<input class="search-input" type="text" placeholder="Search items..." />
+<ul class="item-list">
+  <li>Item one</li>
+  <li>Item two</li>
+</ul>
+```
+
+## Why it fits EaseMotion CSS
+
+Demonstrates real-time DOM filtering, dark-theme form inputs, and highlight styling — a common pattern for documentation and component browsers built with EaseMotion CSS.

--- a/submissions/examples/searchable-highlight-list/demo.html
+++ b/submissions/examples/searchable-highlight-list/demo.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Searchable List with Highlight</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Searchable List</h1>
+    <p class="subtitle">Type to filter and highlight matches</p>
+    <input class="search-input" id="search" type="text" placeholder="Search items..." autofocus />
+    <ul class="item-list" id="list">
+      <li>Animation utilities</li>
+      <li>Button components</li>
+      <li>Card variants</li>
+      <li>Dark mode tokens</li>
+      <li>Form inputs</li>
+      <li>Grid layouts</li>
+      <li>Marquee effects</li>
+      <li>Modal dialogs</li>
+      <li>Navigation bars</li>
+      <li>Scroll animations</li>
+      <li>Segmented controls</li>
+      <li>Toast notifications</li>
+    </ul>
+  </div>
+  <script>
+    const search = document.getElementById("search");
+    const list = document.getElementById("list");
+    search.addEventListener("input", () => {
+      const q = search.value.trim().toLowerCase();
+      Array.from(list.children).forEach(li => {
+        const text = li.textContent.toLowerCase();
+        if (q === "") {
+          li.innerHTML = li.textContent;
+          li.style.display = "";
+        } else if (text.includes(q)) {
+          const idx = text.indexOf(q);
+          li.innerHTML = li.textContent.slice(0, idx) + "<mark>" + li.textContent.slice(idx, idx + q.length) + "</mark>" + li.textContent.slice(idx + q.length);
+          li.style.display = "";
+        } else {
+          li.innerHTML = li.textContent;
+          li.style.display = "none";
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/searchable-highlight-list/style.css
+++ b/submissions/examples/searchable-highlight-list/style.css
@@ -1,0 +1,52 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.container { width: 100%; max-width: 420px; padding: 2rem; }
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.subtitle { color: #94a3b8; font-size: 0.85rem; margin-bottom: 1.5rem; }
+
+.search-input {
+  width: 100%;
+  padding: 12px 16px;
+  border: 1px solid #334155;
+  border-radius: 10px;
+  background: #1e293b;
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.search-input:focus { border-color: #3b82f6; }
+.search-input::placeholder { color: #64748b; }
+
+.item-list {
+  list-style: none;
+  margin-top: 1rem;
+}
+
+.item-list li {
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  color: #cbd5e1;
+  transition: background 0.15s;
+}
+
+.item-list li:hover { background: #1e293b; }
+
+mark {
+  background: #3b82f6;
+  color: #fff;
+  border-radius: 3px;
+  padding: 1px 4px;
+}


### PR DESCRIPTION
Closes #8034\n\nA searchable list that filters items and highlights the matching text portion using `<mark>`.\n\n### Files\n- `submissions/examples/searchable-highlight-list/demo.html`\n- `submissions/examples/searchable-highlight-list/style.css`\n- `submissions/examples/searchable-highlight-list/README.md`