### PR TITLE
feat : added shimmer gradient variant to progress bars

### DIFF
--- a/submissions/examples/progress-shimmer-tm/README.md
+++ b/submissions/examples/progress-shimmer-tm/README.md
@@ -1,0 +1,24 @@
+# Progress Bar Shimmer Variant
+
+## What does this do?
+Proposes adding `.ease-progress-shimmer` to `components/progress.css`. A layered gradient sweep animates across the progress bar fill, giving it a premium loading feel. This is visually distinct from the existing `.ease-progress-striped` variant.
+
+## How is it used?
+```html
+<div class="ease-progress ease-progress-shimmer">
+  <div class="ease-progress-bar" style="width: 65%;"></div>
+</div>
+```
+
+Works with all existing progress color variants: `.ease-progress-success`, `.ease-progress-danger`, `.ease-progress-warning`, `.ease-progress-info`.
+
+## Why is this useful?
+The shimmer effect is a common UI pattern for loading indicators in modern web apps (GitHub, YouTube, and many design systems use it). It conveys "in progress" more dynamically than a static bar while remaining subtle enough to not distract from content. It complements the existing striped variant with a different visual language.
+
+## Tech Stack
+- Pure CSS: layered `linear-gradient` + `background-size` + `animation`
+- No external dependencies or JavaScript
+- Works with all existing color variants
+
+## Browser Support
+All modern browsers supporting `animation`, `background-image`, and CSS custom properties.

--- a/submissions/examples/progress-shimmer-tm/demo.html
+++ b/submissions/examples/progress-shimmer-tm/demo.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Progress Bar Shimmer - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h1>Progress Bar Shimmer Variant</h1>
+    <p class="description">
+      Submission proposing <code>.ease-progress-shimmer</code> for
+      <code>components/progress.css</code>. An animated gradient
+      sweep gives progress bars a premium loading feel —
+      distinct from the existing striped variant. Linked to issue #11693.
+    </p>
+
+    <div class="demo-section">
+      <h2>Shimmer variants by color</h2>
+
+      <div class="progress-group">
+        <label>Default (Primary)</label>
+        <div class="ease-progress ease-progress-shimmer">
+          <div class="ease-progress-bar" style="width: 72%;"></div>
+        </div>
+      </div>
+
+      <div class="progress-group">
+        <label>Success</label>
+        <div class="ease-progress ease-progress-success ease-progress-shimmer">
+          <div class="ease-progress-bar" style="width: 58%;"></div>
+        </div>
+      </div>
+
+      <div class="progress-group">
+        <label>Danger</label>
+        <div class="ease-progress ease-progress-danger ease-progress-shimmer">
+          <div class="ease-progress-bar" style="width: 35%;"></div>
+        </div>
+      </div>
+
+      <div class="progress-group">
+        <label>Warning</label>
+        <div class="ease-progress ease-progress-warning ease-progress-shimmer">
+          <div class="ease-progress-bar" style="width: 85%;"></div>
+        </div>
+      </div>
+
+      <div class="progress-group">
+        <label>Info</label>
+        <div class="ease-progress ease-progress-info ease-progress-shimmer">
+          <div class="ease-progress-bar" style="width: 60%;"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Size variants</h2>
+
+      <div class="progress-group">
+        <label>Small (sm)</label>
+        <div class="ease-progress ease-progress-sm ease-progress-shimmer">
+          <div class="ease-progress-bar" style="width: 55%;"></div>
+        </div>
+      </div>
+
+      <div class="progress-group">
+        <label>Default</label>
+        <div class="ease-progress ease-progress-shimmer">
+          <div class="ease-progress-bar" style="width: 55%;"></div>
+        </div>
+      </div>
+
+      <div class="progress-group">
+        <label>Large (lg)</label>
+        <div class="ease-progress ease-progress-lg ease-progress-shimmer">
+          <div class="ease-progress-bar" style="width: 55%;"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Shimmer vs Striped (comparison)</h2>
+      <div class="progress-group">
+        <label>Shimmer (proposed)</label>
+        <div class="ease-progress ease-progress-shimmer">
+          <div class="ease-progress-bar" style="width: 65%;"></div>
+        </div>
+      </div>
+      <div class="progress-group">
+        <label>Striped (existing)</label>
+        <div class="ease-progress ease-progress-striped ease-progress-animated">
+          <div class="ease-progress-bar" style="width: 65%;"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>CSS class reference</h2>
+      <table class="ref-table">
+        <thead>
+          <tr><th>Class</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>.ease-progress-shimmer</code></td><td>Applies animated gradient sweep across the progress bar</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/progress-shimmer-tm/style.css
+++ b/submissions/examples/progress-shimmer-tm/style.css
@@ -1,0 +1,132 @@
+/* ============================================================
+   Submission: progress bar shimmer variant
+   Proposal: add .ease-progress-shimmer to components/progress.css
+   ============================================================ */
+
+:root {
+  --ease-shimmer-color: rgba(255, 255, 255, 0.35);
+}
+
+/* ── Shimmer animation ───────────────────────────────────── */
+@keyframes ease-kf-progress-shimmer {
+  from { background-position: -200% center; }
+  to   { background-position: 200% center; }
+}
+
+/* Apply shimmer overlay to the progress bar via pseudo-element */
+.ease-progress-shimmer .ease-progress-bar {
+  position: relative;
+  overflow: hidden;
+}
+
+.ease-progress-shimmer .ease-progress-bar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--ease-shimmer-color, rgba(255, 255, 255, 0.35)) 40%,
+    rgba(255, 255, 255, 0.6) 50%,
+    var(--ease-shimmer-color, rgba(255, 255, 255, 0.35)) 60%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: ease-kf-progress-shimmer 1.5s ease-in-out infinite;
+}
+
+/* Variant-specific shimmer overlays (lighter so color shows through) */
+.ease-progress-success.ease-progress-shimmer .ease-progress-bar::after {
+  --ease-shimmer-color: rgba(255, 255, 255, 0.4);
+}
+.ease-progress-danger.ease-progress-shimmer .ease-progress-bar::after {
+  --ease-shimmer-color: rgba(255, 255, 255, 0.3);
+}
+.ease-progress-warning.ease-progress-shimmer .ease-progress-bar::after {
+  --ease-shimmer-color: rgba(255, 255, 255, 0.4);
+}
+.ease-progress-info.ease-progress-shimmer .ease-progress-bar::after {
+  --ease-shimmer-color: rgba(255, 255, 255, 0.4);
+}
+
+/* ── Demo page styling ───────────────────────────────────── */
+.demo-wrapper {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 2rem;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  min-height: 100vh;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: var(--ease-color-neutral-600, #475569);
+}
+
+code {
+  font-family: var(--ease-font-mono, monospace);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+.description {
+  color: var(--ease-color-muted, #64748b);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.demo-section {
+  background: #ffffff;
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 0.75rem);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.progress-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.progress-group label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--ease-color-muted, #64748b);
+}
+
+.ref-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.ref-table th {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  font-weight: 600;
+}
+
+.ref-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}


### PR DESCRIPTION
Closes #11693.

Summary of What Has Been Done:
Added `.ease-progress-shimmer` to a new submission folder demonstrating the proposed shimmer gradient sweep for progress bars in `components/progress.css`. The animation gives progress bars a premium loading feel, distinct from the existing striped variant.

Changes Made:
- Created `submissions/examples/progress-shimmer-tm/` with `demo.html`, `style.css`, and `README.md`
- `demo.html` shows all color variants (default, success, danger, warning, info) and all size variants (sm, default, lg)
- `style.css` defines `@keyframes ease-kf-progress-shimmer` and the shimmer `::after` pseudo-element
- Works composably with all existing progress bar color and size classes

Impact it Made:
Provides a richer loading indicator for progress bars. The shimmer effect is a widely-recognized UI pattern (GitHub, YouTube, Material Design) that conveys "in progress" more dynamically than a static bar without distracting from content. Pure CSS, no dependencies.