### PR TITLE
test: submission ease-import-layer-demo-ai-v2 to reproduce issue #9622

### DIFF
--- a/submissions/examples/ease-import-layer-demo-ai-v2/README.md
+++ b/submissions/examples/ease-import-layer-demo-ai-v2/README.md
@@ -1,0 +1,24 @@
+# Import Layer Bug Demonstration (v2)
+
+**What does this do?**
+This is a minimal demonstration component designed specifically to trigger and reproduce the bundler bug reported in Issue #9622.
+
+**How is it used?**
+```html
+<div class="ease-import-demo-ai">...</div>
+```
+
+**Why is it useful?**
+It provides a safe, submission-compliant way for the maintainer to verify the `@import` cascade layer bug (#9622) without requiring contributors to bypass the repository's Core Framework Protection bot.
+
+## Reproduction Steps
+
+1. Open `demo.html` directly in any browser — no server required.
+2. Observe the `ease-import-demo-ai` component renders with the cascade layer styles applied correctly.
+3. Without the fix from #9622, bundling this component would silently break the `@import` resolution in `easemotion.min.css`.
+
+## Notes
+
+- No changes to `core/` or `components/`
+- Relates to Issue #9622
+- This is v2 of the submission, following up on the merged PR #10927

--- a/submissions/examples/ease-import-layer-demo-ai-v2/demo.html
+++ b/submissions/examples/ease-import-layer-demo-ai-v2/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Import Layer Bug Demo v2</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-import-demo-ai">
+    <h1>CSS @import Layer Test (v2)</h1>
+    <p>This component uses a local @import with a cascade layer to demonstrate <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/9622">Issue #9622</a>.</p>
+    <p>This is a follow-up submission to <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/pull/10927">PR #10927</a> which was merged.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-import-layer-demo-ai-v2/style.css
+++ b/submissions/examples/ease-import-layer-demo-ai-v2/style.css
@@ -1,0 +1,16 @@
+/* 
+ * This local import uses a cascade layer.
+ * Because of Issue #9622, the bundler regex fails to match this line.
+ * As a result, this local import will NOT be inlined, leaving a broken relative path
+ * in the final easemotion.min.css bundle.
+ *
+ * v2: Follow-up submission to merged PR #10927
+ */
+@import "../../../core/utilities.css" layer(framework-utilities);
+
+.ease-import-demo-ai {
+  padding: 2rem;
+  border: 2px solid #333;
+  border-radius: 8px;
+  background: #fafafa;
+}


### PR DESCRIPTION
## Pull Request Description

This PR provides a compliant submission designed to reproduce the bug reported in Issue #9622. This is a follow-up to the merged PR #10927.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: Bug reproduction case

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-import-layer-demo-ai-v2/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This adds a minimal demonstration component designed specifically to reproduce the bundler bug reported in Issue #9622.

**How does a developer use it?**

```html
<div class="ease-import-demo-ai">...</div>
```

**Why does it fit EaseMotion CSS?**

It provides a safe, submission-compliant way for the maintainer to verify the `@import` cascade layer bug (#9622) without requiring contributors to bypass the repository's Core Framework Protection bot.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This is a follow-up to the merged PR #10927. Because of the strict Core Protection rules, I cannot submit a PR that directly patches `scripts/build-minified-css.mjs`. Therefore, I created this PR containing a local `@import` with a cascade layer to demonstrate the exact failure mode.

If you attempt to bundle this component into the main framework before applying the fix in #9622, the bundler will silently fail to inline `core/utilities.css`, leaving a broken relative import path in `easemotion.min.css`.

Once you apply the 1-line regex fix provided in #9622, this component will bundle successfully.