### PR TITLE
fix: use correct muted color token in modal body

### DIFF
--- a/submissions/examples/modal-muted-token-fix/README.md
+++ b/submissions/examples/modal-muted-token-fix/README.md
@@ -1,0 +1,26 @@
+# Modal Muted Token Fix
+
+## What does this do?
+
+Fixes the modal body text color to reference the correct design token `--ease-color-muted` instead of the undefined `--ease-color-text-muted`.
+
+## How is it used?
+
+In `components/modals.css` line 127, change:
+
+```css
+/* Before (broken — token does not exist) */
+color: var(--ease-color-text-muted, #4b5563);
+
+/* After (fixed — uses the defined token) */
+color: var(--ease-color-muted, #4b5563);
+```
+
+No new classes or markup changes are needed. The fix is a single token name correction.
+
+## Why is it useful?
+
+- `--ease-color-text-muted` is not defined anywhere in `core/variables.css`.
+- `--ease-color-muted` is defined in three places: `:root` (line 55), `prefers-color-scheme: dark` (line 168), and `[data-theme="dark"]` (line 202).
+- Because the token never resolves, the modal body text always uses the hardcoded fallback `#4b5563` and cannot be themed through the design token system.
+- This one-line fix restores proper theming support for modal body text.

--- a/submissions/examples/modal-muted-token-fix/demo.html
+++ b/submissions/examples/modal-muted-token-fix/demo.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal Muted Token Fix — Demo</title>
+  <style>
+    :root {
+      --ease-color-muted: #475569;
+      --ease-color-bg: #f8fafc;
+      --ease-color-surface: #ffffff;
+      --ease-color-text: #1e293b;
+      --ease-color-primary: #6c63ff;
+      --ease-radius-lg: 1rem;
+      --ease-font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --ease-color-muted: #94a3b8;
+        --ease-color-bg: #0b1121;
+        --ease-color-surface: #141e33;
+        --ease-color-text: #e2e8f0;
+      }
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: var(--ease-font-sans);
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 2rem;
+      gap: 2rem;
+    }
+
+    h1 { font-size: 1.5rem; font-weight: 600; }
+    h2 { font-size: 1.125rem; font-weight: 600; margin-bottom: 0.5rem; }
+    p.subtitle { color: var(--ease-color-muted); margin-bottom: 1rem; }
+
+    .demo-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 2rem;
+      width: 100%;
+      max-width: 800px;
+    }
+
+    @media (max-width: 600px) {
+      .demo-grid { grid-template-columns: 1fr; }
+    }
+
+    .modal-card {
+      background: var(--ease-color-surface);
+      border-radius: var(--ease-radius-lg);
+      box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.10);
+      overflow: hidden;
+    }
+
+    .modal-header {
+      padding: 1.25rem 1.5rem;
+      font-weight: 600;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    }
+
+    .modal-body-buggy {
+      padding: 1.5rem;
+      color: var(--ease-color-text-muted, #4b5563);
+      line-height: 1.6;
+    }
+
+    .modal-body-fixed {
+      padding: 1.5rem;
+      color: var(--ease-color-muted, #4b5563);
+      line-height: 1.6;
+    }
+
+    .label {
+      display: inline-block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      margin: 1rem 1.5rem;
+    }
+
+    .label-bug {
+      background: rgba(239, 68, 68, 0.12);
+      color: #ef4444;
+    }
+
+    .label-fix {
+      background: rgba(34, 197, 94, 0.12);
+      color: #22c55e;
+    }
+
+    .note {
+      font-size: 0.8rem;
+      color: var(--ease-color-muted);
+      text-align: center;
+      max-width: 600px;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Modal Muted Token Fix</h1>
+  <p class="subtitle">Corrects --ease-color-text-muted to --ease-color-muted in modal body</p>
+
+  <div class="demo-grid">
+    <div class="modal-card">
+      <span class="label label-bug">BUG — before</span>
+      <div class="modal-header">Modal Title</div>
+      <div class="modal-body-buggy">
+        This text uses <code>var(--ease-color-text-muted)</code>, which is undefined.
+        It always falls back to the hardcoded value and cannot be themed.
+      </div>
+    </div>
+
+    <div class="modal-card">
+      <span class="label label-fix">FIX — after</span>
+      <div class="modal-header">Modal Title</div>
+      <div class="modal-body-fixed">
+        This text uses <code>var(--ease-color-muted)</code>, which is properly
+        defined in core/variables.css and responds to theming.
+      </div>
+    </div>
+  </div>
+
+  <p class="note">
+    Try overriding <code>--ease-color-muted</code> in DevTools. The right card responds;
+    the left card always uses the hardcoded fallback.
+  </p>
+
+</body>
+</html>

--- a/submissions/examples/modal-muted-token-fix/style.css
+++ b/submissions/examples/modal-muted-token-fix/style.css
@@ -1,0 +1,22 @@
+/*
+   Fix: Modal body references undefined --ease-color-text-muted token.
+
+   Bug:
+   - components/modals.css line 127 uses:
+       color: var(--ease-color-text-muted, #4b5563);
+   - core/variables.css defines --ease-color-muted (NOT --ease-color-text-muted)
+   - The token never resolves; the hardcoded fallback is always used
+
+   Proposed change in components/modals.css line 127:
+
+     BEFORE:  color: var(--ease-color-text-muted, #4b5563);
+     AFTER:   color: var(--ease-color-muted, #4b5563);
+*/
+
+/* Demo: modal body using the correct token */
+.modal-body-fixed {
+  padding: 1.5rem;
+  color: var(--ease-color-muted, #4b5563);
+  line-height: 1.6;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a submission example demonstrating the correct usage of the existing design token `--ease-color-muted` for modal body text styling.

This submission highlights an inconsistency where modal text styling may reference a non-existent token and shows the correct token usage through a self-contained example.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [x] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/examples/modal-muted-token-fix/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A demonstration showing the correct usage of the `--ease-color-muted` design token for modal body text styling.

**How does a developer use it?**

```html
<p class="modal-body">
  This modal text uses the muted design token.
</p>
```

```css
.modal-body {
  color: var(--ease-color-muted, #4b5563);
}
```

**Why does it fit EaseMotion CSS?**

EaseMotion CSS promotes reusable, human-readable design tokens. This example demonstrates proper token usage and helps contributors understand how to apply theme-aware color variables consistently.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission does not modify framework source files.

The example demonstrates the correct use of the existing `--ease-color-muted` design token and serves as a reference implementation for modal body text styling.

All changes are contained within:

```text
submissions/examples/modal-muted-token-fix/
```

No unrelated files were modified.
