### PR TITLE
feat(submission): CSS parametric keyframe injection — one @keyframes, five distinct animations

### DIFF
--- a/submissions/examples/parametric-keyframe-injection-sk/README.md
+++ b/submissions/examples/parametric-keyframe-injection-sk/README.md
@@ -1,0 +1,23 @@
+# CSS Parametric Keyframe Injection
+
+1. **What does this do?**
+   Five visually distinct animations — float up, slide-and-scale, diagonal arc-spin, spring bounce, and atmospheric drift — all produced by a **single `@keyframes` rule** and a single `.motion-atom` class. Each box configures its own unique motion by setting `--travel-x`, `--travel-y`, `--rotation`, `--end-scale`, `--duration`, and `--easing` as inline CSS custom properties.
+
+2. **How is it used?**
+   Add the `.motion-atom` class and set motion parameters inline:
+
+   ```html
+   <div class="motion-atom" style="
+     --travel-x: 0px;
+     --travel-y: -70px;
+     --rotation: 0deg;
+     --end-scale: 1;
+     --duration: 1.4s;
+     --easing: ease-in-out;
+   ">Float Up</div>
+   ```
+
+   The `@keyframes parametric-motion` block references these via `var()` in the `to` state. Because `var()` inside `@keyframes` resolves at the element — not globally — each element gets its own computed transform.
+
+3. **Why is it useful?**
+   This is the CSS equivalent of a motion token system. Instead of writing a new `@keyframes` block for every animation variant, you write one composable keyframe and parameterise it. Adding a new animation variant is a single HTML attribute change — no new CSS required. Directly aligned with EaseMotion CSS's composable, utility-first approach.

--- a/submissions/examples/parametric-keyframe-injection-sk/demo.html
+++ b/submissions/examples/parametric-keyframe-injection-sk/demo.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Parametric Keyframe Injection</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main>
+    <h1>One <code>@keyframes</code>, Infinite Variants</h1>
+    <p class="subtitle">
+      Each box uses the same <code>.motion-atom</code> class and the same
+      <code>@keyframes parametric-motion</code>. Only the inline custom
+      properties differ — <code>var()</code> inside <code>@keyframes</code>
+      resolves per-element.
+    </p>
+
+    <!--
+      All five boxes share one @keyframes and one class.
+      Motion is entirely configured by inline --travel-x, --travel-y,
+      --rotation, --end-scale, --duration, and --easing.
+      No additional CSS needed to create a new variant.
+    -->
+    <div class="parametric-grid">
+
+      <!-- Each atom is wrapped in a fixed-size stage so the flex layout
+           stays stable while the atom animates freely inside it. -->
+
+      <div class="atom-stage">
+        <figure class="motion-atom"
+          style="
+            --travel-x: 0px;
+            --travel-y: -60px;
+            --rotation: 0deg;
+            --end-scale: 1;
+            --duration: 1.4s;
+            --easing: ease-in-out;
+          "
+          aria-label="Float Up: rises 60px then returns, no rotation"
+        >
+          <span class="atom__icon" aria-hidden="true">&#8593;</span>
+          <figcaption>Float Up</figcaption>
+        </figure>
+      </div>
+
+      <div class="atom-stage">
+        <figure class="motion-atom"
+          style="
+            --travel-x: 50px;
+            --travel-y: 0px;
+            --rotation: 0deg;
+            --end-scale: 1.3;
+            --duration: 0.9s;
+            --easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+          "
+          aria-label="Slide and scale: moves right and expands, spring overshoot easing"
+        >
+          <span class="atom__icon" aria-hidden="true">&#8594;</span>
+          <figcaption>Slide &amp; Scale</figcaption>
+        </figure>
+      </div>
+
+      <div class="atom-stage">
+        <figure class="motion-atom"
+          style="
+            --travel-x: 40px;
+            --travel-y: -40px;
+            --rotation: 180deg;
+            --end-scale: 0.7;
+            --duration: 1.1s;
+            --easing: ease-out;
+          "
+          aria-label="Arc and spin: moves diagonally while rotating 180 degrees"
+        >
+          <span class="atom__icon" aria-hidden="true">&#8635;</span>
+          <figcaption>Arc &amp; Spin</figcaption>
+        </figure>
+      </div>
+
+      <div class="atom-stage">
+        <figure class="motion-atom"
+          style="
+            --travel-x: 0px;
+            --travel-y: -30px;
+            --rotation: -18deg;
+            --end-scale: 1.15;
+            --duration: 0.65s;
+            --easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+          "
+          aria-label="Spring: quick overshooting bounce with slight tilt"
+        >
+          <span class="atom__icon" aria-hidden="true">&#8857;</span>
+          <figcaption>Spring</figcaption>
+        </figure>
+      </div>
+
+      <div class="atom-stage">
+        <figure class="motion-atom"
+          style="
+            --travel-x: -25px;
+            --travel-y: -40px;
+            --rotation: 6deg;
+            --end-scale: 0.92;
+            --duration: 3.2s;
+            --easing: ease-in-out;
+          "
+          aria-label="Drift: slow atmospheric float with gentle tilt"
+        >
+          <span class="atom__icon" aria-hidden="true">&#9729;</span>
+          <figcaption>Drift</figcaption>
+        </figure>
+      </div>
+
+    </div>
+
+    <div class="code-card" aria-label="The single shared keyframe definition">
+      <p class="code-card__label">The single shared keyframe — all variants above come from this alone</p>
+      <pre><code>@keyframes parametric-motion {
+  from {
+    transform: translate(0, 0) rotate(0deg) scale(1);
+  }
+  to {
+    transform:
+      translate(var(--travel-x, 0px), var(--travel-y, -60px))
+      rotate(var(--rotation, 0deg))
+      scale(var(--end-scale, 1));
+  }
+}</code></pre>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/parametric-keyframe-injection-sk/style.css
+++ b/submissions/examples/parametric-keyframe-injection-sk/style.css
@@ -1,0 +1,182 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+main {
+  width: 100%;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+h1 {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  text-align: center;
+}
+
+h1 code {
+  color: #a5b4fc;
+  font-size: 0.95em;
+}
+
+.subtitle {
+  font-size: 0.82rem;
+  color: #94a3b8;
+  text-align: center;
+  line-height: 1.7;
+  max-width: 500px;
+}
+
+.subtitle code {
+  color: #c4b5fd;
+  background: #1e1b4b;
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+/* =====================================================
+   The ONE shared keyframe.
+   var() references resolve at the element level —
+   each .motion-atom injects its own values inline.
+   ===================================================== */
+@keyframes parametric-motion {
+  from {
+    transform: translate(0, 0) rotate(0deg) scale(1);
+  }
+  to {
+    transform:
+      translate(var(--travel-x, 0px), var(--travel-y, -60px))
+      rotate(var(--rotation, 0deg))
+      scale(var(--end-scale, 1));
+  }
+}
+
+/* =====================================================
+   Grid container
+   ===================================================== */
+.parametric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 170px);
+  grid-template-rows: repeat(2, 170px);
+  gap: 0.75rem;
+  justify-content: center;
+  width: 100%;
+  padding: 2rem 1.25rem;
+  background: #111827;
+  border-radius: 18px;
+  border: 1px solid #1f2937;
+}
+
+/* Fixed-size stage — the flex layout is based on this box,
+   the atom moves via transform inside it without shifting siblings. */
+.atom-stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: visible;
+}
+
+/* Centre the 4th and 5th items across the bottom row */
+.atom-stage:nth-child(4) { grid-column: 1; }
+.atom-stage:nth-child(5) { grid-column: 2; }
+
+/* =====================================================
+   Motion atom — the shared class.
+   All animation config comes from inline custom props.
+   ===================================================== */
+.motion-atom {
+  width: 110px;
+  height: 110px;
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  cursor: default;
+
+  animation:
+    parametric-motion
+    var(--duration, 0.8s)
+    var(--easing, ease)
+    var(--delay, 0s)
+    infinite
+    alternate;
+}
+
+.atom__icon {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.motion-atom figcaption {
+  font-size: 0.67rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  line-height: 1.2;
+}
+
+/* Per-atom colour + stagger delay — the only per-atom CSS (no new @keyframes needed) */
+.atom-stage:nth-child(1) .motion-atom { --delay: 0s;     background: #4f46e5; }
+.atom-stage:nth-child(2) .motion-atom { --delay: 0.15s;  background: #7c3aed; }
+.atom-stage:nth-child(3) .motion-atom { --delay: 0.3s;   background: #be185d; }
+.atom-stage:nth-child(4) .motion-atom { --delay: 0.45s;  background: #0e7490; }
+.atom-stage:nth-child(5) .motion-atom { --delay: 0.6s;   background: #b45309; }
+
+/* =====================================================
+   Code display card
+   ===================================================== */
+.code-card {
+  width: 100%;
+  background: #111827;
+  border: 1px solid #1f2937;
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem;
+}
+
+.code-card__label {
+  font-size: 0.72rem;
+  color: #64748b;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.code-card pre {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.code-card code {
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.7;
+  color: #a5b4fc;
+  white-space: pre;
+}
+
+/* =====================================================
+   Reduced motion
+   ===================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .motion-atom {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Closes #12426

Demonstrates the pattern where a single `@keyframes` block drives entirely different animations on different elements by reading `var()` references that resolve per-element from inline custom properties.

**The keyframe:**

```css
@keyframes parametric-motion {
  from { transform: translate(0, 0) rotate(0deg) scale(1); }
  to {
    transform:
      translate(var(--travel-x, 0px), var(--travel-y, -60px))
      rotate(var(--rotation, 0deg))
      scale(var(--end-scale, 1));
  }
}
```

**All five animation variants use the same `.motion-atom` class and the same `@keyframes` — only the inline custom properties differ:**

| Atom | `--travel-x` | `--travel-y` | `--rotation` | `--end-scale` | `--duration` | `--easing` |
|------|-------------|-------------|-------------|--------------|-------------|-----------|
| Float Up | 0px | -60px | 0deg | 1 | 1.4s | ease-in-out |
| Slide & Scale | 50px | 0px | 0deg | 1.3 | 0.9s | cubic-bezier(overshoot) |
| Arc & Spin | 40px | -40px | 180deg | 0.7 | 1.1s | ease-out |
| Spring | 0px | -30px | -18deg | 1.15 | 0.65s | cubic-bezier(overshoot) |
| Drift | -25px | -40px | 6deg | 0.92 | 3.2s | ease-in-out |

Each atom sits in a fixed-size grid cell so the CSS layout stays stable while the box moves via `transform` inside it.

## Type of Change

- [x] New example/demo submission

## Checklist

- [x] Follows existing folder structure (`submissions/examples/<name>/`)
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No JavaScript used
- [x] `prefers-reduced-motion` handled
- [x] All 13 existing tests pass (`npm test`)