### PR TITLE
fix: allow theme toggle script to load by updating CSP

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'unsafe-inline' 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'unsafe-inline' 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;"
     />
     <!-- Favicon and App Icons -->
     <link


### PR DESCRIPTION
## Pull Request Description

### Description

This PR fixes the theme toggle issue reported in **#12224**.

The documentation site's Content Security Policy (CSP) blocked the external `docs.js` file from loading because the `script-src` directive did not include `'self'`. As a result, the JavaScript responsible for handling the theme toggle was not executed, preventing users from switching between light and dark mode.

This PR updates the CSP by adding `'self'` to the `script-src` directive, allowing the documentation JavaScript to load correctly and restoring the theme toggle functionality.

---

## Type of Change

* [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One issue addressed in this PR

All other checklist items are **not applicable** because this PR fixes an existing documentation bug rather than adding a new component or animation.

---

## Browser Testing

* [x] Chrome

---

## Notes for Maintainer

* Fixes #12224.
* The change is limited to `docs/index.html`.
* No framework functionality or component code was modified.
