### PR TITLE
feat: add ease-fade-in-up entrance animation

### DIFF
--- a/submissions/examples/ease-fade-in-up/README.md
+++ b/submissions/examples/ease-fade-in-up/README.md
@@ -1,0 +1,44 @@
+# ease-fade-in-up
+
+Element fades in while gently rising upward from its starting position — the most common entrance animation pattern on the web.
+
+## Classes
+
+| Class | Effect |
+|-------|--------|
+| `.ease-fade-in-up` | Fades from opacity 0 → 1 while translating from `--ease-rise-distance` → 0 |
+
+## Custom property
+
+| Property | Default | Description |
+|----------|---------|--------------|
+| `--ease-rise-distance` | `20px` | How far the element rises during the entrance |
+
+## Usage
+
+```html
+<!-- Default 20px rise -->
+<div class="ease-fade-in-up">Content</div>
+
+<!-- Custom rise distance -->
+<div class="ease-fade-in-up" style="--ease-rise-distance: 60px;">Content</div>
+```
+
+## Why is this useful?
+
+The single most common entrance pattern across landing pages, cards, and content sections — opacity + translateY combined into one named class with a configurable rise distance, instead of writing the same keyframe by hand in every project.
+
+## Tech Stack
+
+- HTML
+- CSS only — no JavaScript
+
+## Accessibility
+
+Includes `@media (prefers-reduced-motion: reduce)`, disabling the animation and snapping the element directly to its final visible, resting position.
+
+## Why it fits EaseMotion CSS
+
+Follows the existing `ease-kf-` keyframe naming convention and `var(--ease-speed-*)`/`var(--ease-ease)` timing tokens used throughout `core/animations.css`, and exposes a configurable `--ease-rise-distance` custom property consistent with the framework's token-driven design philosophy.
+
+Closes #11826

--- a/submissions/examples/ease-fade-in-up/demo.html
+++ b/submissions/examples/ease-fade-in-up/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-fade-in-up — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 700px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 600px; }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    .demo-card {
+      background: var(--ease-color-surface);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      padding: var(--ease-space-5);
+      margin-bottom: 1rem;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <h2>ease-fade-in-up</h2>
+  <p class="intro">
+    Element fades in while gently rising from
+    <code>translateY(--ease-rise-distance)</code> to its resting
+    position. Reload the page to replay the entrance. Reload to see it again.
+  </p>
+
+  <div class="info">
+    💡 <strong>Custom rise distance:</strong> Override <code>--ease-rise-distance</code>
+    inline to control how far the element travels.
+  </div>
+
+  <div class="demo-card ease-fade-in-up">Default rise (20px)</div>
+  <div class="demo-card ease-fade-in-up" style="--ease-rise-distance: 60px;">Custom rise (60px)</div>
+  <div class="demo-card ease-fade-in-up" style="--ease-rise-distance: 8px;">Subtle rise (8px)</div>
+</body>
+</html>

--- a/submissions/examples/ease-fade-in-up/style.css
+++ b/submissions/examples/ease-fade-in-up/style.css
@@ -1,0 +1,36 @@
+/* ============================================================
+   ease-fade-in-up — fade in while moving up (#11826)
+
+   Element fades from opacity 0 to 1 while rising from
+   translateY(--ease-rise-distance) to translateY(0).
+   --ease-rise-distance defaults to 20px and can be overridden
+   per-element via inline style or a custom CSS rule.
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  .ease-fade-in-up {
+    --ease-rise-distance: 20px;
+    animation: ease-kf-fade-in-up var(--ease-speed-medium, 400ms) var(--ease-ease, ease) both;
+  }
+
+  @keyframes ease-kf-fade-in-up {
+    from {
+      opacity: 0;
+      transform: translateY(var(--ease-rise-distance, 20px));
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-fade-in-up {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds `.ease-fade-in-up` — the element fades from opacity 0 to 1 while rising from `--ease-rise-distance` to its resting position. `--ease-rise-distance` defaults to 20px per the acceptance criteria and can be overridden per element.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-fade-in-up/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | Effect |
|-------|--------|
| `.ease-fade-in-up` | opacity(0) + translateY(`--ease-rise-distance`) → normal |

**How does a developer use it?**
```html
<div class="ease-fade-in-up">Default 20px rise</div>
<div class="ease-fade-in-up" style="--ease-rise-distance: 60px;">Custom rise</div>
```

**Why does it fit EaseMotion CSS?**
Follows the existing `ease-kf-` keyframe naming convention and `var(--ease-speed-*)`/`var(--ease-ease)` timing tokens from `core/animations.css`, and exposes a configurable `--ease-rise-distance` consistent with the framework's token-driven design.

---

## Demo
- [x] Demo added (`demo.html` — three cards showing default, 60px, and 8px rise distances)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer
Satisfies the acceptance criteria exactly: `opacity(0) + translateY(20px) → normal`, with `--ease-rise-distance` as a configurable custom property defaulting to 20px.

Closes #11826