### PR TITLE
feat: add ease-decoration-skip-ink text-decoration-skip-ink utility classes

### DIFF
--- a/submissions/examples/text-decoration-skip-ink-utilities/README.md
+++ b/submissions/examples/text-decoration-skip-ink-utilities/README.md
@@ -1,0 +1,44 @@
+# ease-decoration-skip-ink — Text Decoration Skip Ink Utility Classes
+
+Utility classes to control `text-decoration-skip-ink` — how underlines and overlines render around descenders (g, j, p, q, y). No such utilities currently exist in `core/base.css` or `components/*.css`.
+
+## Classes
+
+| Class | `text-decoration-skip-ink` |
+|-------|------------------------------|
+| `.ease-decoration-skip-ink-auto` | `auto` |
+| `.ease-decoration-skip-ink-none` | `none` |
+| `.ease-decoration-skip-ink-all` | `all` |
+
+## Usage
+
+```html
+<!-- Default behavior, skips descenders -->
+<a href="#" class="ease-decoration-skip-ink-auto">Typography jungle gym</a>
+
+<!-- Strikethrough or brutalist full-line underline -->
+<span class="ease-decoration-skip-ink-none">Deprecated price</span>
+
+<!-- Decorative heading underline with max clearance -->
+<h1 class="ease-decoration-skip-ink-all">Big Underlined Heading</h1>
+```
+
+## When to use each class
+
+| Class | Best for |
+|-------|----------|
+| `.ease-decoration-skip-ink-auto` | Standard body links and inline text (browser default) |
+| `.ease-decoration-skip-ink-none` | Strikethrough-style or deliberate full-line emphasis |
+| `.ease-decoration-skip-ink-all` | Large decorative underlines needing extra glyph clearance |
+
+## Notes
+
+- No `text-decoration-skip-ink` declarations exist anywhere in `core/` or `components/` today
+- Effect is most visible on bold/large underlined text containing descenders
+- Supported in all modern browsers (Chrome, Firefox, Safari, Edge)
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS has underline styling scattered across `core/base.css`, `buttons.css`, `breadcrumb.css`, and others, but no control over skip-ink behavior. These classes complete the text-decoration utility set.
+
+Closes #11604

--- a/submissions/examples/text-decoration-skip-ink-utilities/demo.html
+++ b/submissions/examples/text-decoration-skip-ink-utilities/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text Decoration Skip Ink Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .compare-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .compare-box {
+      padding: var(--ease-space-5);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      background: var(--ease-color-surface);
+    }
+    .compare-label {
+      font-family: var(--ease-font-mono);
+      font-size: 0.7rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+    .sample-text {
+      font-size: 1.5rem;
+      font-weight: 600;
+      text-decoration: underline;
+      line-height: 1.6;
+    }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    @media (max-width: 600px) { .compare-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h2>Text Decoration Skip Ink Utility Classes</h2>
+  <p class="intro">
+    Control how underlines render around descenders (g, j, p, q, y) using
+    <code>text-decoration-skip-ink</code>. Best seen on words with descenders,
+    underlined.
+  </p>
+
+  <div class="info">
+    💡 <strong>Note:</strong> Most browsers default to <code>auto</code>, which already
+    skips descenders. <code>none</code> forces the line straight through every glyph —
+    useful for strikethrough-style emphasis or deliberate brutalist underlines.
+  </div>
+
+  <h3>Skip-ink comparison on descenders</h3>
+  <div class="compare-grid">
+    <div class="compare-box">
+      <span class="compare-label">.ease-decoration-skip-ink-auto</span>
+      <p class="sample-text ease-decoration-skip-ink-auto">Typography jungle gym</p>
+    </div>
+    <div class="compare-box">
+      <span class="compare-label">.ease-decoration-skip-ink-none</span>
+      <p class="sample-text ease-decoration-skip-ink-none">Typography jungle gym</p>
+    </div>
+  </div>
+
+  <h3>Skip all glyph intersections</h3>
+  <div class="compare-grid">
+    <div class="compare-box">
+      <span class="compare-label">.ease-decoration-skip-ink-all</span>
+      <p class="sample-text ease-decoration-skip-ink-all">Typography jungle gym</p>
+    </div>
+    <div class="compare-box">
+      <span class="compare-label">No utility applied (browser default)</span>
+      <p class="sample-text">Typography jungle gym</p>
+    </div>
+  </div>
+
+  <h3>Common use cases</h3>
+  <ul style="font-size:0.9375rem;line-height:2;color:var(--ease-color-text);">
+    <li>Body link text — leave default (<code>auto</code>), usually no class needed</li>
+    <li>Strikethrough / deliberate full-line emphasis — <code>.ease-decoration-skip-ink-none</code></li>
+    <li>Decorative heading underlines with extra clearance — <code>.ease-decoration-skip-ink-all</code></li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/text-decoration-skip-ink-utilities/style.css
+++ b/submissions/examples/text-decoration-skip-ink-utilities/style.css
@@ -1,0 +1,36 @@
+/* ============================================================
+   ease-decoration-skip-ink — text-decoration-skip-ink utilities
+
+   Controls how underlines/overlines render around descenders
+   (g, j, p, q, y) and ascenders. No skip-ink utilities currently
+   exist in core/base.css or components/*.css.
+
+   Classes:
+     .ease-decoration-skip-ink-auto — auto (browser default, skips descenders)
+     .ease-decoration-skip-ink-none — none (draws straight through descenders)
+     .ease-decoration-skip-ink-all  — all (skips all glyph intersections)
+
+   When to use:
+     .ease-decoration-skip-ink-auto — default link/underline behavior
+     .ease-decoration-skip-ink-none — strikethrough or deliberate full-line look
+     .ease-decoration-skip-ink-all  — decorative underlines needing max clearance
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  /* Browser default — skips descenders for readability */
+  .ease-decoration-skip-ink-auto {
+    text-decoration-skip-ink: auto;
+  }
+
+  /* Straight line through descenders — no skipping */
+  .ease-decoration-skip-ink-none {
+    text-decoration-skip-ink: none;
+  }
+
+  /* Skips all glyph intersections, not just descenders */
+  .ease-decoration-skip-ink-all {
+    text-decoration-skip-ink: all;
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds 3 `text-decoration-skip-ink` utility classes for controlling how underlines/overlines render around descenders (g, j, p, q, y) — no skip-ink control currently exists despite `text-decoration` usage across `core/base.css`, `buttons.css`, `breadcrumb.css`, `announce-bar.css`, `command-palette.css`, and `footer.css`.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | `text-decoration-skip-ink` | Use case |
|-------|------------------------------|----------|
| `.ease-decoration-skip-ink-auto` | `auto` | Standard links/body text |
| `.ease-decoration-skip-ink-none` | `none` | Strikethrough / brutalist underline |
| `.ease-decoration-skip-ink-all` | `all` | Decorative headings, max clearance |

**How does a developer use it?**
```html
<a href="#" class="ease-decoration-skip-ink-auto">Typography jungle gym</a>
<span class="ease-decoration-skip-ink-none">Deprecated price</span>
```

**Why does it fit EaseMotion CSS?**
Underline styling is scattered across multiple component files but no skip-ink control exists. These classes complete the text-decoration utility set.

---

## Demo
- [x] Demo added (`demo.html` — side-by-side comparison on descender-heavy words for all 3 classes, with use case guidance)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
`text-decoration-skip-ink` is supported in all modern browsers. Naming follows the existing `.ease-` prefix convention used across the utility set.

Closes #11604