### PR TITLE
feat: add CSS view-timeline-inset offset example

### DIFF
--- a/submissions/examples/css-view-timeline-inset/README.md
+++ b/submissions/examples/css-view-timeline-inset/README.md
@@ -1,0 +1,19 @@
+# CSS view-timeline-inset Offset Example
+
+Scroll-driven animation using `view-timeline-inset` to control when the animation starts and ends relative to the viewport.
+
+## Features
+
+- Cards animate in as they scroll into view
+- `view-timeline-inset: 20%` delays start until card is 20% in view
+- Smooth opacity and translation transitions
+- Dark theme with `prefers-reduced-motion` support
+
+## Files
+
+- `demo.html` — Scrollable card list with entrance animations
+- `style.css` — Self-contained CSS (95 lines)
+
+## Preview
+
+Cards that fade and slide in as they scroll into the viewport, with a 20% inset offset.

--- a/submissions/examples/css-view-timeline-inset/demo.html
+++ b/submissions/examples/css-view-timeline-inset/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS view-timeline-inset – EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+  <h1 class="title"><code>view-timeline-inset</code> Offset</h1>
+  <p class="subtitle">Cards animate when 20% visible — scroll down.</p>
+
+  <div class="card-list">
+    <div class="scroll-card">Card 1</div>
+    <div class="scroll-card">Card 2</div>
+    <div class="scroll-card">Card 3</div>
+    <div class="scroll-card">Card 4</div>
+    <div class="scroll-card">Card 5</div>
+    <div class="scroll-card">Card 6</div>
+    <div class="scroll-card">Card 7</div>
+    <div class="scroll-card">Card 8</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-view-timeline-inset/style.css
+++ b/submissions/examples/css-view-timeline-inset/style.css
@@ -1,0 +1,79 @@
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+
+body{
+  font-family:'Segoe UI',system-ui,-apple-system,sans-serif;
+  background:#0a0f1e;
+  color:#e2e8f0;
+  min-height:100vh;
+  padding:40px 20px
+}
+
+.container{max-width:600px;margin:0 auto}
+
+.title{
+  font-size:24px;
+  font-weight:700;
+  text-align:center;
+  margin-bottom:8px
+}
+
+.title code{
+  background:#1e293b;
+  padding:2px 10px;
+  border-radius:6px;
+  font-size:20px
+}
+
+.subtitle{
+  text-align:center;
+  color:#64748b;
+  font-size:14px;
+  margin-bottom:40px
+}
+
+.card-list{
+  display:flex;
+  flex-direction:column;
+  gap:40px;
+  padding-bottom:200px
+}
+
+.scroll-card{
+  height:200px;
+  background:#111827;
+  border:1px solid #1e293b;
+  border-radius:16px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:20px;
+  font-weight:600;
+  color:#475569;
+
+  view-timeline-name:--card;
+  view-timeline-axis:block;
+  view-timeline-inset:20%;
+
+  animation:reveal linear both;
+  animation-timeline:--card;
+  animation-range:entry 0% entry 100%
+}
+
+@keyframes reveal{
+  from{
+    opacity:0;
+    transform:translateY(60px) scale(0.95);
+    color:#3b82f6;
+    border-color:#3b82f6
+  }
+  to{
+    opacity:1;
+    transform:translateY(0) scale(1);
+    color:#e2e8f0;
+    border-color:#1e293b
+  }
+}
+
+@media(prefers-reduced-motion:reduce){
+  .scroll-card{animation:none;opacity:1;transform:none}
+}


### PR DESCRIPTION
Closes #9141

### Changes
Added a scroll-driven animation demo using `view-timeline-inset: 20%` to delay each card's reveal animation until 20% visible.

### Files added
- submissions/examples/css-view-timeline-inset/README.md
- submissions/examples/css-view-timeline-inset/demo.html
- submissions/examples/css-view-timeline-inset/style.css