### PR TITLE
feat: add CSS calc-size() smooth animation example

### DIFF
--- a/submissions/examples/css-calc-size/README.md
+++ b/submissions/examples/css-calc-size/README.md
@@ -1,0 +1,19 @@
+# CSS calc-size() Smooth Animation Example
+
+Demo of the CSS `calc-size()` function — animate smoothly between `auto` and fixed sizes without layout jumps.
+
+## Features
+
+- Accordion panel using `calc-size(height, auto)` for smooth expand/collapse
+- Animated width transition with `calc-size()`
+- Button to toggle between open/closed states
+- Dark theme with `prefers-reduced-motion` support
+
+## Files
+
+- `demo.html` — Interactive accordion and width demo
+- `style.css` — Self-contained CSS (100 lines)
+
+## Preview
+
+A panel that smoothly expands from 0 to auto height, and a box that smoothly transitions width from a fixed value to auto.

--- a/submissions/examples/css-calc-size/demo.html
+++ b/submissions/examples/css-calc-size/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS calc-size() – EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+  <h1 class="title">CSS <code>calc-size()</code></h1>
+  <p class="subtitle">Smoothly animate between fixed sizes and <code>auto</code>.</p>
+
+  <div class="demo-section">
+    <h2 class="section-title">Accordion Height</h2>
+    <div class="accordion">
+      <button class="accordion-trigger" onclick="this.parentElement.classList.toggle('open')">Toggle Content</button>
+      <div class="accordion-body">
+        <div class="accordion-content">
+          <p>This panel animates from <code>height: 0</code> to <code>height: auto</code> using <code>calc-size()</code>. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2 class="section-title">Width Transition</h2>
+    <div class="width-box" id="widthBox">
+      <span class="width-label" id="widthLabel">Click to expand</span>
+    </div>
+    <button class="toggle-btn" onclick="document.getElementById('widthBox').classList.toggle('expanded')">Toggle Width</button>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-calc-size/style.css
+++ b/submissions/examples/css-calc-size/style.css
@@ -1,0 +1,133 @@
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+
+body{
+  font-family:'Segoe UI',system-ui,-apple-system,sans-serif;
+  background:#0a0f1e;
+  color:#e2e8f0;
+  min-height:100vh;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:40px 20px
+}
+
+.container{max-width:600px;width:100%}
+
+.title{
+  font-size:24px;
+  font-weight:700;
+  text-align:center;
+  margin-bottom:8px
+}
+
+.title code{
+  background:#1e293b;
+  padding:2px 10px;
+  border-radius:6px;
+  font-size:20px
+}
+
+.subtitle{
+  text-align:center;
+  color:#64748b;
+  font-size:14px;
+  margin-bottom:40px
+}
+
+.demo-section{
+  margin-bottom:36px
+}
+
+.section-title{
+  font-size:16px;
+  font-weight:600;
+  color:#94a3b8;
+  margin-bottom:16px;
+  text-transform:uppercase;
+  letter-spacing:0.5px
+}
+
+.accordion{
+  background:#111827;
+  border:1px solid #1e293b;
+  border-radius:12px;
+  overflow:hidden
+}
+
+.accordion-trigger{
+  width:100%;
+  padding:14px 20px;
+  background:none;
+  border:none;
+  color:#e2e8f0;
+  font-size:15px;
+  font-weight:600;
+  font-family:inherit;
+  cursor:pointer;
+  text-align:left;
+  transition:background 0.2s
+}
+
+.accordion-trigger:hover{background:#1e293b}
+
+.accordion-body{
+  height:0;
+  overflow:hidden;
+  transition:height 0.4s ease;
+  transition-behavior:allow-discrete
+}
+
+.accordion.open .accordion-body{
+  height:calc-size(auto)
+}
+
+.accordion-content{
+  padding:0 20px 20px;
+  color:#64748b;
+  font-size:14px;
+  line-height:1.6
+}
+
+.accordion-content code{font-size:12px}
+
+.width-box{
+  background:linear-gradient(135deg,#3b82f6,#8b5cf6);
+  border-radius:12px;
+  height:80px;
+  display:flex;
+  align-items:center;
+  padding:0 20px;
+  cursor:pointer;
+  width:200px;
+  transition:width 0.5s ease;
+  margin-bottom:12px
+}
+
+.width-box.expanded{width:100%}
+
+.width-label{
+  font-size:14px;
+  font-weight:600;
+  color:#fff;
+  white-space:nowrap
+}
+
+.toggle-btn{
+  padding:10px 24px;
+  background:#1e293b;
+  border:1px solid #334155;
+  border-radius:8px;
+  color:#e2e8f0;
+  font-size:14px;
+  font-weight:500;
+  font-family:inherit;
+  cursor:pointer;
+  transition:background 0.25s
+}
+
+.toggle-btn:hover{background:#334155}
+
+@media(prefers-reduced-motion:reduce){
+  .accordion-body{transition:none}
+  .width-box{transition:none}
+}


### PR DESCRIPTION
Closes #9139

### Changes
Added a demo showcasing CSS `calc-size()` for smooth height (accordion expand/collapse) and width transitions between fixed and auto sizes.

### Files added
- submissions/examples/css-calc-size/README.md
- submissions/examples/css-calc-size/demo.html
- submissions/examples/css-calc-size/style.css