### PR TITLE
fix: replace hardcoded outline-offset with CSS variable

### DIFF
--- a/components/buttons.css
+++ b/components/buttons.css
@@ -37,7 +37,7 @@
 
 .ease-btn:focus-visible {
   outline: 2px solid var(--ease-btn-focus, var(--ease-color-primary, #6c63ff));
-  outline-offset: 3px;
+  outline-offset: var(--outline-offset, 3px);
 }
 
 /* ── Variants ──────────────────────────────────────────────── */

--- a/core/variables.css
+++ b/core/variables.css
@@ -5,6 +5,14 @@
 
 @layer easemotion-base {
 :root {
+
+  
+  /* existing variables */
+  --color-primary: #...;
+
+  /* add this */
+  --outline-offset: 3px;
+
   /* ── Transition Speeds ─────────────────────────────────── */
   --ease-speed-fast:    150ms;
   --ease-speed-medium:  300ms;


### PR DESCRIPTION
## Description
Replaced hardcoded `outline-offset: 3px` with a CSS variable to improve design system consistency.

## Changes
- Updated `components/buttons.css` to use `var(--outline-offset, 3px)`
- Added `--outline-offset` in `core/variables.css`

## Why
This ensures consistency with the design system and allows global customization.

## Result
Now outline offset can be easily controlled via CSS variables across the project.