### PR TITLE
feat: add ease-font-synthesis font-synthesis utility classes

### DIFF
--- a/submissions/examples/font-synthesis-utilities/README.md
+++ b/submissions/examples/font-synthesis-utilities/README.md
@@ -1,0 +1,46 @@
+# ease-font-synthesis — Font Synthesis Utility Classes
+
+Utility classes for `font-synthesis`, controlling whether the browser is allowed to synthesize (fake) bold or italic styles when the active font lacks a true bold/italic variant. No `font-synthesis` declarations currently exist anywhere in `core/` or `components/`.
+
+## Classes
+
+| Class | `font-synthesis` |
+|-------|---------------------|
+| `.ease-font-synthesis-auto` | `weight style` |
+| `.ease-font-synthesis-none` | `none` |
+| `.ease-font-synthesis-weight-only` | `weight` |
+| `.ease-font-synthesis-style-only` | `style` |
+
+## Usage
+
+```html
+<!-- Brand wordmark — prevent faux-bold distortion -->
+<span class="logo ease-font-synthesis-none">BrandName</span>
+
+<!-- Font with true italic but no true bold -->
+<strong class="ease-font-synthesis-weight-only">Important</strong>
+
+<!-- Font with true bold but no true italic -->
+<em class="ease-font-synthesis-style-only">Emphasis</em>
+```
+
+## When to use each class
+
+| Class | Best for |
+|-------|----------|
+| `.ease-font-synthesis-auto` | Default — let the browser fake missing styles as needed |
+| `.ease-font-synthesis-none` | Logotypes, brand wordmarks, icon fonts |
+| `.ease-font-synthesis-weight-only` | Fonts with a true italic but no true bold face |
+| `.ease-font-synthesis-style-only` | Fonts with a true bold but no true italic face |
+
+## Notes
+
+- No `font-synthesis` declarations exist anywhere in `core/` or `components/` today
+- Effect is only visible when the active font lacks a true bold or italic face
+- Supported in all modern browsers
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS has typography utilities for smoothing, rendering, and decoration but no control over synthetic bold/italic generation. These classes complete the typography control system and prevent faux-style distortion on custom fonts.
+
+Closes #11600

--- a/submissions/examples/font-synthesis-utilities/demo.html
+++ b/submissions/examples/font-synthesis-utilities/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Font Synthesis Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .compare-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .compare-box {
+      padding: var(--ease-space-5);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      background: var(--ease-color-surface);
+    }
+    .compare-label {
+      font-family: var(--ease-font-mono);
+      font-size: 0.7rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+    .sample-text {
+      font-size: 1.375rem;
+      font-style: italic;
+      font-weight: 900;
+      line-height: 1.6;
+    }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    @media (max-width: 600px) { .compare-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h2>Font Synthesis Utility Classes</h2>
+  <p class="intro">
+    Control whether the browser synthesizes (fakes) bold or italic styles
+    when the loaded font doesn't include a true bold or italic variant,
+    via <code>font-synthesis</code>. Most visible with single-weight
+    custom fonts forced into bold italic.
+  </p>
+
+  <div class="info">
+    💡 <strong>Note:</strong> No <code>font-synthesis</code> declarations exist anywhere
+    in <code>core/</code> or <code>components/</code> today. Effect depends on whether
+    the active font already has true bold/italic faces — system fonts like the default
+    sans-serif usually do, so differences may be subtle in this demo unless a single-weight
+    web font is loaded.
+  </div>
+
+  <h3>Auto (synthesize both) vs none (synthesize neither)</h3>
+  <div class="compare-grid">
+    <div class="compare-box">
+      <span class="compare-label">.ease-font-synthesis-auto</span>
+      <p class="sample-text ease-font-synthesis-auto">Bold italic sample</p>
+    </div>
+    <div class="compare-box">
+      <span class="compare-label">.ease-font-synthesis-none</span>
+      <p class="sample-text ease-font-synthesis-none">Bold italic sample</p>
+    </div>
+  </div>
+
+  <h3>Weight only vs style only</h3>
+  <div class="compare-grid">
+    <div class="compare-box">
+      <span class="compare-label">.ease-font-synthesis-weight-only</span>
+      <p class="sample-text ease-font-synthesis-weight-only">Bold italic sample</p>
+    </div>
+    <div class="compare-box">
+      <span class="compare-label">.ease-font-synthesis-style-only</span>
+      <p class="sample-text ease-font-synthesis-style-only">Bold italic sample</p>
+    </div>
+  </div>
+
+  <h3>Common use cases</h3>
+  <ul style="font-size:0.9375rem;line-height:2;color:var(--ease-color-text);">
+    <li>Brand wordmarks / logotypes — <code>.ease-font-synthesis-none</code> to avoid faux-bold distortion</li>
+    <li>Single-weight display fonts with a true italic — <code>.ease-font-synthesis-weight-only</code></li>
+    <li>Fonts with a true bold but no italic face — <code>.ease-font-synthesis-style-only</code></li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/font-synthesis-utilities/style.css
+++ b/submissions/examples/font-synthesis-utilities/style.css
@@ -1,0 +1,43 @@
+/* ============================================================
+   ease-font-synthesis — font-synthesis utility classes
+
+   Controls whether the browser is allowed to synthesize bold or
+   italic styles when a font lacks a true bold/italic variant.
+   No font-synthesis declarations currently exist anywhere in
+   core/ or components/.
+
+   Classes:
+     .ease-font-synthesis-auto           — auto (browser default, synthesize as needed)
+     .ease-font-synthesis-none           — none (never synthesize)
+     .ease-font-synthesis-weight-only    — weight (synthesize bold only)
+     .ease-font-synthesis-style-only     — style (synthesize italic only)
+
+   When to use:
+     .ease-font-synthesis-none        — custom icon fonts, logotypes, brand wordmarks
+     .ease-font-synthesis-weight-only — fonts with a true italic but no true bold
+     .ease-font-synthesis-style-only  — fonts with a true bold but no true italic
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  /* Browser default — synthesize bold/italic when missing from the font */
+  .ease-font-synthesis-auto {
+    font-synthesis: weight style;
+  }
+
+  /* Never synthesize — prevents faux-bold/faux-italic distortion */
+  .ease-font-synthesis-none {
+    font-synthesis: none;
+  }
+
+  /* Only synthesize bold, never italic */
+  .ease-font-synthesis-weight-only {
+    font-synthesis: weight;
+  }
+
+  /* Only synthesize italic, never bold */
+  .ease-font-synthesis-style-only {
+    font-synthesis: style;
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds 4 `font-synthesis` utility classes that control whether the browser synthesizes (fakes) bold or italic styles when the active font lacks a true bold/italic variant — no such control currently exists anywhere in `core/` or `components/`.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | `font-synthesis` | Use case |
|-------|---------------------|----------|
| `.ease-font-synthesis-auto` | `weight style` | Default, browser fakes missing styles |
| `.ease-font-synthesis-none` | `none` | Logotypes, brand wordmarks |
| `.ease-font-synthesis-weight-only` | `weight` | Fonts with true italic, no true bold |
| `.ease-font-synthesis-style-only` | `style` | Fonts with true bold, no true italic |

**How does a developer use it?**
```html
<span class="logo ease-font-synthesis-none">BrandName</span>
<strong class="ease-font-synthesis-weight-only">Important</strong>
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS has typography utilities for smoothing, rendering, and decoration but no control over synthetic bold/italic generation. These classes prevent faux-style distortion on custom fonts.

---

## Demo
- [x] Demo added (`demo.html` — side-by-side bold-italic comparisons for all 4 classes, with use case guidance)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
Effect is only visible when the active font lacks a true bold or italic face. Naming follows the existing `.ease-` prefix convention.

Closes #11600