### PR TITLE
feat: add animated gradient border demo using conic-gradient

### DIFF
--- a/submissions/examples/gradient-border-animation/README.md
+++ b/submissions/examples/gradient-border-animation/README.md
@@ -1,0 +1,47 @@
+# Animated Gradient Border
+
+A rotating conic-gradient border applied to a card and a button, using a pseudo-element with `mask-composite: exclude` so only the border ring itself is visible.
+
+## How it works
+
+```css
+.gb-card::before {
+  position: absolute;
+  inset: 0;
+  padding: 3px;
+  background: conic-gradient(from var(--gb-angle, 0deg), ...);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  animation: ease-kf-gradient-border-spin 4s linear infinite;
+}
+```
+
+The `@property --gb-angle` registration lets the conic-gradient's rotation angle animate smoothly via a custom property, rather than jump-cutting between gradient states.
+
+## Usage
+
+```html
+<div class="gb-card">
+  <h4>Title</h4>
+  <p>Content</p>
+</div>
+
+<button class="gb-btn">Button</button>
+```
+
+## Tech Stack
+
+- HTML
+- Plain CSS (conic-gradient, mask-composite, @property)
+- No JavaScript
+
+## Accessibility
+
+Includes `@media (prefers-reduced-motion: reduce)` — the rotating animation stops and the border resolves to a static solid primary color.
+
+## Why it fits EaseMotion CSS
+
+Uses the framework's existing `--ease-color-primary`/`-secondary`/`-success` tokens for the gradient stops and `--ease-radius-*`/`--ease-space-*` for sizing, keeping the effect consistent with the rest of the design system.
+
+Closes #11298

--- a/submissions/examples/gradient-border-animation/demo.html
+++ b/submissions/examples/gradient-border-animation/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Gradient Border — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 700px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 600px; }
+    .demo-row {
+      display: flex;
+      gap: 2rem;
+      align-items: center;
+      flex-wrap: wrap;
+      margin-bottom: 2rem;
+    }
+    .gb-card { width: 220px; }
+    .gb-card h4 { margin: 0 0 0.5rem; }
+    .gb-card p { margin: 0; font-size: 0.875rem; color: var(--ease-color-muted); }
+  </style>
+</head>
+<body>
+  <h2>Animated Gradient Border</h2>
+  <p class="intro">
+    A rotating conic-gradient ring around a card and a button, built with
+    a pseudo-element and <code>mask-composite: exclude</code> so only the
+    border itself is visible.
+  </p>
+
+  <div class="demo-row">
+    <div class="gb-card">
+      <h4>Premium Card</h4>
+      <p>The border continuously rotates through primary, secondary, and success colors.</p>
+    </div>
+    <button class="gb-btn">Animated Border Button</button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gradient-border-animation/style.css
+++ b/submissions/examples/gradient-border-animation/style.css
@@ -1,0 +1,87 @@
+/* ============================================================
+   Animated Gradient Border (#11298)
+
+   A rotating conic-gradient border using a pseudo-element with
+   mask-composite: exclude, so only the border ring itself is
+   visible (the gradient fills a layer behind the card, masked
+   to a ring shape). Applied here to both a card and a button.
+   ============================================================ */
+
+.gb-card {
+  position: relative;
+  background: var(--ease-color-surface);
+  border-radius: var(--ease-radius-lg);
+  padding: var(--ease-space-6);
+  isolation: isolate;
+}
+
+.gb-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 3px;
+  background: conic-gradient(from var(--gb-angle, 0deg),
+    var(--ease-color-primary),
+    var(--ease-color-secondary),
+    var(--ease-color-success),
+    var(--ease-color-primary));
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  animation: ease-kf-gradient-border-spin 4s linear infinite;
+  z-index: -1;
+}
+
+.gb-btn {
+  position: relative;
+  background: var(--ease-color-bg, #fff);
+  color: var(--ease-color-text);
+  border: none;
+  border-radius: var(--ease-radius-md);
+  padding: 0.75rem 1.75rem;
+  font-weight: 600;
+  font-size: 0.9375rem;
+  cursor: pointer;
+  isolation: isolate;
+}
+
+.gb-btn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 2px;
+  background: conic-gradient(from var(--gb-angle, 0deg),
+    var(--ease-color-secondary),
+    var(--ease-color-primary),
+    var(--ease-color-secondary));
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  animation: ease-kf-gradient-border-spin 3s linear infinite;
+  z-index: -1;
+}
+
+@property --gb-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@keyframes ease-kf-gradient-border-spin {
+  from { --gb-angle: 0deg; }
+  to   { --gb-angle: 360deg; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gb-card::before,
+  .gb-btn::before {
+    animation: none;
+    background: var(--ease-color-primary);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a rotating conic-gradient border applied to both a card and a button, using a pseudo-element with `mask-composite: exclude` so only the border ring itself is visible.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/gradient-border-animation/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — plain CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
- [x] Vanilla JS only (none needed — pure CSS)
- [x] Includes `@media (prefers-reduced-motion: reduce)`

---

## Feature Description

**What does this add?**

A `.gb-card` and `.gb-btn` with a continuously rotating conic-gradient border ring.

**How does a developer use it?**
```html
<div class="gb-card"><h4>Title</h4><p>Content</p></div>
<button class="gb-btn">Button</button>
```

**Why does it fit EaseMotion CSS?**
Uses the framework's existing `--ease-color-primary`/`-secondary`/`-success` tokens for gradient stops and `--ease-radius-*`/`--ease-space-*` for sizing, keeping the effect consistent with the rest of the design system.

---

## Demo
- [x] Demo added (`demo.html` — a card and a button side by side, both with the animated gradient border)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer
`@property --gb-angle` registers the rotation angle as an animatable custom property so the conic-gradient rotates smoothly rather than jump-cutting. `prefers-reduced-motion` stops the animation and falls back to a static solid-color border.

Closes #11298