### PR TITLE
feat: add data density toggle preview example

### DIFF
--- a/submissions/examples/data-density-toggle-preview-ts/README.md
+++ b/submissions/examples/data-density-toggle-preview-ts/README.md
@@ -1,0 +1,55 @@
+# Data Density Toggle Preview
+
+## What does this do?
+
+This is a CSS-only interactive demo comparing Comfortable, Compact, and Dense UI spacing modes, using segmented radio controls and smooth padding/gap transitions.
+
+## How is it used?
+
+Add the appropriate density class to your container element:
+
+```html
+<div class="density-preview">
+  <!-- Comfortable (default) -->
+  <div class="density-row">Orders <span>128</span></div>
+  <div class="density-row">Open tickets <span>14</span></div>
+</div>
+
+<div class="density-preview density-compact">
+  <!-- Compact -->
+  <div class="density-row">Orders <span>128</span></div>
+  <div class="density-row">Open tickets <span>14</span></div>
+</div>
+
+<div class="density-preview density-dense">
+  <!-- Dense -->
+  <div class="density-row">Orders <span>128</span></div>
+  <div class="density-row">Open tickets <span>14</span></div>
+</div>
+```
+
+You can customize the row padding using the CSS variable:
+
+```css
+.density-row {
+  padding: var(--row-padding, 0.85rem);
+}
+```
+
+## Why is it useful?
+
+Operational dashboards, data-intensive tables, and enterprise applications often require density controls to let users choose between scanability (comfortable) and high data throughput (dense). This CSS-only solution shows how spacing, transitions, and layouts can adapt seamlessly to these modes while respecting accessibility (including `prefers-reduced-motion`).
+
+## Tech Stack
+
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+
+Open demo.html directly in your browser to see the effect.
+
+## Contribution Notes
+
+- Class naming was handled by the contributor
+- Maintainer will rename to ease-\* convention before merging

--- a/submissions/examples/data-density-toggle-preview-ts/demo.html
+++ b/submissions/examples/data-density-toggle-preview-ts/demo.html
@@ -1,0 +1,268 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Data Density Toggle Preview - EaseMotion CSS</title>
+
+    <!-- Link to EaseMotion CSS core (if present in build, optional) -->
+    <link rel="stylesheet" href="../../../core/animations.css" />
+    <!-- Link to the local stylesheet -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="demo-wrapper">
+      <!-- Hidden radio inputs for dynamic state toggle -->
+      <input
+        type="radio"
+        id="density-comfortable-toggle"
+        name="density-selector"
+        checked
+        class="density-radio-input"
+      />
+      <input
+        type="radio"
+        id="density-compact-toggle"
+        name="density-selector"
+        class="density-radio-input"
+      />
+      <input
+        type="radio"
+        id="density-dense-toggle"
+        name="density-selector"
+        class="density-radio-input"
+      />
+
+      <header class="header">
+        <div class="badge-tag">Interactive Component</div>
+        <h1>Data Density Toggle Preview</h1>
+        <p class="subtitle">
+          A CSS-only interactive comparison of comfortable, compact, and dense
+          user interface spacing modes.
+        </p>
+      </header>
+
+      <!-- Segmented Control Toggle -->
+      <div class="segmented-control">
+        <label
+          for="density-comfortable-toggle"
+          class="control-label label-comfortable"
+          >Comfortable</label
+        >
+        <label for="density-compact-toggle" class="control-label label-compact"
+          >Compact</label
+        >
+        <label for="density-dense-toggle" class="control-label label-dense"
+          >Dense</label
+        >
+        <span class="selection-indicator"></span>
+      </div>
+
+      <!-- Dynamic Preview Container -->
+      <div class="dynamic-preview density-preview">
+        <!-- Preview Header -->
+        <div class="preview-header">
+          <div class="title-group">
+            <h3>Operational Dashboard</h3>
+            <span class="badge-live">Active Monitor</span>
+          </div>
+          <div class="search-container">
+            <svg class="search-icon" viewBox="0 0 24 24" width="16" height="16">
+              <path
+                fill="currentColor"
+                d="M15.5 14h-.79l-.28-.27A6.47 6.47 0 0 0 16 9.5A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+              />
+            </svg>
+            <span class="search-text">Search tasks...</span>
+          </div>
+        </div>
+
+        <!-- Data Rows -->
+        <div class="density-row list-row">
+          <div class="user-cell">
+            <div class="avatar avatar-blue">JD</div>
+            <div class="user-info">
+              <span class="user-name">John Doe</span>
+              <span class="user-email">john@example.com</span>
+            </div>
+          </div>
+          <div class="task-cell">
+            <span class="task-title">Database Replication Check</span>
+            <span class="task-id">#DB-892</span>
+          </div>
+          <div class="status-cell">
+            <span class="status status-success">Completed</span>
+          </div>
+          <span class="timestamp">12m ago</span>
+        </div>
+
+        <div class="density-row list-row">
+          <div class="user-cell">
+            <div class="avatar avatar-emerald">AS</div>
+            <div class="user-info">
+              <span class="user-name">Alice Smith</span>
+              <span class="user-email">alice@example.com</span>
+            </div>
+          </div>
+          <div class="task-cell">
+            <span class="task-title">CSS Regression Test Audit</span>
+            <span class="task-id">#FE-104</span>
+          </div>
+          <div class="status-cell">
+            <span class="status status-warning">In Progress</span>
+          </div>
+          <span class="timestamp">28m ago</span>
+        </div>
+
+        <div class="density-row list-row">
+          <div class="user-cell">
+            <div class="avatar avatar-amber">BW</div>
+            <div class="user-info">
+              <span class="user-name">Bob Wright</span>
+              <span class="user-email">bob@example.com</span>
+            </div>
+          </div>
+          <div class="task-cell">
+            <span class="task-title">Deploy Minor Release v2.1.0</span>
+            <span class="task-id">#OPS-305</span>
+          </div>
+          <div class="status-cell">
+            <span class="status status-danger">Failed</span>
+          </div>
+          <span class="timestamp">1h ago</span>
+        </div>
+
+        <!-- Divider / Section Title inside Preview -->
+        <div class="density-row section-header">
+          <span>System Summary Widgets</span>
+        </div>
+
+        <!-- Standard HTML snippet requested in Issue 11161 -->
+        <div class="original-snippet-container">
+          <div class="density-row">
+            Orders <span class="snippet-value">128</span>
+          </div>
+          <div class="density-row">
+            Open tickets <span class="snippet-value">14</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Divider for sections -->
+      <hr class="divider" />
+
+      <!-- Static Side-by-Side Comparison -->
+      <section class="comparison-section">
+        <h2>Side-by-Side Comparison</h2>
+        <p class="subtitle">
+          A static overview showing the spacing layout differences across
+          Comfortable, Compact, and Dense modes simultaneously.
+        </p>
+
+        <div class="comparison-grid">
+          <!-- Comfortable Mode -->
+          <div class="comparison-card">
+            <div class="card-title-bar">
+              <h3>Comfortable</h3>
+              <span class="spec-label">Padding: 1.0rem</span>
+            </div>
+            <div class="density-preview density-comfortable">
+              <div class="density-row list-row">
+                <div class="user-cell">
+                  <div class="avatar avatar-blue">JD</div>
+                  <div class="user-info">
+                    <span class="user-name">John Doe</span>
+                  </div>
+                </div>
+                <span class="status status-success">Completed</span>
+              </div>
+              <div class="density-row list-row">
+                <div class="user-cell">
+                  <div class="avatar avatar-emerald">AS</div>
+                  <div class="user-info">
+                    <span class="user-name">Alice Smith</span>
+                  </div>
+                </div>
+                <span class="status status-warning">In Progress</span>
+              </div>
+              <div class="density-row">
+                Orders <span class="snippet-value">128</span>
+              </div>
+              <div class="density-row">
+                Open tickets <span class="snippet-value">14</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Compact Mode -->
+          <div class="comparison-card">
+            <div class="card-title-bar">
+              <h3>Compact</h3>
+              <span class="spec-label">Padding: 0.55rem</span>
+            </div>
+            <div class="density-preview density-compact">
+              <div class="density-row list-row">
+                <div class="user-cell">
+                  <div class="avatar avatar-blue">JD</div>
+                  <div class="user-info">
+                    <span class="user-name">John Doe</span>
+                  </div>
+                </div>
+                <span class="status status-success">Completed</span>
+              </div>
+              <div class="density-row list-row">
+                <div class="user-cell">
+                  <div class="avatar avatar-emerald">AS</div>
+                  <div class="user-info">
+                    <span class="user-name">Alice Smith</span>
+                  </div>
+                </div>
+                <span class="status status-warning">In Progress</span>
+              </div>
+              <div class="density-row">
+                Orders <span class="snippet-value">128</span>
+              </div>
+              <div class="density-row">
+                Open tickets <span class="snippet-value">14</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Dense Mode -->
+          <div class="comparison-card">
+            <div class="card-title-bar">
+              <h3>Dense</h3>
+              <span class="spec-label">Padding: 0.35rem</span>
+            </div>
+            <div class="density-preview density-dense">
+              <div class="density-row list-row">
+                <div class="user-cell">
+                  <div class="avatar avatar-blue">JD</div>
+                  <div class="user-info">
+                    <span class="user-name">John Doe</span>
+                  </div>
+                </div>
+                <span class="status status-success">Completed</span>
+              </div>
+              <div class="density-row list-row">
+                <div class="user-cell">
+                  <div class="avatar avatar-emerald">AS</div>
+                  <div class="user-info">
+                    <span class="user-name">Alice Smith</span>
+                  </div>
+                </div>
+                <span class="status status-warning">In Progress</span>
+              </div>
+              <div class="density-row">
+                Orders <span class="snippet-value">128</span>
+              </div>
+              <div class="density-row">
+                Open tickets <span class="snippet-value">14</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/data-density-toggle-preview-ts/style.css
+++ b/submissions/examples/data-density-toggle-preview-ts/style.css
@@ -1,0 +1,604 @@
+/* ==========================================================================
+   Data Density Toggle Preview - EaseMotion CSS
+   ========================================================================== */
+
+/* Modern CSS Reset & Variable Definitions */
+:root {
+  /* Color Palette - Premium Dark HSL */
+  --bg-color: #0b0f19;
+  --card-bg: #161e2e;
+  --card-border: rgba(255, 255, 255, 0.08);
+  --primary-accent: #6366f1; /* Indigo */
+  --primary-accent-glow: rgba(99, 102, 241, 0.15);
+  --success: #10b981; /* Emerald */
+  --warning: #f59e0b; /* Amber */
+  --danger: #ef4444; /* Rose */
+
+  --text-primary: #f3f4f6;
+  --text-secondary: #9ca3af;
+  --text-muted: #6b7280;
+
+  /* Typography */
+  --font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif;
+
+  /* Defaults for Density (Comfortable) */
+  --row-padding: 1rem 1.25rem;
+  --element-gap: 1.25rem;
+  --avatar-size: 44px;
+  --badge-padding: 6px 12px;
+  --font-scale: 1;
+}
+
+/* Base Layout & Typography */
+body {
+  font-family: var(--font-family);
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+  margin: 0;
+  padding: 40px 20px;
+  display: flex;
+  justify-content: center;
+  min-height: 100vh;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+.demo-wrapper {
+  max-width: 960px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin: 10px 0;
+  background: linear-gradient(135deg, #fff 40%, var(--text-secondary));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+h2 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+  text-align: center;
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  margin: 0 auto;
+  max-width: 600px;
+}
+
+.badge-tag {
+  display: inline-block;
+  background: rgba(99, 102, 241, 0.1);
+  color: #818cf8;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+/* ==========================================================================
+   Segmented Control (Toggles)
+   ========================================================================== */
+
+/* Hidden native radios */
+.density-radio-input {
+  display: none;
+}
+
+.segmented-control {
+  position: relative;
+  display: flex;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 30px;
+  padding: 4px;
+  border: 1px solid var(--card-border);
+  width: 380px;
+  margin: 0 auto 3rem auto;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.control-label {
+  flex: 1;
+  text-align: center;
+  padding: 10px 0;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 500;
+  z-index: 2;
+  transition: color 220ms ease;
+  color: var(--text-secondary);
+}
+
+/* Sliding Background Selection Indicator */
+.selection-indicator {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 4px;
+  width: calc((100% - 8px) / 3);
+  background: linear-gradient(135deg, var(--primary-accent), #4f46e5);
+  border-radius: 26px;
+  z-index: 1;
+  box-shadow: 0 2px 10px rgba(99, 102, 241, 0.4);
+  transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Checkbox-driven Selection Indicator Shift */
+#density-comfortable-toggle:checked ~ .segmented-control .label-comfortable {
+  color: white;
+}
+
+#density-compact-toggle:checked ~ .segmented-control .label-compact {
+  color: white;
+}
+
+#density-dense-toggle:checked ~ .segmented-control .label-dense {
+  color: white;
+}
+
+#density-comfortable-toggle:checked ~ .segmented-control .selection-indicator {
+  transform: translateX(0);
+}
+
+#density-compact-toggle:checked ~ .segmented-control .selection-indicator {
+  transform: translateX(100%);
+}
+
+#density-dense-toggle:checked ~ .segmented-control .selection-indicator {
+  transform: translateX(200%);
+}
+
+/* ==========================================================================
+   Dynamic Spacing Variables (Based on Selected Radio)
+   ========================================================================== */
+
+#density-comfortable-toggle:checked ~ .dynamic-preview {
+  --row-padding: 1rem 1.25rem;
+  --element-gap: 1.25rem;
+  --avatar-size: 42px;
+  --badge-padding: 6px 12px;
+  --font-scale: 1;
+}
+
+#density-compact-toggle:checked ~ .dynamic-preview {
+  --row-padding: 0.65rem 1rem;
+  --element-gap: 0.75rem;
+  --avatar-size: 32px;
+  --badge-padding: 4px 8px;
+  --font-scale: 0.92;
+}
+
+#density-dense-toggle:checked ~ .dynamic-preview {
+  --row-padding: 0.4rem 0.75rem;
+  --element-gap: 0.4rem;
+  --avatar-size: 24px;
+  --badge-padding: 2px 6px;
+  --font-scale: 0.84;
+}
+
+/* ==========================================================================
+   Dashboard Preview Container
+   ========================================================================== */
+
+.density-preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--element-gap, 0.75rem);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  transition:
+    gap 220ms ease,
+    padding 220ms ease;
+}
+
+/* Individual Preview Header styling */
+.preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--card-border);
+  padding-bottom: var(--element-gap, 0.75rem);
+  margin-bottom: calc(var(--element-gap, 0.75rem) / 2);
+  transition:
+    padding 220ms ease,
+    margin 220ms ease;
+}
+
+.preview-header h3 {
+  font-size: calc(1.2rem * var(--font-scale, 1));
+  font-weight: 600;
+  margin: 0;
+  transition: font-size 220ms ease;
+}
+
+.badge-live {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--success);
+  font-size: calc(0.75rem * var(--font-scale, 1));
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  transition: font-size 220ms ease;
+}
+
+.badge-live::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--success);
+  animation: pulse-dot 2s infinite;
+}
+
+@keyframes pulse-dot {
+  0% {
+    transform: scale(0.95);
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.7);
+  }
+  70% {
+    transform: scale(1);
+    box-shadow: 0 0 0 4px rgba(16, 185, 129, 0);
+  }
+  100% {
+    transform: scale(0.95);
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0);
+  }
+}
+
+/* Search Box Container */
+.search-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 6px 12px;
+  color: var(--text-secondary);
+  font-size: calc(0.85rem * var(--font-scale, 1));
+  max-width: 200px;
+  width: 100%;
+}
+
+.search-icon {
+  color: var(--text-muted);
+}
+
+/* ==========================================================================
+   Density Row (Core animation logic)
+   ========================================================================== */
+
+.density-row {
+  /* Dynamic padding via CSS variable custom set above */
+  padding: var(--row-padding, 0.85rem);
+
+  /* Required CSS transition for smooth animation */
+  transition:
+    padding 220ms ease,
+    background-color 220ms ease,
+    gap 220ms ease,
+    font-size 220ms ease;
+
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.03);
+  display: flex;
+  align-items: center;
+  gap: var(--element-gap, 0.75rem);
+  font-size: calc(0.95rem * var(--font-scale, 1));
+}
+
+.density-row:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+/* Specific static subclasses as requested */
+.density-comfortable {
+  --row-padding: 1rem 1.25rem;
+  --element-gap: 1.25rem;
+  --avatar-size: 42px;
+  --badge-padding: 6px 12px;
+  --font-scale: 1;
+}
+
+.density-compact {
+  --row-padding: 0.55rem;
+  --element-gap: 0.55rem;
+  --avatar-size: 32px;
+  --badge-padding: 4px 8px;
+  --font-scale: 0.92;
+}
+
+.density-dense {
+  --row-padding: 0.35rem;
+  --element-gap: 0.35rem;
+  --avatar-size: 24px;
+  --badge-padding: 2px 6px;
+  --font-scale: 0.84;
+}
+
+/* Row-specific Layout Structure */
+.list-row {
+  justify-content: space-between;
+}
+
+.user-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--element-gap, 0.75rem);
+  flex: 1;
+  min-width: 180px;
+}
+
+.user-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.user-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.user-email {
+  font-size: 0.8em;
+  color: var(--text-muted);
+}
+
+.task-cell {
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  min-width: 220px;
+}
+
+.task-title {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.task-id {
+  font-size: 0.8em;
+  color: var(--primary-accent);
+  font-weight: 600;
+}
+
+.status-cell {
+  flex: 1;
+  min-width: 100px;
+}
+
+.timestamp {
+  font-size: 0.85em;
+  color: var(--text-muted);
+  min-width: 60px;
+  text-align: right;
+}
+
+/* Avatar Elements */
+.avatar {
+  width: var(--avatar-size, 32px);
+  height: var(--avatar-size, 32px);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: calc(var(--avatar-size, 32px) * 0.4);
+  color: white;
+  transition:
+    width 220ms ease,
+    height 220ms ease,
+    font-size 220ms ease;
+  user-select: none;
+}
+
+.avatar-blue {
+  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+}
+
+.avatar-emerald {
+  background: linear-gradient(135deg, var(--success), #047857);
+}
+
+.avatar-amber {
+  background: linear-gradient(135deg, var(--warning), #b45309);
+}
+
+/* Status Badges */
+.status {
+  display: inline-block;
+  padding: var(--badge-padding, 4px 8px);
+  border-radius: 6px;
+  font-size: 0.8em;
+  font-weight: 600;
+  text-align: center;
+  transition: padding 220ms ease;
+}
+
+.status-success {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--success);
+}
+
+.status-warning {
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--warning);
+}
+
+.status-danger {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--danger);
+}
+
+/* Section Header in Dashboard List */
+.section-header {
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--card-border);
+  border-radius: 0;
+  padding: var(--row-padding) 0 !important;
+}
+
+/* Widget for standard snippet validation code */
+.original-snippet-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--element-gap, 0.75rem);
+}
+
+.original-snippet-container .density-row {
+  justify-content: space-between;
+}
+
+.snippet-value {
+  font-weight: 700;
+  color: var(--primary-accent);
+}
+
+/* ==========================================================================
+   Side-by-Side Comparison Section
+   ========================================================================== */
+
+.divider {
+  border: 0;
+  height: 1px;
+  background: var(--card-border);
+  margin: 4rem 0 3rem 0;
+}
+
+.comparison-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.comparison-card {
+  background: rgba(255, 255, 255, 0.015);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card-title-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--card-border);
+  padding-bottom: 0.75rem;
+}
+
+.card-title-bar h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.spec-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+/* Adjust static modes inside comparison grid */
+.comparison-card .density-preview {
+  padding: 0.75rem;
+  box-shadow: none;
+}
+
+.comparison-card .user-email,
+.comparison-card .timestamp {
+  display: none;
+}
+
+.comparison-card .user-cell {
+  min-width: auto;
+}
+
+/* ==========================================================================
+   Responsive & Accessibility Rules
+   ========================================================================== */
+
+/* Reduced-motion handling - standard checklist requirement */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-delay: 0s !important;
+    animation-duration: 0s !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0s !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Tablet & Mobile Layout optimization */
+@media (max-width: 820px) {
+  .comparison-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .list-row {
+    flex-wrap: wrap;
+    row-gap: 8px;
+  }
+
+  .user-cell {
+    flex: 1 1 100%;
+  }
+
+  .task-cell {
+    flex: 1 1 calc(100% - 130px);
+  }
+
+  .status-cell {
+    flex: 0 0 100px;
+  }
+
+  .timestamp {
+    flex: 0 0 auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .segmented-control {
+    width: 100%;
+    max-width: 320px;
+  }
+
+  .control-label {
+    font-size: 0.85rem;
+  }
+}


### PR DESCRIPTION
### Description
This PR resolves issue #11161 by adding a CSS-only interactive preview and side-by-side comparison for Data Density modes (Comfortable, Compact, and Dense spacing).

### Changes
- Created a new directory under `submissions/examples/data-density-toggle-preview-ts/` containing:
  - `demo.html`: Structure for the interactive dashboard and side-by-side static comparison cards.
  - `style.css`: Responsive CSS implementing spacing variables (`--row-padding`, `--element-gap`, `--avatar-size`, etc.), transition animations, HSL dark mode colors, and reduced-motion handling.
  - `README.md`: Documentation detailing features, usage, and usefulness of the feature.

### Checklist
- [x] Pure HTML and CSS implementation (no JS)
- [x] Responsive layout
- [x] Handled `prefers-reduced-motion` media query
- [x] Self-contained under `submissions/examples/`