### PR TITLE
feat(submission): add CSS skeuomorphic tactile press button

### DIFF
--- a/submissions/examples/skeuomorphic-press-button-sk/README.md
+++ b/submissions/examples/skeuomorphic-press-button-sk/README.md
@@ -1,0 +1,19 @@
+# CSS Skeuomorphic Tactile Press Button
+
+1. **What does this do?**
+   Simulates a physical mechanical key press: the button sinks 5px on `:active` while its multi-layer `box-shadow` transitions from a raised outer shadow to an inset inner shadow — giving tactile depth feedback with no JavaScript.
+
+2. **How is it used?**
+   Apply `.press-btn` to any `<button>`. Use `.press-btn--danger` or `.press-btn--success` for colour variants. For a sticky toggle, wrap a checkbox inside a `<label class="press-btn press-toggle">`.
+
+   ```html
+   <button class="press-btn">Click me</button>
+
+   <label class="press-btn press-toggle">
+     <input type="checkbox">
+     Enable
+   </label>
+   ```
+
+3. **Why is it useful?**
+   Interactive affordance is part of motion design — a convincing press state communicates that something happened without a visual indicator change. The 80ms transition is tuned to feel physical. Useful for CTAs, game controls, and keyboard-key displays. Respects `prefers-reduced-motion` by retaining colour feedback while removing the translate.

--- a/submissions/examples/skeuomorphic-press-button-sk/demo.html
+++ b/submissions/examples/skeuomorphic-press-button-sk/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Skeuomorphic Tactile Press Button</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <h1>Skeuomorphic Tactile Press Button</h1>
+
+  <div class="demo-row">
+
+    <div class="demo-col">
+      <label>Primary</label>
+      <button class="press-btn">Click me</button>
+    </div>
+
+    <div class="demo-col">
+      <label>Danger</label>
+      <button class="press-btn press-btn--danger">Delete</button>
+    </div>
+
+    <div class="demo-col">
+      <label>Success</label>
+      <button class="press-btn press-btn--success">Confirm</button>
+    </div>
+
+    <div class="demo-col">
+      <label>Toggle (stays pressed)</label>
+      <label class="press-btn press-toggle" aria-label="Toggle feature">
+        <input type="checkbox">
+        Enable
+      </label>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/skeuomorphic-press-button-sk/style.css
+++ b/submissions/examples/skeuomorphic-press-button-sk/style.css
@@ -1,0 +1,173 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  padding: 2rem 1rem;
+}
+
+h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  text-align: center;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.demo-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.demo-col label {
+  font-size: 0.75rem;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ===================================================
+   Base press button
+   =================================================== */
+.press-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 2rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-family: inherit;
+  color: #fff;
+  background: #6366f1;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  user-select: none;
+  /* Raised state: hard bottom face + ambient blur */
+  box-shadow:
+    0 6px 0 0 #3d2b9e,
+    0 8px 20px rgba(0, 0, 0, 0.45);
+  transform: translateY(0);
+  transition:
+    transform     0.08s ease,
+    box-shadow    0.08s ease,
+    background    0.08s ease;
+}
+
+.press-btn:hover {
+  background: #7274f3;
+}
+
+.press-btn:active {
+  background: #4f46e5;
+  transform: translateY(5px);
+  box-shadow:
+    0 1px 0 0 #3d2b9e,
+    0 2px 6px rgba(0, 0, 0, 0.3),
+    inset 0 2px 5px rgba(0, 0, 0, 0.35);
+}
+
+.press-btn:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 3px;
+}
+
+/* ===================================================
+   Colour variants
+   =================================================== */
+.press-btn--danger {
+  background: #ef4444;
+  box-shadow:
+    0 6px 0 0 #991b1b,
+    0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+.press-btn--danger:hover { background: #f16a6a; }
+
+.press-btn--danger:active {
+  background: #dc2626;
+  box-shadow:
+    0 1px 0 0 #991b1b,
+    0 2px 6px rgba(0, 0, 0, 0.3),
+    inset 0 2px 5px rgba(0, 0, 0, 0.35);
+}
+
+.press-btn--success {
+  background: #22c55e;
+  box-shadow:
+    0 6px 0 0 #14532d,
+    0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+.press-btn--success:hover { background: #4ade80; }
+
+.press-btn--success:active {
+  background: #16a34a;
+  box-shadow:
+    0 1px 0 0 #14532d,
+    0 2px 6px rgba(0, 0, 0, 0.3),
+    inset 0 2px 5px rgba(0, 0, 0, 0.35);
+}
+
+/* ===================================================
+   Toggle variant — stays pressed when checked
+   =================================================== */
+.press-toggle {
+  position: relative;
+  cursor: pointer;
+}
+
+.press-toggle input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
+.press-toggle:has(input:checked) {
+  background: #4f46e5;
+  transform: translateY(5px);
+  box-shadow:
+    0 1px 0 0 #3d2b9e,
+    0 2px 6px rgba(0, 0, 0, 0.3),
+    inset 0 2px 5px rgba(0, 0, 0, 0.35);
+}
+
+/* ===================================================
+   Reduced motion: keep colour feedback, drop translate
+   =================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .press-btn,
+  .press-toggle {
+    transition: background 0.1s ease, box-shadow 0.1s ease;
+  }
+
+  .press-btn:active,
+  .press-toggle:has(input:checked) {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `submissions/examples/skeuomorphic-press-button-sk/` — a button that physically sinks on `:active` using a multi-layer `box-shadow` transition (outer raised face → inset inner shadow) and `translateY(5px)`. Three colour variants (primary, danger, success) plus a `:has()`-powered checkbox toggle that stays sunken when checked. Transition is 80ms to feel physical rather than floaty.

Closes #12420

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/skeuomorphic-press-button-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A tactile press button that simulates a mechanical key depress — distinct from hover-lift (elements raise) and neumorphic (soft-UI aesthetic). This is about the downward depress with inner shadow feedback.

**How does a developer use it?**

```html
<button class="press-btn">Click me</button>

<label class="press-btn press-toggle">
  <input type="checkbox"> Enable
</label>
```

**Why does it fit EaseMotion CSS?**

Interactive affordance is part of motion design. A convincing press state communicates action without needing a visual label update. Composable with existing colour tokens.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

The toggle variant uses `:has(input:checked)` — supported in all evergreen browsers (Chrome 105+, Firefox 121+, Safari 15.4+). The 5px depress value can be tuned per design system.