### PR TITLE
feat: add dark mode token layer with data-theme support

### DIFF
--- a/submissions/examples/dark-mode-token-layer/README.md
+++ b/submissions/examples/dark-mode-token-layer/README.md
@@ -1,75 +1,41 @@
 # Dark Mode Token Layer
 
-## What does this do?
-
-Adds a reusable CSS custom property layer for light and dark themes with both automatic system preference support and manual `data-theme` overrides.
+## What does it do?
+Adds a robust dark mode token layer using CSS custom properties.
+Developers can toggle dark mode via `data-theme="dark"` on the
+`<html>` element — no JavaScript framework required.
 
 ## How is it used?
-
-Use the default token layer for system preference-based theming:
-
 ```html
-<section class="theme-preview">
-  <div class="theme-card">
-    <h2>System Theme</h2>
-    <p>This follows the user's device preference.</p>
-  </div>
-</section>
+<!-- Activate dark mode -->
+<html data-theme="dark">
+
+<!-- Toggle with JS -->
+<button onclick="
+  const html = document.documentElement;
+  const current = html.getAttribute('data-theme');
+  html.setAttribute('data-theme', current === 'dark' ? 'light' : 'dark');
+">Toggle Theme</button>
 ```
 
-Use manual light mode by applying `data-theme="light"`:
-
-```html
-<section class="theme-preview" data-theme="light">
-  <div class="theme-card">
-    <h2>Manual Light Theme</h2>
-    <p>This section always uses light theme tokens.</p>
-  </div>
-</section>
-```
-
-Use manual dark mode by applying `data-theme="dark"`:
-
-```html
-<section class="theme-preview" data-theme="dark">
-  <div class="theme-card">
-    <h2>Manual Dark Theme</h2>
-    <p>This section always uses dark theme tokens.</p>
-  </div>
-</section>
-```
-
-## Why is it useful?
-
-This fits EaseMotion CSS because it keeps theming readable, composable, dependency-free, and easy to reuse across cards, buttons, surfaces, borders, text, hover states, and focus states.
+## CSS Tokens
+| Token | Light | Dark |
+|---|---|---|
+| `--ease-color-bg` | `#f8fafc` | `#0f172a` |
+| `--ease-color-surface` | `#ffffff` | `#1e293b` |
+| `--ease-color-text` | `#0f172a` | `#f8fafc` |
+| `--ease-color-muted` | `#64748b` | `#94a3b8` |
+| `--ease-color-border` | `#e2e8f0` | `#334155` |
+| `--ease-color-primary` | `#6c63ff` | `#818cf8` |
 
 ## Features
-
-* Uses CSS custom properties for reusable design tokens
-* Supports automatic dark mode through `prefers-color-scheme`
-* Supports manual overrides with `data-theme="light"` and `data-theme="dark"`
-* Keeps backgrounds, text, borders, buttons, hover states, and focus states theme-safe
-* Provides accessible contrast between foreground and background colors
-* Requires no build step and no external dependency
+- Manual toggle via `data-theme` attribute
+- System preference fallback via `prefers-color-scheme`
+- Smooth transitions between themes
+- Works alongside all existing EaseMotion classes
 
 ## Tech Stack
-
-* HTML
-* CSS only
-* No external frameworks
-* No build tools
+- CSS only for theming, minimal JS for toggle button
 
 ## Preview
-
-Open `demo.html` directly in the browser to preview:
-
-1. System preference-based theme
-2. Manual light theme
-3. Manual dark theme
-4. Reusable token swatches
-
-## Contribution Notes
-
-* This submission only adds files inside `submissions/examples/dark-mode-token-layer/`
-* No changes are made to `core/`, `components/`, `docs/`, or root examples
-* Class names are intentionally simple and readable; the maintainer can standardize naming later
+Open `demo.html` directly in browser.

--- a/submissions/examples/dark-mode-token-layer/demo.html
+++ b/submissions/examples/dark-mode-token-layer/demo.html
@@ -1,106 +1,76 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Dark Mode Token Layer</title>
-    <link rel="stylesheet" href="style.css" />
-  </head>
-  <body>
-    <main class="theme-page">
-      <section class="hero-section">
-        <p class="eyebrow">Theme Tokens</p>
-        <h1>Dark Mode Token Layer</h1>
-        <p class="hero-text">
-          A reusable CSS variable layer that supports system preference themes
-          and manual light or dark mode overrides using data-theme attributes.
-        </p>
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dark Mode Token Layer — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { font-family: sans-serif; min-height: 100vh; padding: 2rem; }
 
-        <div class="theme-controls" aria-label="Theme controls">
-          <button class="theme-button" type="button" data-set-theme="system">
-            System Mode
-          </button>
-          <button class="theme-button" type="button" data-set-theme="light">
-            Light Mode
-          </button>
-          <button class="theme-button" type="button" data-set-theme="dark">
-            Dark Mode
-          </button>
-        </div>
-      </section>
+    .container { max-width: 600px; margin: 0 auto; display: flex; flex-direction: column; gap: 1.5rem; }
 
-      <section class="theme-grid" aria-label="Theme mode previews">
-        <article class="theme-preview theme-system">
-          <span class="theme-label">System / Page Theme</span>
-          <div class="theme-card">
-            <div class="theme-icon" aria-hidden="true">◐</div>
-            <h2>Active Theme</h2>
-            <p>
-              Use the buttons above to switch the whole page between system,
-              light, and dark theme modes.
-            </p>
-          </div>
-        </article>
+    h1 { color: var(--ease-color-text); font-size: 1.75rem; }
+    p  { color: var(--ease-color-muted); line-height: 1.6; }
 
-        <article class="theme-preview" data-theme="light">
-          <span class="theme-label">Manual Light</span>
-          <div class="theme-card">
-            <div class="theme-icon" aria-hidden="true">☀</div>
-            <h2>Light Override</h2>
-            <p>
-              This section stays light because it uses
-              <code>data-theme="light"</code>.
-            </p>
-          </div>
-        </article>
+    .card {
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-border);
+      border-radius: 12px;
+      padding: 1.5rem;
+      box-shadow: var(--ease-shadow-md);
+      transition: background 0.3s ease, border-color 0.3s ease;
+    }
 
-        <article class="theme-preview" data-theme="dark">
-          <span class="theme-label">Manual Dark</span>
-          <div class="theme-card">
-            <div class="theme-icon" aria-hidden="true">☾</div>
-            <h2>Dark Override</h2>
-            <p>
-              This section stays dark because it uses
-              <code>data-theme="dark"</code>.
-            </p>
-          </div>
-        </article>
-      </section>
+    .card h2 { color: var(--ease-color-text); margin-bottom: 0.5rem; }
+    .card p  { color: var(--ease-color-muted); font-size: 0.9rem; }
 
-      <section class="token-section" aria-label="Theme token preview">
-        <h2>Theme Token Preview</h2>
-        <p class="token-description">
-          These swatches show the reusable CSS variables used for backgrounds,
-          surfaces, text, borders, and primary accents.
-        </p>
+    .toggle-btn {
+      padding: 10px 24px;
+      background: var(--ease-color-primary);
+      color: white;
+      border: none;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.2s ease;
+      align-self: flex-start;
+    }
+    .toggle-btn:hover { opacity: 0.85; }
 
-        <div class="token-grid">
-          <div class="token-box token-bg">Background</div>
-          <div class="token-box token-surface">Surface</div>
-          <div class="token-box token-text">Text</div>
-          <div class="token-box token-muted">Muted</div>
-          <div class="token-box token-border">Border</div>
-          <div class="token-box token-primary">Primary</div>
-        </div>
-      </section>
-    </main>
+    .badge {
+      display: inline-block;
+      padding: 3px 10px;
+      border-radius: 9999px;
+      font-size: 12px;
+      font-weight: 600;
+      background: var(--ease-color-primary);
+      color: white;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Dark Mode Token Layer</h1>
+    <p>Click the button to toggle between light and dark themes using <code>data-theme</code> attribute.</p>
 
-    <script>
-      const root = document.documentElement;
-      const themeButtons = document.querySelectorAll("[data-set-theme]");
+    <button class="toggle-btn" onclick="
+      const html = document.documentElement;
+      const current = html.getAttribute('data-theme');
+      html.setAttribute('data-theme', current === 'dark' ? 'light' : 'dark');
+      this.textContent = current === 'dark' ? '🌙 Switch to Dark' : '☀️ Switch to Light';
+    ">🌙 Switch to Dark</button>
 
-      themeButtons.forEach((button) => {
-        button.addEventListener("click", () => {
-          const selectedTheme = button.dataset.setTheme;
+    <div class="card">
+      <h2>Surface Card <span class="badge">New</span></h2>
+      <p>This card uses <code>--ease-color-surface</code> and <code>--ease-color-border</code> tokens. It automatically adapts to the active theme.</p>
+    </div>
 
-          if (selectedTheme === "system") {
-            root.removeAttribute("data-theme");
-            return;
-          }
-
-          root.setAttribute("data-theme", selectedTheme);
-        });
-      });
-    </script>
-  </body>
+    <div class="card">
+      <h2>How it works</h2>
+      <p>Set <code>data-theme="dark"</code> on the <code>&lt;html&gt;</code> element to activate dark mode. Remove it or set <code>data-theme="light"</code> to go back to light mode. Falls back to system preference automatically.</p>
+    </div>
+  </div>
+</body>
 </html>

--- a/submissions/examples/dark-mode-token-layer/style.css
+++ b/submissions/examples/dark-mode-token-layer/style.css
@@ -1,327 +1,56 @@
-:root {
-  color-scheme: light;
+/* ============================================================
+   EaseMotion CSS — Dark Mode Token Layer
+   Toggle via data-theme="dark" on <html> or <body>
+   ============================================================ */
 
-  --theme-bg: #f8fafc;
-  --theme-surface: #ffffff;
-  --theme-surface-soft: #eef2ff;
-  --theme-text: #0f172a;
-  --theme-muted-text: #475569;
-  --theme-border: #cbd5e1;
-  --theme-primary: #2563eb;
-  --theme-primary-hover: #1d4ed8;
-  --theme-button-text: #ffffff;
-  --theme-ring: rgba(37, 99, 235, 0.32);
-  --theme-shadow: rgba(15, 23, 42, 0.12);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    color-scheme: dark;
-
-    --theme-bg: #020617;
-    --theme-surface: #0f172a;
-    --theme-surface-soft: #172554;
-    --theme-text: #f8fafc;
-    --theme-muted-text: #cbd5e1;
-    --theme-border: #334155;
-    --theme-primary: #60a5fa;
-    --theme-primary-hover: #93c5fd;
-    --theme-button-text: #020617;
-    --theme-ring: rgba(96, 165, 250, 0.36);
-    --theme-shadow: rgba(0, 0, 0, 0.4);
-  }
-}
-
+/* Light Theme (Default) */
+:root,
 [data-theme="light"] {
-  color-scheme: light;
+  --ease-color-bg:      #f8fafc;
+  --ease-color-surface: #ffffff;
+  --ease-color-text:    #0f172a;
+  --ease-color-muted:   #64748b;
+  --ease-color-border:  #e2e8f0;
+  --ease-color-primary: #6c63ff;
 
-  --theme-bg: #f8fafc;
-  --theme-surface: #ffffff;
-  --theme-surface-soft: #eef2ff;
-  --theme-text: #0f172a;
-  --theme-muted-text: #475569;
-  --theme-border: #cbd5e1;
-  --theme-primary: #2563eb;
-  --theme-primary-hover: #1d4ed8;
-  --theme-button-text: #ffffff;
-  --theme-ring: rgba(37, 99, 235, 0.32);
-  --theme-shadow: rgba(15, 23, 42, 0.12);
+  --ease-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --ease-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
+                    0 2px 4px -1px rgba(0, 0, 0, 0.06);
 }
 
+/* Dark Theme */
 [data-theme="dark"] {
-  color-scheme: dark;
+  --ease-color-bg:      #0f172a;
+  --ease-color-surface: #1e293b;
+  --ease-color-text:    #f8fafc;
+  --ease-color-muted:   #94a3b8;
+  --ease-color-border:  #334155;
+  --ease-color-primary: #818cf8;
 
-  --theme-bg: #020617;
-  --theme-surface: #0f172a;
-  --theme-surface-soft: #172554;
-  --theme-text: #f8fafc;
-  --theme-muted-text: #cbd5e1;
-  --theme-border: #334155;
-  --theme-primary: #60a5fa;
-  --theme-primary-hover: #93c5fd;
-  --theme-button-text: #020617;
-  --theme-ring: rgba(96, 165, 250, 0.36);
-  --theme-shadow: rgba(0, 0, 0, 0.4);
+  --ease-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
+  --ease-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.5),
+                    0 2px 4px -1px rgba(0, 0, 0, 0.3);
 }
 
-* {
-  box-sizing: border-box;
+/* System preference fallback */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ease-color-bg:      #0f172a;
+    --ease-color-surface: #1e293b;
+    --ease-color-text:    #f8fafc;
+    --ease-color-muted:   #94a3b8;
+    --ease-color-border:  #334155;
+    --ease-color-primary: #818cf8;
+
+    --ease-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
+    --ease-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.5),
+                      0 2px 4px -1px rgba(0, 0, 0, 0.3);
+  }
 }
 
+/* Global resets using tokens */
 body {
-  margin: 0;
-  min-height: 100vh;
-  background:
-    radial-gradient(circle at top left, var(--theme-surface-soft), transparent 32rem),
-    var(--theme-bg);
-  color: var(--theme-text);
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-}
-
-.theme-page {
-  width: min(1120px, calc(100% - 32px));
-  margin: 0 auto;
-  padding: 64px 0;
-}
-
-.hero-section {
-  max-width: 980px;
-  margin-bottom: 40px;
-}
-
-.eyebrow {
-  margin: 0 0 12px;
-  color: var(--theme-primary);
-  font-size: 0.78rem;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-h1,
-h2,
-p {
-  margin-top: 0;
-}
-
-h1 {
-  margin-bottom: 16px;
-  max-width: 980px;
-  font-size: clamp(2.4rem, 5.8vw, 4.8rem);
-  line-height: 0.98;
-  letter-spacing: -0.06em;
-}
-
-.hero-text {
-  max-width: 620px;
-  color: var(--theme-muted-text);
-  font-size: 1.08rem;
-  line-height: 1.7;
-}
-
-.theme-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 24px;
-}
-
-.theme-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 22px;
-  margin-bottom: 36px;
-}
-
-.theme-preview {
-  padding: 18px;
-  border: 1px solid var(--theme-border);
-  border-radius: 24px;
-  background: var(--theme-bg);
-  color: var(--theme-text);
-  transition:
-    background-color 240ms ease,
-    border-color 240ms ease,
-    color 240ms ease;
-}
-
-.theme-label {
-  display: inline-flex;
-  margin-bottom: 14px;
-  padding: 7px 12px;
-  border: 1px solid var(--theme-border);
-  border-radius: 999px;
-  background: var(--theme-surface);
-  color: var(--theme-muted-text);
-  font-size: 0.78rem;
-  font-weight: 800;
-}
-
-.theme-card {
-  min-height: 280px;
-  padding: 26px;
-  border: 1px solid var(--theme-border);
-  border-radius: 20px;
-  background: var(--theme-surface);
-  box-shadow: 0 24px 70px var(--theme-shadow);
-  transition:
-    transform 220ms ease,
-    background-color 240ms ease,
-    border-color 240ms ease,
-    box-shadow 240ms ease;
-}
-
-.theme-card:hover {
-  transform: translateY(-6px);
-}
-
-.theme-icon {
-  display: grid;
-  place-items: center;
-  width: 48px;
-  height: 48px;
-  margin-bottom: 24px;
-  border-radius: 16px;
-  background: var(--theme-surface-soft);
-  color: var(--theme-primary);
-  font-size: 1.45rem;
-  font-weight: 900;
-}
-
-.theme-card h2 {
-  margin-bottom: 12px;
-  font-size: 1.35rem;
-}
-
-.theme-card p {
-  margin-bottom: 24px;
-  color: var(--theme-muted-text);
-  line-height: 1.65;
-}
-
-code {
-  color: var(--theme-primary);
-  font-size: 0.95em;
-  font-weight: 700;
-}
-
-.theme-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 44px;
-  padding: 0 18px;
-  border: 0;
-  border-radius: 999px;
-  background: var(--theme-primary);
-  color: var(--theme-button-text);
-  cursor: pointer;
-  font: inherit;
-  font-weight: 800;
-  transition:
-    background-color 180ms ease,
-    box-shadow 180ms ease,
-    transform 180ms ease;
-}
-
-.theme-button:hover {
-  background: var(--theme-primary-hover);
-  transform: translateY(-2px);
-}
-
-.theme-button:focus-visible {
-  outline: 3px solid var(--theme-ring);
-  outline-offset: 3px;
-}
-
-.token-section {
-  padding: 28px;
-  border: 1px solid var(--theme-border);
-  border-radius: 24px;
-  background: var(--theme-surface);
-  box-shadow: 0 24px 70px var(--theme-shadow);
-}
-
-.token-section h2 {
-  margin-bottom: 18px;
-}
-
-.token-grid {
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.token-box {
-  display: grid;
-  min-height: 76px;
-  place-items: center;
-  border: 1px solid var(--theme-border);
-  border-radius: 16px;
-  font-size: 0.78rem;
-  font-weight: 800;
-  text-align: center;
-}
-
-.token-bg {
-  background: var(--theme-bg);
-  color: var(--theme-text);
-}
-
-.token-surface {
-  background: var(--theme-surface);
-  color: var(--theme-text);
-}
-
-.token-text {
-  background: var(--theme-text);
-  color: var(--theme-surface);
-}
-
-.token-muted {
-  background: var(--theme-muted-text);
-  color: var(--theme-surface);
-}
-
-.token-border {
-  background: var(--theme-border);
-  color: var(--theme-text);
-}
-
-.token-description {
-  max-width: 620px;
-  margin-bottom: 20px;
-  color: var(--theme-muted-text);
-  line-height: 1.6;
-}
-
-.token-primary {
-  background: var(--theme-primary);
-  color: var(--theme-button-text);
-}
-
-@media (max-width: 900px) {
-  .theme-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .token-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 560px) {
-  .theme-page {
-    width: min(100% - 24px, 1120px);
-    padding: 36px 0;
-  }
-
-  .theme-card,
-  .token-section {
-    padding: 22px;
-  }
-
-  .token-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  background-color: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }


### PR DESCRIPTION
Closes #7815

## Changes
- Added `submissions/examples/dark-mode-token-layer/`
- `style.css` — CSS token layer for light/dark themes
- `demo.html` — interactive toggle demo
- `README.md` — token table + usage documentation

## Features
- `data-theme="dark"` for manual control
- `data-theme="light"` to force light mode
- `prefers-color-scheme` fallback for system preference
- Smooth transitions between themes
- Zero JS dependencies for the CSS layer itself