### PR TITLE
feat : added keyboard shortcut key dark mode pattern demo

### DIFF
--- a/submissions/examples/kbd-dark-mode-tm/README.md
+++ b/submissions/examples/kbd-dark-mode-tm/README.md
@@ -1,31 +1,42 @@
-# KBD Dark Mode Support
+# Keyboard Shortcut Key Styles — Dark Mode Demo
 
-Demonstrates `[data-theme="dark"]` dark mode support for the KBD component.
+## Overview
 
-## What This Submission Shows
-
-The `style.css` in this folder contains the dark mode CSS pattern that should be added to `components/kbd.css`:
-
-```css
-/* Dark mode */
-[data-theme="dark"] .ease-kbd {
-  color: #e2e8f0;
-  background: #1e293b;
-  border-color: #334155;
-  box-shadow: 0 1px 0 #475569;
-}
-```
+This submission demonstrates how the `.ease-kbd` component from EaseMotion CSS renders correctly in both light and dark modes. The dark mode override targets the `--kbd-bg`, `--kbd-color`, `--kbd-border`, and `--kbd-shadow` CSS variables to maintain legibility on dark surfaces.
 
 ## Usage
 
-Include the KBD component classes and add `data-theme="dark"` to your HTML:
+Apply `.ease-kbd` to any `<kbd>`-style inline element:
 
 ```html
-<html data-theme="dark">
-  <kbd class="ease-kbd">Ctrl</kbd>
-</html>
+<span class="ease-kbd">Ctrl</span>
+<span class="ease-kbd ease-kbd-sm">S</span>
+<span class="ease-kbd ease-kbd-lg">Enter</span>
+```
+
+Wrap a shortcut combo in `.ease-kbd-group`:
+
+```html
+<div class="ease-kbd-group">
+  <span class="ease-kbd">Cmd</span>
+  <span class="ease-kbd">Shift</span>
+  <span class="ease-kbd">P</span>
+</div>
+```
+
+To enable dark mode, add the `data-theme="dark"` attribute to `<html>` and define CSS variable overrides in `[data-theme="dark"]`.
+
+## Dark Mode Overrides
+
+```css
+[data-theme="dark"] {
+  --kbd-bg: #334155;
+  --kbd-color: #f1f5f9;
+  --kbd-border: #475569;
+  --kbd-shadow: #1e293b;
+}
 ```
 
 ## Browser Support
 
-All modern browsers. CSS custom properties and attribute selectors are widely supported.
+All modern browsers supporting CSS Custom Properties (`:root` variables) and `color-scheme: dark` — Chrome 87+, Firefox 78+, Safari 13.1+, Edge 88+.

--- a/submissions/examples/kbd-dark-mode-tm/demo.html
+++ b/submissions/examples/kbd-dark-mode-tm/demo.html
@@ -1,55 +1,133 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="light">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>KBD Dark Mode Demo</title>
-  <link rel="stylesheet" href="style.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Keyboard Shortcut Styles - Dark Mode Demo</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<div class="demo-container">
-  <h1>KBD Component - Dark Mode</h1>
-  <p>Toggle between light and dark themes to see the keyboard key styles adapt using CSS attribute selectors.</p>
-  <div class="theme-toggle-row">
-    <button class="theme-btn" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark')">
-      Toggle Dark Mode
-    </button>
-  </div>
-  <section>
-    <h2>Small Keys</h2>
-    <div class="kbd-group">
-      <kbd class="ease-kbd ease-kbd-sm">Ctrl</kbd>
-      <kbd class="ease-kbd ease-kbd-sm">+</kbd>
-      <kbd class="ease-kbd ease-kbd-sm">S</kbd>
-    </div>
-  </section>
-  <section>
-    <h2>Default Keys</h2>
-    <div class="kbd-group">
-      <kbd class="ease-kbd">A</kbd>
-      <kbd class="ease-kbd">B</kbd>
-      <kbd class="ease-kbd">C</kbd>
-    </div>
-  </section>
-  <section>
-    <h2>Large Keys</h2>
-    <div class="kbd-group">
-      <kbd class="ease-kbd ease-kbd-lg">Enter</kbd>
-      <kbd class="ease-kbd ease-kbd-lg">Esc</kbd>
-    </div>
-  </section>
-  <section>
-    <h2>Shortcut Sequence</h2>
-    <p>Press <kbd class="ease-kbd">Ctrl</kbd> + <kbd class="ease-kbd">Shift</kbd> + <kbd class="ease-kbd">P</kbd> to open the command palette.</p>
-  </section>
-  <section>
-    <h2>Key Group</h2>
-    <div class="kbd-group ease-kbd-group">
-      <kbd class="ease-kbd">Cmd</kbd>
-      <kbd class="ease-kbd">Option</kbd>
-      <kbd class="ease-kbd">J</kbd>
-    </div>
-  </section>
+
+<div class="page-wrapper">
+
+    <!-- Header with dark mode toggle -->
+    <header class="demo-header">
+        <div>
+            <h1 class="demo-title">Keyboard Shortcut Styles</h1>
+            <p class="demo-subtitle">EaseMotion CSS &middot; Dark Mode Demo</p>
+        </div>
+        <div class="toggle-area">
+            <span class="theme-label" id="themeLabel">Light mode</span>
+            <button class="theme-toggle" id="toggleBtn" aria-label="Toggle dark mode">
+                <span class="toggle-track">
+                    <span class="toggle-thumb"></span>
+                </span>
+            </button>
+        </div>
+    </header>
+
+    <main class="demo-main">
+
+        <!-- Section: Basic kbd styles -->
+        <section class="demo-section">
+            <p class="section-label">Section 01</p>
+            <h2 class="section-title">Basic Keyboard Shortcut Keys</h2>
+            <p class="section-desc">The <code>.ease-kbd</code> class styles inline keyboard keys with a raised 3D look. Override <code>--kbd-bg</code>, <code>--kbd-color</code>, and <code>--kbd-border</code> in dark mode to maintain contrast.</p>
+            <div class="demo-grid center-grid">
+                <div class="kbd-group-row">
+                    <span class="ease-kbd">Ctrl</span>
+                    <span class="plus-sign">+</span>
+                    <span class="ease-kbd">C</span>
+                </div>
+                <div class="kbd-group-row">
+                    <span class="ease-kbd">Cmd</span>
+                    <span class="plus-sign">+</span>
+                    <span class="ease-kbd">Shift</span>
+                    <span class="plus-sign">+</span>
+                    <span class="ease-kbd">P</span>
+                </div>
+                <div class="kbd-group-row">
+                    <span class="ease-kbd">Alt</span>
+                    <span class="plus-sign">+</span>
+                    <span class="ease-kbd">Tab</span>
+                </div>
+                <div class="kbd-group-row">
+                    <span class="ease-kbd">Esc</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Size variants -->
+        <section class="demo-section">
+            <p class="section-label">Section 02</p>
+            <h2 class="section-title">Size Variants</h2>
+            <p class="section-desc"><code>.ease-kbd-sm</code> and <code>.ease-kbd-lg</code> adjust padding and font size while preserving the dark mode overrides.</p>
+            <div class="demo-grid center-grid">
+                <div class="kbd-group-row">
+                    <span class="ease-kbd ease-kbd-sm">Ctrl</span>
+                    <span class="plus-sign">+</span>
+                    <span class="ease-kbd ease-kbd-sm">S</span>
+                </div>
+                <div class="kbd-group-row">
+                    <span class="ease-kbd">Ctrl</span>
+                    <span class="plus-sign">+</span>
+                    <span class="ease-kbd">S</span>
+                </div>
+                <div class="kbd-group-row">
+                    <span class="ease-kbd ease-kbd-lg">Ctrl</span>
+                    <span class="plus-sign">+</span>
+                    <span class="ease-kbd ease-kbd-lg">S</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Key groups -->
+        <section class="demo-section">
+            <p class="section-label">Section 03</p>
+            <h2 class="section-title">Shortcut Combos in Action</h2>
+            <p class="section-desc">Use <code>.ease-kbd-group</code> to wrap a sequence with consistent spacing.</p>
+            <div class="demo-grid center-grid">
+                <div class="kbd-group-row">
+                    <div class="ease-kbd-group">
+                        <span class="ease-kbd ease-kbd-sm">Ctrl</span>
+                        <span class="ease-kbd ease-kbd-sm">Shift</span>
+                        <span class="ease-kbd ease-kbd-sm">I</span>
+                    </div>
+                    <span class="shortcut-desc">Open DevTools</span>
+                </div>
+                <div class="kbd-group-row">
+                    <div class="ease-kbd-group">
+                        <span class="ease-kbd ease-kbd-sm">Ctrl</span>
+                        <span class="ease-kbd ease-kbd-sm">K</span>
+                    </div>
+                    <span class="shortcut-desc">Quick search</span>
+                </div>
+                <div class="kbd-group-row">
+                    <div class="ease-kbd-group">
+                        <span class="ease-kbd">Cmd</span>
+                        <span class="ease-kbd">Option</span>
+                        <span class="ease-kbd">J</span>
+                    </div>
+                    <span class="shortcut-desc">Console (Mac)</span>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
 </div>
+
+<script>
+    const toggleBtn = document.getElementById('toggleBtn');
+    const themeLabel = document.getElementById('themeLabel');
+    const html = document.documentElement;
+
+    toggleBtn.addEventListener('click', () => {
+        const current = html.getAttribute('data-theme');
+        const next = current === 'dark' ? 'light' : 'dark';
+        html.setAttribute('data-theme', next);
+        themeLabel.textContent = next === 'dark' ? 'Dark mode' : 'Light mode';
+    });
+</script>
 </body>
 </html>

--- a/submissions/examples/kbd-dark-mode-tm/style.css
+++ b/submissions/examples/kbd-dark-mode-tm/style.css
@@ -1,34 +1,226 @@
-/* KBD Dark Mode Demo Styles */
-/* Dark mode CSS using component class selectors - demonstrates the fix pattern */
+/* ─────────────────────────────────────────────────────────
+   Dark Mode Tokens
+   ───────────────────────────────────────────────────────── */
+:root {
+    --kbd-bg: #f1f5f9;
+    --kbd-color: #374151;
+    --kbd-border: #d1d5db;
+    --kbd-shadow: #cbd5e1;
+    --shortcut-desc-color: #6b7280;
+    --page-bg: #ffffff;
+    --page-color: #1e293b;
+    --card-bg: #f8fafc;
+    --card-border: #e2e8f0;
+    --toggle-track: #e2e8f0;
+    --toggle-active: #6c63ff;
+    --toggle-thumb: #ffffff;
+    --section-border: #e2e8f0;
+    --code-bg: #f1f5f9;
+    --code-color: #374151;
+}
+
+[data-theme="dark"] {
+    color-scheme: dark;
+    --kbd-bg: #334155;
+    --kbd-color: #f1f5f9;
+    --kbd-border: #475569;
+    --kbd-shadow: #1e293b;
+    --shortcut-desc-color: #94a3b8;
+    --page-bg: #0f172a;
+    --page-color: #f1f5f9;
+    --card-bg: #1e293b;
+    --card-border: #334155;
+    --toggle-track: #334155;
+    --toggle-active: #a78bfa;
+    --toggle-thumb: #f1f5f9;
+    --section-border: #334155;
+    --code-bg: #1e293b;
+    --code-color: #f1f5f9;
+}
+
+/* ─────────────────────────────────────────────────────────
+   Base
+   ───────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
 
 body {
-  font-family: system-ui, -apple-system, sans-serif;
-  background: #f8fafc;
-  color: #1e293b;
-  padding: 2rem;
-  margin: 0;
-  transition: background 0.3s, color 0.3s;
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--page-bg);
+    color: var(--page-color);
+    min-height: 100vh;
+    padding: 2rem 1rem;
+    transition: background-color 0.2s, color 0.2s;
 }
-[data-theme="dark"] body {
-  background: #0f172a;
-  color: #e2e8f0;
-}
-.demo-container { max-width: 700px; margin: 0 auto; }
-h1 { margin-bottom: 0.5rem; }
-h2 { font-size: 1rem; color: #64748b; margin: 1.5rem 0 0.5rem; }
-[data-theme="dark"] h2 { color: #94a3b8; }
-p { line-height: 1.6; color: #475569; }
-[data-theme="dark"] p { color: #94a3b8; }
-section { margin-bottom: 1.5rem; }
-.kbd-group { display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; margin-top: 0.5rem; }
-.theme-toggle-row { margin: 1.5rem 0; }
-.theme-btn { padding: 0.5rem 1rem; background: #6c63ff; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
-[data-theme="dark"] .theme-btn { background: #818cf8; }
 
-/* Dark mode overrides for kbd component - same pattern as components/kbd.css */
-[data-theme="dark"] .ease-kbd {
-  color: #e2e8f0;
-  background: #1e293b;
-  border-color: #334155;
-  box-shadow: 0 1px 0 #475569;
+/* ─────────────────────────────────────────────────────────
+   Page layout
+   ───────────────────────────────────────────────────────── */
+.page-wrapper { max-width: 760px; margin: 0 auto; }
+
+.demo-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--section-border);
+    margin-bottom: 2.5rem;
+}
+
+.demo-title {
+    margin: 0 0 0.25rem;
+    font-size: 1.5rem;
+    font-weight: 700;
+}
+
+.demo-subtitle {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--shortcut-desc-color);
+}
+
+.toggle-area {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.theme-label {
+    font-size: 0.875rem;
+    color: var(--shortcut-desc-color);
+}
+
+.theme-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+}
+
+.toggle-track {
+    display: flex;
+    align-items: center;
+    width: 44px;
+    height: 24px;
+    background: var(--toggle-track);
+    border-radius: 999px;
+    padding: 2px;
+    transition: background 0.2s;
+}
+
+[data-theme="dark"] .toggle-track {
+    background: var(--toggle-active);
+}
+
+.toggle-thumb {
+    width: 20px;
+    height: 20px;
+    background: var(--toggle-thumb);
+    border-radius: 50%;
+    transition: transform 0.2s;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+[data-theme="dark"] .toggle-thumb {
+    transform: translateX(20px);
+}
+
+/* ─────────────────────────────────────────────────────────
+   Sections
+   ───────────────────────────────────────────────────────── */
+.demo-section { margin-bottom: 3rem; }
+
+.section-label {
+    margin: 0 0 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--toggle-active);
+}
+
+.section-title {
+    margin: 0 0 0.5rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+    border-bottom: 1px solid var(--section-border);
+    padding-bottom: 0.5rem;
+}
+
+.section-desc {
+    margin: 0 0 1.5rem;
+    font-size: 0.9rem;
+    color: var(--shortcut-desc-color);
+    line-height: 1.6;
+}
+
+code {
+    background: var(--code-bg);
+    color: var(--toggle-active);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25rem;
+    font-size: 0.85em;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.demo-grid { display: flex; flex-wrap: wrap; gap: 1.5rem; }
+.center-grid { justify-content: center; }
+
+/* ─────────────────────────────────────────────────────────
+   Keyboard shortcut keys — core component
+   ───────────────────────────────────────────────────────── */
+.ease-kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.15rem 0.5rem;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--kbd-color);
+    background: var(--kbd-bg);
+    border: 1px solid var(--kbd-border);
+    border-bottom-width: 3px;
+    border-radius: 0.375rem;
+    line-height: 1.4;
+    white-space: nowrap;
+    box-shadow: 0 1px 0 var(--kbd-shadow);
+    transition: background 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.ease-kbd-sm { font-size: 0.65rem; padding: 0.1rem 0.35rem; }
+.ease-kbd-lg { font-size: 0.9rem; padding: 0.25rem 0.65rem; }
+
+.ease-kbd-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+/* ─────────────────────────────────────────────────────────
+   Demo layout rows
+   ───────────────────────────────────────────────────────── */
+.kbd-group-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 0.5rem;
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.plus-sign {
+    font-size: 0.875rem;
+    color: var(--shortcut-desc-color);
+    font-weight: 600;
+}
+
+.shortcut-desc {
+    font-size: 0.8rem;
+    color: var(--shortcut-desc-color);
+    margin-left: 0.25rem;
 }


### PR DESCRIPTION
Closes #12274.

Summary of What Has Been Done:
Created a dark mode pattern demo for the kbd (keyboard shortcut key) component showing basic kbd styles, size variants (sm/default/lg), and keyboard shortcut groups in both light and dark modes with a working theme toggle.

Changes Made:
- Created submissions/examples/kbd-dark-mode-tm/demo.html with interactive dark mode toggle and all kbd variants
- Created submissions/examples/kbd-dark-mode-tm/style.css with [data-theme="dark"] CSS variable overrides for --kbd-bg, --kbd-color, --kbd-border, --kbd-shadow
- Created submissions/examples/kbd-dark-mode-tm/README.md with usage documentation and dark mode token reference

Impact it Made:
Demonstrates the kbd component with proper dark mode contrast, helping users understand how to apply dark mode to keyboard shortcut UIs without modifying the core component file. No changes to core files.