### PR TITLE
Clarify JavaScript file policy

### DIFF
--- a/submissions/docs/javascript-file-policy-ts/README.md
+++ b/submissions/docs/javascript-file-policy-ts/README.md
@@ -1,0 +1,18 @@
+# JavaScript File Policy
+
+1. What does this do? Clarifies that standard EaseMotion CSS submissions should include only `demo.html`, `style.css`, and `README.md`.
+2. How is it used? Review the policy demo and keep JavaScript out of new submission folders unless a maintainer explicitly requests it.
+3. Why is it useful? It prevents confusion around extra `script.js` files and keeps submissions aligned with the repository validator.
+
+## Submission Rule
+
+Use this structure for normal CSS examples:
+
+```text
+submissions/examples/your-feature-name/
+|-- demo.html
+|-- style.css
+`-- README.md
+```
+
+Do not add `script.js`, generated assets, screenshots, nested folders, or build output by default. If an issue specifically asks for JavaScript, mention that exception in the PR notes so the maintainer can review it intentionally.

--- a/submissions/docs/javascript-file-policy-ts/demo.html
+++ b/submissions/docs/javascript-file-policy-ts/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JavaScript File Policy</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="policy-page">
+    <section class="policy-panel" aria-labelledby="policy-title">
+      <p class="eyebrow">Submission guide</p>
+      <h1 id="policy-title">Keep CSS demos self-contained</h1>
+      <p class="intro">
+        A standard EaseMotion CSS submission should include only the required
+        demo, stylesheet, and README files.
+      </p>
+
+      <div class="file-grid" aria-label="Expected submission files">
+        <article class="file-card allowed">
+          <span class="file-status">Required</span>
+          <strong>demo.html</strong>
+          <p>Shows the effect with semantic, local markup.</p>
+        </article>
+
+        <article class="file-card allowed">
+          <span class="file-status">Required</span>
+          <strong>style.css</strong>
+          <p>Contains the raw CSS for the animation or component idea.</p>
+        </article>
+
+        <article class="file-card allowed">
+          <span class="file-status">Required</span>
+          <strong>README.md</strong>
+          <p>Explains what the submission does, how to use it, and why it fits.</p>
+        </article>
+
+        <article class="file-card limited">
+          <span class="file-status">Only if requested</span>
+          <strong>script.js</strong>
+          <p>Leave JavaScript out unless a maintainer explicitly asks for it.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/docs/javascript-file-policy-ts/style.css
+++ b/submissions/docs/javascript-file-policy-ts/style.css
@@ -1,0 +1,134 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f7f8fb;
+  color: #18202f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.policy-page {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 32px;
+}
+
+.policy-panel {
+  width: min(920px, 100%);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #4f46e5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  max-width: 680px;
+  color: #111827;
+  font-size: 4.25rem;
+  line-height: 0.95;
+}
+
+.intro {
+  margin: 18px 0 30px;
+  max-width: 620px;
+  color: #4b5563;
+  font-size: 1.08rem;
+  line-height: 1.6;
+}
+
+.file-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.file-card {
+  min-height: 190px;
+  border: 1px solid #d9deeb;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 45px rgba(20, 30, 60, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  justify-content: space-between;
+  padding: 18px;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.file-card:hover,
+.file-card:focus-within {
+  border-color: #4f46e5;
+  box-shadow: 0 22px 60px rgba(79, 70, 229, 0.16);
+  transform: translateY(-4px);
+}
+
+.file-card strong {
+  color: #111827;
+  font-size: 1.15rem;
+}
+
+.file-card p {
+  margin: 0;
+  color: #5f6879;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.file-status {
+  align-self: flex-start;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.allowed .file-status {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.limited {
+  border-style: dashed;
+}
+
+.limited .file-status {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+@media (max-width: 760px) {
+  .policy-page {
+    align-items: start;
+    padding: 24px;
+  }
+
+  .file-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .file-card {
+    min-height: 150px;
+  }
+
+  h1 {
+    font-size: 2.45rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a documentation-style submission clarifying that standard EaseMotion CSS examples should stay self-contained with only demo.html, style.css, and README.md unless maintainers request otherwise.

Closes #11996

---

## Type of Change

- [ ] New animation / hover effect
- [ ] New component
- [x] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## What changed

Added a validator-friendly docs submission under submissions/docs/javascript-file-policy-ts with a simple policy demo, supporting CSS, and README guidance about script.js usage.

---

## Validation

- [x] Ran stylelint on the new stylesheet