### PR TITLE
feat: add notification inbox priority stack component (issue #11160)

### DIFF
--- a/submissions/examples/notification-inbox-stack-ts/README.md
+++ b/submissions/examples/notification-inbox-stack-ts/README.md
@@ -1,0 +1,75 @@
+# Notification Inbox Priority Stack
+
+## What does this do?
+
+A stacked notification inbox with four priority states: high (red), medium (amber), low (blue), and success (green). Unread items show a coloured dot. High and medium unread dots pulse with an expanding ring animation to draw attention without being intrusive. Each card has a left accent bar that expands on hover, a slide-right entrance on hover, and a dismiss button that triggers a slide-out exit animation. An empty state is shown when all items are dismissed.
+
+## How is it used?
+
+Wrap notifications in `.notification-inbox`. Each notification is an `.inbox-item` — add modifier classes to set priority and read state:
+
+```html
+<section class="notification-inbox" aria-label="Notifications">
+
+  <div class="inbox-header">
+    <span class="inbox-title">
+      Notifications
+      <span class="inbox-count">3</span>
+    </span>
+    <button class="inbox-mark-all" type="button">Mark all read</button>
+  </div>
+
+  <!-- High priority, unread -->
+  <article class="inbox-item is-unread is-high" tabindex="0">
+    <span class="inbox-dot" aria-hidden="true"></span>
+    <div class="inbox-icon" aria-hidden="true">&#9888;</div>
+    <div class="inbox-body">
+      <div class="inbox-item-title">Payment failed</div>
+      <p class="inbox-item-desc">Update billing details to keep the workspace active.</p>
+      <div class="inbox-meta">
+        <span class="inbox-time">2 min ago</span>
+        <span class="inbox-badge inbox-badge-high">High</span>
+      </div>
+    </div>
+    <button class="inbox-dismiss" type="button" aria-label="Dismiss">&times;</button>
+  </article>
+
+  <!-- Medium priority, unread -->
+  <article class="inbox-item is-unread is-medium" tabindex="0">
+    <!-- ... -->
+  </article>
+
+  <!-- Read item (no is-unread class) -->
+  <article class="inbox-item" tabindex="0">
+    <!-- ... -->
+  </article>
+
+  <div class="inbox-footer">
+    <button class="inbox-view-all" type="button">View all &rarr;</button>
+  </div>
+
+</section>
+```
+
+Priority modifier classes:
+
+| Class | Dot colour | Accent bar | Badge class |
+|---|---|---|---|
+| `is-high` | Red, pulsing ring | Red | `inbox-badge-high` |
+| `is-medium` | Amber, pulsing ring | Amber | `inbox-badge-medium` |
+| `is-low` | Blue (no pulse) | — | `inbox-badge-low` |
+| `is-success` | Green (no pulse) | — | `inbox-badge-success` |
+| *(none)* | Indigo (no pulse) | — | `inbox-badge-info` |
+
+Add `is-unread` to any item to activate the coloured dot and background tint. Remove it (or remove the class via JavaScript) to mark the item as read.
+
+To dismiss an item with animation:
+
+```js
+item.classList.add('is-dismissed');
+setTimeout(() => item.remove(), 300);
+```
+
+## Why is it useful?
+
+Many apps need notification centres, but the pattern is often handled as a plain list with no motion context. This component shows how subtle, purposeful animation — a pulsing ring for urgent items, an accent bar that expands on hover, and a slide-out on dismiss — draws attention to what matters without turning every notification into an alarming toast. The priority system maps to real-world severity levels, the empty state gives the user clear closure, and the whole component works with keyboard navigation, dark mode, and `prefers-reduced-motion` out of the box.

--- a/submissions/examples/notification-inbox-stack-ts/demo.html
+++ b/submissions/examples/notification-inbox-stack-ts/demo.html
@@ -1,0 +1,267 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notification Inbox Priority Stack</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #f1f5f9;
+        color: #0f172a;
+        min-height: 100vh;
+        padding: 2.5rem 1.25rem 3.5rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2.5rem;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body { background: #0f172a; color: #e2e8f0; }
+      }
+
+      .demo-header {
+        text-align: center;
+        max-width: 500px;
+      }
+
+      .demo-header h1 {
+        font-size: 1.45rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        margin-bottom: 0.4rem;
+        color: #0f172a;
+      }
+
+      .demo-header p {
+        font-size: 0.875rem;
+        color: #64748b;
+        line-height: 1.6;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .demo-header h1 { color: #f1f5f9; }
+        .demo-header p  { color: #94a3b8; }
+      }
+
+      .demo-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: #94a3b8;
+        text-align: center;
+      }
+
+      .demo-divider {
+        width: 100%;
+        max-width: 480px;
+        height: 1px;
+        background: linear-gradient(90deg, transparent, #cbd5e1, transparent);
+        border: none;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .demo-divider { background: linear-gradient(90deg, transparent, #334155, transparent); }
+      }
+    </style>
+  </head>
+  <body>
+
+    <header class="demo-header">
+      <h1>Notification Inbox Priority Stack</h1>
+      <p>
+        Stacked notification cards with high, medium, low, and success
+        priority states. High and medium unread items pulse their indicator
+        dot. Click the &times; button on any card to dismiss it.
+      </p>
+    </header>
+
+    <!-- ── Main inbox ─────────────────────────────────────── -->
+
+    <p class="demo-label">Full inbox — mixed priorities</p>
+
+    <section class="notification-inbox" aria-label="Notifications" id="mainInbox">
+
+      <div class="inbox-header">
+        <span class="inbox-title">
+          Notifications
+          <span class="inbox-count" aria-label="4 unread notifications">4</span>
+        </span>
+        <button class="inbox-mark-all" type="button" onclick="markAllRead('mainInbox')" aria-label="Mark all notifications as read">
+          Mark all read
+        </button>
+      </div>
+
+      <!-- High priority unread -->
+      <article class="inbox-item is-unread is-high" tabindex="0" aria-label="Payment failed. High priority. Unread.">
+        <span class="inbox-dot" aria-hidden="true"></span>
+        <div class="inbox-icon" aria-hidden="true">&#9888;</div>
+        <div class="inbox-body">
+          <div class="inbox-item-title">Payment failed</div>
+          <p class="inbox-item-desc">Update your billing details to keep the workspace active. This requires action.</p>
+          <div class="inbox-meta">
+            <span class="inbox-time">2 min ago</span>
+            <span class="inbox-badge inbox-badge-high">High</span>
+          </div>
+        </div>
+        <button class="inbox-dismiss" type="button" onclick="dismiss(this)" aria-label="Dismiss payment failed notification">&times;</button>
+      </article>
+
+      <!-- Medium priority unread -->
+      <article class="inbox-item is-unread is-medium" tabindex="0" aria-label="Storage limit approaching. Medium priority. Unread.">
+        <span class="inbox-dot" aria-hidden="true"></span>
+        <div class="inbox-icon" aria-hidden="true">&#128190;</div>
+        <div class="inbox-body">
+          <div class="inbox-item-title">Storage limit approaching</div>
+          <p class="inbox-item-desc">You have used 87% of your 10 GB storage. Consider upgrading your plan.</p>
+          <div class="inbox-meta">
+            <span class="inbox-time">18 min ago</span>
+            <span class="inbox-badge inbox-badge-medium">Medium</span>
+          </div>
+        </div>
+        <button class="inbox-dismiss" type="button" onclick="dismiss(this)" aria-label="Dismiss storage notification">&times;</button>
+      </article>
+
+      <!-- Default unread -->
+      <article class="inbox-item is-unread" tabindex="0" aria-label="New team member joined. Unread.">
+        <span class="inbox-dot" aria-hidden="true"></span>
+        <div class="inbox-icon" aria-hidden="true">&#128101;</div>
+        <div class="inbox-body">
+          <div class="inbox-item-title">Priya joined your workspace</div>
+          <p class="inbox-item-desc">Priya Rao accepted your invitation and joined the Design team.</p>
+          <div class="inbox-meta">
+            <span class="inbox-time">1 hr ago</span>
+            <span class="inbox-badge inbox-badge-info">Team</span>
+          </div>
+        </div>
+        <button class="inbox-dismiss" type="button" onclick="dismiss(this)" aria-label="Dismiss team notification">&times;</button>
+      </article>
+
+      <!-- Success unread -->
+      <article class="inbox-item is-unread is-success" tabindex="0" aria-label="Deployment successful. Unread.">
+        <span class="inbox-dot" aria-hidden="true"></span>
+        <div class="inbox-icon" aria-hidden="true">&#10003;</div>
+        <div class="inbox-body">
+          <div class="inbox-item-title">Deploy to production succeeded</div>
+          <p class="inbox-item-desc">v2.4.1 was deployed successfully. Zero downtime detected.</p>
+          <div class="inbox-meta">
+            <span class="inbox-time">2 hr ago</span>
+            <span class="inbox-badge inbox-badge-success">Success</span>
+          </div>
+        </div>
+        <button class="inbox-dismiss" type="button" onclick="dismiss(this)" aria-label="Dismiss deploy notification">&times;</button>
+      </article>
+
+      <!-- Read item -->
+      <article class="inbox-item is-low" tabindex="0" aria-label="Weekly digest. Read.">
+        <span class="inbox-dot" aria-hidden="true"></span>
+        <div class="inbox-icon" aria-hidden="true">&#128240;</div>
+        <div class="inbox-body">
+          <div class="inbox-item-title">Weekly activity digest</div>
+          <p class="inbox-item-desc">Your team closed 14 tasks and merged 6 pull requests last week.</p>
+          <div class="inbox-meta">
+            <span class="inbox-time">Yesterday</span>
+            <span class="inbox-badge inbox-badge-low">Digest</span>
+          </div>
+        </div>
+        <button class="inbox-dismiss" type="button" onclick="dismiss(this)" aria-label="Dismiss digest notification">&times;</button>
+      </article>
+
+      <!-- Read item -->
+      <article class="inbox-item" tabindex="0" aria-label="Security audit complete. Read.">
+        <span class="inbox-dot" aria-hidden="true"></span>
+        <div class="inbox-icon" aria-hidden="true">&#128274;</div>
+        <div class="inbox-body">
+          <div class="inbox-item-title">Security scan complete</div>
+          <p class="inbox-item-desc">No critical vulnerabilities found in the last automated scan.</p>
+          <div class="inbox-meta">
+            <span class="inbox-time">2 days ago</span>
+          </div>
+        </div>
+        <button class="inbox-dismiss" type="button" onclick="dismiss(this)" aria-label="Dismiss security notification">&times;</button>
+      </article>
+
+      <div class="inbox-footer">
+        <button class="inbox-view-all" type="button">View all notifications &rarr;</button>
+      </div>
+
+    </section>
+
+    <hr class="demo-divider" />
+
+    <!-- ── Empty state ────────────────────────────────────── -->
+
+    <p class="demo-label">Empty state</p>
+
+    <section class="notification-inbox" aria-label="Notifications empty state">
+      <div class="inbox-header">
+        <span class="inbox-title">Notifications</span>
+      </div>
+      <div class="inbox-empty" role="status" aria-label="No notifications">
+        <span class="inbox-empty-icon" aria-hidden="true">&#128276;</span>
+        <span>You're all caught up!</span>
+      </div>
+    </section>
+
+    <script>
+      function dismiss(btn) {
+        var item = btn.closest('.inbox-item');
+        item.classList.add('is-dismissed');
+        item.setAttribute('aria-hidden', 'true');
+
+        setTimeout(function() {
+          var inbox = item.closest('.notification-inbox');
+          item.remove();
+          updateCount(inbox);
+          checkEmpty(inbox);
+        }, 300);
+      }
+
+      function markAllRead(inboxId) {
+        var inbox = document.getElementById(inboxId);
+        var items = inbox.querySelectorAll('.inbox-item.is-unread');
+        items.forEach(function(item) {
+          item.classList.remove('is-unread');
+          var dot = item.querySelector('.inbox-dot');
+          if (dot) dot.style.background = '#cbd5e1';
+        });
+        updateCount(inbox);
+      }
+
+      function updateCount(inbox) {
+        var badge  = inbox.querySelector('.inbox-count');
+        var unread = inbox.querySelectorAll('.inbox-item.is-unread').length;
+        if (badge) {
+          badge.textContent = unread;
+          badge.style.display = unread > 0 ? '' : 'none';
+          badge.setAttribute('aria-label', unread + ' unread notifications');
+        }
+      }
+
+      function checkEmpty(inbox) {
+        var items = inbox.querySelectorAll('.inbox-item');
+        var footer = inbox.querySelector('.inbox-footer');
+        if (items.length === 0) {
+          if (footer) footer.remove();
+          var header = inbox.querySelector('.inbox-header');
+          var empty  = document.createElement('div');
+          empty.className  = 'inbox-empty';
+          empty.setAttribute('role', 'status');
+          empty.setAttribute('aria-label', 'No notifications');
+          empty.innerHTML  = '<span class="inbox-empty-icon" aria-hidden="true">&#128276;</span><span>You\'re all caught up!</span>';
+          if (header) {
+            header.insertAdjacentElement('afterend', empty);
+          } else {
+            inbox.appendChild(empty);
+          }
+        }
+      }
+    </script>
+
+  </body>
+</html>

--- a/submissions/examples/notification-inbox-stack-ts/style.css
+++ b/submissions/examples/notification-inbox-stack-ts/style.css
@@ -1,0 +1,453 @@
+/* Notification Inbox Priority Stack
+   Stacked notification cards with priority states, unread indicators,
+   timestamps, hover/focus animations, and a high-priority pulse.
+   Pure CSS — state is driven by modifier classes on each .inbox-item.
+*/
+
+/* ── Inbox container ─────────────────────────────────────── */
+
+.notification-inbox {
+  width: 100%;
+  max-width: 440px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.07),
+    0 2px 4px -1px rgba(0, 0, 0, 0.04);
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+/* ── Inbox header ────────────────────────────────────────── */
+
+.inbox-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1rem 0.75rem;
+  border-bottom: 1px solid #f1f5f9;
+  gap: 0.5rem;
+}
+
+.inbox-title {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #0f172a;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.inbox-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #6366f1;
+  color: #ffffff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  min-width: 1.2rem;
+  height: 1.2rem;
+  padding: 0 0.3rem;
+  border-radius: 999px;
+  line-height: 1;
+}
+
+.inbox-mark-all {
+  font-size: 0.72rem;
+  color: #6366f1;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 500;
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.3rem;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.inbox-mark-all:hover { background: rgba(99,102,241,0.08); }
+.inbox-mark-all:focus-visible { outline: 2px solid #6366f1; outline-offset: 2px; }
+
+/* ── Inbox item (base) ───────────────────────────────────── */
+
+.inbox-item {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid #f1f5f9;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    transform  200ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  outline: none;
+}
+
+.inbox-item:last-child { border-bottom: none; }
+
+@media (hover: hover) and (pointer: fine) {
+  .inbox-item:hover {
+    background: #f8fafc;
+    transform: translateX(3px);
+  }
+}
+
+.inbox-item:focus-visible {
+  background: #f8fafc;
+  outline: 2px solid #6366f1;
+  outline-offset: -2px;
+}
+
+.inbox-item:active { transform: scale(0.99); }
+
+/* ── Unread indicator dot ────────────────────────────────── */
+
+.inbox-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #cbd5e1;
+  flex-shrink: 0;
+  margin-top: 0.35rem;
+  transition: background 160ms ease;
+}
+
+.inbox-item.is-unread .inbox-dot {
+  background: #6366f1;
+}
+
+/* High priority dot pulses */
+.inbox-item.is-unread.is-high .inbox-dot {
+  background: #ef4444;
+  animation: unreadPulse 1.6s ease-in-out infinite;
+}
+
+.inbox-item.is-unread.is-medium .inbox-dot {
+  background: #f59e0b;
+  animation: unreadPulse 2s ease-in-out infinite;
+}
+
+@keyframes unreadPulse {
+  0%, 100% { box-shadow: 0 0 0 0 currentColor; opacity: 1; }
+  50%       { box-shadow: 0 0 0 4px transparent; opacity: 0.7; }
+}
+
+/* Coloured pulse rings using outline trick */
+.inbox-item.is-unread.is-high .inbox-dot {
+  box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.5);
+  animation: unreadPulseRed 1.6s ease-in-out infinite;
+}
+
+.inbox-item.is-unread.is-medium .inbox-dot {
+  box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.5);
+  animation: unreadPulseAmber 2s ease-in-out infinite;
+}
+
+@keyframes unreadPulseRed {
+  0%, 100% { box-shadow: 0 0 0 0   rgba(239, 68,  68,  0.5); }
+  50%       { box-shadow: 0 0 0 5px rgba(239, 68,  68,  0);   }
+}
+
+@keyframes unreadPulseAmber {
+  0%, 100% { box-shadow: 0 0 0 0   rgba(245, 158, 11, 0.5); }
+  50%       { box-shadow: 0 0 0 5px rgba(245, 158, 11, 0);   }
+}
+
+/* ── Icon slot ───────────────────────────────────────────── */
+
+.inbox-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  background: #f1f5f9;
+  color: #64748b;
+  transition: background 160ms ease;
+}
+
+.inbox-item.is-high   .inbox-icon { background: #fee2e2; color: #b91c1c; }
+.inbox-item.is-medium .inbox-icon { background: #fef3c7; color: #92400e; }
+.inbox-item.is-low    .inbox-icon { background: #dbeafe; color: #1d4ed8; }
+.inbox-item.is-success .inbox-icon { background: #dcfce7; color: #15803d; }
+
+/* ── Item body ───────────────────────────────────────────── */
+
+.inbox-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.inbox-item-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #0f172a;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Unread title is slightly bolder */
+.inbox-item.is-unread .inbox-item-title {
+  font-weight: 700;
+}
+
+.inbox-item-desc {
+  font-size: 0.75rem;
+  color: #64748b;
+  line-height: 1.5;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+/* ── Meta row (timestamp + badge) ────────────────────────── */
+
+.inbox-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.inbox-time {
+  font-size: 0.68rem;
+  color: #94a3b8;
+  white-space: nowrap;
+}
+
+.inbox-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1em 0.5em;
+  border-radius: 999px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.inbox-badge-high    { background: #fee2e2; color: #b91c1c; }
+.inbox-badge-medium  { background: #fef3c7; color: #92400e; }
+.inbox-badge-low     { background: #dbeafe; color: #1d4ed8; }
+.inbox-badge-success { background: #dcfce7; color: #15803d; }
+.inbox-badge-info    { background: #e0f2fe; color: #0369a1; }
+
+/* ── Item action (dismiss button) ────────────────────────── */
+
+.inbox-dismiss {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: #94a3b8;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 150ms ease, background 150ms ease, color 150ms ease;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .inbox-item:hover .inbox-dismiss,
+  .inbox-item:focus-within .inbox-dismiss {
+    opacity: 1;
+  }
+}
+
+.inbox-dismiss:hover { background: #f1f5f9; color: #334155; }
+.inbox-dismiss:focus-visible { outline: 2px solid #6366f1; outline-offset: 1px; opacity: 1; }
+
+/* ── Unread background tint ──────────────────────────────── */
+
+.inbox-item.is-unread {
+  background: rgba(99, 102, 241, 0.03);
+}
+
+.inbox-item.is-unread.is-high {
+  background: rgba(239, 68, 68, 0.03);
+}
+
+.inbox-item.is-unread.is-medium {
+  background: rgba(245, 158, 11, 0.03);
+}
+
+/* ── Left accent bar ─────────────────────────────────────── */
+
+.inbox-item.is-high::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 10%;
+  bottom: 10%;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: #ef4444;
+  transition: top 160ms ease, bottom 160ms ease;
+}
+
+.inbox-item.is-medium::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 10%;
+  bottom: 10%;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: #f59e0b;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .inbox-item.is-high:hover::after,
+  .inbox-item.is-medium:hover::after {
+    top: 0;
+    bottom: 0;
+  }
+}
+
+/* ── Inbox footer ────────────────────────────────────────── */
+
+.inbox-footer {
+  padding: 0.65rem 1rem;
+  border-top: 1px solid #f1f5f9;
+  text-align: center;
+}
+
+.inbox-view-all {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6366f1;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.3rem;
+  transition: background 120ms ease;
+}
+
+.inbox-view-all:hover { background: rgba(99,102,241,0.07); }
+.inbox-view-all:focus-visible { outline: 2px solid #6366f1; outline-offset: 2px; }
+
+/* ── Empty state ─────────────────────────────────────────── */
+
+.inbox-empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 0.8rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.inbox-empty-icon {
+  font-size: 1.75rem;
+  opacity: 0.5;
+}
+
+/* ── Dismissed state ─────────────────────────────────────── */
+
+.inbox-item.is-dismissed {
+  animation: inboxDismiss 0.28s cubic-bezier(0.4, 0, 1, 1) both;
+  pointer-events: none;
+}
+
+@keyframes inboxDismiss {
+  to {
+    opacity: 0;
+    transform: translateX(100%);
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    margin: 0;
+  }
+}
+
+/* ── Dark mode ───────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .notification-inbox {
+    background: #1e293b;
+    border-color: #334155;
+    box-shadow:
+      0 4px 6px -1px rgba(0, 0, 0, 0.3),
+      0 2px 4px -1px rgba(0, 0, 0, 0.18);
+  }
+
+  .inbox-header       { border-bottom-color: #334155; }
+  .inbox-item         { border-bottom-color: #334155; }
+  .inbox-footer       { border-top-color: #334155; }
+
+  .inbox-title        { color: #f1f5f9; }
+  .inbox-item-title   { color: #f1f5f9; }
+  .inbox-item-desc    { color: #94a3b8; }
+  .inbox-time         { color: #475569; }
+
+  @media (hover: hover) and (pointer: fine) {
+    .inbox-item:hover   { background: #0f172a; }
+  }
+  .inbox-item:focus-visible { background: #0f172a; }
+
+  .inbox-item.is-unread         { background: rgba(99, 102, 241, 0.06); }
+  .inbox-item.is-unread.is-high { background: rgba(239, 68,  68,  0.06); }
+  .inbox-item.is-unread.is-medium { background: rgba(245, 158, 11, 0.06); }
+
+  .inbox-icon    { background: #334155; color: #94a3b8; }
+  .inbox-item.is-high    .inbox-icon { background: rgba(239,68,68,0.15);  color: #fca5a5; }
+  .inbox-item.is-medium  .inbox-icon { background: rgba(245,158,11,0.15); color: #fcd34d; }
+  .inbox-item.is-low     .inbox-icon { background: rgba(59,130,246,0.15); color: #93c5fd; }
+  .inbox-item.is-success .inbox-icon { background: rgba(34,197,94,0.15);  color: #86efac; }
+
+  .inbox-badge-high    { background: rgba(239,68,68,0.15);  color: #fca5a5; }
+  .inbox-badge-medium  { background: rgba(245,158,11,0.15); color: #fcd34d; }
+  .inbox-badge-low     { background: rgba(59,130,246,0.15); color: #93c5fd; }
+  .inbox-badge-success { background: rgba(34,197,94,0.15);  color: #86efac; }
+  .inbox-badge-info    { background: rgba(14,165,233,0.15); color: #7dd3fc; }
+
+  .inbox-dismiss:hover { background: #334155; color: #e2e8f0; }
+  .inbox-dot { background: #475569; }
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .inbox-item { transition: background 150ms ease; }
+
+  @media (hover: hover) and (pointer: fine) {
+    .inbox-item:hover { transform: none; }
+  }
+
+  .inbox-item:active { transform: none; }
+
+  .inbox-item.is-unread.is-high   .inbox-dot,
+  .inbox-item.is-unread.is-medium .inbox-dot {
+    animation: none;
+    box-shadow: none;
+  }
+
+  .inbox-item.is-dismissed { animation: none; opacity: 0; }
+}


### PR DESCRIPTION
## Pull Request Description

Add a notification inbox example with priority states, unread indicators, timestamps, and stacked cards. It should demonstrate hover and focus states plus a subtle unread pulse for high-priority items.

Fixes: #11160

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- One-sentence description -->

**How does a developer use it?**

```html
<!-- Show the class usage in HTML -->
```

**Why does it fit EaseMotion CSS?**

<!-- Explain how this fits the human-readable, animation-first philosophy -->

