### PR TITLE
Clarify submission JavaScript policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,18 @@ Answer these three questions:
 
 ---
 
+### JavaScript files
+
+Current submissions should use only the required three-file structure:
+
+- `demo.html`
+- `style.css`
+- `README.md`
+
+Do not add `script.js`, generated assets, screenshots, or extra folders unless a maintainer explicitly asks for them on the issue.
+
+---
+
 ## Naming Rules
 
 | Who              | Rule                                                      |

--- a/submissions/README.md
+++ b/submissions/README.md
@@ -19,6 +19,8 @@ submissions/examples/your-feature-name/
 
 All three files are required. Missing any one of them will result in the PR being asked to revise.
 
+Do not add `script.js`, images, generated assets, or nested folders unless a maintainer explicitly requests them. The default submission format is HTML + CSS + README only.
+
 ---
 
 ## 📢 Contribution Policy Update


### PR DESCRIPTION
## Pull Request Description

Clarifies whether submission folders may include JavaScript files or extra assets.

Closes #11996

---

## Type of Change

- [ ] ? New animation / hover effect
- [ ] ?? New component
- [x] ?? Documentation improvement
- [ ] ?? Bug fix in an existing submission
- [ ] Other (describe below)

---

## What changed

Adds a note to the contributor docs and submissions guide that the default submission format is limited to `demo.html`, `style.css`, and `README.md` unless maintainers explicitly request extra files.

---

## Validation

- [x] Reviewed documentation diff
