### PR TITLE
fix : added dark mode support to kbd component

### DIFF
--- a/components/kbd.css
+++ b/components/kbd.css
@@ -15,14 +15,22 @@
     line-height: 1.4;
     white-space: nowrap;
   }
-  
+
   .ease-kbd-sm { font-size: 0.65rem; padding: 0.1rem 0.35rem; }
-  
+
   .ease-kbd-lg { font-size: 0.9rem; padding: 0.25rem 0.65rem; }
-  
+
   .ease-kbd-group {
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
+  }
+
+  /* Dark mode */
+  [data-theme="dark"] .ease-kbd {
+    color: #e2e8f0;
+    background: #1e293b;
+    border-color: #334155;
+    box-shadow: 0 1px 0 #475569;
   }
 }

--- a/submissions/examples/kbd-dark-mode-tm/README.md
+++ b/submissions/examples/kbd-dark-mode-tm/README.md
@@ -1,0 +1,25 @@
+# KBD Dark Mode Support
+
+Adds `[data-theme="dark"]` dark mode support to the `kbd.css` component.
+
+## What Changed
+
+- Added `[data-theme="dark"] .ease-kbd` block inside the `@layer easemotion-components` wrapper in `components/kbd.css`
+- Flips `color`, `background`, `border-color`, and `box-shadow` to dark-appropriate values
+
+## Usage
+
+```html
+<kbd class="ease-kbd">Ctrl</kbd>
+```
+
+Switch to dark mode:
+```html
+<html data-theme="dark">
+  <kbd class="ease-kbd">Ctrl</kbd>
+</html>
+```
+
+## Browser Support
+
+All modern browsers. CSS custom properties and attribute selectors are widely supported.

--- a/submissions/examples/kbd-dark-mode-tm/demo.html
+++ b/submissions/examples/kbd-dark-mode-tm/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KBD Dark Mode Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="demo-container">
+  <h1>KBD Component - Dark Mode</h1>
+  <p>Toggle between light and dark themes to see the keyboard key styles adapt.</p>
+  <div class="theme-toggle-row">
+    <button class="theme-btn" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark')">
+      Toggle Theme
+    </button>
+  </div>
+  <section>
+    <h2>Small Keys</h2>
+    <div class="kbd-group">
+      <kbd class="ease-kbd ease-kbd-sm">Ctrl</kbd>
+      <kbd class="ease-kbd ease-kbd-sm">+</kbd>
+      <kbd class="ease-kbd ease-kbd-sm">S</kbd>
+    </div>
+  </section>
+  <section>
+    <h2>Default Keys</h2>
+    <div class="kbd-group">
+      <kbd class="ease-kbd">A</kbd>
+      <kbd class="ease-kbd">B</kbd>
+      <kbd class="ease-kbd">C</kbd>
+    </div>
+  </section>
+  <section>
+    <h2>Large Keys</h2>
+    <div class="kbd-group">
+      <kbd class="ease-kbd ease-kbd-lg">Enter</kbd>
+      <kbd class="ease-kbd ease-kbd-lg">Esc</kbd>
+    </div>
+  </section>
+  <section>
+    <h2>Shortcut Sequence</h2>
+    <p>Press <kbd class="ease-kbd">Ctrl</kbd> + <kbd class="ease-kbd">Shift</kbd> + <kbd class="ease-kbd">P</kbd> to open the command palette.</p>
+  </section>
+</div>
+</body>
+</html>

--- a/submissions/examples/kbd-dark-mode-tm/style.css
+++ b/submissions/examples/kbd-dark-mode-tm/style.css
@@ -1,0 +1,19 @@
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  padding: 2rem;
+  margin: 0;
+  transition: background 0.3s, color 0.3s;
+}
+[data-theme="dark"] body { background: #0f172a; color: #e2e8f0; }
+.demo-container { max-width: 700px; margin: 0 auto; }
+h1 { margin-bottom: 0.5rem; }
+h2 { font-size: 1rem; color: #64748b; margin: 1.5rem 0 0.5rem; }
+[data-theme="dark"] h2 { color: #94a3b8; }
+p { line-height: 1.6; }
+section { margin-bottom: 1.5rem; }
+.kbd-group { display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; margin-top: 0.5rem; }
+.theme-toggle-row { margin: 1.5rem 0; }
+.theme-btn { padding: 0.5rem 1rem; background: #6c63ff; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
+[data-theme="dark"] .theme-btn { background: #818cf8; }


### PR DESCRIPTION
Closes #11969.

Summary of What Has Been Done:
Added `[data-theme="dark"] .ease-kbd` dark mode block inside the `@layer easemotion-components` wrapper in `components/kbd.css`. The dark mode flips `color`, `background`, `border-color`, and `box-shadow` to dark-appropriate slate values while maintaining visual hierarchy.

Changes Made:
- Added `[data-theme="dark"] .ease-kbd { color: #e2e8f0; background: #1e293b; border-color: #334155; box-shadow: 0 1px 0 #475569; }`
- Created `submissions/examples/kbd-dark-mode-tm/demo.html`, `style.css`, `README.md`

Impact it Made:
- KBD component now renders correctly in dark mode
- Consistent with dark mode patterns used in other EaseMotion components
- Keyboard shortcut displays remain legible in dark themes

Please assign this task to me (@tmdeveloper007).