### PR TITLE
feat: add discount-calculator-ak

### DIFF
--- a/submissions/examples/discount-calculator-ak/README.md
+++ b/submissions/examples/discount-calculator-ak/README.md
@@ -1,0 +1,22 @@
+# Discount Calculator
+
+## What does this do?
+A discount calculator that computes savings with single percentage, stackable discounts, and BOGO simulation modes with a visual price comparison bar.
+
+## How is it used?
+Enter the original price and discount percentage. Switch between single %, stacked % (two sequential discounts), or BOGO mode. Results show discount amount, final price, and total savings with color-coded highlights.
+
+## Why is this useful?
+This helps shoppers and retailers quickly compare different discount scenarios and understand the true final price after various promotional strategies.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks)
+- Vanilla JavaScript
+
+## Preview
+Open demo.html directly in your browser to use the calculator.
+
+## Contribution Notes
+- Class naming was handled by the contributor
+- Maintainer will rename to ease-* convention before merging

--- a/submissions/examples/discount-calculator-ak/demo.html
+++ b/submissions/examples/discount-calculator-ak/demo.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Discount Calculator - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="calculator-wrapper">
+    <h1>Discount Calculator</h1>
+    <div class="input-section">
+      <div class="field">
+        <label for="origPrice">Original Price ($)</label>
+        <input type="number" id="origPrice" class="input" value="100" min="0" step="0.01">
+      </div>
+      <div class="field">
+        <label for="discPct">Discount %</label>
+        <input type="number" id="discPct" class="input" value="20" min="0" max="100" step="0.1">
+      </div>
+      <div class="mode-selector">
+        <button class="mode-btn active" data-mode="single">Single %</button>
+        <button class="mode-btn" data-mode="stacked">Stacked %</button>
+        <button class="mode-btn" data-mode="bogo">BOGO</button>
+      </div>
+      <div class="field stacked-field" style="display:none">
+        <label for="discPct2">Second Discount %</label>
+        <input type="number" id="discPct2" class="input" value="10" min="0" max="100" step="0.1">
+      </div>
+    </div>
+    <div class="results" id="results">
+      <div class="result-row highlight-green">
+        <span>Discount Amount</span>
+        <span id="discAmount">$0.00</span>
+      </div>
+      <div class="result-row highlight-blue">
+        <span>Final Price</span>
+        <span id="finalPrice">$0.00</span>
+      </div>
+      <div class="result-row highlight-yellow">
+        <span>You Save</span>
+        <span id="youSave">$0.00</span>
+      </div>
+    </div>
+    <div class="comparison-section" id="comparisonSection">
+      <div class="comparison-header">Price Comparison</div>
+      <div class="comparison-bar-wrapper">
+        <div class="comparison-bar">
+          <div class="bar-original" id="barOriginal"></div>
+          <div class="bar-final" id="barFinal"></div>
+        </div>
+        <div class="comparison-labels">
+          <span><span class="dot dot-original"></span> Original: <span id="labelOriginal">$100.00</span></span>
+          <span><span class="dot dot-final"></span> Final: <span id="labelFinal">$80.00</span></span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>
+    const origPrice = document.getElementById('origPrice');
+    const discPct = document.getElementById('discPct');
+    const discPct2 = document.getElementById('discPct2');
+    const discAmount = document.getElementById('discAmount');
+    const finalPrice = document.getElementById('finalPrice');
+    const youSave = document.getElementById('youSave');
+    const barOriginal = document.getElementById('barOriginal');
+    const barFinal = document.getElementById('barFinal');
+    const labelOriginal = document.getElementById('labelOriginal');
+    const labelFinal = document.getElementById('labelFinal');
+    const modeBtns = document.querySelectorAll('.mode-btn');
+    const stackedField = document.querySelector('.stacked-field');
+    let mode = 'single';
+
+    function fmt(n) {
+      return '$' + n.toFixed(2);
+    }
+
+    modeBtns.forEach(btn => {
+      btn.addEventListener('click', function() {
+        modeBtns.forEach(b => b.classList.remove('active'));
+        this.classList.add('active');
+        mode = this.dataset.mode;
+        stackedField.style.display = mode === 'stacked' ? 'block' : 'none';
+        calculate();
+      });
+    });
+
+    function calculate() {
+      const price = parseFloat(origPrice.value) || 0;
+      const pct = parseFloat(discPct.value) || 0;
+      const pct2 = parseFloat(discPct2.value) || 0;
+      let discountTotal = 0;
+      let final = price;
+
+      if (mode === 'single') {
+        discountTotal = price * (pct / 100);
+        final = price - discountTotal;
+      } else if (mode === 'stacked') {
+        const firstDisc = price * (pct / 100);
+        const afterFirst = price - firstDisc;
+        const secondDisc = afterFirst * (pct2 / 100);
+        discountTotal = firstDisc + secondDisc;
+        final = afterFirst - secondDisc;
+      } else if (mode === 'bogo') {
+        const bogoPct = Math.min(pct, 50);
+        discountTotal = price * (bogoPct / 100);
+        final = price - discountTotal;
+      }
+
+      discAmount.textContent = fmt(Math.max(0, discountTotal));
+      finalPrice.textContent = fmt(Math.max(0, final));
+      youSave.textContent = fmt(Math.max(0, price - final));
+      labelOriginal.textContent = fmt(price);
+      labelFinal.textContent = fmt(Math.max(0, final));
+
+      const totalWidth = price || 1;
+      const finalPct = Math.max(0, Math.min(100, (final / totalWidth) * 100));
+      const discPctVis = 100 - finalPct;
+      barOriginal.style.width = discPctVis + '%';
+      barFinal.style.width = finalPct + '%';
+    }
+
+    origPrice.addEventListener('input', calculate);
+    discPct.addEventListener('input', calculate);
+    discPct2.addEventListener('input', calculate);
+    calculate();
+  </script>
+</body>
+</html>

--- a/submissions/examples/discount-calculator-ak/style.css
+++ b/submissions/examples/discount-calculator-ak/style.css
@@ -1,0 +1,188 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0f0f;
+  color: #fff;
+}
+
+.calculator-wrapper {
+  padding: 2rem;
+  max-width: 480px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.input-section {
+  margin-bottom: 1.5rem;
+}
+
+.field {
+  margin-bottom: 1rem;
+}
+
+.field label {
+  display: block;
+  font-size: 0.75rem;
+  color: #888;
+  margin-bottom: 0.375rem;
+  letter-spacing: 0.05em;
+}
+
+.input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #333;
+  border-radius: 12px;
+  background: #1a1a1a;
+  color: #fff;
+  font-size: 0.9rem;
+  outline: none;
+}
+
+.input:focus {
+  border-color: #6366f1;
+}
+
+.mode-selector {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.mode-btn {
+  flex: 1;
+  padding: 0.6rem;
+  border: 1px solid #333;
+  border-radius: 10px;
+  background: #1a1a1a;
+  color: #888;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.mode-btn.active {
+  border-color: #6366f1;
+  background: #6366f1;
+  color: #fff;
+}
+
+.mode-btn:hover {
+  border-color: #6366f1;
+}
+
+.results {
+  background: #1a1a1a;
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid #333;
+  margin-bottom: 1.5rem;
+}
+
+.result-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  font-size: 0.875rem;
+}
+
+.result-row + .result-row {
+  border-top: 1px solid #333;
+}
+
+.result-row span:last-child {
+  font-weight: 600;
+}
+
+.highlight-green span:last-child {
+  color: #22c55e;
+}
+
+.highlight-blue span:last-child {
+  color: #6366f1;
+}
+
+.highlight-yellow span:last-child {
+  color: #eab308;
+}
+
+.comparison-section {
+  background: #1a1a1a;
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid #333;
+}
+
+.comparison-header {
+  font-size: 0.8rem;
+  color: #888;
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.comparison-bar-wrapper {
+  width: 100%;
+}
+
+.comparison-bar {
+  display: flex;
+  height: 24px;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.bar-original {
+  background: #6366f1;
+  transition: width 0.4s ease;
+}
+
+.bar-final {
+  background: #22c55e;
+  transition: width 0.4s ease;
+}
+
+.comparison-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: #888;
+}
+
+.dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  margin-right: 4px;
+}
+
+.dot-original {
+  background: #6366f1;
+}
+
+.dot-final {
+  background: #22c55e;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Adds a discount calculator with single and stackable discount modes, buy-one-get-one simulation, and visual savings breakdown showing original vs final price comparison. Closes #11343