### PR TITLE
feat: add CSS Relative Color Syntax example

### DIFF
--- a/submissions/examples/css-relative-color-syntax/README.md
+++ b/submissions/examples/css-relative-color-syntax/README.md
@@ -1,0 +1,20 @@
+# CSS Relative Color Syntax
+
+Interactive demo of the CSS `oklch(from ...)` relative color syntax — derive new colors from an existing base color by adjusting lightness, chroma, and hue channels.
+
+## Features
+
+- Base color card shown in `oklch(55% 0.15 260)`
+- Four derived colors: lighter, more saturated, complementary hue, muted
+- Uses `oklch(from var(--base) L C H)` syntax
+- Responsive grid layout with hover effects
+- Dark theme with `prefers-reduced-motion` support
+
+## Files
+
+- `demo.html` — Color palette comparison layout
+- `style.css` — Self-contained CSS (80 lines)
+
+## Preview
+
+Base color and four derived relatives displayed in a clean card grid.

--- a/submissions/examples/css-relative-color-syntax/demo.html
+++ b/submissions/examples/css-relative-color-syntax/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Relative Color Syntax – EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="palette">
+  <h1 class="title">CSS <code>oklch(from …)</code> Relative Colors</h1>
+  <p class="subtitle">Derive new colors from a single base by adjusting L, C, or H channels.</p>
+
+  <div class="grid">
+    <div class="card base">
+      <div class="swatch" style="--base: oklch(55% 0.15 260)"></div>
+      <div class="info">
+        <span class="label">Base</span>
+        <code>oklch(55% 0.15 260)</code>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="swatch" style="--base: oklch(55% 0.15 260); background: oklch(from var(--base) 75% c h)"></div>
+      <div class="info">
+        <span class="label">Lighter</span>
+        <code>L → 75%</code>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="swatch" style="--base: oklch(55% 0.15 260); background: oklch(from var(--base) l 0.25 h)"></div>
+      <div class="info">
+        <span class="label">More Saturated</span>
+        <code>C → 0.25</code>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="swatch" style="--base: oklch(55% 0.15 260); background: oklch(from var(--base) l c calc(h + 180))"></div>
+      <div class="info">
+        <span class="label">Complementary</span>
+        <code>H + 180&deg;</code>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="swatch" style="--base: oklch(55% 0.15 260); background: oklch(from var(--base) 40% 0.05 h)"></div>
+      <div class="info">
+        <span class="label">Muted Dark</span>
+        <code>L → 40%, C → 0.05</code>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-relative-color-syntax/style.css
+++ b/submissions/examples/css-relative-color-syntax/style.css
@@ -1,0 +1,92 @@
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+
+body{
+  font-family:'Segoe UI',system-ui,-apple-system,sans-serif;
+  background:#0a0f1e;
+  color:#e2e8f0;
+  min-height:100vh;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:40px 20px
+}
+
+.palette{max-width:800px;width:100%}
+
+.title{
+  font-size:24px;
+  font-weight:700;
+  text-align:center;
+  margin-bottom:8px
+}
+
+.title code{
+  background:#1e293b;
+  padding:2px 10px;
+  border-radius:6px;
+  font-size:20px
+}
+
+.subtitle{
+  text-align:center;
+  color:#64748b;
+  font-size:14px;
+  margin-bottom:32px
+}
+
+.grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+  gap:16px
+}
+
+.card{
+  background:#111827;
+  border:1px solid #1e293b;
+  border-radius:12px;
+  overflow:hidden;
+  transition:transform 0.25s,box-shadow 0.25s
+}
+
+.card:hover{
+  transform:translateY(-4px);
+  box-shadow:0 8px 24px rgba(0,0,0,0.3)
+}
+
+.card.base{
+  border-color:#3b82f6;
+  box-shadow:0 0 0 1px #3b82f6
+}
+
+.swatch{
+  height:120px;
+  transition:filter 0.3s
+}
+
+.card:hover .swatch{filter:brightness(1.1)}
+
+.info{
+  padding:12px 16px;
+  display:flex;
+  flex-direction:column;
+  gap:4px
+}
+
+.label{
+  font-size:13px;
+  font-weight:600;
+  color:#94a3b8;
+  text-transform:uppercase;
+  letter-spacing:0.5px
+}
+
+.info code{
+  font-size:12px;
+  color:#64748b;
+  word-break:break-all
+}
+
+@media(prefers-reduced-motion:reduce){
+  .card{transition:none}
+  .swatch{transition:none}
+}


### PR DESCRIPTION
Closes #9144

### Changes
Added a demo showcasing CSS `oklch(from ...)` relative color syntax with a base color and four derived variants (lighter, more saturated, complementary hue, muted dark).

### Files added
- submissions/examples/css-relative-color-syntax/README.md
- submissions/examples/css-relative-color-syntax/demo.html
- submissions/examples/css-relative-color-syntax/style.css