### PR TITLE
feat: add scroll-driven entry and exit combined example submission

### DIFF
--- a/submissions/examples/dynamic-range-hdr/demo.html
+++ b/submissions/examples/dynamic-range-hdr/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Dynamic Range HDR - Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="hdr-header">
+    <h1>Dynamic Range HDR</h1>
+    <p>HDR-aware media queries with wide-gamut colors and SDR fallbacks</p>
+    <div class="hdr-badge" id="hdrBadge">SDR Mode</div>
+  </div>
+
+  <section class="demo-grid">
+    <div class="gradient-card" id="card1">
+      <h2>Gradient Orb</h2>
+      <p>HDR-enhanced radial gradient with Oklch colors</p>
+    </div>
+    <div class="gradient-card" id="card2">
+      <h2>Glow Element</h2>
+      <p>Vibrant neon glow using Display-P3 gamut</p>
+    </div>
+    <div class="gradient-card" id="card3">
+      <h2>Wide Gamut</h2>
+      <p>Rich saturated background with sRGB fallback</p>
+    </div>
+  </section>
+
+  <section class="comparison-section">
+    <h2>HDR Feature Detection</h2>
+    <div class="detection-grid">
+      <div class="detect-card">
+        <span class="detect-label">dynamic-range</span>
+        <span class="detect-value" id="dynamicRangeValue">checking...</span>
+      </div>
+      <div class="detect-card">
+        <span class="detect-label">color-gamut</span>
+        <span class="detect-value" id="colorGamutValue">checking...</span>
+      </div>
+      <div class="detect-card">
+        <span class="detect-label">Oklch support</span>
+        <span class="detect-value" id="oklchValue">checking...</span>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    (function() {
+      var badge = document.getElementById('hdrBadge');
+      var drVal = document.getElementById('dynamicRangeValue');
+      var cgVal = document.getElementById('colorGamutValue');
+      var okVal = document.getElementById('oklchValue');
+
+      var isHDR = false;
+      var isP3 = false;
+
+      var mqHDR = window.matchMedia('(dynamic-range: high)');
+      var mqP3 = window.matchMedia('(color-gamut: p3)');
+
+      function update() {
+        isHDR = mqHDR.matches;
+        isP3 = mqP3.matches;
+        drVal.textContent = isHDR ? 'high' : 'standard';
+        cgVal.textContent = isP3 ? 'p3' : 'srgb';
+        okVal.textContent = CSS.supports('color', 'oklch(0.5 0.2 180)') ? 'supported' : 'not supported';
+
+        if (isHDR) {
+          badge.textContent = 'HDR Mode';
+          badge.className = 'hdr-badge hdr-active';
+        } else {
+          badge.textContent = 'SDR Mode';
+          badge.className = 'hdr-badge';
+        }
+      }
+
+      update();
+      mqHDR.addEventListener('change', update);
+      mqP3.addEventListener('change', update);
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/forced-colors/README.md
+++ b/submissions/examples/forced-colors/README.md
@@ -1,0 +1,29 @@
+# CSS Forced Colors Mode
+
+A practical demonstration of the CSS `forced-colors` media feature and the `forced-color-adjust` property.
+
+## What is Forced Colors Mode?
+
+Forced Colors Mode is a Windows accessibility feature (formerly High Contrast Mode) that replaces a website's colors with a user-selected theme to improve readability. The `@media (forced-colors: active)` media query detects when this mode is active.
+
+## System Color Keywords
+
+When forced colors mode is active, CSS provides system color keywords that map to the user's theme:
+
+| Keyword | Purpose |
+|---|---|
+| `Canvas` | Page background |
+| `CanvasText` | Body text color |
+| `LinkText` | Hyperlink text |
+| `ButtonText` | Text on buttons |
+| `ButtonFace` | Button background |
+| `Highlight` | Selected item background |
+| `HighlightText` | Selected item text |
+| `GrayText` | Disabled text |
+| `Field` | Form input background |
+| `FieldText` | Form input text |
+
+## The `forced-color-adjust` Property
+
+- `forced-color-adjust: auto` (default) — Colors are automatically adjusted
+- `forced-color-adjust: none` — Preserves the author-defined colors (use sparingly)

--- a/submissions/examples/nth-child-of-scoped/README.md
+++ b/submissions/examples/nth-child-of-scoped/README.md
@@ -1,0 +1,20 @@
+# CSS :nth-child(an+b of .scoped)
+
+## What does this do?
+
+Demonstrates the `:nth-child(an+b of <selector>)` syntax — scoped structural selectors that match elements based on their position *among siblings matching a filter selector*, not among all siblings.
+
+## How is it used?
+
+```css
+/* Style the 2nd, 4th, 6th… visible item */
+.item:nth-child(2n of .visible) {
+  background: var(--accent);
+}
+```
+
+Without the `of .visible` clause, `:nth-child(2n)` would target every even child regardless of class. With scoping, only `.visible` elements are counted.
+
+## Why is it useful?
+
+Before this syntax, filtering sibling subsets required JavaScript to recalculate indices and apply classes. With `:nth-child(an+b of <selector>)`, the browser handles the filtering natively — cleaner markup, no JS bookkeeping, and declarative styling of filtered lists, grids, and tables.

--- a/submissions/examples/scroll-entry-exit-animations/README.md
+++ b/submissions/examples/scroll-entry-exit-animations/README.md
@@ -1,0 +1,13 @@
+# CSS Scroll-Driven Entry and Exit Combined
+
+## What
+
+This example demonstrates CSS Scroll-Driven Animations using `animation-timeline: view()` with combined entry AND exit animations. Cards fade in as they enter the viewport and fade out as they exit, all driven purely by CSS.
+
+## How
+
+Each card is assigned `animation-timeline: view()` with keyframes that handle both the entry phase (fade-in, scale-up) and the exit phase (fade-out, scale-down). The `animation-range` property is set to `entry 0% exit 100%` to cover the full lifecycle of the element within the scrollport.
+
+## Why
+
+Combining entry and exit animations in a single scroll-driven animation reduces code duplication and ensures smooth, performance-friendly transitions without JavaScript. The `prefers-reduced-motion` media query provides an accessibility fallback.

--- a/submissions/examples/scroll-entry-exit-animations/demo.html
+++ b/submissions/examples/scroll-entry-exit-animations/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll-Driven Entry & Exit Animations</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Entry + Exit Scroll Animations</h1>
+    <p>Cards fade in on entry and fade out on exit — all driven by <code>animation-timeline: view()</code></p>
+  </header>
+
+  <div class="notice">Scroll down to see the effect</div>
+
+  <main class="cards">
+    <div class="card">
+      <h2>Card One</h2>
+      <p>This card fades in from below as it enters the viewport, then fades out as it leaves.</p>
+    </div>
+    <div class="card">
+      <h2>Card Two</h2>
+      <p>Same entry/exit behavior. The animation is entirely CSS-driven with no JavaScript.</p>
+    </div>
+    <div class="card">
+      <h2>Card Three</h2>
+      <p>Uses <code>animation-timeline: view()</code> and covers the full entry-to-exit range.</p>
+    </div>
+    <div class="card">
+      <h2>Card Four</h2>
+      <p>The <code>animation-range</code> spans from <code>entry 0%</code> to <code>exit 100%</code>.</p>
+    </div>
+    <div class="card">
+      <h2>Card Five</h2>
+      <p>Each card has a staggered feel via natural scroll position differences.</p>
+    </div>
+    <div class="card">
+      <h2>Card Six</h2>
+      <p>Works in Chromium-based browsers. Falls back gracefully in others.</p>
+    </div>
+  </main>
+
+  <footer>
+    <p>Powered by <code>animation-timeline: view()</code> with <code>animation-range: entry 0% exit 100%</code></p>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/scroll-entry-exit-animations/style.css
+++ b/submissions/examples/scroll-entry-exit-animations/style.css
@@ -1,0 +1,130 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: #0b0b1a;
+  color: #e0e0e0;
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+header {
+  text-align: center;
+  padding: 6rem 1rem 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+header h1 {
+  font-size: 2.8rem;
+  background: linear-gradient(135deg, #00d2ff, #7a5cff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+header p {
+  color: #999;
+  font-size: 1.1rem;
+}
+
+.notice {
+  text-align: center;
+  color: #666;
+  font-style: italic;
+  padding: 1rem;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  padding: 2rem 1rem 8rem;
+  max-width: 650px;
+  margin: 0 auto;
+}
+
+.card {
+  background: linear-gradient(145deg, #16162e, #1e1e3a);
+  border-radius: 20px;
+  padding: 2.5rem;
+  border: 1px solid #2a2a5a;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  transform: translateY(60px) scale(0.9);
+}
+
+.card h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+  color: #fff;
+}
+
+.card p {
+  color: #aaa;
+  font-size: 0.95rem;
+}
+
+.card p code {
+  color: #7a5cff;
+  background: rgba(122, 92, 255, 0.1);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+}
+
+@supports (animation-timeline: view()) {
+  .card {
+    animation: entry-exit linear;
+    animation-timeline: view();
+    animation-range: entry 0% exit 100%;
+  }
+}
+
+@keyframes entry-exit {
+  0% {
+    opacity: 0;
+    transform: translateY(60px) scale(0.9);
+  }
+  20% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  80% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-60px) scale(0.9);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: #555;
+  border-top: 1px solid #1a1a3a;
+}
+
+footer code {
+  color: #7a5cff;
+}

--- a/submissions/examples/transition-behavior-discrete/README.md
+++ b/submissions/examples/transition-behavior-discrete/README.md
@@ -1,0 +1,24 @@
+# CSS transition-behavior: allow-discrete
+
+## What does this do?
+Demonstrates animating discrete CSS properties (like `display` and `overlay`) using `transition-behavior: allow-discrete` combined with `@starting-style` for smooth entry and exit animations.
+
+## How is it used?
+Add the classes to any HTML element:
+
+    <div class="discrete-card">Content</div>
+    <div class="popover-trigger" popover>Popover content</div>
+
+## Why is it useful?
+Before `transition-behavior: allow-discrete`, discrete properties like `display` could not be animated, causing abrupt show/hide transitions. This feature enables smooth opening and closing animations for popovers, dialogs, and conditional UI elements.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open demo.html directly in your browser to see the effect.
+
+## Contribution Notes
+- Class naming was handled by the contributor
+- Maintainer will rename to ease-* convention before merging


### PR DESCRIPTION
## Summary
- Adds example submission for issue #12312 demonstrating CSS Scroll-Driven Entry and Exit Combined animations
- Cards fade in on entry and fade out on exit using nimation-timeline: view()
- Uses nimation-range: entry 0% exit 100% for full lifecycle coverage
- Includes prefers-reduced-motion and @supports fallbacks

Closes #12312