### PR TITLE
feat: add css selection styling example (#10258)

### DIFF
--- a/submissions/examples/selection-styling-bv/README.md
+++ b/submissions/examples/selection-styling-bv/README.md
@@ -1,0 +1,7 @@
+# CSS ::selection Styling (#10258)
+
+## Description
+A demonstration of custom text selection styling using the `::selection` pseudo-element, showcasing how to apply themed variants across an application.
+
+## Why EaseMotion CSS?
+Small details like text selection define an "ultra-premium" experience. By standardizing these via CSS tokens, we ensure visual consistency that reinforces brand identity during interaction.

--- a/submissions/examples/selection-styling-bv/demo.html
+++ b/submissions/examples/selection-styling-bv/demo.html
@@ -1,0 +1,4 @@
+<div class="text-container">
+    <p>Try selecting this text to see the default custom highlight!</p>
+    <p class="alt-selection">This paragraph uses an alternative selection color theme.</p>
+</div>

--- a/submissions/examples/selection-styling-bv/style.css
+++ b/submissions/examples/selection-styling-bv/style.css
@@ -1,0 +1,16 @@
+/* Custom selection styling */
+::selection {
+    background: var(--ease-primary);
+    color: white;
+}
+
+.alt-selection::selection {
+    background: var(--ease-secondary);
+    color: var(--ease-primary);
+}
+
+.text-container {
+    padding: 2rem;
+    font-family: sans-serif;
+    line-height: 1.6;
+}


### PR DESCRIPTION
Pull Request Description
This PR addresses issue #10258 by implementing a custom ::selection styling example. It demonstrates how to apply branded, thematic text highlighting across an application using the pseudo-element, ensuring visual consistency in user interactions.

Type of Change
[x] ✨ New animation / hover effect

[x] 🧩 New component

Submission Checklist
[x] All changes are inside submissions/examples/selection-styling-bv/

[x] Includes demo.html

[x] Includes style.css

[x] Includes README.md

[x] No changes to core/

[x] No changes to components/

[x] One feature per PR

Feature Description
What does this add?
It adds a thematic implementation of the ::selection pseudo-element, providing developers with a template to apply brand-specific colors and background styles to selected text.

How does a developer use it?

HTML
<div class="text-container">
    <p>Try selecting this text to see the default custom highlight!</p>
    <p class="alt-selection">This paragraph uses an alternative selection color theme.</p>
</div>
Why does it fit EaseMotion CSS?
It elevates design fidelity. Small, thoughtful details like branded text selection define an "ultra-premium" experience, reinforcing brand identity during routine user interactions.

Demo
[x] Demo added

Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

Notes for Maintainer
The selection styles use CSS variables from the EaseMotion token system to ensure they remain consistent with the broader project design. The implementation includes both default and variant classes to showcase how themes can be applied selectively.