### PR TITLE
fix: use --ease-radius-full token for chip border-radius in chip.css

### DIFF
--- a/submissions/examples/fix-chip-border-radius-token/README.md
+++ b/submissions/examples/fix-chip-border-radius-token/README.md
@@ -1,0 +1,43 @@
+# Fix: Use --ease-radius-full Token for Chip Border Radius
+
+## Problem
+
+`components/chip.css` hardcoded `border-radius: 9999px` instead of using `--ease-radius-full`:
+
+```css
+.ease-chip {
+  border-radius: 9999px; /* hardcoded literal */
+}
+```
+
+`variables.css` defines `--ease-radius-full: 9999px` exactly for pill-shaped elements. Using the hardcoded literal means chip border-radius cannot be adjusted via the token system — inconsistent with badges and other pill-shaped elements that should use this token.
+
+## Solution
+
+Use `--ease-radius-full` with the original value as fallback:
+
+```css
+.ease-chip {
+  border-radius: var(--ease-radius-full, 9999px);
+}
+```
+
+## Usage
+
+```css
+/* Switch all chips to rounded-square style */
+:root {
+  --ease-radius-full: var(--ease-radius-md);
+}
+
+/* Per-instance override */
+.my-chip {
+  --ease-radius-full: 4px;
+}
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses `--ease-radius-full: 9999px` as the standard token for pill/circular shapes. All components using pill-shaped border-radius should reference this token for consistency.
+
+Fixes #10419

--- a/submissions/examples/fix-chip-border-radius-token/demo.html
+++ b/submissions/examples/fix-chip-border-radius-token/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Chip Border Radius Token — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    .row { display: flex; gap: 1rem; flex-wrap: wrap; align-items: center; margin-bottom: 1.5rem; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted); margin-bottom: 0.75rem; }
+    .info {
+      background: var(--ease-color-primary-alpha);
+      border: 1px solid var(--ease-color-primary);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.875rem;
+      margin-bottom: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+  <h2>Chip Border Radius Token Fix</h2>
+  <div class="info">
+    <code>.ease-chip</code> now uses <code>var(--ease-radius-full, 9999px)</code>
+    instead of hardcoded <code>9999px</code> — consistent with badges and
+    other pill-shaped elements in the framework.
+  </div>
+
+  <h3>Default pill shape (--ease-radius-full: 9999px)</h3>
+  <div class="row">
+    <span class="ease-chip ease-chip-sm">Small</span>
+    <span class="ease-chip">Default</span>
+    <span class="ease-chip ease-chip-lg">Large</span>
+    <span class="ease-chip ease-chip-primary">Primary</span>
+    <span class="ease-chip ease-chip-success">Success</span>
+  </div>
+
+  <h3>Custom radius via token override</h3>
+  <div class="row" style="--ease-radius-full: var(--ease-radius-md);">
+    <span class="ease-chip">Rounded square</span>
+    <span class="ease-chip ease-chip-primary">Rounded primary</span>
+    <span class="ease-chip ease-chip-success">Rounded success</span>
+  </div>
+
+  <h3>Sharp corners via token override</h3>
+  <div class="row" style="--ease-radius-full: 4px;">
+    <span class="ease-chip">Sharp chip</span>
+    <span class="ease-chip ease-chip-primary">Sharp primary</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-chip-border-radius-token/style.css
+++ b/submissions/examples/fix-chip-border-radius-token/style.css
@@ -1,0 +1,16 @@
+/* Fix: Use --ease-radius-full token for chip border-radius
+
+   Problem: .ease-chip hardcoded border-radius: 9999px instead of
+   using --ease-radius-full token from variables.css.
+
+   variables.css defines --ease-radius-full: 9999px exactly for
+   circular/pill-shaped elements. Using the literal value instead
+   of the token means chip border-radius cannot be adjusted via
+   the token system.
+
+   Solution: Replace 9999px with var(--ease-radius-full, 9999px).
+*/
+
+.ease-chip {
+  border-radius: var(--ease-radius-full, 9999px);
+}


### PR DESCRIPTION
## Pull Request Description
`chip.css` hardcoded `border-radius: 9999px` instead of using `--ease-radius-full` from `variables.css`. The token is defined as exactly `9999px` for pill-shaped elements — using the hardcoded literal means chip border-radius cannot be adjusted via the token system, inconsistent with badges and other pill-shaped elements.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Replaces `border-radius: 9999px` in `.ease-chip` with `var(--ease-radius-full, 9999px)` so chip shape participates in the design token system.

**How does a developer use it?**
```css
/* Switch chips to rounded-square style globally */
:root { --ease-radius-full: var(--ease-radius-md); }

/* Per-instance */
.my-chip { --ease-radius-full: 4px; }
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS uses `--ease-radius-full: 9999px` as the standard token for pill/circular shapes. All components using this shape should reference the token for consistency.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows default pill shape, rounded-square override, and sharp corner override via token)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
One line change in `components/chip.css`: `border-radius: 9999px` becomes `border-radius: var(--ease-radius-full, 9999px)`. Default behaviour is completely unchanged.

Fixes #10419