### PR TITLE
feat: add text-emphasis utility classes

### DIFF
--- a/submissions/examples/ease-text-emphasis/README.md
+++ b/submissions/examples/ease-text-emphasis/README.md
@@ -1,0 +1,17 @@
+# ease-text-emphasis
+
+CSS utility classes for the `text-emphasis` property.
+
+## Usage
+
+```html
+<div class="ease-text-emphasis-example">Content</div>
+```
+
+## Classes
+
+See `style.css` for the full list of available classes.
+
+## Demo
+
+Open `demo.html` to see the utility classes in action.

--- a/submissions/examples/ease-text-emphasis/demo.html
+++ b/submissions/examples/ease-text-emphasis/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-text-emphasis Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; background: #f8f9fa; color: #1a1a2e; }
+    h1 { font-size: 1.5rem; color: #6366f1; }
+    p { margin-bottom: 1.5rem; color: #555; }
+    .demo-grid { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .demo-item { background: #fff; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1rem; text-align: center; min-width: 180px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
+    .demo-item code { display: block; font-size: 0.75rem; color: #64748b; margin-bottom: 0.5rem; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <h1>ease-text-emphasis</h1>
+  <p>CSS utility classes demo. See <code>style.css</code> for all classes.</p>
+  <div class="demo-grid">
+    <div class="demo-item"><code>.ease-text-emphasis-none</code><div class="ease-text-emphasis-none">Example</div></div>
+    <div class="demo-item"><code>.ease-text-emphasis-dot</code><div class="ease-text-emphasis-dot">Example</div></div>
+    <div class="demo-item"><code>.ease-text-emphasis-circle</code><div class="ease-text-emphasis-circle">Example</div></div>
+    <div class="demo-item"><code>.ease-text-emphasis-double-circle</code><div class="ease-text-emphasis-double-circle">Example</div></div>
+    <div class="demo-item"><code>.ease-text-emphasis-triangle</code><div class="ease-text-emphasis-triangle">Example</div></div>
+    <div class="demo-item"><code>.ease-text-emphasis-sesame</code><div class="ease-text-emphasis-sesame">Example</div></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-text-emphasis/style.css
+++ b/submissions/examples/ease-text-emphasis/style.css
@@ -1,0 +1,8 @@
+/* EaseMotion CSS - ease-text-emphasis utility classes */
+
+.ease-text-emphasis-none { text-emphasis: none !important; }
+.ease-text-emphasis-dot { text-emphasis: dot !important; }
+.ease-text-emphasis-circle { text-emphasis: circle !important; }
+.ease-text-emphasis-double-circle { text-emphasis: double-circle !important; }
+.ease-text-emphasis-triangle { text-emphasis: triangle !important; }
+.ease-text-emphasis-sesame { text-emphasis: sesame !important; }


### PR DESCRIPTION
## Description

Adds CSS utility classes for the `text-emphasis` shorthand property.

- `.ease-text-emphasis-none` through `.ease-text-emphasis-sesame` (6 emphasis styles)

Closes #11590

### Changes
- Adds style.css with utility classes
- Adds demo.html for visual preview
- Adds README.md with usage instructions

participant: gssoc26