### PR TITLE
feat : added toast notification dark mode pattern demo

### DIFF
--- a/submissions/examples/toast-dark-mode-tm/README.md
+++ b/submissions/examples/toast-dark-mode-tm/README.md
@@ -1,28 +1,37 @@
-# Toast Dark Mode Support
+# Toast Notifications — Dark Mode Demo
 
-Demonstrates `[data-theme="dark"]` dark mode support for the Toast component.
+## Overview
 
-## What This Submission Shows
-
-The CSS pattern for toast dark mode (to be added to `components/toast.css`):
-
-```css
-/* Dark mode */
-[data-theme="dark"] .ease-toast {
-  background: var(--ease-color-surface-dark, #1e293b);
-}
-[data-theme="dark"] .ease-toast-body p {
-  color: var(--ease-color-text-muted, #94a3b8);
-}
-```
+This submission demonstrates the `.ease-toast` notification component from EaseMotion CSS rendered in both light and dark modes. Dark mode overrides `--toast-bg`, `--toast-border`, `--toast-shadow`, and the variant accent colors to maintain contrast and readability.
 
 ## Usage
 
 ```html
 <div class="ease-toast ease-toast-success">
-  <div class="ease-toast-icon">+</div>
-  <div class="ease-toast-body"><strong>Title</strong><p>Message text.</p></div>
+  <svg class="ease-toast-icon" viewBox="0 0 20 20" fill="currentColor">
+    <path fill-rule="evenodd" d="..."/>
+  </svg>
+  <div class="ease-toast-body">
+    <strong>Changes saved</strong>
+    <p>Your profile has been updated.</p>
+  </div>
 </div>
 ```
 
-Enable dark mode: `<html data-theme="dark">`
+Toast variants: `.ease-toast-success`, `.ease-toast-danger`, `.ease-toast-warning`, `.ease-toast-info`.
+Size variants: `.ease-toast-sm`, `.ease-toast-lg`.
+
+## Dark Mode Overrides
+
+```css
+[data-theme="dark"] {
+  --toast-bg: #1e293b;
+  --toast-border: #334155;
+  --toast-shadow: rgba(0,0,0,0.3);
+  --toast-body-color: #94a3b8;
+}
+```
+
+## Browser Support
+
+CSS Custom Properties + CSS Color Scheme: Chrome 87+, Firefox 78+, Safari 13.1+, Edge 88+.

--- a/submissions/examples/toast-dark-mode-tm/demo.html
+++ b/submissions/examples/toast-dark-mode-tm/demo.html
@@ -1,34 +1,104 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="light">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Toast Dark Mode Demo</title>
-  <link rel="stylesheet" href="style.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Toast Notifications — Dark Mode Demo</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<div class="demo-container">
-  <h1>Toast Component - Dark Mode</h1>
-  <p>Toggle dark mode to see toast body text and surface adapt correctly.</p>
-  <div class="controls">
-    <button class="theme-btn" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark')">Toggle Dark Mode</button>
-  </div>
-  <div class="ease-toast ease-toast-enter">
-    <div class="ease-toast-icon">i</div>
-    <div class="ease-toast-body"><strong>Default Toast</strong><p>This is the default toast body text that needs dark mode support.</p></div>
-  </div>
-  <div class="ease-toast ease-toast-success ease-toast-enter">
-    <div class="ease-toast-icon">+</div>
-    <div class="ease-toast-body"><strong>Success Toast</strong><p>Your changes have been saved successfully.</p></div>
-  </div>
-  <div class="ease-toast ease-toast-danger ease-toast-enter">
-    <div class="ease-toast-icon">x</div>
-    <div class="ease-toast-body"><strong>Danger Toast</strong><p>Something went wrong. Please try again.</p></div>
-  </div>
-  <div class="ease-toast ease-toast-warning ease-toast-enter">
-    <div class="ease-toast-icon">!</div>
-    <div class="ease-toast-body"><strong>Warning Toast</strong><p>Your session will expire in 5 minutes.</p></div>
-  </div>
+
+<div class="page-wrapper">
+
+    <header class="demo-header">
+        <div>
+            <h1 class="demo-title">Toast Notifications</h1>
+            <p class="demo-subtitle">EaseMotion CSS &middot; Dark Mode Demo</p>
+        </div>
+        <div class="toggle-area">
+            <span class="theme-label" id="themeLabel">Light mode</span>
+            <button class="theme-toggle" id="toggleBtn" aria-label="Toggle dark mode">
+                <span class="toggle-track"><span class="toggle-thumb"></span></span>
+            </button>
+        </div>
+    </header>
+
+    <main class="demo-main">
+
+        <!-- Toast variants -->
+        <section class="demo-section">
+            <p class="section-label">Section 01</p>
+            <h2 class="section-title">Toast Variants</h2>
+            <p class="section-desc">The <code>.ease-toast</code> family uses a left border accent and surface-aware dark mode tokens to stay readable on dark backgrounds.</p>
+            <div class="toast-stack">
+                <div class="ease-toast ease-toast-success">
+                    <svg class="ease-toast-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"/>
+                    </svg>
+                    <div class="ease-toast-body">
+                        <strong>Changes saved</strong>
+                        <p>Your profile has been updated successfully.</p>
+                    </div>
+                </div>
+                <div class="ease-toast ease-toast-danger">
+                    <svg class="ease-toast-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"/>
+                    </svg>
+                    <div class="ease-toast-body">
+                        <strong>Upload failed</strong>
+                        <p>The file exceeds the 10 MB size limit.</p>
+                    </div>
+                </div>
+                <div class="ease-toast ease-toast-warning">
+                    <svg class="ease-toast-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"/>
+                    </svg>
+                    <div class="ease-toast-body">
+                        <strong>Session expiring</strong>
+                        <p>Your session will expire in 5 minutes.</p>
+                    </div>
+                </div>
+                <div class="ease-toast ease-toast-info">
+                    <svg class="ease-toast-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"/>
+                    </svg>
+                    <div class="ease-toast-body">
+                        <strong>New update available</strong>
+                        <p>Version 2.4.0 is ready to install.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Size variants -->
+        <section class="demo-section">
+            <p class="section-label">Section 02</p>
+            <h2 class="section-title">Size Variants</h2>
+            <div class="toast-stack">
+                <div class="ease-toast ease-toast-sm ease-toast-success">
+                    <svg class="ease-toast-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"/></svg>
+                    <div class="ease-toast-body"><strong>Small toast</strong></div>
+                </div>
+                <div class="ease-toast ease-toast-success">
+                    <svg class="ease-toast-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"/></svg>
+                    <div class="ease-toast-body"><strong>Default toast</strong><p>Standard size notification.</p></div>
+                </div>
+                <div class="ease-toast ease-toast-lg ease-toast-success">
+                    <svg class="ease-toast-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"/></svg>
+                    <div class="ease-toast-body"><strong>Large toast</strong><p>Use large toasts for critical messages that need more context.</p></div>
+                </div>
+            </div>
+        </section>
+
+    </main>
 </div>
+
+<script>
+    document.getElementById('toggleBtn').addEventListener('click', function() {
+        var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        document.getElementById('themeLabel').textContent = next === 'dark' ? 'Dark mode' : 'Light mode';
+    });
+</script>
 </body>
 </html>

--- a/submissions/examples/toast-dark-mode-tm/style.css
+++ b/submissions/examples/toast-dark-mode-tm/style.css
@@ -1,19 +1,202 @@
-/* Toast Dark Mode Demo Styles */
-body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; padding: 2rem; margin: 0; transition: background 0.3s, color 0.3s; }
-[data-theme="dark"] body { background: #0f172a; color: #e2e8f0; }
-.demo-container { max-width: 600px; margin: 0 auto; }
-h1 { margin-bottom: 0.5rem; }
-p { color: #64748b; line-height: 1.6; }
-[data-theme="dark"] p { color: #94a3b8; }
-.controls { margin: 1rem 0 2rem; }
-.theme-btn { padding: 0.5rem 1rem; background: #6c63ff; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; }
-[data-theme="dark"] .theme-btn { background: #818cf8; }
-.demo-container > .ease-toast { margin-bottom: 1rem; }
+/* ─────────────────────────────────────────────────────────
+   Dark Mode Tokens
+   ───────────────────────────────────────────────────────── */
+:root {
+    --toast-bg: #ffffff;
+    --toast-border: #e2e8f0;
+    --toast-shadow: rgba(0,0,0,0.08);
+    --toast-body-color: #6b7280;
+    --page-bg: #f8fafc;
+    --page-color: #1e293b;
+    --card-bg: #ffffff;
+    --toggle-track: #e2e8f0;
+    --toggle-active: #6c63ff;
+    --section-border: #e2e8f0;
+    --success-color: #22c55e;
+    --danger-color: #ef4444;
+    --warning-color: #f59e0b;
+    --info-color: #3b82f6;
+}
 
-/* Dark mode overrides for toast component */
-[data-theme="dark"] .ease-toast {
-  background: #1e293b;
+[data-theme="dark"] {
+    color-scheme: dark;
+    --toast-bg: #1e293b;
+    --toast-border: #334155;
+    --toast-shadow: rgba(0,0,0,0.3);
+    --toast-body-color: #94a3b8;
+    --page-bg: #0f172a;
+    --page-color: #f1f5f9;
+    --card-bg: #1e293b;
+    --toggle-track: #334155;
+    --toggle-active: #a78bfa;
+    --toggle-thumb: #f1f5f9;
+    --section-border: #334155;
+    --success-color: #4ade80;
+    --danger-color: #f87171;
+    --warning-color: #fbbf24;
+    --info-color: #60a5fa;
 }
-[data-theme="dark"] .ease-toast-body p {
-  color: #94a3b8;
+
+/* ─────────────────────────────────────────────────────────
+   Base
+   ───────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--page-bg);
+    color: var(--page-color);
+    min-height: 100vh;
+    padding: 2rem 1rem;
+    transition: background-color 0.2s, color 0.2s;
 }
+
+.page-wrapper { max-width: 640px; margin: 0 auto; }
+
+/* ─────────────────────────────────────────────────────────
+   Header
+   ───────────────────────────────────────────────────────── */
+.demo-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--section-border);
+    margin-bottom: 2.5rem;
+}
+
+.demo-title { margin: 0 0 0.25rem; font-size: 1.5rem; font-weight: 700; }
+.demo-subtitle { margin: 0; font-size: 0.875rem; color: var(--toast-body-color); }
+
+.toggle-area { display: flex; align-items: center; gap: 0.75rem; }
+.theme-label { font-size: 0.875rem; color: var(--toast-body-color); }
+
+.theme-toggle { background: none; border: none; cursor: pointer; padding: 0; }
+
+.toggle-track {
+    display: flex;
+    align-items: center;
+    width: 44px;
+    height: 24px;
+    background: var(--toggle-track);
+    border-radius: 999px;
+    padding: 2px;
+    transition: background 0.2s;
+}
+
+[data-theme="dark"] .toggle-track { background: var(--toggle-active); }
+
+.toggle-thumb {
+    width: 20px;
+    height: 20px;
+    background: #ffffff;
+    border-radius: 50%;
+    transition: transform 0.2s;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+[data-theme="dark"] .toggle-thumb { transform: translateX(20px); }
+
+/* ─────────────────────────────────────────────────────────
+   Sections
+   ───────────────────────────────────────────────────────── */
+.demo-section { margin-bottom: 3rem; }
+
+.section-label {
+    margin: 0 0 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--toggle-active);
+}
+
+.section-title {
+    margin: 0 0 0.5rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+    border-bottom: 1px solid var(--section-border);
+    padding-bottom: 0.5rem;
+}
+
+.section-desc {
+    margin: 0 0 1.5rem;
+    font-size: 0.9rem;
+    color: var(--toast-body-color);
+    line-height: 1.6;
+}
+
+code {
+    background: var(--card-bg);
+    color: var(--toggle-active);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25rem;
+    font-size: 0.85em;
+    font-family: 'JetBrains Mono', monospace;
+}
+
+/* ─────────────────────────────────────────────────────────
+   Toast Stack
+   ───────────────────────────────────────────────────────── */
+.toast-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+/* ─────────────────────────────────────────────────────────
+   Toast Component — .ease-toast family
+   ───────────────────────────────────────────────────────── */
+.ease-toast {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    background: var(--toast-bg);
+    border: 1px solid var(--toast-border);
+    border-left: 4px solid var(--info-color);
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 12px var(--toast-shadow);
+    max-width: 28rem;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.ease-toast-success { border-left-color: var(--success-color); }
+.ease-toast-danger  { border-left-color: var(--danger-color); }
+.ease-toast-warning { border-left-color: var(--warning-color); }
+.ease-toast-info    { border-left-color: var(--info-color); }
+
+.ease-toast-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+    margin-top: 1px;
+    color: var(--info-color);
+}
+
+.ease-toast-success .ease-toast-icon { color: var(--success-color); }
+.ease-toast-danger  .ease-toast-icon { color: var(--danger-color); }
+.ease-toast-warning .ease-toast-icon { color: var(--warning-color); }
+.ease-toast-info    .ease-toast-icon { color: var(--info-color); }
+
+.ease-toast-body strong {
+    display: block;
+    margin-bottom: 2px;
+    font-size: 0.9rem;
+    color: var(--page-color);
+}
+
+.ease-toast-body p {
+    margin: 0;
+    color: var(--toast-body-color);
+    font-size: 0.85rem;
+}
+
+/* Size variants */
+.ease-toast-sm { padding: 0.6rem 0.875rem; font-size: 0.85rem; max-width: 20rem; }
+.ease-toast-lg { padding: 1.25rem 1.5rem; font-size: 1rem; max-width: 32rem; }


### PR DESCRIPTION
Closes #12275.

Summary of What Has Been Done:
Created a dark mode pattern demo for the toast notification component showing all 4 toast variants (success, danger, warning, info) and size variants (sm/default/lg) in both light and dark modes with a working theme toggle.

Changes Made:
- Created submissions/examples/toast-dark-mode-tm/demo.html with interactive dark mode toggle and all toast variants
- Created submissions/examples/toast-dark-mode-tm/style.css with [data-theme="dark"] CSS variable overrides for --toast-bg, --toast-border, --toast-shadow, --toast-body-color, and variant accent colors
- Created submissions/examples/toast-dark-mode-tm/README.md with usage documentation and dark mode token reference

Impact it Made:
Demonstrates the toast component with proper dark mode contrast, helping users understand how to apply dark mode to notification UIs without modifying the core component file. No changes to core files.