### PR TITLE
feat: add ease-text-gradient-scroll scroll-driven gradient demo

### DIFF
--- a/submissions/examples/text-gradient-scroll-demo/README.md
+++ b/submissions/examples/text-gradient-scroll-demo/README.md
@@ -1,0 +1,45 @@
+# ease-text-gradient-scroll — Scroll-Driven Text Gradient Demo
+
+A text gradient effect where the gradient position is tied to scroll progress instead of time, using the CSS Scroll-Driven Animations spec (`animation-timeline: view()`). `core/utilities.css` already has `.ease-gradient-text` (static) and `.ease-gradient-text-animated` (time-based, infinite loop), but neither ties gradient motion to scroll position.
+
+## How it works
+
+```css
+.ease-text-gradient-scroll {
+  background: linear-gradient(135deg, var(--ease-color-primary), var(--ease-color-secondary));
+  background-size: 200% 200%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+@supports (animation-timeline: view()) {
+  .ease-text-gradient-scroll {
+    animation: ease-kf-gradient-scroll linear both;
+    animation-timeline: view();
+    animation-range: entry 0% cover 50%;
+  }
+}
+```
+
+## Usage
+
+```html
+<h1 class="ease-text-gradient-scroll">Scroll-tied gradient heading</h1>
+```
+
+No JavaScript, no `IntersectionObserver`, no scroll event listeners — the browser drives the animation directly off scroll position.
+
+## Browser support
+
+| Browser | Behavior |
+|---------|----------|
+| Chrome / Edge 115+ | Full scroll-driven gradient animation |
+| Firefox, Safari | Falls back to the static `.ease-gradient-text` look via `@supports` — no broken or jumpy output |
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS already has static and time-based gradient text utilities, but no scroll-position-driven variant. This demo extends the existing `-webkit-background-clip: text` pattern used in `.ease-gradient-text`/`.ease-shimmer-text` with modern scroll-driven animations, with a safe fallback for unsupported browsers.
+
+Closes #11299

--- a/submissions/examples/text-gradient-scroll-demo/demo.html
+++ b/submissions/examples/text-gradient-scroll-demo/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text Gradient Scroll Demo — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 2rem;
+      line-height: 1.6;
+    }
+    .spacer { height: 60vh; }
+    .gradient-heading {
+      font-size: 2.5rem;
+      font-weight: 800;
+      line-height: 1.3;
+      margin: 0;
+    }
+    section { margin-bottom: 2rem; }
+    .filler { color: var(--ease-color-muted); font-size: 0.9375rem; line-height: 1.7; max-width: 600px; }
+  </style>
+</head>
+<body>
+  <h2>Scroll-Driven Text Gradient Demo</h2>
+  <p class="intro">
+    The headings below animate their gradient position as they scroll through
+    the viewport, using <code>animation-timeline: view()</code>. Scroll down
+    slowly to see each heading's gradient shift from left to right as it
+    enters and crosses the viewport.
+  </p>
+
+  <div class="info">
+    💡 <strong>Browser support:</strong> Chrome/Edge 115+ animate via scroll position.
+    Firefox and Safari fall back to the existing static <code>.ease-gradient-text</code>
+    look — no broken or jumpy behavior, just no scroll-tied motion.
+  </div>
+
+  <div class="spacer"></div>
+
+  <section>
+    <h1 class="gradient-heading ease-text-gradient-scroll">Scroll to reveal</h1>
+    <p class="filler">This heading's gradient shifts as it scrolls through the viewport. Keep scrolling to see the next one.</p>
+  </section>
+
+  <div class="spacer"></div>
+
+  <section>
+    <h1 class="gradient-heading ease-text-gradient-scroll">Gradient follows scroll</h1>
+    <p class="filler">Each heading is independently tied to its own position in the viewport via animation-timeline: view().</p>
+  </section>
+
+  <div class="spacer"></div>
+
+  <section>
+    <h1 class="gradient-heading ease-text-gradient-scroll">No JavaScript required</h1>
+    <p class="filler">This entire effect is pure CSS — no IntersectionObserver, no scroll event listeners.</p>
+  </section>
+
+  <div class="spacer"></div>
+</body>
+</html>

--- a/submissions/examples/text-gradient-scroll-demo/style.css
+++ b/submissions/examples/text-gradient-scroll-demo/style.css
@@ -1,0 +1,45 @@
+/* ============================================================
+   ease-text-gradient-scroll — scroll-driven text gradient demo
+
+   core/utilities.css already has .ease-gradient-text (static) and
+   .ease-gradient-text-animated (time-based, infinite loop). Neither
+   ties the gradient progress to scroll position. This demo uses the
+   CSS Scroll-Driven Animations spec (animation-timeline: view()) to
+   drive the gradient based on how far the element has scrolled
+   through the viewport, with a graceful fallback to the existing
+   static .ease-gradient-text look in unsupported browsers.
+
+   Browser support: Chrome/Edge 115+. Firefox and Safari fall back
+   to the static gradient via @supports.
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  .ease-text-gradient-scroll {
+    background: linear-gradient(135deg, var(--ease-color-primary), var(--ease-color-secondary));
+    background-size: 200% 200%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+  }
+
+  /* Scroll-driven progression where supported */
+  @supports (animation-timeline: view()) {
+    .ease-text-gradient-scroll {
+      animation: ease-kf-gradient-scroll linear both;
+      animation-timeline: view();
+      animation-range: entry 0% cover 50%;
+    }
+  }
+
+  @keyframes ease-kf-gradient-scroll {
+    from {
+      background-position: 0% 50%;
+    }
+    to {
+      background-position: 100% 50%;
+    }
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds a text gradient effect where gradient position is tied to scroll progress instead of time, using `animation-timeline: view()` from the CSS Scroll-Driven Animations spec. `core/utilities.css` already ships `.ease-gradient-text` (static) and `.ease-gradient-text-animated` (time-based, infinite loop), but neither ties gradient motion to scroll position.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `.ease-text-gradient-scroll` class that animates gradient position based on how far the element has scrolled through the viewport — no JavaScript, no `IntersectionObserver`, no scroll listeners.

**How does a developer use it?**
```html
<h1 class="ease-text-gradient-scroll">Scroll-tied gradient heading</h1>
```

**Why does it fit EaseMotion CSS?**
Reuses the existing `-webkit-background-clip: text` pattern from `.ease-gradient-text`/`.ease-shimmer-text`, extending it with modern scroll-driven animation while falling back gracefully where unsupported.

---

## Demo
- [x] Demo added (`demo.html` — 3 scroll-tied gradient headings with spacer sections to demonstrate the scroll effect)

---

## Browser Testing
- [x] Chrome (scroll-driven animation works)
- [x] Edge (scroll-driven animation works)
- [x] Firefox (falls back to static gradient via @supports)
- [ ] Safari (falls back to static gradient via @supports)

---

## Notes for Maintainer
`animation-timeline: view()` is currently Chrome/Edge 115+ only. The `@supports` fallback ensures Firefox/Safari users see the existing static gradient look with zero breakage — no flash of unstyled content or jumpy behavior.

Closes #11299