### PR TITLE
feat: add ease-font-smooth per-element font smoothing utility classes

### DIFF
--- a/submissions/examples/font-smooth-utilities/README.md
+++ b/submissions/examples/font-smooth-utilities/README.md
@@ -1,0 +1,53 @@
+# ease-font-smooth — Font Smoothing Utility Classes
+
+Utility classes to control `-webkit-font-smoothing` and `-moz-osx-font-smoothing` per element — allowing targeted overrides from the global antialiased base set in `core/base.css`.
+
+## Classes
+
+| Class | `-webkit-font-smoothing` | `-moz-osx-font-smoothing` |
+|-------|--------------------------|---------------------------|
+| `.ease-antialiased` | `antialiased` | `grayscale` |
+| `.ease-subpixel` | `subpixel-antialiased` | `auto` |
+| `.ease-font-smooth-auto` | `auto` | `auto` |
+| `.ease-font-smooth-none` | `none` | `unset` |
+
+## Usage
+
+```html
+<!-- Most common: smooth text on dark backgrounds -->
+<div class="dark-hero ease-antialiased">
+  <h1>Hero Heading</h1>
+  <p>Clean, light text on dark backgrounds.</p>
+</div>
+
+<!-- Reset a section to browser default -->
+<section class="ease-font-smooth-auto">
+  Body copy that should use browser default rendering.
+</section>
+
+<!-- Heavier weight for small LCD text -->
+<p class="ease-subpixel" style="font-size: 0.75rem;">
+  Tiny label text
+</p>
+```
+
+## When to use each class
+
+| Class | Best for |
+|-------|----------|
+| `.ease-antialiased` | Light text on dark backgrounds, HiDPI screens, most UI headings |
+| `.ease-subpixel` | Small body text on light LCD displays |
+| `.ease-font-smooth-auto` | Resetting sections that inherit global antialiased base |
+| `.ease-font-smooth-none` | Pixel-art or bitmap text effects (rare) |
+
+## Notes
+
+- `core/base.css` already sets `antialiased` globally — these utilities allow per-element overrides
+- Effect is only visible on macOS Safari and Chrome on Retina/HiDPI displays
+- No effect on Windows or Linux — graceful degradation
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS sets `antialiased` globally in `core/base.css` but provides no utility to override per element. These classes complete the typography control system by allowing targeted smoothing overrides — essential for mixed light/dark section layouts.
+
+Closes #11617

--- a/submissions/examples/font-smooth-utilities/demo.html
+++ b/submissions/examples/font-smooth-utilities/demo.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Font Smooth Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .compare-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .compare-box {
+      padding: var(--ease-space-5);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      background: var(--ease-color-surface);
+    }
+    .compare-box.dark {
+      background: #0f172a;
+      border-color: #1e293b;
+    }
+    .compare-label {
+      font-family: var(--ease-font-mono);
+      font-size: 0.7rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+    .compare-box.dark .compare-label { color: #475569; }
+    .sample-text { font-size: 1.125rem; font-weight: 500; line-height: 1.6; }
+    .sample-text-lg { font-size: 1.75rem; font-weight: 700; line-height: 1.2; }
+    .dark .sample-text,
+    .dark .sample-text-lg { color: #f8fafc; }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    @media (max-width: 600px) { .compare-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h2>Font Smooth Utility Classes</h2>
+  <p class="intro">
+    Override <code>-webkit-font-smoothing</code> and <code>-moz-osx-font-smoothing</code>
+    per element. Best seen on macOS with a retina display. The difference is most visible
+    on dark backgrounds and at medium font weights.
+  </p>
+
+  <div class="info">
+    💡 <strong>Note:</strong> Font smoothing differences are most visible on macOS Safari
+    and Chrome on HiDPI (Retina) displays. On Windows and Linux the properties have no
+    effect — text renders the same regardless.
+  </div>
+
+  <h3>Light background comparison</h3>
+  <div class="compare-grid">
+    <div class="compare-box">
+      <span class="compare-label">.ease-antialiased</span>
+      <p class="sample-text ease-antialiased">
+        The quick brown fox jumps over the lazy dog. Smooth antialiasing
+        makes text appear lighter and crisper on HiDPI screens.
+      </p>
+    </div>
+    <div class="compare-box">
+      <span class="compare-label">.ease-subpixel</span>
+      <p class="sample-text ease-subpixel">
+        The quick brown fox jumps over the lazy dog. Subpixel rendering
+        makes text appear slightly heavier — better for small body text
+        on LCD displays.
+      </p>
+    </div>
+  </div>
+
+  <h3>Dark background comparison (most visible difference)</h3>
+  <div class="compare-grid">
+    <div class="compare-box dark">
+      <span class="compare-label">.ease-antialiased</span>
+      <p class="sample-text ease-antialiased">
+        Antialiased text on dark backgrounds looks clean and sharp —
+        the recommended setting for light-on-dark UI text.
+      </p>
+      <p class="sample-text-lg ease-antialiased">Large heading</p>
+    </div>
+    <div class="compare-box dark">
+      <span class="compare-label">.ease-subpixel</span>
+      <p class="sample-text ease-subpixel">
+        Subpixel rendering on dark backgrounds can look heavy or blurry
+        on some displays. Generally avoid for dark UIs.
+      </p>
+      <p class="sample-text-lg ease-subpixel">Large heading</p>
+    </div>
+  </div>
+
+  <h3>Reset to browser default</h3>
+  <div class="compare-grid">
+    <div class="compare-box">
+      <span class="compare-label">.ease-font-smooth-auto</span>
+      <p class="sample-text ease-font-smooth-auto">
+        Browser default smoothing — useful to reset a section that
+        inherits the global antialiased base from core/base.css.
+      </p>
+    </div>
+    <div class="compare-box">
+      <span class="compare-label">.ease-font-smooth-none</span>
+      <p class="sample-text ease-font-smooth-none">
+        No smoothing — rarely used but available for special cases
+        like pixel-art or bitmap-style text effects.
+      </p>
+    </div>
+  </div>
+
+  <h3>Common use cases</h3>
+  <ul style="font-size:0.9375rem;line-height:2;color:var(--ease-color-text);">
+    <li>Dark mode UI — add <code>.ease-antialiased</code> to text containers</li>
+    <li>Hero headings on dark hero sections</li>
+    <li>Reset a component that overrides the global base setting</li>
+    <li>Small body copy on light backgrounds — try <code>.ease-subpixel</code></li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/font-smooth-utilities/style.css
+++ b/submissions/examples/font-smooth-utilities/style.css
@@ -1,0 +1,46 @@
+/* ============================================================
+   ease-font-smooth — font smoothing utility classes
+
+   Controls -webkit-font-smoothing and -moz-osx-font-smoothing
+   per element, allowing overrides from the global antialiased
+   base set in core/base.css.
+
+   Classes:
+     .ease-antialiased     — antialiased (smooth, lighter weight)
+     .ease-subpixel        — subpixel-antialiased (crispier on LCDs)
+     .ease-font-smooth-auto — auto (browser default, no smoothing hint)
+     .ease-font-smooth-none — none (disable smoothing entirely)
+
+   When to use:
+     .ease-antialiased    — most UI text on dark backgrounds or HiDPI
+     .ease-subpixel       — small body text on light LCD displays
+     .ease-font-smooth-auto — reset to browser default for a section
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  /* Smooth antialiasing — light, clean rendering */
+  .ease-antialiased {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* Subpixel antialiasing — crisp, heavier weight on LCD screens */
+  .ease-subpixel {
+    -webkit-font-smoothing: subpixel-antialiased;
+    -moz-osx-font-smoothing: auto;
+  }
+
+  /* Browser default — no explicit smoothing hint */
+  .ease-font-smooth-auto {
+    -webkit-font-smoothing: auto;
+    -moz-osx-font-smoothing: auto;
+  }
+
+  /* Disable font smoothing entirely */
+  .ease-font-smooth-none {
+    -webkit-font-smoothing: none;
+    -moz-osx-font-smoothing: unset;
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds 4 font smoothing utility classes that allow per-element overrides of the global `antialiased` base set in `core/base.css` — essential for mixed light/dark section layouts where different smoothing is needed in different parts of the page.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | `-webkit-font-smoothing` | Use case |
|-------|--------------------------|----------|
| `.ease-antialiased` | `antialiased` | Dark backgrounds, HiDPI, most UI text |
| `.ease-subpixel` | `subpixel-antialiased` | Small body text on LCD |
| `.ease-font-smooth-auto` | `auto` | Reset to browser default |
| `.ease-font-smooth-none` | `none` | Pixel/bitmap text effects |

**How does a developer use it?**
```html
<!-- Smooth text on dark hero section -->
<div class="dark-bg ease-antialiased">
  <h1>Hero Heading</h1>
</div>

<!-- Reset section to browser default -->
<section class="ease-font-smooth-auto">Body copy</section>
```

**Why does it fit EaseMotion CSS?**
`core/base.css` sets `antialiased` globally but provides no utility to override per element. These classes complete the typography control system.

---

## Demo
- [x] Demo added (`demo.html` — side-by-side light and dark background comparisons for all 4 classes, with use case guidance)

---

## Browser Testing
- [x] Chrome (macOS — visible difference)
- [x] Firefox (macOS — visible difference)
- [x] Edge
- [ ] Safari *(optional — most visible effect on Safari macOS)*

---

## Notes for Maintainer
Effect is only visible on macOS Retina/HiDPI displays. On Windows and Linux these properties have no effect — graceful degradation. `.ease-antialiased` is consistent with the naming used by Tailwind CSS for the same property.

Closes #11617