### PR TITLE
feat: add ease-count-up-scroll pure-CSS scroll-triggered counter demo

### DIFF
--- a/submissions/examples/scroll-triggered-counter-demo/README.md
+++ b/submissions/examples/scroll-triggered-counter-demo/README.md
@@ -1,0 +1,45 @@
+# ease-count-up-scroll — Scroll-Triggered Counter Demo (Pure CSS)
+
+A counter that animates from 0 to a target value only as it scrolls into view — built entirely with CSS Scroll-Driven Animations (`animation-timeline: view()`), with no JavaScript at all.
+
+## Why this differs from the existing `scroll-triggered-counter` submission
+
+That submission uses `IntersectionObserver` + `requestAnimationFrame` in vanilla JS. This one reuses the `@property --ease-count` and `ease-kf-count-up` keyframe already defined in `core/animations.css` for `.ease-count-up`, but swaps the animation's timeline from the default document timeline to `view()`, so the existing count-up infrastructure becomes scroll-triggered for free.
+
+## How it works
+
+```css
+.ease-count-up-scroll {
+  counter-reset: n var(--ease-count);
+  animation: ease-kf-count-up var(--ease-speed-slow, 600ms) var(--ease-ease) both;
+}
+.ease-count-up-scroll::after {
+  content: counter(n);
+}
+
+@supports (animation-timeline: view()) {
+  .ease-count-up-scroll {
+    animation-timeline: view();
+    animation-range: entry 0% cover 40%;
+  }
+}
+```
+
+## Usage
+
+```html
+<span class="ease-count-up-scroll" style="--ease-count-target: 1500;">0</span>
+```
+
+## Browser support
+
+| Browser | Behavior |
+|---------|----------|
+| Chrome / Edge 115+ | Counts up as the element scrolls into view |
+| Firefox, Safari | Falls back to the existing `.ease-count-up` on-load behavior — still animates, just on page load |
+
+## Why it fits EaseMotion CSS
+
+`core/animations.css` already ships the `@property --ease-count` integer and `ease-kf-count-up` keyframe used by `.ease-count-up`. This demo extends that exact infrastructure with a scroll-driven timeline instead of duplicating counter logic in JavaScript, staying consistent with the framework's CSS-first philosophy.
+
+Closes #11295

--- a/submissions/examples/scroll-triggered-counter-demo/demo.html
+++ b/submissions/examples/scroll-triggered-counter-demo/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll-Triggered Counter Demo (Pure CSS) — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 2rem;
+      line-height: 1.6;
+    }
+    .spacer { height: 60vh; }
+    .stat-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1.5rem;
+      text-align: center;
+    }
+    .stat-card {
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-6);
+    }
+    .stat-number {
+      font-size: 2.5rem;
+      font-weight: 800;
+      color: var(--ease-color-primary);
+      display: block;
+    }
+    .stat-label {
+      font-size: 0.875rem;
+      color: var(--ease-color-muted);
+      margin-top: 0.5rem;
+    }
+    @media (max-width: 600px) { .stat-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h2>Scroll-Triggered Counter Demo (Pure CSS)</h2>
+  <p class="intro">
+    Numbers count up from 0 to their target value only as they scroll into
+    view, using <code>animation-timeline: view()</code> — no JavaScript,
+    no IntersectionObserver. Scroll down to see the stats animate.
+  </p>
+
+  <div class="info">
+    💡 <strong>Browser support:</strong> Chrome/Edge 115+ trigger the count-up
+    on scroll. Firefox/Safari fall back to the existing <code>.ease-count-up</code>
+    on-load behavior from <code>core/animations.css</code> — numbers still animate,
+    just on page load instead of on scroll.
+  </div>
+
+  <div class="spacer"></div>
+
+  <div class="stat-grid">
+    <div class="stat-card">
+      <span class="stat-number ease-count-up-scroll" style="--ease-count-target: 1500;">0</span>
+      <div class="stat-label">Happy Customers</div>
+    </div>
+    <div class="stat-card">
+      <span class="stat-number ease-count-up-scroll" style="--ease-count-target: 42;">0</span>
+      <div class="stat-label">Countries Served</div>
+    </div>
+    <div class="stat-card">
+      <span class="stat-number ease-count-up-scroll" style="--ease-count-target: 99;">0</span>
+      <div class="stat-label">% Uptime</div>
+    </div>
+  </div>
+
+  <div class="spacer"></div>
+</body>
+</html>

--- a/submissions/examples/scroll-triggered-counter-demo/style.css
+++ b/submissions/examples/scroll-triggered-counter-demo/style.css
@@ -1,0 +1,37 @@
+/* ============================================================
+   ease-count-up-scroll — scroll-triggered counter demo (pure CSS)
+
+   core/animations.css already has --ease-count (a @property
+   integer) and .ease-count-up, which animates from 0 to a target
+   value once on load using the default document timeline. There's
+   no way to delay that animation until the counter scrolls into
+   view without JavaScript.
+
+   This demo reuses the existing @property --ease-count and
+   ease-kf-count-up keyframe from core/animations.css, but swaps
+   the animation-timeline to view() so the count-up only plays as
+   the element enters the viewport. No IntersectionObserver, no
+   requestAnimationFrame, no JS at all.
+
+   Browser support: Chrome/Edge 115+. Falls back to the existing
+   on-load .ease-count-up behavior in Firefox/Safari via @supports.
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  .ease-count-up-scroll {
+    counter-reset: n var(--ease-count);
+    animation: ease-kf-count-up var(--ease-speed-slow, 600ms) var(--ease-ease) both;
+  }
+  .ease-count-up-scroll::after {
+    content: counter(n);
+  }
+
+  @supports (animation-timeline: view()) {
+    .ease-count-up-scroll {
+      animation-timeline: view();
+      animation-range: entry 0% cover 40%;
+    }
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds a counter that animates from 0 to a target value only as it scrolls into view, built entirely with CSS Scroll-Driven Animations (`animation-timeline: view()`) — no JavaScript at all. Reuses the existing `@property --ease-count` and `ease-kf-count-up` keyframe already defined in `core/animations.css` for `.ease-count-up`.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `.ease-count-up-scroll` class that triggers the existing count-up animation infrastructure off scroll position instead of page load.

**How does a developer use it?**
```html
<span class="ease-count-up-scroll" style="--ease-count-target: 1500;">0</span>
```

**Why does it fit EaseMotion CSS?**
`core/animations.css` already ships `@property --ease-count` and `ease-kf-count-up`. This extends that exact infrastructure with a scroll-driven timeline instead of duplicating counter logic in JavaScript — staying consistent with the framework's CSS-first philosophy.

**Note on the existing `scroll-triggered-counter` submission:** that one uses `IntersectionObserver` + `requestAnimationFrame` in vanilla JS. This is a distinct, pure-CSS approach building directly on `core/animations.css`'s existing counter primitives.

---

## Demo
- [x] Demo added (`demo.html` — 3-stat grid that counts up as it scrolls into view)

---

## Browser Testing
- [x] Chrome (scroll-driven count-up works)
- [x] Edge (scroll-driven count-up works)
- [x] Firefox (falls back to on-load count-up via @supports)
- [ ] Safari (falls back to on-load count-up via @supports)

---

## Notes for Maintainer
`animation-timeline: view()` is currently Chrome/Edge 115+ only. The `@supports` fallback means Firefox/Safari users still get a working count-up animation, just triggered on load instead of on scroll — no breakage.

Closes #11295