### PR TITLE
feat: add ease-text-rendering text-rendering utility classes

### DIFF
--- a/submissions/examples/text-rendering-utilities/README.md
+++ b/submissions/examples/text-rendering-utilities/README.md
@@ -1,0 +1,46 @@
+# ease-text-rendering — Text Rendering Utility Classes
+
+Utility classes for the `text-rendering` property, hinting the browser to prioritize speed, legibility, or geometric precision when rendering glyphs. No `text-rendering` declarations currently exist anywhere in `core/` or `components/`.
+
+## Classes
+
+| Class | `text-rendering` |
+|-------|-------------------|
+| `.ease-text-rendering-auto` | `auto` |
+| `.ease-text-rendering-optimize-speed` | `optimizeSpeed` |
+| `.ease-text-rendering-optimize-legibility` | `optimizeLegibility` |
+| `.ease-text-rendering-geometric-precision` | `geometricPrecision` |
+
+## Usage
+
+```html
+<!-- Large dynamic/scrolling text -->
+<ul class="ease-text-rendering-optimize-speed">...</ul>
+
+<!-- Editorial heading with kerning + ligatures -->
+<h1 class="ease-text-rendering-optimize-legibility">Article Title</h1>
+
+<!-- SVG/data viz labels -->
+<text class="ease-text-rendering-geometric-precision">42.5%</text>
+```
+
+## When to use each class
+
+| Class | Best for |
+|-------|----------|
+| `.ease-text-rendering-auto` | Default, no opinion needed |
+| `.ease-text-rendering-optimize-speed` | Large scrolling lists, dynamic content |
+| `.ease-text-rendering-optimize-legibility` | Headings, logotypes, editorial copy |
+| `.ease-text-rendering-geometric-precision` | SVG text, data viz, precisely scaled UI |
+
+## Notes
+
+- No `text-rendering` declarations exist anywhere in `core/` or `components/` today
+- Effect is subtle and font/engine dependent — most visible with ligature-rich fonts
+- Supported in all modern browsers
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS has no rendering-strategy control for text despite extensive typography utilities elsewhere. These classes complete the typography control system with a performance/legibility trade-off knob.
+
+Closes #11602

--- a/submissions/examples/text-rendering-utilities/demo.html
+++ b/submissions/examples/text-rendering-utilities/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text Rendering Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .compare-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .compare-box {
+      padding: var(--ease-space-5);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      background: var(--ease-color-surface);
+    }
+    .compare-label {
+      font-family: var(--ease-font-mono);
+      font-size: 0.7rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+    .sample-text { font-size: 1.375rem; font-weight: 600; line-height: 1.5; }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    @media (max-width: 600px) { .compare-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h2>Text Rendering Utility Classes</h2>
+  <p class="intro">
+    Hint the browser to prioritize speed, legibility, or geometric precision
+    when rendering text via the <code>text-rendering</code> property. Differences
+    are subtle and most visible with ligature-rich fonts and kerning pairs (e.g. "AV", "fi").
+  </p>
+
+  <div class="info">
+    💡 <strong>Note:</strong> No <code>text-rendering</code> declarations exist anywhere
+    in <code>core/</code> or <code>components/</code> today. Effect is subtle and depends
+    on font and browser engine.
+  </div>
+
+  <h3>Speed vs legibility</h3>
+  <div class="compare-grid">
+    <div class="compare-box">
+      <span class="compare-label">.ease-text-rendering-optimize-speed</span>
+      <p class="sample-text ease-text-rendering-optimize-speed">AVAST fish waffle</p>
+    </div>
+    <div class="compare-box">
+      <span class="compare-label">.ease-text-rendering-optimize-legibility</span>
+      <p class="sample-text ease-text-rendering-optimize-legibility">AVAST fish waffle</p>
+    </div>
+  </div>
+
+  <h3>Geometric precision vs auto</h3>
+  <div class="compare-grid">
+    <div class="compare-box">
+      <span class="compare-label">.ease-text-rendering-geometric-precision</span>
+      <p class="sample-text ease-text-rendering-geometric-precision">AVAST fish waffle</p>
+    </div>
+    <div class="compare-box">
+      <span class="compare-label">.ease-text-rendering-auto</span>
+      <p class="sample-text ease-text-rendering-auto">AVAST fish waffle</p>
+    </div>
+  </div>
+
+  <h3>Common use cases</h3>
+  <ul style="font-size:0.9375rem;line-height:2;color:var(--ease-color-text);">
+    <li>Large scrolling/dynamic text lists — <code>.ease-text-rendering-optimize-speed</code></li>
+    <li>Editorial headings, logotypes — <code>.ease-text-rendering-optimize-legibility</code></li>
+    <li>SVG labels, data viz, scaled UI text — <code>.ease-text-rendering-geometric-precision</code></li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/text-rendering-utilities/style.css
+++ b/submissions/examples/text-rendering-utilities/style.css
@@ -1,0 +1,43 @@
+/* ============================================================
+   ease-text-rendering — text-rendering utility classes
+
+   Controls the text-rendering property, which hints the browser
+   to prioritize speed, legibility, or geometric precision when
+   rendering glyphs. No text-rendering declarations currently
+   exist anywhere in core/ or components/.
+
+   Classes:
+     .ease-text-rendering-auto                — auto (browser default)
+     .ease-text-rendering-optimize-speed       — optimizeSpeed (fast, no kerning/ligatures)
+     .ease-text-rendering-optimize-legibility  — optimizeLegibility (kerning + ligatures)
+     .ease-text-rendering-geometric-precision  — geometricPrecision (precise scaling)
+
+   When to use:
+     .ease-text-rendering-optimize-speed       — large blocks of dynamic/scrolling text
+     .ease-text-rendering-optimize-legibility   — headings, logotypes, editorial text
+     .ease-text-rendering-geometric-precision  — SVG text, data viz labels, scaled UI
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  /* Browser default rendering strategy */
+  .ease-text-rendering-auto {
+    text-rendering: auto;
+  }
+
+  /* Prioritize rendering speed over kerning/ligatures */
+  .ease-text-rendering-optimize-speed {
+    text-rendering: optimizeSpeed;
+  }
+
+  /* Prioritize legibility — enables kerning and ligatures */
+  .ease-text-rendering-optimize-legibility {
+    text-rendering: optimizeLegibility;
+  }
+
+  /* Prioritize geometric precision over legibility/speed */
+  .ease-text-rendering-geometric-precision {
+    text-rendering: geometricPrecision;
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds 4 `text-rendering` utility classes that hint the browser to prioritize speed, legibility, or geometric precision when rendering text — no such control currently exists anywhere in `core/` or `components/`.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | `text-rendering` | Use case |
|-------|-------------------|----------|
| `.ease-text-rendering-auto` | `auto` | Default, no opinion needed |
| `.ease-text-rendering-optimize-speed` | `optimizeSpeed` | Large scrolling/dynamic lists |
| `.ease-text-rendering-optimize-legibility` | `optimizeLegibility` | Headings, logotypes, editorial |
| `.ease-text-rendering-geometric-precision` | `geometricPrecision` | SVG text, data viz, scaled UI |

**How does a developer use it?**
```html
<ul class="ease-text-rendering-optimize-speed">...</ul>
<h1 class="ease-text-rendering-optimize-legibility">Article Title</h1>
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS has extensive typography utilities but no rendering-strategy control for text. These classes complete that system with a performance/legibility trade-off knob.

---

## Demo
- [x] Demo added (`demo.html` — side-by-side comparisons using ligature/kerning sample text for all 4 classes, with use case guidance)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
Effect is subtle and font/engine dependent — most visible with ligature-rich fonts and kerning pairs. Naming follows the existing `.ease-` prefix convention.

Closes #11602