### PR TITLE
feat(submission): add CSS animated multi-segment donut chart

### DIFF
--- a/submissions/examples/animated-donut-chart-sk/README.md
+++ b/submissions/examples/animated-donut-chart-sk/README.md
@@ -1,0 +1,16 @@
+# CSS Animated Multi-Segment Donut Chart
+
+1. **What does this do?**
+   Renders a four-segment donut chart where each arc animates from `0deg` to its final angle on page load, using four registered `@property` custom properties of type `<angle>` and a single `conic-gradient()` background. Segments are staggered with `animation-delay`.
+
+2. **How is it used?**
+   Add the `.donut-chart` div and nest a `.donut-label` span inside it. A `::before` pseudo-element creates the punch-hole. Segment angles are driven by `--s1`–`--s4` which animate via `@keyframes`.
+
+   ```html
+   <div class="donut-chart">
+     <span class="donut-label">Q2</span>
+   </div>
+   ```
+
+3. **Why is it useful?**
+   Demonstrates that `@property` + `conic-gradient` compose into a real data-visualisation primitive — no JavaScript, no SVG, no canvas. The `prefers-reduced-motion` fallback sets all angles to their final values immediately so the data is always visible.

--- a/submissions/examples/animated-donut-chart-sk/demo.html
+++ b/submissions/examples/animated-donut-chart-sk/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Animated Donut Chart</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <h1>CSS Animated Donut Chart</h1>
+
+  <figure class="donut-wrap" role="img" aria-label="Q2 breakdown: Design 39%, Development 25%, Research 22%, Other 14%">
+
+    <div class="donut-chart">
+      <span class="donut-label">Q2</span>
+    </div>
+
+    <ul class="legend" aria-hidden="true">
+      <li class="legend-item">
+        <span class="legend-swatch" style="background:#6366f1"></span>
+        Design
+        <span class="legend-value">39%</span>
+      </li>
+      <li class="legend-item">
+        <span class="legend-swatch" style="background:#ec4899"></span>
+        Development
+        <span class="legend-value">25%</span>
+      </li>
+      <li class="legend-item">
+        <span class="legend-swatch" style="background:#06b6d4"></span>
+        Research
+        <span class="legend-value">22%</span>
+      </li>
+      <li class="legend-item">
+        <span class="legend-swatch" style="background:#f59e0b"></span>
+        Other
+        <span class="legend-value">14%</span>
+      </li>
+    </ul>
+
+  </figure>
+</body>
+</html>

--- a/submissions/examples/animated-donut-chart-sk/style.css
+++ b/submissions/examples/animated-donut-chart-sk/style.css
@@ -1,0 +1,141 @@
+@property --s1 { syntax: '<angle>'; initial-value: 0deg; inherits: false; }
+@property --s2 { syntax: '<angle>'; initial-value: 0deg; inherits: false; }
+@property --s3 { syntax: '<angle>'; initial-value: 0deg; inherits: false; }
+@property --s4 { syntax: '<angle>'; initial-value: 0deg; inherits: false; }
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 2rem 1rem;
+}
+
+h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  text-align: center;
+}
+
+.donut-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+/* === Chart ring === */
+.donut-chart {
+  position: relative;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: conic-gradient(
+    #6366f1 0deg var(--s1),
+    #ec4899 var(--s1) calc(var(--s1) + var(--s2)),
+    #06b6d4 calc(var(--s1) + var(--s2)) calc(var(--s1) + var(--s2) + var(--s3)),
+    #f59e0b calc(var(--s1) + var(--s2) + var(--s3)) 360deg
+  );
+  animation:
+    fill-s1 0.65s ease-out 0.15s both,
+    fill-s2 0.65s ease-out 0.35s both,
+    fill-s3 0.65s ease-out 0.55s both,
+    fill-s4 0.65s ease-out 0.75s both;
+}
+
+/* Donut punch-hole */
+.donut-chart::before {
+  content: '';
+  position: absolute;
+  inset: 22%;
+  border-radius: 50%;
+  background: #0f172a;
+}
+
+/* Center label */
+.donut-chart::after {
+  content: 'Q2';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #94a3b8;
+  /* pseudo-element content can't use flex, use grid trick */
+}
+
+.donut-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #94a3b8;
+  pointer-events: none;
+}
+
+@keyframes fill-s1 { to { --s1: 140deg; } }
+@keyframes fill-s2 { to { --s2:  90deg; } }
+@keyframes fill-s3 { to { --s3:  79deg; } }
+@keyframes fill-s4 { to { --s4:  51deg; } }
+
+/* === Legend === */
+.legend {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-width: 220px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.875rem;
+  color: #cbd5e1;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.legend-value {
+  margin-left: auto;
+  font-weight: 600;
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+}
+
+/* === Reduced motion: skip animation, show final state === */
+@media (prefers-reduced-motion: reduce) {
+  .donut-chart {
+    animation: none;
+    --s1: 140deg;
+    --s2:  90deg;
+    --s3:  79deg;
+    --s4:  51deg;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `submissions/examples/animated-donut-chart-sk/` — a four-segment donut chart where each arc grows from `0deg` to its target angle on page load. Built with four `@property` registered `<angle>` custom properties and a single `conic-gradient()`. Segments are staggered with `animation-delay`. `prefers-reduced-motion` sets all angles to final values immediately so data is never hidden.

Closes #12419

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/animated-donut-chart-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only animated donut chart with four segments, staggered entrance animation, and a colour-matched legend.

**How does a developer use it?**

```html
<div class="donut-chart">
  <span class="donut-label">Q2</span>
</div>
```

**Why does it fit EaseMotion CSS?**

Demonstrates `@property` + `conic-gradient` as a data-visualisation primitive. No JS, no SVG. Directly composable with existing EaseMotion easing tokens.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

`@property` with `syntax: '<angle>'` is required for the browser to interpolate the conic-gradient correctly. Without it, the gradient jumps from 0 to the final value with no animation. Safari 16.4+ supports this — older Safari will fall through to the `prefers-reduced-motion` static state.