### PR TITLE
fix : added dark mode support to progress bar component

### DIFF
--- a/components/progress.css
+++ b/components/progress.css
@@ -6,7 +6,7 @@
     border-radius: 999px;
     overflow: hidden;
   }
-  
+
   .ease-progress-bar {
     height: 100%;
     background: var(--ease-color-primary, #6c63ff);
@@ -14,30 +14,35 @@
     transition: width 0.3s ease;
     width: 0%;
   }
-  
+
   .ease-progress-sm { height: 0.375rem; }
-  
+
   .ease-progress-lg { height: 1.125rem; }
-  
+
   .ease-progress-success .ease-progress-bar { background: var(--ease-color-success, #22c55e); }
-  
+
   .ease-progress-danger .ease-progress-bar { background: var(--ease-color-danger, #ef4444); }
-  
+
   .ease-progress-warning .ease-progress-bar { background: var(--ease-color-warning, #f59e0b); }
-  
+
   .ease-progress-striped .ease-progress-bar {
     background-image: linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);
     background-size: 1rem 1rem;
   }
 
-.ease-progress-info .ease-progress-bar { background: var(--ease-color-info, #3b82f6); }
+  .ease-progress-info .ease-progress-bar { background: var(--ease-color-info, #3b82f6); }
 
-.ease-progress-animated .ease-progress-bar {
-  animation: ease-kf-progress-stripes 1s linear infinite;
-}
+  .ease-progress-animated .ease-progress-bar {
+    animation: ease-kf-progress-stripes 1s linear infinite;
+  }
 
-@keyframes ease-kf-progress-stripes {
-  from { background-position: 1rem 0; }
-  to { background-position: 0 0; }
-}
+  @keyframes ease-kf-progress-stripes {
+    from { background-position: 1rem 0; }
+    to { background-position: 0 0; }
+  }
+
+  /* Dark mode */
+  [data-theme="dark"] .ease-progress {
+    background: var(--ease-color-neutral-700, #334155);
+  }
 }

--- a/submissions/examples/progress-dark-mode-tm/README.md
+++ b/submissions/examples/progress-dark-mode-tm/README.md
@@ -1,0 +1,22 @@
+# Progress Bar Dark Mode Support
+
+Adds `[data-theme="dark"]` dark mode support to the `progress.css` component.
+
+## What Changed
+
+- Added `[data-theme="dark"] .ease-progress { background }` override using `--ease-color-neutral-700` token
+- All progress bar variants (success, danger, warning, info) inherit correctly since their bar colors use CSS custom property tokens
+
+## Usage
+
+```html
+<div class="ease-progress">
+  <div class="ease-progress-bar" style="width:60%"></div>
+</div>
+```
+
+Enable dark mode: `<html data-theme="dark">`
+
+## Browser Support
+
+All modern browsers supporting CSS custom properties and attribute selectors.

--- a/submissions/examples/progress-dark-mode-tm/demo.html
+++ b/submissions/examples/progress-dark-mode-tm/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Progress Dark Mode Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="demo-container">
+  <h1>Progress Bar - Dark Mode</h1>
+  <p>Toggle dark mode to see the progress bar background adapt.</p>
+  <div class="controls">
+    <button class="theme-btn" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark')">Toggle Theme</button>
+  </div>
+  <section>
+    <h2>Default Progress (60%)</h2>
+    <div class="ease-progress"><div class="ease-progress-bar" style="width:60%"></div></div>
+  </section>
+  <section>
+    <h2>Small Progress (45%)</h2>
+    <div class="ease-progress ease-progress-sm"><div class="ease-progress-bar" style="width:45%"></div></div>
+  </section>
+  <section>
+    <h2>Large Progress (75%)</h2>
+    <div class="ease-progress ease-progress-lg"><div class="ease-progress-bar" style="width:75%"></div></div>
+  </section>
+  <section>
+    <h2>Success (80%)</h2>
+    <div class="ease-progress ease-progress-success"><div class="ease-progress-bar" style="width:80%"></div></div>
+  </section>
+  <section>
+    <h2>Danger (25%)</h2>
+    <div class="ease-progress ease-progress-danger"><div class="ease-progress-bar" style="width:25%"></div></div>
+  </section>
+  <section>
+    <h2>Warning (55%)</h2>
+    <div class="ease-progress ease-progress-warning"><div class="ease-progress-bar" style="width:55%"></div></div>
+  </section>
+  <section>
+    <h2>Info (90%)</h2>
+    <div class="ease-progress ease-progress-info"><div class="ease-progress-bar" style="width:90%"></div></div>
+  </section>
+  <section>
+    <h2>Striped Animated</h2>
+    <div class="ease-progress ease-progress-striped ease-progress-animated"><div class="ease-progress-bar" style="width:65%"></div></div>
+  </section>
+</div>
+</body>
+</html>

--- a/submissions/examples/progress-dark-mode-tm/style.css
+++ b/submissions/examples/progress-dark-mode-tm/style.css
@@ -1,0 +1,10 @@
+body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; padding: 2rem; margin: 0; transition: background 0.3s, color 0.3s; }
+[data-theme="dark"] body { background: #0f172a; color: #e2e8f0; }
+.demo-container { max-width: 600px; margin: 0 auto; }
+h1 { margin-bottom: 0.5rem; }
+h2 { font-size: 0.95rem; color: #64748b; margin: 1.25rem 0 0.5rem; }
+[data-theme="dark"] h2 { color: #94a3b8; }
+section { margin-bottom: 1rem; }
+.controls { margin: 1rem 0 1.5rem; }
+.theme-btn { padding: 0.5rem 1rem; background: #6c63ff; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; }
+[data-theme="dark"] .theme-btn { background: #818cf8; }


### PR DESCRIPTION
Closes #11972.

Summary of What Has Been Done:
Added `[data-theme="dark"]` dark mode override in `components/progress.css`. The `.ease-progress` background switches from hardcoded `#e2e8f0` to `--ease-color-neutral-700` (`#334155`) so the progress track is visible against dark backgrounds.

Changes Made:
- Added `[data-theme="dark"] .ease-progress { background: var(--ease-color-neutral-700, #334155); }`
- Created `submissions/examples/progress-dark-mode-tm/demo.html`, `style.css`, `README.md`

Impact it Made:
- Progress bar tracks are clearly visible in dark mode
- Consistent with the CSS custom property dark mode pattern
- All progress variants (success, danger, warning, info) inherit correctly since they use CSS var tokens

Please assign this task to me (@tmdeveloper007).