### PR TITLE
feat: add tag-input-sk chip input component

### DIFF
--- a/submissions/examples/tag-input-sk/README.md
+++ b/submissions/examples/tag-input-sk/README.md
@@ -1,0 +1,16 @@
+# Tag Input SK
+
+Chip-style tag field with animated tag pills and focus ring.
+
+## Usage
+
+```html
+<div class="tag-input">
+  <span class="tag-input__chip">DSA<span class="tag-input__remove">×</span></span>
+  <input class="tag-input__field" type="text" placeholder="Add tag..." />
+</div>
+```
+
+## Why EaseMotion CSS
+
+Demonstrates micro-interactions for form chips using only CSS animations.

--- a/submissions/examples/tag-input-sk/demo.html
+++ b/submissions/examples/tag-input-sk/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tag Input SK</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="tag-input">
+    <span class="tag-input__chip">DSA<span class="tag-input__remove" aria-hidden="true">×</span></span>
+    <span class="tag-input__chip">Graphs<span class="tag-input__remove" aria-hidden="true">×</span></span>
+    <input class="tag-input__field" type="text" placeholder="Add tag..." aria-label="Add tag" />
+  </div>
+</body>
+</html>

--- a/submissions/examples/tag-input-sk/style.css
+++ b/submissions/examples/tag-input-sk/style.css
@@ -1,0 +1,71 @@
+/* Tag Input SK */
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  margin: 0;
+  background: #f8fafc;
+  font-family: system-ui, sans-serif;
+}
+
+.tag-input {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  width: min(420px, 92vw);
+  padding: 0.65rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 14px;
+  background: white;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.tag-input__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #4338ca;
+  font-size: 0.82rem;
+  font-weight: 700;
+  animation: tag-pop 0.35s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.tag-input__chip:nth-child(2) { animation-delay: 0.06s; }
+
+.tag-input__remove {
+  opacity: 0.65;
+  font-weight: 900;
+}
+
+.tag-input__field {
+  flex: 1 1 120px;
+  min-width: 120px;
+  border: none;
+  outline: none;
+  font-size: 0.9rem;
+  padding: 0.35rem 0.25rem;
+}
+
+.tag-input:focus-within {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+
+@keyframes tag-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.85) translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tag-input__chip { animation: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new CSS-only tag input chip field submission.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/tag-input-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Animated tag chip input field with focus ring and pop-in chips.

**How does a developer use it?**

```html
<div class="tag-input">
  <span class="tag-input__chip">DSA</span>
  <input class="tag-input__field" type="text" placeholder="Add tag..." />
</div>
```

**Why does it fit EaseMotion CSS?**

Pure CSS micro-interactions for form UI patterns.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

GSSoC submission from saurabhhhcodes.

Made with [Cursor](https://cursor.com)