### PR TITLE
feat: add pure-CSS scroll-animated timeline demo

### DIFF
--- a/submissions/examples/scroll-animated-timeline-demo/README.md
+++ b/submissions/examples/scroll-animated-timeline-demo/README.md
@@ -1,0 +1,52 @@
+# Scroll-Animated Timeline (Pure CSS)
+
+A vertical timeline where each entry slides in and fades up as it scrolls into view — built entirely with CSS Scroll-Driven Animations (`animation-timeline: view()`), with zero JavaScript.
+
+## How this differs from the existing `scroll-animated-timeline` submission
+
+That submission uses `IntersectionObserver` in `script.js` to toggle a reveal class on each timeline item as it enters the viewport. This demo achieves the identical visual effect with no JavaScript at all, using the same `@supports (animation-timeline: view())` pattern already established for `.ease-reveal` in `core/animations.css`.
+
+## How it works
+
+```css
+@supports (animation-timeline: view()) {
+  .cq-timeline-item {
+    opacity: 0;
+    transform: translateX(-24px);
+    animation: ease-kf-timeline-reveal 600ms var(--ease-ease, ease) both;
+    animation-timeline: view();
+    animation-range: entry 0% cover 30%;
+  }
+}
+```
+
+In unsupported browsers, the `@supports` guard simply never applies, leaving items visible and in place by default — a safe, static fallback rather than a broken empty page.
+
+## Usage
+
+```html
+<div class="cq-timeline">
+  <div class="cq-timeline-item">
+    <span class="cq-timeline-date">2024</span>
+    <h4 class="cq-timeline-title">Milestone</h4>
+    <p class="cq-timeline-desc">Description</p>
+  </div>
+</div>
+```
+
+## Browser support
+
+| Browser | Behavior |
+|---------|----------|
+| Chrome / Edge 115+ | Items slide/fade in as they scroll into view |
+| Firefox, Safari | Static, always-visible timeline (no animation, no breakage) |
+
+## Accessibility
+
+Includes `@media (prefers-reduced-motion: reduce)` to force all items to their final visible state immediately, disabling the reveal animation entirely.
+
+## Why it fits EaseMotion CSS
+
+Reuses the exact `@supports (animation-timeline: view())` + `ease-kf-` keyframe pattern already established in `core/animations.css` for `.ease-reveal`, applying it to a timeline component instead of duplicating reveal logic in JavaScript — consistent with the framework's CSS-first, progressive-enhancement philosophy.
+
+Closes #11306

--- a/submissions/examples/scroll-animated-timeline-demo/demo.html
+++ b/submissions/examples/scroll-animated-timeline-demo/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll-Animated Timeline (Pure CSS) — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 700px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 600px; }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    .spacer { height: 40vh; }
+  </style>
+</head>
+<body>
+  <h2>Scroll-Animated Timeline (Pure CSS, No JavaScript)</h2>
+  <p class="intro">
+    Each timeline entry slides in and fades up as it scrolls into view,
+    using <code>animation-timeline: view()</code> — zero JavaScript,
+    no IntersectionObserver. Scroll down slowly to see each item reveal.
+  </p>
+
+  <div class="info">
+    💡 <strong>Browser support:</strong> Chrome/Edge 115+ animate the reveal
+    on scroll. Firefox/Safari fall back to a static, always-visible timeline —
+    no broken layout, just no scroll-tied motion.
+  </div>
+
+  <div class="spacer"></div>
+
+  <div class="cq-timeline">
+    <div class="cq-timeline-item">
+      <span class="cq-timeline-date">2024</span>
+      <h4 class="cq-timeline-title">Project Kickoff</h4>
+      <p class="cq-timeline-desc">Initial planning and design system setup.</p>
+    </div>
+    <div class="cq-timeline-item">
+      <span class="cq-timeline-date">2024 Q3</span>
+      <h4 class="cq-timeline-title">First Public Release</h4>
+      <p class="cq-timeline-desc">Shipped v1.0 with core utilities and components.</p>
+    </div>
+    <div class="cq-timeline-item">
+      <span class="cq-timeline-date">2025</span>
+      <h4 class="cq-timeline-title">Community Contributions</h4>
+      <p class="cq-timeline-desc">Opened up submissions/examples for community-built demos.</p>
+    </div>
+    <div class="cq-timeline-item">
+      <span class="cq-timeline-date">Today</span>
+      <h4 class="cq-timeline-title">Scroll-Driven Animations</h4>
+      <p class="cq-timeline-desc">Adopting native CSS scroll-timeline APIs across the framework.</p>
+    </div>
+  </div>
+
+  <div class="spacer"></div>
+</body>
+</html>

--- a/submissions/examples/scroll-animated-timeline-demo/style.css
+++ b/submissions/examples/scroll-animated-timeline-demo/style.css
@@ -1,0 +1,87 @@
+/* ============================================================
+   Scroll-Animated Timeline (Pure CSS) — #11306
+
+   The existing scroll-animated-timeline submission uses
+   IntersectionObserver in JS to fade/slide each item in on scroll.
+   This demo achieves the same effect with zero JavaScript, using
+   animation-timeline: view() per timeline item, consistent with
+   the @supports (animation-timeline: view()) pattern already used
+   for .ease-reveal in core/animations.css.
+
+   Falls back to a static (always-visible) timeline in browsers
+   without scroll-driven animation support.
+   ============================================================ */
+
+.cq-timeline {
+  position: relative;
+  max-width: 600px;
+  margin: 0 auto;
+  padding-left: 2rem;
+  border-left: 2px solid var(--ease-color-neutral-200);
+}
+
+.cq-timeline-item {
+  position: relative;
+  margin-bottom: 2.5rem;
+  opacity: 1;
+  transform: none;
+}
+
+.cq-timeline-item::before {
+  content: "";
+  position: absolute;
+  left: -2.4rem;
+  top: 0.25rem;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--ease-color-primary);
+  border: 3px solid var(--ease-color-bg, #fff);
+  box-shadow: 0 0 0 2px var(--ease-color-primary);
+}
+
+.cq-timeline-date {
+  font-family: var(--ease-font-mono);
+  font-size: 0.75rem;
+  color: var(--ease-color-muted);
+  margin-bottom: 0.25rem;
+  display: block;
+}
+
+.cq-timeline-title {
+  font-weight: 700;
+  font-size: 1.0625rem;
+  margin: 0 0 0.35rem;
+}
+
+.cq-timeline-desc {
+  font-size: 0.875rem;
+  color: var(--ease-color-muted);
+  margin: 0;
+  line-height: 1.6;
+}
+
+@supports (animation-timeline: view()) {
+  .cq-timeline-item {
+    opacity: 0;
+    transform: translateX(-24px);
+    animation: ease-kf-timeline-reveal 600ms var(--ease-ease, ease) both;
+    animation-timeline: view();
+    animation-range: entry 0% cover 30%;
+  }
+}
+
+@keyframes ease-kf-timeline-reveal {
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cq-timeline-item {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a vertical timeline where each entry slides in and fades up as it scrolls into view, using `animation-timeline: view()` — zero JavaScript. Reuses the exact `@supports (animation-timeline: view())` pattern already established for `.ease-reveal` in `core/animations.css`.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/scroll-animated-timeline-demo/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — plain CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
- [x] Includes `@media (prefers-reduced-motion: reduce)`

---

## Feature Description

**What does this add?**

A timeline component where each item animates in based on scroll position, with no JS at all.

**How this differs from the existing `scroll-animated-timeline` submission:** that one uses `IntersectionObserver` in `script.js` to toggle a reveal class. This achieves the identical visual effect with pure CSS, using the framework's already-established scroll-driven animation pattern.

**How does a developer use it?**
```html
<div class="cq-timeline">
  <div class="cq-timeline-item">
    <span class="cq-timeline-date">2024</span>
    <h4 class="cq-timeline-title">Milestone</h4>
    <p class="cq-timeline-desc">Description</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Reuses the exact `@supports (animation-timeline: view())` + `ease-kf-` keyframe pattern already in `core/animations.css` for `.ease-reveal`, consistent with the framework's CSS-first, progressive-enhancement philosophy.

---

## Demo
- [x] Demo added (`demo.html` — 4-entry timeline with spacer sections to demonstrate the scroll reveal)

---

## Browser Testing
- [x] Chrome (scroll-driven reveal works)
- [x] Edge (scroll-driven reveal works)
- [x] Firefox (static fallback, no breakage)
- [x] Safari (static fallback, no breakage)

---

## Notes for Maintainer
`animation-timeline: view()` is currently Chrome/Edge 115+ only. The `@supports` guard ensures Firefox/Safari users see a static, fully-visible timeline with zero broken layout or flash of unstyled content.

Closes #11306