### PR TITLE
feat: add ease-fade-out-left exit animation with complementary ease-fade-in-right

### DIFF
--- a/submissions/examples/ease-fade-out-left/README.md
+++ b/submissions/examples/ease-fade-out-left/README.md
@@ -1,0 +1,61 @@
+# ease-fade-out-left — Fade Out While Moving Left
+
+Exit animation that fades an element to opacity 0 while translating it left. The directional counterpart to the existing `.ease-slide-in-left`.
+
+## Classes
+
+| Class | Distance | Description |
+|-------|----------|-------------|
+| `.ease-fade-out-left` | 32px | Default exit animation |
+| `.ease-fade-out-left` + `.ease-fade-out-left-sm` | 16px | Subtle exit |
+| `.ease-fade-out-left` + `.ease-fade-out-left-lg` | 64px | Dramatic exit |
+| `.ease-fade-in-right` | 32px | Complementary enter animation |
+
+## CSS Custom Properties
+
+| Token | Default | Description |
+|-------|---------|-------------|
+| `--ease-fade-out-left-distance` | `32px` | Translation distance |
+| `--ease-fade-out-left-duration` | `--ease-speed-medium` | Animation duration |
+| `--ease-fade-out-left-easing` | `--ease-ease` | Timing function |
+
+## Usage
+
+```html
+<!-- Add class to trigger exit -->
+<div class="ease-fade-out-left">Exits left</div>
+
+<!-- Remove item after animation -->
+<div id="item" class="list-item">
+  <button onclick="
+    const el = document.getElementById('item');
+    el.classList.add('ease-fade-out-left');
+    el.addEventListener('animationend', () => el.remove(), { once: true });
+  ">Dismiss</button>
+</div>
+
+<!-- Custom distance -->
+<div class="ease-fade-out-left" style="--ease-fade-out-left-distance: 80px;">
+  Far exit
+</div>
+
+<!-- Page transition pair -->
+<!-- Outgoing page -->
+<div class="ease-fade-out-left">Old content</div>
+<!-- Incoming page -->
+<div class="ease-fade-in-right">New content</div>
+```
+
+## Direction family
+
+EaseMotion CSS follows a consistent naming pattern:
+- `ease-slide-in-left` → enter from left
+- `ease-fade-out-left` → exit to left ← this submission
+- `ease-slide-in-right` → enter from right
+- `ease-fade-in-right` → enter from right (fade variant) ← included
+
+## Accessibility
+
+`animation-duration` is reduced to `1ms` when `prefers-reduced-motion: reduce` is set, effectively disabling the animation while preserving the final state.
+
+Closes #11832

--- a/submissions/examples/ease-fade-out-left/demo.html
+++ b/submissions/examples/ease-fade-out-left/demo.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-fade-out-left — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p  { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 600px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .controls { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+    .demo-box {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: var(--ease-space-4) var(--ease-space-6);
+      background: var(--ease-color-primary);
+      color: #fff;
+      border-radius: var(--ease-radius-md);
+      font-weight: 700;
+      font-size: 0.9375rem;
+      min-width: 140px;
+    }
+    .demo-stage {
+      min-height: 80px;
+      display: flex;
+      align-items: center;
+      padding: var(--ease-space-4);
+      background: var(--ease-color-neutral-50);
+      border: 1px dashed var(--ease-color-neutral-300);
+      border-radius: var(--ease-radius-lg);
+      margin-bottom: var(--ease-space-3);
+      overflow: hidden;
+    }
+    .list-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--ease-space-3) var(--ease-space-4);
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-md);
+      margin-bottom: var(--ease-space-2);
+      font-size: 0.9375rem;
+      font-weight: 500;
+    }
+    .del-btn {
+      background: none;
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-sm);
+      padding: 2px 8px;
+      cursor: pointer;
+      font-size: 0.75rem;
+      color: var(--ease-color-muted);
+      transition: all 150ms;
+    }
+    .del-btn:hover { background: var(--ease-color-danger); color: #fff; border-color: var(--ease-color-danger); }
+    .label { font-family: var(--ease-font-mono); font-size: 0.75rem; color: var(--ease-color-muted); margin-top: 0.5rem; }
+    .row { display: flex; gap: 1.5rem; flex-wrap: wrap; }
+    .col { display: flex; flex-direction: column; }
+  </style>
+</head>
+<body>
+  <h2>ease-fade-out-left</h2>
+  <p>
+    Fades out while translating left — the exit counterpart to
+    <code>.ease-slide-in-left</code>. Useful for dismissing items,
+    page transitions, and swipe-away interactions.
+  </p>
+
+  <h3>Trigger demo</h3>
+  <div class="demo-stage" id="stage-default">
+    <div class="demo-box" id="box-default">Fade out left</div>
+  </div>
+  <div class="controls">
+    <button class="ease-btn ease-btn-primary" onclick="trigger('box-default', 'ease-fade-out-left', 'stage-default')">
+      Trigger .ease-fade-out-left
+    </button>
+    <button class="ease-btn ease-btn-outline" onclick="reset('box-default', 'ease-fade-out-left')">
+      Reset
+    </button>
+  </div>
+
+  <h3>Size variants</h3>
+  <div class="row">
+    <div class="col">
+      <div class="demo-stage" id="stage-sm">
+        <div class="demo-box" id="box-sm" style="background:var(--ease-color-success);">Small (16px)</div>
+      </div>
+      <div class="controls">
+        <button class="ease-btn ease-btn-outline" onclick="trigger('box-sm', 'ease-fade-out-left ease-fade-out-left-sm', 'stage-sm')">Trigger sm</button>
+        <button class="ease-btn ease-btn-outline" onclick="reset('box-sm', 'ease-fade-out-left ease-fade-out-left-sm')">Reset</button>
+      </div>
+      <div class="label">.ease-fade-out-left-sm (16px)</div>
+    </div>
+    <div class="col">
+      <div class="demo-stage" id="stage-lg">
+        <div class="demo-box" id="box-lg" style="background:var(--ease-color-warning);">Large (64px)</div>
+      </div>
+      <div class="controls">
+        <button class="ease-btn ease-btn-outline" onclick="trigger('box-lg', 'ease-fade-out-left ease-fade-out-left-lg', 'stage-lg')">Trigger lg</button>
+        <button class="ease-btn ease-btn-outline" onclick="reset('box-lg', 'ease-fade-out-left ease-fade-out-left-lg')">Reset</button>
+      </div>
+      <div class="label">.ease-fade-out-left-lg (64px)</div>
+    </div>
+  </div>
+
+  <h3>Complementary enter: .ease-fade-in-right</h3>
+  <div class="demo-stage" id="stage-enter">
+    <div class="demo-box" id="box-enter" style="background:var(--ease-color-secondary,#ec4899);">Fade in right</div>
+  </div>
+  <div class="controls">
+    <button class="ease-btn ease-btn-primary" onclick="triggerEnter('box-enter')">Trigger .ease-fade-in-right</button>
+    <button class="ease-btn ease-btn-outline" onclick="reset('box-enter', 'ease-fade-in-right')">Reset</button>
+  </div>
+
+  <h3>List item removal (real-world pattern)</h3>
+  <div id="list-demo">
+    <div class="list-item" id="item-1">
+      <span>Task: Review pull request</span>
+      <button class="del-btn" onclick="removeItem('item-1')">Dismiss ×</button>
+    </div>
+    <div class="list-item" id="item-2">
+      <span>Task: Update documentation</span>
+      <button class="del-btn" onclick="removeItem('item-2')">Dismiss ×</button>
+    </div>
+    <div class="list-item" id="item-3">
+      <span>Task: Deploy to staging</span>
+      <button class="del-btn" onclick="removeItem('item-3')">Dismiss ×</button>
+    </div>
+    <div class="list-item" id="item-4">
+      <span>Task: Write release notes</span>
+      <button class="del-btn" onclick="removeItem('item-4')">Dismiss ×</button>
+    </div>
+  </div>
+
+  <h3>Custom distance via token</h3>
+  <div class="demo-stage" id="stage-custom">
+    <div class="demo-box" id="box-custom" style="background:#8b5cf6;">Custom 120px</div>
+  </div>
+  <div class="controls">
+    <button class="ease-btn ease-btn-outline"
+      onclick="triggerCustom('box-custom', 'stage-custom')">Trigger 120px</button>
+    <button class="ease-btn ease-btn-outline"
+      onclick="reset('box-custom', 'ease-fade-out-left')">Reset</button>
+  </div>
+  <div class="label">style="--ease-fade-out-left-distance: 120px"</div>
+
+  <script>
+    function trigger(id, cls, stageId) {
+      const el = document.getElementById(id);
+      cls.split(' ').forEach(c => el.classList.add(c));
+    }
+
+    function reset(id, cls) {
+      const el = document.getElementById(id);
+      el.classList.remove(...cls.split(' '));
+      void el.offsetWidth;
+    }
+
+    function triggerEnter(id) {
+      const el = document.getElementById(id);
+      el.classList.remove('ease-fade-in-right');
+      void el.offsetWidth;
+      el.classList.add('ease-fade-in-right');
+    }
+
+    function triggerCustom(id, stageId) {
+      const el = document.getElementById(id);
+      el.style.setProperty('--ease-fade-out-left-distance', '120px');
+      el.classList.remove('ease-fade-out-left');
+      void el.offsetWidth;
+      el.classList.add('ease-fade-out-left');
+    }
+
+    function removeItem(id) {
+      const el = document.getElementById(id);
+      el.classList.add('ease-fade-out-left');
+      el.addEventListener('animationend', () => el.remove(), { once: true });
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-fade-out-left/style.css
+++ b/submissions/examples/ease-fade-out-left/style.css
@@ -1,0 +1,97 @@
+/* ============================================================
+   ease-fade-out-left — Fade out while moving left
+   EaseMotion CSS Submission
+
+   The element fades to opacity 0 while translating left —
+   the directional counterpart to .ease-slide-in-left.
+   Useful for exit animations, page transitions, and list
+   item removal.
+
+   Classes:
+     .ease-fade-out-left       — fade out moving left (default 32px)
+     .ease-fade-out-left-sm    — subtle exit (16px)
+     .ease-fade-out-left-lg    — dramatic exit (64px)
+
+   Also provides the matching enter animation:
+     .ease-fade-in-right       — fade in from right (reverse exit)
+
+   CSS Custom Properties:
+     --ease-fade-out-left-distance  — translation distance (default 32px)
+     --ease-fade-out-left-duration  — animation duration (default --ease-speed-medium)
+     --ease-fade-out-left-easing    — timing function (default --ease-ease)
+   ============================================================ */
+
+@layer easemotion-components {
+
+  /* ── Keyframes ───────────────────────────────────────────── */
+
+  /* Fade out while moving left */
+  @keyframes ease-kf-fade-out-left {
+    from {
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+    }
+    to {
+      opacity: 0;
+      transform: translate3d(
+        calc(var(--ease-fade-out-left-distance, 32px) * -1),
+        0,
+        0
+      );
+    }
+  }
+
+  /* Complementary: fade in from right (pair with fade-out-left) */
+  @keyframes ease-kf-fade-in-right {
+    from {
+      opacity: 0;
+      transform: translate3d(
+        var(--ease-fade-out-left-distance, 32px),
+        0,
+        0
+      );
+    }
+    to {
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+    }
+  }
+
+  /* ── Utility classes ─────────────────────────────────────── */
+  .ease-fade-out-left {
+    --ease-fade-out-left-distance: 32px;
+    animation:
+      ease-kf-fade-out-left
+      var(--ease-fade-out-left-duration, var(--ease-speed-medium, 300ms))
+      var(--ease-fade-out-left-easing, var(--ease-ease, cubic-bezier(0.4,0,0.2,1)))
+      both;
+  }
+
+  .ease-fade-out-left-sm {
+    --ease-fade-out-left-distance: 16px;
+  }
+
+  .ease-fade-out-left-lg {
+    --ease-fade-out-left-distance: 64px;
+  }
+
+  /* Complementary enter */
+  .ease-fade-in-right {
+    --ease-fade-out-left-distance: 32px;
+    animation:
+      ease-kf-fade-in-right
+      var(--ease-fade-out-left-duration, var(--ease-speed-medium, 300ms))
+      var(--ease-fade-out-left-easing, var(--ease-ease, cubic-bezier(0.4,0,0.2,1)))
+      both;
+  }
+
+  /* ── Reduced motion ──────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-fade-out-left,
+    .ease-fade-in-right {
+      animation-duration: 1ms;
+      transform: none;
+    }
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-fade-out-left` — an exit animation that fades an element to opacity 0 while translating it left. The directional counterpart to the existing `.ease-slide-in-left`. Includes the complementary `.ease-fade-in-right` for page transition pairs.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | Distance | Use |
|-------|----------|-----|
| `.ease-fade-out-left` | 32px | Default exit |
| `+ .ease-fade-out-left-sm` | 16px | Subtle exit |
| `+ .ease-fade-out-left-lg` | 64px | Dramatic exit |
| `.ease-fade-in-right` | 32px | Complementary enter |

**Key use case — list item removal:**
```js
el.classList.add('ease-fade-out-left');
el.addEventListener('animationend', () => el.remove(), { once: true });
```

**Why does it fit EaseMotion CSS?**
Fills the gap in the directional animation family. Existing: `ease-slide-in-left`, `ease-slide-in-right`. Missing: exit equivalents. This adds `ease-fade-out-left` + `ease-fade-in-right` as a matched pair for page transitions and list dismissals.

---

## Demo
- [x] Demo added (`demo.html` — trigger/reset buttons for all variants, live list item removal, complementary enter animation, and custom token override)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

Closes #11832