### PR TITLE
Use overlay z-index token in sidebar mobile overlay

### DIFF
--- a/components/sidebar.css
+++ b/components/sidebar.css
@@ -80,7 +80,7 @@
       top: 0;
       left: 0;
       height: 100vh;
-      z-index: 100;
+      z-index: var(--ease-z-overlay, 100);
       width: var(--ease-sidebar-width, 260px);
       visibility: hidden;
       transform: translateX(-100%);


### PR DESCRIPTION
## Pull Request Description

Replaces the hardcoded mobile overlay z-index value in components/sidebar.css with the existing design token --ease-z-overlay.

This change improves consistency with the project's z-index scale and ensures the overlay automatically stays synchronized if overlay layer values are adjusted in the future.
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

Fixes the mobile sidebar overlay to use the existing overlay z-index design token instead of a hardcoded value.


**How does a developer use it?**

No usage changes are required.

Before:

.mobile-overlay {
  z-index: 100;
}

After:

.mobile-overlay {
  z-index: var(--ease-z-overlay, 100);
}
**Why does it fit EaseMotion CSS?**

EaseMotion CSS uses design tokens to maintain consistency and scalability across components. Replacing hardcoded values with an existing token improves maintainability while preserving current behavior through the fallback value.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Minimal one-line change.
No visual changes expected.
Preserves current z-index value through the fallback.
Aligns the sidebar overlay with the repository's established z-index token system.
No unrelated files modified.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
