### PR TITLE
feat : added kbd dark mode pattern demo

### DIFF
--- a/submissions/examples/kbd-dark-mode-tm/README.md
+++ b/submissions/examples/kbd-dark-mode-tm/README.md
@@ -1,0 +1,31 @@
+# KBD Dark Mode Support
+
+Demonstrates `[data-theme="dark"]` dark mode support for the KBD component.
+
+## What This Submission Shows
+
+The `style.css` in this folder contains the dark mode CSS pattern that should be added to `components/kbd.css`:
+
+```css
+/* Dark mode */
+[data-theme="dark"] .ease-kbd {
+  color: #e2e8f0;
+  background: #1e293b;
+  border-color: #334155;
+  box-shadow: 0 1px 0 #475569;
+}
+```
+
+## Usage
+
+Include the KBD component classes and add `data-theme="dark"` to your HTML:
+
+```html
+<html data-theme="dark">
+  <kbd class="ease-kbd">Ctrl</kbd>
+</html>
+```
+
+## Browser Support
+
+All modern browsers. CSS custom properties and attribute selectors are widely supported.

--- a/submissions/examples/kbd-dark-mode-tm/demo.html
+++ b/submissions/examples/kbd-dark-mode-tm/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KBD Dark Mode Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="demo-container">
+  <h1>KBD Component - Dark Mode</h1>
+  <p>Toggle between light and dark themes to see the keyboard key styles adapt using CSS attribute selectors.</p>
+  <div class="theme-toggle-row">
+    <button class="theme-btn" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark')">
+      Toggle Dark Mode
+    </button>
+  </div>
+  <section>
+    <h2>Small Keys</h2>
+    <div class="kbd-group">
+      <kbd class="ease-kbd ease-kbd-sm">Ctrl</kbd>
+      <kbd class="ease-kbd ease-kbd-sm">+</kbd>
+      <kbd class="ease-kbd ease-kbd-sm">S</kbd>
+    </div>
+  </section>
+  <section>
+    <h2>Default Keys</h2>
+    <div class="kbd-group">
+      <kbd class="ease-kbd">A</kbd>
+      <kbd class="ease-kbd">B</kbd>
+      <kbd class="ease-kbd">C</kbd>
+    </div>
+  </section>
+  <section>
+    <h2>Large Keys</h2>
+    <div class="kbd-group">
+      <kbd class="ease-kbd ease-kbd-lg">Enter</kbd>
+      <kbd class="ease-kbd ease-kbd-lg">Esc</kbd>
+    </div>
+  </section>
+  <section>
+    <h2>Shortcut Sequence</h2>
+    <p>Press <kbd class="ease-kbd">Ctrl</kbd> + <kbd class="ease-kbd">Shift</kbd> + <kbd class="ease-kbd">P</kbd> to open the command palette.</p>
+  </section>
+  <section>
+    <h2>Key Group</h2>
+    <div class="kbd-group ease-kbd-group">
+      <kbd class="ease-kbd">Cmd</kbd>
+      <kbd class="ease-kbd">Option</kbd>
+      <kbd class="ease-kbd">J</kbd>
+    </div>
+  </section>
+</div>
+</body>
+</html>

--- a/submissions/examples/kbd-dark-mode-tm/style.css
+++ b/submissions/examples/kbd-dark-mode-tm/style.css
@@ -1,0 +1,34 @@
+/* KBD Dark Mode Demo Styles */
+/* Dark mode CSS using component class selectors - demonstrates the fix pattern */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  padding: 2rem;
+  margin: 0;
+  transition: background 0.3s, color 0.3s;
+}
+[data-theme="dark"] body {
+  background: #0f172a;
+  color: #e2e8f0;
+}
+.demo-container { max-width: 700px; margin: 0 auto; }
+h1 { margin-bottom: 0.5rem; }
+h2 { font-size: 1rem; color: #64748b; margin: 1.5rem 0 0.5rem; }
+[data-theme="dark"] h2 { color: #94a3b8; }
+p { line-height: 1.6; color: #475569; }
+[data-theme="dark"] p { color: #94a3b8; }
+section { margin-bottom: 1.5rem; }
+.kbd-group { display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; margin-top: 0.5rem; }
+.theme-toggle-row { margin: 1.5rem 0; }
+.theme-btn { padding: 0.5rem 1rem; background: #6c63ff; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
+[data-theme="dark"] .theme-btn { background: #818cf8; }
+
+/* Dark mode overrides for kbd component - same pattern as components/kbd.css */
+[data-theme="dark"] .ease-kbd {
+  color: #e2e8f0;
+  background: #1e293b;
+  border-color: #334155;
+  box-shadow: 0 1px 0 #475569;
+}


### PR DESCRIPTION
Closes #11969.

Summary of What Has Been Done:
Added a demonstration submission showing the `[data-theme="dark"]` CSS pattern for the KBD component. The demo showcases keyboard key styling that adapts to dark mode via CSS attribute selectors, with full interactive toggle between light and dark themes.

Changes Made:
- Created `submissions/examples/kbd-dark-mode-tm/demo.html` with interactive dark mode toggle
- Created `submissions/examples/kbd-dark-mode-tm/style.css` containing the dark mode override pattern: `[data-theme="dark"] .ease-kbd { color: #e2e8f0; background: #1e293b; border-color: #334155; box-shadow: 0 1px 0 #475569; }`
- Created `submissions/examples/kbd-dark-mode-tm/README.md` with usage documentation

Impact it Made:
- Demonstrates the exact CSS change needed to add dark mode to `components/kbd.css`
- Interactive demo lets maintainers preview the dark mode visually before merging
- Pattern can be directly copy-pasted into the component file

Please assign this task to me (@tmdeveloper007).