### PR TITLE
fix: submission fix-buttons-stray-brace-ag to resolve stray closing brace in buttons.css 

### DIFF
--- a/submissions/examples/fix-buttons-stray-brace-ag/README.md
+++ b/submissions/examples/fix-buttons-stray-brace-ag/README.md
@@ -1,0 +1,45 @@
+# Fix: Stray Closing Brace in buttons.css (Issue #11738)
+
+**What does this do?**
+This submission reproduces and demonstrates the impact of the stray unmatched `}` at line 330 of `components/buttons.css` (reported in Issue #11738), and provides a corrected standalone CSS reference that bundlers and Stylelint can parse cleanly.
+
+**How is it used?**
+```html
+<button class="ease-btn ease-btn-primary ease-btn-hover">Primary</button>
+<button class="ease-btn ease-btn-success">Success</button>
+<button class="ease-btn ease-btn-danger">Danger</button>
+<button class="ease-btn ease-btn-outline">Outline</button>
+<button class="ease-btn ease-btn-loading">Loading</button>
+<button class="ease-btn" disabled>Disabled</button>
+```
+
+**Why is it useful?**
+The stray `}` at the end of `components/buttons.css` is a CSS syntax error that:
+
+1. Causes Stylelint to report `Unexpected closing brace` — breaking CI validation
+2. Can cause CSS bundlers/minifiers to silently misparse the file when it is concatenated into `easemotion.min.css`, potentially dropping rules after concatenation
+3. Is an invalid construct per the CSS specification
+
+This submission provides a clean, corrected copy of the button CSS for the maintainer to use as a reference when applying the one-line fix (removing the orphan `}` from line 330 of `components/buttons.css`).
+
+## Reproduction
+
+Run Stylelint against the original file to see the error:
+```bash
+npx stylelint components/buttons.css
+# → Unexpected closing brace (CssSyntaxError) at line 330
+```
+
+## Fix
+
+Remove the lone `}` on line 330 of `components/buttons.css`:
+
+```diff
+ }
+-}
+```
+
+## References
+
+- Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/11738
+- Affected file: `components/buttons.css` line 330

--- a/submissions/examples/fix-buttons-stray-brace-ag/demo.html
+++ b/submissions/examples/fix-buttons-stray-brace-ag/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bug Fix Demo — Stray Closing Brace in buttons.css (Issue #11738)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Bug Fix: Stray <code>}</code> in <code>components/buttons.css</code></h1>
+    <p class="subtitle">
+      Reproduces &amp; demonstrates Issue
+      <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/11738" target="_blank">#11738</a>
+      — an unmatched closing brace at line 330 of <code>components/buttons.css</code> causes Stylelint CI failures and can silently break CSS bundling.
+    </p>
+
+    <section class="section">
+      <h2>All Button Variants (with clean CSS — no stray brace)</h2>
+      <div class="btn-row">
+        <button class="ease-btn ease-btn-primary ease-btn-hover">Primary</button>
+        <button class="ease-btn ease-btn-success ease-btn-hover">Success</button>
+        <button class="ease-btn ease-btn-danger ease-btn-hover">Danger</button>
+        <button class="ease-btn ease-btn-outline ease-btn-hover">Outline</button>
+        <button class="ease-btn ease-btn-ghost ease-btn-hover">Ghost</button>
+        <button class="ease-btn ease-btn-link">Link</button>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Sizes</h2>
+      <div class="btn-row btn-row--align-center">
+        <button class="ease-btn ease-btn-primary ease-btn-sm">Small</button>
+        <button class="ease-btn ease-btn-primary">Default</button>
+        <button class="ease-btn ease-btn-primary ease-btn-lg">Large</button>
+        <button class="ease-btn ease-btn-primary ease-btn-xl">X-Large</button>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>States</h2>
+      <div class="btn-row">
+        <button class="ease-btn ease-btn-primary ease-btn-loading">Loading</button>
+        <button class="ease-btn ease-btn-primary" disabled>Disabled</button>
+        <button class="ease-btn ease-btn-primary ease-btn-pill ease-btn-hover">Pill</button>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Button Group</h2>
+      <div class="ease-btn-group">
+        <button class="ease-btn ease-btn-primary">Left</button>
+        <button class="ease-btn ease-btn-primary">Center</button>
+        <button class="ease-btn ease-btn-primary">Right</button>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>The Bug (line 330 of <code>components/buttons.css</code>)</h2>
+      <pre class="code-block"><code>@media (prefers-reduced-motion: reduce) {
+  .ease-btn,
+  .ease-btn-hover,
+  .ease-btn-loading::after {
+    transition: none !important;
+    animation: none !important;
+  }
+  .ease-btn:active,
+  .ease-btn-hover:hover {
+    transform: none !important;
+  }
+}     ← line 329: correct close for @media
+}     ← line 330: STRAY BRACE — no matching opening {  ❌</code></pre>
+      <p class="fix-note">
+        <strong>Fix:</strong> Remove the lone <code>}</code> on line 330.
+        Run <code>npx stylelint components/buttons.css</code> to confirm the error before and after the fix.
+      </p>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-buttons-stray-brace-ag/style.css
+++ b/submissions/examples/fix-buttons-stray-brace-ag/style.css
@@ -1,0 +1,413 @@
+/*
+ * Fix Demo: Stray Closing Brace in components/buttons.css
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/11738
+ *
+ * This file is a self-contained, corrected reference for all button classes.
+ * The stray } on line 330 of the original components/buttons.css is NOT present here.
+ */
+
+/* ── CSS Variables (local fallbacks for standalone demo) ────── */
+:root {
+  --ease-color-primary: #6c63ff;
+  --ease-color-primary-dark: #4b44cc;
+  --ease-color-success: #22c55e;
+  --ease-color-success-dark: #15803d;
+  --ease-color-danger: #ef4444;
+  --ease-color-danger-dark: #b91c1c;
+  --ease-color-neutral-100: #f1f5f9;
+  --ease-color-neutral-200: #e2e8f0;
+  --ease-color-neutral-500: #64748b;
+  --ease-color-neutral-700: #334155;
+  --ease-color-neutral-900: #0f172a;
+  --ease-glow-primary: 0 0 16px rgba(108, 99, 255, 0.45);
+  --ease-glow-success: 0 0 16px rgba(34, 197, 94, 0.45);
+  --ease-glow-danger: 0 0 16px rgba(239, 68, 68, 0.45);
+  --ease-shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.40), 0 4px 6px -2px rgba(0,0,0,0.25);
+  --ease-speed-fast: 150ms;
+  --ease-speed-medium: 300ms;
+  --ease-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-radius-sm: 0.25rem;
+  --ease-radius-md: 0.5rem;
+  --ease-radius-lg: 1rem;
+  --ease-radius-full: 9999px;
+  --ease-space-2: 0.5rem;
+  --ease-space-3: 0.75rem;
+  --ease-space-4: 1rem;
+  --ease-space-5: 1.25rem;
+  --ease-space-8: 2rem;
+  --ease-space-10: 2.5rem;
+  --ease-text-xs: 0.75rem;
+  --ease-text-sm: 0.875rem;
+  --ease-text-base: 1rem;
+  --ease-text-lg: 1.125rem;
+  --ease-font-medium: 500;
+}
+
+/* ── Base Button ────────────────────────────────────────────── */
+.ease-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-6, 1.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: var(--ease-font-medium, 500);
+  line-height: 1.25;
+  border: 2px solid transparent;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  user-select: none;
+  background-color: transparent;
+}
+
+.ease-btn:focus-visible {
+  outline: 2px solid var(--ease-btn-focus, var(--ease-color-primary, #6c63ff));
+  outline-offset: 3px;
+}
+
+.ease-btn:active {
+  transform: scale(0.97);
+}
+
+/* ── Variants ───────────────────────────────────────────────── */
+
+/* Primary */
+.ease-btn-primary {
+  --ease-btn-glow: var(--ease-glow-primary, 0 0 16px rgba(108, 99, 255, 0.45));
+  background-color: var(--ease-color-primary, #6c63ff);
+  color: #ffffff;
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-primary:hover {
+    background-color: var(--ease-color-primary-dark, #4b44cc);
+    border-color: var(--ease-color-primary-dark, #4b44cc);
+    box-shadow: var(--ease-glow-primary, 0 0 16px rgba(108, 99, 255, 0.45));
+  }
+}
+
+/* Success */
+.ease-btn-success {
+  --ease-btn-focus: var(--ease-color-success, #22c55e);
+  --ease-btn-glow: var(--ease-glow-success, 0 0 16px rgba(34, 197, 94, 0.45));
+  background-color: var(--ease-color-success, #22c55e);
+  color: #ffffff;
+  border-color: var(--ease-color-success, #22c55e);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-success:hover {
+    background-color: var(--ease-color-success-dark, #15803d);
+    border-color: var(--ease-color-success-dark, #15803d);
+    box-shadow: var(--ease-glow-success, 0 0 16px rgba(34, 197, 94, 0.45));
+  }
+}
+
+/* Danger */
+.ease-btn-danger {
+  --ease-btn-focus: var(--ease-color-danger, #ef4444);
+  --ease-btn-glow: var(--ease-glow-danger, 0 0 16px rgba(239, 68, 68, 0.45));
+  background-color: var(--ease-color-danger, #ef4444);
+  color: #ffffff;
+  border-color: var(--ease-color-danger, #ef4444);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-danger:hover {
+    background-color: var(--ease-color-danger-dark, #b91c1c);
+    border-color: var(--ease-color-danger-dark, #b91c1c);
+    box-shadow: var(--ease-glow-danger, 0 0 16px rgba(239, 68, 68, 0.45));
+  }
+}
+
+/* Outline (Primary) */
+.ease-btn-outline {
+  --ease-btn-glow: var(--ease-glow-primary, 0 0 16px rgba(108, 99, 255, 0.45));
+  background-color: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-outline:hover {
+    background-color: var(--ease-color-primary, #6c63ff);
+    color: #ffffff;
+  }
+}
+
+/* Ghost */
+.ease-btn-ghost {
+  background-color: transparent;
+  color: var(--ease-color-neutral-700, #334155);
+  border-color: transparent;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-ghost:hover {
+    background-color: var(--ease-color-neutral-100, #f1f5f9);
+    color: var(--ease-color-neutral-900, #0f172a);
+  }
+}
+
+/* Link style */
+.ease-btn-link {
+  background: none;
+  border: none;
+  color: var(--ease-color-primary, #6c63ff);
+  padding-left: 0;
+  padding-right: 0;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-link:hover {
+    color: var(--ease-color-primary-dark, #4b44cc);
+    text-decoration: none;
+  }
+}
+
+.ease-btn-link:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 3px;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+/* ── Sizes ──────────────────────────────────────────────────── */
+.ease-btn-sm {
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-4, 1rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+.ease-btn-lg {
+  padding: var(--ease-space-4, 1rem) var(--ease-space-8, 2rem);
+  font-size: var(--ease-text-base, 1rem);
+  border-radius: var(--ease-radius-lg, 1rem);
+}
+
+.ease-btn-xl {
+  padding: var(--ease-space-5, 1.25rem) var(--ease-space-10, 2.5rem);
+  font-size: var(--ease-text-lg, 1.125rem);
+  border-radius: var(--ease-radius-lg, 1rem);
+}
+
+.ease-btn-block {
+  width: 100%;
+}
+
+.ease-btn-pill {
+  border-radius: var(--ease-radius-full, 9999px);
+}
+
+.ease-btn-icon {
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-md, 0.5rem);
+}
+
+/* ── States ─────────────────────────────────────────────────── */
+.ease-btn:disabled,
+.ease-btn[disabled],
+.ease-btn-disabled {
+  background-color: var(--ease-color-neutral-200, #e2e8f0) !important;
+  color: var(--ease-color-neutral-500, #64748b) !important;
+  border-color: var(--ease-color-neutral-200, #e2e8f0) !important;
+  cursor: not-allowed;
+  box-shadow: none !important;
+}
+
+.ease-btn:disabled:hover,
+.ease-btn:disabled:focus,
+.ease-btn:disabled:active,
+.ease-btn[disabled]:hover,
+.ease-btn[disabled]:focus,
+.ease-btn[disabled]:active,
+.ease-btn-disabled:hover,
+.ease-btn-disabled:focus,
+.ease-btn-disabled:active {
+  background-color: var(--ease-color-neutral-200, #e2e8f0) !important;
+  color: var(--ease-color-neutral-500, #64748b) !important;
+  border-color: var(--ease-color-neutral-200, #e2e8f0) !important;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
+  filter: none !important;
+}
+
+/* Loading spinner inside button */
+.ease-btn-loading {
+  pointer-events: none;
+  position: relative;
+  color: transparent !important;
+}
+
+.ease-btn-loading > * {
+  visibility: hidden;
+}
+
+.ease-btn-loading::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  font-size: var(--ease-text-base, 1rem);
+  width: 0.85em;
+  height: 0.85em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ease-kf-btn-spin 0.7s linear infinite;
+  transform: translate(-50%, -50%);
+}
+
+@keyframes ease-kf-btn-spin {
+  from { transform: translate(-50%, -50%) rotate(0deg); }
+  to   { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+/* ── Hover Class ─────────────────────────────────────────────── */
+.ease-btn-hover {
+  transition:
+    transform    var(--ease-speed-medium, 300ms) var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1)),
+    box-shadow   var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    background-color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    border-color     var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-hover:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--ease-shadow-lg, 0 10px 15px -3px rgba(0,0,0,0.40), 0 4px 6px -2px rgba(0,0,0,0.25)),
+                var(--ease-btn-glow, var(--ease-glow-primary, 0 0 16px rgba(108, 99, 255, 0.45)));
+  }
+}
+
+/* ── Button Group ───────────────────────────────────────────── */
+.ease-btn-group {
+  display: inline-flex;
+}
+
+.ease-btn-group .ease-btn {
+  border-radius: 0;
+}
+
+.ease-btn-group .ease-btn:first-child {
+  border-top-left-radius: var(--ease-radius-md, 0.5rem);
+  border-bottom-left-radius: var(--ease-radius-md, 0.5rem);
+}
+
+.ease-btn-group .ease-btn:last-child {
+  border-top-right-radius: var(--ease-radius-md, 0.5rem);
+  border-bottom-right-radius: var(--ease-radius-md, 0.5rem);
+}
+
+.ease-btn-group .ease-btn:focus-visible {
+  z-index: 1;
+}
+
+.ease-btn-group .ease-btn:not(:last-child) {
+  border-right-width: 1px;
+  border-right-color: color-mix(in srgb, currentColor 30%, transparent);
+}
+
+/* ── Responsive ─────────────────────────────────────────────── */
+@media (max-width: 480px) {
+  .ease-btn {
+    max-width: 100%;
+    white-space: normal;
+    text-align: center;
+  }
+
+  .ease-btn-group {
+    display: flex;
+    flex-wrap: wrap;
+  }
+}
+
+/* ── Accessibility: Reduced Motion ──────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn,
+  .ease-btn-hover,
+  .ease-btn-loading::after {
+    transition: none !important;
+    animation: none !important;
+  }
+
+  .ease-btn:active,
+  .ease-btn-hover:hover {
+    transform: none !important;
+  }
+}
+/* NOTE: No stray } here — this is the corrected version fixing Issue #11738 */
+
+/* ── Demo page styles ────────────────────────────────────────── */
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  margin: 0;
+  padding: 2rem;
+}
+
+.demo-wrapper {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: #475569;
+  margin-bottom: 2rem;
+}
+
+.section {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.section h2 {
+  font-size: 1rem;
+  margin: 0 0 1rem;
+  color: #334155;
+}
+
+.btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn-row--align-center {
+  align-items: center;
+}
+
+.code-block {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.fix-note {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  background: #fef9c3;
+  border-left: 4px solid #eab308;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
## Pull Request Description

This PR provides a submission that reproduces and demonstrates the stray unmatched `}` at line 330 of `components/buttons.css` (Issue #11738), and supplies a corrected clean reference CSS for the maintainer to use when applying the fix.

Closes #11738

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/fix-buttons-stray-brace-ag/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Bug Description

**Root Cause:**

`components/buttons.css` ends with a stray, unmatched closing brace `}` at line 330:

```css
@media (prefers-reduced-motion: reduce) {
  ...
}     ← line 329: correct close for @media block
}     ← line 330: ORPHAN brace — no matching opening {
```

**Impact:**
- Stylelint reports `Unexpected closing brace (CssSyntaxError)` — breaking CI validation
- CSS bundlers/minifiers can silently misparse the file when concatenated into `easemotion.min.css`
- Invalid per the CSS specification

**Fix for Maintainer:**

Apply this 1-line change to `components/buttons.css`:

```diff
 }
-}
```

---

## What This Submission Provides

- `style.css`: A corrected, complete button CSS with **no stray brace** — usable as a clean reference
- `demo.html`: Shows all button variants (primary, success, danger, outline, ghost, link, sizes, states, group) rendering correctly with the corrected CSS
- `README.md`: Documents the bug, fix, and references Issue #11738

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The actual 1-line fix must be applied to `components/buttons.css` directly (remove line 330). This submission is the compliant bug-reproduction + clean-reference per the contribution model. Running `npx stylelint components/buttons.css` before the fix will confirm the error.