### PR TITLE
feat: add ease-skeleton shimmer loading placeholder component

### DIFF
--- a/submissions/examples/ease-skeleton-component/README.md
+++ b/submissions/examples/ease-skeleton-component/README.md
@@ -1,0 +1,74 @@
+# ease-skeleton — Shimmer Loading Placeholder Component
+
+A CSS-only shimmer skeleton loader for EaseMotion CSS. Zero JavaScript. Full token customisation. Respects `prefers-reduced-motion`.
+
+## Classes
+
+| Class | Description |
+|-------|-------------|
+| `.ease-skeleton` | Base skeleton block — any size |
+| `.ease-skeleton-text` | Single-line text placeholder |
+| `.ease-skeleton-text-block` | Multi-line text block (last line auto-shortened) |
+| `.ease-skeleton-avatar` | Circular avatar placeholder (3rem default) |
+| `.ease-skeleton-avatar-sm` | Small avatar (2rem) |
+| `.ease-skeleton-avatar-lg` | Large avatar (4rem) |
+| `.ease-skeleton-btn` | Button-shaped placeholder (2.5rem × 8rem) |
+| `.ease-skeleton-card` | Full card with padding and border |
+| `.ease-skeleton-card-header` | Card header row with avatar + text |
+| `.ease-skeleton-card-body` | Card body text lines |
+| `.ease-skeleton-wave` | Reverse shimmer direction |
+| `.ease-skeleton-no-shimmer` | Static background, no animation |
+
+## CSS Custom Properties
+
+| Token | Default | Description |
+|-------|---------|-------------|
+| `--ease-skeleton-bg` | `--ease-color-neutral-200` | Base skeleton background |
+| `--ease-skeleton-shimmer-from` | `--ease-color-neutral-100` | Shimmer highlight |
+| `--ease-skeleton-shimmer-to` | `--ease-color-neutral-300` | Shimmer shadow |
+| `--ease-skeleton-radius` | `--ease-radius-md` | Border radius |
+| `--ease-skeleton-duration` | `1.6s` | Animation duration |
+| `--ease-skeleton-height` | `1rem` | Default height |
+| `--ease-skeleton-width` | `100%` | Default width |
+| `--ease-skeleton-avatar-size` | `3rem` | Avatar diameter |
+
+## Usage
+
+```html
+<!-- Basic block -->
+<span class="ease-skeleton" style="height: 1rem; width: 80%;"></span>
+
+<!-- Avatar -->
+<span class="ease-skeleton ease-skeleton-avatar"></span>
+
+<!-- Card skeleton -->
+<div class="ease-skeleton-card">
+  <div class="ease-skeleton-card-header">
+    <span class="ease-skeleton ease-skeleton-avatar ease-skeleton-avatar-sm"></span>
+    <div style="flex:1;">
+      <span class="ease-skeleton" style="height:0.875rem;width:70%;"></span>
+    </div>
+  </div>
+  <div class="ease-skeleton-card-body">
+    <span class="ease-skeleton ease-skeleton-text"></span>
+    <span class="ease-skeleton ease-skeleton-text"></span>
+  </div>
+</div>
+
+<!-- Custom colors -->
+<span class="ease-skeleton"
+      style="--ease-skeleton-bg: rgba(108,99,255,0.15);
+             --ease-skeleton-shimmer-from: rgba(108,99,255,0.3);">
+</span>
+```
+
+## Accessibility
+
+- Shimmer animation disabled when `prefers-reduced-motion: reduce` is set
+- All skeleton elements are `display: block` — use `role="status"` and `aria-label="Loading"` on the container for screen reader support
+
+## Dark Mode
+
+Automatically adapts via `prefers-color-scheme: dark` — darker background and shimmer colors from the `--ease-color-neutral-*` scale.
+
+Closes #11498

--- a/submissions/examples/ease-skeleton-component/demo.html
+++ b/submissions/examples/ease-skeleton-component/demo.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-skeleton — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p { color: var(--ease-color-muted); margin-bottom: 1.5rem; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2rem 0 0.75rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 1rem; }
+    .row { display: flex; gap: 1rem; align-items: center; flex-wrap: wrap; }
+  </style>
+</head>
+<body>
+  <h2>ease-skeleton — Shimmer Loading Placeholder</h2>
+  <p>CSS-only shimmer skeleton using <code>--ease-skeleton-*</code> design tokens.
+     No JavaScript required. Respects <code>prefers-reduced-motion</code>.</p>
+
+  <h3>Basic blocks</h3>
+  <div style="display:flex;flex-direction:column;gap:0.5rem;max-width:400px;">
+    <span class="ease-skeleton" style="height:2rem;width:60%;"></span>
+    <span class="ease-skeleton" style="height:1rem;"></span>
+    <span class="ease-skeleton" style="height:1rem;width:80%;"></span>
+    <span class="ease-skeleton" style="height:1rem;width:90%;"></span>
+  </div>
+
+  <h3>Avatar sizes</h3>
+  <div class="row">
+    <span class="ease-skeleton ease-skeleton-avatar ease-skeleton-avatar-sm"></span>
+    <span class="ease-skeleton ease-skeleton-avatar"></span>
+    <span class="ease-skeleton ease-skeleton-avatar ease-skeleton-avatar-lg"></span>
+  </div>
+
+  <h3>Button placeholder</h3>
+  <div class="row">
+    <span class="ease-skeleton ease-skeleton-btn"></span>
+    <span class="ease-skeleton ease-skeleton-btn" style="width:6rem;"></span>
+  </div>
+
+  <h3>Card skeletons</h3>
+  <div class="grid">
+    <div class="ease-skeleton-card">
+      <div class="ease-skeleton-card-header">
+        <span class="ease-skeleton ease-skeleton-avatar ease-skeleton-avatar-sm"></span>
+        <div style="flex:1;display:flex;flex-direction:column;gap:0.5rem;">
+          <span class="ease-skeleton" style="height:0.875rem;width:70%;"></span>
+          <span class="ease-skeleton" style="height:0.75rem;width:40%;"></span>
+        </div>
+      </div>
+      <span class="ease-skeleton" style="height:120px;border-radius:var(--ease-radius-md);"></span>
+      <div class="ease-skeleton-card-body">
+        <span class="ease-skeleton ease-skeleton-text"></span>
+        <span class="ease-skeleton ease-skeleton-text"></span>
+        <span class="ease-skeleton ease-skeleton-text" style="width:60%;"></span>
+      </div>
+      <span class="ease-skeleton ease-skeleton-btn"></span>
+    </div>
+
+    <div class="ease-skeleton-card">
+      <div class="ease-skeleton-card-header">
+        <span class="ease-skeleton ease-skeleton-avatar ease-skeleton-avatar-sm"></span>
+        <div style="flex:1;display:flex;flex-direction:column;gap:0.5rem;">
+          <span class="ease-skeleton" style="height:0.875rem;width:55%;"></span>
+          <span class="ease-skeleton" style="height:0.75rem;width:35%;"></span>
+        </div>
+      </div>
+      <span class="ease-skeleton" style="height:120px;border-radius:var(--ease-radius-md);"></span>
+      <div class="ease-skeleton-card-body">
+        <span class="ease-skeleton ease-skeleton-text"></span>
+        <span class="ease-skeleton ease-skeleton-text" style="width:75%;"></span>
+      </div>
+      <span class="ease-skeleton ease-skeleton-btn"></span>
+    </div>
+  </div>
+
+  <h3>Wave direction variant</h3>
+  <div style="display:flex;flex-direction:column;gap:0.5rem;max-width:400px;">
+    <span class="ease-skeleton ease-skeleton-wave" style="height:1rem;"></span>
+    <span class="ease-skeleton ease-skeleton-wave" style="height:1rem;width:80%;"></span>
+    <span class="ease-skeleton ease-skeleton-wave" style="height:1rem;width:60%;"></span>
+  </div>
+
+  <h3>No shimmer (static)</h3>
+  <div style="display:flex;flex-direction:column;gap:0.5rem;max-width:400px;">
+    <span class="ease-skeleton ease-skeleton-no-shimmer" style="height:1rem;"></span>
+    <span class="ease-skeleton ease-skeleton-no-shimmer" style="height:1rem;width:80%;"></span>
+  </div>
+
+  <h3>Custom token override</h3>
+  <p>Override <code>--ease-skeleton-bg</code> and <code>--ease-skeleton-duration</code> per instance:</p>
+  <div style="display:flex;flex-direction:column;gap:0.5rem;max-width:400px;
+              --ease-skeleton-bg:rgba(108,99,255,0.15);
+              --ease-skeleton-shimmer-from:rgba(108,99,255,0.3);
+              --ease-skeleton-shimmer-to:rgba(108,99,255,0.05);
+              --ease-skeleton-duration:0.8s;">
+    <span class="ease-skeleton" style="height:1rem;"></span>
+    <span class="ease-skeleton" style="height:1rem;width:75%;"></span>
+    <span class="ease-skeleton" style="height:1rem;width:55%;"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-skeleton-component/style.css
+++ b/submissions/examples/ease-skeleton-component/style.css
@@ -1,0 +1,159 @@
+/* ============================================================
+   ease-skeleton — Shimmer Loading Placeholder Component
+   EaseMotion CSS Submission
+   ============================================================
+
+   A CSS-only shimmer skeleton loader using CSS custom properties
+   for full token-driven customisation.
+
+   Classes:
+     .ease-skeleton           — base skeleton block
+     .ease-skeleton-text      — single-line text placeholder
+     .ease-skeleton-text-block — multi-line text block
+     .ease-skeleton-avatar    — circular avatar placeholder
+     .ease-skeleton-avatar-sm — small circular avatar
+     .ease-skeleton-avatar-lg — large circular avatar
+     .ease-skeleton-btn       — button-shaped placeholder
+     .ease-skeleton-card      — full card placeholder with inner layout
+
+   Modifiers:
+     .ease-skeleton-no-shimmer — disable shimmer animation
+     .ease-skeleton-wave       — alternate wave shimmer direction
+
+   All key values exposed as CSS custom properties.
+   Respects prefers-reduced-motion.
+*/
+
+@layer easemotion-components {
+
+  /* ── Tokens ──────────────────────────────────────────────── */
+  :root {
+    --ease-skeleton-bg:           var(--ease-color-neutral-200, #e2e8f0);
+    --ease-skeleton-shimmer-from: var(--ease-color-neutral-100, #f1f5f9);
+    --ease-skeleton-shimmer-to:   var(--ease-color-neutral-300, #cbd5e1);
+    --ease-skeleton-radius:       var(--ease-radius-md, 0.5rem);
+    --ease-skeleton-duration:     1.6s;
+    --ease-skeleton-height:       1rem;
+    --ease-skeleton-width:        100%;
+    --ease-skeleton-avatar-size:  3rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ease-skeleton-bg:           var(--ease-color-neutral-800, #1e293b);
+      --ease-skeleton-shimmer-from: var(--ease-color-neutral-700, #334155);
+      --ease-skeleton-shimmer-to:   var(--ease-color-neutral-600, #475569);
+    }
+  }
+
+  /* ── Shimmer keyframe ────────────────────────────────────── */
+  @keyframes ease-skeleton-shimmer {
+    0%   { background-position: -200% center; }
+    100% { background-position:  200% center; }
+  }
+
+  @keyframes ease-skeleton-wave {
+    0%   { background-position: 200% center; }
+    100% { background-position: -200% center; }
+  }
+
+  /* ── Base skeleton ───────────────────────────────────────── */
+  .ease-skeleton {
+    display: block;
+    width: var(--ease-skeleton-width, 100%);
+    height: var(--ease-skeleton-height, 1rem);
+    border-radius: var(--ease-skeleton-radius, 0.5rem);
+    background: linear-gradient(
+      90deg,
+      var(--ease-skeleton-bg)           25%,
+      var(--ease-skeleton-shimmer-from) 50%,
+      var(--ease-skeleton-bg)           75%
+    );
+    background-size: 200% 100%;
+    animation: ease-skeleton-shimmer var(--ease-skeleton-duration, 1.6s) linear infinite;
+  }
+
+  /* ── Wave variant ────────────────────────────────────────── */
+  .ease-skeleton-wave {
+    animation-name: ease-skeleton-wave;
+  }
+
+  /* ── No shimmer ──────────────────────────────────────────── */
+  .ease-skeleton-no-shimmer {
+    animation: none;
+    background: var(--ease-skeleton-bg);
+  }
+
+  /* ── Text placeholder ────────────────────────────────────── */
+  .ease-skeleton-text {
+    height: var(--ease-text-base, 1rem);
+    border-radius: var(--ease-radius-sm, 0.25rem);
+    margin-bottom: var(--ease-space-2, 0.5rem);
+  }
+
+  /* ── Multi-line text block ───────────────────────────────── */
+  .ease-skeleton-text-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ease-space-2, 0.5rem);
+  }
+
+  .ease-skeleton-text-block .ease-skeleton:last-child {
+    width: 60%;
+  }
+
+  /* ── Avatar placeholder ──────────────────────────────────── */
+  .ease-skeleton-avatar {
+    width: var(--ease-skeleton-avatar-size, 3rem);
+    height: var(--ease-skeleton-avatar-size, 3rem);
+    border-radius: var(--ease-radius-full, 9999px);
+    flex-shrink: 0;
+  }
+
+  .ease-skeleton-avatar-sm {
+    --ease-skeleton-avatar-size: 2rem;
+  }
+
+  .ease-skeleton-avatar-lg {
+    --ease-skeleton-avatar-size: 4rem;
+  }
+
+  /* ── Button placeholder ──────────────────────────────────── */
+  .ease-skeleton-btn {
+    height: 2.5rem;
+    width: 8rem;
+    border-radius: var(--ease-radius-md, 0.5rem);
+  }
+
+  /* ── Card skeleton ───────────────────────────────────────── */
+  .ease-skeleton-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ease-space-4, 1rem);
+    padding: var(--ease-space-6, 1.5rem);
+    border-radius: var(--ease-radius-lg, 1rem);
+    background: var(--ease-color-surface, #ffffff);
+    border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  }
+
+  .ease-skeleton-card-header {
+    display: flex;
+    align-items: center;
+    gap: var(--ease-space-3, 0.75rem);
+  }
+
+  .ease-skeleton-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ease-space-2, 0.5rem);
+  }
+
+  /* ── Reduced motion ──────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-skeleton {
+      animation: none;
+      background: var(--ease-skeleton-bg);
+    }
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-skeleton` — a CSS-only shimmer loading placeholder component with full token customisation, dark mode support, and `prefers-reduced-motion` compliance. Zero JavaScript required.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A complete skeleton loading system:

| Class | Purpose |
|-------|---------|
| `.ease-skeleton` | Base shimmer block |
| `.ease-skeleton-avatar` / `-sm` / `-lg` | Circular avatar placeholders |
| `.ease-skeleton-btn` | Button-shaped placeholder |
| `.ease-skeleton-card` + header/body | Full card layout |
| `.ease-skeleton-text` / `-text-block` | Text line placeholders |
| `.ease-skeleton-wave` | Reverse shimmer direction |
| `.ease-skeleton-no-shimmer` | Static, no animation |

**CSS Custom Properties:**

| Token | Default |
|-------|---------|
| `--ease-skeleton-bg` | `--ease-color-neutral-200` |
| `--ease-skeleton-shimmer-from` | `--ease-color-neutral-100` |
| `--ease-skeleton-shimmer-to` | `--ease-color-neutral-300` |
| `--ease-skeleton-radius` | `--ease-radius-md` |
| `--ease-skeleton-duration` | `1.6s` |
| `--ease-skeleton-avatar-size` | `3rem` |

**Why does it fit EaseMotion CSS?**
Skeleton loaders are a fundamental UI pattern. This implementation is CSS-only, uses the `--ease-*` token system throughout, adapts to dark mode automatically, and respects `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — shows basic blocks, avatar sizes, button, card skeletons, wave variant, no-shimmer, and custom token override)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

Closes #11498