### PR TITLE
feat: add ease-zoom-in-up-pp feature submission (#11822)

### DIFF
--- a/submissions/examples/ease-zoom-in-up-pp/README.md
+++ b/submissions/examples/ease-zoom-in-up-pp/README.md
@@ -1,0 +1,68 @@
+# ease-zoom-in-up-pp
+
+An entrance animation combining scaling (zoom-in) and moving upwards simultaneously with smooth ease-out.
+
+## What does this do?
+
+This animation fades an element in while zooming it in (scaling up) and sliding it up from a lower offset. This combined motion makes entrance transitions feel modern and smooth.
+
+---
+
+## How is it used?
+
+Simply apply the `.ease-zoom-in-up` class to any HTML element:
+
+```html
+<div class="ease-zoom-in-up">Hello World</div>
+```
+
+### Custom Variables
+
+You can customize the initial scale and slide distance directly using CSS custom variables:
+
+- `--ease-zoom-in-up-scale`: The starting scale factor (default: `0.5`).
+- `--ease-zoom-in-up-distance`: The starting translateY offset (default: `40px`).
+
+```css
+.my-hero-card {
+  --ease-zoom-in-up-scale: 0.75;
+  --ease-zoom-in-up-distance: 80px;
+}
+```
+
+```html
+<div class="ease-zoom-in-up my-hero-card">Custom Hero Card</div>
+```
+
+### Speed Modifiers
+
+Adjust the duration using standard EaseMotion speed helper classes:
+
+- `.ease-zoom-in-up-fast` (500ms duration)
+- _(default)_ (800ms duration)
+- `.ease-zoom-in-up-slow` (1200ms duration)
+
+---
+
+## Why is it useful?
+
+This combination is a highly popular pattern in modern landing page design for hero headings, call-to-actions, and content grids. It draws focus cleanly and dynamically as elements resolve into place.
+
+---
+
+## Tech Stack
+
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+---
+
+## Accessibility
+
+Respects user preferences for motion sensitivity: if `prefers-reduced-motion` is active, the animation is skipped and the element immediately displays statically.
+
+---
+
+## Preview
+
+Open `demo.html` directly in your browser to experience the live playground.

--- a/submissions/examples/ease-zoom-in-up-pp/demo.html
+++ b/submissions/examples/ease-zoom-in-up-pp/demo.html
@@ -1,0 +1,286 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>ease-zoom-in-up - EaseMotion CSS</title>
+
+    <!-- Link to EaseMotion CSS core -->
+    <link rel="stylesheet" href="../../../core/animations.css" />
+    <!-- Link to style.css containing our component and demo layout -->
+    <link rel="stylesheet" href="style.css" />
+
+    <!-- Google Fonts for premium typography -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header>
+      <h1>ease-zoom-in-up</h1>
+      <p>
+        Entrance animation combining scaling (zoom-in) and moving upwards
+        simultaneously with smooth ease-out.
+      </p>
+    </header>
+
+    <div class="demo-container">
+      <!-- Left Column: Interactive Live Preview -->
+      <div class="preview-panel">
+        <div class="preview-grid-bg"></div>
+
+        <div class="preview-card-wrapper">
+          <!-- Animating Glass Card Component -->
+          <div class="ease-zoom-in-up preview-card" id="target-card">
+            <div class="card-icon">⚡</div>
+            <div class="card-title">Launch Analytics</div>
+            <div class="card-description">
+              Track user conversion rates, loading benchmarks, and performance
+              indexes dynamically in real-time. Built to optimize modern
+              application interfaces.
+            </div>
+            <div class="card-action">Learn more <span>&rarr;</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right Column: Interactive Configuration Panel -->
+      <div class="controls-panel">
+        <!-- Trigger Control -->
+        <div class="control-card">
+          <h3>Trigger Animation</h3>
+          <div class="control-group">
+            <button class="btn-trigger" id="trigger-btn">
+              Replay Animation
+            </button>
+          </div>
+        </div>
+
+        <!-- Animation Variables Customization -->
+        <div class="control-card">
+          <h3>Custom Variables</h3>
+          <div class="control-group">
+            <label class="control-label" for="scale-slider"
+              >Starting Scale <span id="scale-val">0.5</span></label
+            >
+            <input
+              type="range"
+              id="scale-slider"
+              class="slider"
+              min="0.1"
+              max="0.9"
+              step="0.05"
+              value="0.5"
+            />
+          </div>
+          <div class="control-group">
+            <label class="control-label" for="distance-slider"
+              >translateY Distance <span id="distance-val">40px</span></label
+            >
+            <input
+              type="range"
+              id="distance-slider"
+              class="slider"
+              min="10"
+              max="200"
+              value="40"
+            />
+          </div>
+        </div>
+
+        <!-- Speed Control -->
+        <div class="control-card">
+          <h3>Animation Speed</h3>
+          <div class="control-group">
+            <div class="segmented-control" id="speed-control">
+              <button class="segment-btn" data-speed="slow">Slow</button>
+              <button class="segment-btn active" data-speed="normal">
+                Normal
+              </button>
+              <button class="segment-btn" data-speed="fast">Fast</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Live Code Generator -->
+        <div class="control-card code-card">
+          <div class="code-header">
+            <h4>Integration Code</h4>
+            <button class="copy-btn" id="copy-code-btn">Copy HTML & CSS</button>
+          </div>
+          <div class="code-container">
+            <pre id="code-output"></pre>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      // Elements
+      const targetCard = document.getElementById("target-card");
+      const triggerBtn = document.getElementById("trigger-btn");
+      const scaleSlider = document.getElementById("scale-slider");
+      const scaleVal = document.getElementById("scale-val");
+      const distanceSlider = document.getElementById("distance-slider");
+      const distanceVal = document.getElementById("distance-val");
+      const speedControl = document.getElementById("speed-control");
+      const codeOutput = document.getElementById("code-output");
+      const copyCodeBtn = document.getElementById("copy-code-btn");
+
+      const speedButtons = speedControl.querySelectorAll(".segment-btn");
+
+      // Configuration state
+      let startScale = 0.5;
+      let translateYDistance = 40;
+      let animSpeed = "normal"; // slow, normal, fast
+
+      // Replay animation utility
+      function replayAnimation() {
+        // Remove classes
+        targetCard.classList.remove("ease-zoom-in-up");
+        targetCard.classList.remove("ease-zoom-in-up-fast");
+        targetCard.classList.remove("ease-zoom-in-up-slow");
+
+        // Force repaint to reset CSS animation state
+        void targetCard.offsetWidth;
+
+        // Re-apply custom properties
+        targetCard.style.setProperty("--ease-zoom-in-up-scale", startScale);
+        targetCard.style.setProperty(
+          "--ease-zoom-in-up-distance",
+          `${translateYDistance}px`
+        );
+
+        // Add classes back
+        targetCard.classList.add("ease-zoom-in-up");
+        if (animSpeed === "fast") {
+          targetCard.classList.add("ease-zoom-in-up-fast");
+        } else if (animSpeed === "slow") {
+          targetCard.classList.add("ease-zoom-in-up-slow");
+        }
+      }
+
+      // Trigger Event
+      triggerBtn.addEventListener("click", replayAnimation);
+
+      // Scale Slider Event
+      scaleSlider.addEventListener("input", (e) => {
+        startScale = e.target.value;
+        scaleVal.textContent = startScale;
+        targetCard.style.setProperty("--ease-zoom-in-up-scale", startScale);
+        updateCode();
+      });
+
+      scaleSlider.addEventListener("change", replayAnimation);
+
+      // Distance Slider Event
+      distanceSlider.addEventListener("input", (e) => {
+        translateYDistance = e.target.value;
+        distanceVal.textContent = `${translateYDistance}px`;
+        targetCard.style.setProperty(
+          "--ease-zoom-in-up-distance",
+          `${translateYDistance}px`
+        );
+        updateCode();
+      });
+
+      distanceSlider.addEventListener("change", replayAnimation);
+
+      // Speed Control Event
+      speedButtons.forEach((btn) => {
+        btn.addEventListener("click", () => {
+          speedButtons.forEach((b) => b.classList.remove("active"));
+          btn.classList.add("active");
+
+          animSpeed = btn.dataset.speed;
+
+          replayAnimation();
+          updateCode();
+        });
+      });
+
+      // Update Code Display
+      function updateCode() {
+        // HTML classes
+        let htmlClass = "ease-zoom-in-up";
+        if (animSpeed === "fast") htmlClass += " ease-zoom-in-up-fast";
+        if (animSpeed === "slow") htmlClass += " ease-zoom-in-up-slow";
+
+        // Custom property string
+        let styleAttr = "";
+        if (parseFloat(startScale) !== 0.5)
+          styleAttr += ` --ease-zoom-in-up-scale: ${startScale};`;
+        if (parseInt(translateYDistance) !== 40)
+          styleAttr += ` --ease-zoom-in-up-distance: ${translateYDistance}px;`;
+
+        const styleMarkup = styleAttr ? ` style="${styleAttr.trim()}"` : "";
+        const htmlBlock = `&lt;<span class="code-keyword">div</span> <span class="code-property">class</span>=<span class="code-string">"${htmlClass}"</span>${styleMarkup}&gt;Content&lt;/<span class="code-keyword">div</span>&gt;`;
+
+        let cssBlock = `<span class="code-comment">/* Customize in stylesheet */</span>\n.<span class="code-keyword">custom-zoom-up</span> {`;
+        if (
+          parseFloat(startScale) !== 0.5 ||
+          parseInt(translateYDistance) !== 40
+        ) {
+          if (parseFloat(startScale) !== 0.5) {
+            cssBlock += `\n  <span class="code-property">--ease-zoom-in-up-scale</span>: <span class="code-value">${startScale}</span>;`;
+          }
+          if (parseInt(translateYDistance) !== 40) {
+            cssBlock += `\n  <span class="code-property">--ease-zoom-in-up-distance</span>: <span class="code-value">${translateYDistance}px</span>;`;
+          }
+          cssBlock += "\n}";
+        } else {
+          cssBlock += `\n  <span class="code-comment">/* Use defaults, or custom scale / translate values */</span>\n  <span class="code-property">--ease-zoom-in-up-scale</span>: <span class="code-value">0.7</span>;\n  <span class="code-property">--ease-zoom-in-up-distance</span>: <span class="code-value">80px</span>;\n}`;
+        }
+
+        codeOutput.innerHTML = `${htmlBlock}\n\n${cssBlock}`;
+      }
+
+      // Copy Code Button
+      copyCodeBtn.addEventListener("click", () => {
+        let htmlClass = "ease-zoom-in-up";
+        if (animSpeed === "fast") htmlClass += " ease-zoom-in-up-fast";
+        if (animSpeed === "slow") htmlClass += " ease-zoom-in-up-slow";
+
+        let styleAttr = "";
+        let cssCustomProps = "";
+        if (parseFloat(startScale) !== 0.5) {
+          styleAttr += ` --ease-zoom-in-up-scale: ${startScale};`;
+          cssCustomProps += `\n  --ease-zoom-in-up-scale: ${startScale};`;
+        }
+        if (parseInt(translateYDistance) !== 40) {
+          styleAttr += ` --ease-zoom-in-up-distance: ${translateYDistance}px;`;
+          cssCustomProps += `\n  --ease-zoom-in-up-distance: ${translateYDistance}px;`;
+        }
+
+        const styleMarkup = styleAttr ? ` style="${styleAttr.trim()}"` : "";
+        const rawHtml = `<div class="${htmlClass}"${styleMarkup}>Content</div>`;
+
+        let rawCss = `/* Custom Zoom-in-up Style */\n.custom-zoom-up {`;
+        if (cssCustomProps) {
+          rawCss += cssCustomProps + "\n}";
+        } else {
+          rawCss += `\n  --ease-zoom-in-up-scale: 0.7;\n  --ease-zoom-in-up-distance: 80px;\n}`;
+        }
+
+        const fullCode = `${rawHtml}\n\n${rawCss}`;
+
+        navigator.clipboard.writeText(fullCode).then(() => {
+          copyCodeBtn.textContent = "Copied!";
+          copyCodeBtn.classList.add("copied");
+
+          setTimeout(() => {
+            copyCodeBtn.textContent = "Copy HTML & CSS";
+            copyCodeBtn.classList.remove("copied");
+          }, 2000);
+        });
+      });
+
+      // Initial load
+      updateCode();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/ease-zoom-in-up-pp/style.css
+++ b/submissions/examples/ease-zoom-in-up-pp/style.css
@@ -1,0 +1,471 @@
+/* ============================================================
+   EaseMotion CSS — ease-zoom-in-up-pp
+   Submission by: Pratyush-Panda-2006
+   Description: Zoom in while sliding up entrance animation.
+                Element fades in from scale(0.5), translateY(40px)
+                and opacity(0) to normal. Zero JS.
+   ============================================================ */
+
+/* CSS Houdini Custom Property Registration */
+@property --ease-zoom-in-up-scale {
+  syntax: "<number>";
+  initial-value: 0.5;
+  inherits: true;
+}
+
+@property --ease-zoom-in-up-distance {
+  syntax: "<length-percentage>";
+  initial-value: 40px;
+  inherits: true;
+}
+
+/* ============================================================
+   CORE LIBRARY STYLES (EaseMotion CSS Component)
+   ============================================================ */
+
+.ease-zoom-in-up {
+  --ease-zoom-in-up-scale: 0.5;
+  --ease-zoom-in-up-distance: 40px;
+  animation: ease-kf-zoom-in-up-pp var(--ease-speed-slow, 800ms)
+    cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes ease-kf-zoom-in-up-pp {
+  from {
+    opacity: 0;
+    transform: scale(var(--ease-zoom-in-up-scale, 0.5))
+      translateY(var(--ease-zoom-in-up-distance, 40px));
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+/* Speed variants to align with EaseMotion conventions */
+.ease-zoom-in-up-fast {
+  animation-duration: var(--ease-speed-medium, 500ms);
+}
+
+.ease-zoom-in-up-slow {
+  animation-duration: 1200ms;
+}
+
+/* Respect user prefers-reduced-motion settings */
+@media (prefers-reduced-motion: reduce) {
+  .ease-zoom-in-up {
+    animation: none;
+    transform: none;
+    opacity: 1;
+  }
+}
+
+/* ============================================================
+   DEMO APP STYLES (Not part of core framework)
+   ============================================================ */
+
+:root {
+  --bg-dark: #050508;
+  --panel-bg: rgba(18, 18, 24, 0.7);
+  --panel-border: rgba(255, 255, 255, 0.08);
+  --accent-teal: #14b8a6;
+  --accent-blue: #3b82f6;
+  --text-muted: #94a3b8;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    "Outfit",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  background-color: var(--bg-dark);
+  color: #ffffff;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: absolute;
+  top: -10%;
+  left: -10%;
+  width: 120%;
+  height: 120%;
+  background:
+    radial-gradient(
+      circle at 75% 15%,
+      rgba(20, 184, 166, 0.06) 0%,
+      transparent 40%
+    ),
+    radial-gradient(
+      circle at 25% 85%,
+      rgba(59, 130, 246, 0.06) 0%,
+      transparent 40%
+    );
+  pointer-events: none;
+  z-index: 0;
+}
+
+header {
+  position: relative;
+  z-index: 10;
+  padding: 3rem 2rem 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+  text-align: center;
+}
+
+header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #ffffff 40%, var(--text-muted) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+header p {
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.demo-container {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 2.5rem;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 2rem 4rem;
+  position: relative;
+  z-index: 10;
+  flex-grow: 1;
+}
+
+@media (max-width: 968px) {
+  .demo-container {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Interactive Preview Box */
+.preview-panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 4rem;
+  min-height: 450px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+}
+
+.preview-grid-bg {
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(
+    rgba(255, 255, 255, 0.02) 1px,
+    transparent 1px
+  );
+  background-size: 20px 20px;
+  pointer-events: none;
+}
+
+/* Glass Card Showcase */
+.preview-card-wrapper {
+  width: 100%;
+  max-width: 420px;
+}
+
+.preview-card {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.06) 0%,
+    rgba(255, 255, 255, 0.01) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transform-origin: center bottom;
+}
+
+.card-icon {
+  width: 48px;
+  height: 48px;
+  background: linear-gradient(
+    135deg,
+    var(--accent-teal) 0%,
+    var(--accent-blue) 100%
+  );
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(20, 184, 166, 0.3);
+}
+
+.card-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: #ffffff;
+}
+
+.card-description {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.card-action {
+  align-self: flex-start;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent-teal);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+  transition: gap 0.2s ease;
+}
+
+.card-action:hover {
+  gap: 0.75rem;
+}
+
+/* Control Panel Grid */
+.controls-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.control-card {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 20px;
+  padding: 1.5rem;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.control-card h3 {
+  font-size: 1.1rem;
+  margin-bottom: 1.2rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  padding-bottom: 0.5rem;
+  color: #f3f4f6;
+}
+
+.control-group {
+  margin-bottom: 1.2rem;
+}
+
+.control-group:last-child {
+  margin-bottom: 0;
+}
+
+.control-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.control-label span {
+  font-weight: 500;
+  color: #fff;
+}
+
+/* Trigger Button */
+.btn-trigger {
+  width: 100%;
+  background: linear-gradient(
+    135deg,
+    var(--accent-teal) 0%,
+    var(--accent-blue) 100%
+  );
+  border: none;
+  color: #fff;
+  padding: 0.85rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(20, 184, 166, 0.25);
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-trigger:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(20, 184, 166, 0.35);
+}
+
+.btn-trigger:active {
+  transform: translateY(0);
+}
+
+/* Slider styling */
+.slider {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.1);
+  outline: none;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  cursor: pointer;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  transition: transform 0.1s ease;
+}
+
+.slider::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+}
+
+/* Segmented Control */
+.segmented-control {
+  display: flex;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 2px;
+  gap: 2px;
+}
+
+.segment-btn {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  padding: 0.5rem;
+  cursor: pointer;
+  border-radius: 6px;
+  font-family: inherit;
+  transition: all 0.2s ease;
+}
+
+.segment-btn:hover {
+  color: #fff;
+}
+
+.segment-btn.active {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-weight: 500;
+}
+
+/* Code Snippet Card */
+.code-card {
+  position: relative;
+}
+
+.code-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.code-header h4 {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.copy-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.copy-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.copy-btn.copied {
+  background: rgba(16, 185, 129, 0.2);
+  border-color: rgb(16, 185, 129);
+  color: rgb(16, 185, 129);
+}
+
+.code-container {
+  background: #000000;
+  border-radius: 10px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: #a9b2c3;
+  max-height: 250px;
+}
+
+.code-container pre {
+  margin: 0;
+}
+
+.code-keyword {
+  color: #f472b6;
+}
+.code-property {
+  color: #38bdf8;
+}
+.code-value {
+  color: #fbbf24;
+}
+.code-string {
+  color: #34d399;
+}
+.code-comment {
+  color: #6b7280;
+  font-style: italic;
+}


### PR DESCRIPTION
Resolves #11822

### Description
This PR implements the `ease-zoom-in-up-pp` feature, which adds an entrance animation combining scaling (zoom-in) and moving upwards simultaneously with smooth ease-out.

### Key Changes
- Created a self-contained feature directory `submissions/examples/ease-zoom-in-up-pp/`.
- Built `style.css` which includes:
  - `@property` CSS Houdini registration for `--ease-zoom-in-up-scale` (default `0.5`) and `--ease-zoom-in-up-distance` (default `40px`).
  - Zoom-in-up keyframes scaling and translating elements simultaneously.
  - Duration speed modifier classes and media query for `prefers-reduced-motion` to skip the animation for motion sensitivity.
- Built an interactive `demo.html` page featuring a glass card widget, customized starting scale slider, slide translateY distance slider, speed segmented buttons, animation re-trigger button, and copy-pasteable snippet generator.
- Added comprehensive documentation in `README.md`.