### PR TITLE
fix: add webhook payload validation to autoClaimHandle.js and autoUnclaimHandler.js

### DIFF
--- a/.github/scripts/autoClaimHandle.js
+++ b/.github/scripts/autoClaimHandle.js
@@ -43,14 +43,17 @@ async function handleClaim({ github, context }) {
     return;
   }
 
+  if (!context.payload.issue || !Array.isArray(context.payload.issue.assignees)) return;
+  if (!Array.isArray(context.payload.issue.labels)) return;
+
   const currentAssignees = context.payload.issue.assignees.map((a) =>
-    a.login.toLowerCase()
+    String(a.login || "").toLowerCase()
   );
   const issueLabels = context.payload.issue.labels.map((l) =>
-    l.name.toLowerCase()
+    String(l.name || "").toLowerCase()
   );
-  const issueTitle = (context.payload.issue.title || "").toLowerCase();
-  const issueBody = (context.payload.issue.body || "").toLowerCase();
+  const issueTitle = String(context.payload.issue.title || "").toLowerCase();
+  const issueBody = String(context.payload.issue.body || "").toLowerCase();
 
   const isSubmissionIssue =
     issueLabels.some(

--- a/.github/scripts/autoUnclaimHandler.js
+++ b/.github/scripts/autoUnclaimHandler.js
@@ -15,7 +15,9 @@ async function handleUnclaim({ github, context }) {
     return;
   }
 
-  const currentAssignees = context.payload.issue.assignees.map((a) => a.login.toLowerCase());
+  if (!context.payload.issue || !Array.isArray(context.payload.issue.assignees)) return;
+
+  const currentAssignees = context.payload.issue.assignees.map((a) => String(a.login || "").toLowerCase());
 
   if (!currentAssignees.includes(commenter.toLowerCase())) {
     await github.rest.issues.createComment({


### PR DESCRIPTION
## Pull Request Description

Resolves #4625

Adds robust input validation guards and string type coercion inside both `autoClaimHandle.js` and `autoUnclaimHandler.js` scripts. 

---

## Technical Details

- **Issue:** Webhook payload fields (`context.payload.issue.assignees`, `.labels`, `.title`, and `.body`) were consumed directly without verifying presence or structure, throwing `TypeError: Cannot read properties of undefined` if the payload structure was malformed or partial.
- **The Fix:**
  - Added Array check validation guards: `Array.isArray(context.payload.issue.assignees)` and `Array.isArray(context.payload.issue.labels)` with clean early-exit behavior.
  - Coerced string fields using `String(...)` before executing string methods like `.toLowerCase()` to handle null or non-string values gracefully.

---

## Submission Checklist

- [x] All changes are inside `.github/scripts/`
- [x] Code is verified and lint-free
- [x] **No changes to framework core or component templates**

Closes #4625