### PR TITLE
feat : added CSS tabs dark mode pattern demo

### DIFF
--- a/submissions/examples/tabs-dark-mode-tm/README.md
+++ b/submissions/examples/tabs-dark-mode-tm/README.md
@@ -1,0 +1,49 @@
+# CSS Tabs — Dark Mode Demo
+
+## Overview
+
+Demonstrates the `.ease-tabs` component from EaseMotion CSS in both light and dark modes. The component uses radio inputs for state management and CSS sibling selectors to show/hide panels. Dark mode overrides `--tab-color`, `--tab-active-color`, `--tab-panel-bg`, and `--tab-panel-border`.
+
+## Usage
+
+```html
+<div class="ease-tabs">
+  <input type="radio" name="tabs" id="tab1" class="ease-tab-input" checked>
+  <input type="radio" name="tabs" id="tab2" class="ease-tab-input">
+
+  <div class="ease-tabs-nav">
+    <label for="tab1" class="ease-tab-label">Tab One</label>
+    <label for="tab2" class="ease-tab-label">Tab Two</label>
+  </div>
+
+  <div class="ease-tab-panels">
+    <div class="ease-tab-panel" data-tab="1">
+      <h3>Tab One Content</h3>
+      <p>Your content here.</p>
+    </div>
+    <div class="ease-tab-panel" data-tab="2">
+      <h3>Tab Two Content</h3>
+      <p>Your content here.</p>
+    </div>
+  </div>
+</div>
+```
+
+Pill variant: add `.ease-tabs-pill` to the root `.ease-tabs` element.
+
+## Dark Mode Overrides
+
+```css
+[data-theme="dark"] {
+  --tab-color: #94a3b8;
+  --tab-active-color: #a78bfa;
+  --tab-panel-bg: #1e293b;
+  --tab-panel-border: #334155;
+  --pill-bg: #334155;
+  --pill-active-bg: #a78bfa;
+}
+```
+
+## Browser Support
+
+CSS Custom Properties + CSS sibling combinators: Chrome 87+, Firefox 78+, Safari 13.1+, Edge 88+.

--- a/submissions/examples/tabs-dark-mode-tm/demo.html
+++ b/submissions/examples/tabs-dark-mode-tm/demo.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tabs — Dark Mode Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="page-wrapper">
+
+    <header class="demo-header">
+        <div>
+            <h1 class="demo-title">CSS Tabs</h1>
+            <p class="demo-subtitle">EaseMotion CSS &middot; Dark Mode Demo</p>
+        </div>
+        <div class="toggle-area">
+            <span class="theme-label" id="themeLabel">Light mode</span>
+            <button class="theme-toggle" id="toggleBtn" aria-label="Toggle dark mode">
+                <span class="toggle-track"><span class="toggle-thumb"></span></span>
+            </button>
+        </div>
+    </header>
+
+    <main class="demo-main">
+
+        <section class="demo-section">
+            <p class="section-label">Section 01</p>
+            <h2 class="section-title">Interactive Tabs</h2>
+            <p class="section-desc">The <code>.ease-tabs</code> component uses radio inputs for state and CSS selectors for the active tab indicator. Dark mode overrides the tab label color, active indicator, and tab panel background.</p>
+
+            <div class="ease-tabs">
+                <input type="radio" name="tab-demo" id="tab1" class="ease-tab-input" checked>
+                <input type="radio" name="tab-demo" id="tab2" class="ease-tab-input">
+                <input type="radio" name="tab-demo" id="tab3" class="ease-tab-input">
+
+                <div class="ease-tabs-nav" role="tablist">
+                    <label for="tab1" class="ease-tab-label" role="tab" tabindex="0">Overview</label>
+                    <label for="tab2" class="ease-tab-label" role="tab" tabindex="0">Features</label>
+                    <label for="tab3" class="ease-tab-label" role="tab" tabindex="0">Pricing</label>
+                </div>
+
+                <div class="ease-tab-panels">
+                    <div class="ease-tab-panel">
+                        <h3>Overview</h3>
+                        <p>EaseMotion CSS is a lightweight, accessible animation and UI component library for modern web projects. It provides a collection of composable utility classes and components.</p>
+                    </div>
+                    <div class="ease-tab-panel">
+                        <h3>Features</h3>
+                        <ul>
+                            <li>Zero-dependency, pure CSS components</li>
+                            <li>Accessible by default (keyboard + screen reader)</li>
+                            <li>CSS variable-based theming and dark mode</li>
+                            <li>Reduced-motion safe animations</li>
+                        </ul>
+                    </div>
+                    <div class="ease-tab-panel">
+                        <h3>Pricing</h3>
+                        <p>Free and open source under the MIT license. Use it in personal and commercial projects with no attribution required.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="demo-section">
+            <p class="section-label">Section 02</p>
+            <h2 class="section-title">Pill-style Tabs</h2>
+            <div class="ease-tabs ease-tabs-pill">
+                <input type="radio" name="tab-pill" id="pill1" class="ease-tab-input" checked>
+                <input type="radio" name="tab-pill" id="pill2" class="ease-tab-input">
+                <input type="radio" name="tab-pill" id="pill3" class="ease-tab-input">
+
+                <div class="ease-tabs-nav">
+                    <label for="pill1" class="ease-tab-label">Daily</label>
+                    <label for="pill2" class="ease-tab-label">Weekly</label>
+                    <label for="pill3" class="ease-tab-label">Monthly</label>
+                </div>
+
+                <div class="ease-tab-panels">
+                    <div class="ease-tab-panel"><p>Daily view: showing today's activity and tasks.</p></div>
+                    <div class="ease-tab-panel"><p>Weekly view: your 7-day summary and progress chart.</p></div>
+                    <div class="ease-tab-panel"><p>Monthly view: full calendar month overview.</p></div>
+                </div>
+            </div>
+        </section>
+
+    </main>
+</div>
+
+<script>
+    document.getElementById('toggleBtn').addEventListener('click', function() {
+        var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        document.getElementById('themeLabel').textContent = next === 'dark' ? 'Dark mode' : 'Light mode';
+    });
+</script>
+</body>
+</html>

--- a/submissions/examples/tabs-dark-mode-tm/style.css
+++ b/submissions/examples/tabs-dark-mode-tm/style.css
@@ -1,0 +1,259 @@
+/* ─────────────────────────────────────────────────────────
+   Dark Mode Tokens
+   ───────────────────────────────────────────────────────── */
+:root {
+    --page-bg: #f8fafc;
+    --page-color: #1e293b;
+    --card-bg: #ffffff;
+    --card-border: #e2e8f0;
+    --toggle-track: #e2e8f0;
+    --toggle-active: #6c63ff;
+    --section-border: #e2e8f0;
+    --muted: #6b7280;
+    --tab-border: #e2e8f0;
+    --tab-color: #6b7280;
+    --tab-active-color: #6c63ff;
+    --tab-panel-bg: #ffffff;
+    --tab-panel-border: #e2e8f0;
+    --pill-bg: #f1f5f9;
+    --pill-border: #e2e8f0;
+    --pill-active-bg: #6c63ff;
+    --pill-active-color: #ffffff;
+}
+
+[data-theme="dark"] {
+    color-scheme: dark;
+    --page-bg: #0f172a;
+    --page-color: #f1f5f9;
+    --card-bg: #1e293b;
+    --card-border: #334155;
+    --toggle-track: #334155;
+    --toggle-active: #a78bfa;
+    --toggle-thumb: #f1f5f9;
+    --section-border: #334155;
+    --muted: #94a3b8;
+    --tab-border: #334155;
+    --tab-color: #94a3b8;
+    --tab-active-color: #a78bfa;
+    --tab-panel-bg: #1e293b;
+    --tab-panel-border: #334155;
+    --pill-bg: #334155;
+    --pill-border: #475569;
+    --pill-active-bg: #a78bfa;
+    --pill-active-color: #0f172a;
+}
+
+/* ─────────────────────────────────────────────────────────
+   Base
+   ───────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--page-bg);
+    color: var(--page-color);
+    min-height: 100vh;
+    padding: 2rem 1rem;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.page-wrapper { max-width: 700px; margin: 0 auto; }
+
+/* ─────────────────────────────────────────────────────────
+   Header
+   ───────────────────────────────────────────────────────── */
+.demo-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--section-border);
+    margin-bottom: 2.5rem;
+}
+
+.demo-title { margin: 0 0 0.25rem; font-size: 1.5rem; font-weight: 700; }
+.demo-subtitle { margin: 0; font-size: 0.875rem; color: var(--muted); }
+
+.toggle-area { display: flex; align-items: center; gap: 0.75rem; }
+.theme-label { font-size: 0.875rem; color: var(--muted); }
+.theme-toggle { background: none; border: none; cursor: pointer; padding: 0; }
+
+.toggle-track {
+    display: flex;
+    align-items: center;
+    width: 44px;
+    height: 24px;
+    background: var(--toggle-track);
+    border-radius: 999px;
+    padding: 2px;
+    transition: background 0.2s;
+}
+
+[data-theme="dark"] .toggle-track { background: var(--toggle-active); }
+
+.toggle-thumb {
+    width: 20px;
+    height: 20px;
+    background: #ffffff;
+    border-radius: 50%;
+    transition: transform 0.2s;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+[data-theme="dark"] .toggle-thumb { transform: translateX(20px); }
+
+/* ─────────────────────────────────────────────────────────
+   Sections
+   ───────────────────────────────────────────────────────── */
+.demo-section { margin-bottom: 3rem; }
+
+.section-label {
+    margin: 0 0 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--toggle-active);
+}
+
+.section-title {
+    margin: 0 0 0.5rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+    border-bottom: 1px solid var(--section-border);
+    padding-bottom: 0.5rem;
+}
+
+.section-desc {
+    margin: 0 0 1.5rem;
+    font-size: 0.9rem;
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+code {
+    background: var(--card-bg);
+    color: var(--toggle-active);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25rem;
+    font-size: 0.85em;
+    font-family: 'JetBrains Mono', monospace;
+}
+
+/* ─────────────────────────────────────────────────────────
+   Tabs Component — .ease-tabs
+   ───────────────────────────────────────────────────────── */
+.ease-tabs {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-tab-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.ease-tabs-nav {
+    display: flex;
+    border-bottom: 2px solid var(--tab-border);
+    position: relative;
+    margin-bottom: 1rem;
+}
+
+.ease-tab-label {
+    flex: 1;
+    text-align: center;
+    padding: 0.75rem 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--tab-color);
+    transition: color 0.15s;
+    user-select: none;
+    font-size: 0.9rem;
+}
+
+.ease-tab-label:hover {
+    color: var(--page-color);
+}
+
+#tab1:checked ~ .ease-tabs-nav [for="tab1"],
+#tab2:checked ~ .ease-tabs-nav [for="tab2"],
+#tab3:checked ~ .ease-tabs-nav [for="tab3"] {
+    color: var(--tab-active-color);
+    position: relative;
+}
+
+#tab1:checked ~ .ease-tabs-nav [for="tab1"]::after,
+#tab2:checked ~ .ease-tabs-nav [for="tab2"]::after,
+#tab3:checked ~ .ease-tabs-nav [for="tab3"]::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--tab-active-color);
+    border-radius: 2px 2px 0 0;
+}
+
+/* Tab panels */
+.ease-tab-panels { position: relative; }
+
+.ease-tab-panel {
+    display: none;
+    padding: 1.25rem;
+    background: var(--tab-panel-bg);
+    border: 1px solid var(--tab-panel-border);
+    border-top: none;
+    border-radius: 0 0 0.5rem 0.5rem;
+    color: var(--page-color);
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.ease-tab-panel h3 { margin: 0 0 0.5rem; font-size: 1.1rem; }
+.ease-tab-panel p { margin: 0; color: var(--muted); line-height: 1.6; }
+.ease-tab-panel ul { margin: 0.5rem 0 0; padding-left: 1.25rem; color: var(--muted); }
+.ease-tab-panel li { margin-bottom: 0.25rem; line-height: 1.5; }
+
+#tab1:checked ~ .ease-tab-panels [data-tab="1"],
+#tab2:checked ~ .ease-tab-panels [data-tab="2"],
+#tab3:checked ~ .ease-tab-panels [data-tab="3"] { display: block; }
+
+/* ─────────────────────────────────────────────────────────
+   Pill variant
+   ───────────────────────────────────────────────────────── */
+.ease-tabs-pill .ease-tabs-nav {
+    border-bottom: none;
+    gap: 0.25rem;
+    background: var(--pill-bg);
+    border: 1px solid var(--pill-border);
+    border-radius: 0.5rem;
+    padding: 3px;
+}
+
+#pill1:checked ~ .ease-tabs-nav [for="pill1"],
+#pill2:checked ~ .ease-tabs-nav [for="pill2"],
+#pill3:checked ~ .ease-tabs-nav [for="pill3"] {
+    color: var(--pill-active-color);
+    background: var(--pill-active-bg);
+    border-radius: calc(0.5rem - 3px);
+    transition: background 0.15s, color 0.15s;
+}
+
+.ease-tabs-pill .ease-tab-panel { display: none; }
+
+#pill1:checked ~ .ease-tab-panels [data-pill="1"],
+#pill2:checked ~ .ease-tab-panels [data-pill="2"],
+#pill3:checked ~ .ease-tab-panels [data-pill="3"] { display: block; }


### PR DESCRIPTION
Closes #12278.

Summary of What Has Been Done:
Created a dark mode pattern demo for the CSS tabs component showing basic tabs and pill-style tabs in both light and dark modes with a working theme toggle.

Changes Made:
- Created submissions/examples/tabs-dark-mode-tm/demo.html with interactive dark mode toggle and two tab styles (basic + pill)
- Created submissions/examples/tabs-dark-mode-tm/style.css with [data-theme="dark"] CSS variable overrides for --tab-color, --tab-active-color, --tab-panel-bg, --tab-panel-border, --pill-bg, --pill-active-bg
- Created submissions/examples/tabs-dark-mode-tm/README.md with usage documentation and dark mode token reference

Impact it Made:
Demonstrates the CSS tabs component with proper dark mode contrast, helping users understand how to apply dark mode to tabbed interfaces without modifying the core component file. No changes to core files.