### PR TITLE
feat: add ease-skip-ink text-decoration-skip-ink utility classes

### DIFF
--- a/submissions/examples/text-decoration-skip-ink/README.md
+++ b/submissions/examples/text-decoration-skip-ink/README.md
@@ -1,0 +1,48 @@
+# ease-skip-ink — Text Decoration Skip Ink Utility Classes
+
+Utility classes to control `text-decoration-skip-ink` — whether underline, overline, and line-through decorations skip over the descenders of letters like g, j, p, q, y.
+
+## Classes
+
+| Class | `text-decoration-skip-ink` |
+|-------|------------------------------|
+| `.ease-skip-ink-auto` | `auto` |
+| `.ease-skip-ink-none` | `none` |
+| `.ease-skip-ink-all` | `all` |
+
+## Usage
+
+```html
+<!-- Default body links -->
+<p class="ease-skip-ink-auto">
+  Read more about our <a href="#">pricing page</a>.
+</p>
+
+<!-- Decorative underline, descenders intentionally crossed -->
+<span class="ease-skip-ink-none">Brand wordmark</span>
+
+<!-- Force skip on every decoration line, including line-through -->
+<p class="ease-skip-ink-all" style="text-decoration-line: line-through;">
+  Discontinued product
+</p>
+```
+
+## When to use each class
+
+| Class | Best for |
+|-------|----------|
+| `.ease-skip-ink-auto` | Body links and inline text, safest cross-browser default |
+| `.ease-skip-ink-none` | Decorative underlines, buttons, brand marks |
+| `.ease-skip-ink-all` | Long-form article links, line-through with heavy descenders |
+
+## Notes
+
+- No existing utility for this property in `core/base.css` or `components/*.css` — only `text-underline-offset` is used in a few places
+- Supported in all modern browsers (Chrome, Firefox, Safari, Edge)
+- Safari has historically skipped ink by default, so `.ease-skip-ink-none` shows the most visible cross-browser difference
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS sets underline decorations in several components (`announce-bar.css`, `breadcrumb.css`, `buttons.css`) but never controls skip-ink behavior explicitly. These classes give consumers fine-grained control over decoration legibility without touching `core/` or `components/`.
+
+Closes #11604

--- a/submissions/examples/text-decoration-skip-ink/demo.html
+++ b/submissions/examples/text-decoration-skip-ink/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text Decoration Skip Ink Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { padding: 2rem; font-family: var(--ease-font-sans); max-width: 800px; margin: 0 auto; }
+    h2 { margin-bottom: 0.5rem; }
+    p.intro { color: var(--ease-color-muted); margin-bottom: 2rem; max-width: 620px; }
+    h3 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase;
+         letter-spacing: 0.05em; color: var(--ease-color-muted);
+         margin: 2.5rem 0 1rem; border-top: 1px solid var(--ease-color-neutral-200);
+         padding-top: 1.5rem; }
+    h3:first-of-type { border-top: none; padding-top: 0; }
+    .compare-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .compare-box {
+      padding: var(--ease-space-5);
+      border: 1px solid var(--ease-color-neutral-200);
+      border-radius: var(--ease-radius-lg);
+      background: var(--ease-color-surface);
+    }
+    .compare-label {
+      font-family: var(--ease-font-mono);
+      font-size: 0.7rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+    .sample-text { font-size: 1.25rem; font-weight: 500; line-height: 1.8;
+      text-decoration: underline; text-decoration-thickness: 2px; }
+    .info {
+      background: var(--ease-color-neutral-100);
+      border-radius: var(--ease-radius-md);
+      padding: var(--ease-space-4);
+      font-size: 0.8125rem;
+      color: var(--ease-color-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+    @media (max-width: 600px) { .compare-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h2>Text Decoration Skip Ink Utility Classes</h2>
+  <p class="intro">
+    Controls whether underline/overline/line-through decorations skip over
+    descenders (g, j, p, q, y). Use words with descenders below to see the
+    difference — the gap under the loops of each letter.
+  </p>
+
+  <div class="info">
+    💡 <strong>Note:</strong> Supported in all modern browsers. Safari has
+    historically defaulted to skipping ink even without this property set;
+    Chrome and Firefox respect <code>auto</code> as skip-by-default too, so
+    <code>.ease-skip-ink-none</code> is the one with the most visible effect.
+  </div>
+
+  <h3>Auto vs none (most visible difference)</h3>
+  <div class="compare-grid">
+    <div class="compare-box">
+      <span class="compare-label">.ease-skip-ink-auto</span>
+      <p class="sample-text ease-skip-ink-auto">
+        Jumping pygmy quails enjoy yoga
+      </p>
+    </div>
+    <div class="compare-box">
+      <span class="compare-label">.ease-skip-ink-none</span>
+      <p class="sample-text ease-skip-ink-none">
+        Jumping pygmy quails enjoy yoga
+      </p>
+    </div>
+  </div>
+
+  <h3>All — forces skip on every decoration line</h3>
+  <div class="compare-grid">
+    <div class="compare-box">
+      <span class="compare-label">.ease-skip-ink-all (underline)</span>
+      <p class="sample-text ease-skip-ink-all">
+        Jumping pygmy quails enjoy yoga
+      </p>
+    </div>
+    <div class="compare-box">
+      <span class="compare-label">.ease-skip-ink-all (line-through)</span>
+      <p class="sample-text ease-skip-ink-all" style="text-decoration-line: line-through;">
+        Jumping pygmy quails enjoy yoga
+      </p>
+    </div>
+  </div>
+
+  <h3>Common use cases</h3>
+  <ul style="font-size:0.9375rem;line-height:2;color:var(--ease-color-text);">
+    <li>Body links and inline text — <code>.ease-skip-ink-auto</code> (default, safest)</li>
+    <li>Decorative underlines, buttons, brand wordmarks — <code>.ease-skip-ink-none</code></li>
+    <li>Long-form article links with heavy descender usage — <code>.ease-skip-ink-all</code></li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/text-decoration-skip-ink/style.css
+++ b/submissions/examples/text-decoration-skip-ink/style.css
@@ -1,0 +1,37 @@
+/* ============================================================
+   ease-skip-ink — text-decoration-skip-ink utility classes
+
+   Controls whether underlines/overlines skip over the descenders
+   of letters like g, j, p, q, y. No utility currently exists in
+   core/base.css or components/*.css for this — underline-offset
+   is used in several places but skip-ink is never set explicitly.
+
+   Classes:
+     .ease-skip-ink-auto — auto (browser default, usually skips)
+     .ease-skip-ink-none — none (line is unbroken, ignores descenders)
+     .ease-skip-ink-all  — all (forces skip on all decoration lines)
+
+   When to use:
+     .ease-skip-ink-auto — default body links, safest cross-browser
+     .ease-skip-ink-none — decorative underlines, buttons, brand marks
+     .ease-skip-ink-all  — long-form article links with heavy descenders
+   ============================================================ */
+
+@layer easemotion-utilities {
+
+  /* Browser default — skips descenders in most engines */
+  .ease-skip-ink-auto {
+    text-decoration-skip-ink: auto;
+  }
+
+  /* Unbroken line — ignores descenders entirely */
+  .ease-skip-ink-none {
+    text-decoration-skip-ink: none;
+  }
+
+  /* Forces skip on every decoration line, including underline/overline/line-through */
+  .ease-skip-ink-all {
+    text-decoration-skip-ink: all;
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
Adds 3 `text-decoration-skip-ink` utility classes for controlling whether underline/overline/line-through decorations skip over descenders (g, j, p, q, y) — no such utility currently exists; only `text-underline-offset` is set in a few components.

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

| Class | `text-decoration-skip-ink` | Use case |
|-------|------------------------------|----------|
| `.ease-skip-ink-auto` | `auto` | Body links, safest default |
| `.ease-skip-ink-none` | `none` | Decorative underlines, buttons |
| `.ease-skip-ink-all` | `all` | Long-form links, line-through |

**How does a developer use it?**
```html
<p class="ease-skip-ink-auto">
  Read more about our <a href="#">pricing page</a>.
</p>
```

**Why does it fit EaseMotion CSS?**
EaseMotion CSS sets underline decorations in `announce-bar.css`, `breadcrumb.css`, `buttons.css` but never controls skip-ink explicitly. These classes complete the decoration control system.

---

## Demo
- [x] Demo added (`demo.html` — auto/none/all comparisons with descender-heavy sample text)

---

## Browser Testing
- [x] Chrome (macOS)
- [x] Firefox (macOS)
- [x] Edge
- [ ] Safari *(optional — historically skips ink by default)*

---

## Notes for Maintainer
`.ease-skip-ink-none` shows the most visible cross-browser difference since Safari has historically skipped ink by default even without this property set.

Closes #11604