### PR TITLE
Fix: Corrected CSS variable in modal component (#11643)

### DIFF
--- a/components/modals.css
+++ b/components/modals.css
@@ -124,7 +124,7 @@
   /* Modal Body */
   .ease-modal-body {
     padding: var(--ease-space-6, 1.5rem);
-    color: var(--ease-color-text-muted, #4b5563);
+    color: var(--ease-color-muted, #4b5563);
     line-height: 1.6;
     overflow-y: auto;
   }


### PR DESCRIPTION
## Pull Request Description

Fixes the issue where the modal component referenced an undefined CSS variable `--ease-color-text-muted`. Changed it to the correct existing token `--ease-color-muted` in `components/modals.css`.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

> ⚠️ I understand this PR touches `components/` because the bug is in `components/modals.css` as described in the issue. The issue itself explicitly requires this change.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] No changes to `core/`
- [x] **⚠️ This PR changes `components/modals.css` as required by the bug fix**
- [ ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This is a bug fix, not a new feature. It corrects a CSS variable reference.

---

## Notes for Maintainer

This PR directly addresses the issue described in #11643. The change is minimal and fixes the undefined variable issue.

The PR template says "No changes to components/", but the bug fix requires editing `components/modals.css` as described in the issue. Please let me know if you'd prefer this submitted differently.