### PR TITLE
fix : added dark mode support to toast component

### DIFF
--- a/components/toast.css
+++ b/components/toast.css
@@ -12,51 +12,60 @@
     font-size: 0.9rem;
     line-height: 1.5;
   }
-  
+
   .ease-toast-success { border-left-color: var(--ease-color-success, #22c55e); }
-  
+
   .ease-toast-danger { border-left-color: var(--ease-color-danger, #ef4444); }
-  
+
   .ease-toast-warning { border-left-color: var(--ease-color-warning, #f59e0b); }
-  
+
   .ease-toast-info { border-left-color: var(--ease-color-info, #3b82f6); }
-  
+
   .ease-toast-icon {
     width: 1.25rem;
     height: 1.25rem;
     flex-shrink: 0;
     margin-top: 1px;
   }
-  
+
   .ease-toast-success .ease-toast-icon { color: var(--ease-color-success, #22c55e); }
-  
+
   .ease-toast-danger .ease-toast-icon { color: var(--ease-color-danger, #ef4444); }
-  
+
   .ease-toast-warning .ease-toast-icon { color: var(--ease-color-warning, #f59e0b); }
-  
+
   .ease-toast-info .ease-toast-icon { color: var(--ease-color-info, #3b82f6); }
-  
+
   .ease-toast-body strong { display: block; margin-bottom: 2px; }
-  
+
   .ease-toast-body p { margin: 0; color: #6b7280; font-size: 0.85rem; }
-  
+
   .ease-toast-sm { padding: var(--ease-space-3) var(--ease-space-4); font-size: 0.85rem; max-width: 20rem; }
-  
+
   .ease-toast-lg { padding: var(--ease-space-5) var(--ease-space-6); font-size: 1rem; max-width: 28rem; }
-  
+
   @keyframes ease-kf-slide-out-right {
     from { opacity: 1; transform: translateX(0); }
     to { opacity: 0; transform: translateX(100%); }
   }
-  
+
   .ease-toast-enter { animation: ease-kf-slide-in-right 300ms ease-out both; }
-  
+
   .ease-toast-leave { animation: ease-kf-slide-out-right 300ms ease-in both; }
-  
+
   .ease-toast-fixed-bottom-right {
     position: fixed;
     bottom: var(--ease-space-6, 1.5rem);
     right: var(--ease-space-6, 1.5rem);
     z-index: 1000;
+  }
+
+  /* Dark mode */
+  [data-theme="dark"] .ease-toast {
+    background: var(--ease-color-surface-dark, #1e293b);
+  }
+
+  [data-theme="dark"] .ease-toast-body p {
+    color: var(--ease-color-text-muted, #94a3b8);
   }
 }

--- a/submissions/examples/toast-dark-mode-tm/README.md
+++ b/submissions/examples/toast-dark-mode-tm/README.md
@@ -1,0 +1,25 @@
+# Toast Dark Mode Support
+
+Adds `[data-theme="dark"]` dark mode support to the `toast.css` component.
+
+## What Changed
+
+- Added `[data-theme="dark"] .ease-toast { background }` override to use dark surface token
+- Added `[data-theme="dark"] .ease-toast-body p { color }` override to use dark muted text token
+- Uses existing CSS custom property tokens for consistency
+
+## Usage
+
+```html
+<div class="ease-toast ease-toast-enter">
+  <div class="ease-toast-icon">i</div>
+  <div class="ease-toast-body">
+    <strong>Title</strong>
+    <p>Message text here.</p>
+  </div>
+</div>
+```
+
+## Browser Support
+
+All modern browsers supporting CSS custom properties and attribute selectors.

--- a/submissions/examples/toast-dark-mode-tm/demo.html
+++ b/submissions/examples/toast-dark-mode-tm/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toast Dark Mode Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="demo-container">
+  <h1>Toast Component - Dark Mode</h1>
+  <p>Toggle dark mode to see toast body text adapt correctly.</p>
+  <div class="controls">
+    <button class="theme-btn" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark')">Toggle Theme</button>
+  </div>
+  <div class="toast-row">
+    <div class="ease-toast ease-toast-enter">
+      <div class="ease-toast-icon">i</div>
+      <div class="ease-toast-body">
+        <strong>Default Toast</strong>
+        <p>This is the default toast body text.</p>
+      </div>
+    </div>
+  </div>
+  <div class="toast-row">
+    <div class="ease-toast ease-toast-success ease-toast-enter">
+      <div class="ease-toast-icon">+</div>
+      <div class="ease-toast-body">
+        <strong>Success Toast</strong>
+        <p>Your changes have been saved successfully.</p>
+      </div>
+    </div>
+  </div>
+  <div class="toast-row">
+    <div class="ease-toast ease-toast-danger ease-toast-enter">
+      <div class="ease-toast-icon">x</div>
+      <div class="ease-toast-body">
+        <strong>Danger Toast</strong>
+        <p>Something went wrong. Please try again.</p>
+      </div>
+    </div>
+  </div>
+  <div class="toast-row">
+    <div class="ease-toast ease-toast-warning ease-toast-enter">
+      <div class="ease-toast-icon">!</div>
+      <div class="ease-toast-body">
+        <strong>Warning Toast</strong>
+        <p>Your session will expire in 5 minutes.</p>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/toast-dark-mode-tm/style.css
+++ b/submissions/examples/toast-dark-mode-tm/style.css
@@ -1,0 +1,10 @@
+body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; padding: 2rem; margin: 0; transition: background 0.3s, color 0.3s; }
+[data-theme="dark"] body { background: #0f172a; color: #e2e8f0; }
+.demo-container { max-width: 600px; margin: 0 auto; }
+h1 { margin-bottom: 0.5rem; }
+p { color: #64748b; line-height: 1.6; }
+[data-theme="dark"] p { color: #94a3b8; }
+.controls { margin: 1rem 0 2rem; }
+.theme-btn { padding: 0.5rem 1rem; background: #6c63ff; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; }
+[data-theme="dark"] .theme-btn { background: #818cf8; }
+.toast-row { margin-bottom: 1rem; }


### PR DESCRIPTION
Closes #11971.

Summary of What Has Been Done:
Added `[data-theme="dark"]` dark mode overrides in `components/toast.css`. The `.ease-toast` background switches to `--ease-color-surface-dark` and `.ease-toast-body p` text switches to `--ease-color-text-muted` for proper dark mode readability.

Changes Made:
- Added `[data-theme="dark"] .ease-toast { background: var(--ease-color-surface-dark, #1e293b); }`
- Added `[data-theme="dark"] .ease-toast-body p { color: var(--ease-color-text-muted, #94a3b8); }`
- Created `submissions/examples/toast-dark-mode-tm/demo.html`, `style.css`, `README.md`

Impact it Made:
- Toast notifications render correctly in dark mode
- Consistent with the dark mode architecture used by other components
- Body text remains readable and appropriately muted in dark themes

Please assign this task to me (@tmdeveloper007).