### PR TITLE
Example: CSS dynamic-range HDR Media Query

### DIFF
--- a/submissions/examples/dynamic-range-hdr/README.md
+++ b/submissions/examples/dynamic-range-hdr/README.md
@@ -1,0 +1,17 @@
+# CSS Dynamic Range HDR Demo
+
+## Overview
+Demonstrates using `@media (dynamic-range: high)` to detect HDR-capable displays and serve enhanced wide-gamut colors using `oklch()` and `color(display-p3)` while providing graceful SDR fallbacks.
+
+## Features
+- **`@media (dynamic-range: high)`** — detects displays with high dynamic range capability
+- **`color-gamut`** — detects P3 or sRGB color space support
+- **`oklch()` colors** — perceptually uniform color space with wide gamut
+- **`color(display-p3)`** — Display P3 color space for in-gamut HDR colors
+- **Graceful degradation** — SDR displays receive sRGB-safe fallback colors
+
+## How to Use
+1. Define base colors in `oklch()` for all displays
+2. Wrap HDR-enhanced versions inside `@media (dynamic-range: high)`
+3. Optionally use `@supports (color: color(display-p3 1 0 0))` for P3 support
+4. Add glow/shadow effects for HDR to take advantage of the higher luminance range

--- a/submissions/examples/dynamic-range-hdr/demo.html
+++ b/submissions/examples/dynamic-range-hdr/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Dynamic Range HDR Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Dynamic Range &amp; HDR Colors</h1>
+    <p>Using <code>@media (dynamic-range: high)</code> to serve vibrant wide-gamut colors on HDR displays with smooth SDR fallbacks.</p>
+  </header>
+
+  <main>
+    <section class="hdr-status" id="hdrStatus">
+      <span class="status-dot"></span>
+      <span class="status-text">Detecting display capabilities...</span>
+    </section>
+
+    <section class="card-grid">
+      <article class="color-card" style="--hue: 15">
+        <div class="card-swatch"></div>
+        <h3>Vibrant Coral</h3>
+        <p>oklch(70% 0.2 25) — pushes beyond sRGB gamut for a rich, luminous coral tone.</p>
+      </article>
+      <article class="color-card" style="--hue: 190">
+        <div class="card-swatch"></div>
+        <h3>Deep Cyan</h3>
+        <p>oklch(65% 0.15 200) — a saturated cyan that appears deeper on HDR panels.</p>
+      </article>
+      <article class="color-card" style="--hue: 85">
+        <div class="card-swatch"></div>
+        <h3>Bright Lime</h3>
+        <p>oklch(80% 0.18 140) — luminous green only achievable with wide-gamut color.</p>
+      </article>
+      <article class="color-card" style="--hue: 280">
+        <div class="card-swatch"></div>
+        <h3>Neon Purple</h3>
+        <p>oklch(60% 0.22 300) — extreme chromatic purple that exceeds sRGB limits.</p>
+      </article>
+    </section>
+
+    <section class="gradient-showcase">
+      <h2>HDR-Enhanced Gradients</h2>
+      <div class="gradient-bar g1"></div>
+      <div class="gradient-bar g2"></div>
+      <div class="gradient-bar g3"></div>
+    </section>
+
+    <section class="sdr-notice">
+      <p>If you are viewing on a standard SDR display, the colors above have been gracefully degraded to sRGB. On an HDR-capable screen, they will appear more vibrant and luminous.</p>
+    </section>
+  </main>
+
+  <script>
+    const status = document.getElementById('hdrStatus');
+    const dot = status.querySelector('.status-dot');
+    const text = status.querySelector('.status-text');
+    const isHDR = window.matchMedia('(dynamic-range: high)').matches;
+    const gamut = window.matchMedia('(color-gamut: p3)').matches ? 'P3' : 'sRGB';
+    dot.className = 'status-dot ' + (isHDR ? 'hdr' : 'sdr');
+    text.textContent = isHDR
+      ? 'HDR display detected — wide-gamut colors active (color-gamut: ' + gamut + ')'
+      : 'SDR display — colors shown within sRGB limits (color-gamut: ' + gamut + ')';
+  </script>
+</body>
+</html>

--- a/submissions/examples/dynamic-range-hdr/style.css
+++ b/submissions/examples/dynamic-range-hdr/style.css
@@ -1,0 +1,216 @@
+:root {
+  --bg: #0b1120;
+  --surface: #131c31;
+  --text: #e2e8f0;
+  --muted: #64748b;
+  --radius: 12px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+header {
+  text-align: center;
+  padding: 3rem 1rem 2rem;
+  border-bottom: 1px solid #1e293b;
+}
+
+header h1 {
+  font-size: 2rem;
+  background: linear-gradient(90deg, #60a5fa, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+header p {
+  color: var(--muted);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+header code {
+  background: #1e293b;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.hdr-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid #1e293b;
+  margin-bottom: 2rem;
+}
+
+.status-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-dot.sdr {
+  background: #64748b;
+}
+
+.status-dot.hdr {
+  background: #22c55e;
+  box-shadow: 0 0 8px #22c55e;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.color-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  border: 1px solid #1e293b;
+  transition: transform 0.2s;
+}
+
+.color-card:hover {
+  transform: translateY(-2px);
+}
+
+.card-swatch {
+  width: 100%;
+  height: 80px;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+.color-card:nth-child(1) .card-swatch {
+  background: oklch(70% 0.2 25);
+}
+
+.color-card:nth-child(2) .card-swatch {
+  background: oklch(65% 0.15 200);
+}
+
+.color-card:nth-child(3) .card-swatch {
+  background: oklch(80% 0.18 140);
+}
+
+.color-card:nth-child(4) .card-swatch {
+  background: oklch(60% 0.22 300);
+}
+
+@supports (color: color(display-p3 1 0 0)) {
+  .color-card:nth-child(1) .card-swatch {
+    background: color(display-p3 1 0.4 0.2);
+  }
+  .color-card:nth-child(2) .card-swatch {
+    background: color(display-p3 0.1 0.8 0.9);
+  }
+  .color-card:nth-child(3) .card-swatch {
+    background: color(display-p3 0.5 1 0.2);
+  }
+  .color-card:nth-child(4) .card-swatch {
+    background: color(display-p3 0.8 0.2 1);
+  }
+}
+
+@media (dynamic-range: high) {
+  .color-card:nth-child(1) .card-swatch {
+    background: oklch(75% 0.25 25);
+    box-shadow: 0 0 20px oklch(75% 0.25 25 / 0.3);
+  }
+  .color-card:nth-child(2) .card-swatch {
+    background: oklch(70% 0.2 200);
+    box-shadow: 0 0 20px oklch(70% 0.2 200 / 0.3);
+  }
+  .color-card:nth-child(3) .card-swatch {
+    background: oklch(85% 0.22 140);
+    box-shadow: 0 0 20px oklch(85% 0.22 140 / 0.3);
+  }
+  .color-card:nth-child(4) .card-swatch {
+    background: oklch(65% 0.28 300);
+    box-shadow: 0 0 20px oklch(65% 0.28 300 / 0.3);
+  }
+}
+
+.color-card h3 {
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.color-card p {
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.gradient-showcase {
+  margin-bottom: 2rem;
+}
+
+.gradient-showcase h2 {
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+  color: #60a5fa;
+}
+
+.gradient-bar {
+  height: 48px;
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
+}
+
+.gradient-bar.g1 {
+  background: linear-gradient(90deg, oklch(60% 0.2 10), oklch(70% 0.2 90), oklch(80% 0.2 170));
+}
+
+.gradient-bar.g2 {
+  background: linear-gradient(90deg, oklch(55% 0.25 280), oklch(65% 0.2 340), oklch(75% 0.2 40));
+}
+
+.gradient-bar.g3 {
+  background: linear-gradient(90deg, oklch(70% 0.18 180), oklch(75% 0.15 130), oklch(80% 0.15 80));
+}
+
+@media (dynamic-range: high) {
+  .gradient-bar {
+    box-shadow: 0 0 30px rgb(255 255 255 / 0.05);
+  }
+}
+
+.sdr-notice {
+  background: #1e293b;
+  border-radius: var(--radius);
+  padding: 1rem 1.5rem;
+  border: 1px solid #334155;
+}
+
+.sdr-notice p {
+  font-size: 0.9rem;
+  color: var(--muted);
+  line-height: 1.6;
+}


### PR DESCRIPTION
﻿Adds a complete example submission demonstrating CSS `@media (dynamic-range: high)` for HDR content delivery. Features oklch() wide-gamut colors with graceful SDR fallbacks, HDR status detection, and Display P3 color space support.

- `demo.html` — responsive card grid with gradient showcase, HDR status indicator
- `style.css` — @media (dynamic-range), @supports (color-gamut: p3), oklch() colors
- `README.md` — documentation of HDR media query and color space concepts

Closes #12291
