### PR TITLE
feat : added pagination dark mode pattern demo

### DIFF
--- a/submissions/examples/pagination-dark-mode-tm/README.md
+++ b/submissions/examples/pagination-dark-mode-tm/README.md
@@ -1,0 +1,36 @@
+# Pagination — Dark Mode Demo
+
+## Overview
+
+Demonstrates the `.ease-pagination` component from EaseMotion CSS in both light and dark modes. Dark mode overrides `--btn-color`, `--btn-border`, `--btn-hover-bg`, and the `--btn-active-bg` tokens so the active page button and hover states remain visible on dark surfaces.
+
+## Usage
+
+```html
+<nav class="ease-pagination" aria-label="Page navigation">
+  <a href="#" class="ease-page-btn" aria-label="Previous page">&lsaquo;</a>
+  <a href="#" class="ease-page-btn">1</a>
+  <a href="#" class="ease-page-btn ease-page-btn-active">2</a>
+  <a href="#" class="ease-page-btn">3</a>
+  <a href="#" class="ease-page-btn" aria-label="Next page">&rsaquo;</a>
+</nav>
+```
+
+Size variant: `.ease-page-btn-sm` for compact buttons.
+Center alignment: `.ease-pagination-center` on the wrapper.
+
+## Dark Mode Overrides
+
+```css
+[data-theme="dark"] {
+  --btn-color: #cbd5e1;
+  --btn-border: #475569;
+  --btn-hover-bg: #334155;
+  --btn-active-bg: #a78bfa;
+  --btn-active-color: #0f172a;
+}
+```
+
+## Browser Support
+
+CSS Custom Properties + Flexbox: Chrome 87+, Firefox 78+, Safari 13.1+, Edge 88+.

--- a/submissions/examples/pagination-dark-mode-tm/demo.html
+++ b/submissions/examples/pagination-dark-mode-tm/demo.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pagination — Dark Mode Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="page-wrapper">
+
+    <header class="demo-header">
+        <div>
+            <h1 class="demo-title">Pagination</h1>
+            <p class="demo-subtitle">EaseMotion CSS &middot; Dark Mode Demo</p>
+        </div>
+        <div class="toggle-area">
+            <span class="theme-label" id="themeLabel">Light mode</span>
+            <button class="theme-toggle" id="toggleBtn" aria-label="Toggle dark mode">
+                <span class="toggle-track"><span class="toggle-thumb"></span></span>
+            </button>
+        </div>
+    </header>
+
+    <main class="demo-main">
+
+        <section class="demo-section">
+            <p class="section-label">Section 01</p>
+            <h2 class="section-title">Basic Pagination</h2>
+            <p class="section-desc">The <code>.ease-pagination</code> component renders page buttons with hover, active, and disabled states. Dark mode flips the button background, border, and active fill to work on dark surfaces.</p>
+            <nav class="ease-pagination" aria-label="Page navigation">
+                <a href="#" class="ease-page-btn" aria-label="Previous page">
+                    <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"/>
+                    </svg>
+                </a>
+                <a href="#" class="ease-page-btn">1</a>
+                <a href="#" class="ease-page-btn ease-page-btn-active">2</a>
+                <a href="#" class="ease-page-btn">3</a>
+                <span class="ease-page-btn ease-page-btn-ellipsis" aria-hidden="true">&hellip;</span>
+                <a href="#" class="ease-page-btn">8</a>
+                <a href="#" class="ease-page-btn" aria-label="Next page">
+                    <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/>
+                    </svg>
+                </a>
+            </nav>
+        </section>
+
+        <section class="demo-section">
+            <p class="section-label">Section 02</p>
+            <h2 class="section-title">Compact Pagination</h2>
+            <nav class="ease-pagination" aria-label="Compact pagination">
+                <a href="#" class="ease-page-btn ease-page-btn-sm" aria-label="First page">&laquo;</a>
+                <a href="#" class="ease-page-btn ease-page-btn-sm" aria-label="Previous page">&lsaquo;</a>
+                <a href="#" class="ease-page-btn ease-page-btn-sm">1</a>
+                <a href="#" class="ease-page-btn ease-page-btn-sm">2</a>
+                <a href="#" class="ease-page-btn ease-page-btn-sm ease-page-btn-active" aria-current="page">3</a>
+                <a href="#" class="ease-page-btn ease-page-btn-sm">4</a>
+                <a href="#" class="ease-page-btn ease-page-btn-sm">5</a>
+                <a href="#" class="ease-page-btn ease-page-btn-sm" aria-label="Next page">&rsaquo;</a>
+                <a href="#" class="ease-page-btn ease-page-btn-sm" aria-label="Last page">&raquo;</a>
+            </nav>
+        </section>
+
+        <section class="demo-section">
+            <p class="section-label">Section 03</p>
+            <h2 class="section-title">Centered Pagination</h2>
+            <nav class="ease-pagination ease-pagination-center" aria-label="Centered pagination">
+                <a href="#" class="ease-page-btn">1</a>
+                <a href="#" class="ease-page-btn">2</a>
+                <span class="ease-page-btn ease-page-btn-ellipsis">&hellip;</span>
+                <a href="#" class="ease-page-btn ease-page-btn-active">5</a>
+                <span class="ease-page-btn ease-page-btn-ellipsis">&hellip;</span>
+                <a href="#" class="ease-page-btn">12</a>
+                <a href="#" class="ease-page-btn">13</a>
+            </nav>
+        </section>
+
+        <section class="demo-section">
+            <p class="section-label">Section 04</p>
+            <h2 class="section-title">Disabled State</h2>
+            <nav class="ease-pagination" aria-label="Disabled pagination">
+                <span class="ease-page-btn ease-page-btn-disabled" aria-disabled="true" aria-label="Previous page, disabled">
+                    <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"/>
+                    </svg>
+                </span>
+                <a href="#" class="ease-page-btn">1</a>
+                <a href="#" class="ease-page-btn ease-page-btn-active">2</a>
+                <a href="#" class="ease-page-btn">3</a>
+                <a href="#" class="ease-page-btn" aria-label="Next page">
+                    <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/>
+                    </svg>
+                </a>
+            </nav>
+        </section>
+
+    </main>
+</div>
+
+<script>
+    document.getElementById('toggleBtn').addEventListener('click', function() {
+        var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        document.getElementById('themeLabel').textContent = next === 'dark' ? 'Dark mode' : 'Light mode';
+    });
+</script>
+</body>
+</html>

--- a/submissions/examples/pagination-dark-mode-tm/style.css
+++ b/submissions/examples/pagination-dark-mode-tm/style.css
@@ -1,0 +1,217 @@
+/* ─────────────────────────────────────────────────────────
+   Dark Mode Tokens
+   ───────────────────────────────────────────────────────── */
+:root {
+    --page-bg: #f8fafc;
+    --page-color: #1e293b;
+    --card-bg: #ffffff;
+    --card-border: #e2e8f0;
+    --toggle-track: #e2e8f0;
+    --toggle-active: #6c63ff;
+    --section-border: #e2e8f0;
+    --muted: #6b7280;
+
+    --btn-bg: transparent;
+    --btn-color: #374151;
+    --btn-border: #e5e7eb;
+    --btn-hover-bg: #f3f4f6;
+    --btn-hover-border: #d1d5db;
+    --btn-active-bg: #6c63ff;
+    --btn-active-color: #ffffff;
+    --btn-active-border: #6c63ff;
+    --btn-disabled-opacity: 0.4;
+    --btn-ellipsis-border: transparent;
+}
+
+[data-theme="dark"] {
+    color-scheme: dark;
+    --page-bg: #0f172a;
+    --page-color: #f1f5f9;
+    --card-bg: #1e293b;
+    --card-border: #334155;
+    --toggle-track: #334155;
+    --toggle-active: #a78bfa;
+    --toggle-thumb: #f1f5f9;
+    --section-border: #334155;
+    --muted: #94a3b8;
+
+    --btn-bg: transparent;
+    --btn-color: #cbd5e1;
+    --btn-border: #475569;
+    --btn-hover-bg: #334155;
+    --btn-hover-border: #475569;
+    --btn-active-bg: #a78bfa;
+    --btn-active-color: #0f172a;
+    --btn-active-border: #a78bfa;
+    --btn-disabled-opacity: 0.3;
+    --btn-ellipsis-border: transparent;
+}
+
+/* ─────────────────────────────────────────────────────────
+   Base
+   ───────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--page-bg);
+    color: var(--page-color);
+    min-height: 100vh;
+    padding: 2rem 1rem;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.page-wrapper { max-width: 700px; margin: 0 auto; }
+
+/* ─────────────────────────────────────────────────────────
+   Header
+   ───────────────────────────────────────────────────────── */
+.demo-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--section-border);
+    margin-bottom: 2.5rem;
+}
+
+.demo-title { margin: 0 0 0.25rem; font-size: 1.5rem; font-weight: 700; }
+.demo-subtitle { margin: 0; font-size: 0.875rem; color: var(--muted); }
+
+.toggle-area { display: flex; align-items: center; gap: 0.75rem; }
+.theme-label { font-size: 0.875rem; color: var(--muted); }
+.theme-toggle { background: none; border: none; cursor: pointer; padding: 0; }
+
+.toggle-track {
+    display: flex;
+    align-items: center;
+    width: 44px;
+    height: 24px;
+    background: var(--toggle-track);
+    border-radius: 999px;
+    padding: 2px;
+    transition: background 0.2s;
+}
+
+[data-theme="dark"] .toggle-track { background: var(--toggle-active); }
+
+.toggle-thumb {
+    width: 20px;
+    height: 20px;
+    background: #ffffff;
+    border-radius: 50%;
+    transition: transform 0.2s;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+[data-theme="dark"] .toggle-thumb { transform: translateX(20px); }
+
+/* ─────────────────────────────────────────────────────────
+   Sections
+   ───────────────────────────────────────────────────────── */
+.demo-section { margin-bottom: 3rem; }
+
+.section-label {
+    margin: 0 0 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--toggle-active);
+}
+
+.section-title {
+    margin: 0 0 0.5rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+    border-bottom: 1px solid var(--section-border);
+    padding-bottom: 0.5rem;
+}
+
+.section-desc {
+    margin: 0 0 1.5rem;
+    font-size: 0.9rem;
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+code {
+    background: var(--card-bg);
+    color: var(--toggle-active);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25rem;
+    font-size: 0.85em;
+    font-family: 'JetBrains Mono', monospace;
+}
+
+/* ─────────────────────────────────────────────────────────
+   Pagination Component — .ease-pagination
+   ───────────────────────────────────────────────────────── */
+.ease-pagination {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    flex-wrap: wrap;
+}
+
+.ease-page-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.25rem;
+    height: 2.25rem;
+    padding: 0 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--btn-color);
+    background: var(--btn-bg);
+    border: 1px solid var(--btn-border);
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+    text-decoration: none;
+    user-select: none;
+}
+
+.ease-page-btn:hover:not(:disabled):not(.ease-page-btn-active):not(.ease-page-btn-ellipsis) {
+    background: var(--btn-hover-bg);
+    border-color: var(--btn-hover-border);
+    color: var(--page-color);
+}
+
+.ease-page-btn-active,
+.ease-page-btn:checked {
+    background: var(--btn-active-bg) !important;
+    color: var(--btn-active-color) !important;
+    border-color: var(--btn-active-border) !important;
+}
+
+.ease-page-btn:disabled,
+.ease-page-btn-disabled {
+    opacity: var(--btn-disabled-opacity);
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.ease-page-btn-ellipsis {
+    border: 1px solid var(--btn-ellipsis-border);
+    background: transparent;
+    cursor: default;
+}
+
+.ease-page-btn-sm {
+    min-width: 1.75rem;
+    height: 1.75rem;
+    font-size: 0.8rem;
+    padding: 0 0.35rem;
+}
+
+.ease-pagination-center {
+    justify-content: center;
+}


### PR DESCRIPTION
Closes #12277.

Summary of What Has Been Done:
Created a dark mode pattern demo for the pagination component showing basic pagination, compact pagination, centered pagination, and disabled states in both light and dark modes with a working theme toggle.

Changes Made:
- Created submissions/examples/pagination-dark-mode-tm/demo.html with interactive dark mode toggle and multiple pagination styles
- Created submissions/examples/pagination-dark-mode-tm/style.css with [data-theme="dark"] CSS variable overrides for --btn-color, --btn-border, --btn-hover-bg, --btn-active-bg, --btn-active-color
- Created submissions/examples/pagination-dark-mode-tm/README.md with usage documentation and dark mode token reference

Impact it Made:
Demonstrates the pagination component with proper dark mode contrast, helping users understand how to apply dark mode to pagination UIs without modifying the core component file. No changes to core files.