### PR TITLE
fix: document global prefers-reduced-motion catch-all for core/base.css

### DIFF
--- a/submissions/examples/prefers-reduced-motion-audit/README.md
+++ b/submissions/examples/prefers-reduced-motion-audit/README.md
@@ -1,0 +1,55 @@
+# Fix: Fragmented `prefers-reduced-motion` Implementation (#1714)
+
+## The Bug
+
+`core/base.css` only disables `scroll-behavior` under `prefers-reduced-motion: reduce`:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+```
+
+There is no global animation/transition kill-switch. This means every component file has to remember to add its own `@media (prefers-reduced-motion: reduce)` guard individually. An audit of `components/*.css` found 9 files that do this correctly, and 17 that animate or transition something with **zero** reduced-motion handling at all:
+
+`announce-bar.css`, `avatar.css`, `badges.css`, `breadcrumb.css`, `compare-table.css`, `connection-status.css`, `fab.css`, `loaders.css`, `navbar.css`, `pagination.css`, `password-strength.css`, `progress.css`, `read-more.css`, `skeleton.css`, `tabs.css`, `toast.css`, `view-transitions.css`
+
+## Why this is a submissions/ entry, not a core/ edit
+
+Per `CONTRIBUTING.md` and the repo's submission validator, contributors may only modify files inside `submissions/`. This folder demonstrates the bug and the highest-leverage fix in isolation, for a maintainer to apply to `core/base.css`.
+
+## The Fix
+
+Rather than patching all 17 files individually (which would also leave any future component file unprotected by default), add one global catch-all rule to the existing `@media (prefers-reduced-motion: reduce)` block in `core/base.css`:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+This is the same pattern used by most modern CSS resets (e.g. `sanitize.css`, the classic CSS-Tricks reduced-motion snippet): rather than removing the animation/transition declaration entirely, it collapses the duration to effectively zero, so the end state still applies instantly without a visible motion effect. This protects every existing component automatically, and any future component file by default — without requiring every contributor to remember to add their own guard.
+
+## Demo
+
+`demo.html` shows a spinner with no guard today (always animates), plus a simulated toggle showing the same spinner with the global patch's effect applied.
+
+## Files
+
+- `style.css` — the exact CSS snippet to add to `core/base.css`, plus demo-only scoping classes
+- `demo.html` — before/after comparison, the full list of 17 affected files, and the patch snippet
+- `README.md` — this file
+
+Closes #1714

--- a/submissions/examples/prefers-reduced-motion-audit/demo.html
+++ b/submissions/examples/prefers-reduced-motion-audit/demo.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Fragmented prefers-reduced-motion — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 640px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2rem 0 1rem; }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    .pram-row {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-5);
+      margin-bottom: 1rem;
+    }
+    .pram-spin {
+      width: 40px;
+      height: 40px;
+      border: 4px solid var(--ease-color-neutral-200);
+      border-top-color: var(--ease-color-primary);
+      border-radius: 50%;
+    }
+    .pram-toggle-btn {
+      margin-left: auto;
+      background: var(--ease-color-primary);
+      color: #fff;
+      border: none;
+      border-radius: var(--ease-radius-md);
+      padding: 0.5rem 1rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--ease-color-neutral-200); }
+    code.inline { font-family: var(--ease-font-mono); background: var(--ease-color-neutral-100); padding: 0.1rem 0.35rem; border-radius: 0.25rem; }
+  </style>
+</head>
+<body>
+  <h2>Fix: Fragmented <code class="inline">prefers-reduced-motion</code> Implementation</h2>
+  <p class="intro">
+    <code class="inline">core/base.css</code> only disables <code class="inline">scroll-behavior</code>
+    under <code class="inline">prefers-reduced-motion: reduce</code> — there's no global
+    animation/transition kill-switch. An audit found 17 component files animating or
+    transitioning something with zero reduced-motion guard at all.
+  </p>
+
+  <div class="info">
+    💡 <strong>Why this matters:</strong> Today, whether a spinning loader or sliding tab
+    respects reduced-motion depends entirely on whether that specific component file
+    remembered to add its own <code class="inline">@media</code> block. A single global
+    catch-all rule in <code class="inline">core/base.css</code> would protect every current
+    and future component automatically.
+  </div>
+
+  <h3>Before (no global guard — spinner always animates)</h3>
+  <div class="pram-row pram-demo-before">
+    <div class="pram-spin"></div>
+    <span>This spinner ignores reduced-motion preference entirely today, since this exact animation lives in a component with no guard.</span>
+  </div>
+
+  <h3>After (patch applied — toggle "simulated reduced motion" below)</h3>
+  <div class="pram-row pram-demo-after" id="pram-after-row">
+    <div class="pram-spin"></div>
+    <span id="pram-after-label">Spinning normally — click the button to simulate prefers-reduced-motion: reduce.</span>
+    <button class="pram-toggle-btn" id="pram-toggle">Simulate reduced motion</button>
+  </div>
+
+  <h3>17 component files with animation/transition but no reduced-motion guard</h3>
+  <table>
+    <tr><th>File</th><th>File</th></tr>
+    <tr><td><code class="inline">announce-bar.css</code></td><td><code class="inline">pagination.css</code></td></tr>
+    <tr><td><code class="inline">avatar.css</code></td><td><code class="inline">password-strength.css</code></td></tr>
+    <tr><td><code class="inline">badges.css</code></td><td><code class="inline">progress.css</code></td></tr>
+    <tr><td><code class="inline">breadcrumb.css</code></td><td><code class="inline">read-more.css</code></td></tr>
+    <tr><td><code class="inline">compare-table.css</code></td><td><code class="inline">skeleton.css</code></td></tr>
+    <tr><td><code class="inline">connection-status.css</code></td><td><code class="inline">tabs.css</code></td></tr>
+    <tr><td><code class="inline">fab.css</code></td><td><code class="inline">toast.css</code></td></tr>
+    <tr><td><code class="inline">loaders.css</code></td><td><code class="inline">view-transitions.css</code></td></tr>
+    <tr><td><code class="inline">navbar.css</code></td><td></td></tr>
+  </table>
+
+  <h3>The exact patch needed in core/base.css</h3>
+  <pre style="background:var(--ease-color-neutral-100);padding:1rem;border-radius:var(--ease-radius-md);font-size:0.8125rem;overflow-x:auto;">@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}</pre>
+
+  <script>
+    const toggle = document.getElementById("pram-after-row").parentElement === document ? null : null;
+    const row = document.getElementById("pram-after-row");
+    const label = document.getElementById("pram-after-label");
+    const btn = document.getElementById("pram-toggle");
+    let reduced = false;
+    btn.addEventListener("click", () => {
+      reduced = !reduced;
+      row.classList.toggle("pram-simulated-reduced-motion", reduced);
+      label.textContent = reduced
+        ? "Reduced motion simulated — spin animation is effectively frozen."
+        : "Spinning normally — click the button to simulate prefers-reduced-motion: reduce.";
+      btn.textContent = reduced ? "Remove simulated reduced motion" : "Simulate reduced motion";
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/prefers-reduced-motion-audit/style.css
+++ b/submissions/examples/prefers-reduced-motion-audit/style.css
@@ -1,0 +1,52 @@
+/* ============================================================
+   fix: fragmented prefers-reduced-motion implementation (#1714)
+
+   core/base.css currently only disables scroll-behavior under
+   prefers-reduced-motion. There is no global animation/transition
+   kill-switch, so every component file has to opt in individually.
+   An audit found 17 component files that animate or transition
+   something with ZERO reduced-motion guard at all:
+
+     announce-bar, avatar, badges, breadcrumb, compare-table,
+     connection-status, fab, loaders, navbar, pagination,
+     password-strength, progress, read-more, skeleton, tabs,
+     toast, view-transitions
+
+   This file demonstrates the fix in isolation: a single global
+   catch-all rule added to core/base.css that disables nearly all
+   animation/transition duration framework-wide for users who
+   prefer reduced motion, regardless of whether an individual
+   component remembered to add its own guard.
+   ============================================================ */
+
+/* ---- Patch for core/base.css (add inside the existing
+        @media (prefers-reduced-motion: reduce) block) ---- */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ---- Demo-only scoping so this page can show before/after ---- */
+.pram-demo-before .pram-spin {
+  animation: pram-kf-spin 1.2s linear infinite;
+}
+.pram-demo-after .pram-spin {
+  animation: pram-kf-spin 1.2s linear infinite;
+}
+.pram-demo-after.pram-simulated-reduced-motion .pram-spin {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+}
+
+@keyframes pram-kf-spin {
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Pull Request Description
`core/base.css` only disables `scroll-behavior` under `prefers-reduced-motion: reduce` — there's no global animation/transition kill-switch. An audit found 17 component files (out of 26 that animate or transition anything) with zero reduced-motion handling at all. Since contributors can't edit `core/` directly, this submission documents the bug, the full affected file list, and the exact fix for a maintainer to apply.

---

## Type of Change
- [x] 🐛 Bug fix (documented, not applied to core/ directly)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/prefers-reduced-motion-audit/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed fix
- [x] Includes `README.md` — what's broken, the exact patch, why it matters
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature/fix per PR

---

## Bug Description

**What's broken?**

```css
/* core/base.css today */
@media (prefers-reduced-motion: reduce) {
  html { scroll-behavior: auto; }
}
```

17 component files animate or transition something with no guard at all: `announce-bar.css`, `avatar.css`, `badges.css`, `breadcrumb.css`, `compare-table.css`, `connection-status.css`, `fab.css`, `loaders.css`, `navbar.css`, `pagination.css`, `password-strength.css`, `progress.css`, `read-more.css`, `skeleton.css`, `tabs.css`, `toast.css`, `view-transitions.css`.

**The fix (for a maintainer to apply to `core/base.css`):**

```css
@media (prefers-reduced-motion: reduce) {
  html {
    scroll-behavior: auto;
  }
  *,
  *::before,
  *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

This follows the standard reduced-motion reset pattern used by `sanitize.css` and the widely-cited CSS-Tricks snippet: collapsing duration rather than removing the property, so end states still apply instantly. Protects every current and future component by default.

---

## Demo
- [x] Demo added (`demo.html` — unguarded spinner today, a simulated before/after toggle, the full 17-file list, and the patch snippet)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
This is a one-time global fix versus patching 17 files individually, and it protects any future component file by default without requiring every contributor to remember their own guard. Happy to follow up with a separate PR auditing per-component guards if maintainers prefer defense-in-depth on top of the global rule.

Closes #1714