### PR TITLE
feat : added badge dark mode pattern demo

### DIFF
--- a/submissions/examples/badge-dark-mode-tm/README.md
+++ b/submissions/examples/badge-dark-mode-tm/README.md
@@ -1,0 +1,31 @@
+# Badge Dark Mode Support
+
+Demonstrates `[data-theme="dark"]` dark mode support for the Badge component.
+
+## What This Submission Shows
+
+The CSS pattern for badge dark mode (to be added to `components/badges.css`):
+
+```css
+/* Dark mode */
+[data-theme="dark"] .ease-badge {
+  color: var(--ease-color-text, #e2e8f0);
+}
+[data-theme="dark"] .ease-badge-pulse::after {
+  box-shadow: 0 0 0 0 rgba(129, 140, 248, 0.7);
+}
+[data-theme="dark"] .ease-badge-danger.ease-badge-pulse::after {
+  box-shadow: 0 0 0 0 rgba(248, 113, 113, 0.7);
+}
+[data-theme="dark"] .ease-badge-success.ease-badge-pulse::after {
+  box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.7);
+}
+```
+
+## Usage
+
+```html
+<span class="ease-badge ease-badge-pulse">Pulsing</span>
+```
+
+Enable dark mode: `<html data-theme="dark">`

--- a/submissions/examples/badge-dark-mode-tm/demo.html
+++ b/submissions/examples/badge-dark-mode-tm/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Badge Dark Mode Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="demo-container">
+  <h1>Badge Component - Dark Mode</h1>
+  <p>Toggle dark mode to see badge text and pulse variants adapt.</p>
+  <div class="controls">
+    <button class="theme-btn" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark')">Toggle Dark Mode</button>
+  </div>
+  <section>
+    <h2>Default Badges</h2>
+    <div class="badge-row">
+      <span class="ease-badge">Primary</span>
+      <span class="ease-badge ease-badge-sm">Small</span>
+      <span class="ease-badge ease-badge-lg">Large</span>
+    </div>
+  </section>
+  <section>
+    <h2>Variant Badges</h2>
+    <div class="badge-row">
+      <span class="ease-badge ease-badge-danger">Danger</span>
+      <span class="ease-badge ease-badge-success">Success</span>
+    </div>
+  </section>
+  <section>
+    <h2>Pulse Variants</h2>
+    <div class="badge-row">
+      <span class="ease-badge ease-badge-pulse">Primary Pulse</span>
+      <span class="ease-badge ease-badge-danger ease-badge-pulse">Danger Pulse</span>
+      <span class="ease-badge ease-badge-success ease-badge-pulse">Success Pulse</span>
+    </div>
+  </section>
+</div>
+</body>
+</html>

--- a/submissions/examples/badge-dark-mode-tm/style.css
+++ b/submissions/examples/badge-dark-mode-tm/style.css
@@ -1,0 +1,25 @@
+/* Badge Dark Mode Demo Styles */
+body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; padding: 2rem; margin: 0; transition: background 0.3s, color 0.3s; }
+[data-theme="dark"] body { background: #0f172a; color: #e2e8f0; }
+.demo-container { max-width: 600px; margin: 0 auto; }
+h1 { margin-bottom: 0.5rem; }
+h2 { font-size: 0.95rem; color: #64748b; margin: 1.25rem 0 0.75rem; }
+[data-theme="dark"] h2 { color: #94a3b8; }
+.badge-row { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+.controls { margin: 1rem 0 1.5rem; }
+.theme-btn { padding: 0.5rem 1rem; background: #6c63ff; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; }
+[data-theme="dark"] .theme-btn { background: #818cf8; }
+
+/* Dark mode overrides for badge component */
+[data-theme="dark"] .ease-badge {
+  color: #e2e8f0;
+}
+[data-theme="dark"] .ease-badge-pulse::after {
+  box-shadow: 0 0 0 0 rgba(129, 140, 248, 0.7);
+}
+[data-theme="dark"] .ease-badge-danger.ease-badge-pulse::after {
+  box-shadow: 0 0 0 0 rgba(248, 113, 113, 0.7);
+}
+[data-theme="dark"] .ease-badge-success.ease-badge-pulse::after {
+  box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.7);
+}


### PR DESCRIPTION
Closes #11973.

Summary of What Has Been Done:
Added a demonstration submission showing the `[data-theme="dark"]` CSS pattern for the Badge component. The demo shows badge text and pulse animation adapting to dark mode.

Changes Made:
- Created `submissions/examples/badge-dark-mode-tm/demo.html` with interactive dark mode toggle
- Created `submissions/examples/badge-dark-mode-tm/style.css` with dark mode overrides for `.ease-badge` text color and pulse ring colors
- Created `submissions/examples/badge-dark-mode-tm/README.md`

Impact it Made:
- Demonstrates the CSS changes needed for badge dark mode
- Shows all badge variants (primary, danger, success) with pulse animations in both themes
- Pattern ready for copy-paste into `components/badges.css`

Please assign this task to me (@tmdeveloper007).