### PR TITLE
feat: add container-query-demo with width-aware responsive cards

### DIFF
--- a/submissions/examples/container-query-demo/README.md
+++ b/submissions/examples/container-query-demo/README.md
@@ -1,26 +1,60 @@
-# Container Query Demo
+# Container Query Demo — Width-Aware Responsive Cards
+
+Demonstrates CSS container queries (`@container`) with cards that adapt their internal layout based on their own container's width, not the browser viewport.
 
 ## What does this do?
-Demonstrates CSS container queries where a card adapts its layout based on container width.
+
+Each `.cq-card` establishes its own containment context via `container-type: inline-size` and `container-name: cq-card`. As the container's available width grows, the card progressively switches from a stacked layout to horizontal, then scales up its media size, typography, and padding — all via `@container` queries scoped to that single card's container, completely independent of every other card on the page or the viewport size.
 
 ## How is it used?
-Wrap content in a container with `container-type: inline-size`:
 
-    <div class="cq-container">
-      <div class="cq-card">...</div>
+```html
+<div class="cq-card">
+  <div class="cq-card-inner">
+    <div class="cq-card-media"></div>
+    <div>
+      <h4 class="cq-card-title">Title</h4>
+      <p class="cq-card-desc">Description</p>
     </div>
+  </div>
+</div>
+```
 
-## Why is it useful?
-Enables truly reusable responsive components that adapt to their parent, not the viewport.
+```css
+.cq-card {
+  container-type: inline-size;
+  container-name: cq-card;
+}
+
+@container cq-card (min-width: 280px) {
+  .cq-card-inner { flex-direction: row; }
+}
+
+@container cq-card (min-width: 420px) {
+  .cq-card-media { width: 110px; height: 110px; }
+}
+```
+
+## Why is this useful?
+
+Traditional media queries respond to viewport size, which breaks down for reusable components placed in varying contexts — a sidebar widget, a grid cell, a full-width hero. Container queries let the same card component look correct everywhere it's dropped, based purely on the space actually available to it.
 
 ## Tech Stack
+
 - HTML
-- CSS (container queries)
-- Vanilla JS (resize controls)
+- Plain CSS (container queries) — no EaseMotion utility classes needed beyond design tokens (`--ease-color-*`, `--ease-space-*`, `--ease-radius-*`)
+- No JavaScript
+
+## Accessibility
+
+Includes `@media (prefers-reduced-motion: reduce)` to disable the card's hover shadow transition for users who prefer reduced motion.
 
 ## Preview
-Open demo.html directly in your browser to see the effect.
 
-## Contribution Notes
-- Class naming was handled by the contributor
-- Maintainer will rename to ease-* convention before merging
+Open `demo.html` directly in your browser. Drag the resizable dashed box to see one card adapt live, or view the card grid below it to see the same component at three different container widths simultaneously.
+
+## Why it fits EaseMotion CSS
+
+`core/utilities.css` already applies `container-type`/`container-name` to the global `.ease-container` page wrapper, establishing the pattern. This demo extends that same container-query approach to component-level cards, using the framework's existing design tokens (`--ease-color-*`, `--ease-space-*`, `--ease-radius-*`).
+
+Closes #11307

--- a/submissions/examples/container-query-demo/demo.html
+++ b/submissions/examples/container-query-demo/demo.html
@@ -1,31 +1,106 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Container Query Demo - EaseMotion CSS</title>
-  <link rel="stylesheet" href="../../../core/animations.css">
-  <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Container Query Demo — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 960px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 640px; }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 2rem;
+      line-height: 1.6;
+    }
+    .resize-wrapper {
+      resize: horizontal;
+      overflow: auto;
+      min-width: 220px;
+      max-width: 100%;
+      border: 2px dashed var(--ease-color-neutral-300, #cbd5e1);
+      border-radius: var(--ease-radius-md);
+      padding: 1rem;
+      margin-bottom: 2rem;
+    }
+    .resize-label {
+      font-family: var(--ease-font-mono);
+      font-size: 0.75rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2rem 0 1rem; }
+  </style>
 </head>
 <body>
-  <div class="demo-wrapper">
-    <h1>Container Query Demo</h1>
-    <div class="container-demo">
-      <div class="cq-container">
-        <div class="cq-card">
-          <div class="cq-card-icon">✦</div>
-          <h3>Card Title</h3>
-          <p>This card adapts its layout based on the container width, not the viewport.</p>
+  <h2>Container Query Demo: Width-Aware Cards</h2>
+  <p class="intro">
+    Each card's internal layout (media size, font size, stacked vs horizontal)
+    responds to how much space its own CONTAINER has — not the browser viewport.
+    Drag the bottom-right corner of the dashed box below to resize it and watch
+    a single card adapt without any viewport media query or JavaScript.
+  </p>
+
+  <div class="info">
+    💡 <strong>How it works:</strong> Each <code>.cq-card</code> sets
+    <code>container-type: inline-size</code> and <code>container-name: cq-card</code>.
+    The <code>@container cq-card (min-width: ...)</code> rules in <code>style.css</code>
+    then respond to that single card's own width, independent of every other card
+    on the page or the viewport size.
+  </div>
+
+  <h3>Resize me (drag bottom-right corner)</h3>
+  <div class="resize-wrapper">
+    <span class="resize-label">Drag to resize this box →</span>
+    <div class="cq-card">
+      <div class="cq-card-inner">
+        <div class="cq-card-media"></div>
+        <div>
+          <h4 class="cq-card-title">Adaptive Card</h4>
+          <p class="cq-card-desc">This card switches from a stacked to a horizontal layout once its own container crosses 280px, then grows its media and type past 420px — independent of the page's viewport width.</p>
         </div>
       </div>
-      <div class="cq-controls">
-        <button class="cq-btn" data-size="200">200px</button>
-        <button class="cq-btn" data-size="350">350px</button>
-        <button class="cq-btn" data-size="500">500px</button>
+    </div>
+  </div>
+
+  <h3>Same component, different container widths (no JS, no resizing needed)</h3>
+  <div class="cq-grid">
+    <div class="cq-card">
+      <div class="cq-card-inner">
+        <div class="cq-card-media"></div>
+        <div>
+          <h4 class="cq-card-title">Narrow Slot</h4>
+          <p class="cq-card-desc">Small container — stacked layout.</p>
+        </div>
       </div>
     </div>
-    <p class="description">Resize the container to see the card adapt using CSS container queries.</p>
+    <div class="cq-card" style="grid-column: span 2;">
+      <div class="cq-card-inner">
+        <div class="cq-card-media"></div>
+        <div>
+          <h4 class="cq-card-title">Medium Slot</h4>
+          <p class="cq-card-desc">Wider container — horizontal layout kicks in automatically.</p>
+        </div>
+      </div>
+    </div>
+    <div class="cq-card" style="grid-column: 1 / -1;">
+      <div class="cq-card-inner">
+        <div class="cq-card-media"></div>
+        <div>
+          <h4 class="cq-card-title">Full-Width Slot</h4>
+          <p class="cq-card-desc">Widest container — largest media, biggest type, roomiest padding. Same exact markup and CSS as every other card on this page; only the available container width differs.</p>
+        </div>
+      </div>
+    </div>
   </div>
-  <script src="script.js"></script>
 </body>
 </html>

--- a/submissions/examples/container-query-demo/style.css
+++ b/submissions/examples/container-query-demo/style.css
@@ -1,121 +1,98 @@
-body {
-  font-family: sans-serif;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 100vh;
-  margin: 0;
-  background: #0f0f0f;
-  color: white;
-}
+/* ============================================================
+   Container Query Demo — responsive cards that adapt to
+   container width, not viewport width (#11307)
 
-.demo-wrapper {
-  text-align: center;
-}
+   core/utilities.css already sets container-type/container-name
+   on the global .ease-container class (page-level container).
+   This demo defines its own scoped container so it doesn't
+   collide with that global container-name, and demonstrates
+   cards that change their internal layout based on how much
+   space their PARENT has, regardless of viewport size.
+   ============================================================ */
 
-.container-demo {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2rem;
-  margin: 2rem 0;
-}
-
-.cq-container {
-  container-type: inline-size;
-  width: 500px;
-  max-width: 100%;
-  transition: width 0.4s ease;
+.cq-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1.5rem;
 }
 
 .cq-card {
-  background: #1a1a2e;
-  border-radius: 12px;
-  padding: 1.5rem;
-  border: 1px solid #333;
-  transition: background 0.3s, border-color 0.3s;
+  container-type: inline-size;
+  container-name: cq-card;
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-neutral-200);
+  border-radius: var(--ease-radius-lg);
+  overflow: hidden;
+  transition: box-shadow 200ms var(--ease-ease, ease);
 }
 
-.cq-card-icon {
-  font-size: 2rem;
-  margin-bottom: 0.5rem;
+.cq-card-inner {
+  display: flex;
+  flex-direction: column;
+  padding: var(--ease-space-4);
 }
 
-.cq-card h3 {
-  margin: 0 0 0.5rem;
-  color: #fff;
+.cq-card-media {
+  width: 100%;
+  height: 90px;
+  border-radius: var(--ease-radius-md);
+  background: linear-gradient(135deg, var(--ease-color-primary), var(--ease-color-secondary));
+  flex-shrink: 0;
+  margin-bottom: var(--ease-space-3);
 }
 
-.cq-card p {
+.cq-card-title {
+  font-weight: 700;
+  font-size: 1rem;
+  margin: 0 0 0.25rem;
+}
+
+.cq-card-desc {
+  font-size: 0.8125rem;
+  color: var(--ease-color-muted);
   margin: 0;
-  color: #888;
   line-height: 1.5;
 }
 
-@container (max-width: 300px) {
-  .cq-card {
-    background: #16213e;
-    border-color: #6366f1;
-    text-align: center;
-  }
-  .cq-card p {
-    font-size: 0.85rem;
-  }
-}
+/* Narrow container: stacked layout, small media (default above) */
 
-@container (min-width: 301px) and (max-width: 450px) {
-  .cq-card {
-    background: #1a1a2e;
-    display: flex;
-    gap: 1rem;
-    align-items: flex-start;
-  }
-  .cq-card-icon {
-    font-size: 2.5rem;
-    min-width: 40px;
-  }
-}
-
-@container (min-width: 451px) {
-  .cq-card {
-    background: #0f3460;
-    border-color: #10b981;
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 1rem;
+/* Medium container: switch to a horizontal layout */
+@container cq-card (min-width: 280px) {
+  .cq-card-inner {
+    flex-direction: row;
     align-items: center;
+    gap: var(--ease-space-4);
   }
-  .cq-card-icon {
-    font-size: 3rem;
-    grid-row: span 2;
+  .cq-card-media {
+    width: 80px;
+    height: 80px;
+    margin-bottom: 0;
   }
-  .cq-card p {
-    grid-column: 2;
+  .cq-card-title {
+    font-size: 1.0625rem;
   }
 }
 
-.cq-controls {
-  display: flex;
-  gap: 0.75rem;
+/* Wide container: larger media, bigger type, richer spacing */
+@container cq-card (min-width: 420px) {
+  .cq-card-media {
+    width: 110px;
+    height: 110px;
+  }
+  .cq-card-title {
+    font-size: 1.25rem;
+  }
+  .cq-card-desc {
+    font-size: 0.875rem;
+  }
+  .cq-card-inner {
+    padding: var(--ease-space-5);
+  }
 }
 
-.cq-btn {
-  padding: 0.5rem 1.25rem;
-  border: 1px solid #333;
-  background: #1a1a2e;
-  color: white;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: border-color 0.2s, background 0.2s;
-}
-
-.cq-btn:hover {
-  border-color: #6366f1;
-  background: #16213e;
-}
-
+/* Respect reduced motion preference */
 @media (prefers-reduced-motion: reduce) {
-  .cq-container {
+  .cq-card {
     transition: none;
   }
 }


### PR DESCRIPTION
## Pull Request Description
Demonstrates CSS container queries (`@container`) with cards that adapt their internal layout based on their own container's width rather than the browser viewport — addressing the requested "responsive cards that adapt to container width" demo.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/container-query-demo/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — plain CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
- [x] Vanilla JS only (none needed here — pure CSS)
- [x] Includes `@media (prefers-reduced-motion: reduce)`

---

## Feature Description

**What does this add?**

Cards that switch from a stacked to horizontal layout, then scale up media/type/padding, purely based on their own container's width via `@container cq-card (min-width: ...)` queries.

**How does a developer use it?**
```html
<div class="cq-card">
  <div class="cq-card-inner">
    <div class="cq-card-media"></div>
    <div><h4 class="cq-card-title">Title</h4><p class="cq-card-desc">Description</p></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
`core/utilities.css` already applies `container-type`/`container-name` to the global `.ease-container` page wrapper. This extends that same pattern to component-level cards, using the framework's existing design tokens.

---

## Demo
- [x] Demo added (`demo.html` — a live-resizable card to drag and observe adaptation, plus a 3-card grid showing narrow/medium/full container widths side by side)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari (container queries supported since Safari 16)

---

## Notes for Maintainer
Each card's `container-name: cq-card` is scoped independently from the existing global `--ease-container` name, so this won't collide with the page-level container query setup already in `core/utilities.css`.

Closes #11307