### PR TITLE
fix: document --ease-shadow-2xl undefined variable fix in submissions/

### DIFF
--- a/submissions/examples/fix-shadow-2xl-variable/README.md
+++ b/submissions/examples/fix-shadow-2xl-variable/README.md
@@ -1,0 +1,44 @@
+# Fix: Undefined `--ease-shadow-2xl` Variable (#11625)
+
+## The Bug
+
+`components/modals.css` references:
+
+```css
+box-shadow: var(--ease-shadow-2xl, 0 25px 50px -12px rgba(0, 0, 0, 0.25));
+```
+
+but `--ease-shadow-2xl` is never defined anywhere in `core/variables.css`. The shadow scale only goes up to `--ease-shadow-xl`. As a result, the modal silently always uses the hardcoded fallback value in every theme, and never gets a dark-mode-specific 2xl shadow like every other shadow token does.
+
+## Why this is a submissions/ entry, not a core/ edit
+
+Per `CONTRIBUTING.md` and the repo's submission validator, contributors may only modify files inside `submissions/`. This folder demonstrates the bug and the exact fix in isolation, with the patch documented below for a maintainer to apply to `core/variables.css`.
+
+## The Fix
+
+Add `--ease-shadow-2xl` to all three theme contexts in `core/variables.css`, following the existing `sm`/`md`/`lg`/`xl` pattern:
+
+```css
+/* In :root (light theme) */
+--ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+
+/* In @media (prefers-color-scheme: dark) :root block */
+--ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);
+
+/* In [data-theme="dark"] block */
+--ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);
+```
+
+The dark value follows the same opacity progression already used for `sm`/`md`/`lg`/`xl` in dark mode.
+
+## Demo
+
+`demo.html` shows a fake modal before and after the patch.
+
+## Files
+
+- `style.css` — contains the exact CSS snippet to add to `core/variables.css`
+- `demo.html` — visual before/after comparison plus the patch snippet
+- `README.md` — this file
+
+Closes #11625

--- a/submissions/examples/fix-shadow-2xl-variable/demo.html
+++ b/submissions/examples/fix-shadow-2xl-variable/demo.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: --ease-shadow-2xl Undefined Variable — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; background: var(--ease-color-bg); }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .fake-modal {
+      background: var(--ease-color-surface);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-6);
+      margin: 2rem 0;
+    }
+    .demo-before .fake-modal {
+      box-shadow: var(--ease-shadow-2xl, 0 25px 50px -12px rgba(0, 0, 0, 0.25));
+    }
+    .demo-after .fake-modal {
+      box-shadow: var(--ease-shadow-2xl, 0 25px 50px -12px rgba(0, 0, 0, 0.25));
+    }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    code.inline { font-family: var(--ease-font-mono); background: var(--ease-color-neutral-100); padding: 0.1rem 0.35rem; border-radius: 0.25rem; }
+  </style>
+</head>
+<body>
+  <h2>Fix: Undefined <code class="inline">--ease-shadow-2xl</code> Variable</h2>
+  <p class="intro">
+    <code class="inline">components/modals.css</code> references
+    <code class="inline">var(--ease-shadow-2xl, 0 25px 50px -12px rgba(0, 0, 0, 0.25))</code>
+    but <code class="inline">--ease-shadow-2xl</code> is never defined in
+    <code class="inline">core/variables.css</code>. This demo shows the modal
+    shadow with the variable missing versus with it properly defined per-theme.
+  </p>
+
+  <div class="info">
+    💡 <strong>Why this matters:</strong> Today the modal always renders the
+    hardcoded fallback shadow in every theme. Once <code class="inline">--ease-shadow-2xl</code>
+    is defined in <code class="inline">core/variables.css</code> for light and dark themes,
+    the modal shadow correctly darkens in dark mode — consistent with every other
+    shadow token (<code class="inline">sm</code>/<code class="inline">md</code>/<code class="inline">lg</code>/<code class="inline">xl</code>).
+  </div>
+
+  <h3>Before (variable undefined — fallback always used)</h3>
+  <div class="demo-before">
+    <div class="fake-modal">
+      <strong>Modal title</strong>
+      <p style="margin-top:0.5rem;color:var(--ease-color-muted);font-size:0.875rem;">
+        This shadow never changes between light and dark mode because
+        --ease-shadow-2xl is undefined.
+      </p>
+    </div>
+  </div>
+
+  <h3>After (variable defined — patch from style.css applied)</h3>
+  <div class="demo-after">
+    <div class="fake-modal">
+      <strong>Modal title</strong>
+      <p style="margin-top:0.5rem;color:var(--ease-color-muted);font-size:0.875rem;">
+        With the patch applied, this shadow correctly darkens to
+        rgba(0,0,0,0.50) in dark mode.
+      </p>
+    </div>
+  </div>
+
+  <h3>The exact patch needed in core/variables.css</h3>
+  <pre style="background:var(--ease-color-neutral-100);padding:1rem;border-radius:var(--ease-radius-md);font-size:0.8125rem;overflow-x:auto;">:root {
+  --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);
+  }
+}
+
+[data-theme="dark"] {
+  --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);
+}</pre>
+</body>
+</html>

--- a/submissions/examples/fix-shadow-2xl-variable/style.css
+++ b/submissions/examples/fix-shadow-2xl-variable/style.css
@@ -1,0 +1,36 @@
+/* ============================================================
+   fix: --ease-shadow-2xl undefined variable (#11625)
+
+   components/modals.css references var(--ease-shadow-2xl, ...)
+   but --ease-shadow-2xl is never defined in core/variables.css.
+   The fallback value is silently used in every browser regardless
+   of theme, and dark mode never gets a 2xl shadow at all.
+
+   This file demonstrates the fix in isolation. The snippet below
+   is what should be added to core/variables.css by a maintainer
+   (contributors cannot edit core/ directly per CONTRIBUTING.md).
+   ============================================================ */
+
+/* ---- Patch for core/variables.css :root block (light theme) ---- */
+:root {
+  --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+
+/* ---- Patch for core/variables.css dark theme blocks ---- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);
+  }
+}
+
+[data-theme="dark"] {
+  --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);
+}
+
+/* ---- Demo-only scoping so this page can show before/after ---- */
+.demo-before {
+  --ease-shadow-2xl: unset;
+}
+.demo-after {
+  --ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}


### PR DESCRIPTION
## Pull Request Description
`components/modals.css` references `var(--ease-shadow-2xl, ...)` but `--ease-shadow-2xl` is never defined in `core/variables.css`, so the modal always silently falls back to the hardcoded inline value in every theme. Since contributors can't edit `core/` directly, this submission documents the bug and the exact fix for a maintainer to apply.

---

## Type of Change
- [x] 🐛 Bug fix (documented, not applied to core/ directly)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed fix
- [x] Includes `README.md` — what's broken, the exact patch, why it matters
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature/fix per PR

---

## Bug Description

**What's broken?**

`--ease-shadow-2xl` is referenced in `components/modals.css` but never defined anywhere in `core/variables.css`. The shadow scale stops at `xl`. The modal always uses the hardcoded fallback shadow regardless of theme, and never gets a dark-mode-specific 2xl shadow like every other token does.

**The fix (for a maintainer to apply to `core/variables.css`):**

```css
/* :root (light theme) */
--ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);

/* @media (prefers-color-scheme: dark) :root block */
--ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);

/* [data-theme="dark"] block */
--ease-shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.50);
```

Dark value follows the same opacity progression already used for `sm`/`md`/`lg`/`xl`.

---

## Demo
- [x] Demo added (`demo.html` — before/after comparison of the modal shadow, plus the exact patch snippet displayed inline)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
This PR only adds documentation/demo under `submissions/`, per the validator's core-file protection rule. The actual one-line-per-theme addition to `core/variables.css` needs to be applied by a maintainer with write access to `core/`.

Closes #11625