### PR TITLE
feat: add prefers-color-scheme light/dark specific adjustments example submission

### DIFF
--- a/submissions/examples/prefers-color-scheme-specific/README.md
+++ b/submissions/examples/prefers-color-scheme-specific/README.md
@@ -1,0 +1,13 @@
+# CSS prefers-color-scheme Light/Dark Specific Adjustments
+
+## What
+
+This example demonstrates light-only and dark-only specific refinements using `prefers-color-scheme` media queries and the `light-dark()` CSS function. UI components adapt with tailored styles for each mode — beyond simple color swapping.
+
+## How
+
+The `@media (prefers-color-scheme: light)` and `@media (prefers-color-scheme: dark)` queries apply mode-specific overrides. The `light-dark()` function provides inline dual-color syntax. Components like cards, badges, buttons, and form inputs get refined shadows, borders, and opacity values that look natural in both themes.
+
+## Why
+
+Using `prefers-color-scheme` with explicit light/dark queries and `light-dark()` allows designers to fine-tune each mode independently, creating a polished user experience. The `light-dark()` function reduces boilerplate by encoding both color values in a single declaration.

--- a/submissions/examples/prefers-color-scheme-specific/demo.html
+++ b/submissions/examples/prefers-color-scheme-specific/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>prefers-color-scheme Light/Dark Specific</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Light / Dark Specific Refinements</h1>
+      <p>UI components adapt with mode-specific tweaks — shadows, borders, opacity, and colors</p>
+      <div class="theme-note">Your system theme is applied automatically</div>
+    </header>
+
+    <section class="demo-section">
+      <h2>Cards</h2>
+      <div class="card-grid">
+        <div class="card">
+          <h3>Elevated Card</h3>
+          <p>Shadow and border adjust per color scheme for optimal depth.</p>
+        </div>
+        <div class="card card-outlined">
+          <h3>Outlined Card</h3>
+          <p>Border color and background transparency change with the theme.</p>
+        </div>
+        <div class="card card-glass">
+          <h3>Glass Card</h3>
+          <p>Backdrop blur and background opacity tuned for light and dark.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Badges & Tags</h2>
+      <div class="badge-row">
+        <span class="badge badge-success">Success</span>
+        <span class="badge badge-warning">Warning</span>
+        <span class="badge badge-error">Error</span>
+        <span class="badge badge-info">Info</span>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Buttons</h2>
+      <div class="button-row">
+        <button class="btn btn-primary">Primary</button>
+        <button class="btn btn-secondary">Secondary</button>
+        <button class="btn btn-outline">Outline</button>
+        <button class="btn btn-ghost">Ghost</button>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Form Inputs</h2>
+      <form class="form-demo">
+        <div class="form-group">
+          <label for="name">Name</label>
+          <input type="text" id="name" placeholder="Enter your name" class="input">
+        </div>
+        <div class="form-group">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" class="input">
+        </div>
+        <div class="form-group">
+          <label for="message">Message</label>
+          <textarea id="message" placeholder="Your message" class="input"></textarea>
+        </div>
+      </form>
+    </section>
+
+    <footer>
+      <p>Adjust your system color scheme to see all refinements in action.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/submissions/examples/prefers-color-scheme-specific/style.css
+++ b/submissions/examples/prefers-color-scheme-specific/style.css
@@ -1,0 +1,307 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  color-scheme: light dark;
+  --font: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --radius: 12px;
+  --transition: 0.3s ease;
+
+  /* Light defaults */
+  --bg: #f5f5f7;
+  --surface: #ffffff;
+  --text: #1d1d1f;
+  --text-secondary: #6e6e73;
+  --border: #d2d2d7;
+  --shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 30px rgba(0, 0, 0, 0.12);
+  --primary: #0071e3;
+  --primary-text: #ffffff;
+  --secondary: #e8e8ed;
+  --secondary-text: #1d1d1f;
+  --success: #34c759;
+  --warning: #ff9500;
+  --error: #ff3b30;
+  --info: #5ac8fa;
+}
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  transition: background var(--transition), color var(--transition);
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+header {
+  text-align: center;
+  padding: 4rem 0 2rem;
+}
+
+header h1 {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+header p {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+}
+
+.theme-note {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  padding: 0.5rem 1rem;
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  display: inline-block;
+}
+
+.demo-section {
+  margin: 3rem 0;
+}
+
+.demo-section h2 {
+  font-size: 1.4rem;
+  margin-bottom: 1rem;
+  color: var(--text);
+}
+
+/* Cards */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  transition: all var(--transition);
+}
+
+.card h3 {
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+.card p {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.card-outlined {
+  background: transparent;
+  box-shadow: none;
+}
+
+.card-glass {
+  background: light-dark(rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.05));
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
+}
+
+/* Badges */
+.badge-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.badge {
+  padding: 0.3rem 0.8rem;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.badge-success {
+  background: light-dark(#d4edda, #1a3a1a);
+  color: light-dark(#155724, #4ade80);
+  border: 1px solid light-dark(#c3e6cb, #2d6a2d);
+}
+
+.badge-warning {
+  background: light-dark(#fff3cd, #3a2e1a);
+  color: light-dark(#856404, #fbbf24);
+  border: 1px solid light-dark(#ffeaa7, #6a4d2d);
+}
+
+.badge-error {
+  background: light-dark(#f8d7da, #3a1a1a);
+  color: light-dark(#721c24, #f87171);
+  border: 1px solid light-dark(#f5c6cb, #6a2d2d);
+}
+
+.badge-info {
+  background: light-dark(#d1ecf1, #1a2a3a);
+  color: light-dark(#0c5460, #60a5fa);
+  border: 1px solid light-dark(#bee5eb, #2d4a6a);
+}
+
+/* Buttons */
+.button-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.btn {
+  padding: 0.6rem 1.4rem;
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: var(--primary-text);
+  border: 1px solid transparent;
+}
+
+.btn-primary:hover {
+  filter: brightness(1.1);
+}
+
+.btn-secondary {
+  background: var(--secondary);
+  color: var(--secondary-text);
+  border: 1px solid var(--border);
+}
+
+.btn-secondary:hover {
+  filter: brightness(0.95);
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid var(--primary);
+}
+
+.btn-outline:hover {
+  background: var(--primary);
+  color: var(--primary-text);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid transparent;
+}
+
+.btn-ghost:hover {
+  background: var(--secondary);
+}
+
+/* Forms */
+.form-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-group label {
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.input {
+  padding: 0.7rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: light-dark(#ffffff, #1c1c1e);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 0.95rem;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px light-dark(rgba(0, 113, 227, 0.2), rgba(0, 113, 227, 0.4));
+}
+
+textarea.input {
+  min-height: 100px;
+  resize: vertical;
+}
+
+/* Light-specific refinements */
+@media (prefers-color-scheme: light) {
+  .card {
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.04);
+  }
+
+  .card-outlined {
+    border-color: #c0c0c5;
+  }
+
+  .input {
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
+  }
+}
+
+/* Dark-specific refinements */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #000000;
+    --surface: #1c1c1e;
+    --text: #f5f5f7;
+    --text-secondary: #98989d;
+    --border: #38383a;
+    --shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
+    --shadow-lg: 0 8px 30px rgba(0, 0, 0, 0.6);
+    --primary: #0a84ff;
+    --secondary: #2c2c2e;
+    --secondary-text: #f5f5f7;
+  }
+
+  .card {
+    border-color: #38383a;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4), 0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+
+  .card-outlined {
+    border-color: #505052;
+    background: transparent;
+  }
+
+  .input {
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3);
+  }
+}
+
+footer {
+  text-align: center;
+  padding: 3rem 0;
+  color: var(--text-secondary);
+  border-top: 1px solid var(--border);
+  margin-top: 2rem;
+}


### PR DESCRIPTION
## Summary
- Adds example submission for issue #12314 demonstrating CSS prefers-color-scheme light/dark specific adjustments
- Uses @media (prefers-color-scheme: light) and @media (prefers-color-scheme: dark) for mode-specific refinements
- Demonstrates light-dark() function for dual-color inline declarations
- Includes cards, badges, buttons, and form inputs with tailored styles per color scheme

Closes #12314