### PR TITLE
feat: add CSS drag-select interactive component

### DIFF
--- a/submissions/examples/css-drag-select-sk/README.md
+++ b/submissions/examples/css-drag-select-sk/README.md
@@ -1,0 +1,14 @@
+# CSS Drag Select
+
+A CSS-only drag-to-select interaction using `:active` and sibling combinators. Drag across items to highlight them.
+
+## Usage
+```html
+<div class="drag-select">
+  <div class="drag-select__item">Item 1</div>
+  <div class="drag-select__item">Item 2</div>
+</div>
+```
+
+## Why EaseMotion CSS?
+Demonstrates how CSS selectors can create interactive selection UIs without JavaScript.

--- a/submissions/examples/css-drag-select-sk/demo.html
+++ b/submissions/examples/css-drag-select-sk/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Drag Select</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="drag-select">
+    <div class="drag-select__item" data-label="Item 1">Item 1</div>
+    <div class="drag-select__item" data-label="Item 2">Item 2</div>
+    <div class="drag-select__item" data-label="Item 3">Item 3</div>
+    <div class="drag-select__item" data-label="Item 4">Item 4</div>
+    <div class="drag-select__item" data-label="Item 5">Item 5</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-drag-select-sk/style.css
+++ b/submissions/examples/css-drag-select-sk/style.css
@@ -1,0 +1,44 @@
+.drag-select {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 12px;
+  padding: 20px;
+  user-select: none;
+  max-width: 600px;
+  margin: 40px auto;
+}
+.drag-select__item {
+  background: #f0f0f0;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  padding: 24px 16px;
+  text-align: center;
+  font-family: system-ui, sans-serif;
+  cursor: default;
+  transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+  position: relative;
+}
+.drag-select__item::before {
+  content: attr(data-label);
+  font-weight: 600;
+  color: #555;
+}
+.drag-select:active .drag-select__item {
+  border-color: #84a0ff;
+  background: #eef1ff;
+  box-shadow: 0 0 0 3px rgba(80, 130, 255, 0.15);
+}
+.drag-select:active .drag-select__item:hover {
+  border-color: #3b6eff;
+  background: #dce3ff;
+  box-shadow: 0 0 0 3px rgba(80, 130, 255, 0.3);
+}
+.drag-select__item::selection {
+  background: transparent;
+}
+.drag-select:active .drag-select__item:has(~ .drag-select__item:hover),
+.drag-select:active .drag-select__item:hover ~ .drag-select__item {
+  border-color: #84a0ff;
+  background: #eef1ff;
+  box-shadow: 0 0 0 3px rgba(80, 130, 255, 0.15);
+}


### PR DESCRIPTION
## Pull Request Description

CSS-only drag-to-select component using `:active` and sibling combinators.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-drag-select-sk/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
CSS-only drag-to-select interaction using `:active` on the container combined with sibling combinators to highlight items under drag.

**How does a developer use it?**
```html
<div class="drag-select">
  <div class="drag-select__item">Item</div>
</div>
```

**Why does it fit EaseMotion CSS?**
Reusable interactive selection pattern without JavaScript.

---

## Demo

- [x] Demo added

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

Unique component — no existing drag-select in the repo.