### PR TITLE
Add table row scan highlight example

### DIFF
--- a/submissions/examples/table-row-scan-highlight-ts/README.md
+++ b/submissions/examples/table-row-scan-highlight-ts/README.md
@@ -1,0 +1,44 @@
+# Animated Table Row Scan Highlight
+
+## What does this do?
+
+This example adds a subtle scan-style highlight to table rows on hover and keyboard focus.
+
+## How is it used?
+
+Add the `scan-row` class to focusable table rows:
+
+```html
+<tr class="scan-row" tabindex="0">
+  <td>#1042</td>
+  <td><span class="status paid">Paid</span></td>
+  <td>$240.00</td>
+</tr>
+```
+
+## Why is it useful?
+
+Dense admin tables can be hard to track visually. A scan highlight helps users follow wide rows without changing table layout or adding JavaScript.
+
+## Features
+
+- CSS-only row scan highlight
+- Hover and keyboard focus support
+- Responsive overflow wrapper
+- Status pill examples
+- `prefers-reduced-motion` support
+
+## Tech Stack
+
+- HTML
+- CSS
+
+## Preview
+
+Open `demo.html` directly in a browser to view the example.
+
+## Contribution Notes
+
+- Proposed for issue #11120
+- All files are scoped to this submission folder
+- No framework source files are modified

--- a/submissions/examples/table-row-scan-highlight-ts/demo.html
+++ b/submissions/examples/table-row-scan-highlight-ts/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Table Row Scan Highlight</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="table-panel" aria-labelledby="demo-title">
+      <div class="panel-header">
+        <div>
+          <p class="eyebrow">Billing table</p>
+          <h1 id="demo-title">Table row scan highlight</h1>
+        </div>
+        <span class="panel-badge">Keyboard friendly</span>
+      </div>
+
+      <div class="table-wrap">
+        <table class="scan-table">
+          <thead>
+            <tr>
+              <th>Invoice</th>
+              <th>Status</th>
+              <th>Customer</th>
+              <th>Amount</th>
+              <th>Due date</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="scan-row" tabindex="0">
+              <td>#1042</td>
+              <td><span class="status paid">Paid</span></td>
+              <td>Northline Studio</td>
+              <td>$240.00</td>
+              <td>Jan 14</td>
+            </tr>
+            <tr class="scan-row" tabindex="0">
+              <td>#1043</td>
+              <td><span class="status pending">Pending</span></td>
+              <td>Vertex Labs</td>
+              <td>$980.00</td>
+              <td>Jan 18</td>
+            </tr>
+            <tr class="scan-row" tabindex="0">
+              <td>#1044</td>
+              <td><span class="status overdue">Overdue</span></td>
+              <td>Bluegrain Co.</td>
+              <td>$415.00</td>
+              <td>Jan 21</td>
+            </tr>
+            <tr class="scan-row" tabindex="0">
+              <td>#1045</td>
+              <td><span class="status paid">Paid</span></td>
+              <td>Signal Works</td>
+              <td>$720.00</td>
+              <td>Jan 28</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/table-row-scan-highlight-ts/style.css
+++ b/submissions/examples/table-row-scan-highlight-ts/style.css
@@ -1,0 +1,173 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b1120;
+  --panel: #111827;
+  --table: #162033;
+  --border: rgba(148, 163, 184, 0.22);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --blue: #38bdf8;
+  --green: #22c55e;
+  --amber: #f59e0b;
+  --red: #ef4444;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 15% 20%, rgba(56, 189, 248, 0.16), transparent 26rem),
+    radial-gradient(circle at 86% 74%, rgba(34, 197, 94, 0.12), transparent 28rem),
+    var(--bg);
+  color: var(--text);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.table-panel {
+  width: min(1040px, 100%);
+  padding: clamp(1rem, 4vw, 1.5rem);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.06), transparent), var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.28);
+}
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.2rem;
+}
+
+.eyebrow,
+h1 {
+  margin-top: 0;
+}
+
+.eyebrow {
+  margin-bottom: 0.5rem;
+  color: #7dd3fc;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: clamp(1.85rem, 5vw, 3.4rem);
+  line-height: 1;
+}
+
+.panel-badge {
+  flex: 0 0 auto;
+  padding: 0.45rem 0.7rem;
+  color: #bae6fd;
+  font-size: 0.8rem;
+  font-weight: 800;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  border-radius: 999px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 18px;
+}
+
+.scan-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+  background: var(--table);
+}
+
+th,
+td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+th {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.scan-row {
+  background-image: linear-gradient(90deg, transparent, rgba(56, 189, 248, 0.16), transparent);
+  background-size: 230% 100%;
+  background-position: 125% 0;
+  outline: none;
+  transition: background-position 520ms ease, color 180ms ease;
+}
+
+.scan-row:hover,
+.scan-row:focus-visible {
+  background-position: -25% 0;
+}
+
+.scan-row:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--blue);
+}
+
+.status {
+  display: inline-flex;
+  min-width: 4.8rem;
+  justify-content: center;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.78rem;
+  font-weight: 800;
+  border-radius: 999px;
+}
+
+.paid {
+  color: #bbf7d0;
+  background: rgba(34, 197, 94, 0.14);
+}
+
+.pending {
+  color: #fde68a;
+  background: rgba(245, 158, 11, 0.14);
+}
+
+.overdue {
+  color: #fecaca;
+  background: rgba(239, 68, 68, 0.14);
+}
+
+@media (max-width: 700px) {
+  .panel-header {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition: none !important;
+    animation: none !important;
+  }
+
+  .scan-row:hover,
+  .scan-row:focus-visible {
+    background-position: 50% 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained animated table row scan highlight example for dense admin tables.

Closes #11120

---

## Type of Change

- [x] ? New animation / hover effect
- [ ] ?? New component
- [ ] ?? Documentation improvement
- [ ] ?? Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/table-row-scan-highlight-ts/`
- [x] Includes `demo.html` ? self-contained, opens in browser with no server
- [x] Includes `style.css` ? raw CSS for the proposed feature
- [x] Includes `README.md` ? what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only scan highlight for focusable table rows, including hover and keyboard focus states.

**How does a developer use it?**

```html
<tr class="scan-row" tabindex="0">
  <td>#1042</td>
  <td><span class="status paid">Paid</span></td>
</tr>
```

**Why does it fit EaseMotion CSS?**

It adds a practical micro-interaction that improves table scanning without JavaScript.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer

CSS lint passed for the new stylesheet.
