### PR TITLE
feat: add CSS scroll-driven horizontal slideshow zoom and slide trans…

### DIFF
--- a/submissions/examples/scroll-horizontal-zoom-pp/README.md
+++ b/submissions/examples/scroll-horizontal-zoom-pp/README.md
@@ -1,0 +1,46 @@
+# CSS Scroll-Driven Horizontal Slideshow Zoom and Slide Transition
+
+This feature implements a high-end product gallery (Apple landing page style) where vertical page scrolling translates cards horizontally and zooms in on the active card using native CSS scroll-driven animations, resolving Issue #11762.
+
+## What does this do?
+
+It provides CSS-driven scroll transitions linking vertical page scrolling to horizontal slide translation and card zooming:
+
+- **Sticky Viewport**: Stays locked in position as the page scrolls vertically.
+- **Horizontal Translation**: Translates a horizontal track container proportionally to scroll depth.
+- **Active Zoom & Blur**: The centered card scales up to `1` and achieves full opacity, while inactive cards scale down to `0.8` and gain a blur filter.
+
+## How is it used?
+
+Structure of the scroll-driven horizontal gallery:
+
+```html
+<div class="scroll-container">
+  <div class="sticky-wrapper">
+    <div class="horizontal-track">
+      <!-- Card 1 -->
+      <div class="card card-1">...</div>
+      <!-- Card 2 -->
+      <div class="card card-2">...</div>
+      <!-- Card 3 -->
+      <div class="card card-3">...</div>
+    </div>
+
+    <!-- Optional Pagination -->
+    <div class="pagination-dots">
+      <div class="dot active-dot"></div>
+      <div class="dot"></div>
+      <div class="dot"></div>
+      <div class="dot"></div>
+    </div>
+  </div>
+</div>
+```
+
+## Viewport Sizing & Calculations
+
+- **Scroll Height**: `.scroll-container` uses `height: 300vh` (for 3 cards) to create scrollable space.
+- **Sticky Screen**: `.sticky-wrapper` uses `height: 100vh` and `position: sticky; top: 0` to hold the gallery in place during the scroll.
+- **Horizontal Track**: `.horizontal-track` uses `width: 300vw` (3 cards \* 100vw) and translates from `translateX(0)` to `translateX(-200vw)`.
+- **Scroll Timeline**: Driven natively by `animation-timeline: scroll(root)` which syncs animations to the root scroll.
+- **Accessibility**: Smoothly resets to a standard vertical column layout under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/scroll-horizontal-zoom-pp/demo.html
+++ b/submissions/examples/scroll-horizontal-zoom-pp/demo.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Scroll-Driven Horizontal Slideshow Zoom - EaseMotion CSS</title>
+    <!-- Google Fonts Outfit -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      /* Intro and Outro vertical sections */
+      .scroll-intro,
+      .scroll-outro {
+        height: 100vh;
+        width: 100vw;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 24px;
+        background: #000;
+        color: #f5f5f7;
+      }
+      @media (prefers-color-scheme: light) {
+        .scroll-intro,
+        .scroll-outro {
+          background: #f5f5f7;
+          color: #1d1d1f;
+        }
+      }
+      .scroll-arrow {
+        margin-top: 24px;
+        font-size: 2rem;
+        animation: bounce-arrow 1.6s infinite ease-in-out;
+      }
+      @keyframes bounce-arrow {
+        0%,
+        100% {
+          transform: translateY(0);
+        }
+        50% {
+          transform: translateY(8px);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Introductory Scroll Guide -->
+    <header class="scroll-intro">
+      <span class="badge">Scroll Showcase</span>
+      <h1 class="title">Product Gallery</h1>
+      <p class="description" style="max-width: 500px">
+        Experience native CSS scroll-driven slideshow transitions. Scroll down
+        vertically to begin horizontal slide transformations.
+      </p>
+      <div class="scroll-arrow">↓</div>
+    </header>
+
+    <!-- Interactive Scroll Gallery Section -->
+    <section class="scroll-container">
+      <div class="sticky-wrapper">
+        <!-- Horizontal Translating Track -->
+        <div class="horizontal-track">
+          <!-- Slide 1: MacBook Pro -->
+          <div class="card card-1">
+            <span class="card-badge">Supercharged</span>
+            <h2 class="card-title">MacBook Pro</h2>
+            <p class="card-description">Mind-blowing. Head-turning.</p>
+
+            <!-- Laptop Device Mockup -->
+            <div
+              style="display: flex; flex-direction: column; align-items: center"
+            >
+              <div class="device-mockup">
+                <div class="mockup-screen screen-1">💻</div>
+              </div>
+              <div class="laptop-base"></div>
+            </div>
+          </div>
+
+          <!-- Slide 2: iPad Pro -->
+          <div class="card card-2">
+            <span class="card-badge">Thinnest Apple Product</span>
+            <h2 class="card-title">iPad Pro</h2>
+            <p class="card-description">Thinpossible.</p>
+
+            <!-- Tablet Device Mockup -->
+            <div
+              class="device-mockup"
+              style="
+                border-radius: 12px;
+                border-width: 8px;
+                width: 220px;
+                height: 310px;
+              "
+            >
+              <div class="mockup-screen screen-2">✍️</div>
+            </div>
+          </div>
+
+          <!-- Slide 3: iPhone 16 Pro -->
+          <div class="card card-3">
+            <span class="card-badge">Apple Intelligence</span>
+            <h2 class="card-title">iPhone 16 Pro</h2>
+            <p class="card-description">Built for Apple Intelligence.</p>
+
+            <!-- Phone Device Mockup -->
+            <div
+              class="device-mockup"
+              style="
+                border-radius: 28px;
+                border-width: 6px;
+                width: 150px;
+                height: 300px;
+              "
+            >
+              <div class="mockup-screen screen-3">📱</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Pagination Indicators -->
+        <div class="pagination">
+          <div class="dot dot-1"></div>
+          <div class="dot dot-2"></div>
+          <div class="dot dot-3"></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Outro Section -->
+    <footer class="scroll-outro">
+      <h2 class="title">End of Showcase</h2>
+      <p class="description" style="max-width: 500px">
+        Developed with native CSS scroll-driven timelines. No JavaScript was
+        used to monitor scroll positions or trigger transition animations.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/submissions/examples/scroll-horizontal-zoom-pp/style.css
+++ b/submissions/examples/scroll-horizontal-zoom-pp/style.css
@@ -1,0 +1,397 @@
+/* ==========================================================
+   EaseMotion CSS - Scroll-Driven Horizontal Slideshow Style
+   ========================================================== */
+
+/* Design System Tokens */
+:root {
+  --font-sans: "Outfit", "Inter", system-ui, -apple-system, sans-serif;
+
+  /* Color Palette (Apple dark aesthetic) */
+  --bg-page: #000000;
+  --bg-card-1: radial-gradient(circle at center, #1c1917 0%, #0c0a09 100%);
+  --bg-card-2: radial-gradient(circle at center, #1e1b4b 0%, #0f0f1c 100%);
+  --bg-card-3: radial-gradient(circle at center, #182825 0%, #050a09 100%);
+
+  --text-main: #f5f5f7;
+  --text-muted: #86868b;
+  --accent: #0071e3;
+  --accent-light: rgba(0, 113, 227, 0.1);
+  --border-color: rgba(255, 255, 255, 0.08);
+}
+
+/* Light Theme Mode override */
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg-page: #f5f5f7;
+    --bg-card-1: radial-gradient(circle at center, #ffffff 0%, #f5f5f7 100%);
+    --bg-card-2: radial-gradient(circle at center, #e0e7ff 0%, #f5f5f7 100%);
+    --bg-card-3: radial-gradient(circle at center, #ccfbf1 0%, #f5f5f7 100%);
+
+    --text-main: #1d1d1f;
+    --text-muted: #86868b;
+    --accent: #0066cc;
+    --accent-light: rgba(0, 102, 204, 0.06);
+    --border-color: #d2d2d7;
+  }
+}
+
+/* Base resets */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg-page);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  line-height: 1.5;
+  overflow-x: hidden;
+}
+
+/* Scroll Container Height = (Number of slides * 100vh) */
+.scroll-container {
+  height: 300vh;
+  position: relative;
+}
+
+/* Sticky Wrapper holds slideshow visible during vertical scroll */
+.sticky-wrapper {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+/* Horizontal Track Translating horizontally */
+.horizontal-track {
+  display: flex;
+  width: 300vw; /* 3 slides * 100vw */
+  height: 100%;
+  will-change: transform;
+  transform: translateX(0);
+}
+
+/* Individual full-screen slide cards */
+.card {
+  width: 100vw;
+  height: 100vh;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  position: relative;
+  will-change: transform, opacity, filter;
+  transform: scale(1);
+  opacity: 1;
+}
+
+.card-1 {
+  background: var(--bg-card-1);
+}
+.card-2 {
+  background: var(--bg-card-2);
+}
+.card-3 {
+  background: var(--bg-card-3);
+}
+
+/* Slide Card Content */
+.card-badge {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--accent);
+  margin-bottom: 12px;
+}
+
+.card-title {
+  font-size: 2.5rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin-bottom: 8px;
+  text-align: center;
+  max-width: 600px;
+}
+
+@media (min-width: 768px) {
+  .card-title {
+    font-size: 3.5rem;
+  }
+}
+
+.card-description {
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  font-weight: 500;
+  margin-bottom: 40px;
+  text-align: center;
+  max-width: 500px;
+}
+
+/* Product Device CSS Mockups */
+.device-mockup {
+  width: 280px;
+  height: 180px;
+  border: 12px solid #2d2d30;
+  border-radius: 20px;
+  background: #000;
+  position: relative;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (min-width: 640px) {
+  .device-mockup {
+    width: 440px;
+    height: 260px;
+  }
+}
+
+/* Laptop specific spine */
+.laptop-base {
+  width: 340px;
+  height: 8px;
+  background: #4e4e52;
+  border-radius: 0 0 8px 8px;
+  margin-top: -2px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+}
+@media (min-width: 640px) {
+  .laptop-base {
+    width: 520px;
+  }
+}
+
+.mockup-screen {
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 2rem;
+  font-weight: 800;
+}
+
+/* Mockup screen gradients */
+.screen-1 {
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+}
+.screen-2 {
+  background: linear-gradient(135deg, #ec4899, #6366f1);
+}
+.screen-3 {
+  background: linear-gradient(135deg, #10b981, #06b6d4);
+}
+
+/* Pagination Dots Indicator */
+.pagination {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 16px;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 8px 16px;
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  backdrop-filter: blur(8px);
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  background-color: var(--text-muted);
+  border-radius: 50%;
+  opacity: 0.4;
+  transition: opacity 0.3s ease;
+}
+
+/* CSS Scroll-Driven Keyframes - Issue #11762 Specifications */
+
+/* 1. Slide Track horizontal translation timeline */
+@keyframes slide-horizontal {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-200vw);
+  } /* Translates exactly (N-1)*100vw */
+}
+
+/* 2. Card Zoom / Focus transitions */
+@keyframes card-zoom-1 {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+    filter: blur(0);
+  }
+  35%,
+  100% {
+    transform: scale(0.8);
+    opacity: 0.35;
+    filter: blur(6px);
+  }
+}
+
+@keyframes card-zoom-2 {
+  0% {
+    transform: scale(0.8);
+    opacity: 0.35;
+    filter: blur(6px);
+  }
+  50% {
+    transform: scale(1);
+    opacity: 1;
+    filter: blur(0);
+  }
+  100% {
+    transform: scale(0.8);
+    opacity: 0.35;
+    filter: blur(6px);
+  }
+}
+
+@keyframes card-zoom-3 {
+  0%,
+  65% {
+    transform: scale(0.8);
+    opacity: 0.35;
+    filter: blur(6px);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
+/* 3. Pagination dots active transitions */
+@keyframes dot-highlight-1 {
+  0% {
+    opacity: 1;
+    background-color: var(--accent);
+  }
+  35%,
+  100% {
+    opacity: 0.4;
+    background-color: var(--text-muted);
+  }
+}
+
+@keyframes dot-highlight-2 {
+  0% {
+    opacity: 0.4;
+    background-color: var(--text-muted);
+  }
+  50% {
+    opacity: 1;
+    background-color: var(--accent);
+  }
+  100% {
+    opacity: 0.4;
+    background-color: var(--text-muted);
+  }
+}
+
+@keyframes dot-highlight-3 {
+  0%,
+  65% {
+    opacity: 0.4;
+    background-color: var(--text-muted);
+  }
+  100% {
+    opacity: 1;
+    background-color: var(--accent);
+  }
+}
+
+/* Bind animations to scroll timeline natively */
+.horizontal-track {
+  animation: slide-horizontal linear both;
+  animation-timeline: scroll(root);
+}
+
+.card-1 {
+  animation: card-zoom-1 linear both;
+  animation-timeline: scroll(root);
+}
+
+.card-2 {
+  animation: card-zoom-2 linear both;
+  animation-timeline: scroll(root);
+}
+
+.card-3 {
+  animation: card-zoom-3 linear both;
+  animation-timeline: scroll(root);
+}
+
+.dot-1 {
+  animation: dot-highlight-1 linear both;
+  animation-timeline: scroll(root);
+}
+
+.dot-2 {
+  animation: dot-highlight-2 linear both;
+  animation-timeline: scroll(root);
+}
+
+.dot-3 {
+  animation: dot-highlight-3 linear both;
+  animation-timeline: scroll(root);
+}
+
+/* Accessibility prefers-reduced-motion: reduce configuration */
+@media (prefers-reduced-motion: reduce) {
+  /* Disable tall scroll depth wrapper */
+  .scroll-container {
+    height: auto !important;
+  }
+
+  /* Reset sticky wrapper to normal vertical list */
+  .sticky-wrapper {
+    position: relative !important;
+    height: auto !important;
+    overflow: visible !important;
+  }
+
+  /* Stack slides vertically */
+  .horizontal-track {
+    display: flex;
+    flex-direction: column;
+    width: 100vw !important;
+    height: auto !important;
+    transform: none !important;
+    animation: none !important;
+  }
+
+  /* Render cards standard size and focus */
+  .card {
+    width: 100vw !important;
+    height: 100vh !important;
+    transform: none !important;
+    opacity: 1 !important;
+    filter: none !important;
+    animation: none !important;
+  }
+
+  /* Hide active scroll indicators */
+  .pagination {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
### Description
This pull request adds an Apple-style CSS scroll-driven horizontal slideshow zoom and slide transition component, resolving issue #11762.

It places the implementation under `submissions/examples/scroll-horizontal-zoom-pp/` to avoid naming conflicts.

### Features Included
- **Scroll-Driven Horizontal Sliding**: Viewport vertical scrolling drives horizontal layout track translation using native `animation-timeline: scroll(root)`.
- **Card Zoom and Focus**: Smoothly scales up centered elements to `scale(1)` and fades them in while translating other slides to `scale(0.8)` with blur filters.
- **Scroll-Synced Pagination**: Interactive pagination dots highlight the currently active slide card based on scroll depth.
- **Mock Device Showcase**: Beautiful CSS-rendered laptop, tablet, and mobile mockups displaying products.
- **A11y Fallback**: Layout falls back gracefully to a standard vertical stacked list under `prefers-reduced-motion: reduce`.

### Checklist
- [x] This feature does not duplicate an existing EaseMotion CSS class
- [x] Naming can be standardized by the maintainer
- [x] Code lives inside submissions/examples/ only
- [x] Pure HTML and CSS implementation
- [x] Responsive design
- [x] Includes reduced-motion handling