### PR TITLE
feat(submission): add ease-tabs-db toggle fix up to 8 tabs for issue …

### DIFF
--- a/submissions/examples/tabs-toggle-fix-db-12437/README.md
+++ b/submissions/examples/tabs-toggle-fix-db-12437/README.md
@@ -1,0 +1,5 @@
+# Tabs Toggle Fix (8 Tabs Support)
+
+1. What does this do? Enables full CSS-only display toggling and underline animations for up to 8 tabs.
+2. How is it used? Apply `.tabs-container` and its children using the radio input selectors as shown in the demo.
+3. Why is it useful? It fixes a core framework limitation where tabs 7 and 8 could not toggle their panel visibility.

--- a/submissions/examples/tabs-toggle-fix-db-12437/demo.html
+++ b/submissions/examples/tabs-toggle-fix-db-12437/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tabs Toggle Fix Demo (8 Tabs)</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <div class="tabs-container">
+    <!-- Tab Inputs -->
+    <input type="radio" name="tabs" id="tab-1" class="tab-input" checked>
+    <input type="radio" name="tabs" id="tab-2" class="tab-input">
+    <input type="radio" name="tabs" id="tab-3" class="tab-input">
+    <input type="radio" name="tabs" id="tab-4" class="tab-input">
+    <input type="radio" name="tabs" id="tab-5" class="tab-input">
+    <input type="radio" name="tabs" id="tab-6" class="tab-input">
+    <input type="radio" name="tabs" id="tab-7" class="tab-input">
+    <input type="radio" name="tabs" id="tab-8" class="tab-input">
+
+    <!-- Tab Navigation -->
+    <div class="tabs-nav">
+      <label for="tab-1" class="tab-label">Tab 1</label>
+      <label for="tab-2" class="tab-label">Tab 2</label>
+      <label for="tab-3" class="tab-label">Tab 3</label>
+      <label for="tab-4" class="tab-label">Tab 4</label>
+      <label for="tab-5" class="tab-label">Tab 5</label>
+      <label for="tab-6" class="tab-label">Tab 6</label>
+      <label for="tab-7" class="tab-label">Tab 7</label>
+      <label for="tab-8" class="tab-label">Tab 8</label>
+      <div class="tab-underline"></div>
+    </div>
+
+    <!-- Tab Content -->
+    <div class="tabs-content">
+      <div class="tab-panel"><h3>Tab Content 1</h3><p>This is the content panel for Tab 1.</p></div>
+      <div class="tab-panel"><h3>Tab Content 2</h3><p>This is the content panel for Tab 2.</p></div>
+      <div class="tab-panel"><h3>Tab Content 3</h3><p>This is the content panel for Tab 3.</p></div>
+      <div class="tab-panel"><h3>Tab Content 4</h3><p>This is the content panel for Tab 4.</p></div>
+      <div class="tab-panel"><h3>Tab Content 5</h3><p>This is the content panel for Tab 5.</p></div>
+      <div class="tab-panel"><h3>Tab Content 6</h3><p>This is the content panel for Tab 6.</p></div>
+      <div class="tab-panel"><h3>Tab Content 7</h3><p>This is the content panel for Tab 7. It displays correctly now!</p></div>
+      <div class="tab-panel"><h3>Tab Content 8</h3><p>This is the content panel for Tab 8. It displays correctly now!</p></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tabs-toggle-fix-db-12437/style.css
+++ b/submissions/examples/tabs-toggle-fix-db-12437/style.css
@@ -1,0 +1,105 @@
+/* Tabs Container */
+.tabs-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  font-family: sans-serif;
+  max-width: 600px;
+  margin: 2rem auto;
+}
+
+.tabs-nav {
+  display: flex;
+  border-bottom: 2px solid #cbd5e1;
+  position: relative;
+  margin-bottom: 1rem;
+}
+
+.tab-label {
+  flex: 1;
+  text-align: center;
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #64748b;
+  transition: color 0.15s ease;
+  user-select: none;
+}
+
+.tab-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Sliding Underline Effect */
+.tab-underline {
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  height: 2px;
+  width: calc(100% / 8);
+  background-color: #6c63ff;
+  transition: transform 0.30s ease;
+}
+
+/* Content Toggling */
+.tab-panel {
+  display: none;
+  padding: 1.5rem;
+  background: #f8fafc;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5e1;
+  animation: fadeIn 0.30s ease both;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Select state for labels */
+.tab-input:nth-of-type(1):checked ~ .tabs-nav .tab-label:nth-of-type(1),
+.tab-input:nth-of-type(2):checked ~ .tabs-nav .tab-label:nth-of-type(2),
+.tab-input:nth-of-type(3):checked ~ .tabs-nav .tab-label:nth-of-type(3),
+.tab-input:nth-of-type(4):checked ~ .tabs-nav .tab-label:nth-of-type(4),
+.tab-input:nth-of-type(5):checked ~ .tabs-nav .tab-label:nth-of-type(5),
+.tab-input:nth-of-type(6):checked ~ .tabs-nav .tab-label:nth-of-type(6),
+.tab-input:nth-of-type(7):checked ~ .tabs-nav .tab-label:nth-of-type(7),
+.tab-input:nth-of-type(8):checked ~ .tabs-nav .tab-label:nth-of-type(8) {
+  color: #6c63ff;
+}
+
+/* Underline translation */
+.tab-input:nth-of-type(1):checked ~ .tabs-nav .tab-underline { transform: translateX(0); }
+.tab-input:nth-of-type(2):checked ~ .tabs-nav .tab-underline { transform: translateX(100%); }
+.tab-input:nth-of-type(3):checked ~ .tabs-nav .tab-underline { transform: translateX(200%); }
+.tab-input:nth-of-type(4):checked ~ .tabs-nav .tab-underline { transform: translateX(300%); }
+.tab-input:nth-of-type(5):checked ~ .tabs-nav .tab-underline { transform: translateX(400%); }
+.tab-input:nth-of-type(6):checked ~ .tabs-nav .tab-underline { transform: translateX(500%); }
+.tab-input:nth-of-type(7):checked ~ .tabs-nav .tab-underline { transform: translateX(600%); }
+.tab-input:nth-of-type(8):checked ~ .tabs-nav .tab-underline { transform: translateX(700%); }
+
+/* Content Panel toggling up to 8 tabs */
+.tab-input:nth-of-type(1):checked ~ .tabs-content .tab-panel:nth-of-type(1),
+.tab-input:nth-of-type(2):checked ~ .tabs-content .tab-panel:nth-of-type(2),
+.tab-input:nth-of-type(3):checked ~ .tabs-content .tab-panel:nth-of-type(3),
+.tab-input:nth-of-type(4):checked ~ .tabs-content .tab-panel:nth-of-type(4),
+.tab-input:nth-of-type(5):checked ~ .tabs-content .tab-panel:nth-of-type(5),
+.tab-input:nth-of-type(6):checked ~ .tabs-content .tab-panel:nth-of-type(6),
+.tab-input:nth-of-type(7):checked ~ .tabs-content .tab-panel:nth-of-type(7),
+.tab-input:nth-of-type(8):checked ~ .tabs-content .tab-panel:nth-of-type(8) {
+  display: block;
+}


### PR DESCRIPTION
Closes #12437 
## Pull Request Description

This PR resolves the issue regarding: fix: extend tab panel toggling to support up to eight tabs.
All modifications are kept strictly inside the submissions directory to comply with the core protection rules.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (performance enhancement)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/tabs-toggle-fix-db/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Enables full CSS-only display toggling and underline animations for up to 8 tabs.

**How does a developer use it?**

```html
Apply `.tabs-container` layout with matching input radio selectors as shown in the demo.
```

**Why does it fit EaseMotion CSS?**

It resolves a framework limitation where tabs 7 and 8 could not toggle their panel visibility.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional)*

---

