### PR TITLE
feat: add salary calculator with US tax brackets and take-home pay visualization

### DIFF
--- a/submissions/examples/salary-calculator/README.md
+++ b/submissions/examples/salary-calculator/README.md
@@ -1,0 +1,45 @@
+# Salary Calculator
+
+An interactive salary calculator that breaks down annual gross salary into monthly, bi-weekly, and weekly amounts with US federal tax bracket calculation, state tax, FICA estimation, and a visual take-home pay breakdown.
+
+## Features
+
+- **Salary breakdown** — Annual, monthly, bi-weekly, and weekly gross and net amounts
+- **US federal tax brackets** — 2024 brackets for Single, Married Filing Jointly, and Head of Household
+- **Standard deduction** applied before federal tax calculation
+- **State tax** — Selectable rates from 0% to 13.3% (California)
+- **FICA** — Social Security + Medicare employee share (7.65%)
+- **Visual tax bar** — Colour-coded breakdown of take-home vs each tax type
+- **Effective tax rate** displayed in legend
+- **Live updates** — Recalculates instantly on every input change
+
+## Styling
+
+All visual properties use `--ease-*` design tokens:
+
+| Token used | Purpose |
+|------------|---------|
+| `--ease-color-primary` | Federal tax segment, input focus |
+| `--ease-color-success` | Take-home pay segment |
+| `--ease-color-warning` | State tax segment |
+| `--ease-color-danger` | FICA segment |
+| `--ease-radius-lg` | Card and input border radius |
+| `--ease-space-*` | All spacing and gaps |
+| `--ease-text-*` | Typography scale |
+
+## Usage
+
+```html
+<link rel="stylesheet" href="easemotion.css" />
+<link rel="stylesheet" href="salary-calculator/style.css" />
+
+<div class="ease-salary-calc">
+  <!-- See demo.html for full markup -->
+</div>
+```
+
+## Disclaimer
+
+Tax calculations are estimates based on 2024 US federal brackets and simplified state tax rates. Not financial advice — consult a tax professional for accurate figures.
+
+Closes #11325

--- a/submissions/examples/salary-calculator/demo.html
+++ b/submissions/examples/salary-calculator/demo.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Salary Calculator — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; background: var(--ease-color-bg); font-family: var(--ease-font-sans); }
+    h2 { text-align: center; margin-bottom: 0.5rem; }
+    p.sub { text-align: center; color: var(--ease-color-muted); margin-bottom: 2rem; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+    @media (max-width: 480px) { .row { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h2>Salary Calculator</h2>
+  <p class="sub">Break down your salary and estimate take-home pay</p>
+
+  <div class="ease-salary-calc">
+
+    <!-- Input -->
+    <div class="ease-salary-calc__input-group">
+      <label class="ease-salary-calc__label" for="salary-input">Annual Gross Salary</label>
+      <div class="ease-salary-calc__input-wrap">
+        <span class="ease-salary-calc__currency">$</span>
+        <input
+          class="ease-salary-calc__input"
+          id="salary-input"
+          type="number"
+          min="0"
+          step="1000"
+          value="75000"
+          placeholder="Enter annual salary"
+          aria-label="Annual gross salary in dollars"
+        />
+      </div>
+
+      <div class="row">
+        <div>
+          <label class="ease-salary-calc__label" for="state-select">State</label>
+          <select class="ease-salary-calc__select" id="state-select" aria-label="State tax rate">
+            <option value="0">No state tax (TX, FL, WA...)</option>
+            <option value="0.0325">Low (3.25%)</option>
+            <option value="0.05" selected>Medium (5%)</option>
+            <option value="0.0725">High (7.25%)</option>
+            <option value="0.133">California (13.3%)</option>
+          </select>
+        </div>
+        <div>
+          <label class="ease-salary-calc__label" for="filing-select">Filing Status</label>
+          <select class="ease-salary-calc__select" id="filing-select" aria-label="Tax filing status">
+            <option value="single" selected>Single</option>
+            <option value="married">Married Filing Jointly</option>
+            <option value="hoh">Head of Household</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <!-- Breakdown cards -->
+    <div class="ease-salary-calc__breakdown" id="breakdown">
+      <!-- populated by JS -->
+    </div>
+
+    <!-- Tax visualization -->
+    <div class="ease-salary-calc__tax-section" id="tax-section">
+      <div class="ease-salary-calc__tax-title">Annual Tax Breakdown</div>
+      <div class="ease-salary-calc__tax-bar" id="tax-bar" role="img" aria-label="Tax breakdown bar"></div>
+      <div class="ease-salary-calc__tax-legend" id="tax-legend"></div>
+    </div>
+
+  </div>
+
+  <script>
+    // US 2024 federal tax brackets (single)
+    const BRACKETS = {
+      single:   [[11600,0.10],[47150,0.12],[100525,0.22],[191950,0.24],[243725,0.32],[609350,0.35],[Infinity,0.37]],
+      married:  [[23200,0.10],[94300,0.12],[201050,0.22],[383900,0.24],[487450,0.32],[731200,0.35],[Infinity,0.37]],
+      hoh:      [[16550,0.10],[63100,0.12],[100500,0.22],[191950,0.24],[243700,0.32],[609350,0.35],[Infinity,0.37]],
+    };
+    const FICA_RATE = 0.0765; // Social Security + Medicare (employee share)
+    const STD_DED  = { single: 14600, married: 29200, hoh: 21900 };
+
+    function calcFedTax(taxable, status) {
+      const brackets = BRACKETS[status];
+      let tax = 0, prev = 0;
+      for (const [limit, rate] of brackets) {
+        if (taxable <= prev) break;
+        tax += (Math.min(taxable, limit) - prev) * rate;
+        prev = limit;
+      }
+      return tax;
+    }
+
+    function fmt(n) {
+      return n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+    }
+
+    function fmtPct(n) { return (n * 100).toFixed(1) + '%'; }
+
+    function update() {
+      const gross   = Math.max(0, parseFloat(document.getElementById('salary-input').value) || 0);
+      const stateR  = parseFloat(document.getElementById('state-select').value);
+      const status  = document.getElementById('filing-select').value;
+
+      const fica      = gross * FICA_RATE;
+      const taxable   = Math.max(0, gross - STD_DED[status]);
+      const fedTax    = calcFedTax(taxable, status);
+      const stateTax  = gross * stateR;
+      const totalTax  = fedTax + stateTax + fica;
+      const net       = gross - totalTax;
+      const effRate   = gross > 0 ? totalTax / gross : 0;
+
+      // Breakdown cards
+      const periods = [
+        { label: 'Annual Take-Home', gross: gross, net: net, highlight: true },
+        { label: 'Monthly',    gross: gross/12,   net: net/12   },
+        { label: 'Bi-Weekly',  gross: gross/26,   net: net/26   },
+        { label: 'Weekly',     gross: gross/52,   net: net/52   },
+      ];
+
+      const breakdown = document.getElementById('breakdown');
+      breakdown.innerHTML = periods.map(p => `
+        <div class="ease-salary-calc__card${p.highlight ? ' ease-salary-calc__card--highlight' : ''}">
+          <div class="ease-salary-calc__card-period">${p.label}</div>
+          <div class="ease-salary-calc__card-gross">${fmt(p.net)}</div>
+          <div class="ease-salary-calc__card-net">Gross: ${fmt(p.gross)}</div>
+        </div>
+      `).join('');
+
+      // Tax bar
+      const segments = [
+        { key: 'net',   pct: net/gross,      label: 'Take-Home',     color: 'var(--ease-color-success,#22c55e)',  amount: net      },
+        { key: 'fed',   pct: fedTax/gross,   label: 'Federal Tax',   color: 'var(--ease-color-primary,#6c63ff)', amount: fedTax   },
+        { key: 'state', pct: stateTax/gross, label: 'State Tax',     color: 'var(--ease-color-warning,#f59e0b)', amount: stateTax },
+        { key: 'fica',  pct: fica/gross,     label: 'FICA (SS+Med)', color: 'var(--ease-color-danger,#ef4444)',  amount: fica     },
+      ].filter(s => s.pct > 0);
+
+      document.getElementById('tax-bar').innerHTML = segments.map(s =>
+        `<div class="ease-salary-calc__tax-segment ease-salary-calc__tax-segment--${s.key}"
+              style="width:${(s.pct*100).toFixed(2)}%"
+              title="${s.label}: ${fmt(s.amount)}"></div>`
+      ).join('');
+
+      document.getElementById('tax-legend').innerHTML = segments.map(s => `
+        <div class="ease-salary-calc__tax-legend-item">
+          <div class="ease-salary-calc__tax-legend-left">
+            <div class="ease-salary-calc__tax-dot" style="background:${s.color}"></div>
+            <span class="ease-salary-calc__tax-legend-label">${s.label}</span>
+          </div>
+          <div>
+            <span class="ease-salary-calc__tax-legend-amount">${fmt(s.amount)}</span>
+            <span class="ease-salary-calc__tax-legend-label"> &nbsp;${fmtPct(s.pct)}</span>
+          </div>
+        </div>
+      `).join('');
+    }
+
+    document.getElementById('salary-input').addEventListener('input', update);
+    document.getElementById('state-select').addEventListener('change', update);
+    document.getElementById('filing-select').addEventListener('change', update);
+    update();
+  </script>
+</body>
+</html>

--- a/submissions/examples/salary-calculator/style.css
+++ b/submissions/examples/salary-calculator/style.css
@@ -1,0 +1,234 @@
+/* ============================================================
+   Salary Calculator — EaseMotion CSS Submission
+   Breaks down annual salary into monthly, bi-weekly, and weekly
+   amounts with tax bracket visualization and take-home pay.
+   All styling uses --ease-* design tokens.
+   ============================================================ */
+
+@layer easemotion-components {
+
+  /* ── Container ───────────────────────────────────────────── */
+  .ease-salary-calc {
+    max-width: 640px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--ease-space-6, 1.5rem);
+    font-family: var(--ease-font-sans, system-ui, sans-serif);
+  }
+
+  /* ── Input section ───────────────────────────────────────── */
+  .ease-salary-calc__input-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ease-space-4, 1rem);
+  }
+
+  .ease-salary-calc__label {
+    font-size: var(--ease-text-sm, 0.875rem);
+    font-weight: 600;
+    color: var(--ease-color-text, #1e293b);
+    margin-bottom: var(--ease-space-1, 0.25rem);
+    display: block;
+  }
+
+  .ease-salary-calc__input-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .ease-salary-calc__currency {
+    position: absolute;
+    left: var(--ease-space-4, 1rem);
+    font-size: var(--ease-text-lg, 1.125rem);
+    font-weight: 600;
+    color: var(--ease-color-muted, #64748b);
+    pointer-events: none;
+  }
+
+  .ease-salary-calc__input {
+    width: 100%;
+    padding: var(--ease-space-4, 1rem) var(--ease-space-4, 1rem)
+             var(--ease-space-4, 1rem) var(--ease-space-8, 2rem);
+    font-size: var(--ease-text-xl, 1.25rem);
+    font-weight: 700;
+    color: var(--ease-color-text, #1e293b);
+    background: var(--ease-color-surface, #fff);
+    border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+    border-radius: var(--ease-radius-lg, 1rem);
+    outline: none;
+    transition: border-color var(--ease-speed-fast, 150ms);
+    box-sizing: border-box;
+  }
+
+  .ease-salary-calc__input:focus {
+    border-color: var(--ease-color-primary, #6c63ff);
+    box-shadow: 0 0 0 3px var(--ease-color-primary-alpha, rgba(108,99,255,0.15));
+  }
+
+  .ease-salary-calc__select {
+    padding: var(--ease-space-3, 0.75rem) var(--ease-space-4, 1rem);
+    font-size: var(--ease-text-sm, 0.875rem);
+    font-weight: 500;
+    color: var(--ease-color-text, #1e293b);
+    background: var(--ease-color-surface, #fff);
+    border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+    border-radius: var(--ease-radius-md, 0.5rem);
+    outline: none;
+    cursor: pointer;
+    transition: border-color var(--ease-speed-fast, 150ms);
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .ease-salary-calc__select:focus {
+    border-color: var(--ease-color-primary, #6c63ff);
+  }
+
+  /* ── Breakdown cards ─────────────────────────────────────── */
+  .ease-salary-calc__breakdown {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--ease-space-3, 0.75rem);
+  }
+
+  @media (max-width: 480px) {
+    .ease-salary-calc__breakdown { grid-template-columns: 1fr; }
+  }
+
+  .ease-salary-calc__card {
+    background: var(--ease-color-surface, #fff);
+    border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+    border-radius: var(--ease-radius-lg, 1rem);
+    padding: var(--ease-space-5, 1.25rem);
+    display: flex;
+    flex-direction: column;
+    gap: var(--ease-space-1, 0.25rem);
+    transition: box-shadow var(--ease-speed-medium, 300ms);
+  }
+
+  .ease-salary-calc__card:hover {
+    box-shadow: var(--ease-shadow-md, 0 4px 12px rgba(0,0,0,0.1));
+  }
+
+  .ease-salary-calc__card--highlight {
+    background: linear-gradient(135deg,
+      var(--ease-color-primary, #6c63ff),
+      var(--ease-color-primary-light, #a09af8)
+    );
+    border-color: transparent;
+    color: #fff;
+    grid-column: 1 / -1;
+  }
+
+  .ease-salary-calc__card-period {
+    font-size: var(--ease-text-xs, 0.75rem);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--ease-color-muted, #64748b);
+  }
+
+  .ease-salary-calc__card--highlight .ease-salary-calc__card-period {
+    color: rgba(255,255,255,0.75);
+  }
+
+  .ease-salary-calc__card-gross {
+    font-size: var(--ease-text-2xl, 1.75rem);
+    font-weight: 800;
+    color: var(--ease-color-text, #1e293b);
+    line-height: 1.1;
+  }
+
+  .ease-salary-calc__card--highlight .ease-salary-calc__card-gross {
+    color: #fff;
+  }
+
+  .ease-salary-calc__card-net {
+    font-size: var(--ease-text-sm, 0.875rem);
+    color: var(--ease-color-muted, #64748b);
+    font-weight: 500;
+  }
+
+  .ease-salary-calc__card--highlight .ease-salary-calc__card-net {
+    color: rgba(255,255,255,0.85);
+  }
+
+  /* ── Tax bracket visualization ───────────────────────────── */
+  .ease-salary-calc__tax-section {
+    background: var(--ease-color-surface, #fff);
+    border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+    border-radius: var(--ease-radius-lg, 1rem);
+    padding: var(--ease-space-5, 1.25rem);
+  }
+
+  .ease-salary-calc__tax-title {
+    font-size: var(--ease-text-sm, 0.875rem);
+    font-weight: 700;
+    color: var(--ease-color-text, #1e293b);
+    margin-bottom: var(--ease-space-4, 1rem);
+  }
+
+  .ease-salary-calc__tax-bar {
+    height: 12px;
+    border-radius: var(--ease-radius-full, 9999px);
+    overflow: hidden;
+    display: flex;
+    margin-bottom: var(--ease-space-3, 0.75rem);
+    gap: 2px;
+  }
+
+  .ease-salary-calc__tax-segment {
+    height: 100%;
+    transition: width var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4,0,0.2,1));
+    border-radius: var(--ease-radius-full, 9999px);
+  }
+
+  .ease-salary-calc__tax-segment--net    { background: var(--ease-color-success, #22c55e); }
+  .ease-salary-calc__tax-segment--fed    { background: var(--ease-color-primary, #6c63ff); }
+  .ease-salary-calc__tax-segment--state  { background: var(--ease-color-warning, #f59e0b); }
+  .ease-salary-calc__tax-segment--fica   { background: var(--ease-color-danger, #ef4444); }
+
+  .ease-salary-calc__tax-legend {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ease-space-2, 0.5rem);
+  }
+
+  .ease-salary-calc__tax-legend-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: var(--ease-text-xs, 0.75rem);
+  }
+
+  .ease-salary-calc__tax-legend-left {
+    display: flex;
+    align-items: center;
+    gap: var(--ease-space-2, 0.5rem);
+  }
+
+  .ease-salary-calc__tax-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .ease-salary-calc__tax-legend-label { color: var(--ease-color-muted, #64748b); }
+  .ease-salary-calc__tax-legend-amount { font-weight: 700; color: var(--ease-color-text, #1e293b); }
+
+  /* ── Dark mode ───────────────────────────────────────────── */
+  @media (prefers-color-scheme: dark) {
+    .ease-salary-calc__input,
+    .ease-salary-calc__select,
+    .ease-salary-calc__card,
+    .ease-salary-calc__tax-section {
+      background: var(--ease-color-neutral-800, #1e293b);
+      border-color: var(--ease-color-neutral-700, #334155);
+      color: var(--ease-color-neutral-100, #f1f5f9);
+    }
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds an interactive salary calculator that breaks down annual gross salary into monthly, bi-weekly, and weekly amounts with US federal tax bracket calculation, state tax, FICA, and a colour-coded take-home pay visualization.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- Annual / monthly / bi-weekly / weekly gross and net breakdown cards
- 2024 US federal tax brackets (Single, MFJ, HoH) with standard deduction
- Selectable state tax rates (0% → 13.3%)
- FICA (Social Security + Medicare) at 7.65%
- Colour-coded visual tax bar with legend and effective rate
- Live updates on every input change

**Styling:**
All visual properties use `--ease-color-*`, `--ease-space-*`, `--ease-radius-*`, and `--ease-text-*` tokens — fully consistent with the EaseMotion CSS design system.

---

## Demo
- [x] Demo added (`demo.html` opens directly in browser — fully interactive, no server needed)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

Closes #11325