### PR TITLE
fix: use --ease-z-overlay token for sidebar mobile overlay z-index

### DIFF
--- a/submissions/examples/fix-sidebar-z-index-token/README.md
+++ b/submissions/examples/fix-sidebar-z-index-token/README.md
@@ -1,0 +1,43 @@
+# Fix: Use --ease-z-overlay Token for Sidebar Mobile Overlay z-index
+
+## Problem
+
+`components/sidebar.css` hardcoded `z-index: 100` on the mobile overlay:
+
+```css
+@media (max-width: 768px) {
+  .ease-sidebar {
+    z-index: 100;
+  }
+}
+```
+
+`variables.css` defines `--ease-z-overlay: 100` exactly for this purpose. Using the hardcoded value instead of the token means the sidebar z-index cannot be adjusted via the token system and may fall out of sync if the z-index scale is updated globally.
+
+## Solution
+
+Use `--ease-z-overlay` with the original value as fallback:
+
+```css
+@media (max-width: 768px) {
+  .ease-sidebar {
+    z-index: var(--ease-z-overlay, 100);
+  }
+}
+```
+
+## Usage
+
+Override globally via token:
+
+```css
+:root {
+  --ease-z-overlay: 200;
+}
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS defines a z-index token scale for consistent stacking order management. All components should use these tokens so z-index can be adjusted globally without targeting individual component selectors.
+
+Fixes #10422

--- a/submissions/examples/fix-sidebar-z-index-token/demo.html
+++ b/submissions/examples/fix-sidebar-z-index-token/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Sidebar z-index Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: var(--ease-font-sans); margin: 0; }
+    .layout { display: flex; min-height: 100vh; }
+    .main { flex: 1; padding: 2rem; }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1rem; }
+    .token-info {
+      background: var(--ease-color-primary-alpha);
+      border: 1px solid var(--ease-color-primary);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.875rem;
+      margin-bottom: 1.5rem;
+    }
+    .controls { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+    .overlay-demo {
+      position: fixed;
+      inset: 0;
+      background: var(--ease-modal-backdrop, rgba(15,23,42,0.5));
+      z-index: var(--ease-z-overlay, 100);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      display: none;
+    }
+    .overlay-demo.active { display: flex; }
+    .overlay-content {
+      background: var(--ease-color-surface);
+      padding: 2rem;
+      border-radius: var(--ease-radius-lg);
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <div class="ease-sidebar">
+      <nav class="ease-sidebar-nav">
+        <a href="#" class="ease-sidebar-link ease-sidebar-link--active">Dashboard</a>
+        <a href="#" class="ease-sidebar-link">Profile</a>
+        <a href="#" class="ease-sidebar-link">Settings</a>
+      </nav>
+    </div>
+    <main class="main">
+      <h2>Sidebar z-index Token Fix</h2>
+      <div class="token-info">
+        Mobile overlay now uses <code>var(--ease-z-overlay, 100)</code> instead of
+        hardcoded <code>z-index: 100</code> — consistent with the z-index token scale.
+      </div>
+      <p>
+        Resize to mobile viewport to see the sidebar overlay. The z-index is now
+        driven by <code>--ease-z-overlay</code> from <code>variables.css</code>.
+      </p>
+      <div class="controls">
+        <button class="ease-btn ease-btn-primary"
+                onclick="document.querySelector('.overlay-demo').classList.add('active')">
+          Preview overlay z-index
+        </button>
+      </div>
+      <div class="overlay-demo" onclick="this.classList.remove('active')">
+        <div class="overlay-content">
+          <p>z-index: var(--ease-z-overlay, 100)</p>
+          <button class="ease-btn ease-btn-outline"
+                  onclick="this.closest('.overlay-demo').classList.remove('active')">
+            Close
+          </button>
+        </div>
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-sidebar-z-index-token/style.css
+++ b/submissions/examples/fix-sidebar-z-index-token/style.css
@@ -1,0 +1,15 @@
+/* Fix: Use --ease-z-overlay token for sidebar mobile overlay z-index
+
+   Problem: sidebar.css hardcoded z-index: 100 on the mobile overlay
+   instead of using --ease-z-overlay token from variables.css.
+
+   variables.css defines --ease-z-overlay: 100 exactly for this purpose.
+   Using the token ensures the value stays in sync if the z-index scale
+   is ever adjusted globally.
+*/
+
+@media (max-width: 768px) {
+  .ease-sidebar {
+    z-index: var(--ease-z-overlay, 100);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
`sidebar.css` hardcoded `z-index: 100` on the mobile overlay instead of using `--ease-z-overlay` from `variables.css`. The token is defined as exactly `100` for this purpose — using the hardcoded value means the sidebar z-index cannot be adjusted via the token system and may fall out of sync if the z-index scale is updated globally.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Replaces `z-index: 100` on `.ease-sidebar` mobile overlay with `var(--ease-z-overlay, 100)` so the sidebar participates in the global z-index token scale.

**How does a developer use it?**
```css
/* Adjust all overlay-level elements globally */
:root {
  --ease-z-overlay: 200;
}
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS defines a z-index token scale for consistent stacking order management. All components should use these tokens so z-index can be adjusted globally without targeting individual selectors.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows sidebar with token-driven z-index and overlay preview)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
One line change in `components/sidebar.css`: `z-index: 100` becomes `z-index: var(--ease-z-overlay, 100)` inside the mobile media query.

Fixes #10422