### PR TITLE
feat: add rotate-out-down-right animation #11889

### DIFF
--- a/submissions/examples/rotate-out-down-right-gc/README.md
+++ b/submissions/examples/rotate-out-down-right-gc/README.md
@@ -1,0 +1,10 @@
+# Rotate Out Down Right
+
+### What does this do?
+Rotates an element out towards the lower-right corner while fading it out.
+
+### How is it used?
+Apply the class `rotate-out-down-right-gc` to any element you wish to animate as it exits the view.
+
+### Why is it useful?
+It provides a smooth, directional exit animation that feels natural and dynamic. It's particularly useful for dismissing notifications, closing modals, or removing items from a list with a more expressive motion than a simple fade.

--- a/submissions/examples/rotate-out-down-right-gc/demo.html
+++ b/submissions/examples/rotate-out-down-right-gc/demo.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rotate Out Down Right Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background-color: #f8fafc;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            color: #1e293b;
+        }
+        .container {
+            text-align: center;
+            background: white;
+            padding: 3rem;
+            border-radius: 20px;
+            box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+        }
+        h1 {
+            margin-bottom: 2rem;
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+        .box-wrapper {
+            width: 150px;
+            height: 150px;
+            margin: 0 auto 2rem;
+            perspective: 1000px;
+        }
+        .box {
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+            border-radius: 16px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            color: white;
+            font-weight: 700;
+            font-size: 1.2rem;
+            box-shadow: 0 10px 15px -3px rgba(79, 70, 229, 0.4);
+        }
+        .controls {
+            display: flex;
+            gap: 1rem;
+            justify-content: center;
+        }
+        button {
+            padding: 0.75rem 1.5rem;
+            font-size: 1rem;
+            font-weight: 500;
+            cursor: pointer;
+            border: none;
+            border-radius: 8px;
+            transition: all 0.2s;
+        }
+        .btn-primary {
+            background: #4f46e5;
+            color: white;
+        }
+        .btn-primary:hover {
+            background: #4338ca;
+            transform: translateY(-1px);
+        }
+        .btn-secondary {
+            background: #e2e8f0;
+            color: #475569;
+        }
+        .btn-secondary:hover {
+            background: #cbd5e1;
+        }
+        .animate {
+            animation: rotate-out-down-right-gc 0.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Rotate Out Down Right</h1>
+        <div class="box-wrapper">
+            <div id="box" class="box">EXIT</div>
+        </div>
+        <div class="controls">
+            <button class="btn-primary" onclick="animateBox()">Animate Exit</button>
+            <button class="btn-secondary" onclick="resetBox()">Reset</button>
+        </div>
+    </div>
+
+    <script>
+        function animateBox() {
+            const box = document.getElementById('box');
+            box.classList.remove('animate');
+            void box.offsetWidth; // trigger reflow
+            box.classList.add('animate');
+        }
+        function resetBox() {
+            const box = document.getElementById('box');
+            box.classList.remove('animate');
+        }
+    </script>
+</body>
+</html>

--- a/submissions/examples/rotate-out-down-right-gc/style.css
+++ b/submissions/examples/rotate-out-down-right-gc/style.css
@@ -1,0 +1,16 @@
+@keyframes rotate-out-down-right-gc {
+  from {
+    opacity: 1;
+    transform: rotate(0deg);
+    transform-origin: right bottom;
+  }
+  to {
+    opacity: 0;
+    transform: rotate(-45deg);
+    transform-origin: right bottom;
+  }
+}
+
+.rotate-out-down-right-gc {
+  animation: rotate-out-down-right-gc 0.6s ease-in forwards;
+}


### PR DESCRIPTION

  Summary of Changes
   - New Animation Implementation: Created a
     self-contained example for the
     ease-rotate-out-down-right animation in
     submissions/examples/rotate-out-down-right-gc/.
   - Keyframe Logic: Defined the
     rotate-out-down-right-gc keyframes to rotate an
     element from 0deg to -45deg with transform-origin:
     right bottom and opacity: 0 as per the acceptance
     criteria.
   - Demo & Documentation: 
     - Included a demo.html for visual verification.
     - Added a style.css containing the raw animation
       logic.
     - Provided a README.md explaining the animation's
       purpose and usage.
   - Repository Compliance: Adhered to the strict
     submissions/ workflow and naming conventions
     (appending -gc to the feature name) to avoid
     conflicts.