### PR TITLE
Example: CSS :nth-child(an+b of .scoped) Selectors

### DIFF
--- a/submissions/examples/nth-child-scoped-selectors/README.md
+++ b/submissions/examples/nth-child-scoped-selectors/README.md
@@ -1,0 +1,17 @@
+# CSS :nth-child(an+b of .scoped) Selectors
+
+## What does this do?
+
+Demonstrates the `:nth-child(an+b of <selector>)` CSS selector syntax, which scopes the element counting to only elements matching a given selector. This enables styling items based on their position among visible peers in a filterable grid.
+
+## Key Features
+
+- `:nth-child(an+b of .visible)` counts only `.visible` elements
+- Filterable item grid with dynamic scoped counting
+- `:nth-child(2n of .visible)` for alternating visible items
+- `:nth-child(3n+1 of .visible)` for every third visible item
+- Graceful fallback: items without matching scope are styled normally
+
+## Preview
+
+Open `demo.html` in a supporting browser (Chrome 129+, Safari 18+).

--- a/submissions/examples/nth-child-scoped-selectors/demo.html
+++ b/submissions/examples/nth-child-scoped-selectors/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS :nth-child(an+b of .scoped) Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>:nth-child(an+b of .scoped)</h1>
+    <p class="subtitle">Filter items and see how visible elements are styled based on their position among visible peers.</p>
+
+    <div class="controls">
+      <button class="filter-btn active" data-filter="all">All</button>
+      <button class="filter-btn" data-filter="web">Web</button>
+      <button class="filter-btn" data-filter="mobile">Mobile</button>
+      <button class="filter-btn" data-filter="design">Design</button>
+      <button class="filter-btn" data-filter="backend">Backend</button>
+    </div>
+
+    <div class="legend">
+      <span class="legend-item"><span class="dot dot-1"></span> 1st visible</span>
+      <span class="legend-item"><span class="dot dot-2"></span> 2nd visible</span>
+      <span class="legend-item"><span class="dot dot-3"></span> 3rd visible</span>
+      <span class="legend-item"><span class="dot dot-4"></span> 4th+ visible</span>
+    </div>
+
+    <div class="grid" id="itemGrid">
+      <div class="item visible" data-category="web">HTML</div>
+      <div class="item visible" data-category="web">CSS</div>
+      <div class="item visible" data-category="web">JavaScript</div>
+      <div class="item visible" data-category="design">Figma</div>
+      <div class="item visible" data-category="mobile">React Native</div>
+      <div class="item visible" data-category="backend">Node.js</div>
+      <div class="item visible" data-category="web">TypeScript</div>
+      <div class="item visible" data-category="design">UI/UX</div>
+      <div class="item visible" data-category="mobile">Flutter</div>
+      <div class="item visible" data-category="backend">Python</div>
+      <div class="item visible" data-category="web">React</div>
+      <div class="item visible" data-category="design">Illustrator</div>
+      <div class="item visible" data-category="backend">Go</div>
+      <div class="item visible" data-category="mobile">Swift</div>
+      <div class="item visible" data-category="web">Vue</div>
+      <div class="item visible" data-category="design">Photoshop</div>
+    </div>
+
+    <div class="info-panel">
+      <h3>How it works</h3>
+      <ul>
+        <li><code>.item:nth-child(1 of .visible)</code> — first visible item gets a gold border</li>
+        <li><code>.item:nth-child(2 of .visible)</code> — second visible item gets a silver border</li>
+        <li><code>.item:nth-child(3 of .visible)</code> — third visible item gets bronze</li>
+        <li><code>.item:nth-child(n+4 of .visible)</code> — fourth+ visible items get default</li>
+      </ul>
+      <p>Filter by category to see the scoped counting in action!</p>
+    </div>
+  </div>
+
+  <script>
+    var filters = document.querySelectorAll('.filter-btn');
+    var items = document.querySelectorAll('.item');
+
+    filters.forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        filters.forEach(function(b) { b.classList.remove('active'); });
+        this.classList.add('active');
+        var filter = this.dataset.filter;
+        items.forEach(function(item) {
+          if (filter === 'all' || item.dataset.category === filter) {
+            item.classList.add('visible');
+          } else {
+            item.classList.remove('visible');
+          }
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/nth-child-scoped-selectors/style.css
+++ b/submissions/examples/nth-child-scoped-selectors/style.css
@@ -1,0 +1,180 @@
+
+:root {
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --text: #1e293b;
+  --muted: #64748b;
+  --border: #e2e8f0;
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 800;
+  margin: 0 0 0.25rem;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin: 0 0 1.5rem;
+}
+
+.controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.filter-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+
+.filter-btn:hover {
+  border-color: #94a3b8;
+}
+
+.filter-btn.active {
+  background: #1e293b;
+  color: #fff;
+  border-color: #1e293b;
+}
+
+.legend {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.8125rem;
+  color: var(--muted);
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.dot-1 { background: #f59e0b; border: 2px solid #d97706; }
+.dot-2 { background: #e2e8f0; border: 2px solid #94a3b8; }
+.dot-3 { background: #d97706; border: 2px solid #92400e; }
+.dot-4 { background: #e2e8f0; border: 1px solid #cbd5e1; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.item {
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  text-align: center;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.2s;
+  background: var(--surface);
+}
+
+.item.visible {
+  opacity: 1;
+}
+
+.item:not(.visible) {
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+.item:nth-child(1 of .visible) {
+  border-color: #f59e0b;
+  background: #fffbeb;
+  font-weight: 700;
+}
+
+.item:nth-child(2 of .visible) {
+  border-color: #94a3b8;
+  background: #f8fafc;
+}
+
+.item:nth-child(3 of .visible) {
+  border-color: #d97706;
+  background: #fff7ed;
+}
+
+.item:nth-child(n+4 of .visible) {
+  border-color: var(--border);
+  background: var(--surface);
+}
+
+.info-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.5rem;
+}
+
+.info-panel h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.info-panel ul {
+  margin: 0 0 0.75rem;
+  padding-left: 1.25rem;
+}
+
+.info-panel li {
+  margin-bottom: 0.375rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.info-panel code {
+  background: #f1f5f9;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-size: 0.8125rem;
+}
+
+.info-panel p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--muted);
+}


### PR DESCRIPTION
﻿Demonstrates CSS :nth-child(an+b of .scoped) scoped selectors. Features a filterable grid where visible items are styled based on their position among visible peers using scoped :nth-child counting.

Closes #12297
