### PR TITLE
feat: add theme preview swatch grid component (issue #11159)

### DIFF
--- a/submissions/examples/theme-preview-swatch-grid-ts/README.md
+++ b/submissions/examples/theme-preview-swatch-grid-ts/README.md
@@ -1,0 +1,74 @@
+# Theme Preview Swatch Grid
+
+## What does this do?
+
+Displays a responsive grid of palette cards, each showing a five-step colour swatch strip, a row of UI token dots (surface, text, accent, success, danger), and a tiny mock UI preview bar. Clicking a card marks it selected: a tick badge pops in, the border highlights, and an `aria-live` banner announces the choice. The swatch strips expand on hover using a CSS `flex` transition with no JavaScript.
+
+## How is it used?
+
+Wrap cards in `.theme-grid`, give each card a palette modifier class (e.g. `theme-ocean`), and add `is-selected` to the default choice.
+
+```html
+<div class="theme-grid" role="radiogroup" aria-label="Theme palettes">
+
+  <button class="theme-card theme-ocean is-selected"
+          type="button"
+          role="radio"
+          aria-checked="true"
+          aria-label="Ocean theme"
+          onclick="selectTheme(this, 'Ocean')">
+
+    <div class="swatch-row" aria-hidden="true">
+      <span class="swatch swatch-1"></span>
+      <span class="swatch swatch-2"></span>
+      <span class="swatch swatch-3"></span>
+      <span class="swatch swatch-4"></span>
+      <span class="swatch swatch-5"></span>
+    </div>
+
+    <div class="token-row" aria-hidden="true">
+      <span class="token-dot token-surface"></span>
+      <span class="token-dot token-text"></span>
+      <span class="token-dot token-accent"></span>
+      <span class="token-dot token-success"></span>
+      <span class="token-dot token-danger"></span>
+    </div>
+
+    <div class="theme-ui-preview" aria-hidden="true">
+      <div class="theme-ui-bar"></div>
+      <div class="theme-ui-body">
+        <div class="theme-ui-line long"></div>
+        <div class="theme-ui-line short"></div>
+      </div>
+    </div>
+
+    <div class="theme-card-label">
+      <span class="theme-card-name">Ocean</span>
+      <span class="theme-card-desc">Cool blues, deep navy</span>
+    </div>
+
+  </button>
+
+  <!-- repeat for each palette -->
+
+</div>
+```
+
+Six palette modifier classes are included out of the box: `theme-ocean`, `theme-violet`, `theme-ember`, `theme-forest`, `theme-rose`, `theme-slate`. Each one sets five swatch colours, five token dot colours, and three CSS custom properties (`--theme-accent`, `--theme-surface`, `--theme-text`) used by the mini UI preview strip.
+
+To mark a card selected from JavaScript:
+
+```js
+function selectTheme(card, name) {
+  document.querySelectorAll('.theme-card').forEach(function(c) {
+    c.classList.remove('is-selected');
+    c.setAttribute('aria-checked', 'false');
+  });
+  card.classList.add('is-selected');
+  card.setAttribute('aria-checked', 'true');
+}
+```
+
+## Why is it useful?
+
+Design systems and app settings screens commonly need a theme or colour scheme picker. This example shows how CSS variables and small motion details — a lift-and-shadow on hover, expanding swatch slots, and a pop-in tick badge — make palette selection feel considered rather than just functional. All six palettes are self-contained in the CSS, so adding a new one only requires one class definition block. The component is accessible (radio group semantics, `aria-live` announcement on selection), dark-mode aware, and respects `prefers-reduced-motion` by disabling the lift and swatch-expand transitions.

--- a/submissions/examples/theme-preview-swatch-grid-ts/demo.html
+++ b/submissions/examples/theme-preview-swatch-grid-ts/demo.html
@@ -1,0 +1,408 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Theme Preview Swatch Grid</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #f1f5f9;
+        color: #0f172a;
+        min-height: 100vh;
+        padding: 2.5rem 1.25rem 3.5rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2.5rem;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body { background: #0f172a; color: #e2e8f0; }
+      }
+
+      .demo-header {
+        text-align: center;
+        max-width: 560px;
+      }
+
+      .demo-header h1 {
+        font-size: 1.45rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        margin-bottom: 0.4rem;
+        color: #0f172a;
+      }
+
+      .demo-header p {
+        font-size: 0.875rem;
+        color: #64748b;
+        line-height: 1.6;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .demo-header h1 { color: #f1f5f9; }
+        .demo-header p  { color: #94a3b8; }
+      }
+
+      .demo-section {
+        width: 100%;
+        max-width: 740px;
+        display: flex;
+        flex-direction: column;
+        gap: 0.65rem;
+      }
+
+      .demo-divider {
+        width: 100%;
+        max-width: 740px;
+        height: 1px;
+        background: linear-gradient(90deg, transparent, #cbd5e1, transparent);
+        border: none;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .demo-divider {
+          background: linear-gradient(90deg, transparent, #334155, transparent);
+        }
+      }
+
+      /* Selected theme feedback banner */
+      .theme-chosen-banner {
+        width: 100%;
+        max-width: 740px;
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+        border-radius: 0.6rem;
+        padding: 0.65rem 1rem;
+        font-size: 0.82rem;
+        color: #15803d;
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-height: 2.4rem;
+        transition: opacity 200ms ease;
+      }
+
+      .theme-chosen-banner.is-hidden {
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .theme-chosen-banner {
+          background: rgba(21, 128, 61, 0.12);
+          border-color: rgba(34, 197, 94, 0.25);
+          color: #86efac;
+        }
+      }
+
+      .theme-chosen-banner svg {
+        flex-shrink: 0;
+        width: 1rem;
+        height: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+
+    <header class="demo-header">
+      <h1>Theme Preview Swatch Grid</h1>
+      <p>
+        Six palette cards with animated swatch strips and UI token dots.
+        Click any card to select it — the tick badge pops in and the card
+        gets a highlighted border. Hover the swatches to see them expand.
+      </p>
+    </header>
+
+    <!-- Selected theme feedback -->
+    <div class="theme-chosen-banner is-hidden" id="chosenBanner" role="status" aria-live="polite">
+      <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd"/>
+      </svg>
+      <span id="chosenText">Theme selected</span>
+    </div>
+
+    <!-- ── Main swatch grid ───────────────────────────────── -->
+
+    <section class="demo-section" aria-label="Theme palette selection">
+      <p class="swatch-section-title">Choose a palette</p>
+
+      <div class="theme-grid" id="themeGrid" role="radiogroup" aria-label="Theme palettes">
+
+        <!-- Ocean -->
+        <button
+          class="theme-card theme-ocean is-selected"
+          type="button"
+          role="radio"
+          aria-checked="true"
+          aria-label="Ocean theme"
+          onclick="selectTheme(this, 'Ocean')"
+        >
+          <div class="swatch-row" aria-hidden="true">
+            <span class="swatch swatch-1"></span>
+            <span class="swatch swatch-2"></span>
+            <span class="swatch swatch-3"></span>
+            <span class="swatch swatch-4"></span>
+            <span class="swatch swatch-5"></span>
+          </div>
+          <div class="token-row" aria-hidden="true">
+            <span class="token-dot token-surface" title="Surface"></span>
+            <span class="token-dot token-text"    title="Text"></span>
+            <span class="token-dot token-accent"  title="Accent"></span>
+            <span class="token-dot token-success" title="Success"></span>
+            <span class="token-dot token-danger"  title="Danger"></span>
+          </div>
+          <div class="theme-ui-preview" aria-hidden="true">
+            <div class="theme-ui-bar"></div>
+            <div class="theme-ui-body">
+              <div class="theme-ui-line long"></div>
+              <div class="theme-ui-line short"></div>
+            </div>
+          </div>
+          <div class="theme-card-label">
+            <span class="theme-card-name">Ocean</span>
+            <span class="theme-card-desc">Cool blues, deep navy</span>
+          </div>
+        </button>
+
+        <!-- Violet -->
+        <button
+          class="theme-card theme-violet"
+          type="button"
+          role="radio"
+          aria-checked="false"
+          aria-label="Violet theme"
+          onclick="selectTheme(this, 'Violet')"
+        >
+          <div class="swatch-row" aria-hidden="true">
+            <span class="swatch swatch-1"></span>
+            <span class="swatch swatch-2"></span>
+            <span class="swatch swatch-3"></span>
+            <span class="swatch swatch-4"></span>
+            <span class="swatch swatch-5"></span>
+          </div>
+          <div class="token-row" aria-hidden="true">
+            <span class="token-dot token-surface" title="Surface"></span>
+            <span class="token-dot token-text"    title="Text"></span>
+            <span class="token-dot token-accent"  title="Accent"></span>
+            <span class="token-dot token-success" title="Success"></span>
+            <span class="token-dot token-danger"  title="Danger"></span>
+          </div>
+          <div class="theme-ui-preview" aria-hidden="true">
+            <div class="theme-ui-bar"></div>
+            <div class="theme-ui-body">
+              <div class="theme-ui-line long"></div>
+              <div class="theme-ui-line short"></div>
+            </div>
+          </div>
+          <div class="theme-card-label">
+            <span class="theme-card-name">Violet</span>
+            <span class="theme-card-desc">Rich purple, lavender</span>
+          </div>
+        </button>
+
+        <!-- Ember -->
+        <button
+          class="theme-card theme-ember"
+          type="button"
+          role="radio"
+          aria-checked="false"
+          aria-label="Ember theme"
+          onclick="selectTheme(this, 'Ember')"
+        >
+          <div class="swatch-row" aria-hidden="true">
+            <span class="swatch swatch-1"></span>
+            <span class="swatch swatch-2"></span>
+            <span class="swatch swatch-3"></span>
+            <span class="swatch swatch-4"></span>
+            <span class="swatch swatch-5"></span>
+          </div>
+          <div class="token-row" aria-hidden="true">
+            <span class="token-dot token-surface" title="Surface"></span>
+            <span class="token-dot token-text"    title="Text"></span>
+            <span class="token-dot token-accent"  title="Accent"></span>
+            <span class="token-dot token-success" title="Success"></span>
+            <span class="token-dot token-danger"  title="Danger"></span>
+          </div>
+          <div class="theme-ui-preview" aria-hidden="true">
+            <div class="theme-ui-bar"></div>
+            <div class="theme-ui-body">
+              <div class="theme-ui-line long"></div>
+              <div class="theme-ui-line short"></div>
+            </div>
+          </div>
+          <div class="theme-card-label">
+            <span class="theme-card-name">Ember</span>
+            <span class="theme-card-desc">Warm orange, amber</span>
+          </div>
+        </button>
+
+        <!-- Forest -->
+        <button
+          class="theme-card theme-forest"
+          type="button"
+          role="radio"
+          aria-checked="false"
+          aria-label="Forest theme"
+          onclick="selectTheme(this, 'Forest')"
+        >
+          <div class="swatch-row" aria-hidden="true">
+            <span class="swatch swatch-1"></span>
+            <span class="swatch swatch-2"></span>
+            <span class="swatch swatch-3"></span>
+            <span class="swatch swatch-4"></span>
+            <span class="swatch swatch-5"></span>
+          </div>
+          <div class="token-row" aria-hidden="true">
+            <span class="token-dot token-surface" title="Surface"></span>
+            <span class="token-dot token-text"    title="Text"></span>
+            <span class="token-dot token-accent"  title="Accent"></span>
+            <span class="token-dot token-success" title="Success"></span>
+            <span class="token-dot token-danger"  title="Danger"></span>
+          </div>
+          <div class="theme-ui-preview" aria-hidden="true">
+            <div class="theme-ui-bar"></div>
+            <div class="theme-ui-body">
+              <div class="theme-ui-line long"></div>
+              <div class="theme-ui-line short"></div>
+            </div>
+          </div>
+          <div class="theme-card-label">
+            <span class="theme-card-name">Forest</span>
+            <span class="theme-card-desc">Deep greens, sage</span>
+          </div>
+        </button>
+
+        <!-- Rose -->
+        <button
+          class="theme-card theme-rose"
+          type="button"
+          role="radio"
+          aria-checked="false"
+          aria-label="Rose theme"
+          onclick="selectTheme(this, 'Rose')"
+        >
+          <div class="swatch-row" aria-hidden="true">
+            <span class="swatch swatch-1"></span>
+            <span class="swatch swatch-2"></span>
+            <span class="swatch swatch-3"></span>
+            <span class="swatch swatch-4"></span>
+            <span class="swatch swatch-5"></span>
+          </div>
+          <div class="token-row" aria-hidden="true">
+            <span class="token-dot token-surface" title="Surface"></span>
+            <span class="token-dot token-text"    title="Text"></span>
+            <span class="token-dot token-accent"  title="Accent"></span>
+            <span class="token-dot token-success" title="Success"></span>
+            <span class="token-dot token-danger"  title="Danger"></span>
+          </div>
+          <div class="theme-ui-preview" aria-hidden="true">
+            <div class="theme-ui-bar"></div>
+            <div class="theme-ui-body">
+              <div class="theme-ui-line long"></div>
+              <div class="theme-ui-line short"></div>
+            </div>
+          </div>
+          <div class="theme-card-label">
+            <span class="theme-card-name">Rose</span>
+            <span class="theme-card-desc">Crimson, blush pink</span>
+          </div>
+        </button>
+
+        <!-- Slate -->
+        <button
+          class="theme-card theme-slate"
+          type="button"
+          role="radio"
+          aria-checked="false"
+          aria-label="Slate theme"
+          onclick="selectTheme(this, 'Slate')"
+        >
+          <div class="swatch-row" aria-hidden="true">
+            <span class="swatch swatch-1"></span>
+            <span class="swatch swatch-2"></span>
+            <span class="swatch swatch-3"></span>
+            <span class="swatch swatch-4"></span>
+            <span class="swatch swatch-5"></span>
+          </div>
+          <div class="token-row" aria-hidden="true">
+            <span class="token-dot token-surface" title="Surface"></span>
+            <span class="token-dot token-text"    title="Text"></span>
+            <span class="token-dot token-accent"  title="Accent"></span>
+            <span class="token-dot token-success" title="Success"></span>
+            <span class="token-dot token-danger"  title="Danger"></span>
+          </div>
+          <div class="theme-ui-preview" aria-hidden="true">
+            <div class="theme-ui-bar"></div>
+            <div class="theme-ui-body">
+              <div class="theme-ui-line long"></div>
+              <div class="theme-ui-line short"></div>
+            </div>
+          </div>
+          <div class="theme-card-label">
+            <span class="theme-card-name">Slate</span>
+            <span class="theme-card-desc">Neutral greys, minimal</span>
+          </div>
+        </button>
+
+      </div>
+    </section>
+
+    <hr class="demo-divider" />
+
+    <!-- ── Single swatch strip reference ─────────────────── -->
+
+    <section class="demo-section" aria-label="Token reference">
+      <p class="swatch-section-title">Token dot legend</p>
+
+      <div style="display:flex; flex-wrap:wrap; gap:1rem; align-items:center; font-size:0.78rem; font-family:system-ui,-apple-system,sans-serif; color:#64748b;">
+        <span style="display:flex;align-items:center;gap:0.35rem;">
+          <span style="width:0.7rem;height:0.7rem;border-radius:50%;background:#ffffff;border:1.5px solid #e2e8f0;display:inline-block;"></span>
+          Surface
+        </span>
+        <span style="display:flex;align-items:center;gap:0.35rem;">
+          <span style="width:0.7rem;height:0.7rem;border-radius:50%;background:#0f172a;border:1.5px solid rgba(0,0,0,0.08);display:inline-block;"></span>
+          Text
+        </span>
+        <span style="display:flex;align-items:center;gap:0.35rem;">
+          <span style="width:0.7rem;height:0.7rem;border-radius:50%;background:#6366f1;border:1.5px solid rgba(0,0,0,0.08);display:inline-block;"></span>
+          Accent
+        </span>
+        <span style="display:flex;align-items:center;gap:0.35rem;">
+          <span style="width:0.7rem;height:0.7rem;border-radius:50%;background:#16a34a;border:1.5px solid rgba(0,0,0,0.08);display:inline-block;"></span>
+          Success
+        </span>
+        <span style="display:flex;align-items:center;gap:0.35rem;">
+          <span style="width:0.7rem;height:0.7rem;border-radius:50%;background:#dc2626;border:1.5px solid rgba(0,0,0,0.08);display:inline-block;"></span>
+          Danger
+        </span>
+      </div>
+    </section>
+
+    <script>
+      function selectTheme(card, name) {
+        var grid  = document.getElementById('themeGrid');
+        var cards = grid.querySelectorAll('.theme-card');
+
+        cards.forEach(function(c) {
+          c.classList.remove('is-selected');
+          c.setAttribute('aria-checked', 'false');
+        });
+
+        card.classList.add('is-selected');
+        card.setAttribute('aria-checked', 'true');
+
+        var banner = document.getElementById('chosenBanner');
+        var text   = document.getElementById('chosenText');
+        text.textContent = '\u201c' + name + '\u201d theme selected';
+        banner.classList.remove('is-hidden');
+      }
+    </script>
+
+  </body>
+</html>

--- a/submissions/examples/theme-preview-swatch-grid-ts/style.css
+++ b/submissions/examples/theme-preview-swatch-grid-ts/style.css
@@ -1,0 +1,362 @@
+/* Theme Preview Swatch Grid
+   Palette cards with animated swatch rows, selected state,
+   and token preview strips (surface, text, accent, success, danger).
+   Pure CSS — add .is-selected to a .theme-card to mark it active.
+*/
+
+/* ── Grid layout ─────────────────────────────────────────── */
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 200px), 1fr));
+  gap: 1rem;
+  width: 100%;
+}
+
+/* ── Card ────────────────────────────────────────────────── */
+
+.theme-card {
+  background: #ffffff;
+  border: 2px solid #e2e8f0;
+  border-radius: 0.875rem;
+  padding: 1rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: left;
+  font-family: system-ui, -apple-system, sans-serif;
+  transition:
+    transform   220ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow  220ms ease,
+    border-color 180ms ease;
+  position: relative;
+  outline: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .theme-card:hover {
+    transform: translateY(-4px);
+    box-shadow:
+      0 10px 20px -4px rgba(0, 0, 0, 0.12),
+      0 4px 8px -2px rgba(0, 0, 0, 0.06);
+    border-color: #cbd5e1;
+  }
+}
+
+.theme-card:focus-visible {
+  transform: translateY(-4px);
+  box-shadow:
+    0 10px 20px -4px rgba(0, 0, 0, 0.12),
+    0 4px 8px -2px rgba(0, 0, 0, 0.06);
+  border-color: #6366f1;
+  outline: 2px solid #6366f1;
+  outline-offset: 3px;
+}
+
+.theme-card:active {
+  transform: scale(0.97);
+}
+
+/* ── Selected state ──────────────────────────────────────── */
+
+.theme-card.is-selected {
+  border-color: #6366f1;
+  box-shadow:
+    0 0 0 3px rgba(99, 102, 241, 0.18),
+    0 8px 16px -4px rgba(99, 102, 241, 0.2);
+}
+
+/* Tick badge */
+.theme-card.is-selected::after {
+  content: "";
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 50%;
+  background: #6366f1;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='white' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='2 6 5 9 10 3'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 70%;
+  animation: swatchTickPop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes swatchTickPop {
+  from { transform: scale(0); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+
+/* ── Swatch strip ────────────────────────────────────────── */
+
+.swatch-row {
+  display: flex;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  height: 2.5rem;
+  gap: 0;
+}
+
+.swatch {
+  flex: 1;
+  height: 100%;
+  transition: flex 260ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .theme-card:hover .swatch,
+  .theme-card:focus-visible .swatch {
+    flex: 1.5;
+  }
+
+  .theme-card:hover .swatch:hover {
+    flex: 2.5;
+  }
+}
+
+/* ── Token preview dots ──────────────────────────────────── */
+
+.token-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.token-dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  border: 1.5px solid rgba(0, 0, 0, 0.08);
+  flex-shrink: 0;
+  transition: transform 180ms ease;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .theme-card:hover .token-dot {
+    transform: scale(1.25);
+  }
+}
+
+/* ── Card label area ─────────────────────────────────────── */
+
+.theme-card-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.theme-card-name {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1.2;
+}
+
+.theme-card-desc {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  line-height: 1.4;
+}
+
+.theme-card.is-selected .theme-card-name {
+  color: #4338ca;
+}
+
+/* ── Palette: Ocean ──────────────────────────────────────── */
+
+.theme-ocean .swatch-1 { background: #0f172a; }
+.theme-ocean .swatch-2 { background: #0369a1; }
+.theme-ocean .swatch-3 { background: #38bdf8; }
+.theme-ocean .swatch-4 { background: #e0f2fe; }
+.theme-ocean .swatch-5 { background: #f0fdf4; }
+
+.theme-ocean .token-surface  { background: #ffffff; }
+.theme-ocean .token-text     { background: #0f172a; }
+.theme-ocean .token-accent   { background: #0369a1; }
+.theme-ocean .token-success  { background: #16a34a; }
+.theme-ocean .token-danger   { background: #dc2626; }
+
+/* ── Palette: Violet ─────────────────────────────────────── */
+
+.theme-violet .swatch-1 { background: #1e1b4b; }
+.theme-violet .swatch-2 { background: #6d28d9; }
+.theme-violet .swatch-3 { background: #a78bfa; }
+.theme-violet .swatch-4 { background: #ede9fe; }
+.theme-violet .swatch-5 { background: #faf5ff; }
+
+.theme-violet .token-surface  { background: #ffffff; }
+.theme-violet .token-text     { background: #1e1b4b; }
+.theme-violet .token-accent   { background: #6d28d9; }
+.theme-violet .token-success  { background: #059669; }
+.theme-violet .token-danger   { background: #e11d48; }
+
+/* ── Palette: Ember ──────────────────────────────────────── */
+
+.theme-ember .swatch-1 { background: #1c0a00; }
+.theme-ember .swatch-2 { background: #c2410c; }
+.theme-ember .swatch-3 { background: #fb923c; }
+.theme-ember .swatch-4 { background: #fff7ed; }
+.theme-ember .swatch-5 { background: #fefce8; }
+
+.theme-ember .token-surface  { background: #ffffff; }
+.theme-ember .token-text     { background: #1c0a00; }
+.theme-ember .token-accent   { background: #c2410c; }
+.theme-ember .token-success  { background: #15803d; }
+.theme-ember .token-danger   { background: #b91c1c; }
+
+/* ── Palette: Forest ─────────────────────────────────────── */
+
+.theme-forest .swatch-1 { background: #052e16; }
+.theme-forest .swatch-2 { background: #166534; }
+.theme-forest .swatch-3 { background: #4ade80; }
+.theme-forest .swatch-4 { background: #dcfce7; }
+.theme-forest .swatch-5 { background: #f0fdf4; }
+
+.theme-forest .token-surface  { background: #ffffff; }
+.theme-forest .token-text     { background: #052e16; }
+.theme-forest .token-accent   { background: #166534; }
+.theme-forest .token-success  { background: #15803d; }
+.theme-forest .token-danger   { background: #dc2626; }
+
+/* ── Palette: Rose ───────────────────────────────────────── */
+
+.theme-rose .swatch-1 { background: #4c0519; }
+.theme-rose .swatch-2 { background: #be123c; }
+.theme-rose .swatch-3 { background: #fb7185; }
+.theme-rose .swatch-4 { background: #ffe4e6; }
+.theme-rose .swatch-5 { background: #fff1f2; }
+
+.theme-rose .token-surface  { background: #ffffff; }
+.theme-rose .token-text     { background: #4c0519; }
+.theme-rose .token-accent   { background: #be123c; }
+.theme-rose .token-success  { background: #059669; }
+.theme-rose .token-danger   { background: #b91c1c; }
+
+/* ── Palette: Slate ──────────────────────────────────────── */
+
+.theme-slate .swatch-1 { background: #0f172a; }
+.theme-slate .swatch-2 { background: #334155; }
+.theme-slate .swatch-3 { background: #94a3b8; }
+.theme-slate .swatch-4 { background: #e2e8f0; }
+.theme-slate .swatch-5 { background: #f8fafc; }
+
+.theme-slate .token-surface  { background: #ffffff; }
+.theme-slate .token-text     { background: #0f172a; }
+.theme-slate .token-accent   { background: #334155; }
+.theme-slate .token-success  { background: #16a34a; }
+.theme-slate .token-danger   { background: #dc2626; }
+
+/* ── UI preview mini-card ────────────────────────────────── */
+
+.theme-ui-preview {
+  border-radius: 0.5rem;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.07);
+  font-size: 0.65rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.theme-ui-bar {
+  height: 0.55rem;
+}
+
+.theme-ui-body {
+  padding: 0.4rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.theme-ui-line {
+  height: 0.35rem;
+  border-radius: 999px;
+  opacity: 0.35;
+}
+
+.theme-ui-line.short { width: 55%; }
+.theme-ui-line.long  { width: 85%; }
+
+/* Colour utilities for ui-preview driven by --theme-* vars */
+.theme-ui-bar       { background: var(--theme-accent, #6366f1); }
+.theme-ui-body      { background: var(--theme-surface, #ffffff); }
+.theme-ui-line      { background: var(--theme-text, #0f172a); }
+
+/* Set vars per palette */
+.theme-ocean  { --theme-accent: #0369a1; --theme-surface: #f0f9ff; --theme-text: #0f172a; }
+.theme-violet { --theme-accent: #6d28d9; --theme-surface: #faf5ff; --theme-text: #1e1b4b; }
+.theme-ember  { --theme-accent: #c2410c; --theme-surface: #fff7ed; --theme-text: #1c0a00; }
+.theme-forest { --theme-accent: #166534; --theme-surface: #f0fdf4; --theme-text: #052e16; }
+.theme-rose   { --theme-accent: #be123c; --theme-surface: #fff1f2; --theme-text: #4c0519; }
+.theme-slate  { --theme-accent: #334155; --theme-surface: #f8fafc; --theme-text: #0f172a; }
+
+/* ── Section title ───────────────────────────────────────── */
+
+.swatch-section-title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  margin-bottom: 0.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+/* ── Dark mode ───────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .theme-card {
+    background: #1e293b;
+    border-color: #334155;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .theme-card:hover {
+      border-color: #475569;
+      box-shadow:
+        0 10px 20px -4px rgba(0, 0, 0, 0.4),
+        0 4px 8px -2px rgba(0, 0, 0, 0.2);
+    }
+  }
+
+  .theme-card.is-selected {
+    border-color: #818cf8;
+    box-shadow:
+      0 0 0 3px rgba(129, 140, 248, 0.2),
+      0 8px 16px -4px rgba(99, 102, 241, 0.25);
+  }
+
+  .theme-card.is-selected .theme-card-name {
+    color: #a5b4fc;
+  }
+
+  .theme-card-name { color: #f1f5f9; }
+  .theme-card-desc { color: #64748b; }
+
+  .token-dot { border-color: rgba(255, 255, 255, 0.1); }
+
+  .theme-ui-preview { border-color: rgba(255, 255, 255, 0.07); }
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-card {
+    transition: border-color 150ms ease, box-shadow 150ms ease;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .theme-card:hover,
+    .theme-card:focus-visible {
+      transform: none;
+    }
+
+    .theme-card:hover .swatch { flex: 1; }
+    .theme-card:hover .token-dot { transform: none; }
+  }
+
+  .theme-card:active { transform: none; }
+  .theme-card.is-selected::after { animation: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a theme preview swatch grid to `submissions/examples/theme-preview-swatch-grid-ts/` as requested in issue #11159. The component shows six palette cards, each with an animated five-step swatch strip, a row of UI token dots (surface, text, accent, success, danger), a mini UI preview bar, and a selected state with a pop-in tick badge.

Fixes #11159
---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/theme-preview-swatch-grid-ts/`
- [x] Includes `demo.html` -- self-contained, opens in browser with no server
- [x] Includes `style.css` -- raw CSS for the proposed feature
- [x] Includes `README.md` -- what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A responsive grid of palette preview cards. Each card shows a five-step colour swatch strip that expands on hover via a CSS flex transition, a row of five token dots (surface, text, accent, success, danger), and a mini UI mockup driven by CSS custom properties. Adding `is-selected` to a card shows a pop-in tick badge and a highlighted border.

**How does a developer use it?**

`html
<div class="theme-grid" role="radiogroup" aria-label="Theme palettes">
  <button class="theme-card theme-ocean is-selected"
          type="button" role="radio" aria-checked="true"
          onclick="selectTheme(this, 'Ocean')">
    <div class="swatch-row" aria-hidden="true">
      <span class="swatch swatch-1"></span>
      <span class="swatch swatch-2"></span>
      <span class="swatch swatch-3"></span>
      <span class="swatch swatch-4"></span>
      <span class="swatch swatch-5"></span>
    </div>
    <div class="token-row" aria-hidden="true">
      <span class="token-dot token-surface"></span>
      <span class="token-dot token-text"></span>
      <span class="token-dot token-accent"></span>
      <span class="token-dot token-success"></span>
      <span class="token-dot token-danger"></span>
    </div>
    <div class="theme-card-label">
      <span class="theme-card-name">Ocean</span>
      <span class="theme-card-desc">Cool blues, deep navy</span>
    </div>
  </button>
</div>
`

Six palette modifier classes included: `theme-ocean`, `theme-violet`, `theme-ember`, `theme-forest`, `theme-rose`, `theme-slate`.

**Why does it fit EaseMotion CSS?**

Design system theme pickers are a common but often under-animated UI pattern. This component demonstrates how CSS variables and small motion details -- expanding swatch slots on hover (flex transition), a lift-and-shadow on hover, and a pop-in tick badge on selection -- can make palette selection feel considered. The class names read like plain English, adding a new palette only requires one CSS block, and the selected state is driven by a single modifier class.

---
## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

