### PR TITLE
feat: add 3D book cover flip showcase (#11757)

### DIFF
--- a/submissions/examples/3d-book-flip-pp/README.md
+++ b/submissions/examples/3d-book-flip-pp/README.md
@@ -1,0 +1,44 @@
+# Interactive 3D Book Cover Flip Showcase
+
+This feature creates a realistic 3D book model showcase component, resolving Issue #11757. When hovered, the front cover swings open on its hinge, revealing inner page layers and casting a dynamic shadow behind it.
+
+## What does this do?
+
+It provides 3D styling for book showcases where hovering triggers a realistic opening effect:
+
+- **Hinge swing**: The front cover rotates outward by `rotateY(-140deg)` from the left edge.
+- **Inner pages**: Pages fan out slightly with progressive offsets along the Z-axis, creating the appearance of book thickness.
+- **Dynamic shadow**: The shadow cast behind the book shifts angle, skew, and blur to match the movement of the cover.
+
+## How is it used?
+
+Structure of a 3D book component:
+
+```html
+<div class="book-container">
+  <div class="book">
+    <!-- Cover Front -->
+    <div class="book-cover front">
+      <div class="cover-design">...</div>
+    </div>
+
+    <!-- Page Layers -->
+    <div class="book-page page-1"></div>
+    <div class="book-page page-2"></div>
+    <div class="book-page page-3"></div>
+
+    <!-- Cover Back -->
+    <div class="book-cover back"></div>
+
+    <!-- Shadow -->
+    <div class="book-shadow"></div>
+  </div>
+</div>
+```
+
+## Styling Options & Hinge Coordinates
+
+- **Hinge origin**: Set to `transform-origin: left center` on the `.front` cover.
+- **Opening angle**: Customisable opening swing set to `rotateY(-140deg)` on hover.
+- **3D Depth**: `.book` holds the 3D context with `transform-style: preserve-3d; perspective: 1000px;`.
+- **Accessibility**: Smoothly resets to a clean static layout under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/3d-book-flip-pp/demo.html
+++ b/submissions/examples/3d-book-flip-pp/demo.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Interactive 3D Book Cover Flip Showcase - EaseMotion CSS</title>
+    <!-- Google Fonts Outfit -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Header -->
+    <header class="library-header">
+      <span class="badge">3D Motion Component</span>
+      <h1 class="title">3D Book Showcase</h1>
+      <p class="description">
+        Hover over any book on the shelf to watch the cover open smoothly on its
+        hinge, revealing inner pages and shifting the dynamic backdrop shadow.
+      </p>
+    </header>
+
+    <!-- Bookshelf Grid Container -->
+    <main class="bookshelf">
+      <!-- Book 1: Blue Cover -->
+      <div class="book-container">
+        <div class="book">
+          <!-- Cover Front -->
+          <div class="book-cover front theme-blue">
+            <div class="cover-design">
+              <span class="cover-category">Design</span>
+              <div class="cover-title">Creative CSS Animations</div>
+              <span class="cover-author">By Alexander Wright</span>
+            </div>
+          </div>
+
+          <!-- Page 1 (Topmost visible page) -->
+          <div class="book-page page-1">
+            <div class="page-content">
+              <h4
+                style="
+                  font-size: 0.85rem;
+                  font-weight: 700;
+                  margin-bottom: 4px;
+                  color: #1e293b;
+                "
+              >
+                Chapter 1
+              </h4>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder medium"></div>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder short"></div>
+            </div>
+          </div>
+
+          <!-- Page 2 -->
+          <div class="book-page page-2">
+            <div class="page-content">
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder medium"></div>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder"></div>
+            </div>
+          </div>
+
+          <!-- Page 3 -->
+          <div class="book-page page-3">
+            <div class="page-content">
+              <div class="line-placeholder medium"></div>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder short"></div>
+            </div>
+          </div>
+
+          <!-- Cover Back -->
+          <div class="book-cover back"></div>
+
+          <!-- Dynamic Shadow -->
+          <div class="book-shadow"></div>
+        </div>
+      </div>
+
+      <!-- Book 2: Pink Cover -->
+      <div class="book-container">
+        <div class="book">
+          <!-- Cover Front -->
+          <div class="book-cover front theme-pink">
+            <div class="cover-design">
+              <span class="cover-category">Motion</span>
+              <div class="cover-title">Mastering 3D Transforms</div>
+              <span class="cover-author">By Sophia Martinez</span>
+            </div>
+          </div>
+
+          <!-- Page 1 -->
+          <div class="book-page page-1">
+            <div class="page-content">
+              <h4
+                style="
+                  font-size: 0.85rem;
+                  font-weight: 700;
+                  margin-bottom: 4px;
+                  color: #1e293b;
+                "
+              >
+                Chapter 2
+              </h4>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder medium"></div>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder short"></div>
+            </div>
+          </div>
+
+          <!-- Page 2 -->
+          <div class="book-page page-2">
+            <div class="page-content">
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder medium"></div>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder"></div>
+            </div>
+          </div>
+
+          <!-- Page 3 -->
+          <div class="book-page page-3">
+            <div class="page-content">
+              <div class="line-placeholder medium"></div>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder short"></div>
+            </div>
+          </div>
+
+          <!-- Cover Back -->
+          <div class="book-cover back"></div>
+
+          <!-- Dynamic Shadow -->
+          <div class="book-shadow"></div>
+        </div>
+      </div>
+
+      <!-- Book 3: Green Cover -->
+      <div class="book-container">
+        <div class="book">
+          <!-- Cover Front -->
+          <div class="book-cover front theme-green">
+            <div class="cover-design">
+              <span class="cover-category">Performance</span>
+              <div class="cover-title">Speed & Compositing</div>
+              <span class="cover-author">By Liam Peterson</span>
+            </div>
+          </div>
+
+          <!-- Page 1 -->
+          <div class="book-page page-1">
+            <div class="page-content">
+              <h4
+                style="
+                  font-size: 0.85rem;
+                  font-weight: 700;
+                  margin-bottom: 4px;
+                  color: #1e293b;
+                "
+              >
+                Chapter 3
+              </h4>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder medium"></div>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder short"></div>
+            </div>
+          </div>
+
+          <!-- Page 2 -->
+          <div class="book-page page-2">
+            <div class="page-content">
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder medium"></div>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder"></div>
+            </div>
+          </div>
+
+          <!-- Page 3 -->
+          <div class="book-page page-3">
+            <div class="page-content">
+              <div class="line-placeholder medium"></div>
+              <div class="line-placeholder"></div>
+              <div class="line-placeholder short"></div>
+            </div>
+          </div>
+
+          <!-- Cover Back -->
+          <div class="book-cover back"></div>
+
+          <!-- Dynamic Shadow -->
+          <div class="book-shadow"></div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Control & Details info -->
+    <footer class="shelf-caption">
+      Interactive 3D cover swing utilizing CSS
+      <code>transform-style: preserve-3d</code> and <code>rotateY</code> hinge
+      animations.
+    </footer>
+  </body>
+</html>

--- a/submissions/examples/3d-book-flip-pp/style.css
+++ b/submissions/examples/3d-book-flip-pp/style.css
@@ -1,0 +1,386 @@
+/* =======================================================
+   EaseMotion CSS - Interactive 3D Book Cover Flip Style
+   ======================================================= */
+
+/* Design System Tokens */
+:root {
+  --font-sans: "Outfit", "Inter", system-ui, -apple-system, sans-serif;
+
+  /* Book Geometry */
+  --book-width: 170px;
+  --book-height: 250px;
+  --book-spine: 20px;
+
+  /* Color Palette (Dark Theme Library) */
+  --bg-page: #0a0c10;
+  --bg-shelf: #12151e;
+  --border-shelf: rgba(255, 255, 255, 0.05);
+
+  --text-main: #f1f5f9;
+  --text-muted: #64748b;
+  --accent: #6366f1;
+  --accent-light: rgba(99, 102, 241, 0.1);
+  --accent-glow: rgba(99, 102, 241, 0.25);
+
+  /* Cover Gradients */
+  --cover-gradient-1: linear-gradient(135deg, #3b82f6, #1d4ed8);
+  --cover-gradient-2: linear-gradient(135deg, #ec4899, #be185d);
+  --cover-gradient-3: linear-gradient(135deg, #10b981, #047857);
+}
+
+/* Light Theme Support */
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg-page: #f8fafc;
+    --bg-shelf: #ffffff;
+    --border-shelf: #e2e8f0;
+
+    --text-main: #0f172a;
+    --text-muted: #64748b;
+    --accent: #4f46e5;
+    --accent-light: rgba(79, 70, 229, 0.06);
+    --accent-glow: rgba(79, 70, 229, 0.1);
+  }
+}
+
+/* Base resets */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg-page);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  line-height: 1.5;
+  overflow-x: hidden;
+}
+
+/* Page Header */
+.library-header {
+  text-align: center;
+  max-width: 600px;
+  margin-bottom: 50px;
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  background: var(--accent-light);
+  color: var(--accent);
+  padding: 4px 12px;
+  border-radius: 9999px;
+  margin-bottom: 12px;
+  border: 1px solid rgba(99, 102, 241, 0.15);
+}
+
+.title {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-bottom: 12px;
+  background: linear-gradient(135deg, var(--text-main) 40%, var(--accent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.description {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+/* Bookshelf Grid Container */
+.bookshelf {
+  width: 100%;
+  max-width: 900px;
+  background: var(--bg-shelf);
+  border: 1px solid var(--border-shelf);
+  border-radius: 20px;
+  padding: 50px 30px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 40px;
+  justify-items: center;
+  align-items: center;
+}
+
+/* 3D Book Container Wrapper - Holds 3D perspective context */
+.book-container {
+  width: var(--book-width);
+  height: var(--book-height);
+  perspective: 1000px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Main 3D Book Model Element */
+.book {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+  /* Default resting 3D perspective angles */
+  transform: rotateX(25deg) rotateY(-22deg) rotateZ(-3deg);
+}
+
+/* Hover rotation of the entire book to show fanning */
+.book-container:hover .book {
+  transform: rotateX(20deg) rotateY(-10deg) rotateZ(0deg);
+}
+
+/* Base Cover Stencil */
+.book-cover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 3px 12px 12px 3px;
+  box-shadow: inset 4px 0 10px rgba(0, 0, 0, 0.3);
+}
+
+/* Spine Hinge coordinates & origin - Issue #11757 Specifications */
+.book-cover.front {
+  transform-origin: left center;
+  z-index: 5;
+  transition:
+    transform 0.6s cubic-bezier(0.25, 1, 0.5, 1),
+    box-shadow 0.6s ease;
+  transform: rotateY(0deg) translateZ(10px); /* Stacked slightly forward */
+  border-left: 5px solid rgba(0, 0, 0, 0.2);
+}
+
+/* Front Cover design contents styling */
+.cover-design {
+  width: 100%;
+  height: 100%;
+  border-radius: 3px 12px 12px 3px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  color: #ffffff;
+  position: relative;
+  overflow: hidden;
+}
+
+.cover-design::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.08) 0%,
+    rgba(255, 255, 255, 0) 5%,
+    rgba(0, 0, 0, 0.1) 6%,
+    rgba(0, 0, 0, 0) 8%
+  );
+}
+
+.cover-category {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  opacity: 0.8;
+}
+
+.cover-title {
+  font-size: 1.35rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.cover-author {
+  font-size: 0.75rem;
+  font-weight: 500;
+  opacity: 0.9;
+}
+
+/* Back Cover Stencil */
+.book-cover.back {
+  background: #1e1e24;
+  transform: rotateY(0deg) translateZ(-10px);
+  z-index: 1;
+}
+
+/* Inner fanning pages */
+.book-page {
+  position: absolute;
+  top: 4px;
+  left: 6px;
+  width: calc(100% - 10px);
+  height: calc(100% - 8px);
+  background-color: #faf6ee;
+  border-radius: 0 10px 10px 0;
+  box-shadow:
+    inset 3px 0 6px rgba(0, 0, 0, 0.1),
+    1px 1px 3px rgba(0, 0, 0, 0.1);
+  transform-origin: left center;
+  transition: transform 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 3;
+}
+
+/* Page inner design simulation */
+.page-content {
+  width: 100%;
+  height: 100%;
+  border-left: 1px solid rgba(0, 0, 0, 0.08);
+  padding-left: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.line-placeholder {
+  height: 6px;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
+}
+.line-placeholder.short {
+  width: 60%;
+}
+.line-placeholder.medium {
+  width: 80%;
+}
+
+/* Stacking depths for page thickness */
+.page-1 {
+  transform: rotateY(0deg) translateZ(6px);
+  z-index: 4;
+}
+
+.page-2 {
+  transform: rotateY(0deg) translateZ(2px);
+  z-index: 3;
+}
+
+.page-3 {
+  transform: rotateY(0deg) translateZ(-2px);
+  z-index: 2;
+}
+
+/* Active Book Opening transformations on Hover */
+
+/* Front cover swings open 140 degrees */
+.book-container:hover .book-cover.front {
+  transform: rotateY(-140deg) translateZ(10px);
+  box-shadow: 5px 5px 20px rgba(0, 0, 0, 0.2);
+}
+
+/* Progressive page fanning Y-axis angles */
+.book-container:hover .page-1 {
+  transform: rotateY(-30deg) translateZ(6px);
+}
+
+.book-container:hover .page-2 {
+  transform: rotateY(-20deg) translateZ(2px);
+}
+
+.book-container:hover .page-3 {
+  transform: rotateY(-10deg) translateZ(-2px);
+}
+
+/* Dynamic shifting shadow behind the book - Issue #11757 Specifications */
+.book-shadow {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  filter: blur(12px);
+  border-radius: 12px;
+  z-index: 0;
+  /* Default shadow projection */
+  transform: translate3d(12px, 12px, -30px) rotateY(-22deg) skewY(2deg);
+  transition:
+    transform 0.6s cubic-bezier(0.25, 1, 0.5, 1),
+    filter 0.6s ease,
+    opacity 0.6s ease;
+  pointer-events: none;
+  opacity: 0.8;
+}
+
+/* Dynamic shadow updates matching cover opening */
+.book-container:hover .book-shadow {
+  transform: translate3d(36px, 20px, -60px) rotateY(-50deg) skewY(6deg);
+  filter: blur(20px);
+  opacity: 0.4;
+}
+
+/* Accessibility prefers-reduced-motion: reduce configuration */
+@media (prefers-reduced-motion: reduce) {
+  /* Disable active hover animations */
+  .book-container .book,
+  .book-container .book-cover,
+  .book-container .book-page,
+  .book-container .book-shadow {
+    transition: none !important;
+  }
+
+  /* Pivot to static open book configuration on hover immediately */
+  .book-container:hover .book-cover.front {
+    transform: rotateY(-140deg) translateZ(10px);
+  }
+  .book-container:hover .page-1 {
+    transform: rotateY(-30deg) translateZ(6px);
+  }
+  .book-container:hover .page-2 {
+    transform: rotateY(-20deg) translateZ(2px);
+  }
+  .book-container:hover .page-3 {
+    transform: rotateY(-10deg) translateZ(-2px);
+  }
+  .book-container:hover .book-shadow {
+    transform: translate3d(36px, 20px, -60px) rotateY(-50deg) skewY(6deg);
+  }
+}
+
+/* Specific Cover Themes */
+.theme-blue {
+  background: var(--cover-gradient-1);
+}
+.theme-pink {
+  background: var(--cover-gradient-2);
+}
+.theme-green {
+  background: var(--cover-gradient-3);
+}
+
+/* Controls Panel styles */
+.shelf-caption {
+  margin-top: 24px;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+.shelf-caption code {
+  background: var(--accent-light);
+  color: var(--accent);
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-family: monospace;
+}


### PR DESCRIPTION
### Description
This pull request adds an interactive 3D book cover flip showcase component, resolving issue #11757.

It places the implementation under `submissions/examples/3d-book-flip-pp/` to avoid naming conflicts.

### Features Included
- **Hinge Cover Rotation**: Smooth outward swing transformation of the front cover (`rotateY(-140deg)`) using a `transform-origin` left edge.
- **Inner Page Fanning**: Stacking depths and rotation offsets for inner pages to simulate realistic thickness.
- **Dynamic Backdrop Shadow**: Transforming the blur, skew, and translation of the backdrop shadow to match the cover swing on hover.
- **A11y Preferences**: Transition resets automatically under `prefers-reduced-motion: reduce`.

### Checklist
- [x] This feature does not duplicate an existing EaseMotion CSS class
- [x] Naming can be standardized by the maintainer
- [x] Code lives inside submissions/examples/ only
- [x] Pure HTML and CSS implementation
- [x] Responsive design
- [x] Includes reduced-motion handling