### PR TITLE
feat: add ease-roll-in-right roll in from right — translateX(100%) + rotate(120deg) → 0 with ease-out

### DIFF
--- a/submissions/examples/ease-roll-in-right/README.md
+++ b/submissions/examples/ease-roll-in-right/README.md
@@ -1,0 +1,38 @@
+# ease-roll-in-right — Roll In from Right with Rotation
+
+Enter animation: `translateX(100%) + rotate(120deg)` → `translateX(0) + rotate(0)` with `ease-out` timing. Direction variant of `ease-roll-in-left`.
+
+## Acceptance Criteria
+
+- ✅ `translateX(100%) + rotate(120deg)` → `0`
+- ✅ Smooth `ease-out` timing
+
+## Classes
+
+| Class | Distance | Rotation | Duration |
+|-------|----------|----------|----------|
+| `.ease-roll-in-right` | 100% | 120° | 0.6s |
+| `+ .ease-roll-in-right-sm` | 50% | 60° | 0.6s |
+| `+ .ease-roll-in-right-fast` | 100% | 120° | 0.4s |
+| `+ .ease-roll-in-right-slow` | 100% | 120° | 1s |
+
+## CSS Custom Properties
+
+| Token | Default | Description |
+|-------|---------|-------------|
+| `--ease-roll-in-right-distance` | `100%` | Start translateX |
+| `--ease-roll-in-right-rotation` | `120deg` | Start rotation |
+| `--ease-roll-in-right-duration` | `0.6s` | Duration |
+
+## Usage
+
+```html
+<div class="ease-roll-in-right">Rolls in from right</div>
+
+<!-- Full rotation -->
+<div class="ease-roll-in-right" style="--ease-roll-in-right-rotation: 360deg;">
+  Full spin entry
+</div>
+```
+
+Closes #11844

--- a/submissions/examples/ease-roll-in-right/demo.html
+++ b/submissions/examples/ease-roll-in-right/demo.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-roll-in-right — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 780px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p  { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 600px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .controls { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1rem; }
+    .demo-box {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 64px; height: 64px;
+      background: var(--ease-color-primary); color: #fff;
+      border-radius: var(--ease-radius-full); font-size: 1.5rem;
+      box-shadow: var(--ease-shadow-md);
+    }
+    .demo-stage {
+      min-height: 100px; display: flex; align-items: center;
+      padding: var(--ease-space-4);
+      background: var(--ease-color-neutral-50);
+      border: 1px dashed var(--ease-color-neutral-300);
+      border-radius: var(--ease-radius-lg);
+      margin-bottom: var(--ease-space-3);
+      overflow: hidden;
+    }
+    .label { font-family: var(--ease-font-mono); font-size: 0.75rem;
+             color: var(--ease-color-muted); margin-top: 0.25rem; }
+    .row { display: flex; gap: 1.5rem; flex-wrap: wrap; }
+    .col { display: flex; flex-direction: column; align-items: center; }
+  </style>
+</head>
+<body>
+  <h2>ease-roll-in-right</h2>
+  <p>
+    Rolls in from the right with matching rotation —
+    <code>translateX(100%) + rotate(120deg) → 0</code>
+    with <code>ease-out</code> timing.
+    Direction variant of <code>.ease-roll-in-left</code>.
+  </p>
+
+  <h3>Default</h3>
+  <div class="demo-stage">
+    <div class="demo-box ease-roll-in-right" id="box-default">⚽</div>
+  </div>
+  <div class="controls">
+    <button class="ease-btn ease-btn-primary" onclick="retrigger('box-default','ease-roll-in-right')">Retrigger</button>
+  </div>
+  <div class="label">.ease-roll-in-right</div>
+
+  <h3>Variants</h3>
+  <div class="row">
+    <div class="col">
+      <div class="demo-stage" style="width:200px;">
+        <div class="demo-box" id="box-sm" style="background:var(--ease-color-success);">🎱</div>
+      </div>
+      <div class="controls">
+        <button class="ease-btn ease-btn-outline" onclick="retrigger('box-sm','ease-roll-in-right ease-roll-in-right-sm')">Trigger</button>
+      </div>
+      <div class="label">.ease-roll-in-right-sm (50%, 60deg)</div>
+    </div>
+    <div class="col">
+      <div class="demo-stage" style="width:200px;">
+        <div class="demo-box" id="box-fast" style="background:var(--ease-color-danger);">🔴</div>
+      </div>
+      <div class="controls">
+        <button class="ease-btn ease-btn-outline" onclick="retrigger('box-fast','ease-roll-in-right ease-roll-in-right-fast')">Trigger</button>
+      </div>
+      <div class="label">.ease-roll-in-right-fast (0.4s)</div>
+    </div>
+    <div class="col">
+      <div class="demo-stage" style="width:200px;">
+        <div class="demo-box" id="box-slow" style="background:var(--ease-color-warning);">🟡</div>
+      </div>
+      <div class="controls">
+        <button class="ease-btn ease-btn-outline" onclick="retrigger('box-slow','ease-roll-in-right ease-roll-in-right-slow')">Trigger</button>
+      </div>
+      <div class="label">.ease-roll-in-right-slow (1s)</div>
+    </div>
+  </div>
+
+  <h3>Custom rotation via token</h3>
+  <div class="demo-stage">
+    <div class="demo-box" id="box-custom" style="background:#8b5cf6;">🌀</div>
+  </div>
+  <div class="controls">
+    <button class="ease-btn ease-btn-outline" onclick="triggerCustom('box-custom')">Trigger 360deg</button>
+  </div>
+  <div class="label">--ease-roll-in-right-rotation: 360deg</div>
+
+  <script>
+    function retrigger(id, cls) {
+      const el = document.getElementById(id);
+      el.classList.remove(...cls.split(' '));
+      void el.offsetWidth;
+      cls.split(' ').forEach(c => el.classList.add(c));
+    }
+    function triggerCustom(id) {
+      const el = document.getElementById(id);
+      el.style.setProperty('--ease-roll-in-right-rotation', '360deg');
+      el.classList.remove('ease-roll-in-right');
+      void el.offsetWidth;
+      el.classList.add('ease-roll-in-right');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-roll-in-right/style.css
+++ b/submissions/examples/ease-roll-in-right/style.css
@@ -1,0 +1,73 @@
+/* ============================================================
+   ease-roll-in-right — Roll in from right with rotation
+   EaseMotion CSS Submission
+
+   translateX(100%) + rotate(120deg) → translateX(0) + rotate(0)
+   Smooth ease-out timing.
+   Direction variant of ease-roll-in-left.
+
+   Acceptance Criteria:
+     ✅ translateX(100%) + rotate(120deg) → 0
+     ✅ Smooth ease-out
+
+   Classes:
+     .ease-roll-in-right       — default roll in from right (0.6s)
+     .ease-roll-in-right-sm    — short roll (50%, 60deg)
+     .ease-roll-in-right-fast  — quick entry (0.4s)
+     .ease-roll-in-right-slow  — slow dramatic entry (1s)
+
+   CSS Custom Properties:
+     --ease-roll-in-right-distance  — translateX start (default 100%)
+     --ease-roll-in-right-rotation  — rotation start (default 120deg)
+     --ease-roll-in-right-duration  — animation duration (default 0.6s)
+   ============================================================ */
+
+@layer easemotion-components {
+
+  /* ── Keyframe ────────────────────────────────────────────── */
+  @keyframes ease-kf-roll-in-right {
+    from {
+      opacity: 0;
+      transform:
+        translateX(var(--ease-roll-in-right-distance, 100%))
+        rotate(var(--ease-roll-in-right-rotation, 120deg));
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0) rotate(0deg);
+    }
+  }
+
+  /* ── Base class ──────────────────────────────────────────── */
+  .ease-roll-in-right {
+    --ease-roll-in-right-distance: 100%;
+    --ease-roll-in-right-rotation: 120deg;
+    --ease-roll-in-right-duration: 0.6s;
+
+    animation:
+      ease-kf-roll-in-right
+      var(--ease-roll-in-right-duration)
+      ease-out
+      both;
+  }
+
+  /* ── Size variants ───────────────────────────────────────── */
+  .ease-roll-in-right-sm {
+    --ease-roll-in-right-distance: 50%;
+    --ease-roll-in-right-rotation: 60deg;
+  }
+
+  /* ── Speed variants ──────────────────────────────────────── */
+  .ease-roll-in-right-fast { --ease-roll-in-right-duration: 0.4s; }
+  .ease-roll-in-right-slow { --ease-roll-in-right-duration: 1s;   }
+
+  /* ── Reduced motion ──────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-roll-in-right {
+      animation-duration: 1ms;
+      transform: none;
+      opacity: 1;
+    }
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-roll-in-right` — enter animation rolling in from the right with rotation. Direction variant of `ease-roll-in-left`.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Acceptance Criteria

- ✅ `translateX(100%) + rotate(120deg)` → `0`
- ✅ Smooth `ease-out` timing

## Feature Description

| Class | Distance | Rotation | Duration |
|-------|----------|----------|----------|
| `.ease-roll-in-right` | 100% | 120° | 0.6s |
| `+ .ease-roll-in-right-sm` | 50% | 60° | 0.6s |
| `+ .ease-roll-in-right-fast` | 100% | 120° | 0.4s |
| `+ .ease-roll-in-right-slow` | 100% | 120° | 1s |

```css
--ease-roll-in-right-distance: 100%;
--ease-roll-in-right-rotation: 120deg;
--ease-roll-in-right-duration: 0.6s;
```

---

## Demo
- [x] Demo added (`demo.html` — auto-plays on load, retrigger buttons for all variants, 360° custom token)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

Closes #11844