### PR TITLE
feat(submission): CSS @layer cascade animation priority — interactive pure-CSS demo

### DIFF
--- a/submissions/examples/layer-cascade-animation-sk/README.md
+++ b/submissions/examples/layer-cascade-animation-sk/README.md
@@ -1,0 +1,12 @@
+# CSS @layer Cascade Animation Priority Demo
+
+1. **What does this do?**
+   Shows, interactively with pure CSS, which `animation` declaration wins when three `@layer` blocks all target the same element. Toggling the layer checkboxes reveals how layer *order* — not source order or specificity — determines the winning animation.
+
+2. **How is it used?**
+   Three toggle labels control hidden `<input type="checkbox">` siblings. Each layer's `@keyframes` is activated with an `#id:checked ~ .contest-box` selector inside the corresponding `@layer` block. The layer declared last in `@layer base, theme, override` has the highest priority, so `override` beats `theme` beats `base` when multiple toggles are on.
+
+   A separate `.unlayered-box` carries an animation defined *outside* any `@layer`, proving the rule: unlayered styles always win the cascade regardless of layer priority.
+
+3. **Why is it useful?**
+   `@layer` ordering is a common source of confusion — developers expect source order or specificity to win, but layer order takes precedence. Seeing the box change animations in real time as toggles are switched makes the abstract rule concrete. No JavaScript required.

--- a/submissions/examples/layer-cascade-animation-sk/demo.html
+++ b/submissions/examples/layer-cascade-animation-sk/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS @layer Cascade Animation Priority</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="layer-demo">
+    <h1>@layer Cascade — Which Animation Wins?</h1>
+
+    <div class="layer-order" aria-label="Layer priority order">
+      <code>@layer base, theme, override;</code>
+      <span class="order-arrow" aria-hidden="true">lower priority &rarr; higher priority</span>
+    </div>
+
+    <!--
+      Technique: hidden checkbox inputs are DOM siblings of .contest-box and .winner-badge.
+      @layer rules use #id:checked ~ .contest-box to target the box.
+      The layer with the highest priority that has a matching checked selector wins.
+      Labels use `for` to link to the hidden inputs — click anywhere on the label.
+    -->
+    <input type="checkbox" id="base-on"     class="layer-toggle" checked>
+    <input type="checkbox" id="theme-on"    class="layer-toggle" checked>
+    <input type="checkbox" id="override-on" class="layer-toggle" checked>
+
+    <div class="controls" role="group" aria-label="Layer toggles">
+      <label for="base-on" class="ctrl ctrl--base">
+        <span class="ctrl__indicator" aria-hidden="true"></span>
+        <span class="ctrl__name">base</span>
+        <span class="ctrl__desc">slow blue pulse</span>
+      </label>
+      <label for="theme-on" class="ctrl ctrl--theme">
+        <span class="ctrl__indicator" aria-hidden="true"></span>
+        <span class="ctrl__name">theme</span>
+        <span class="ctrl__desc">pink bounce</span>
+      </label>
+      <label for="override-on" class="ctrl ctrl--override">
+        <span class="ctrl__indicator" aria-hidden="true"></span>
+        <span class="ctrl__name">override</span>
+        <span class="ctrl__desc">green spin</span>
+      </label>
+    </div>
+
+    <div class="contest-box" role="img" aria-live="polite" aria-label="Animated contest box — active animation reflects the winning layer">
+      <span class="contest-box__label" aria-hidden="true">contest box</span>
+    </div>
+
+    <p class="winner-badge" aria-live="polite">
+      <span class="winner-badge__text"></span>
+    </p>
+
+    <section class="unlayered-section" aria-labelledby="unlayered-heading">
+      <h2 id="unlayered-heading">Unlayered rule — always wins</h2>
+      <p class="unlayered-desc">
+        This box's animation is declared <em>outside</em> any <code>@layer</code>. It beats every layered
+        rule, regardless of layer priority or which toggles above are active.
+      </p>
+      <div class="unlayered-box" role="img" aria-label="Box animated by an unlayered rule — amber pulse, always active">
+        <span class="unlayered-box__label" aria-hidden="true">unlayered</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/layer-cascade-animation-sk/style.css
+++ b/submissions/examples/layer-cascade-animation-sk/style.css
@@ -1,0 +1,327 @@
+/* =====================================================
+   Declare layer order — last name = highest priority.
+   override > theme > base
+   ===================================================== */
+@layer base, theme, override;
+
+/* =====================================================
+   Keyframes — defined outside layers so all layers
+   can reference them without re-declaring.
+   ===================================================== */
+@keyframes pulse-blue {
+  0%, 100% { transform: scale(1);    background: #1d4ed8; }
+  50%       { transform: scale(1.2); background: #3b82f6; }
+}
+
+@keyframes bounce-pink {
+  from { transform: translateY(0);     background: #db2777; }
+  to   { transform: translateY(-28px); background: #f472b6; }
+}
+
+@keyframes spin-green {
+  from { transform: rotate(0deg);   background: #059669; }
+  to   { transform: rotate(360deg); background: #34d399; }
+}
+
+@keyframes pulse-amber {
+  from { transform: scale(1)    rotate(-3deg); }
+  to   { transform: scale(1.15) rotate( 3deg); }
+}
+
+/* =====================================================
+   Global reset / base styles
+   ===================================================== */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+/* =====================================================
+   Demo wrapper
+   ===================================================== */
+.layer-demo {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+h1 {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  text-align: center;
+}
+
+/* =====================================================
+   Layer order declaration panel
+   ===================================================== */
+.layer-order {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 10px;
+  padding: 0.75rem 1.25rem;
+  text-align: center;
+  width: 100%;
+}
+
+.layer-order code {
+  display: block;
+  font-size: 0.95rem;
+  color: #a5b4fc;
+  letter-spacing: 0.02em;
+  margin-bottom: 0.3rem;
+}
+
+.order-arrow {
+  font-size: 0.7rem;
+  color: #64748b;
+  letter-spacing: 0.04em;
+}
+
+/* =====================================================
+   Hidden toggle inputs — still participate in DOM
+   sibling combinators, invisible to the eye.
+   ===================================================== */
+.layer-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none; /* labels handle clicks via `for` */
+}
+
+/* =====================================================
+   Layer control labels
+   ===================================================== */
+.controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 100%;
+}
+
+.ctrl {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  background: #1e293b;
+  border: 2px solid #334155;
+  border-radius: 12px;
+  padding: 0.8rem 1rem;
+  min-width: 110px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, opacity 0.15s ease;
+  user-select: none;
+}
+
+.ctrl:hover { background: #263347; }
+
+.ctrl__indicator {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 3px solid currentColor;
+  transition: background 0.15s ease;
+}
+
+.ctrl__name {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ctrl__desc {
+  font-size: 0.67rem;
+  color: #64748b;
+}
+
+/* Per-layer colour tinting */
+.ctrl--base   { color: #60a5fa; }
+.ctrl--theme  { color: #f472b6; }
+.ctrl--override { color: #34d399; }
+
+/* Active state — checkbox checked */
+#base-on:checked     ~ .controls .ctrl--base     { border-color: #60a5fa; background: #1a2744; }
+#theme-on:checked    ~ .controls .ctrl--theme    { border-color: #f472b6; background: #2a1a2e; }
+#override-on:checked ~ .controls .ctrl--override { border-color: #34d399; background: #152a22; }
+
+#base-on:checked     ~ .controls .ctrl--base     .ctrl__indicator { background: #60a5fa; }
+#theme-on:checked    ~ .controls .ctrl--theme    .ctrl__indicator { background: #f472b6; }
+#override-on:checked ~ .controls .ctrl--override .ctrl__indicator { background: #34d399; }
+
+/* Unchecked → dim the control */
+.ctrl--base,
+.ctrl--theme,
+.ctrl--override { opacity: 0.4; }
+
+#base-on:checked     ~ .controls .ctrl--base     { opacity: 1; }
+#theme-on:checked    ~ .controls .ctrl--theme    { opacity: 1; }
+#override-on:checked ~ .controls .ctrl--override { opacity: 1; }
+
+/* =====================================================
+   Contest box — the element that multiple layers fight over
+   ===================================================== */
+.contest-box {
+  width: 120px;
+  height: 120px;
+  border-radius: 18px;
+  background: #1e293b;
+  border: 2px dashed #334155;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.contest-box__label {
+  font-size: 0.65rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* =====================================================
+   @layer rules — each layer claims the contest box.
+   The layer declared last in @layer base, theme, override
+   wins: override > theme > base.
+
+   Because we use #id:checked ~ .contest-box selectors,
+   a layer only "claims" the box when its toggle is on.
+   ===================================================== */
+@layer base {
+  #base-on:checked ~ .contest-box {
+    background: #1d4ed8;
+    border-color: #3b82f6;
+    animation: pulse-blue 2s ease-in-out infinite;
+  }
+  #base-on:checked ~ .contest-box .contest-box__label { color: #bfdbfe; }
+}
+
+@layer theme {
+  #theme-on:checked ~ .contest-box {
+    background: #db2777;
+    border-color: #f472b6;
+    animation: bounce-pink 0.45s ease-in-out infinite alternate;
+  }
+  #theme-on:checked ~ .contest-box .contest-box__label { color: #fce7f3; }
+}
+
+@layer override {
+  #override-on:checked ~ .contest-box {
+    background: #059669;
+    border-color: #34d399;
+    animation: spin-green 1.5s linear infinite;
+  }
+  #override-on:checked ~ .contest-box .contest-box__label { color: #d1fae5; }
+}
+
+/* =====================================================
+   Winner badge — unlayered CSS, so regular source-order
+   cascade applies. The last matching :checked rule wins.
+   This naturally mirrors @layer priority because override
+   is declared last here too — a satisfying double-proof.
+   ===================================================== */
+.winner-badge {
+  font-size: 0.78rem;
+  text-align: center;
+  color: #64748b;
+  min-height: 1.4em;
+}
+
+.winner-badge__text::before { content: "No layers active"; }
+
+#base-on:checked     ~ .winner-badge .winner-badge__text::before {
+  content: "base wins \2192  slow blue pulse";
+  color: #93c5fd;
+}
+
+#theme-on:checked    ~ .winner-badge .winner-badge__text::before {
+  content: "theme wins \2192  pink bounce";
+  color: #f9a8d4;
+}
+
+#override-on:checked ~ .winner-badge .winner-badge__text::before {
+  content: "override wins \2192  green spin";
+  color: #6ee7b7;
+}
+
+/* =====================================================
+   Unlayered section
+   ===================================================== */
+.unlayered-section {
+  width: 100%;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.unlayered-section h2 {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #fbbf24;
+  letter-spacing: 0.02em;
+}
+
+.unlayered-desc {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  line-height: 1.6;
+  max-width: 380px;
+}
+
+.unlayered-desc code {
+  color: #fbbf24;
+  background: #292524;
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+/* Unlayered rule — beats all @layer rules automatically */
+.unlayered-box {
+  width: 100px;
+  height: 100px;
+  border-radius: 14px;
+  background: #d97706;
+  border: 2px solid #fbbf24;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: pulse-amber 0.75s ease-in-out infinite alternate;
+}
+
+.unlayered-box__label {
+  font-size: 0.65rem;
+  color: #fef3c7;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* =====================================================
+   Reduced motion
+   ===================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .contest-box,
+  .unlayered-box {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Description

Closes #12425

Interactive demo that makes the `@layer` cascade priority rule viscerally obvious through motion — no JavaScript.

**How the toggle works:** Three `<input type="checkbox">` elements are placed in the DOM *before* the `.contest-box`. Each `@layer` block uses an `#id:checked ~ .contest-box` selector to claim the box's animation:

```css
@layer base, theme, override;   /* override = highest priority */

@layer base     { #base-on:checked     ~ .contest-box { animation: pulse-blue  2s ... } }
@layer theme    { #theme-on:checked    ~ .contest-box { animation: bounce-pink 0.45s ... } }
@layer override { #override-on:checked ~ .contest-box { animation: spin-green  1.5s ... } }
```

When all three are checked, all three selectors match — but `@layer` priority means `override` wins and the box spins green. Unchecking `override` hands control to `theme` (pink bounce). Unchecking both hands it to `base` (blue pulse). The cascade priority rule becomes interactive proof.

A `.unlayered-box` carries an animation outside any `@layer`. It always plays its amber animation regardless of toggle state, demonstrating that unlayered rules beat every layered rule.

## Type of Change

- [x] New example/demo submission

## Checklist

- [x] Follows existing folder structure (`submissions/examples/<name>/`)
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No JavaScript used
- [x] `prefers-reduced-motion` handled
- [x] All 13 existing tests pass (`npm test`)