### PR TITLE
feat(submission): add CSS tilt-shift depth-of-field blur effect

### DIFF
--- a/submissions/examples/tilt-shift-depth-blur-sk/README.md
+++ b/submissions/examples/tilt-shift-depth-blur-sk/README.md
@@ -1,0 +1,18 @@
+# CSS Tilt-Shift / Depth-of-Field Blur Effect
+
+1. **What does this do?**
+   Simulates tilt-shift photography — a narrow band of the scene stays in sharp focus while everything above and below progressively blurs. A registered `@property --focus-y` controls where the sharp band sits and animates slowly up and down, creating a scanning-camera effect.
+
+2. **How is it used?**
+   Wrap three `.depth-layer` divs inside a `.tilt-shift-scene`. The scene's `--focus-y` custom property is animated via `@keyframes`; the `mask-image` on each blurred layer references `var(--focus-y)` to position the blur gradient dynamically.
+
+   ```html
+   <div class="tilt-shift-scene">
+     <div class="depth-layer depth-layer--far"></div>
+     <div class="depth-layer depth-layer--mid"></div>
+     <div class="depth-layer depth-layer--near"></div>
+   </div>
+   ```
+
+3. **Why is it useful?**
+   Tilt-shift depth is one of the most visually distinctive photographic effects. A pure CSS implementation — using `filter: blur()` + `mask-image: linear-gradient()` driven by a single registered custom property — gives designers this effect for hero sections and galleries without WebGL or canvas.

--- a/submissions/examples/tilt-shift-depth-blur-sk/demo.html
+++ b/submissions/examples/tilt-shift-depth-blur-sk/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Tilt-Shift Depth-of-Field Effect</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <h1>CSS Tilt-Shift / Depth-of-Field</h1>
+  <p class="subtitle">
+    A narrow in-focus band scans the scene. Background and foreground layers
+    use <code style="color:#7dd3fc">filter: blur()</code> + <code style="color:#7dd3fc">mask-image</code>
+    driven by a registered <code style="color:#7dd3fc">--focus-y</code> custom property.
+  </p>
+
+  <div class="tilt-shift-scene">
+    <div class="depth-layer depth-layer--far"></div>
+    <div class="depth-layer depth-layer--mid">
+      <div class="city-row"></div>
+    </div>
+    <div class="depth-layer depth-layer--near"></div>
+    <div class="focus-line" aria-hidden="true"></div>
+  </div>
+
+  <p class="legend">
+    The purple line marks the current focus band &mdash; everything outside it blurs progressively.
+  </p>
+</body>
+</html>

--- a/submissions/examples/tilt-shift-depth-blur-sk/style.css
+++ b/submissions/examples/tilt-shift-depth-blur-sk/style.css
@@ -1,0 +1,208 @@
+@property --focus-y {
+  syntax: '<percentage>';
+  initial-value: 50%;
+  inherits: true;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 2rem 1rem;
+}
+
+h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  text-align: center;
+}
+
+.subtitle {
+  font-size: 0.8rem;
+  color: #64748b;
+  text-align: center;
+  max-width: 480px;
+  line-height: 1.6;
+}
+
+/* ===================================================
+   Scene container
+   =================================================== */
+.tilt-shift-scene {
+  position: relative;
+  width: 100%;
+  max-width: 680px;
+  height: 360px;
+  border-radius: 16px;
+  overflow: hidden;
+  --focus-y: 50%;
+  animation: scan-focus 5s ease-in-out infinite alternate;
+  border: 1px solid #1e293b;
+}
+
+@keyframes scan-focus {
+  from { --focus-y: 22%; }
+  to   { --focus-y: 78%; }
+}
+
+/* ===================================================
+   Depth layers — all absolutely fill the scene
+   =================================================== */
+.depth-layer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+/* Far background — blurred, fades out toward the focus band */
+.depth-layer--far {
+  background: linear-gradient(160deg, #1e3a5f 0%, #0f4c75 50%, #1b6ca8 100%);
+  filter: blur(5px) brightness(0.7);
+  transform: scale(1.06);
+  mask-image: linear-gradient(
+    to bottom,
+    black 0%,
+    black calc(var(--focus-y) - 18%),
+    transparent calc(var(--focus-y) + 4%)
+  );
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    black 0%,
+    black calc(var(--focus-y) - 18%),
+    transparent calc(var(--focus-y) + 4%)
+  );
+}
+
+.depth-layer--far::after {
+  content: 'Background';
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  position: absolute;
+  top: 18%;
+}
+
+/* Mid — always sharp, the in-focus band */
+.depth-layer--mid {
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    rgba(99, 102, 241, 0.08) calc(var(--focus-y) - 12%),
+    rgba(99, 102, 241, 0.15) var(--focus-y),
+    rgba(99, 102, 241, 0.08) calc(var(--focus-y) + 12%),
+    transparent 100%
+  );
+  color: #fff;
+  font-size: 1.1rem;
+  letter-spacing: 0.03em;
+}
+
+.depth-layer--mid::after {
+  content: 'Focus band';
+  color: rgba(165, 180, 252, 0.9);
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  position: absolute;
+  top: calc(var(--focus-y) - 2rem);
+}
+
+/* Near foreground — blurred, fades out upward from the focus band */
+.depth-layer--near {
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    rgba(15, 23, 42, 0.3) 60%,
+    rgba(15, 23, 42, 0.7) 100%
+  );
+  filter: blur(4px) brightness(0.75);
+  transform: scale(1.04);
+  mask-image: linear-gradient(
+    to bottom,
+    transparent calc(var(--focus-y) - 4%),
+    black calc(var(--focus-y) + 18%),
+    black 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent calc(var(--focus-y) - 4%),
+    black calc(var(--focus-y) + 18%),
+    black 100%
+  );
+}
+
+.depth-layer--near::after {
+  content: 'Foreground';
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  position: absolute;
+  bottom: 14%;
+}
+
+/* Miniature city silhouette via box-shadow layers */
+.city-row {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+  background:
+    linear-gradient(to top, rgba(10, 20, 60, 0.9) 0%, transparent 100%);
+}
+
+/* ===================================================
+   Focus indicator line
+   =================================================== */
+.focus-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: rgba(99, 102, 241, 0.5);
+  top: var(--focus-y);
+  transform: translateY(-50%);
+  pointer-events: none;
+  box-shadow: 0 0 8px rgba(99, 102, 241, 0.6);
+  animation: scan-focus 5s ease-in-out infinite alternate;
+}
+
+/* ===================================================
+   Legend
+   =================================================== */
+.legend {
+  font-size: 0.75rem;
+  color: #475569;
+  text-align: center;
+}
+
+/* ===================================================
+   Reduced motion
+   =================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .tilt-shift-scene,
+  .focus-line {
+    animation: none;
+    --focus-y: 50%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `submissions/examples/tilt-shift-depth-blur-sk/` — a tilt-shift photography simulation using `@property --focus-y` to drive `mask-image: linear-gradient()` gradients on two blurred depth layers. The far and near layers use `filter: blur()` and fade out toward the in-focus band. The `--focus-y` value animates from 22% to 78% on a 5s alternate loop, creating a scanning-camera effect. `prefers-reduced-motion` freezes at 50%.

Closes #12421

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/tilt-shift-depth-blur-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A depth-of-field / tilt-shift effect: a narrow sharp band scans across a layered scene while everything outside it progressively blurs.

**How does a developer use it?**

```html
<div class="tilt-shift-scene">
  <div class="depth-layer depth-layer--far"></div>
  <div class="depth-layer depth-layer--mid"></div>
  <div class="depth-layer depth-layer--near"></div>
</div>
```

**Why does it fit EaseMotion CSS?**

Shows `@property` + `mask-image` + `filter` composing into a photographic depth effect entirely in CSS — no WebGL, no canvas.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

`-webkit-mask-image` fallback is included alongside `mask-image` for broader compatibility. The `transform: scale(1.06)` on blurred layers compensates for the edge bleed that `filter: blur` causes at element boundaries.