### PR TITLE
feat: add entrance fade-up animation with stagger delays

### DIFF
--- a/submissions/examples/entrance-fade-up-reveal/README.md
+++ b/submissions/examples/entrance-fade-up-reveal/README.md
@@ -1,0 +1,41 @@
+# Entrance Fade-Up Animation
+
+An entrance animation that fades elements in while sliding them up slightly — combining opacity and `translateY` into a single class, with stagger-delay helpers for sequencing multiple elements.
+
+## How this differs from existing fade animations
+
+`core/animations.css` already has `.ease-fade-in` (opacity-only, no vertical motion). This adds vertical motion to create a more dynamic entrance effect, plus 5 stagger-delay utility classes that the existing fade-in doesn't provide.
+
+## Classes
+
+| Class | Effect |
+|-------|--------|
+| `.ease-fade-up` | Fades in + slides up 20px on entrance |
+| `.ease-fade-up-delay-1` to `-5` | Adds 0.1s-0.5s animation-delay for staggering |
+
+## Usage
+
+```html
+<div class="card ease-fade-up">First</div>
+<div class="card ease-fade-up ease-fade-up-delay-1">Second</div>
+<div class="card ease-fade-up ease-fade-up-delay-2">Third</div>
+```
+
+## Why is this useful?
+
+A common pattern for landing page sections, card grids, and list items appearing on page load — staggering each one slightly creates a more polished, sequential reveal instead of everything appearing at once.
+
+## Tech Stack
+
+- HTML
+- CSS only — no JavaScript
+
+## Accessibility
+
+Includes `@media (prefers-reduced-motion: reduce)`, disabling the animation entirely and snapping elements straight to their final visible state.
+
+## Why it fits EaseMotion CSS
+
+Follows the existing `ease-kf-` keyframe naming convention and `var(--ease-speed-*)`/`var(--ease-ease)` timing tokens used throughout `core/animations.css`, and mirrors the stagger-delay pattern already established for `.ease-reveal-delay-N`.
+
+Closes #11689

--- a/submissions/examples/entrance-fade-up-reveal/demo.html
+++ b/submissions/examples/entrance-fade-up-reveal/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Entrance Fade-Up Animation — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 700px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 600px; }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1rem;
+    }
+    .demo-card {
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-5);
+      text-align: center;
+      font-weight: 600;
+    }
+    @media (max-width: 600px) { .card-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h2>Entrance Fade-Up Animation</h2>
+  <p class="intro">
+    Elements fade in while sliding up slightly on page load — a common
+    entrance animation for cards, sections, or list items. Reload the
+    page to replay the effect.
+  </p>
+
+  <div class="info">
+    💡 <strong>Note:</strong> Combines opacity + translateY into a single
+    entrance class, with 5 stagger-delay helpers to sequence multiple
+    elements one after another.
+  </div>
+
+  <div class="card-grid">
+    <div class="demo-card ease-fade-up">Card 1</div>
+    <div class="demo-card ease-fade-up ease-fade-up-delay-1">Card 2</div>
+    <div class="demo-card ease-fade-up ease-fade-up-delay-2">Card 3</div>
+    <div class="demo-card ease-fade-up ease-fade-up-delay-3">Card 4</div>
+    <div class="demo-card ease-fade-up ease-fade-up-delay-4">Card 5</div>
+    <div class="demo-card ease-fade-up ease-fade-up-delay-5">Card 6</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/entrance-fade-up-reveal/style.css
+++ b/submissions/examples/entrance-fade-up-reveal/style.css
@@ -1,0 +1,45 @@
+/* ============================================================
+   Entrance Fade-Up Animation (#11689)
+
+   Elements fade in while sliding up slightly, intended as an
+   entrance/mount animation for cards, list items, or sections
+   appearing on page load. Distinct from core/animations.css's
+   .ease-fade-in (opacity only, no vertical motion) and
+   .ease-slide-in-from-bottom (no fade component) — this combines
+   both into a single entrance effect, plus staggered delay helpers
+   for sequencing multiple elements.
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  .ease-fade-up {
+    animation: ease-kf-fade-up var(--ease-speed-medium, 400ms) var(--ease-ease, ease) both;
+  }
+
+  @keyframes ease-kf-fade-up {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* Stagger delay helpers for sequencing multiple fade-up elements */
+  .ease-fade-up-delay-1 { animation-delay: 0.1s; }
+  .ease-fade-up-delay-2 { animation-delay: 0.2s; }
+  .ease-fade-up-delay-3 { animation-delay: 0.3s; }
+  .ease-fade-up-delay-4 { animation-delay: 0.4s; }
+  .ease-fade-up-delay-5 { animation-delay: 0.5s; }
+
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-fade-up {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds `.ease-fade-up`, an entrance animation combining opacity and `translateY` into a single fade-up effect, plus 5 stagger-delay helper classes for sequencing multiple elements on page load.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/entrance-fade-up-reveal/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
- [x] Includes `@media (prefers-reduced-motion: reduce)`

---

## Feature Description

**What does this add?**

| Class | Effect |
|-------|--------|
| `.ease-fade-up` | Fades in + slides up 20px on entrance |
| `.ease-fade-up-delay-1` to `-5` | 0.1s-0.5s animation-delay for staggering |

**How does a developer use it?**
```html
<div class="card ease-fade-up">First</div>
<div class="card ease-fade-up ease-fade-up-delay-1">Second</div>
```

**Why does it fit EaseMotion CSS?**
`core/animations.css` already has `.ease-fade-in` (opacity-only, no vertical motion). This adds vertical motion for a more dynamic entrance, and mirrors the existing `.ease-reveal-delay-N` stagger pattern, which `.ease-fade-in` doesn't have.

---

## Demo
- [x] Demo added (`demo.html` — 6-card grid staggering in on page load, reload to replay)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer
Naming and timing tokens (`ease-kf-`, `var(--ease-speed-*)`, `var(--ease-ease)`) follow the existing conventions in `core/animations.css`. Note: the originally requested folder name `entrance-fade-up-animation` (and its sibling `entrance-fade-up-effect`) already contain an unrelated "Event-Driven Architecture Visualization" submission from a prior merge — used `entrance-fade-up-reveal` instead to avoid colliding with that existing content.

Closes #11689