### PR TITLE
Example: CSS interpolate-size allow-keywords Grid Animation

### DIFF
--- a/submissions/examples/interpolate-size-keywords/README.md
+++ b/submissions/examples/interpolate-size-keywords/README.md
@@ -1,0 +1,17 @@
+# CSS interpolate-size: allow-keywords Grid Animation
+
+## What does this do?
+
+Demonstrates the `interpolate-size: allow-keywords` CSS property, which enables smooth CSS transitions and animations on size keywords like `auto`, `min-content`, `max-content`, and `fit-content`. This makes expand/collapse animations possible without fixed heights.
+
+## Key Features
+
+- `interpolate-size: allow-keywords` on grid rows and cards
+- Smooth expand/collapse animations with `grid-template-rows: 0fr` to `1fr`
+- `auto` height transitions for card content areas
+- Accordion-style card grid with animated height changes
+- Fallback behavior when property is not supported
+
+## Preview
+
+Open `demo.html` in a supporting browser (Chrome 129+).

--- a/submissions/examples/interpolate-size-keywords/demo.html
+++ b/submissions/examples/interpolate-size-keywords/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS interpolate-size Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>interpolate-size: allow-keywords</h1>
+    <p class="subtitle">Smooth expand/collapse with auto-height transitions.</p>
+
+    <div class="card-grid">
+      <article class="card">
+        <button class="card-header" aria-expanded="false" data-target="content1">
+          <span>What is interpolate-size?</span>
+          <span class="icon">+</span>
+        </button>
+        <div class="card-body" id="content1">
+          <div class="card-content">
+            <p><code>interpolate-size: allow-keywords</code> is a CSS property that enables transitions on keyword-based sizes like <code>auto</code>, <code>min-content</code>, <code>max-content</code>, and <code>fit-content</code>.</p>
+          </div>
+        </div>
+      </article>
+
+      <article class="card">
+        <button class="card-header" aria-expanded="false" data-target="content2">
+          <span>Why is this useful?</span>
+          <span class="icon">+</span>
+        </button>
+        <div class="card-body" id="content2">
+          <div class="card-content">
+            <p>Before this property, you could not animate to/from <code>auto</code> height. Developers had to use max-height hacks, JS-based height calculations, or grid tricks. Now you get native, performant animations.</p>
+          </div>
+        </div>
+      </article>
+
+      <article class="card">
+        <button class="card-header" aria-expanded="false" data-target="content3">
+          <span>Browser Support</span>
+          <span class="icon">+</span>
+        </button>
+        <div class="card-body" id="content3">
+          <div class="card-content">
+            <p>Supported in Chrome 129+, Edge 129+, and Safari 18+. Check <a href="https://caniuse.com/mdn-css_properties_interpolate-size" target="_blank">caniuse</a> for updates.</p>
+          </div>
+        </div>
+      </article>
+    </div>
+
+    <div class="demo-section">
+      <h2>Grid Row Animation</h2>
+      <p>Click to expand/collapse grid items with animated <code>grid-template-rows</code>.</p>
+      <div class="grid-demo">
+        <div class="grid-demo-item">
+          <button class="grid-toggle" data-target="gridContent1">Toggle Item 1</button>
+          <div class="grid-content" id="gridContent1">
+            <div class="grid-inner">
+              <p>This content slides open with a smooth grid-row transition.</p>
+              <p>Using <code>grid-template-rows: 0fr</code> to <code>1fr</code> with <code>interpolate-size: allow-keywords</code>.</p>
+            </div>
+          </div>
+        </div>
+        <div class="grid-demo-item">
+          <button class="grid-toggle" data-target="gridContent2">Toggle Item 2</button>
+          <div class="grid-content" id="gridContent2">
+            <div class="grid-inner">
+              <p>Multiple items can be toggled independently.</p>
+              <p>Each transition is smooth and GPU-accelerated.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.card-header').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var expanded = this.getAttribute('aria-expanded') === 'true';
+        this.setAttribute('aria-expanded', !expanded);
+        var target = document.getElementById(this.dataset.target);
+        if (target) {
+          target.classList.toggle('open');
+        }
+        this.querySelector('.icon').textContent = expanded ? '+' : '\u2212';
+      });
+    });
+
+    document.querySelectorAll('.grid-toggle').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var target = document.getElementById(this.dataset.target);
+        if (target) {
+          target.classList.toggle('open');
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/interpolate-size-keywords/style.css
+++ b/submissions/examples/interpolate-size-keywords/style.css
@@ -1,0 +1,202 @@
+
+:root {
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --text: #1e293b;
+  --muted: #64748b;
+  --border: #e2e8f0;
+  --accent: #8b5cf6;
+  --radius: 12px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 800;
+  margin: 0 0 0.25rem;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin: 0 0 2rem;
+}
+
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 1rem 1.25rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  font-family: inherit;
+  text-align: left;
+}
+
+.card-header:hover {
+  background: #f1f5f9;
+}
+
+.icon {
+  font-size: 1.25rem;
+  transition: transform 0.2s;
+  color: var(--accent);
+}
+
+.card-header[aria-expanded="true"] .icon {
+  transform: rotate(45deg);
+}
+
+.card-body {
+  interpolate-size: allow-keywords;
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.35s ease;
+}
+
+.card-body.open {
+  grid-template-rows: 1fr;
+}
+
+.card-content {
+  overflow: hidden;
+  padding: 0 1.25rem;
+}
+
+.card-body.open .card-content {
+  padding-bottom: 1rem;
+}
+
+.card-content p {
+  margin: 0;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.card-content code {
+  background: #f1f5f9;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.demo-section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+}
+
+.demo-section h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+}
+
+.demo-section > p {
+  margin: 0 0 1rem;
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+.demo-section code {
+  background: #f1f5f9;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.grid-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.grid-demo-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.grid-toggle {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--text);
+  font-family: inherit;
+  text-align: left;
+}
+
+.grid-toggle:hover {
+  background: #f1f5f9;
+}
+
+.grid-content {
+  interpolate-size: allow-keywords;
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.35s ease;
+}
+
+.grid-content.open {
+  grid-template-rows: 1fr;
+}
+
+.grid-inner {
+  overflow: hidden;
+  padding: 0 1rem;
+}
+
+.grid-content.open .grid-inner {
+  padding-bottom: 1rem;
+}
+
+.grid-inner p {
+  margin: 0.5rem 0;
+  font-size: 0.875rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+a {
+  color: var(--accent);
+}


### PR DESCRIPTION
﻿Demonstrates CSS interpolate-size: allow-keywords for smooth expand/collapse animations. Features animated grid-template-rows transitions and auto-height card content with accordion-style interaction.

Closes #12296
