### PR TITLE
fix: replace display toggling with visibility in mobile sidebar to enable CSS transitions

### DIFF
--- a/components/sidebar.css
+++ b/components/sidebar.css
@@ -76,7 +76,8 @@
     height: 100vh;
     z-index: 100;
     width: var(--ease-sidebar-width, 260px);
-    display: none;
+    visibility: hidden;
+    pointer-events: none;
     transform: translateX(-100%);
     transition:
       transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
@@ -84,7 +85,8 @@
   }
 
   .ease-sidebar-layout.ease-sidebar-open .ease-sidebar {
-    display: block;
+    visibility: visible;
+    pointer-events: auto;
     transform: translateX(0);
     box-shadow: 12px 0 36px rgba(0, 0, 0, 0.15);
   }


### PR DESCRIPTION
Closes #10177

### Changes
- Replaced `display: none` with `visibility: hidden; pointer-events: none` in mobile sidebar closed state
- Replaced `display: block` with `visibility: visible; pointer-events: auto` in mobile sidebar open state
- Fixes the bug where the sidebar instantaneously appeared/disappeared because `display` changes cannot be animated with CSS transitions

### Files changed
- components/sidebar.css