### PR TITLE
feat: add native dialog modal component #7767

### DIFF
--- a/submissions/examples/native-dialog-modal-cli/README.md
+++ b/submissions/examples/native-dialog-modal-cli/README.md
@@ -1,0 +1,29 @@
+# Native `<dialog>` Modal Component
+
+## What does this do?
+Provides a fully accessible, zero-JavaScript-library modal component powered by the native HTML `<dialog>` element. It applies EaseMotion CSS styling, fluid entry/exit animations, and a blurred backdrop while letting the browser handle complex accessibility requirements like focus trapping and keyboard navigation (Esc to close).
+
+## How is it used?
+
+1. Add the `<dialog>` element to your HTML with the `.ease-modal` class.
+2. Structure the content using `.ease-modal-header`, `.ease-modal-body`, and `.ease-modal-footer`.
+3. Open it using native JS: `document.getElementById('myModal').showModal()`.
+4. Close it using a native form submission `<form method="dialog">` or JS `dialog.close()`.
+
+```html
+<dialog id="myModal" class="ease-modal">
+  <div class="ease-modal-header">
+    <h2>Title</h2>
+    <form method="dialog"><button class="ease-modal-close-btn">✕</button></form>
+  </div>
+  <div class="ease-modal-body">
+    <p>Content goes here.</p>
+  </div>
+</dialog>
+```
+
+### Exit Animation Note
+Native dialogs hide immediately upon `dialog.close()`. To allow a CSS exit animation to play, add the `.ease-modal-closing` class briefly before calling the native `.close()` method (a tiny JS snippet is provided in the demo for this).
+
+## Why is it useful?
+Modals are notoriously difficult to build accessibly from scratch. By styling the native `<dialog>` element, EaseMotion CSS gives developers a plug-and-play solution that adheres to the framework's "animation-first" philosophy with beautiful backdrop blurs and entry animations, without needing to import heavy third-party modal libraries.

--- a/submissions/examples/native-dialog-modal-cli/demo.html
+++ b/submissions/examples/native-dialog-modal-cli/demo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Native Dialog Modal | EaseMotion CSS</title>
+  
+  <!-- Main Framework -->
+  <link rel="stylesheet" href="../../../easemotion.css">
+  
+  <!-- Component specific style -->
+  <link rel="stylesheet" href="style.css">
+
+  <style>
+    body {
+      background-color: var(--ease-color-bg, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      padding: 4rem 2rem;
+      font-family: var(--ease-font-sans, system-ui, sans-serif);
+      max-width: 800px;
+      margin: 0 auto;
+      text-align: center;
+    }
+
+    .demo-header {
+      margin-bottom: 4rem;
+    }
+
+    .demo-header h1 {
+      font-size: 3rem;
+      font-weight: 800;
+      margin-bottom: 1rem;
+    }
+
+    .demo-header p {
+      color: var(--ease-color-muted, #64748b);
+      font-size: 1.125rem;
+    }
+    
+    /* Layout utilities for demo */
+    .ease-margin-y-4 { margin-top: 1rem; margin-bottom: 1rem; }
+    .ease-text-muted { color: var(--ease-color-muted, #64748b); line-height: 1.6; }
+    .ease-flex { display: flex; }
+    .ease-justify-end { justify-content: flex-end; }
+    .ease-gap-2 { gap: 0.5rem; }
+  </style>
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Native Modal</h1>
+    <p>Accessible, animated popups powered by the HTML <code>&lt;dialog&gt;</code> element.</p>
+  </header>
+
+  <!-- Trigger Button -->
+  <button class="ease-btn ease-btn-primary ease-btn-lg ease-hover-grow" onclick="document.getElementById('myModal').showModal()">
+    Open Modal
+  </button>
+
+  <!-- Native Dialog Component -->
+  <dialog id="myModal" class="ease-modal">
+    <div class="ease-modal-header">
+      <h2>Upgrade Your Account</h2>
+      <!-- Natively closes dialog without JS -->
+      <form method="dialog">
+        <button class="ease-modal-close-btn" aria-label="Close modal">✕</button>
+      </form>
+    </div>
+    
+    <div class="ease-modal-body ease-margin-y-4">
+      <p class="ease-text-muted">You are about to upgrade to the Pro tier. This will unlock premium features including unlimited projects and advanced analytics. Please confirm your billing details to continue.</p>
+    </div>
+    
+    <div class="ease-modal-footer ease-flex ease-justify-end ease-gap-2">
+      <!-- Natively closes dialog without JS -->
+      <form method="dialog">
+        <button class="ease-btn ease-btn-ghost">Cancel</button>
+      </form>
+      <button class="ease-btn ease-btn-primary" onclick="closeModalWithAnimation('myModal')">Confirm Upgrade</button>
+    </div>
+  </dialog>
+
+  <script>
+    // Optional: Add a tiny helper to allow CSS exit animations to play before the native .close() method hides the dialog.
+    function closeModalWithAnimation(id) {
+      const dialog = document.getElementById(id);
+      dialog.classList.add('ease-modal-closing');
+      
+      // Wait for CSS transition (300ms defined in style.css)
+      setTimeout(() => {
+        dialog.close();
+        dialog.classList.remove('ease-modal-closing');
+      }, 300);
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/native-dialog-modal-cli/style.css
+++ b/submissions/examples/native-dialog-modal-cli/style.css
@@ -1,0 +1,142 @@
+/* ============================================================
+   EaseMotion CSS — Native <dialog> Modal
+   Submission by: sahare-mayur-0071 (CLI Optimized)
+   Description: Fully accessible, zero-JavaScript-library modal 
+                using the native HTML <dialog> element. Features
+                fluid entry/exit animations and backdrop blurs.
+   ============================================================ */
+
+/* ── Base Modal Setup ── */
+.ease-modal {
+  padding: 0;
+  border: none;
+  border-radius: var(--ease-radius-lg, 1rem);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-text, #1e293b);
+  box-shadow: var(--ease-shadow-xl, 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04));
+  max-width: 500px;
+  width: 90%;
+  margin: auto; /* Centers the dialog natively */
+  
+  /* Initial state for animation */
+  opacity: 0;
+  transform: scale(0.95) translateY(20px);
+  transition: opacity var(--ease-speed-medium, 300ms) var(--ease-ease-out, cubic-bezier(0, 0, 0.2, 1)),
+              transform var(--ease-speed-medium, 300ms) var(--ease-ease-out, cubic-bezier(0, 0, 0.2, 1));
+}
+
+/* Fix for Safari/Firefox where margin: auto doesn't center reliably if top/bottom are auto */
+.ease-modal:not([open]) {
+  display: none;
+}
+
+/* Modal Open State Animation */
+.ease-modal[open] {
+  display: flex;
+  flex-direction: column;
+  opacity: 1;
+  transform: scale(1) translateY(0);
+}
+
+/* ── Backdrop Styling ── */
+.ease-modal::backdrop {
+  background: rgba(15, 23, 42, 0.6); /* Tailwind slate-900 at 60% */
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+
+  /* Initial state for backdrop */
+  opacity: 0;
+  transition: opacity var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+/* Backdrop Open State Animation */
+.ease-modal[open]::backdrop {
+  opacity: 1;
+}
+
+/* ── Content Structure ── */
+.ease-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem);
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.ease-modal-header h2 {
+  margin: 0;
+  font-size: var(--ease-text-lg, 1.125rem);
+  font-weight: 700;
+}
+
+.ease-modal-close-btn {
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--ease-color-muted, #64748b);
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  transition: color var(--ease-speed-fast, 150ms), background-color var(--ease-speed-fast, 150ms);
+}
+
+.ease-modal-close-btn:hover {
+  background-color: var(--ease-color-neutral-100, #f1f5f9);
+  color: var(--ease-color-danger, #ef4444);
+}
+
+.ease-modal-body {
+  padding: var(--ease-space-6, 1.5rem);
+  overflow-y: auto;
+  max-height: 60vh;
+}
+
+.ease-modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-6, 1.5rem);
+  border-top: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background-color: var(--ease-color-neutral-50, #f8fafc);
+  border-bottom-left-radius: var(--ease-radius-lg, 1rem);
+  border-bottom-right-radius: var(--ease-radius-lg, 1rem);
+}
+
+/* ── Exit Animation Fix ── 
+   Native dialogs hide immediately upon closing, interrupting CSS transitions.
+   The class .ease-modal-closing should be added via a tiny JS snippet 
+   to allow the exit animation to play before calling dialog.close().
+*/
+.ease-modal.ease-modal-closing {
+  opacity: 0 !important;
+  transform: scale(0.95) translateY(20px) !important;
+}
+.ease-modal.ease-modal-closing::backdrop {
+  opacity: 0 !important;
+}
+
+/* ── Dark Mode ── */
+@media (prefers-color-scheme: dark) {
+  .ease-modal {
+    border: 1px solid var(--ease-color-neutral-700, #334155);
+  }
+  .ease-modal-header, .ease-modal-footer {
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+  .ease-modal-footer {
+    background-color: rgba(0, 0, 0, 0.2);
+  }
+  .ease-modal-close-btn:hover {
+    background-color: var(--ease-color-neutral-800, #1e293b);
+  }
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-modal, .ease-modal::backdrop {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a native `<dialog>` modal component to address issue #7767 by providing an accessible, animation-first solution for dialogs and popups using the browser's built-in modal API.

This submission introduces a reusable modal system with animated entry and exit states, backdrop blur effects, and structured layout utilities while keeping all changes inside the `submissions/` directory.

Closes #7767

---

## Type of Change

* [x] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/examples/native-dialog-modal-cli/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, and why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fully accessible modal component powered by the native HTML `<dialog>` element, featuring:

* Native focus trapping and keyboard navigation
* `Esc` key support out of the box
* Animated open and close transitions
* Blurred backdrop overlays
* Structured header, body, and footer sections
* Dark mode and reduced motion support

**How does a developer use it?**

```html
<button onclick="document.getElementById('myModal').showModal()">
  Open Modal
</button>

<dialog id="myModal" class="ease-modal">
  <div class="ease-modal-header">
    <h2>Upgrade Your Account</h2>

    <form method="dialog">
      <button
        class="ease-modal-close-btn"
        aria-label="Close modal"
      >
        ✕
      </button>
    </form>
  </div>

  <div class="ease-modal-body">
    <p>Modal content goes here.</p>
  </div>

  <div class="ease-modal-footer">
    <form method="dialog">
      <button class="ease-btn ease-btn-outline">
        Cancel
      </button>
    </form>

    <button class="ease-btn ease-btn-primary">
      Confirm
    </button>
  </div>
</dialog>
```

Core utility classes:

* `.ease-modal`
* `.ease-modal-header`
* `.ease-modal-body`
* `.ease-modal-footer`
* `.ease-modal-close-btn`
* `.ease-modal-closing`

**Why does it fit EaseMotion CSS?**

Modal accessibility is complex to implement correctly. By leveraging the native `<dialog>` element, this component delegates focus management, screen reader announcements, and keyboard interactions to the browser.

The implementation aligns with EaseMotion CSS's animation-first and zero-dependency philosophy by combining native browser capabilities with token-driven styling and smooth CSS transitions.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)
* [x] Includes an upgrade confirmation modal example
* [x] Demonstrates native open and close behaviors

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

* Implemented entirely within `submissions/examples/native-dialog-modal-cli/`
* Uses the native `dialog.showModal()` and `dialog.close()` APIs
* Includes animated `::backdrop` blur effects
* Provides a lightweight helper class for close animations before invoking `dialog.close()`
* Supports dark mode using `prefers-color-scheme`
* Respects `prefers-reduced-motion` preferences
* Requires no third-party libraries
* No modifications were made to framework core files or components
* Branch used: `feat/native-dialog-modal-cli-vb`

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Test the modal using keyboard navigation only (`Tab`, `Shift + Tab`, and `Esc`) to verify the native accessibility behavior across browsers.
