### PR TITLE
Add status page incident banner example

### DIFF
--- a/submissions/examples/status-page-incident-banner-ts/README.md
+++ b/submissions/examples/status-page-incident-banner-ts/README.md
@@ -1,0 +1,36 @@
+# Status Page Incident Banner
+
+## What does this do?
+
+A clear incident banner for investigating, monitoring, and resolved service states.
+
+## How is it used?
+
+Open `demo.html` directly or copy the component markup and stylesheet from this submission folder.
+
+## Why is it useful?
+
+This pattern fits product dashboards, admin tools, and documentation examples where motion should clarify state without requiring a JavaScript framework.
+
+## Features
+
+- Self-contained HTML and CSS
+- Responsive layout
+- Clear visual states
+- Focus and hover styling where relevant
+- `prefers-reduced-motion` support
+
+## Tech Stack
+
+- HTML
+- CSS
+
+## Preview
+
+Open `demo.html` directly in a browser to view the example.
+
+## Contribution Notes
+
+- Proposed for issue #11963
+- All files are scoped to this submission folder
+- No framework source files are modified

--- a/submissions/examples/status-page-incident-banner-ts/demo.html
+++ b/submissions/examples/status-page-incident-banner-ts/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Status Page Incident Banner</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro-panel" aria-labelledby="demo-title">
+      <p class="eyebrow">Status page</p>
+      <h1 id="demo-title">Incident communication banner</h1>
+      <p>A clear incident banner for investigating, monitoring, and resolved service states.</p>
+    </section>
+    <section class="demo-grid" aria-label="Status Page Incident Banner">
+        <article class="incident-banner"><span>Monitoring</span><strong>Elevated API latency</strong><time>Updated 5 min ago</time></article>
+        <article class="incident-banner"><span>Investigating</span><strong>Webhook delivery delays</strong><time>Updated 12 min ago</time></article>
+        <article class="incident-banner"><span>Resolved</span><strong>Search indexing recovered</strong><time>Updated 1 hr ago</time></article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/status-page-incident-banner-ts/style.css
+++ b/submissions/examples/status-page-incident-banner-ts/style.css
@@ -1,0 +1,52 @@
+:root { color-scheme: dark; --bg: #0b1120; --panel: #111827; --surface: #162033; --border: rgba(148, 163, 184, 0.22); --text: #f8fafc; --muted: #94a3b8; --accent: #f59e0b; --danger: #ef4444; }
+* { box-sizing: border-box; }
+body { min-height: 100vh; margin: 0; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: radial-gradient(circle at 18% 16%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 28rem), radial-gradient(circle at 88% 78%, rgba(56, 189, 248, 0.12), transparent 28rem), var(--bg); color: var(--text); }
+.demo-shell { display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(320px, 1.1fr); align-items: center; gap: 2rem; width: min(1120px, calc(100% - 2rem)); min-height: 100vh; margin: 0 auto; padding: 3rem 0; }
+.intro-panel { max-width: 580px; }
+.eyebrow, h1, p { margin-top: 0; }
+.eyebrow { margin-bottom: 0.55rem; color: color-mix(in srgb, var(--accent) 76%, white); font-size: 0.78rem; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; }
+h1 { margin-bottom: 0.85rem; font-size: clamp(2rem, 6vw, 4rem); line-height: 1; }
+.intro-panel p { color: var(--muted); line-height: 1.7; }
+.demo-grid, .demo-stage { display: grid; gap: 1rem; }
+.demo-card, .action-toolbar, .segment-strip, .kanban-limit, .incident-banner, .side-sheet, .search-empty, .release-banner { background: linear-gradient(145deg, rgba(255, 255, 255, 0.06), transparent), var(--surface); border: 1px solid var(--border); border-radius: 18px; box-shadow: 0 24px 70px rgba(0, 0, 0, 0.24); }
+.demo-card, .kanban-limit, .incident-banner { position: relative; padding: 1rem; overflow: hidden; animation: riseIn 520ms ease both; }
+.demo-card::before, .kanban-limit::before, .incident-banner::before { content: ""; position: absolute; inset: 0 auto 0 0; width: 4px; background: var(--accent); }
+.demo-card h2, .kanban-limit h2 { margin: 0 0 0.35rem; font-size: 1rem; }
+.demo-card p, .kanban-limit p, .incident-banner time, .search-empty p, .release-banner p { margin-bottom: 0; color: var(--muted); }
+button { border: 0; border-radius: 999px; padding: 0.55rem 0.8rem; color: white; background: var(--accent); font: inherit; font-weight: 800; cursor: pointer; transition: transform 180ms ease, filter 180ms ease; }
+button:hover, button:focus-visible { transform: translateY(-2px); filter: brightness(1.08); outline: none; }
+.meter-track { display: block; height: 0.55rem; margin-top: 0.9rem; overflow: hidden; background: rgba(148, 163, 184, 0.18); border-radius: 999px; }
+.meter-track span { display: block; width: var(--value, 70%); height: 100%; background: var(--accent); border-radius: inherit; animation: fillIn 700ms ease both; }
+.action-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 0.7rem; padding: 0.85rem; opacity: 0; transform: translateY(12px); animation: toolbarIn 420ms ease forwards; }
+.action-toolbar strong { margin-right: auto; }
+.segment-strip { display: flex; flex-wrap: wrap; gap: 0.4rem; padding: 0.45rem; }
+.segment-strip button { flex: 1 1 7rem; color: var(--muted); background: transparent; }
+.segment-strip .is-active { color: white; background: var(--accent); }
+.calendar-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.55rem; }
+.day { min-height: 4rem; color: var(--text); background: var(--surface); border: 1px solid var(--border); border-radius: 14px; }
+.day.is-range { color: color-mix(in srgb, var(--accent) 72%, white); background: color-mix(in srgb, var(--accent) 18%, var(--surface)); }
+.day.is-start, .day.is-end { background: var(--accent); animation: datePop 260ms ease both; }
+.kanban-limit strong { display: block; color: var(--accent); font-size: 1.8rem; }
+.kanban-limit.is-over-limit { --accent: var(--danger); }
+.incident-banner { display: grid; gap: 0.4rem; }
+.incident-banner span { color: var(--accent); font-size: 0.78rem; font-weight: 800; text-transform: uppercase; }
+.side-sheet { justify-self: end; width: min(420px, 100%); padding: 1rem; transform: translateX(24px); animation: sheetIn 520ms ease forwards; }
+.side-sheet dl { display: grid; gap: 0.75rem; margin: 1rem 0; }
+.side-sheet dl div { display: grid; grid-template-columns: 1fr auto; gap: 0.2rem 0.8rem; padding: 0.75rem; background: rgba(15, 23, 42, 0.45); border-radius: 12px; }
+.side-sheet dt, .side-sheet span { color: var(--muted); }
+.side-sheet dd { margin: 0; font-weight: 800; }
+.search-empty, .release-banner { padding: 1.25rem; text-align: center; animation: riseIn 520ms ease both; }
+.empty-icon { width: 4rem; height: 4rem; margin: 0 auto 1rem; border: 2px solid color-mix(in srgb, var(--accent) 55%, transparent); border-radius: 18px; background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.suggestion-row, .count-grid { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.6rem; margin-top: 1rem; }
+.count-block { min-width: 6rem; padding: 0.85rem; background: rgba(15, 23, 42, 0.48); border: 1px solid var(--border); border-radius: 16px; animation: countdownPulse 1.5s ease-in-out infinite; }
+.count-block strong, .count-block small { display: block; }
+.count-block strong { color: var(--accent); font-size: 2rem; }
+.count-block small { color: var(--muted); }
+@keyframes riseIn { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes toolbarIn { to { opacity: 1; transform: translateY(0); } }
+@keyframes sheetIn { to { transform: translateX(0); } }
+@keyframes fillIn { from { transform: scaleX(0); transform-origin: left; } to { transform: scaleX(1); transform-origin: left; } }
+@keyframes datePop { from { transform: scale(0.9); } to { transform: scale(1); } }
+@keyframes countdownPulse { 50% { transform: translateY(-2px); } }
+@media (max-width: 840px) { .demo-shell { grid-template-columns: 1fr; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { transition: none !important; animation: none !important; } .action-toolbar, .side-sheet { opacity: 1; transform: none; } }


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Status Page Incident Banner example.

Closes #11963

---

## Type of Change

- [ ] ? New animation / hover effect
- [x] ?? New component
- [ ] ?? Documentation improvement
- [ ] ?? Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/status-page-incident-banner-ts/`
- [x] Includes `demo.html` ? self-contained, opens in browser with no server
- [x] Includes `style.css` ? raw CSS for the proposed feature
- [x] Includes `README.md` ? what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A clear incident banner for investigating, monitoring, and resolved service states.

**How does a developer use it?**

Open `demo.html` directly or copy the component markup and stylesheet from this submission folder.

**Why does it fit EaseMotion CSS?**

It uses readable class names and CSS-only motion for a practical interface pattern.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer

CSS lint passed for the new stylesheet.
