### PR TITLE
feat: add ease-fade-in-right — fade in while sliding from left

### DIFF
--- a/submissions/examples/ease-fade-in-right-anim/README.md
+++ b/submissions/examples/ease-fade-in-right-anim/README.md
@@ -1,0 +1,54 @@
+# ease-fade-in-right — Fade In While Sliding from Left
+
+Enter animation: element fades in while sliding from the left to its natural position. Enter counterpart to `ease-fade-out-left`.
+
+## Classes
+
+| Class | Distance | Description |
+|-------|----------|-------------|
+| `.ease-fade-in-right` | 32px | Default entry from left |
+| `+ .ease-fade-in-right-sm` | 16px | Subtle entry |
+| `+ .ease-fade-in-right-lg` | 64px | Dramatic entry |
+
+## CSS Custom Properties
+
+| Token | Default | Description |
+|-------|---------|-------------|
+| `--ease-fade-in-right-distance` | `32px` | Start offset from left |
+| `--ease-fade-in-right-duration` | `--ease-speed-medium` | Duration |
+| `--ease-fade-in-right-easing` | `--ease-ease` | Timing function |
+
+## Direction family (complete)
+
+| Direction | Enter | Exit |
+|-----------|-------|------|
+| → Right (from left) | `.ease-fade-in-right` ← this | `.ease-fade-out-left` |
+| ← Left (from right) | `.ease-fade-in-left` | `.ease-fade-out-right` |
+
+## Usage
+
+```html
+<div class="ease-fade-in-right">Slides in from left</div>
+
+<!-- Stagger -->
+<div class="ease-fade-in-right" style="animation-delay: 0s">Item 1</div>
+<div class="ease-fade-in-right" style="animation-delay: 0.1s">Item 2</div>
+
+<!-- Custom -->
+<div class="ease-fade-in-right" style="--ease-fade-in-right-distance: 80px;">
+  Slides in from further left
+</div>
+```
+
+## Use cases
+
+- Back navigation (page slides in from left)
+- Sidebar content entry
+- Left-to-right list reveal
+- Undo action feedback
+
+## Accessibility
+
+`animation-duration` reduced to `1ms` when `prefers-reduced-motion: reduce` is set.
+
+Closes #11829

--- a/submissions/examples/ease-fade-in-right-anim/demo.html
+++ b/submissions/examples/ease-fade-in-right-anim/demo.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-fade-in-right — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 780px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p  { color: var(--ease-color-muted); margin-bottom: 1.5rem; max-width: 600px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .controls { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1rem; }
+    .demo-box {
+      display: inline-flex; align-items: center; justify-content: center;
+      padding: var(--ease-space-4) var(--ease-space-6);
+      background: var(--ease-color-primary); color: #fff;
+      border-radius: var(--ease-radius-md); font-weight: 700;
+      font-size: 0.9375rem; min-width: 140px;
+    }
+    .demo-stage {
+      min-height: 90px; display: flex; align-items: center;
+      padding: var(--ease-space-4);
+      background: var(--ease-color-neutral-50);
+      border: 1px dashed var(--ease-color-neutral-300);
+      border-radius: var(--ease-radius-lg);
+      margin-bottom: var(--ease-space-3);
+      overflow: hidden;
+    }
+    .label { font-family: var(--ease-font-mono); font-size: 0.75rem;
+             color: var(--ease-color-muted); margin-top: 0.25rem; }
+    .row { display: flex; gap: 1.5rem; flex-wrap: wrap; }
+    .col { display: flex; flex-direction: column; }
+  </style>
+</head>
+<body>
+  <h2>ease-fade-in-right</h2>
+  <p>
+    Fades in while sliding from the left — starts offset to the left and
+    arrives at its natural position moving right.
+    Enter counterpart to <code>.ease-fade-out-left</code>.
+  </p>
+
+  <h3>Default</h3>
+  <div class="demo-stage">
+    <div class="demo-box ease-fade-in-right" id="box-default">Fade in right</div>
+  </div>
+  <div class="controls">
+    <button class="ease-btn ease-btn-primary" onclick="retrigger('box-default','ease-fade-in-right')">Retrigger</button>
+  </div>
+  <div class="label">.ease-fade-in-right (32px from left)</div>
+
+  <h3>Size variants</h3>
+  <div class="row">
+    <div class="col">
+      <div class="demo-stage" style="width:200px;">
+        <div class="demo-box" id="box-sm" style="background:var(--ease-color-success);">Small (16px)</div>
+      </div>
+      <div class="controls">
+        <button class="ease-btn ease-btn-outline" onclick="retrigger('box-sm','ease-fade-in-right ease-fade-in-right-sm')">Trigger</button>
+      </div>
+      <div class="label">.ease-fade-in-right-sm</div>
+    </div>
+    <div class="col">
+      <div class="demo-stage" style="width:200px;">
+        <div class="demo-box" id="box-lg" style="background:var(--ease-color-danger);">Large (64px)</div>
+      </div>
+      <div class="controls">
+        <button class="ease-btn ease-btn-outline" onclick="retrigger('box-lg','ease-fade-in-right ease-fade-in-right-lg')">Trigger</button>
+      </div>
+      <div class="label">.ease-fade-in-right-lg</div>
+    </div>
+  </div>
+
+  <h3>Staggered list entry from left</h3>
+  <div class="demo-stage" style="flex-direction:column;align-items:flex-start;gap:0.5rem;min-height:160px;">
+    <div class="demo-box ease-fade-in-right" id="item-1"
+         style="min-width:180px;background:#6c63ff;animation-delay:0s;">Item 1</div>
+    <div class="demo-box ease-fade-in-right" id="item-2"
+         style="min-width:180px;background:#22c55e;animation-delay:0.1s;">Item 2</div>
+    <div class="demo-box ease-fade-in-right" id="item-3"
+         style="min-width:180px;background:#f59e0b;animation-delay:0.2s;">Item 3</div>
+  </div>
+  <div class="controls">
+    <button class="ease-btn ease-btn-outline" onclick="retriggStagger()">Retrigger stagger</button>
+  </div>
+  <div class="label">Stagger: 0s / 0.1s / 0.2s</div>
+
+  <h3>Custom distance</h3>
+  <div class="demo-stage">
+    <div class="demo-box" id="box-custom" style="background:#8b5cf6;">Custom 80px</div>
+  </div>
+  <div class="controls">
+    <button class="ease-btn ease-btn-outline" onclick="triggerCustom()">Trigger 80px</button>
+  </div>
+  <div class="label">--ease-fade-in-right-distance: 80px</div>
+
+  <script>
+    function retrigger(id, cls) {
+      const el = document.getElementById(id);
+      el.classList.remove(...cls.split(' '));
+      void el.offsetWidth;
+      cls.split(' ').forEach(c => el.classList.add(c));
+    }
+    function retriggStagger() {
+      [['item-1',0],['item-2',100],['item-3',200]].forEach(([id,delay]) => {
+        const el = document.getElementById(id);
+        el.classList.remove('ease-fade-in-right');
+        el.style.animationDelay = delay + 'ms';
+        void el.offsetWidth;
+        el.classList.add('ease-fade-in-right');
+      });
+    }
+    function triggerCustom() {
+      const el = document.getElementById('box-custom');
+      el.style.setProperty('--ease-fade-in-right-distance','80px');
+      el.classList.remove('ease-fade-in-right');
+      void el.offsetWidth;
+      el.classList.add('ease-fade-in-right');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-fade-in-right-anim/style.css
+++ b/submissions/examples/ease-fade-in-right-anim/style.css
@@ -1,0 +1,62 @@
+/* ============================================================
+   ease-fade-in-right — Fade in while sliding from left
+   EaseMotion CSS Submission
+
+   Element fades in from opacity 0 while sliding in from the
+   left side — arrives at its natural position from the left.
+   Enter counterpart to ease-fade-out-left.
+
+   Classes:
+     .ease-fade-in-right       — default entry from left (32px)
+     .ease-fade-in-right-sm    — subtle entry (16px)
+     .ease-fade-in-right-lg    — dramatic entry (64px)
+
+   CSS Custom Properties:
+     --ease-fade-in-right-distance  — start offset from left (default 32px)
+     --ease-fade-in-right-duration  — duration (default --ease-speed-medium)
+     --ease-fade-in-right-easing    — timing function (default --ease-ease)
+   ============================================================ */
+
+@layer easemotion-components {
+
+  /* ── Keyframe ────────────────────────────────────────────── */
+  @keyframes ease-kf-fade-in-right {
+    from {
+      opacity: 0;
+      transform: translate3d(
+        calc(var(--ease-fade-in-right-distance, 32px) * -1),
+        0,
+        0
+      );
+    }
+    to {
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+    }
+  }
+
+  /* ── Base class ──────────────────────────────────────────── */
+  .ease-fade-in-right {
+    --ease-fade-in-right-distance: 32px;
+
+    animation:
+      ease-kf-fade-in-right
+      var(--ease-fade-in-right-duration, var(--ease-speed-medium, 300ms))
+      var(--ease-fade-in-right-easing, var(--ease-ease, cubic-bezier(0.4,0,0.2,1)))
+      both;
+  }
+
+  /* ── Size variants ───────────────────────────────────────── */
+  .ease-fade-in-right-sm { --ease-fade-in-right-distance: 16px; }
+  .ease-fade-in-right-lg { --ease-fade-in-right-distance: 64px; }
+
+  /* ── Reduced motion ──────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-fade-in-right {
+      animation-duration: 1ms;
+      transform: none;
+      opacity: 1;
+    }
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-fade-in-right` — an enter animation where the element fades in while sliding from the left to its natural position. Enter counterpart to `ease-fade-out-left`. Completes the horizontal fade direction set.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

| Class | Distance |
|-------|----------|
| `.ease-fade-in-right` | 32px from left |
| `+ .ease-fade-in-right-sm` | 16px |
| `+ .ease-fade-in-right-lg` | 64px |

```css
--ease-fade-in-right-distance: 32px;
--ease-fade-in-right-duration: var(--ease-speed-medium);
--ease-fade-in-right-easing:   var(--ease-ease);
```

**Complete horizontal fade family:**

| Direction | Enter | Exit |
|-----------|-------|------|
| → (from left) | `.ease-fade-in-right` ← this PR | `.ease-fade-out-left` |
| ← (from right) | `.ease-fade-in-left` | `.ease-fade-out-right` |

**Use cases:** Back navigation, sidebar content entry, left-to-right list reveal, undo feedback.

---

## Demo
- [x] Demo added (`demo.html` — all variants, staggered list, custom 80px token)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

Closes #11829