### PR TITLE
feat(submission): add CSS 3D extruded long-shadow text effect

### DIFF
--- a/submissions/examples/extruded-long-shadow-text-sk/README.md
+++ b/submissions/examples/extruded-long-shadow-text-sk/README.md
@@ -1,0 +1,16 @@
+# CSS 3D Extruded Long-Shadow Text
+
+1. **What does this do?**
+   Creates physical text depth by stacking 20 `text-shadow` declarations at incrementing 1px offsets. On hover, the shadow direction transitions (diagonal → straight-down), making the extrusion appear to rotate as if the light source is moving. Three variants: diagonal extrude, top-left angular extrude, and chrome outlined gradient text.
+
+2. **How is it used?**
+   Apply `.extruded-text` to any heading element. Add `.extruded-text--angular` for the top-left variant. Use `.chrome-text` for the gradient outlined version.
+
+   ```html
+   <h1 class="extruded-text">DEPTH</h1>
+   <h2 class="extruded-text extruded-text--angular">ANGULAR</h2>
+   <h2 class="chrome-text">CHROME</h2>
+   ```
+
+3. **Why is it useful?**
+   Demonstrates that `text-shadow` comma-lists compose into 3D dimensionality. Useful for hero headlines, splash screens, and retro-styled UI. The hover transition teaches that `text-shadow` is animatable — a commonly overlooked CSS fact. Works in all browsers with no dependencies.

--- a/submissions/examples/extruded-long-shadow-text-sk/demo.html
+++ b/submissions/examples/extruded-long-shadow-text-sk/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS 3D Extruded Long-Shadow Text</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <h1>Hover each headline</h1>
+
+  <p class="extruded-text">DEPTH</p>
+
+  <p class="extruded-text extruded-text--angular">ANGULAR</p>
+
+  <p class="chrome-text">CHROME</p>
+</body>
+</html>

--- a/submissions/examples/extruded-long-shadow-text-sk/style.css
+++ b/submissions/examples/extruded-long-shadow-text-sk/style.css
@@ -1,0 +1,132 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  padding: 3rem 1rem;
+}
+
+h1 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #64748b;
+  text-align: center;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ===================================================
+   Variant 1 — bottom-right diagonal extrusion
+   =================================================== */
+.extruded-text {
+  font-size: clamp(3rem, 10vw, 6rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  color: #a5b4fc;
+  text-shadow:
+     1px  1px 0 #3730a3,  2px  2px 0 #3730a3,
+     3px  3px 0 #312e81,  4px  4px 0 #312e81,
+     5px  5px 0 #2a2775,  6px  6px 0 #2a2775,
+     7px  7px 0 #23216a,  8px  8px 0 #23216a,
+     9px  9px 0 #1c1b5e, 10px 10px 0 #1c1b5e,
+    11px 11px 0 #161553, 12px 12px 0 #161553,
+    13px 13px 0 #101048, 14px 14px 0 #101048,
+    15px 15px 0 #0a0b3d, 16px 16px 0 #0a0b3d,
+    17px 17px 0 #060733, 18px 18px 0 #060733,
+    19px 19px 0 #030428, 20px 20px 0 #030428,
+    23px 23px 18px rgba(0, 0, 0, 0.55);
+  transition: text-shadow 0.35s ease, color 0.35s ease;
+}
+
+/* Hover: rotate extrusion to straight-down */
+.extruded-text:hover {
+  color: #c7d2fe;
+  text-shadow:
+    0px  2px 0 #3730a3, 0px  4px 0 #312e81,
+    0px  6px 0 #2a2775, 0px  8px 0 #23216a,
+    0px 10px 0 #1c1b5e, 0px 12px 0 #161553,
+    0px 14px 0 #101048, 0px 16px 0 #0a0b3d,
+    0px 18px 0 #060733, 0px 20px 0 #030428,
+    0px 23px 18px rgba(0, 0, 0, 0.5);
+}
+
+/* ===================================================
+   Variant 2 — top-left angular extrusion
+   =================================================== */
+.extruded-text--angular {
+  font-size: clamp(2rem, 7vw, 4rem);
+  color: #f0abfc;
+  text-shadow:
+    -1px -1px 0 #6b21a8, -2px -2px 0 #6b21a8,
+    -3px -3px 0 #5b1898, -4px -4px 0 #5b1898,
+    -5px -5px 0 #4c1088, -6px -6px 0 #4c1088,
+    -7px -7px 0 #3d0878, -8px -8px 0 #3d0878,
+    -9px -9px 0 #2f0068,
+    -11px -11px 18px rgba(0, 0, 0, 0.5);
+  transition: text-shadow 0.35s ease, color 0.35s ease;
+}
+
+.extruded-text--angular:hover {
+  color: #e879f9;
+  text-shadow:
+    -1px -2px 0 #6b21a8, -2px -4px 0 #5b1898,
+    -3px -6px 0 #4c1088, -4px -8px 0 #3d0878,
+    -5px -10px 0 #2f0068,
+    -6px -12px 16px rgba(0, 0, 0, 0.45);
+}
+
+/* ===================================================
+   Variant 3 — chrome / outlined gradient text
+   =================================================== */
+.chrome-text {
+  font-size: clamp(2rem, 7vw, 4rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  color: transparent;
+  -webkit-text-stroke: 2px #6366f1;
+  background: linear-gradient(135deg, #a5b4fc 0%, #818cf8 50%, #6366f1 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  text-shadow:
+     2px  2px 0 rgba(99, 102, 241, 0.35),
+     4px  4px 0 rgba(99, 102, 241, 0.25),
+     6px  6px 0 rgba(99, 102, 241, 0.15),
+     8px  8px 12px rgba(0, 0, 0, 0.45);
+  transition: text-shadow 0.35s ease;
+}
+
+.chrome-text:hover {
+  text-shadow:
+     3px  3px 0 rgba(99, 102, 241, 0.4),
+     6px  6px 0 rgba(99, 102, 241, 0.3),
+     9px  9px 0 rgba(99, 102, 241, 0.2),
+    12px 12px 0 rgba(99, 102, 241, 0.1),
+    14px 14px 16px rgba(0, 0, 0, 0.5);
+}
+
+/* ===================================================
+   Reduced motion
+   =================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .extruded-text,
+  .extruded-text--angular,
+  .chrome-text {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `submissions/examples/extruded-long-shadow-text-sk/` — a 20-step stacked `text-shadow` that creates physical extrusion depth on headings. On hover, the shadow direction transitions from diagonal bottom-right to straight-down in 350ms. Three variants: bottom-right diagonal extrude, top-left angular extrude, and a chrome outlined gradient text with depth.

Closes #12423

---

## Type of Change

- [x] New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/extruded-long-shadow-text-sk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Three typographic depth effects built purely from stacked `text-shadow` lists — no SVG, no canvas, no images.

**How does a developer use it?**

```html
<h1 class="extruded-text">DEPTH</h1>
<h2 class="extruded-text extruded-text--angular">ANGULAR</h2>
<h2 class="chrome-text">CHROME</h2>
```

**Why does it fit EaseMotion CSS?**

Shows that `text-shadow` comma-lists accumulate into 3D dimensionality, and that `text-shadow` is animatable — both underused CSS facts. Works in all browsers, zero dependencies.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari