### PR TITLE
fix(modal): restore focus on close to meet WCAG 2.1 guidelines

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -1,9 +1,13 @@
 (function () {
   'use strict';
 
+  let previousFocusElement = null;
+
   function checkModal() {
     const hash = window.location.hash;
     const body = document.body;
+
+    const wasModalOpen = document.querySelector('.ease-modal-overlay.is-active') !== null;
 
     // Remove active class from all overlays just in case
     const overlays = document.querySelectorAll('.ease-modal-overlay');
@@ -15,6 +19,9 @@
         const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
         const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
         if (overlay) {
+          if (!wasModalOpen) {
+            previousFocusElement = document.activeElement;
+          }
           body.style.overflow = 'hidden';
           overlay.classList.add('is-active');
 
@@ -32,6 +39,11 @@
 
     // If no active modal is found
     body.style.overflow = '';
+
+    if (previousFocusElement) {
+      previousFocusElement.focus();
+      previousFocusElement = null;
+    }
   }
 
   // Setup event listeners for hash changes (opening/closing via anchors)


### PR DESCRIPTION
## Pull Request Description

This PR resolves an accessibility issue with the `.ease-modal` component where focus is lost upon closing the modal via the Escape key or overlay click. It ensures that the `document.activeElement` is saved when the modal opens and focus is cleanly restored to it when the modal closes, fully complying with WCAG 2.1 Focus Order guidelines.

Resolves #11061

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
      *Bug fix in core modal functionality*

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

*(Note: Items left unchecked because this is a direct core bug fix, not a new example submission)*

---

## Feature Description

**What does this add?**

Automatically restores keyboard focus to the element that triggered the modal once the modal is closed.

**How does a developer use it?**

```html
<!-- No developer changes required; it works automatically with the standard modal HTML -->
<a href="#demo-modal" class="ease-btn">Open Modal</a>

<div id="demo-modal" class="ease-modal-overlay">
  <div class="ease-modal">
    <!-- Modal content -->
  </div>
</div>
