### PR TITLE
Tighten submission validator path policy

### DIFF
--- a/.github/workflows/submission-validator.yml
+++ b/.github/workflows/submission-validator.yml
@@ -94,16 +94,7 @@ jobs:
                   }
                 }
               } else {
-                if (
-                  !filename.startsWith('docs/') &&
-                  filename !== 'README.md' &&
-                  filename !== 'LICENSE' &&
-                  filename !== 'package.json' &&
-                  filename !== 'easemotion.css' &&
-                  filename !== 'easemotion.min.css'
-                ) {
-                  coreFiles.push(filename);
-                }
+                coreFiles.push(filename);
               }
             }
 


### PR DESCRIPTION
## Pull Request Description

Tightens the submission validator so non-submission files are rejected consistently with the current submission-only contribution policy.

Closes #11994

---

## Type of Change

- [ ] ? New animation / hover effect
- [ ] ?? New component
- [ ] ?? Documentation improvement
- [x] ?? Bug fix in an existing submission
- [ ] Other (describe below)

---

## What changed

The validator no longer whitelists top-level files such as `README.md`, `package.json`, bundles, or `docs/` when checking contributor PR scope. Any non-`submissions/` path is now reported as a protected file change.

---

## Validation

- [x] Inspected validator diff
