### PR TITLE
fix: define missing --ease-shadow-2xl variable referenced in modal styles

### DIFF
--- a/core/variables.css
+++ b/core/variables.css
@@ -92,6 +92,7 @@
                      0 4px 6px -2px rgba(0, 0, 0, 0.05);
   --ease-shadow-xl:  0 20px 25px -5px rgba(0, 0, 0, 0.10),
                      0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
   --ease-glow-primary:   0 0 16px rgba(108, 99, 255, 0.45);
   --ease-glow-secondary: 0 0 16px rgba(139, 92, 246, 0.45);
   --ease-glow-success:   0 0 16px rgba(21, 128, 61, 0.45);
@@ -174,6 +175,7 @@
                        0 4px 6px -2px rgba(0, 0, 0, 0.25);
     --ease-shadow-xl:  0 20px 25px -5px rgba(0, 0, 0, 0.45),
                        0 10px 10px -5px rgba(0, 0, 0, 0.30);
+    --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);
      --ease-glass-bg: rgba(15, 23, 42, 0.30);
     --ease-glass-border: rgba(255, 255, 255, 0.08);
     --ease-glow-primary:   0 0 16px rgba(108, 99, 255, 0.45);
@@ -208,6 +210,7 @@
                      0 4px 6px -2px rgba(0, 0, 0, 0.25);
   --ease-shadow-xl:  0 20px 25px -5px rgba(0, 0, 0, 0.45),
                      0 10px 10px -5px rgba(0, 0, 0, 0.30);
+  --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);
   --ease-glass-bg: rgba(15, 23, 42, 0.30);
   --ease-glass-border: rgba(255, 255, 255, 0.08);
   --ease-glow-primary:   0 0 16px rgba(108, 99, 255, 0.45);


### PR DESCRIPTION
## Pull Request Description
`components/modals.css` references `var(--ease-shadow-2xl, ...)` but `--ease-shadow-2xl` was never defined in `core/variables.css`, so the fallback value was silently used in every browser regardless of theme. Added the variable to all three theme contexts to match the existing shadow scale.

---

## Type of Change
- [x] 🐛 Bug fix

---

## Submission Checklist
- [x] Fix is scoped to `core/variables.css` only
- [x] No unrelated changes bundled in
- [x] Matches existing shadow scale naming/structure (sm/md/lg/xl)

---

## Bug Description

**What was broken?**

`--ease-shadow-2xl` was referenced in `components/modals.css` but never defined anywhere in `core/variables.css`. The modal always fell back to its inline default shadow value instead of reading from the design system, and dark mode never got a 2xl shadow at all.

**Fix:**

Added `--ease-shadow-2xl` to all three theme contexts:

| Context | Value |
|---------|-------|
| `:root` (light) | `0 25px 50px -12px rgba(0, 0, 0, 0.25)` |
| `@media (prefers-color-scheme: dark)` | `0 25px 50px -12px rgba(0, 0, 0, 0.50)` |
| `[data-theme="dark"]` | `0 25px 50px -12px rgba(0, 0, 0, 0.50)` |

Dark value follows the same opacity progression already used for `sm`/`md`/`lg`/`xl` in dark mode.

---

## Before / After

**Before:** `--ease-shadow-2xl` undefined → modal always used hardcoded fallback `0 25px 50px -12px rgba(0, 0, 0, 0.25)` in every theme.

**After:** Variable defined per-theme → modal shadow correctly darkens in dark mode like every other shadow token.

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
No utility class (`.ease-shadow-2xl`) was added to `core/utilities.css` since this PR is scoped strictly to the undefined-variable bug. Happy to add it in a follow-up if maintainers want the full sm/md/lg/xl/2xl utility set.

Closes #11625