### PR TITLE
feat: add ease-scrollbar-color themed scrollbar utility classes

### DIFF
--- a/submissions/examples/scrollbar-color-utilities/README.md
+++ b/submissions/examples/scrollbar-color-utilities/README.md
@@ -1,0 +1,47 @@
+# ease-scrollbar-color — Themed Scrollbar Color Utility Classes
+
+Utility classes that apply EaseMotion's brand colors to `scrollbar-color` and the WebKit scrollbar pseudo-elements. `core/utilities.css` already provides `.ease-scrollbar-thin`, `.ease-scrollbar-none`, and `.ease-scrollbar-auto` for width/visibility, but they hardcode a single neutral gray palette with no way to apply brand colors.
+
+## Classes
+
+| Class | Thumb color | Hover color |
+|-------|-------------|-------------|
+| `.ease-scrollbar-primary` | `--ease-color-primary` | `--ease-color-primary-dark` |
+| `.ease-scrollbar-secondary` | `--ease-color-secondary` | `--ease-color-secondary-dark` |
+| `.ease-scrollbar-success` | `--ease-color-success` | `--ease-color-success-dark` |
+| `.ease-scrollbar-danger` | `--ease-color-danger` | `--ease-color-danger-dark` |
+
+## Usage
+
+```html
+<!-- Branded content panel -->
+<div class="content-panel ease-scrollbar-primary" style="overflow-y: scroll;">
+  ...
+</div>
+
+<!-- Destructive dialog with scrollable body -->
+<div class="modal-body ease-scrollbar-danger" style="overflow-y: scroll;">
+  ...
+</div>
+```
+
+## When to use each class
+
+| Class | Best for |
+|-------|----------|
+| `.ease-scrollbar-primary` | Default branded scroll containers |
+| `.ease-scrollbar-secondary` | Secondary panels, sidebars, drawers |
+| `.ease-scrollbar-success` | Success/confirmation modals with scroll |
+| `.ease-scrollbar-danger` | Destructive/warning dialogs with scroll |
+
+## Notes
+
+- Track color reuses the same neutral track as `.ease-scrollbar-thin` for visual consistency
+- Falls back gracefully via `var(..., fallback)` if `--ease-color-neutral-100` is unavailable
+- Firefox renders via native `scrollbar-color`; Chrome/Edge/Safari via WebKit pseudo-elements
+
+## Why it fits EaseMotion CSS
+
+`core/utilities.css` already solves scrollbar width/visibility but only ships one neutral color scheme. These classes extend that system with the framework's existing brand color tokens, completing the scrollbar utility set.
+
+Closes #11584

--- a/submissions/examples/scrollbar-color-utilities/demo.html
+++ b/submissions/examples/scrollbar-color-utilities/demo.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scrollbar Color Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .compare-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .compare-label {
+      font-family: var(--ease-font-mono);
+      font-size: 0.7rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+    .scroll-box {
+      height: 140px;
+      overflow-y: scroll;
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-4);
+      background: var(--ease-color-surface);
+      font-size: 0.875rem;
+      line-height: 1.7;
+    }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    @media (max-width: 600px) { .compare-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h2>Scrollbar Color Utility Classes</h2>
+  <p class="intro">
+    Apply EaseMotion's brand colors to <code>scrollbar-color</code> and the
+    WebKit scrollbar pseudo-elements. Existing <code>.ease-scrollbar-thin</code>
+    controls width but hardcodes a neutral gray palette — these classes add
+    themed color variants.
+  </p>
+
+  <div class="info">
+    💡 <strong>Note:</strong> Scroll inside each box below to see the
+    colored thumb. Firefox uses native <code>scrollbar-color</code>;
+    Chrome/Edge/Safari use the WebKit pseudo-elements.
+  </div>
+
+  <h3>Primary vs Secondary</h3>
+  <div class="compare-grid">
+    <div>
+      <span class="compare-label">.ease-scrollbar-primary</span>
+      <div class="scroll-box ease-scrollbar-primary">
+        <p>Scroll inside this box.</p>
+        <p>Line two of filler text to make the box scrollable.</p>
+        <p>Line three.</p>
+        <p>Line four.</p>
+        <p>Line five.</p>
+        <p>Line six.</p>
+        <p>Line seven.</p>
+      </div>
+    </div>
+    <div>
+      <span class="compare-label">.ease-scrollbar-secondary</span>
+      <div class="scroll-box ease-scrollbar-secondary">
+        <p>Scroll inside this box.</p>
+        <p>Line two of filler text to make the box scrollable.</p>
+        <p>Line three.</p>
+        <p>Line four.</p>
+        <p>Line five.</p>
+        <p>Line six.</p>
+        <p>Line seven.</p>
+      </div>
+    </div>
+  </div>
+
+  <h3>Success vs Danger</h3>
+  <div class="compare-grid">
+    <div>
+      <span class="compare-label">.ease-scrollbar-success</span>
+      <div class="scroll-box ease-scrollbar-success">
+        <p>Scroll inside this box.</p>
+        <p>Line two of filler text to make the box scrollable.</p>
+        <p>Line three.</p>
+        <p>Line four.</p>
+        <p>Line five.</p>
+        <p>Line six.</p>
+        <p>Line seven.</p>
+      </div>
+    </div>
+    <div>
+      <span class="compare-label">.ease-scrollbar-danger</span>
+      <div class="scroll-box ease-scrollbar-danger">
+        <p>Scroll inside this box.</p>
+        <p>Line two of filler text to make the box scrollable.</p>
+        <p>Line three.</p>
+        <p>Line four.</p>
+        <p>Line five.</p>
+        <p>Line six.</p>
+        <p>Line seven.</p>
+      </div>
+    </div>
+  </div>
+
+  <h3>Common use cases</h3>
+  <ul style="font-size:0.9375rem;line-height:2;color:var(--ease-color-text);">
+    <li>Branded content panels — <code>.ease-scrollbar-primary</code></li>
+    <li>Secondary sidebars/drawers — <code>.ease-scrollbar-secondary</code></li>
+    <li>Success/confirmation modals with scrollable content — <code>.ease-scrollbar-success</code></li>
+    <li>Destructive/warning dialogs with scrollable content — <code>.ease-scrollbar-danger</code></li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/scrollbar-color-utilities/style.css
+++ b/submissions/examples/scrollbar-color-utilities/style.css
@@ -1,0 +1,106 @@
+/* ============================================================
+   ease-scrollbar-color — themed scrollbar-color utility classes
+
+   core/utilities.css already provides .ease-scrollbar-thin,
+   .ease-scrollbar-none, and .ease-scrollbar-auto, which control
+   scrollbar WIDTH/visibility but hardcode a single neutral
+   gray color palette. There are no utilities to apply the
+   framework's brand colors (--ease-color-primary, -secondary,
+   -success, -danger) to scrollbar-color.
+
+   Classes:
+     .ease-scrollbar-primary    — brand primary thumb color
+     .ease-scrollbar-secondary  — brand secondary thumb color
+     .ease-scrollbar-success    — success thumb color
+     .ease-scrollbar-danger     — danger thumb color
+
+   When to use:
+     .ease-scrollbar-primary    — default branded scroll containers
+     .ease-scrollbar-secondary  — secondary panels, sidebars
+     .ease-scrollbar-success    — success/confirmation modals with scroll
+     .ease-scrollbar-danger     — destructive/warning dialogs with scroll
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  .ease-scrollbar-primary {
+    scrollbar-width: thin;
+    scrollbar-color: var(--ease-color-primary) var(--ease-color-neutral-100, #f1f5f9);
+  }
+  .ease-scrollbar-primary::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  .ease-scrollbar-primary::-webkit-scrollbar-track {
+    background: var(--ease-color-neutral-100, #f1f5f9);
+    border-radius: 999px;
+  }
+  .ease-scrollbar-primary::-webkit-scrollbar-thumb {
+    background: var(--ease-color-primary);
+    border-radius: 999px;
+  }
+  .ease-scrollbar-primary::-webkit-scrollbar-thumb:hover {
+    background: var(--ease-color-primary-dark);
+  }
+
+  .ease-scrollbar-secondary {
+    scrollbar-width: thin;
+    scrollbar-color: var(--ease-color-secondary) var(--ease-color-neutral-100, #f1f5f9);
+  }
+  .ease-scrollbar-secondary::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  .ease-scrollbar-secondary::-webkit-scrollbar-track {
+    background: var(--ease-color-neutral-100, #f1f5f9);
+    border-radius: 999px;
+  }
+  .ease-scrollbar-secondary::-webkit-scrollbar-thumb {
+    background: var(--ease-color-secondary);
+    border-radius: 999px;
+  }
+  .ease-scrollbar-secondary::-webkit-scrollbar-thumb:hover {
+    background: var(--ease-color-secondary-dark);
+  }
+
+  .ease-scrollbar-success {
+    scrollbar-width: thin;
+    scrollbar-color: var(--ease-color-success) var(--ease-color-neutral-100, #f1f5f9);
+  }
+  .ease-scrollbar-success::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  .ease-scrollbar-success::-webkit-scrollbar-track {
+    background: var(--ease-color-neutral-100, #f1f5f9);
+    border-radius: 999px;
+  }
+  .ease-scrollbar-success::-webkit-scrollbar-thumb {
+    background: var(--ease-color-success);
+    border-radius: 999px;
+  }
+  .ease-scrollbar-success::-webkit-scrollbar-thumb:hover {
+    background: var(--ease-color-success-dark);
+  }
+
+  .ease-scrollbar-danger {
+    scrollbar-width: thin;
+    scrollbar-color: var(--ease-color-danger) var(--ease-color-neutral-100, #f1f5f9);
+  }
+  .ease-scrollbar-danger::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  .ease-scrollbar-danger::-webkit-scrollbar-track {
+    background: var(--ease-color-neutral-100, #f1f5f9);
+    border-radius: 999px;
+  }
+  .ease-scrollbar-danger::-webkit-scrollbar-thumb {
+    background: var(--ease-color-danger);
+    border-radius: 999px;
+  }
+  .ease-scrollbar-danger::-webkit-scrollbar-thumb:hover {
+    background: var(--ease-color-danger-dark, var(--ease-color-danger));
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds 4 utility classes that apply EaseMotion's brand colors to `scrollbar-color` and the WebKit scrollbar pseudo-elements. `core/utilities.css` already has `.ease-scrollbar-thin`, `.ease-scrollbar-none`, and `.ease-scrollbar-auto` for width/visibility, but they hardcode a single neutral gray palette with no brand color variants.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | Thumb color | Hover color |
|-------|-------------|-------------|
| `.ease-scrollbar-primary` | `--ease-color-primary` | `--ease-color-primary-dark` |
| `.ease-scrollbar-secondary` | `--ease-color-secondary` | `--ease-color-secondary-dark` |
| `.ease-scrollbar-success` | `--ease-color-success` | `--ease-color-success-dark` |
| `.ease-scrollbar-danger` | `--ease-color-danger` | `--ease-color-danger-dark` |

**How does a developer use it?**
```html
<div class="content-panel ease-scrollbar-primary" style="overflow-y: scroll;">...</div>
<div class="modal-body ease-scrollbar-danger" style="overflow-y: scroll;">...</div>
```

**Why does it fit EaseMotion CSS?**
`core/utilities.css` solves scrollbar width/visibility but only ships one neutral color scheme. These classes extend that system with the framework's existing brand color tokens.

---

## Demo
- [x] Demo added (`demo.html` — scrollable boxes for all 4 color variants side by side, with use case guidance)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
Track color reuses the same neutral track as `.ease-scrollbar-thin` for visual consistency. Naming follows the existing `.ease-` prefix and brand-color-suffix convention used elsewhere in the framework.

Closes #11584