### PR TITLE
feat : added toast dark mode pattern demo

### DIFF
--- a/submissions/examples/toast-dark-mode-tm/README.md
+++ b/submissions/examples/toast-dark-mode-tm/README.md
@@ -1,0 +1,28 @@
+# Toast Dark Mode Support
+
+Demonstrates `[data-theme="dark"]` dark mode support for the Toast component.
+
+## What This Submission Shows
+
+The CSS pattern for toast dark mode (to be added to `components/toast.css`):
+
+```css
+/* Dark mode */
+[data-theme="dark"] .ease-toast {
+  background: var(--ease-color-surface-dark, #1e293b);
+}
+[data-theme="dark"] .ease-toast-body p {
+  color: var(--ease-color-text-muted, #94a3b8);
+}
+```
+
+## Usage
+
+```html
+<div class="ease-toast ease-toast-success">
+  <div class="ease-toast-icon">+</div>
+  <div class="ease-toast-body"><strong>Title</strong><p>Message text.</p></div>
+</div>
+```
+
+Enable dark mode: `<html data-theme="dark">`

--- a/submissions/examples/toast-dark-mode-tm/demo.html
+++ b/submissions/examples/toast-dark-mode-tm/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toast Dark Mode Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="demo-container">
+  <h1>Toast Component - Dark Mode</h1>
+  <p>Toggle dark mode to see toast body text and surface adapt correctly.</p>
+  <div class="controls">
+    <button class="theme-btn" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark')">Toggle Dark Mode</button>
+  </div>
+  <div class="ease-toast ease-toast-enter">
+    <div class="ease-toast-icon">i</div>
+    <div class="ease-toast-body"><strong>Default Toast</strong><p>This is the default toast body text that needs dark mode support.</p></div>
+  </div>
+  <div class="ease-toast ease-toast-success ease-toast-enter">
+    <div class="ease-toast-icon">+</div>
+    <div class="ease-toast-body"><strong>Success Toast</strong><p>Your changes have been saved successfully.</p></div>
+  </div>
+  <div class="ease-toast ease-toast-danger ease-toast-enter">
+    <div class="ease-toast-icon">x</div>
+    <div class="ease-toast-body"><strong>Danger Toast</strong><p>Something went wrong. Please try again.</p></div>
+  </div>
+  <div class="ease-toast ease-toast-warning ease-toast-enter">
+    <div class="ease-toast-icon">!</div>
+    <div class="ease-toast-body"><strong>Warning Toast</strong><p>Your session will expire in 5 minutes.</p></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/toast-dark-mode-tm/style.css
+++ b/submissions/examples/toast-dark-mode-tm/style.css
@@ -1,0 +1,19 @@
+/* Toast Dark Mode Demo Styles */
+body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; padding: 2rem; margin: 0; transition: background 0.3s, color 0.3s; }
+[data-theme="dark"] body { background: #0f172a; color: #e2e8f0; }
+.demo-container { max-width: 600px; margin: 0 auto; }
+h1 { margin-bottom: 0.5rem; }
+p { color: #64748b; line-height: 1.6; }
+[data-theme="dark"] p { color: #94a3b8; }
+.controls { margin: 1rem 0 2rem; }
+.theme-btn { padding: 0.5rem 1rem; background: #6c63ff; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; }
+[data-theme="dark"] .theme-btn { background: #818cf8; }
+.demo-container > .ease-toast { margin-bottom: 1rem; }
+
+/* Dark mode overrides for toast component */
+[data-theme="dark"] .ease-toast {
+  background: #1e293b;
+}
+[data-theme="dark"] .ease-toast-body p {
+  color: #94a3b8;
+}


### PR DESCRIPTION
Closes #11971.

Summary of What Has Been Done:
Added a demonstration submission showing the `[data-theme="dark"]` CSS pattern for the Toast component. The demo showcases toast notifications that adapt to dark mode via CSS attribute selectors, with full interactive toggle.

Changes Made:
- Created `submissions/examples/toast-dark-mode-tm/demo.html` with interactive dark mode toggle
- Created `submissions/examples/toast-dark-mode-tm/style.css` containing dark mode overrides for `.ease-toast` background and `.ease-toast-body p` text color
- Created `submissions/examples/toast-dark-mode-tm/README.md` with usage documentation

Impact it Made:
- Demonstrates the exact CSS changes needed for toast dark mode
- Interactive demo shows all toast variants (default, success, danger, warning) in both themes
- Pattern can be directly copy-pasted into `components/toast.css`

Please assign this task to me (@tmdeveloper007).