### PR TITLE
fix: add type="button" to <button> elements in docs/demo.html

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -306,7 +306,7 @@
         <li><a href="#layout">Layout</a></li>
         <li><a href="./">Docs</a></li>
         <li>
-          <button
+          <button type="button"
             id="theme-toggle"
             class="theme-toggle-btn ease-hover-grow"
             aria-label="Toggle dark/light theme"
@@ -376,43 +376,43 @@
         <!-- Variants -->
         <div class="demo-chip">// Variants</div>
         <div class="ease-flex ease-flex-wrap ease-gap-3" style="margin-bottom: var(--ease-space-8);">
-          <button class="ease-btn ease-btn-primary">Primary</button>
-          <button class="ease-btn ease-btn-success">Success</button>
-          <button class="ease-btn ease-btn-danger">Danger</button>
-          <button class="ease-btn ease-btn-outline">Outline</button>
-          <button class="ease-btn ease-btn-ghost" style="color: var(--page-text);">Ghost</button>
+          <button type="button" class="ease-btn ease-btn-primary">Primary</button>
+          <button type="button" class="ease-btn ease-btn-success">Success</button>
+          <button type="button" class="ease-btn ease-btn-danger">Danger</button>
+          <button type="button" class="ease-btn ease-btn-outline">Outline</button>
+          <button type="button" class="ease-btn ease-btn-ghost" style="color: var(--page-text);">Ghost</button>
         </div>
 
         <!-- Hover effects -->
         <div class="demo-chip">// With ease-btn-hover</div>
         <div class="ease-flex ease-flex-wrap ease-gap-3" style="margin-bottom: var(--ease-space-8);">
-          <button class="ease-btn ease-btn-primary ease-btn-hover">Hover me ✨</button>
-          <button class="ease-btn ease-btn-outline ease-btn-hover"
+          <button type="button" class="ease-btn ease-btn-primary ease-btn-hover">Hover me ✨</button>
+          <button type="button" class="ease-btn ease-btn-outline ease-btn-hover"
             style="border-color:rgba(255,255,255,0.3); color: var(--page-text);Hover me 🚀</button>
-          <button class="ease-btn ease-btn-success ease-btn-hover">Hover me 🌿</button>
+          <button type="button" class="ease-btn ease-btn-success ease-btn-hover">Hover me 🌿</button>
         </div>
 
         <!-- Sizes -->
         <div class="demo-chip">// Sizes</div>
         <div class="ease-flex ease-flex-wrap ease-items-center ease-gap-3" style="margin-bottom: var(--ease-space-8);">
-          <button class="ease-btn ease-btn-primary ease-btn-sm">Small</button>
-          <button class="ease-btn ease-btn-primary">Default</button>
-          <button class="ease-btn ease-btn-primary ease-btn-lg">Large</button>
-          <button class="ease-btn ease-btn-primary ease-btn-xl">X-Large</button>
+          <button type="button" class="ease-btn ease-btn-primary ease-btn-sm">Small</button>
+          <button type="button" class="ease-btn ease-btn-primary">Default</button>
+          <button type="button" class="ease-btn ease-btn-primary ease-btn-lg">Large</button>
+          <button type="button" class="ease-btn ease-btn-primary ease-btn-xl">X-Large</button>
         </div>
 
         <!-- Squish -->
         <div class="demo-chip">// Squish Button Utility</div>
         <div class="ease-flex ease-flex-wrap ease-gap-3" style="margin-bottom: var(--ease-space-8);">
-          <button class="ease-btn ease-btn-primary ease-squish-button">Squish Me </button>
+          <button type="button" class="ease-btn ease-btn-primary ease-squish-button">Squish Me </button>
         </div>
 
         <!-- Shapes & States -->
         <div class="demo-chip">// Pill · Disabled · Loading</div>
         <div class="ease-flex ease-flex-wrap ease-items-center ease-gap-3">
-          <button class="ease-btn ease-btn-primary ease-btn-pill">Pill Shape</button>
-          <button class="ease-btn ease-btn-primary" disabled>Disabled</button>
-          <button class="ease-btn ease-btn-outline ease-btn-loading"
+          <button type="button" class="ease-btn ease-btn-primary ease-btn-pill">Pill Shape</button>
+          <button type="button" class="ease-btn ease-btn-primary" disabled>Disabled</button>
+          <button type="button" class="ease-btn ease-btn-outline ease-btn-loading"
             style="border-color:rgba(255,255,255,0.3); color:#fff;">Loading</button>
         </div>
       </div>
@@ -446,7 +446,7 @@
                 difference.</p>
             </div>
             <div class="ease-card-footer">
-              <button class="ease-btn ease-btn-primary ease-btn-sm">Explore</button>
+              <button type="button" class="ease-btn ease-btn-primary ease-btn-sm">Explore</button>
             </div>
           </article>
 
@@ -461,7 +461,7 @@
                 obvious.</p>
             </div>
             <div class="ease-card-footer">
-              <button class="ease-btn ease-btn-success ease-btn-sm">Learn More</button>
+              <button type="button" class="ease-btn ease-btn-success ease-btn-sm">Learn More</button>
             </div>
           </article>
 
@@ -475,7 +475,7 @@
               <p>Link one stylesheet. No build steps, no dependencies, no configuration. Just write HTML.</p>
             </div>
             <div class="ease-card-footer">
-              <button class="ease-btn ease-btn-danger ease-btn-sm">Get Started</button>
+              <button type="button" class="ease-btn ease-btn-danger ease-btn-sm">Get Started</button>
             </div>
           </article>
         </div>
@@ -716,7 +716,7 @@
           <div class="ease-flex ease-justify-between ease-items-center ease-padding-4 ease-rounded ease-border"
             style="border-color:rgba(255,255,255,0.08);">
             <span class="tag">ease-flex ease-justify-between</span>
-            <button class="ease-btn ease-btn-primary ease-btn-sm">Action</button>
+            <button type="button" class="ease-btn ease-btn-primary ease-btn-sm">Action</button>
           </div>
         </div>
 


### PR DESCRIPTION
<!-- Briefly describe what you're submitting and the problem it solves. -->
Bug fix for missing `type="button"` attribute on button elements in `docs/demo.html`. Closes #12188

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] No changes to `core/**`
- [ ] No changes to `components/**`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this fix?**
Several `<button>` elements in `docs/demo.html` were missing the `type="button"` attribute. Browsers default to `type="submit"` which can cause unexpected page reloads.

**Files changed:**
`docs/demo.html` — added `type="button"` to 21 button elements including theme-toggle and all ease-btn variants.

---

Closes #12188