### PR TITLE
feat: add ease-orphans orphans utility classes

### DIFF
--- a/submissions/examples/orphans-utilities/README.md
+++ b/submissions/examples/orphans-utilities/README.md
@@ -1,0 +1,43 @@
+# ease-orphans — Orphans Utility Classes
+
+Utility classes for the `orphans` property, controlling the minimum number of lines of a block container that must remain at the bottom of a fragmented region (page or column) before a break. Most relevant for print stylesheets and multi-column layouts. No `orphans`/`widows` declarations currently exist anywhere in `core/` or `components/`.
+
+## Classes
+
+| Class | `orphans` |
+|-------|-----------|
+| `.ease-orphans-1` | `1` |
+| `.ease-orphans-2` | `2` |
+| `.ease-orphans-3` | `3` |
+| `.ease-orphans-4` | `4` |
+
+## Usage
+
+```html
+<!-- Print stylesheet / editorial article -->
+<article class="ease-orphans-3">...</article>
+
+<!-- Multi-column blog layout -->
+<div class="blog-columns ease-orphans-2">...</div>
+```
+
+## When to use each class
+
+| Class | Best for |
+|-------|----------|
+| `.ease-orphans-1` | Browser default, no real protection needed |
+| `.ease-orphans-2` | Multi-column layouts with shorter paragraphs |
+| `.ease-orphans-3` | Print stylesheets, editorial/article content (common minimum) |
+| `.ease-orphans-4` | Long-form print documents needing stricter control |
+
+## Notes
+
+- `orphans` only takes effect when content is fragmented across columns or pages (e.g. `column-count`, print media)
+- No `orphans`/`widows` declarations exist anywhere in `core/` or `components/` today
+- Supported in all modern browsers; most relevant for `@media print` contexts
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS has multi-column and print-adjacent utilities elsewhere but no fragmentation control for paragraph breaks. These classes round out the typography/print utility set.
+
+Closes #11559

--- a/submissions/examples/orphans-utilities/demo.html
+++ b/submissions/examples/orphans-utilities/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Orphans Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .column-demo {
+      column-count: 2;
+      column-gap: 2rem;
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-5);
+      background: var(--ease-color-surface);
+      margin-bottom: 1.5rem;
+      font-size: 0.9375rem;
+      line-height: 1.7;
+    }
+    .compare-label {
+      font-family: var(--ease-font-mono);
+      font-size: 0.7rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  <h2>Orphans Utility Classes</h2>
+  <p class="intro">
+    Control the minimum number of lines of a paragraph that must remain
+    together at the bottom of a column or page before a break, via the
+    <code>orphans</code> property. Most visible in multi-column layouts
+    or when printed (Cmd/Ctrl+P print preview).
+  </p>
+
+  <div class="info">
+    💡 <strong>Note:</strong> <code>orphans</code> only takes effect when content is
+    fragmented across columns or pages. Resize this demo's columns won't show much in a
+    normal browser view — print preview or multi-column text best demonstrates the effect.
+    No orphans/widows declarations exist anywhere in <code>core/</code> or <code>components/</code> today.
+  </div>
+
+  <h3>.ease-orphans-1 (default — no protection)</h3>
+  <div class="column-demo ease-orphans-1">
+    <p>Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+  </div>
+
+  <h3>.ease-orphans-3 (common print/editorial minimum)</h3>
+  <div class="column-demo ease-orphans-3">
+    <p>Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+  </div>
+
+  <h3>Common use cases</h3>
+  <ul style="font-size:0.9375rem;line-height:2;color:var(--ease-color-text);">
+    <li>Print stylesheets — <code>.ease-orphans-3</code> for editorial/article content</li>
+    <li>Multi-column blog/magazine layouts with shorter paragraphs — <code>.ease-orphans-2</code></li>
+    <li>Long-form print documents needing stricter control — <code>.ease-orphans-4</code></li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/orphans-utilities/style.css
+++ b/submissions/examples/orphans-utilities/style.css
@@ -1,0 +1,40 @@
+/* ============================================================
+   ease-orphans — orphans utility classes
+
+   Controls the minimum number of lines of a block container that
+   must be left at the BOTTOM of a fragmented region (page/column)
+   before a break, via the `orphans` property. Most relevant for
+   print stylesheets and multi-column layouts. No orphans/widows
+   declarations currently exist anywhere in core/ or components/.
+
+   Classes:
+     .ease-orphans-1 — orphans: 1 (browser default, no real protection)
+     .ease-orphans-2 — orphans: 2
+     .ease-orphans-3 — orphans: 3 (common print/editorial minimum)
+     .ease-orphans-4 — orphans: 4
+
+   When to use:
+     .ease-orphans-3 — print stylesheets, editorial/article content
+     .ease-orphans-2 — multi-column layouts with shorter paragraphs
+     .ease-orphans-4 — long-form print documents needing stricter control
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  .ease-orphans-1 {
+    orphans: 1;
+  }
+
+  .ease-orphans-2 {
+    orphans: 2;
+  }
+
+  .ease-orphans-3 {
+    orphans: 3;
+  }
+
+  .ease-orphans-4 {
+    orphans: 4;
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds 4 `orphans` utility classes controlling the minimum number of lines of a block container that must remain at the bottom of a fragmented region (page or column) before a break. No `orphans`/`widows` declarations currently exist anywhere in `core/` or `components/`.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | `orphans` | Use case |
|-------|-----------|----------|
| `.ease-orphans-1` | `1` | Browser default, no real protection |
| `.ease-orphans-2` | `2` | Multi-column layouts, shorter paragraphs |
| `.ease-orphans-3` | `3` | Print stylesheets, editorial/article content |
| `.ease-orphans-4` | `4` | Long-form print documents, stricter control |

**How does a developer use it?**
```html
<article class="ease-orphans-3">...</article>
<div class="blog-columns ease-orphans-2">...</div>
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS has multi-column and print-adjacent utilities elsewhere but no fragmentation control for paragraph breaks. These classes round out the typography/print utility set.

---

## Demo
- [x] Demo added (`demo.html` — multi-column text comparing default vs `.ease-orphans-3`, with use case guidance)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
`orphans` only has a visible effect when content is fragmented across columns or pages (e.g. `column-count`, `@media print`). Naming follows the existing `.ease-` prefix convention.

Closes #11559