### PR TITLE
fix: expose --ease-tooltip-max-width token for tooltip width variant customisation

### DIFF
--- a/submissions/examples/fix-tooltip-max-width-token/README.md
+++ b/submissions/examples/fix-tooltip-max-width-token/README.md
@@ -1,0 +1,50 @@
+# Fix: Expose --ease-tooltip-max-width Token for Tooltip Width Customisation
+
+## Problem
+
+`components/tooltips.css` hardcoded `max-width` on tooltip width variants:
+
+```css
+.ease-tooltip[data-width="wide"]::after { max-width: 250px; }
+.ease-tooltip[data-width="full"]::after { max-width: 320px; }
+```
+
+Users who need different tooltip widths must override these attribute selectors directly with higher specificity — inconsistent with other tooltip tokens already exposed (`--ease-tooltip-bg`, `--ease-tooltip-padding` etc.).
+
+## Solution
+
+Expose `--ease-tooltip-max-width` with original values as fallbacks:
+
+```css
+.ease-tooltip[data-width="wide"]::after {
+  max-width: var(--ease-tooltip-max-width, 250px);
+}
+.ease-tooltip[data-width="full"]::after {
+  max-width: var(--ease-tooltip-max-width, 320px);
+}
+```
+
+## Usage
+
+```html
+<!-- Per-instance override -->
+<button class="ease-tooltip"
+        data-tooltip="Wide tooltip"
+        data-width="wide"
+        style="--ease-tooltip-max-width: 400px;">
+  Hover me
+</button>
+```
+
+```css
+/* Global override */
+:root {
+  --ease-tooltip-max-width: 300px;
+}
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS already exposes `--ease-tooltip-bg`, `--ease-tooltip-text`, `--ease-tooltip-padding`, `--ease-tooltip-radius` as tokens. Tooltip max-width should follow the same pattern so all key dimensions are customisable via the token system.
+
+Fixes #10421

--- a/submissions/examples/fix-tooltip-max-width-token/demo.html
+++ b/submissions/examples/fix-tooltip-max-width-token/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Tooltip Max-Width Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 4rem 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 600px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted); margin-bottom: 1rem; }
+    .row { display: flex; gap: 2rem; flex-wrap: wrap; margin-bottom: 3rem; align-items: center; }
+  </style>
+</head>
+<body>
+  <h2>Tooltip Max-Width Token Fix</h2>
+  <p>
+    Tooltip width variants now use <code>--ease-tooltip-max-width</code> token.
+    Override per-instance or globally without specificity battles.
+  </p>
+
+  <h3>Default wide (250px) and full (320px)</h3>
+  <div class="row">
+    <button class="ease-btn ease-btn-outline ease-tooltip"
+            data-tooltip="This is a wide tooltip with medium length text that wraps nicely"
+            data-width="wide"
+            data-position="bottom">
+      Wide (250px default)
+    </button>
+    <button class="ease-btn ease-btn-outline ease-tooltip"
+            data-tooltip="This is a full tooltip that supports longer multi-line continuous text content"
+            data-width="full"
+            data-position="bottom">
+      Full (320px default)
+    </button>
+  </div>
+
+  <h3>Custom width via token override (400px)</h3>
+  <div class="row">
+    <button class="ease-btn ease-btn-primary ease-tooltip my-wide-tooltip"
+            data-tooltip="This tooltip uses --ease-tooltip-max-width: 400px set via a custom class — no specificity override needed"
+            data-width="wide"
+            data-position="bottom">
+      Custom (400px via token)
+    </button>
+    <button class="ease-btn ease-btn-outline ease-tooltip"
+            data-tooltip="Inline token override: --ease-tooltip-max-width: 180px"
+            data-width="wide"
+            data-position="bottom"
+            style="--ease-tooltip-max-width: 180px;">
+      Narrow (180px inline)
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-tooltip-max-width-token/style.css
+++ b/submissions/examples/fix-tooltip-max-width-token/style.css
@@ -1,0 +1,26 @@
+/* Fix: Expose --ease-tooltip-max-width token for tooltip width customisation
+
+   Problem: tooltips.css hardcoded max-width: 250px on [data-width="wide"]
+   and max-width: 320px on [data-width="full"] with no CSS custom properties.
+   Users who need different tooltip widths must override these selectors
+   directly with higher specificity.
+
+   Solution: Expose --ease-tooltip-max-width token with original values
+   as fallbacks on each variant so width can be customised per-instance
+   or globally.
+*/
+
+/* Wide variant */
+.ease-tooltip[data-width="wide"]::after {
+  max-width: var(--ease-tooltip-max-width, 250px);
+}
+
+/* Full variant */
+.ease-tooltip[data-width="full"]::after {
+  max-width: var(--ease-tooltip-max-width, 320px);
+}
+
+/* Per-instance override example */
+.my-wide-tooltip {
+  --ease-tooltip-max-width: 400px;
+}


### PR DESCRIPTION
## Pull Request Description
`tooltips.css` hardcoded `max-width: 250px` on `[data-width="wide"]` and `max-width: 320px` on `[data-width="full"]` with no CSS custom property. Users who needed different tooltip widths had to override attribute selectors with higher specificity — inconsistent with other tooltip tokens already exposed (`--ease-tooltip-bg`, `--ease-tooltip-padding` etc.).

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
`--ease-tooltip-max-width` token on both width variants with original values as fallbacks — `250px` for wide, `320px` for full — so tooltip width is customisable per-instance or globally without specificity overrides.

**How does a developer use it?**
```html
<!-- Per-instance -->
<button class="ease-tooltip" data-tooltip="..." data-width="wide"
        style="--ease-tooltip-max-width: 400px;">Hover</button>
```

```css
/* Global */
:root { --ease-tooltip-max-width: 300px; }
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS already exposes `--ease-tooltip-bg`, `--ease-tooltip-text`, `--ease-tooltip-padding`, `--ease-tooltip-radius`. Tooltip max-width should follow the same token-driven pattern.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows default wide/full variants plus 400px custom class and 180px inline override)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Two line changes in `components/tooltips.css`: `max-width: 250px` → `max-width: var(--ease-tooltip-max-width, 250px)` and `max-width: 320px` → `max-width: var(--ease-tooltip-max-width, 320px)`. Default behaviour unchanged.

Fixes #10421