### PR TITLE
fix : added dark mode support to announce bar component

### DIFF
--- a/components/announce-bar.css
+++ b/components/announce-bar.css
@@ -12,68 +12,33 @@
     justify-content: center;
     gap: 0.75rem;
   }
-  
-  .ease-announce-bar.is-info {
-    background: #6c63ff;
-  }
-  
-  .ease-announce-bar.is-success {
-    background: #10b981;
-  }
-  
-  .ease-announce-bar.is-warning {
-    background: #f59e0b;
-  }
-  
-  .ease-announce-bar.is-danger {
-    background: #ef4444;
-  }
-  
-  .ease-announce-bar-content {
-    flex: 1;
-    text-align: center;
-  }
-  
-  .ease-announce-bar-content a {
-    color: inherit;
-    text-decoration: underline;
-    text-underline-offset: 2px;
-  }
-  
-  .ease-announce-bar-content a:hover {
-    opacity: 0.9;
-  }
-  
+
+  .ease-announce-bar.is-info { background: #6c63ff; }
+  .ease-announce-bar.is-success { background: #10b981; }
+  .ease-announce-bar.is-warning { background: #f59e0b; }
+  .ease-announce-bar.is-danger { background: #ef4444; }
+
+  .ease-announce-bar-content { flex: 1; text-align: center; }
+  .ease-announce-bar-content a { color: inherit; text-decoration: underline; text-underline-offset: 2px; }
+  .ease-announce-bar-content a:hover { opacity: 0.9; }
+
   .ease-announce-bar-close {
-    background: none;
-    border: none;
-    color: inherit;
-    cursor: pointer;
-    opacity: 0.8;
-    padding: 0.25rem;
-    line-height: 1;
-    font-size: 1.1rem;
-    transition: opacity 0.2s;
-    flex-shrink: 0;
+    background: none; border: none; color: inherit; cursor: pointer;
+    opacity: 0.8; padding: 0.25rem; line-height: 1; font-size: 1.1rem;
+    transition: opacity 0.2s; flex-shrink: 0;
   }
-  
-  .ease-announce-bar-close:hover {
-    opacity: 1;
-  }
-  
-  .ease-announce-bar-dismiss {
-    display: none;
-  }
-  
-  .ease-announce-bar-dismiss:checked ~ .ease-announce-bar {
-    display: none;
-  }
-  
+  .ease-announce-bar-close:hover { opacity: 1; }
+
+  .ease-announce-bar-dismiss { display: none; }
+  .ease-announce-bar-dismiss:checked ~ .ease-announce-bar { display: none; }
+
   .ease-announce-bar.is-fixed {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
+    position: fixed; top: 0; left: 0; right: 0; z-index: 1000;
   }
+
+  /* Dark mode */
+  [data-theme="dark"] .ease-announce-bar.is-info { background: #4338ca; }
+  [data-theme="dark"] .ease-announce-bar.is-success { background: #059669; }
+  [data-theme="dark"] .ease-announce-bar.is-warning { background: #d97706; }
+  [data-theme="dark"] .ease-announce-bar.is-danger { background: #dc2626; }
 }

--- a/submissions/examples/announce-bar-dark-mode-tm/README.md
+++ b/submissions/examples/announce-bar-dark-mode-tm/README.md
@@ -1,0 +1,24 @@
+# Announce Bar Dark Mode Support
+
+Adds `[data-theme="dark"]` dark mode support to the `announce-bar.css` component.
+
+## What Changed
+
+- Added `[data-theme="dark"]` overrides for all announce bar variants:
+  - `.is-info` → darker indigo `#4338ca`
+  - `.is-success` → darker green `#059669`
+  - `.is-warning` → darker amber `#d97706`
+  - `.is-danger` → darker red `#dc2626`
+- All variants keep `#fff` text color which remains readable on all dark variants
+
+## Usage
+
+```html
+<div class="ease-announce-bar is-success">Your message here</div>
+```
+
+Enable dark mode: `<html data-theme="dark">`
+
+## Browser Support
+
+All modern browsers supporting CSS custom properties and attribute selectors.

--- a/submissions/examples/announce-bar-dark-mode-tm/demo.html
+++ b/submissions/examples/announce-bar-dark-mode-tm/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Announce Bar Dark Mode Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="demo-container">
+  <h1>Announce Bar - Dark Mode</h1>
+  <p>Toggle dark mode to see announce bar variants adapt.</p>
+  <div class="controls">
+    <button class="theme-btn" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark')">Toggle Theme</button>
+  </div>
+  <section>
+    <h2>Default Info Bar</h2>
+    <div class="ease-announce-bar ease-announce-bar-is-info">Free shipping on orders over $50! <a href="#">Learn more</a></div>
+  </section>
+  <section>
+    <h2>Success Bar</h2>
+    <div class="ease-announce-bar is-success">Order #12345 has been shipped successfully!</div>
+  </section>
+  <section>
+    <h2>Warning Bar</h2>
+    <div class="ease-announce-bar is-warning">Scheduled maintenance in 24 hours.</div>
+  </section>
+  <section>
+    <h2>Danger Bar</h2>
+    <div class="ease-announce-bar is-danger">Security update required. <a href="#">Update now</a></div>
+  </section>
+</div>
+</body>
+</html>

--- a/submissions/examples/announce-bar-dark-mode-tm/style.css
+++ b/submissions/examples/announce-bar-dark-mode-tm/style.css
@@ -1,0 +1,10 @@
+body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; padding: 2rem; margin: 0; transition: background 0.3s; }
+[data-theme="dark"] body { background: #0f172a; }
+.demo-container { max-width: 600px; margin: 0 auto; }
+h1 { margin-bottom: 0.5rem; }
+h2 { font-size: 0.95rem; color: #64748b; margin: 1.5rem 0 0.5rem; }
+[data-theme="dark"] h2 { color: #94a3b8; }
+section { margin-bottom: 1rem; }
+.controls { margin: 1rem 0 1.5rem; }
+.theme-btn { padding: 0.5rem 1rem; background: #6c63ff; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; }
+[data-theme="dark"] .theme-btn { background: #818cf8; }


### PR DESCRIPTION
Closes #11974.

Summary of What Has Been Done:
Added `[data-theme="dark"]` dark mode overrides in `components/announce-bar.css`. All announce bar variants (info, success, warning, danger) get darker background colors in dark mode while keeping `#fff` text which remains readable.

Changes Made:
- `.is-info` in dark mode: `#4338ca` (dark indigo)
- `.is-success` in dark mode: `#059669` (dark emerald)
- `.is-warning` in dark mode: `#d97706` (dark amber)
- `.is-danger` in dark mode: `#dc2626` (dark red)
- Created `submissions/examples/announce-bar-dark-mode-tm/demo.html`, `style.css`, `README.md`

Impact it Made:
- Announce bars maintain proper contrast and readability in dark mode
- Dark mode colors chosen to preserve semantic meaning of each variant
- Consistent with the `[data-theme="dark"]` dark mode architecture

Please assign this task to me (@tmdeveloper007).