### PR TITLE
fix: use --ease-radius-lg token for footer social icon link border-radius

### DIFF
--- a/submissions/examples/fix-footer-border-radius-token/README.md
+++ b/submissions/examples/fix-footer-border-radius-token/README.md
@@ -1,0 +1,43 @@
+# Fix: Use --ease-radius-lg Token for Footer Social Icon Link Border Radius
+
+## Problem
+
+`.ease-footer-social a` hardcoded `border-radius: 12px` with no CSS custom property:
+
+```css
+.ease-footer-social a {
+  border-radius: 12px;
+}
+```
+
+Users who want to adjust the social icon shape (e.g. switch to pill or circular) must override `.ease-footer-social a` directly with higher specificity. The nearest design token is `--ease-radius-lg: 12px`.
+
+## Solution
+
+Replace the hardcoded value with the design token:
+
+```css
+.ease-footer-social a {
+  border-radius: var(--ease-radius-lg, 12px);
+}
+```
+
+## Usage
+
+```css
+/* Switch to circular social icons globally */
+:root {
+  --ease-radius-lg: 9999px;
+}
+
+/* Override per footer instance */
+.my-footer .ease-footer-social a {
+  --ease-radius-lg: 50%;
+}
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses design tokens so users can customise components without specificity battles. Social icon border radius is a key visual property that should follow the same token-driven approach as other border radius values in the framework.
+
+Fixes #10417

--- a/submissions/examples/fix-footer-border-radius-token/demo.html
+++ b/submissions/examples/fix-footer-border-radius-token/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Footer Social Border Radius Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted); margin-bottom: 0.75rem; }
+  </style>
+</head>
+<body>
+  <h2>Footer Social Border Radius Token Fix</h2>
+  <p>
+    Social icon links now use <code>var(--ease-radius-lg, 12px)</code> instead of
+    hardcoded <code>border-radius: 12px</code>.
+  </p>
+
+  <h3>Default (--ease-radius-lg: 12px)</h3>
+  <footer class="ease-footer" style="position:relative;padding:2rem;">
+    <div class="ease-footer-social">
+      <a href="#" aria-label="GitHub">
+        <span class="icon">GH</span>
+      </a>
+      <a href="#" aria-label="Twitter">
+        <span class="icon">TW</span>
+      </a>
+      <a href="#" aria-label="LinkedIn">
+        <span class="icon">LI</span>
+      </a>
+    </div>
+  </footer>
+
+  <h3 style="margin-top:2rem;">Custom radius via token override (--ease-radius-full)</h3>
+  <footer class="ease-footer" style="position:relative;padding:2rem;--ease-radius-lg:9999px;">
+    <div class="ease-footer-social">
+      <a href="#" aria-label="GitHub">
+        <span class="icon">GH</span>
+      </a>
+      <a href="#" aria-label="Twitter">
+        <span class="icon">TW</span>
+      </a>
+      <a href="#" aria-label="LinkedIn">
+        <span class="icon">LI</span>
+      </a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/fix-footer-border-radius-token/style.css
+++ b/submissions/examples/fix-footer-border-radius-token/style.css
@@ -1,0 +1,16 @@
+/* Fix: Use --ease-radius-lg token for footer social icon link border-radius
+
+   Problem: .ease-footer-social a used hardcoded border-radius: 12px
+   instead of a design token. This value cannot be adjusted via the
+   token system.
+
+   Note: The issue title references 50% (pill shape) but the current
+   implementation uses 12px for a rounded-square button style.
+   The nearest token is --ease-radius-lg: 12px.
+
+   Solution: Replace hardcoded 12px with var(--ease-radius-lg, 12px).
+*/
+
+.ease-footer-social a {
+  border-radius: var(--ease-radius-lg, 12px);
+}


### PR DESCRIPTION
## Pull Request Description
`.ease-footer-social a` hardcoded `border-radius: 12px` with no CSS custom property — users who want to adjust the social icon shape must override the selector directly with higher specificity. The nearest design token is `--ease-radius-lg: 12px`.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Replaces `border-radius: 12px` on `.ease-footer-social a` with `var(--ease-radius-lg, 12px)` so the social icon shape can be customised via the token system.

**How does a developer use it?**
```css
/* Switch to circular social icons */
:root { --ease-radius-lg: 9999px; }

/* Per-footer override */
.my-footer .ease-footer-social a { --ease-radius-lg: 50%; }
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS uses design tokens so users can customise components without specificity battles. Social icon border radius should follow the same token-driven approach as other border radius values in the framework.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows default 12px radius and custom pill override via token)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
One line change in `components/footer.css`: `border-radius: 12px` on `.ease-footer-social a` becomes `border-radius: var(--ease-radius-lg, 12px)`. Default behaviour unchanged.

Fixes #10417