### PR TITLE
Add toast notification center example

### DIFF
--- a/submissions/examples/toast-notification-center-ts/README.md
+++ b/submissions/examples/toast-notification-center-ts/README.md
@@ -1,0 +1,36 @@
+# Toast Notification Center Drawer
+
+## What does this do?
+
+A persistent drawer for reviewing recent notifications with unread and category states.
+
+## How is it used?
+
+Open `demo.html` directly in a browser or copy the component markup and styles from this folder.
+
+## Why is it useful?
+
+This pattern uses semantic HTML and CSS-only motion for a practical interface need.
+
+## Features
+
+- Self-contained HTML and CSS
+- Responsive layout
+- Clear visual states
+- Focus and hover styling where relevant
+- `prefers-reduced-motion` support
+
+## Tech Stack
+
+- HTML
+- CSS
+
+## Preview
+
+Open `demo.html` directly in a browser to view the example.
+
+## Contribution Notes
+
+- Proposed for issue #12000
+- All files are scoped to this submission folder
+- No framework source files are modified

--- a/submissions/examples/toast-notification-center-ts/demo.html
+++ b/submissions/examples/toast-notification-center-ts/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toast Notification Center Drawer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="intro-panel" aria-labelledby="demo-title">
+      <p class="eyebrow">Notifications</p>
+      <h1 id="demo-title">Notification center drawer</h1>
+      <p>A persistent drawer for reviewing recent notifications with unread and category states.</p>
+    </section>
+    <section class="demo-stage" aria-label="Toast Notification Center Drawer">
+      <aside class="notification-center is-open" aria-label="Notifications"><article class="notification-item is-unread"><span>Deploy</span><strong>Export ready</strong><time>2 min ago</time></article><article class="notification-item"><span>Billing</span><strong>Invoice paid</strong><time>18 min ago</time></article><article class="notification-item is-unread"><span>Security</span><strong>New device approved</strong><time>1 hr ago</time></article></aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/toast-notification-center-ts/style.css
+++ b/submissions/examples/toast-notification-center-ts/style.css
@@ -1,0 +1,52 @@
+:root { color-scheme: dark; --bg: #0b1120; --surface: #111827; --panel: #162033; --border: rgba(148, 163, 184, 0.22); --text: #f8fafc; --muted: #94a3b8; --accent: #6366f1; --danger: #ef4444; --success: #22c55e; }
+* { box-sizing: border-box; }
+body { min-height: 100vh; margin: 0; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: radial-gradient(circle at 18% 14%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 28rem), radial-gradient(circle at 86% 78%, rgba(34, 197, 94, 0.1), transparent 28rem), var(--bg); color: var(--text); }
+.demo-shell { display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(320px, 1.1fr); align-items: center; gap: 2rem; width: min(1120px, calc(100% - 2rem)); min-height: 100vh; margin: 0 auto; padding: 3rem 0; }
+.intro-panel { max-width: 580px; }
+.eyebrow, h1, p { margin-top: 0; }
+.eyebrow { margin-bottom: 0.55rem; color: color-mix(in srgb, var(--accent) 78%, white); font-size: 0.78rem; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; }
+h1 { margin-bottom: 0.85rem; font-size: clamp(2rem, 6vw, 4rem); line-height: 1; }
+.intro-panel p { color: var(--muted); line-height: 1.7; }
+.demo-stage, .disclosure-stack, .comparison-cards, .checkout-stepper { display: grid; gap: 1rem; }
+details, .error-summary, .demo-form, .notification-center, .checkout-stepper, .help-form, .comparison-card, .phone-frame { background: linear-gradient(145deg, rgba(255, 255, 255, 0.06), transparent), var(--panel); border: 1px solid var(--border); border-radius: 18px; box-shadow: 0 24px 70px rgba(0, 0, 0, 0.24); }
+details { padding: 1rem; }
+summary { cursor: pointer; font-weight: 800; }
+details[open] { border-color: color-mix(in srgb, var(--accent) 50%, var(--border)); }
+details p { margin: 0.8rem 0 0; color: var(--muted); line-height: 1.6; animation: revealContent 260ms ease both; }
+.error-summary { display: grid; gap: 0.55rem; padding: 1rem; border-color: color-mix(in srgb, var(--danger) 50%, var(--border)); animation: revealContent 360ms ease both; }
+.error-summary h2 { margin: 0; }
+.error-summary a { color: #fecaca; }
+.demo-form { display: grid; gap: 0.8rem; padding: 1rem; }
+label { display: grid; gap: 0.35rem; color: var(--muted); }
+input, select { width: 100%; border: 1px solid var(--border); border-radius: 12px; padding: 0.75rem; color: var(--text); background: var(--surface); }
+.notification-center { display: grid; gap: 0.7rem; padding: 1rem; transform: translateX(18px); animation: slideIn 420ms ease forwards; }
+.notification-item { position: relative; display: grid; gap: 0.25rem; padding: 0.85rem; background: rgba(15, 23, 42, 0.45); border-radius: 14px; }
+.notification-item span { color: var(--accent); font-size: 0.78rem; font-weight: 800; text-transform: uppercase; }
+.notification-item time { color: var(--muted); }
+.notification-item.is-unread::before { content: ""; position: absolute; top: 1rem; right: 1rem; width: 0.6rem; height: 0.6rem; border-radius: 999px; background: var(--accent); animation: unreadPulse 1.6s ease-in-out infinite; }
+.checkout-stepper { grid-template-columns: repeat(4, minmax(0, 1fr)); padding: 1rem; list-style: none; counter-reset: step; }
+.checkout-stepper li { position: relative; display: grid; justify-items: center; gap: 0.5rem; color: var(--muted); }
+.checkout-stepper span { display: grid; width: 2.4rem; aspect-ratio: 1; place-items: center; border-radius: 999px; background: rgba(148, 163, 184, 0.18); }
+.checkout-stepper .is-complete span, .checkout-stepper .is-active span { color: white; background: var(--accent); }
+.checkout-stepper .is-active { color: var(--text); animation: revealContent 320ms ease both; }
+.help-form { padding: 1rem; }
+.help-field { position: relative; }
+.help-trigger { display: inline-grid; width: 1.4rem; aspect-ratio: 1; place-items: center; margin-left: 0.35rem; color: white; background: var(--accent); border-radius: 999px; cursor: help; }
+.help-tooltip { position: absolute; left: 0; bottom: calc(100% + 0.6rem); width: min(18rem, 100%); padding: 0.75rem; color: var(--text); background: var(--surface); border: 1px solid var(--border); border-radius: 12px; opacity: 0; transform: translateY(6px); pointer-events: none; transition: opacity 180ms ease, transform 180ms ease; }
+.help-trigger:hover + .help-tooltip, .help-trigger:focus-visible + .help-tooltip { opacity: 1; transform: translateY(0); }
+.comparison-cards { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.comparison-card { padding: 1rem; transition: transform 220ms ease, border-color 220ms ease; }
+.comparison-card strong { display: block; margin: 0.4rem 0; font-size: 2rem; }
+.comparison-card p { color: var(--muted); }
+.comparison-card.is-selected { border-color: color-mix(in srgb, var(--accent) 55%, var(--border)); transform: translateY(-4px); }
+.phone-frame { position: relative; min-height: 34rem; padding: 1rem; overflow: hidden; }
+.mock-content { color: var(--muted); }
+.safe-action-bar { position: absolute; right: 1rem; bottom: max(1rem, env(safe-area-inset-bottom)); left: 1rem; display: flex; gap: 0.7rem; padding: 0.7rem; background: rgba(15, 23, 42, 0.88); border: 1px solid var(--border); border-radius: 18px; animation: barUp 420ms ease both; }
+button { border: 0; border-radius: 999px; padding: 0.65rem 0.9rem; color: white; background: var(--accent); font: inherit; font-weight: 800; cursor: pointer; }
+button.secondary { color: var(--text); background: rgba(148, 163, 184, 0.18); }
+@keyframes revealContent { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes slideIn { to { transform: translateX(0); } }
+@keyframes unreadPulse { 50% { box-shadow: 0 0 0 8px color-mix(in srgb, var(--accent) 14%, transparent); } }
+@keyframes barUp { from { transform: translateY(110%); } to { transform: translateY(0); } }
+@media (max-width: 840px) { .demo-shell, .comparison-cards { grid-template-columns: 1fr; } .checkout-stepper { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { transition: none !important; animation: none !important; } .notification-center, .safe-action-bar { transform: none; } }


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Toast Notification Center Drawer.

Closes #12000

---

## Type of Change

- [ ] ? New animation / hover effect
- [x] ?? New component
- [ ] ?? Documentation improvement
- [ ] ?? Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/toast-notification-center-ts/`
- [x] Includes `demo.html` ? self-contained, opens in browser with no server
- [x] Includes `style.css` ? raw CSS for the proposed feature
- [x] Includes `README.md` ? what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A persistent drawer for reviewing recent notifications with unread and category states.

**How does a developer use it?**

Open `demo.html` directly or copy the component markup and stylesheet from this submission folder.

**Why does it fit EaseMotion CSS?**

It uses readable class names and CSS-only motion for a practical interface pattern.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer

CSS lint passed for the new stylesheet.
