### PR TITLE
fix : added dark mode support to badge component

### DIFF
--- a/components/badges.css
+++ b/components/badges.css
@@ -57,10 +57,7 @@
   .em-badge-pulse::after {
     content: "";
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    top: 0; left: 0; right: 0; bottom: 0;
     border-radius: inherit;
     box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.7);
     animation: ease-kf-ping 1.5s var(--ease-ease-out) infinite;
@@ -75,5 +72,26 @@
   .ease-badge-success.ease-badge-pulse::after,
   .em-badge-success.em-badge-pulse::after {
     box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
+  }
+
+  /* Dark mode */
+  [data-theme="dark"] .ease-badge,
+  [data-theme="dark"] .em-badge {
+    color: var(--ease-color-text, #e2e8f0);
+  }
+
+  [data-theme="dark"] .ease-badge-pulse::after,
+  [data-theme="dark"] .em-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(129, 140, 248, 0.7);
+  }
+
+  [data-theme="dark"] .ease-badge-danger.ease-badge-pulse::after,
+  [data-theme="dark"] .em-badge-danger.em-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(248, 113, 113, 0.7);
+  }
+
+  [data-theme="dark"] .ease-badge-success.ease-badge-pulse::after,
+  [data-theme="dark"] .em-badge-success.em-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.7);
   }
 }

--- a/submissions/examples/badge-dark-mode-tm/README.md
+++ b/submissions/examples/badge-dark-mode-tm/README.md
@@ -1,0 +1,22 @@
+# Badge Dark Mode Support
+
+Adds `[data-theme="dark"]` dark mode support to the `badges.css` component.
+
+## What Changed
+
+- Added `[data-theme="dark"] .ease-badge { color }` to use `--ease-color-text` token for readable text in dark mode
+- Added dark mode pulse ring colors for primary, danger, and success variants
+- Handled deprecated `.em-badge*` aliases
+
+## Usage
+
+```html
+<span class="ease-badge">Primary</span>
+<span class="ease-badge ease-badge-pulse">Pulsing</span>
+```
+
+Enable dark mode: `<html data-theme="dark">`
+
+## Browser Support
+
+All modern browsers supporting CSS custom properties and attribute selectors.

--- a/submissions/examples/badge-dark-mode-tm/demo.html
+++ b/submissions/examples/badge-dark-mode-tm/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Badge Dark Mode Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="demo-container">
+  <h1>Badge Component - Dark Mode</h1>
+  <p>Toggle dark mode to see badge text and pulse variants adapt.</p>
+  <div class="controls">
+    <button class="theme-btn" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark')">Toggle Theme</button>
+  </div>
+  <section>
+    <h2>Default Badges</h2>
+    <div class="badge-row">
+      <span class="ease-badge">Primary</span>
+      <span class="ease-badge ease-badge-sm">Small</span>
+      <span class="ease-badge ease-badge-lg">Large</span>
+    </div>
+  </section>
+  <section>
+    <h2>Variant Badges</h2>
+    <div class="badge-row">
+      <span class="ease-badge ease-badge-danger">Danger</span>
+      <span class="ease-badge ease-badge-success">Success</span>
+    </div>
+  </section>
+  <section>
+    <h2>Pulse Variants</h2>
+    <div class="badge-row">
+      <span class="ease-badge ease-badge-pulse">Primary Pulse</span>
+      <span class="ease-badge ease-badge-danger ease-badge-pulse">Danger Pulse</span>
+      <span class="ease-badge ease-badge-success ease-badge-pulse">Success Pulse</span>
+    </div>
+  </section>
+</div>
+</body>
+</html>

--- a/submissions/examples/badge-dark-mode-tm/style.css
+++ b/submissions/examples/badge-dark-mode-tm/style.css
@@ -1,0 +1,10 @@
+body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; padding: 2rem; margin: 0; transition: background 0.3s, color 0.3s; }
+[data-theme="dark"] body { background: #0f172a; color: #e2e8f0; }
+.demo-container { max-width: 600px; margin: 0 auto; }
+h1 { margin-bottom: 0.5rem; }
+h2 { font-size: 0.95rem; color: #64748b; margin: 1.25rem 0 0.75rem; }
+[data-theme="dark"] h2 { color: #94a3b8; }
+.badge-row { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+.controls { margin: 1rem 0 1.5rem; }
+.theme-btn { padding: 0.5rem 1rem; background: #6c63ff; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; }
+[data-theme="dark"] .theme-btn { background: #818cf8; }


### PR DESCRIPTION
Closes #11973.

Summary of What Has Been Done:
Added `[data-theme="dark"]` dark mode overrides in `components/badges.css`. Badge text switches to `--ease-color-text` token for readability, and pulse variant rings get dark-appropriate glow colors.

Changes Made:
- Added `[data-theme="dark"] .ease-badge { color: var(--ease-color-text, #e2e8f0); }`
- Added dark pulse ring colors for primary, danger, and success variants
- Handled deprecated `.em-badge*` aliases in the dark block
- Created `submissions/examples/badge-dark-mode-tm/demo.html`, `style.css`, `README.md`

Impact it Made:
- Badge text is readable in dark mode (white-on-white issue resolved)
- Pulse animations remain visible and contrasting in dark themes
- Consistency with the `[data-theme="dark"]` dark mode pattern

Please assign this task to me (@tmdeveloper007).