### PR TITLE
feat : added toast auto-dismiss countdown progress bar

### DIFF
--- a/submissions/examples/toast-autodismiss-tm/README.md
+++ b/submissions/examples/toast-autodismiss-tm/README.md
@@ -1,0 +1,30 @@
+# Toast Auto-Dismiss Progress Bar
+
+## What does this do?
+Proposes adding `.ease-toast-autodismiss`, `--ease-toast-duration`, and `.ease-toast-progress` to `components/toast.css`. A thin color-matched progress bar drains at the bottom of the toast over its lifetime, giving users a visual countdown.
+
+## How is it used?
+```html
+<div class="ease-toast ease-toast-success ease-toast-autodismiss"
+     style="--ease-toast-duration: 5s;">
+  <div class="ease-toast-icon">...</div>
+  <div class="ease-toast-body">
+    <strong>Deployment successful</strong>
+    <p>Your site is live.</p>
+  </div>
+  <div class="ease-toast-progress" aria-hidden="true"></div>
+</div>
+```
+
+The `--ease-toast-duration` CSS custom property controls the drain speed and defaults to `5s`. Override it inline per-toast.
+
+## Why is this useful?
+Users often miss auto-dismissing toasts because they disappear without warning. A visual countdown bar lets users decide whether to act on the message or let it go. Commonly expected in modern notification systems (Slack, GitHub, VS Code all use this pattern).
+
+## Tech Stack
+- Pure CSS: `@keyframes ease-toast-drain` with `transform: scaleX()`
+- No JavaScript required for the animation
+- JavaScript only handles adding/removing the toast from the DOM
+
+## Browser Support
+All modern browsers supporting `animation` and CSS custom properties.

--- a/submissions/examples/toast-autodismiss-tm/demo.html
+++ b/submissions/examples/toast-autodismiss-tm/demo.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toast Auto-Dismiss Progress - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h1>Toast Auto-Dismiss Progress Bar</h1>
+    <p class="description">
+      Submission proposing <code>.ease-toast-autodismiss</code> and
+      <code>--ease-toast-duration</code> to
+      <code>components/toast.css</code>. A thin progress bar at
+      the bottom of the toast drains over the toast's lifetime,
+      giving users a visual countdown. Linked to issue #11692.
+    </p>
+
+    <div class="demo-section">
+      <h2>Variants (5-second auto-dismiss)</h2>
+      <div class="toast-stack">
+        <div class="ease-toast ease-toast-success ease-toast-autodismiss" style="--ease-toast-duration: 5s;">
+          <div class="ease-toast-icon" aria-hidden="true">
+            <svg viewBox="0 0 20 20" fill="currentColor" width="20" height="20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+          </div>
+          <div class="ease-toast-body">
+            <strong>Deployment successful</strong>
+            <p>Your site is live at example.com</p>
+          </div>
+          <div class="ease-toast-progress" aria-hidden="true"></div>
+        </div>
+
+        <div class="ease-toast ease-toast-danger ease-toast-autodismiss" style="--ease-toast-duration: 5s;">
+          <div class="ease-toast-icon" aria-hidden="true">
+            <svg viewBox="0 0 20 20" fill="currentColor" width="20" height="20">
+              <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+            </svg>
+          </div>
+          <div class="ease-toast-body">
+            <strong>Error</strong>
+            <p>Failed to connect to the database.</p>
+          </div>
+          <div class="ease-toast-progress" aria-hidden="true"></div>
+        </div>
+
+        <div class="ease-toast ease-toast-warning ease-toast-autodismiss" style="--ease-toast-duration: 5s;">
+          <div class="ease-toast-icon" aria-hidden="true">
+            <svg viewBox="0 0 20 20" fill="currentColor" width="20" height="20">
+              <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+            </svg>
+          </div>
+          <div class="ease-toast-body">
+            <strong>Session expiring</strong>
+            <p>You will be logged out in 5 seconds.</p>
+          </div>
+          <div class="ease-toast-progress" aria-hidden="true"></div>
+        </div>
+
+        <div class="ease-toast ease-toast-info ease-toast-autodismiss" style="--ease-toast-duration: 5s;">
+          <div class="ease-toast-icon" aria-hidden="true">
+            <svg viewBox="0 0 20 20" fill="currentColor" width="20" height="20">
+              <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+            </svg>
+          </div>
+          <div class="ease-toast-body">
+            <strong>New update available</strong>
+            <p>Reload the page to get the latest version.</p>
+          </div>
+          <div class="ease-toast-progress" aria-hidden="true"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Trigger toasts</h2>
+      <div class="trigger-row">
+        <button class="ease-btn ease-btn-success" onclick="showToast('success')">Success toast</button>
+        <button class="ease-btn ease-btn-danger" onclick="showToast('danger')">Danger toast</button>
+        <button class="ease-btn ease-btn-outline" onclick="showToast('info')">Info toast</button>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>CSS class reference</h2>
+      <table class="ref-table">
+        <thead>
+          <tr><th>Class / Variable</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>.ease-toast-autodismiss</code></td><td>Applies the countdown progress bar at the bottom of the toast</td></tr>
+          <tr><td><code>--ease-toast-duration</code></td><td>Controls how long the toast is visible (default: 5s). Inherits to the progress bar</td></tr>
+          <tr><td><code>.ease-toast-progress</code></td><td>The child element that drains from 100% to 0%</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="toast-container" id="toast-container" aria-live="polite" aria-atomic="false"></div>
+
+  <script>
+    const TOAST_DURATION = 5000;
+
+    function showToast(type) {
+      const container = document.getElementById('toast-container');
+      const configs = {
+        success: { label: 'Deployment successful', body: 'Your changes are live.', cls: 'ease-toast-success' },
+        danger:  { label: 'Connection failed', body: 'Please check your network.', cls: 'ease-toast-danger' },
+        info:    { label: 'Sync complete', body: 'All data has been synchronized.', cls: 'ease-toast-info' },
+      };
+      const cfg = configs[type] || configs.info;
+      const icons = {
+        success: '<svg viewBox="0 0 20 20" fill="currentColor" width="20" height="20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>',
+        danger:  '<svg viewBox="0 0 20 20" fill="currentColor" width="20" height="20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>',
+        info:    '<svg viewBox="0 0 20 20" fill="currentColor" width="20" height="20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg>',
+      };
+
+      const toast = document.createElement('div');
+      toast.className = `ease-toast ${cfg.cls} ease-toast-autodismiss ease-toast-enter`;
+      toast.style.setProperty('--ease-toast-duration', `${TOAST_DURATION}ms`);
+      toast.innerHTML = `
+        <div class="ease-toast-icon" aria-hidden="true">${icons[type]}</div>
+        <div class="ease-toast-body"><strong>${cfg.label}</strong><p>${cfg.body}</p></div>
+        <div class="ease-toast-progress" aria-hidden="true"></div>
+      `;
+      container.appendChild(toast);
+
+      setTimeout(() => {
+        toast.classList.remove('ease-toast-enter');
+        toast.classList.add('ease-toast-leave');
+        setTimeout(() => toast.remove(), 300);
+      }, TOAST_DURATION);
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/toast-autodismiss-tm/style.css
+++ b/submissions/examples/toast-autodismiss-tm/style.css
@@ -1,0 +1,136 @@
+/* ============================================================
+   Submission: toast auto-dismiss progress bar
+   Proposal: add .ease-toast-autodismiss, --ease-toast-duration,
+   and .ease-toast-progress to components/toast.css
+   ============================================================ */
+
+:root {
+  --ease-toast-duration: 5s;
+}
+
+/* ── Auto-dismiss progress bar ─────────────────────────────── */
+.ease-toast-autodismiss {
+  position: relative;
+  overflow: hidden;
+}
+
+.ease-toast-progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  width: 100%;
+  background: currentColor;
+  opacity: 0.3;
+  transform-origin: left;
+  animation: ease-toast-drain var(--ease-toast-duration, 5s) linear forwards;
+}
+
+@keyframes ease-toast-drain {
+  from { transform: scaleX(1); }
+  to   { transform: scaleX(0); }
+}
+
+/* Color the progress bar to match the toast variant */
+.ease-toast-success .ease-toast-progress { background: var(--ease-color-success, #22c55e); opacity: 0.5; }
+.ease-toast-danger  .ease-toast-progress { background: var(--ease-color-danger, #ef4444);  opacity: 0.5; }
+.ease-toast-warning .ease-toast-progress { background: var(--ease-color-warning, #f59e0b); opacity: 0.5; }
+.ease-toast-info    .ease-toast-progress { background: var(--ease-color-info, #3b82f6);    opacity: 0.5; }
+
+/* ── Demo page styling ───────────────────────────────────── */
+.demo-wrapper {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 2rem;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  min-height: 100vh;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: var(--ease-color-neutral-600, #475569);
+}
+
+code {
+  font-family: var(--ease-font-mono, monospace);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+.description {
+  color: var(--ease-color-muted, #64748b);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.demo-section {
+  background: #ffffff;
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 0.75rem);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.toast-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.trigger-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.ref-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.ref-table th {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  font-weight: 600;
+}
+
+.ref-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+
+/* ── Toast container (for dynamic toasts) ───────────────── */
+.toast-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  pointer-events: none;
+}
+
+.toast-container .ease-toast {
+  pointer-events: auto;
+}


### PR DESCRIPTION
Closes #11692.

Summary of What Has Been Done:
Added `.ease-toast-autodismiss`, `--ease-toast-duration`, and `.ease-toast-progress` to a new submission folder demonstrating the proposed countdown progress bar for auto-dismissing toasts in `components/toast.css`. A thin color-matched progress bar drains at the bottom of the toast over its lifetime.

Changes Made:
- Created `submissions/examples/toast-autodismiss-tm/` with `demo.html`, `style.css`, and `README.md`
- `demo.html` shows all 4 toast variants (success, danger, warning, info) with the progress bar
- `style.css` defines the `@keyframes ease-toast-drain` animation and the `.ease-toast-progress` element
- `--ease-toast-duration` CSS custom property controls drain speed (default 5s), settable per-toast

Impact it Made:
Users get a visual countdown showing how long a toast has before it disappears. Reduces frustration from toasts vanishing without warning. A standard UI pattern used by Slack, GitHub, and VS Code.