### PR TITLE
fix: navigation button vertical alignment and sticky header positioning

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -127,7 +127,7 @@ body {
 
 .docs-header-links {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: var(--ease-space-5);
   align-items: center;
   justify-content: flex-end;

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -136,6 +136,15 @@ body {
   margin: 0;
 }
 
+.docs-header-links li {
+  display: flex;
+  align-items: center;
+}
+
+.docs-header-links a {
+  white-space: nowrap;
+}
+
 .docs-header-links a:not(.ease-btn) {
   color: var(--nav-link-color);
   font-size: var(--ease-text-sm);
@@ -286,7 +295,9 @@ body {
 }
 
 .docs-sidebar::-webkit-scrollbar-thumb {
-  background: var(--border-color); /* Reuses their existing border color variable */
+  background: var(
+    --border-color
+  ); /* Reuses their existing border color variable */
   border-radius: 4px;
 }
 

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -302,7 +302,10 @@ body {
 }
 
 .docs-sidebar::-webkit-scrollbar-thumb:hover {
-  background: var(--sidebar-accent, #6366f1); /* Brightens up slightly on hover if an accent variable exists, otherwise falls back to purple */
+  background: var(
+    --sidebar-accent,
+    #6366f1
+  ); /* Brightens up slightly on hover if an accent variable exists, otherwise falls back to purple */
 }
 
 .sidebar-group {
@@ -954,11 +957,14 @@ body > .docs-shell {
 }
 
 .docs-header::after {
-  content: '';
+  content: "";
   position: absolute;
-  bottom: 0; left: 0; right: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   height: 1px;
-  background: linear-gradient(90deg,
+  background: linear-gradient(
+    90deg,
     transparent,
     rgba(108, 99, 255, 0.5) 30%,
     rgba(167, 139, 250, 0.5) 70%,
@@ -971,7 +977,9 @@ body > .docs-shell {
   letter-spacing: -0.03em;
   transition: opacity 0.2s ease;
 }
-.docs-logo:hover { opacity: 0.85; }
+.docs-logo:hover {
+  opacity: 0.85;
+}
 
 .docs-sidebar {
   padding: 2rem 1rem;
@@ -1002,7 +1010,8 @@ body > .docs-shell {
 }
 
 .sidebar-nav a.active {
-  background: linear-gradient(90deg,
+  background: linear-gradient(
+    90deg,
     rgba(108, 99, 255, 0.15),
     rgba(108, 99, 255, 0.05)
   );
@@ -1016,36 +1025,36 @@ body > .docs-shell {
   max-width: 820px;
 }
 
-.docs-h1{
-  font-size:clamp(2.2rem, 4.5vw, 3.2rem);
-  letter-spacing:-0.05em;
-  line-height:1.1;
-  margin-bottom:1.25rem;
+.docs-h1 {
+  font-size: clamp(2.2rem, 4.5vw, 3.2rem);
+  letter-spacing: -0.05em;
+  line-height: 1.1;
+  margin-bottom: 1.25rem;
 }
 
-.docs-h2{
-  font-size:1.6rem;
-  letter-spacing:-0.025em;
-  margin-top:0.5rem;
-  margin-bottom:1rem;
-  padding-bottom:0.75rem;
+.docs-h2 {
+  font-size: 1.6rem;
+  letter-spacing: -0.025em;
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
 }
 
-.docs-h3{
-  font-size:1.1rem;
-  letter-spacing:-0.01em;
-  margin-bottom:0.75rem;
+.docs-h3 {
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+  margin-bottom: 0.75rem;
   color: rgba(255, 255, 255, 0.85);
 }
 
-.docs-p{
-  font-size:0.9625rem;
+.docs-p {
+  font-size: 0.9625rem;
   line-height: 1.8;
-  max-width:68ch;
+  max-width: 68ch;
   color: rgba(255, 255, 255, 0.62);
 }
 
-[data-theme="light"] .docs-p{
+[data-theme="light"] .docs-p {
   color: #4b5563;
 }
 
@@ -1059,55 +1068,58 @@ body > .docs-shell {
   margin: 3rem 0;
   border: none;
   height: 1px;
-  background: linear-gradient(90deg,
+  background: linear-gradient(
+    90deg,
     rgba(108, 99, 255, 0.3),
     rgba(255, 255, 255, 0.04),
     transparent
   );
 }
 
-.docs-eyebrow{
-  font-size:0.7rem;
+.docs-eyebrow {
+  font-size: 0.7rem;
   letter-spacing: 0.16em;
-  text-transform:uppercase;
-  font-weight:700;
+  text-transform: uppercase;
+  font-weight: 700;
   color: #a78bfa;
-  margin-bottom:0.4rem;
-  display:flex;
-  align-items:center;
-  gap:6px;
+  margin-bottom: 0.4rem;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
-.docs-eyebrow::before{
-  content: '';
-  display:inline-block;
-  width: 18px;height: 2px;
-  background:linear-gradient(90deg, #6c63ff, #a78bfa);
-  border-radius:2px;
+.docs-eyebrow::before {
+  content: "";
+  display: inline-block;
+  width: 18px;
+  height: 2px;
+  background: linear-gradient(90deg, #6c63ff, #a78bfa);
+  border-radius: 2px;
 }
 
-.docs-info{
-  background:linear-gradient(135deg,
+.docs-info {
+  background: linear-gradient(
+    135deg,
     rgba(108, 99, 255, 0.07),
     rgba(108, 99, 255, 0.03)
   );
-  border:1px solid rgba(108, 99, 255, 0.2);
-  border-radius:10px;
-  padding:1rem 1.25rem;
+  border: 1px solid rgba(108, 99, 255, 0.2);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
 }
 
-.docs-code{
-  border-radius:10px;
-  border:1px solid rgba(255, 255, 255, 0.06);
-  background:rgba(0, 0, 0, 0.3);
-  box-shadow:inset 0 1px 0 rgba(255,255,255,0.04);
+.docs-code {
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(0, 0, 0, 0.3);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
-.docs-table{
-  border:1px solid rgba(255, 255, 255, 0.06);
-  border-radius:10px;
+.docs-table {
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
   overflow: hidden;
-  margin-bottom:2rem;
+  margin-bottom: 2rem;
 }
 
 .docs-table th {
@@ -1121,7 +1133,9 @@ body > .docs-shell {
   padding: 0.75rem 1rem;
   font-size: 0.875rem;
 }
-.docs-table tr:last-child td {border-bottom:none;}
+.docs-table tr:last-child td {
+  border-bottom: none;
+}
 
 .docs-badge {
   font-size: 0.7rem;
@@ -1130,85 +1144,115 @@ body > .docs-shell {
   letter-spacing: 0.04em;
 }
 
-#particle-canvas{
-  position:fixed;
-  top:0; left: 0;
-  width:100%; height: 100%;
-  pointer-events:none;
-  z-index:0;
-  opacity:0.35;
+#particle-canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.35;
 }
 
 .docs-header,
 .docs-shell,
-.ease-scroll-progress{
-  position:relative;
-  z-index:1;
+.ease-scroll-progress {
+  position: relative;
+  z-index: 1;
 }
 
-.hero-orb{
-  position:absolute;
-  border-radius:50%;
-  filter:blur(80px);
-  pointer-events:none;
-  z-index:0;
+.hero-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  pointer-events: none;
+  z-index: 0;
 }
 
-.hero-orb-1{
-  width:400px; height: 400px;
-  background:rgba(108, 99, 255, 0.12);
-  top:-100px; right: -80px;
-  animation:orb-drift 8s ease-in-out infinite alternate;
+.hero-orb-1 {
+  width: 400px;
+  height: 400px;
+  background: rgba(108, 99, 255, 0.12);
+  top: -100px;
+  right: -80px;
+  animation: orb-drift 8s ease-in-out infinite alternate;
 }
 
-.hero-orb-2{
-  width:300px; height: 300px;
-  background:rgba(167, 139, 250, 0.08);
-  top:80px; left: -60px;
-  animation:orb-drift 11s ease-in-out infinite alternate-reverse;
+.hero-orb-2 {
+  width: 300px;
+  height: 300px;
+  background: rgba(167, 139, 250, 0.08);
+  top: 80px;
+  left: -60px;
+  animation: orb-drift 11s ease-in-out infinite alternate-reverse;
 }
 
-@keyframes orb-drift{
-  from{ transform:translate(0, 0) scale(1);}
-  to{ transform:translate(20px, 30px) scale(1.08);}
+@keyframes orb-drift {
+  from {
+    transform: translate(0, 0) scale(1);
+  }
+  to {
+    transform: translate(20px, 30px) scale(1.08);
+  }
 }
 
-@keyframes section-in{
-  from{opacity:0; transform:translateY(10px);}
-  to{opacity:1; transform:translateY(0);}
+@keyframes section-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-[data-theme="light"] .docs-code{
+[data-theme="light"] .docs-code {
   background: #f8fafc;
   border-color: rgba(15, 23, 42, 0.08);
 }
 
-[data-theme="light"] .docs-table{
+[data-theme="light"] .docs-table {
   border-color: rgba(15, 23, 42, 0.08);
 }
 
 [data-theme="light"] #particle-canvas {
-  opacity:0.15;
+  opacity: 0.15;
 }
 
-[data-theme="light"] .hero-orb-1{
+[data-theme="light"] .hero-orb-1 {
   background: rgba(108, 99, 255, 0.07);
 }
 
-@media(max-width:1100px){
-  .docs-content{padding:2.5rem 2rem;}
+@media (max-width: 1100px) {
+  .docs-content {
+    padding: 2.5rem 2rem;
+  }
 }
 
-@media(max-width:900px){
-  .docs-content{padding:2rem 1.25rem;}
-  .docs-h1{font-size:2rem;}
-  .docs-shell{max-width:100%;}
+@media (max-width: 900px) {
+  .docs-content {
+    padding: 2rem 1.25rem;
+  }
+  .docs-h1 {
+    font-size: 2rem;
+  }
+  .docs-shell {
+    max-width: 100%;
+  }
 }
 
-@media(max-width:640px){
-  .docs-header{padding:0 1rem;}
-  .docs-h1{font-size:1.75rem;}
-  .docs-p{max-width:100%;}
+@media (max-width: 640px) {
+  .docs-header {
+    padding: 0 1rem;
+  }
+  .docs-h1 {
+    font-size: 1.75rem;
+  }
+  .docs-p {
+    max-width: 100%;
+  }
 }
 
 /* ── Mobile Overflow Fixes ── */
@@ -1258,4 +1302,3 @@ body > .docs-shell {
     justify-content: center;
   }
 }
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -118,7 +118,14 @@
           <a
             href="demo.html"
             class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
-            style="display:inline-flex; align-items:center; justify-content:center; min-height:48px; padding:0 1.1rem; line-height:1"
+            style="
+              display: inline-flex;
+              align-items: center;
+              justify-content: center;
+              min-height: 48px;
+              padding: 0 1.1rem;
+              line-height: 1;
+            "
             >Live Demo →</a
           >
         </li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
     />
 
     <!-- Link to external docs.css -->
-    <link rel="stylesheet" href="docs.css" />
+    <link rel="stylesheet" href="docs.css?v=3" />
 
     <!-- Apply stored theme before first paint to avoid flash -->
     <script>

--- a/submissions/examples/live-demo-alignment-fix-ag/README.md
+++ b/submissions/examples/live-demo-alignment-fix-ag/README.md
@@ -1,0 +1,38 @@
+# Navigation Button Vertical Alignment Fix
+
+## What does this do?
+
+Fixes the vertical alignment of navigation links and standalone buttons within navigation lists (`ul.docs-header-links`) by centering list items (`li`) using CSS Flexbox, and prevents link wrapping/overflowing using `flex-wrap: nowrap`.
+
+## How is it used?
+
+Apply flex styling to navigation list items and disable wrap on the navigation container:
+
+```html
+<ul class="docs-header-links">
+  <li><a href="#getting-started">Getting Started</a></li>
+  <li>
+    <a
+      href="demo.html"
+      class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
+      >Live Demo →</a
+    >
+  </li>
+</ul>
+```
+
+```css
+.docs-header-links {
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+.docs-header-links li {
+  display: flex;
+  align-items: center;
+}
+```
+
+## Why is it useful?
+
+It keeps the user interface clean and visually aligned when mixing standard inline link text and block/inline-flex styled components (like custom primary action buttons) in the header navigation bar, preventing navigation elements from wrapping and overflowing the header layout on smaller screens.

--- a/submissions/examples/live-demo-alignment-fix-ag/demo.html
+++ b/submissions/examples/live-demo-alignment-fix-ag/demo.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vertical Alignment Fix Demo — EaseMotion CSS</title>
+    <!-- Load EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css" />
+    <!-- Load custom demo styles -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body
+    data-theme="dark"
+    style="
+      background-color: #0f0e17;
+      color: #fffffe;
+      font-family: sans-serif;
+      padding: 3rem;
+      max-width: 900px;
+      margin: 0 auto;
+    "
+  >
+    <header style="margin-bottom: 3rem">
+      <h1
+        style="
+          font-size: 2rem;
+          font-weight: 700;
+          margin-bottom: 0.5rem;
+          color: #ffffff;
+        "
+      >
+        Navigation Button Vertical Alignment Fix
+      </h1>
+      <p style="color: rgba(255, 255, 255, 0.65); line-height: 1.6">
+        This page demonstrates the misalignment issue affecting the
+        <strong>Live Demo</strong> button in the documentation header, alongside
+        the applied CSS flexbox fix.
+      </p>
+    </header>
+
+    <!-- Section 1: Broken State -->
+    <section style="margin-bottom: 3.5rem">
+      <h2
+        style="
+          font-size: 1.25rem;
+          font-weight: 600;
+          color: #ef4444;
+          margin-bottom: 1rem;
+        "
+      >
+        ❌ Misaligned Button (Before Fix)
+      </h2>
+      <p
+        style="
+          font-size: 0.9rem;
+          color: rgba(255, 255, 255, 0.65);
+          margin-bottom: 1rem;
+        "
+      >
+        Without flexbox centering on the list items (<code>li</code>),
+        block-level list-item layout aligns on text baselines. The large height
+        of the inline-flex button pushes its box layout down relative to text
+        links, causing it to sit slightly below the centerline.
+      </p>
+      <div class="nav-container">
+        <ul class="docs-header-links-simulated broken-state">
+          <li><a href="#">Home</a></li>
+          <li><a href="#">Utilities</a></li>
+          <li><a href="#">Animations</a></li>
+          <li><a href="#">Discord</a></li>
+          <li>
+            <a
+              href="#"
+              class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
+              style="
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                min-height: 48px;
+                padding: 0 1.1rem;
+                line-height: 1;
+              "
+              >Live Demo →</a
+            >
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Section 2: Fixed State -->
+    <section>
+      <h2
+        style="
+          font-size: 1.25rem;
+          font-weight: 600;
+          color: #22c55e;
+          margin-bottom: 1rem;
+        "
+      >
+        ✅ Aligned Button (After Fix)
+      </h2>
+      <p
+        style="
+          font-size: 0.9rem;
+          color: rgba(255, 255, 255, 0.65);
+          margin-bottom: 1rem;
+        "
+      >
+        With <code>display: flex; align-items: center;</code> applied to
+        <code>.docs-header-links li</code>, the lists' visual heights (text and
+        button) are aligned perfectly on their centerlines.
+      </p>
+      <div class="nav-container">
+        <ul class="docs-header-links-simulated fixed-state">
+          <li><a href="#">Home</a></li>
+          <li><a href="#">Utilities</a></li>
+          <li><a href="#">Animations</a></li>
+          <li><a href="#">Discord</a></li>
+          <li>
+            <a
+              href="#"
+              class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
+              style="
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                min-height: 48px;
+                padding: 0 1.1rem;
+                line-height: 1;
+              "
+              >Live Demo →</a
+            >
+          </li>
+        </ul>
+      </div>
+    </section>
+  </body>
+</html>

--- a/submissions/examples/live-demo-alignment-fix-ag/style.css
+++ b/submissions/examples/live-demo-alignment-fix-ag/style.css
@@ -1,0 +1,56 @@
+/* ============================================================
+   live-demo-alignment-fix-ag — style.css
+   Demonstrates navigation bar list item centering
+   ============================================================ */
+
+/* ── Container Styles ────────────────────────────────────── */
+.nav-container {
+  background-color: #1a1926;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 1rem 2rem;
+  margin-bottom: 2rem;
+}
+
+.docs-header-links-simulated {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: flex-end;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+/* ── Navigation Links (Standard) ────────────────────────── */
+.docs-header-links-simulated a:not(.ease-btn) {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  padding: 10px 20px;
+  border-radius: 6px;
+  transition: all 0.3s ease;
+}
+
+.docs-header-links-simulated a:not(.ease-btn):hover {
+  color: #ffffff;
+  background: rgba(108, 99, 255, 0.12);
+}
+
+/* ── BEFORE FIX: Direct inline-flex button without flexbox li ─ */
+.broken-state li {
+  /* Default display: list-item (block-level), no vertical centering */
+  display: list-item;
+}
+
+/* ── AFTER FIX: List items are flex containers centering children ─ */
+.fixed-state {
+  flex-wrap: nowrap;
+}
+
+.fixed-state li {
+  display: flex;
+  align-items: center;
+}

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
@@ -26,3 +26,8 @@ Style list items inside navigation bars to center their children vertically, and
   display: flex;
   align-items: center;
 }
+
+.docs-header-links a {
+  white-space: nowrap;
+}
+```

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
@@ -21,3 +21,8 @@ Style list items inside navigation bars to center their children vertically, and
 </ul>
 ```
 
+```css
+.docs-header-links li {
+  display: flex;
+  align-items: center;
+}

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
@@ -1,0 +1,2 @@
+# Navigation Links Alignment and Wrap Fix
+

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
@@ -31,3 +31,4 @@ Style list items inside navigation bars to center their children vertically, and
   white-space: nowrap;
 }
 ```
+

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
@@ -4,3 +4,20 @@
 
 Fixes vertical misalignment and awkward text wrapping inside navigation menus by applying CSS Flexbox centering to list items (`li`) and forcing text links to remain on a single line (`white-space: nowrap`).
 
+## How is it used?
+
+Style list items inside navigation bars to center their children vertically, and enforce single-line text formatting on anchor links:
+
+```html
+<ul class="docs-header-links">
+  <li><a href="#getting-started">Getting Started</a></li>
+  <li>
+    <a
+      href="demo.html"
+      class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
+      >Live Demo →</a
+    >
+  </li>
+</ul>
+```
+

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
@@ -1,2 +1,6 @@
 # Navigation Links Alignment and Wrap Fix
 
+## What does this do?
+
+Fixes vertical misalignment and awkward text wrapping inside navigation menus by applying CSS Flexbox centering to list items (`li`) and forcing text links to remain on a single line (`white-space: nowrap`).
+

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/README.md
@@ -32,3 +32,6 @@ Style list items inside navigation bars to center their children vertically, and
 }
 ```
 
+## Why is it useful?
+
+It prevents navigation text links (especially multi-word items) from wrapping onto two lines when space is limited, which ruins the vertical flow, and ensures all text and button components sit perfectly aligned along a single horizontal axis.

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
@@ -85,3 +85,26 @@
                 align-items: center;
                 justify-content: center;
                 min-height: 48px;
+                padding: 0 1.1rem;
+                line-height: 1;
+              "
+              >Live Demo</a
+            >
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Section 2: Fixed State -->
+    <section>
+      <h2
+        style="
+          font-size: 1.25rem;
+          font-weight: 600;
+          color: #22c55e;
+          margin-bottom: 1rem;
+        "
+      >
+        ✅ Nowrap Links & Centered Baseline (After Fix)
+      </h2>
+      <p

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
@@ -66,3 +66,22 @@
       >
         In a narrow header container, text links like "Getting Started" and
         "Animation Preview" wrap onto multiple lines. Because list items
+        (<code>li</code>) are block-level (no flexbox centering) and links are
+        allowed to wrap, the heights are inconsistent and elements are
+        misaligned.
+      </p>
+      <div class="nav-container">
+        <ul class="docs-header-links-simulated broken-state">
+          <li><a href="#">Getting Started</a></li>
+          <li><a href="#">Utilities</a></li>
+          <li><a href="#">Animations</a></li>
+          <li><a href="#">Animation Preview</a></li>
+          <li>
+            <a
+              href="#"
+              class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
+              style="
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                min-height: 48px;

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
@@ -21,3 +21,26 @@
     "
   >
     <header style="margin-bottom: 3rem">
+      <h1
+        style="
+          font-size: 2rem;
+          font-weight: 700;
+          margin-bottom: 0.5rem;
+          color: #ffffff;
+        "
+      >
+        Navigation Bar Text Wrapping & Alignment Fix
+      </h1>
+      <p
+        style="
+          color: rgba(255, 255, 255, 0.65);
+          line-height: 1.6;
+          max-width: 700px;
+        "
+      >
+        This page demonstrates the issue where multi-word navigation links wrap
+        on small screens, causing uneven heights and baseline misalignment,
+        alongside the fix using <code>white-space: nowrap</code> and Flexbox
+        centering.
+      </p>
+    </header>

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
@@ -44,3 +44,25 @@
         centering.
       </p>
     </header>
+
+    <!-- Section 1: Broken State -->
+    <section style="margin-bottom: 3.5rem">
+      <h2
+        style="
+          font-size: 1.25rem;
+          font-weight: 600;
+          color: #ef4444;
+          margin-bottom: 1rem;
+        "
+      >
+        ❌ Wrapped Links & Misaligned Baseline (Before Fix)
+      </h2>
+      <p
+        style="
+          font-size: 0.9rem;
+          color: rgba(255, 255, 255, 0.65);
+          margin-bottom: 1rem;
+        "
+      >
+        In a narrow header container, text links like "Getting Started" and
+        "Animation Preview" wrap onto multiple lines. Because list items

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
@@ -108,3 +108,41 @@
         ✅ Nowrap Links & Centered Baseline (After Fix)
       </h2>
       <p
+        style="
+          font-size: 0.9rem;
+          color: rgba(255, 255, 255, 0.65);
+          margin-bottom: 1rem;
+        "
+      >
+        With <code>white-space: nowrap</code>, text links remain on a single
+        line, preserving a clean uniform height.
+        <code>display: flex; align-items: center;</code> on the list items
+        (<code>li</code>) keeps the text links and buttons perfectly vertically
+        aligned on the horizontal axis.
+      </p>
+      <div class="nav-container">
+        <ul class="docs-header-links-simulated fixed-state">
+          <li><a href="#">Getting Started</a></li>
+          <li><a href="#">Utilities</a></li>
+          <li><a href="#">Animations</a></li>
+          <li><a href="#">Animation Preview</a></li>
+          <li>
+            <a
+              href="#"
+              class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
+              style="
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                min-height: 48px;
+                padding: 0 1.1rem;
+                line-height: 1;
+              "
+              >Live Demo</a
+            >
+          </li>
+        </ul>
+      </div>
+    </section>
+  </body>
+</html>

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/demo.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Navigation Alignment and nowrap Fix Demo — EaseMotion CSS</title>
+    <!-- Load EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css" />
+    <!-- Load custom demo styles -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body
+    data-theme="dark"
+    style="
+      background-color: #0f0e17;
+      color: #fffffe;
+      font-family: sans-serif;
+      padding: 3rem;
+      max-width: 900px;
+      margin: 0 auto;
+    "
+  >
+    <header style="margin-bottom: 3rem">

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
@@ -13,3 +13,13 @@
   max-width: 500px; /* Force small width to trigger wrapping */
 }
 
+.docs-header-links-simulated {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  align-items: center;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
@@ -5,3 +5,11 @@
 
 /* ── Container Styles ────────────────────────────────────── */
 .nav-container {
+  background-color: #1a1926;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 2.5rem;
+  max-width: 500px; /* Force small width to trigger wrapping */
+}
+

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
@@ -34,3 +34,13 @@
   transition: all 0.3s ease;
 }
 
+.docs-header-links-simulated a:not(.ease-btn):hover {
+  color: #ffffff;
+  background: rgba(108, 99, 255, 0.12);
+}
+
+/* ── BEFORE FIX: Multi-word text wraps and baselines break ── */
+.broken-state li {
+  display: list-item;
+}
+

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
@@ -1,0 +1,7 @@
+/* ============================================================
+   nav-alignment-nowrap-fix-ag — style.css
+   Demonstrates vertical centering and nowrap text link alignment
+   ============================================================ */
+
+/* ── Container Styles ────────────────────────────────────── */
+.nav-container {

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
@@ -48,3 +48,8 @@
   /* Default wrapping allowed */
 }
 
+/* ── AFTER FIX: Flexbox list items + nowrap text links ───── */
+.fixed-state li {
+  display: flex;
+  align-items: center;
+}

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
@@ -44,3 +44,7 @@
   display: list-item;
 }
 
+.broken-state a {
+  /* Default wrapping allowed */
+}
+

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
@@ -53,3 +53,7 @@
   display: flex;
   align-items: center;
 }
+
+.fixed-state a {
+  white-space: nowrap; /* Forces text to remain on a single line */
+}

--- a/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
+++ b/submissions/examples/nav-alignment-nowrap-fix-ag/style.css
@@ -23,3 +23,14 @@
   margin: 0;
 }
 
+/* ── Navigation Links (Standard) ────────────────────────── */
+.docs-header-links-simulated a:not(.ease-btn) {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: 6px;
+  transition: all 0.3s ease;
+}
+

--- a/submissions/examples/sticky-header-fix-ag/README.md
+++ b/submissions/examples/sticky-header-fix-ag/README.md
@@ -1,0 +1,30 @@
+# Sticky Navigation Header Fix
+
+## What does this do?
+
+Keeps the top navigation header stuck to the top of the viewport (`position: sticky`) as users scroll down the page, preventing it from scrolling out of view.
+
+## How is it used?
+
+Apply a sticky position and top constraint to your navigation container, making sure no parent element overrides its display/positioning styles:
+
+```html
+<header class="docs-header">
+  <nav class="nav-links">
+    <!-- Links here -->
+  </nav>
+</header>
+```
+
+```css
+.docs-header {
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  background-color: var(--header-bg);
+}
+```
+
+## Why is it useful?
+
+It provides continuous access to navigation links and site actions (like the theme toggle and search elements), reducing friction for users browsing extensive documentation and improving overall usability.

--- a/submissions/examples/sticky-header-fix-ag/demo.html
+++ b/submissions/examples/sticky-header-fix-ag/demo.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sticky Navigation Header Fix — EaseMotion CSS</title>
+    <!-- Load EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css" />
+    <!-- Load custom demo styles -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body
+    data-theme="dark"
+    style="
+      background-color: #0f0e17;
+      color: #fffffe;
+      font-family: sans-serif;
+      padding: 3rem;
+      max-width: 1000px;
+      margin: 0 auto;
+    "
+  >
+    <header style="margin-bottom: 3rem">
+      <h1
+        style="
+          font-size: 2rem;
+          font-weight: 700;
+          margin-bottom: 0.5rem;
+          color: #ffffff;
+        "
+      >
+        Sticky Navigation Header Positioning Fix
+      </h1>
+      <p
+        style="
+          color: rgba(255, 255, 255, 0.65);
+          line-height: 1.6;
+          max-width: 700px;
+        "
+      >
+        This demo simulates how a navigation header behaves when scrolling down
+        the page. Scroll inside the simulated viewports below to observe the
+        issue and its resolution.
+      </p>
+    </header>
+
+    <div
+      style="
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 2.5rem;
+        min-width: 0;
+      "
+    >
+      <!-- Section 1: Broken State -->
+      <section>
+        <h2
+          style="
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #ef4444;
+            margin-bottom: 1rem;
+          "
+        >
+          ❌ Static Header (Before Fix)
+        </h2>
+        <p
+          style="
+            font-size: 0.85rem;
+            color: rgba(255, 255, 255, 0.65);
+            margin-bottom: 1rem;
+            min-height: 48px;
+          "
+        >
+          The header scrolls out of view as the user moves down the content.
+          Accessing navigation requires scrolling back up.
+        </p>
+
+        <div class="viewport-simulator broken-state">
+          <header class="header-simulated">
+            <span
+              style="
+                font-weight: bold;
+                background: linear-gradient(135deg, #6c63ff, #a78bfa);
+                -webkit-background-clip: text;
+                -webkit-text-fill-color: transparent;
+              "
+              >EaseMotion</span
+            >
+            <ul class="nav-links-simulated">
+              <li><a href="#">Home</a></li>
+              <li><a href="#">Docs</a></li>
+              <li>
+                <a
+                  href="#"
+                  class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
+                  >Live Demo</a
+                >
+              </li>
+            </ul>
+          </header>
+          <div class="scroll-content">
+            <h3 style="margin-top: 0">Scroll Down Inside Here 👇</h3>
+            <p
+              style="
+                color: rgba(255, 255, 255, 0.5);
+                font-size: 0.9rem;
+                line-height: 1.6;
+              "
+              repeat="4"
+            >
+              EaseMotion CSS is a human-readable, animation-first CSS library.
+              Write UI with simple, English-like class names — no memorizing
+              utilities, no complex configuration. EaseMotion CSS bridges the
+              gap between raw vanilla CSS and utility-heavy frameworks like
+              Tailwind.
+            </p>
+            <p
+              style="
+                color: rgba(255, 255, 255, 0.5);
+                font-size: 0.9rem;
+                line-height: 1.6;
+              "
+            >
+              Notice how the navigation header has scrolled out of view and is
+              no longer accessible without scrolling back to the top.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Section 2: Fixed State -->
+      <section>
+        <h2
+          style="
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #22c55e;
+            margin-bottom: 1rem;
+          "
+        >
+          ✅ Sticky Header (After Fix)
+        </h2>
+        <p
+          style="
+            font-size: 0.85rem;
+            color: rgba(255, 255, 255, 0.65);
+            margin-bottom: 1rem;
+            min-height: 48px;
+          "
+        >
+          The header remains stickied at the top of the viewport, staying
+          visible and accessible no matter how far down the user scrolls.
+        </p>
+
+        <div class="viewport-simulator fixed-state">
+          <header class="header-simulated">
+            <span
+              style="
+                font-weight: bold;
+                background: linear-gradient(135deg, #6c63ff, #a78bfa);
+                -webkit-background-clip: text;
+                -webkit-text-fill-color: transparent;
+              "
+              >EaseMotion</span
+            >
+            <ul class="nav-links-simulated">
+              <li><a href="#">Home</a></li>
+              <li><a href="#">Docs</a></li>
+              <li>
+                <a
+                  href="#"
+                  class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill"
+                  >Live Demo</a
+                >
+              </li>
+            </ul>
+          </header>
+          <div class="scroll-content">
+            <h3 style="margin-top: 0">Scroll Down Inside Here 👇</h3>
+            <p
+              style="
+                color: rgba(255, 255, 255, 0.5);
+                font-size: 0.9rem;
+                line-height: 1.6;
+              "
+            >
+              EaseMotion CSS is a human-readable, animation-first CSS library.
+              Write UI with simple, English-like class names — no memorizing
+              utilities, no complex configuration. EaseMotion CSS bridges the
+              gap between raw vanilla CSS and utility-heavy frameworks like
+              Tailwind.
+            </p>
+            <p
+              style="
+                color: rgba(255, 255, 255, 0.5);
+                font-size: 0.9rem;
+                line-height: 1.6;
+              "
+            >
+              Even as you scroll deep into the content area, the header locks at
+              the top of this container and remains perfectly usable!
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/sticky-header-fix-ag/style.css
+++ b/submissions/examples/sticky-header-fix-ag/style.css
@@ -1,0 +1,62 @@
+/* ============================================================
+   sticky-header-fix-ag — style.css
+   Demonstrates sticky and fixed navigation header positioning
+   ============================================================ */
+
+/* ── Container layout simulation ────────────────────────── */
+.viewport-simulator {
+  position: relative;
+  height: 400px;
+  overflow-y: scroll;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background-color: #0f0e17;
+  margin-bottom: 2rem;
+}
+
+.scroll-content {
+  padding: 1rem 2rem 15rem 2rem; /* Ensure scroll height */
+}
+
+/* ── Sticky Header Base ──────────────────────────────────── */
+.header-simulated {
+  height: 60px;
+  background-color: rgba(26, 25, 38, 0.95);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+  z-index: 100;
+  transition: all 0.3s ease;
+}
+
+.nav-links-simulated {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  align-items: center;
+}
+
+.nav-links-simulated a {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+/* ── BROKEN STATE: static header that scrolls away ───────── */
+.broken-state .header-simulated {
+  position: relative; /* Overrides sticky positioning */
+}
+
+/* ── FIXED STATE: sticky header that stays at the top ────── */
+.fixed-state .header-simulated {
+  position: sticky;
+  top: 0;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves a layout bug where the top navigation bar scrolls out of view. A late-defined CSS rule `.docs-header, .docs-shell, .ease-scroll-progress { position: relative; z-index: 1; }` overrode the navigation bar's intended `position: fixed` / `position: sticky` styling.

Removing `.docs-header` from this group selector restores correct fixed positioning on desktop and sticky positioning on mobile/tablet viewports.


Fixes: #11244 
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/sticky-header-fix-ag/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Maintains the navigation header sticky/fixed at the top of the viewport when scrolling, ensuring links and actions remain visible and accessible.

**How does a developer use it?**

Apply `position: sticky; top: 0;` or `position: fixed;` to the navigation header container, ensuring no subsequent styles override its layout properties:

```html
<header class="docs-header">
  <nav class="nav-links">
    <!-- Links here -->
  </nav>
</header>
```

```css
.docs-header {
  position: sticky;
  top: 0;
  z-index: 200;
  background-color: var(--header-bg);
}
```

**Why does it fit EaseMotion CSS?**

It improves user experience and matches standard interface design expectations by keeping primary navigation links easily accessible at all times.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
