### PR TITLE
feat(submission): add CSS spirograph counter-rotating ring animation

### DIFF
--- a/submissions/examples/spirograph-ring-animation-sk/README.md
+++ b/submissions/examples/spirograph-ring-animation-sk/README.md
@@ -1,0 +1,24 @@
+# CSS Spirograph — Counter-Rotating Ring Animation
+
+1. **What does this do?**
+   Renders a pure CSS spirograph using five nested `<div>` elements, each rotating at a prime-number speed (3s, 5s, 7s, 11s, 13s). Because the periods are coprime, the compound dot paths never exactly repeat — producing genuine generative-art motion from a single `@keyframes spin` rule.
+
+2. **How is it used?**
+   Nest five `.ring-N` divs inside a `.spirograph-stage` wrapper. Each ring gets a different animation duration; a `::after` pseudo-element positions the coloured dot at the ring's top edge.
+
+   ```html
+   <div class="spirograph-stage">
+     <div class="ring ring-1">
+       <div class="ring ring-2">
+         <div class="ring ring-3">
+           <div class="ring ring-4">
+             <div class="ring ring-5"></div>
+           </div>
+         </div>
+       </div>
+     </div>
+   </div>
+   ```
+
+3. **Why is it useful?**
+   Demonstrates the compositional power of stacked `animation` declarations — multiple simple `rotate` keyframes building emergent complexity. Useful as a decorative loader, background element, or teaching example for `transform-origin`, `mix-blend-mode`, and prime-ratio timing. Respects `prefers-reduced-motion` by pausing all animations.

--- a/submissions/examples/spirograph-ring-animation-sk/demo.html
+++ b/submissions/examples/spirograph-ring-animation-sk/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Spirograph — Counter-Rotating Ring Animation</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <h1>CSS Spirograph</h1>
+  <p class="subtitle">
+    Five rings rotating at prime-number speed ratios (3s, 5s, 7s, 11s, 13s).
+    Because the periods are coprime, the dot paths never exactly repeat.
+  </p>
+
+  <div class="spirograph-stage" id="stage">
+    <div class="ring ring-1">
+      <div class="ring ring-2">
+        <div class="ring ring-3">
+          <div class="ring ring-4">
+            <div class="ring ring-5"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="controls">
+    <button class="btn-pause" id="pauseBtn" aria-pressed="false">Pause</button>
+  </div>
+
+  <script>
+    const stage = document.getElementById('stage');
+    const btn   = document.getElementById('pauseBtn');
+    btn.addEventListener('click', () => {
+      const paused = stage.classList.toggle('is-paused');
+      btn.textContent     = paused ? 'Resume' : 'Pause';
+      btn.setAttribute('aria-pressed', String(paused));
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/spirograph-ring-animation-sk/style.css
+++ b/submissions/examples/spirograph-ring-animation-sk/style.css
@@ -1,0 +1,149 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #07090f;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 2rem 1rem;
+}
+
+h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  text-align: center;
+  letter-spacing: 0.02em;
+}
+
+.subtitle {
+  font-size: 0.8rem;
+  color: #475569;
+  text-align: center;
+  max-width: 400px;
+  line-height: 1.6;
+}
+
+.spirograph-stage {
+  position: relative;
+  width: 380px;
+  height: 380px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0a0c15;
+  border-radius: 50%;
+  border: 1px solid #1e293b;
+}
+
+.ring {
+  position: absolute;
+  border-radius: 50%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  border: 1px solid transparent;
+}
+
+.ring::after {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  position: absolute;
+  top: -5px;
+  left: 50%;
+  transform: translateX(-50%);
+  mix-blend-mode: screen;
+  filter: blur(0.5px);
+}
+
+.ring-1 {
+  width: 300px;
+  height: 300px;
+  animation: spin 3s linear infinite;
+}
+
+.ring-2 {
+  width: 220px;
+  height: 220px;
+  animation: spin 5s linear infinite;
+}
+
+.ring-3 {
+  width: 155px;
+  height: 155px;
+  animation: spin 7s linear infinite;
+}
+
+.ring-4 {
+  width: 100px;
+  height: 100px;
+  animation: spin 11s linear infinite;
+}
+
+.ring-5 {
+  width: 54px;
+  height: 54px;
+  animation: spin 13s linear infinite;
+}
+
+.ring-1::after { background: hsl(0,   100%, 65%); width: 12px; height: 12px; top: -6px; }
+.ring-2::after { background: hsl(72,  100%, 58%); }
+.ring-3::after { background: hsl(144, 100%, 58%); }
+.ring-4::after { background: hsl(216, 100%, 65%); }
+.ring-5::after { background: hsl(288, 100%, 65%); width: 8px; height: 8px; top: -4px; }
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.btn-pause {
+  padding: 0.45rem 1.1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: #1e293b;
+  color: #94a3b8;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  font-family: inherit;
+}
+
+.btn-pause:hover {
+  background: #334155;
+  color: #e2e8f0;
+}
+
+.btn-pause:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.spirograph-stage.is-paused .ring {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ring {
+    animation-play-state: paused;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `submissions/examples/spirograph-ring-animation-sk/` — a pure CSS spirograph using five nested divs rotating at prime-number speed ratios (3s, 5s, 7s, 11s, 13s). Because the periods are coprime, the compound dot paths never exactly repeat. Single `@keyframes spin` rule, `mix-blend-mode: screen` on the dots, a JS-toggle pause button, and `prefers-reduced-motion` support.

Closes #12418

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/spirograph-ring-animation-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A generative spirograph animation driven entirely by stacked CSS `rotate` keyframes at prime-number durations.

**How does a developer use it?**

```html
<div class="spirograph-stage">
  <div class="ring ring-1">
    <div class="ring ring-2">
      <div class="ring ring-3">
        <div class="ring ring-4">
          <div class="ring ring-5"></div>
        </div>
      </div>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

Shows how composing multiple simple `animation` declarations builds emergent complexity — a core teaching pattern for the library. Works as a decorative loader or background element.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

The `mix-blend-mode: screen` on the dots requires a dark background to be visible — the stage uses `background: #0a0c15`. If integrating into a light-theme context, swap blend mode to `multiply`.