### PR TITLE
feat: add ease-snap-stop scroll-snap-stop utility classes

### DIFF
--- a/submissions/examples/scroll-snap-stop-utilities/README.md
+++ b/submissions/examples/scroll-snap-stop-utilities/README.md
@@ -1,0 +1,39 @@
+# ease-snap-stop — Scroll Snap Stop Utility Classes
+
+Utility classes for `scroll-snap-stop`, controlling whether a fast scroll/swipe/fling can skip past intermediate snap points. Existing scroll-snap utilities in `core/utilities.css` (`.ease-snap-x`/`.ease-snap-y` for `scroll-snap-type`, `.ease-snap-center`/`-start`/`-end` for `scroll-snap-align`) have no equivalent for `scroll-snap-stop`.
+
+## Classes
+
+| Class | `scroll-snap-stop` |
+|-------|----------------------|
+| `.ease-snap-stop-normal` | `normal` |
+| `.ease-snap-stop-always` | `always` |
+
+## Usage
+
+```html
+<!-- Default carousel — fast flicks may skip multiple items -->
+<div class="gallery ease-snap-x ease-snap-stop-normal">...</div>
+
+<!-- Step-by-step flow — every item must be seen -->
+<div class="onboarding ease-snap-x ease-snap-stop-always">...</div>
+```
+
+## When to use each class
+
+| Class | Best for |
+|-------|----------|
+| `.ease-snap-stop-normal` | Image carousels, galleries — natural fast-flick browsing |
+| `.ease-snap-stop-always` | Onboarding flows, story viewers, step wizards |
+
+## Notes
+
+- `scroll-snap-stop` only has an effect inside an element with `scroll-snap-type` set (e.g. `.ease-snap-x`/`.ease-snap-y`)
+- Supported in all modern browsers (Chrome, Firefox, Safari, Edge)
+- `!important` used to match the existing `!important` convention already used by `.ease-snap-x`/`-y`/`-center`/`-start`/`-end` in `core/utilities.css`
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS already ships `scroll-snap-type` and `scroll-snap-align` utilities but has no control over snap-skipping behavior. These classes complete the scroll-snap utility set.
+
+Closes #11580

--- a/submissions/examples/scroll-snap-stop-utilities/demo.html
+++ b/submissions/examples/scroll-snap-stop-utilities/demo.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Snap Stop Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .snap-container {
+      display: flex;
+      overflow-x: auto;
+      scroll-snap-type: x mandatory;
+      gap: 1rem;
+      padding: 1rem;
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      margin-bottom: 1.5rem;
+    }
+    .snap-item {
+      flex: 0 0 80%;
+      scroll-snap-align: center;
+      background: var(--ease-color-primary);
+      color: white;
+      border-radius: var(--ease-radius-md);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 1.25rem;
+      height: 120px;
+    }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  <h2>Scroll Snap Stop Utility Classes</h2>
+  <p class="intro">
+    Control whether a fast swipe/flick can skip past intermediate snap
+    points via <code>scroll-snap-stop</code>. Try flicking quickly through
+    both rows below on a touch device or trackpad.
+  </p>
+
+  <div class="info">
+    💡 <strong>Note:</strong> No <code>scroll-snap-stop</code> utility exists today —
+    only <code>scroll-snap-type</code> (<code>.ease-snap-x</code>/<code>.ease-snap-y</code>)
+    and <code>scroll-snap-align</code> (<code>.ease-snap-center</code>/<code>-start</code>/<code>-end</code>)
+    in <code>core/utilities.css</code>.
+  </div>
+
+  <h3>.ease-snap-stop-normal — fast flicks can skip items</h3>
+  <div class="snap-container ease-snap-stop-normal">
+    <div class="snap-item">1</div>
+    <div class="snap-item">2</div>
+    <div class="snap-item">3</div>
+    <div class="snap-item">4</div>
+    <div class="snap-item">5</div>
+  </div>
+
+  <h3>.ease-snap-stop-always — every item forces a stop</h3>
+  <div class="snap-container ease-snap-stop-always">
+    <div class="snap-item">1</div>
+    <div class="snap-item">2</div>
+    <div class="snap-item">3</div>
+    <div class="snap-item">4</div>
+    <div class="snap-item">5</div>
+  </div>
+
+  <h3>Common use cases</h3>
+  <ul style="font-size:0.9375rem;line-height:2;color:var(--ease-color-text);">
+    <li>Image carousels/galleries — leave default (<code>.ease-snap-stop-normal</code>)</li>
+    <li>Onboarding flows, story viewers, step wizards — <code>.ease-snap-stop-always</code></li>
+    <li>Any UI where skipping a step would break context or comprehension</li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/scroll-snap-stop-utilities/style.css
+++ b/submissions/examples/scroll-snap-stop-utilities/style.css
@@ -1,0 +1,33 @@
+/* ============================================================
+   ease-snap-stop — scroll-snap-stop utility classes
+
+   Controls whether a scroll snap container is allowed to skip
+   past a snap point during fast scrolls/swipes/flings. Existing
+   .ease-snap-x/-y (scroll-snap-type) and .ease-snap-center/-start/-end
+   (scroll-snap-align) in core/utilities.css have no equivalent
+   for scroll-snap-stop.
+
+   Classes:
+     .ease-snap-stop-normal — normal (default, snap points can be skipped)
+     .ease-snap-stop-always — always (forces a stop at every snap point)
+
+   When to use:
+     .ease-snap-stop-normal — default carousels/galleries where fast
+                               flicks may skip multiple items
+     .ease-snap-stop-always — step-by-step flows (onboarding, story
+                               viewers) where every item must be seen
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  /* Default — allows the browser to skip past snap points on fast scrolls */
+  .ease-snap-stop-normal {
+    scroll-snap-stop: normal !important;
+  }
+
+  /* Forces a stop at every snap point, even on fast scrolls/flings */
+  .ease-snap-stop-always {
+    scroll-snap-stop: always !important;
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds 2 `scroll-snap-stop` utility classes that control whether a fast scroll/swipe/fling can skip past intermediate snap points. `core/utilities.css` already ships `scroll-snap-type` (`.ease-snap-x`/`.ease-snap-y`) and `scroll-snap-align` (`.ease-snap-center`/`-start`/`-end`) utilities, but has no equivalent for `scroll-snap-stop`.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | `scroll-snap-stop` | Use case |
|-------|----------------------|----------|
| `.ease-snap-stop-normal` | `normal` | Image carousels, galleries |
| `.ease-snap-stop-always` | `always` | Onboarding flows, story viewers, step wizards |

**How does a developer use it?**
```html
<div class="gallery ease-snap-x ease-snap-stop-normal">...</div>
<div class="onboarding ease-snap-x ease-snap-stop-always">...</div>
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS already ships `scroll-snap-type` and `scroll-snap-align` utilities but has no control over snap-skipping behavior. These classes complete the scroll-snap utility set.

---

## Demo
- [x] Demo added (`demo.html` — two horizontal snap carousels side by side, normal vs always, with use case guidance)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
`scroll-snap-stop` only has an effect inside a `scroll-snap-type` container. `!important` used to match the existing convention on `.ease-snap-x`/`-y`/`-center`/`-start`/`-end`.

Closes #11580