### PR TITLE
fix: replace hardcoded gap and margin values with --ease-space-* tokens in footer.css

### DIFF
--- a/submissions/examples/fix-footer-spacing-tokens/README.md
+++ b/submissions/examples/fix-footer-spacing-tokens/README.md
@@ -1,0 +1,38 @@
+# Fix: Replace Hardcoded Gap and Margin Values with Spacing Tokens in footer.css
+
+## Problem
+
+`components/footer.css` used hardcoded spacing values not from the `--ease-space-*` token scale:
+
+```css
+.ease-footer-links        { gap: 0.75rem; }
+.ease-footer-social       { gap: 0.75rem; margin-top: 1rem; }
+.ease-footer-col          { gap: 1rem; }
+.ease-footer-col-title    { margin-bottom: 0.5rem; }
+.ease-footer-divider      { padding-bottom: 0.75rem; }
+.ease-footer-newsletter   { gap: 0.5rem; }
+.ease-footer-bottom-links { gap: 0.5rem; }
+```
+
+These values cannot be adjusted via the `--ease-space-*` token system, creating inconsistency with the rest of the framework.
+
+## Solution
+
+Replace with spacing tokens using original values as fallbacks:
+
+| Property | Old | Token |
+|----------|-----|-------|
+| `.ease-footer-links` gap | `0.75rem` | `var(--ease-space-3, 0.75rem)` |
+| `.ease-footer-social` gap | `0.75rem` | `var(--ease-space-3, 0.75rem)` |
+| `.ease-footer-social` margin-top | `1rem` | `var(--ease-space-4, 1rem)` |
+| `.ease-footer-col` gap | `1rem` | `var(--ease-space-4, 1rem)` |
+| `.ease-footer-col-title` margin-bottom | `0.5rem` | `var(--ease-space-2, 0.5rem)` |
+| `.ease-footer-divider` padding-bottom | `0.75rem` | `var(--ease-space-3, 0.75rem)` |
+| newsletter form gap | `0.5rem` | `var(--ease-space-2, 0.5rem)` |
+| bottom-links gap | `0.5rem` | `var(--ease-space-2, 0.5rem)` |
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses a complete `--ease-space-*` scale for consistent spacing. All component spacing should reference these tokens so layout density can be adjusted globally.
+
+Fixes #10418

--- a/submissions/examples/fix-footer-spacing-tokens/demo.html
+++ b/submissions/examples/fix-footer-spacing-tokens/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Footer Spacing Tokens — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: var(--ease-font-sans); margin: 0; }
+    .info {
+      padding: 2rem;
+      background: var(--ease-color-primary-alpha);
+      border-bottom: 1px solid var(--ease-color-primary);
+      font-size: 0.875rem;
+    }
+    .info code { font-family: var(--ease-font-mono); }
+    table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 1rem;
+             border: 1px solid var(--ease-color-neutral-200); font-size: 0.8rem; }
+    th { background: var(--ease-color-neutral-100); }
+  </style>
+</head>
+<body>
+  <div class="info">
+    <strong>Footer Spacing Token Fix</strong> — hardcoded gap and margin values
+    replaced with <code>--ease-space-*</code> tokens.
+    <table>
+      <tr><th>Property</th><th>Old value</th><th>Token</th></tr>
+      <tr><td>.ease-footer-links gap</td><td>0.75rem</td><td>var(--ease-space-3)</td></tr>
+      <tr><td>.ease-footer-social gap</td><td>0.75rem</td><td>var(--ease-space-3)</td></tr>
+      <tr><td>.ease-footer-social margin-top</td><td>1rem</td><td>var(--ease-space-4)</td></tr>
+      <tr><td>.ease-footer-col gap</td><td>1rem</td><td>var(--ease-space-4)</td></tr>
+      <tr><td>.ease-footer-col-title margin-bottom</td><td>0.5rem</td><td>var(--ease-space-2)</td></tr>
+      <tr><td>.ease-footer-divider padding-bottom</td><td>0.75rem</td><td>var(--ease-space-3)</td></tr>
+      <tr><td>.ease-footer-newsletter gap</td><td>0.5rem</td><td>var(--ease-space-2)</td></tr>
+      <tr><td>.ease-footer-bottom-links gap</td><td>0.5rem</td><td>var(--ease-space-2)</td></tr>
+      <tr><td>margin-bottom: 3rem</td><td>3rem</td><td>var(--ease-space-12)</td></tr>
+    </table>
+  </div>
+
+  <footer class="ease-footer">
+    <div class="ease-footer-grid">
+      <div class="ease-footer-col">
+        <p class="ease-footer-col-title">Product</p>
+        <ul class="ease-footer-links">
+          <li><a href="#">Features</a></li>
+          <li><a href="#">Pricing</a></li>
+          <li><a href="#">Changelog</a></li>
+        </ul>
+      </div>
+      <div class="ease-footer-col">
+        <p class="ease-footer-col-title">Company</p>
+        <ul class="ease-footer-links">
+          <li><a href="#">About</a></li>
+          <li><a href="#">Blog</a></li>
+          <li><a href="#">Contact</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="ease-footer-bottom">
+      <span>© 2026 EaseMotion CSS</span>
+      <div class="ease-footer-social">
+        <a href="#" aria-label="GitHub">GH</a>
+        <a href="#" aria-label="Twitter">TW</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/fix-footer-spacing-tokens/style.css
+++ b/submissions/examples/fix-footer-spacing-tokens/style.css
@@ -1,0 +1,51 @@
+/* Fix: Replace hardcoded gap and margin values with spacing tokens in footer.css
+
+   Token mapping used:
+     0.5rem  → var(--ease-space-2, 0.5rem)
+     0.75rem → var(--ease-space-3, 0.75rem)
+     1rem    → var(--ease-space-4, 1rem)
+     1.5rem  → var(--ease-space-6, 1.5rem)
+     2rem    → var(--ease-space-8, 2rem)
+     3rem    → var(--ease-space-12, 3rem)
+*/
+
+/* .ease-footer-bottom: margin-bottom: 3rem */
+.ease-footer-bottom-wrapper {
+  margin-bottom: var(--ease-space-12, 3rem);
+}
+
+/* .ease-footer-links: gap: 0.75rem */
+.ease-footer-links {
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+/* .ease-footer-social: gap: 0.75rem, margin-top: 1rem */
+.ease-footer-social {
+  gap: var(--ease-space-3, 0.75rem);
+  margin-top: var(--ease-space-4, 1rem);
+}
+
+/* .ease-footer-col: gap: 1rem */
+.ease-footer-col {
+  gap: var(--ease-space-4, 1rem);
+}
+
+/* .ease-footer-col-title: margin-bottom: 0.5rem */
+.ease-footer-col-title {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+/* .ease-footer-divider: padding-bottom: 0.75rem */
+.ease-footer-divider {
+  padding-bottom: var(--ease-space-3, 0.75rem);
+}
+
+/* .ease-footer-newsletter: gap: 0.5rem */
+.ease-footer-newsletter-form {
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+/* .ease-footer-bottom-links: gap: 0.5rem */
+.ease-footer-bottom-links {
+  gap: var(--ease-space-2, 0.5rem);
+}


### PR DESCRIPTION
## Pull Request Description
`footer.css` used hardcoded spacing values across multiple selectors — `0.5rem`, `0.75rem`, `1rem`, `3rem` — that are not from the `--ease-space-*` token scale. Footer spacing cannot be adjusted via the token system, inconsistent with how other components handle spacing.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Replaces 8 hardcoded spacing values with `--ease-space-*` tokens across footer selectors, all with original values as fallbacks so default behaviour is unchanged.

| Selector | Property | Old | Token |
|----------|----------|-----|-------|
| `.ease-footer-links` | `gap` | `0.75rem` | `var(--ease-space-3)` |
| `.ease-footer-social` | `gap` | `0.75rem` | `var(--ease-space-3)` |
| `.ease-footer-social` | `margin-top` | `1rem` | `var(--ease-space-4)` |
| `.ease-footer-col` | `gap` | `1rem` | `var(--ease-space-4)` |
| `.ease-footer-col-title` | `margin-bottom` | `0.5rem` | `var(--ease-space-2)` |
| `.ease-footer-divider` | `padding-bottom` | `0.75rem` | `var(--ease-space-3)` |
| newsletter form | `gap` | `0.5rem` | `var(--ease-space-2)` |
| `.ease-footer-bottom-links` | `gap` | `0.5rem` | `var(--ease-space-2)` |

**Why does it fit EaseMotion CSS?**
EaseMotion CSS uses a complete `--ease-space-*` scale. All component spacing should reference these tokens so layout density can be adjusted globally without targeting individual selectors.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows full footer with token-driven spacing and a reference table of all replaced values)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All changes are in `submissions/examples/` only — no changes to `components/footer.css`. Each spacing value uses the original hardcoded value as the fallback so default appearance is unchanged.

Fixes #10418