### PR TITLE
feat: add ease-shape-margin utility classes for CSS shape-margin property

### DIFF
--- a/submissions/examples/shape-margin-utilities/README.md
+++ b/submissions/examples/shape-margin-utilities/README.md
@@ -1,0 +1,48 @@
+# ease-shape-margin — CSS shape-margin Utility Classes
+
+Utility classes for the CSS `shape-margin` property — controls the gap between a floated element's `shape-outside` boundary and the surrounding text content.
+
+## Classes
+
+| Class | Value | Token |
+|-------|-------|-------|
+| `.ease-shape-margin-0` | `0` | — |
+| `.ease-shape-margin-1` | `0.25rem` | `--ease-space-1` |
+| `.ease-shape-margin-2` | `0.5rem` | `--ease-space-2` |
+| `.ease-shape-margin-3` | `0.75rem` | `--ease-space-3` |
+| `.ease-shape-margin-4` | `1rem` | `--ease-space-4` |
+| `.ease-shape-margin-5` | `1.25rem` | `--ease-space-5` |
+| `.ease-shape-margin-6` | `1.5rem` | `--ease-space-6` |
+| `.ease-shape-margin-8` | `2rem` | `--ease-space-8` |
+| `.ease-shape-margin-10` | `2.5rem` | `--ease-space-10` |
+| `.ease-shape-margin-12` | `3rem` | `--ease-space-12` |
+| `.ease-shape-margin-16` | `4rem` | `--ease-space-16` |
+
+## Usage
+
+```html
+<!-- Circle float with comfortable text gap -->
+<img
+  src="avatar.jpg"
+  alt="Profile"
+  style="float: left; border-radius: 50%; shape-outside: circle(50%); margin-right: 1rem;"
+  class="ease-shape-margin-4"
+/>
+<p>Text wraps around the circle with 1rem of breathing room...</p>
+```
+
+## Requirements
+
+`shape-margin` only works on elements with:
+- `float: left` or `float: right`
+- A valid `shape-outside` value (e.g. `circle()`, `ellipse()`, `polygon()`, `url()`)
+
+## Browser Support
+
+`shape-margin` is supported in all modern browsers (Chrome 37+, Firefox 62+, Safari 10.1+, Edge 79+).
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS uses a consistent `--ease-space-*` scale for all spacing. These utilities extend that scale to `shape-margin` so editorial layouts with non-rectangular floats use the same spacing tokens as the rest of the framework.
+
+Closes #11526

--- a/submissions/examples/shape-margin-utilities/demo.html
+++ b/submissions/examples/shape-margin-utilities/demo.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>shape-margin Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .demo-section {
+      margin-bottom: 2rem;
+      padding: var(--ease-space-4);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      overflow: hidden;
+    }
+    .demo-shape {
+      float: left;
+      width: 160px;
+      height: 160px;
+      margin-right: var(--ease-space-4);
+      background: linear-gradient(135deg, var(--ease-color-primary), var(--ease-color-primary-light));
+    }
+    .demo-shape-circle {
+      border-radius: 50%;
+      shape-outside: circle(50%);
+    }
+    .demo-shape-ellipse {
+      border-radius: 50%;
+      width: 120px;
+      height: 160px;
+      shape-outside: ellipse(60px 80px at 50% 50%);
+    }
+    .demo-shape-polygon {
+      clip-path: polygon(0 0, 100% 0, 50% 100%);
+      shape-outside: polygon(0 0, 100% 0, 50% 100%);
+    }
+    .demo-text {
+      font-size: 0.9375rem;
+      line-height: 1.7;
+      color: var(--ease-color-text);
+    }
+    .label {
+      display: inline-block;
+      margin-bottom: var(--ease-space-3);
+      padding: var(--ease-space-1) var(--ease-space-3);
+      background: var(--ease-color-primary-alpha);
+      color: var(--ease-color-primary);
+      border-radius: var(--ease-radius-full);
+      font-size: 0.75rem;
+      font-weight: 600;
+      font-family: var(--ease-font-mono);
+    }
+  </style>
+</head>
+<body>
+  <h2>shape-margin Utility Classes</h2>
+  <p class="intro">
+    <code>shape-margin</code> adds space between a float element's
+    <code>shape-outside</code> boundary and the surrounding text.
+    Use <code>.ease-shape-margin-*</code> classes on floated elements
+    to control the gap without extra wrapper elements.
+  </p>
+
+  <h3>Circle — no shape-margin vs shape-margin-4</h3>
+
+  <div class="demo-section">
+    <span class="label">.ease-shape-margin-0</span>
+    <div class="demo-shape demo-shape-circle ease-shape-margin-0"></div>
+    <p class="demo-text">
+      With <code>shape-margin: 0</code> the text wraps tightly against the
+      circular boundary of the float — no breathing room between the shape
+      edge and the paragraph. This can feel cramped on circle or polygon
+      floats where the shape-outside boundary is the exact edge of the content.
+      Notice how the letters almost touch the curved boundary.
+    </p>
+  </div>
+
+  <div class="demo-section">
+    <span class="label">.ease-shape-margin-4</span>
+    <div class="demo-shape demo-shape-circle ease-shape-margin-4"></div>
+    <p class="demo-text">
+      With <code>shape-margin: 1rem</code> (<code>--ease-space-4</code>)
+      the text wraps with a comfortable gap around the circular shape.
+      This mirrors the spacing scale used across EaseMotion CSS — the same
+      token used for padding and gap throughout the framework.
+    </p>
+  </div>
+
+  <h3>Ellipse — shape-margin-2 vs shape-margin-8</h3>
+
+  <div class="demo-section">
+    <span class="label">.ease-shape-margin-2</span>
+    <div class="demo-shape demo-shape-ellipse ease-shape-margin-2"></div>
+    <p class="demo-text">
+      Ellipse float with <code>shape-margin: 0.5rem</code>. A small margin
+      provides just enough air between the curved boundary and the text without
+      pushing content too far from the float element itself. Useful for compact
+      editorial layouts where space is limited.
+    </p>
+  </div>
+
+  <div class="demo-section">
+    <span class="label">.ease-shape-margin-8</span>
+    <div class="demo-shape demo-shape-ellipse ease-shape-margin-8"></div>
+    <p class="demo-text">
+      Ellipse float with <code>shape-margin: 2rem</code>. A generous margin
+      creates a magazine-style pull-quote feel — the text flows around the
+      shape with plenty of visual breathing room. Pairs well with large
+      hero images in article layouts.
+    </p>
+  </div>
+
+  <h3>Polygon triangle — shape-margin-6</h3>
+
+  <div class="demo-section">
+    <span class="label">.ease-shape-margin-6</span>
+    <div class="demo-shape demo-shape-polygon ease-shape-margin-6"></div>
+    <p class="demo-text">
+      Triangle polygon float with <code>shape-margin: 1.5rem</code>. The
+      shape-margin is especially important for polygon shapes — without it
+      the text would be pushed right against the diagonal edge of the triangle.
+      The margin softens the hard geometric boundary and makes the layout
+      feel more intentional and readable.
+    </p>
+  </div>
+
+  <h3>All available classes</h3>
+  <div style="display:flex;flex-wrap:wrap;gap:0.5rem;">
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-0</code>
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-1</code>
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-2</code>
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-3</code>
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-4</code>
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-5</code>
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-6</code>
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-8</code>
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-10</code>
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-12</code>
+    <code style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:0.25rem;font-size:0.75rem;">.ease-shape-margin-16</code>
+  </div>
+</body>
+</html>

--- a/submissions/examples/shape-margin-utilities/style.css
+++ b/submissions/examples/shape-margin-utilities/style.css
@@ -1,0 +1,41 @@
+/* ============================================================
+   ease-shape-margin — CSS shape-margin utility classes
+
+   shape-margin adds space between a float's shape-outside
+   boundary and the wrapped text content.
+
+   Requires the element to have:
+     float: left | right
+     shape-outside: <value>
+
+   Classes:
+     .ease-shape-margin-0   — shape-margin: 0
+     .ease-shape-margin-1   — shape-margin: 0.25rem
+     .ease-shape-margin-2   — shape-margin: 0.5rem
+     .ease-shape-margin-3   — shape-margin: 0.75rem
+     .ease-shape-margin-4   — shape-margin: 1rem
+     .ease-shape-margin-5   — shape-margin: 1.25rem
+     .ease-shape-margin-6   — shape-margin: 1.5rem
+     .ease-shape-margin-8   — shape-margin: 2rem
+     .ease-shape-margin-10  — shape-margin: 2.5rem
+     .ease-shape-margin-12  — shape-margin: 3rem
+     .ease-shape-margin-16  — shape-margin: 4rem
+
+   All values use --ease-space-* tokens as fallbacks.
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  .ease-shape-margin-0  { shape-margin: 0; }
+  .ease-shape-margin-1  { shape-margin: var(--ease-space-1,  0.25rem); }
+  .ease-shape-margin-2  { shape-margin: var(--ease-space-2,  0.5rem);  }
+  .ease-shape-margin-3  { shape-margin: var(--ease-space-3,  0.75rem); }
+  .ease-shape-margin-4  { shape-margin: var(--ease-space-4,  1rem);    }
+  .ease-shape-margin-5  { shape-margin: var(--ease-space-5,  1.25rem); }
+  .ease-shape-margin-6  { shape-margin: var(--ease-space-6,  1.5rem);  }
+  .ease-shape-margin-8  { shape-margin: var(--ease-space-8,  2rem);    }
+  .ease-shape-margin-10 { shape-margin: var(--ease-space-10, 2.5rem);  }
+  .ease-shape-margin-12 { shape-margin: var(--ease-space-12, 3rem);    }
+  .ease-shape-margin-16 { shape-margin: var(--ease-space-16, 4rem);    }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds 11 `shape-margin` utility classes covering the full `--ease-space-*` token scale. `shape-margin` controls the gap between a floated element's `shape-outside` boundary and surrounding text — essential for editorial layouts with circular, elliptical, or polygon floats.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | Value |
|-------|-------|
| `.ease-shape-margin-0` | `0` |
| `.ease-shape-margin-1` | `var(--ease-space-1, 0.25rem)` |
| `.ease-shape-margin-2` | `var(--ease-space-2, 0.5rem)` |
| `.ease-shape-margin-4` | `var(--ease-space-4, 1rem)` |
| `.ease-shape-margin-6` | `var(--ease-space-6, 1.5rem)` |
| `.ease-shape-margin-8` | `var(--ease-space-8, 2rem)` |
| … | … up to `--ease-space-16` |

**How does a developer use it?**
```html
<img
  style="float:left; shape-outside:circle(50%); border-radius:50%;"
  class="ease-shape-margin-4"
/>
<p>Text wraps around the circle with token-driven spacing...</p>
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS uses a consistent `--ease-space-*` scale for all spacing. These utilities extend that scale to `shape-margin` so non-rectangular float layouts use the same spacing tokens as the rest of the framework.

---

## Demo
- [x] Demo added (`demo.html` — shows circle, ellipse, and polygon floats with different `shape-margin` values side by side for easy comparison)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
`shape-margin` has excellent browser support (Chrome 37+, Firefox 62+, Safari 10.1+). All 11 classes use `--ease-space-*` tokens matching the existing spacing scale exactly.

Closes #11526