### PR TITLE
feat : added chip removable variant with close button

### DIFF
--- a/submissions/examples/chip-removable-tm/README.md
+++ b/submissions/examples/chip-removable-tm/README.md
@@ -1,0 +1,35 @@
+# Chip Removable
+
+## What does this do?
+Proposes adding `.ease-chip-removable` and `.ease-chip-remove` to `components/chip.css`. The removable chip adds an inline X button inside the chip label so individual chips can be dismissed without a separate delete control.
+
+## How is it used?
+```html
+<div class="ease-chip-group">
+  <input type="checkbox" id="chip-a" class="ease-chip-input">
+  <label class="ease-chip ease-chip-removable" for="chip-a">
+    JavaScript
+    <button type="button" class="ease-chip-remove" aria-label="Remove JavaScript filter">
+      <svg width="10" height="10" viewBox="0 0 10 10">
+        <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+      </svg>
+    </button>
+  </label>
+</div>
+```
+
+## Why is this useful?
+Enables self-contained chip UIs where users can dismiss individual chips by tapping the X button. Common in tag management, multi-select filters, and notification tag UIs. Keeps the markup localized to the chip group without requiring external delete controls.
+
+## Tech Stack
+- Pure CSS for hover states and focus styles
+- Inline SVG X icon (no CDN dependency)
+- JavaScript handles chip removal (CSS drives the visual states)
+
+## Browser Support
+All modern browsers.
+
+## Accessibility Notes
+- Remove button has `aria-label` describing what will be removed
+- `:focus-visible` styling on the remove button for keyboard users
+- Screen readers announce the button via `aria-label`

--- a/submissions/examples/chip-removable-tm/demo.html
+++ b/submissions/examples/chip-removable-tm/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chip Removable - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h1>Chip Removable</h1>
+    <p class="description">
+      Submission proposing <code>.ease-chip-removable</code> — a
+      dismissible chip variant for <code>components/chip.css</code>.
+      Each chip has an inline X button that removes it from the
+      group. Linked to issue #11691.
+    </p>
+
+    <div class="demo-section">
+      <h2>Removable Chips (click X to remove)</h2>
+      <div class="ease-chip-group" id="chip-group-1">
+        <input type="checkbox" id="chip-1" class="ease-chip-input" checked>
+        <label class="ease-chip ease-chip-removable" for="chip-1">
+          JavaScript
+          <button type="button" class="ease-chip-remove" aria-label="Remove JavaScript filter" onclick="removeChip(this, 'JavaScript')">
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+              <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </button>
+        </label>
+
+        <input type="checkbox" id="chip-2" class="ease-chip-input" checked>
+        <label class="ease-chip ease-chip-removable" for="chip-2">
+          CSS
+          <button type="button" class="ease-chip-remove" aria-label="Remove CSS filter" onclick="removeChip(this, 'CSS')">
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+              <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </button>
+        </label>
+
+        <input type="checkbox" id="chip-3" class="ease-chip-input">
+        <label class="ease-chip ease-chip-removable" for="chip-3">
+          Accessibility
+          <button type="button" class="ease-chip-remove" aria-label="Remove Accessibility filter" onclick="removeChip(this, 'Accessibility')">
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+              <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </button>
+        </label>
+
+        <input type="checkbox" id="chip-4" class="ease-chip-input" checked>
+        <label class="ease-chip ease-chip-removable" for="chip-4">
+          Design Tokens
+          <button type="button" class="ease-chip-remove" aria-label="Remove Design Tokens filter" onclick="removeChip(this, 'Design Tokens')">
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+              <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </button>
+        </label>
+
+        <input type="checkbox" id="chip-5" class="ease-chip-input">
+        <label class="ease-chip ease-chip-removable" for="chip-5">
+          Performance
+          <button type="button" class="ease-chip-remove" aria-label="Remove Performance filter" onclick="removeChip(this, 'Performance')">
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+              <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </button>
+        </label>
+      </div>
+      <p class="chip-status" id="chip-status">3 chips selected</p>
+    </div>
+
+    <div class="demo-section">
+      <h2>Add a chip</h2>
+      <p>Click any unselected chip to toggle it; use the X button to remove it entirely.</p>
+    </div>
+
+    <div class="demo-section">
+      <h2>CSS class reference</h2>
+      <table class="ref-table">
+        <thead>
+          <tr><th>Class</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>.ease-chip-removable</code></td><td>Adds padding-right for the remove button and gap between label and X</td></tr>
+          <tr><td><code>.ease-chip-remove</code></td><td>Inline SVG X button, removes chip on click, hoverable and focusable</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <script>
+    function removeChip(btn, label) {
+      const chip = btn.closest('.ease-chip');
+      const input = chip.previousElementSibling;
+      const group = chip.closest('.ease-chip-group');
+
+      chip.style.transition = 'opacity 200ms, transform 200ms';
+      chip.style.opacity = '0';
+      chip.style.transform = 'scale(0.85)';
+
+      setTimeout(() => {
+        chip.remove();
+        if (input) input.remove();
+        updateStatus();
+      }, 200);
+    }
+
+    function updateStatus() {
+      const chips = document.querySelectorAll('#chip-group-1 .ease-chip-input:checked');
+      const status = document.getElementById('chip-status');
+      status.textContent = chips.length + ' chip' + (chips.length !== 1 ? 's' : '') + ' selected';
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/chip-removable-tm/style.css
+++ b/submissions/examples/chip-removable-tm/style.css
@@ -1,0 +1,154 @@
+/* ============================================================
+   Submission: chip removable variant
+   Proposal: add .ease-chip-removable and .ease-chip-remove
+   to components/chip.css
+   ============================================================ */
+
+:root {
+  --ease-speed-fast: 150ms;
+  --ease-speed-medium: 300ms;
+}
+
+/* ── Removable chip ──────────────────────────────────────── */
+.ease-chip-removable {
+  padding-right: 0.5rem;
+  position: relative;
+}
+
+/* Remove button inside the chip label */
+.ease-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  margin-left: 0.125rem;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 50%;
+  cursor: pointer;
+  flex-shrink: 0;
+  vertical-align: middle;
+  transition:
+    color var(--ease-speed-fast, 150ms) ease,
+    background var(--ease-speed-fast, 150ms) ease,
+    transform var(--ease-speed-fast, 150ms) ease;
+}
+
+.ease-chip-remove:hover {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.2);
+  transform: scale(1.15);
+}
+
+.ease-chip-remove:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: 1px;
+}
+
+/* When chip is NOT selected, the X is darker */
+.ease-chip-group input[type="checkbox"]:not(:checked) + .ease-chip-removable .ease-chip-remove {
+  color: rgba(55, 65, 81, 0.6);
+}
+
+.ease-chip-group input[type="checkbox"]:not(:checked) + .ease-chip-removable .ease-chip-remove:hover {
+  color: var(--ease-color-danger, #ef4444);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+/* Selected state: X is white */
+.ease-chip-group input[type="checkbox"]:checked + .ease-chip-removable .ease-chip-remove {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.ease-chip-group input[type="checkbox"]:checked + .ease-chip-removable .ease-chip-remove:hover {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.25);
+}
+
+/* Hide the checkbox visually — it drives the selected state only */
+.ease-chip-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ── Demo page styling ───────────────────────────────────── */
+.demo-wrapper {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 2rem;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  min-height: 100vh;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: var(--ease-color-neutral-600, #475569);
+}
+
+code {
+  font-family: var(--ease-font-mono, monospace);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+.description {
+  color: var(--ease-color-muted, #64748b);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.demo-section {
+  background: #ffffff;
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 0.75rem);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chip-status {
+  font-size: 0.875rem;
+  color: var(--ease-color-muted, #64748b);
+  margin: 0;
+}
+
+.ref-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.ref-table th {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  font-weight: 600;
+}
+
+.ref-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}


### PR DESCRIPTION
Closes #11691.

Summary of What Has Been Done:
Added `.ease-chip-removable` and `.ease-chip-remove` to a new submission folder demonstrating the proposed dismissible chip variant for `components/chip.css`. Each chip has an inline SVG X button that removes it from the group.

Changes Made:
- Created `submissions/examples/chip-removable-tm/` with `demo.html`, `style.css`, and `README.md`
- `demo.html` shows a multi-select chip group where individual chips can be removed by clicking the X button
- `style.css` defines `.ease-chip-removable` (padding for remove button) and `.ease-chip-remove` (inline SVG X with hover and focus-visible styles)
- README documents usage, accessibility notes, and browser support

Impact it Made:
Enables self-contained chip UIs where individual chips can be dismissed without a separate delete control. Common in tag management, filter chips, and notification tag UIs. Keyboard accessible via focus-visible styling.