### PR TITLE
[BUG] Fix README Table of Contents — add 3 missing sections and quick-install sub-links

### DIFF
--- a/submissions/core_changes/readme-toc-fix-ss/README.md
+++ b/submissions/core_changes/readme-toc-fix-ss/README.md
@@ -1,0 +1,50 @@
+# README Table of Contents Fix (ss)
+
+1. **What does this do?**  
+   Fixes the Table of Contents in root `README.md` — adds 3 missing `##` sections (`Alternative CDN Providers`, `Issue Labels 🏷️`, `Accessibility`), removes the anchor from the `Table of Contents 📑` heading itself (which was linking back to itself), and adds key `###` subsections for better navigation.
+
+2. **How is it used?**  
+   Review `patch.md` for the exact diff. Apply the changes to `README.md` lines 48–67 (the TOC block). The corrected TOC becomes:
+
+   ```markdown
+   - [Support the Project](#support-the-project)
+   - [Project Statistics](#project-statistics)
+   - [Browser Compatibility](#browser-compatibility)
+   - [What is EaseMotion CSS?](#what-is-easemotion-css)
+   - [Why EaseMotion CSS?](#why-easemotion-css)
+   - [Quick Start](#quick-start)
+     - [CDN (recommended)](#option-1--cdn-fastest-zero-setup-recommended)
+     - [npm](#option-2--npm)
+     - [Granular imports](#option-3--granular-imports-pick-only-what-you-need)
+     - [Modular animation imports](#option-4--modular-animation-imports-load-only-what-you-need)
+     - [Full bundle](#full-bundle)
+   - [Alternative CDN Providers](#alternative-cdn-providers)
+   - [Philosophy](#philosophy)
+   - [Usage and Examples](#usage-and-examples)
+   - [Customization](#customization)
+   - [FAQ](#faq)
+   - [File Structure](#file-structure)
+   - [Roadmap](#roadmap)
+   - [Contributing](#contributing)
+   - [Issue Labels 🏷️](#issue-labels-)
+   - [Community](#community)
+   - [Contributors](#contributors)
+   - [Maintainer](#maintainer)
+   - [Changelog](#changelog)
+   - [License](#license)
+   - [Accessibility](#accessibility)
+   ```
+
+3. **Why is it useful?**  
+   A complete TOC makes the ~137KB README navigable. Currently, `## Alternative CDN Providers`, `## Issue Labels 🏷️`, and `## Accessibility` are not reachable from the TOC, forcing readers to scroll manually. The fix also adds commonly-linked sub-sections (CDN, npm, granular imports) so developers can jump directly to the install method they need.
+
+---
+
+## Issues Found
+
+| Problem | Location | Fix |
+|---------|----------|-----|
+| `## Alternative CDN Providers` missing from TOC | Line 234 | Add `- [Alternative CDN Providers](#alternative-cdn-providers)` |
+| `## Issue Labels 🏷️` missing from TOC | Line 886 | Add `- [Issue Labels 🏷️](#issue-labels-)` |
+| `## Accessibility` missing from TOC | Line 1024 | Add `- [Accessibility](#accessibility)` |
+| No quick-install sub-links in TOC | Lines 207–343 | Add indented entries for CDN / npm / granular / modular / full-bundle |

--- a/submissions/core_changes/readme-toc-fix-ss/demo.html
+++ b/submissions/core_changes/readme-toc-fix-ss/demo.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>README TOC Fix — Before & After</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>README Table of Contents — Fix Preview</h1>
+    <p class="subtitle">Issue <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/12465">#12465</a> &middot; 3 missing sections + quick-install sub-links</p>
+
+    <div class="columns">
+      <div class="column before">
+        <h2>❌ Before (current TOC)</h2>
+        <ul class="toc-list">
+          <li><a>Support the Project</a></li>
+          <li><a>Project Statistics</a></li>
+          <li><a>Browser Compatibility</a></li>
+          <li><a>What is EaseMotion CSS?</a></li>
+          <li><a>Why EaseMotion CSS?</a></li>
+          <li><a>Quick Start</a></li>
+          <li><a>Philosophy</a></li>
+          <li><a>Usage and Examples</a></li>
+          <li><a>Customization</a></li>
+          <li><a>FAQ</a></li>
+          <li><a>File Structure</a></li>
+          <li><a>Roadmap</a></li>
+          <li><a>Contributing</a></li>
+          <li><a>Community</a></li>
+          <li><a>Contributors</a></li>
+          <li><a>Maintainer</a></li>
+          <li><a>Changelog</a></li>
+          <li><a>License</a></li>
+        </ul>
+        <div class="missing-badge">3 sections missing</div>
+      </div>
+
+      <div class="column after">
+        <h2>✅ After (fixed TOC)</h2>
+        <ul class="toc-list">
+          <li><a>Support the Project</a></li>
+          <li><a>Project Statistics</a></li>
+          <li><a>Browser Compatibility</a></li>
+          <li><a>What is EaseMotion CSS?</a></li>
+          <li><a>Why EaseMotion CSS?</a></li>
+          <li><a>Quick Start</a>
+            <ul>
+              <li><a>CDN (recommended)</a></li>
+              <li><a>npm</a></li>
+              <li><a>Granular imports</a></li>
+              <li><a>Modular animation imports</a></li>
+              <li><a>Full bundle</a></li>
+            </ul>
+          </li>
+          <li class="added"><span class="tag">+</span> <a>Alternative CDN Providers</a></li>
+          <li><a>Philosophy</a></li>
+          <li><a>Usage and Examples</a></li>
+          <li><a>Customization</a></li>
+          <li><a>FAQ</a></li>
+          <li><a>File Structure</a></li>
+          <li><a>Roadmap</a></li>
+          <li><a>Contributing</a></li>
+          <li class="added"><span class="tag">+</span> <a>Issue Labels 🏷️</a></li>
+          <li><a>Community</a></li>
+          <li><a>Contributors</a></li>
+          <li><a>Maintainer</a></li>
+          <li><a>Changelog</a></li>
+          <li><a>License</a></li>
+          <li class="added"><span class="tag">+</span> <a>Accessibility</a></li>
+        </ul>
+        <div class="fixed-badge">All sections linked</div>
+      </div>
+    </div>
+
+    <div class="details">
+      <h2>Changes Summary</h2>
+      <table>
+        <tr>
+          <th>Change</th>
+          <th>Details</th>
+        </tr>
+        <tr>
+          <td><strong>Add section</strong></td>
+          <td><code>Alternative CDN Providers</code> (line 234) — was unreachable from TOC</td>
+        </tr>
+        <tr>
+          <td><strong>Add section</strong></td>
+          <td><code>Issue Labels 🏷️</code> (line 886) — was unreachable from TOC</td>
+        </tr>
+        <tr>
+          <td><strong>Add section</strong></td>
+          <td><code>Accessibility</code> (line 1024) — was unreachable from TOC</td>
+        </tr>
+        <tr>
+          <td><strong>Add sub-links</strong></td>
+          <td>Quick Install sub-sections under Quick Start for faster navigation</td>
+        </tr>
+        <tr>
+          <td><strong>Anchor verification</strong></td>
+          <td>All 19 existing TOC anchors match their GitHub-generated heading IDs</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes/readme-toc-fix-ss/style.css
+++ b/submissions/core_changes/readme-toc-fix-ss/style.css
@@ -1,0 +1,187 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #0f172a;
+  padding: 40px 20px;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+  background: linear-gradient(135deg, #6366f1, #a855f7);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.subtitle {
+  color: #64748b;
+  margin-bottom: 32px;
+  font-size: 0.95rem;
+}
+
+.subtitle a {
+  color: #6366f1;
+}
+
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  margin-bottom: 40px;
+}
+
+.column {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.column h2 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 2px solid #e2e8f0;
+}
+
+.toc-list {
+  list-style: none;
+  font-size: 0.9rem;
+}
+
+.toc-list li {
+  padding: 4px 0;
+  color: #334155;
+}
+
+.toc-list li a {
+  color: #334155;
+  text-decoration: none;
+  cursor: default;
+}
+
+.toc-list li a:hover {
+  color: #6366f1;
+}
+
+.toc-list ul {
+  list-style: none;
+  padding-left: 20px;
+  font-size: 0.85rem;
+}
+
+.toc-list ul li {
+  color: #64748b;
+}
+
+.added {
+  background: #f0fdf4;
+  border-radius: 4px;
+  padding: 4px 8px !important;
+  margin: 2px 0;
+}
+
+.added .tag {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  background: #22c55e;
+  color: white;
+  border-radius: 50%;
+  text-align: center;
+  line-height: 18px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  margin-right: 4px;
+}
+
+.missing-badge {
+  display: inline-block;
+  margin-top: 16px;
+  padding: 6px 14px;
+  background: #fef2f2;
+  color: #ef4444;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.fixed-badge {
+  display: inline-block;
+  margin-top: 16px;
+  padding: 6px 14px;
+  background: #f0fdf4;
+  color: #22c55e;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.details {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.details h2 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+th {
+  text-align: left;
+  padding: 10px 12px;
+  background: #f8fafc;
+  border-bottom: 2px solid #e2e8f0;
+  font-weight: 600;
+  color: #475569;
+}
+
+td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  color: #334155;
+}
+
+td code {
+  background: #f1f5f9;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  color: #6366f1;
+}
+
+@media (max-width: 640px) {
+  .columns {
+    grid-template-columns: 1fr;
+  }
+
+  body {
+    padding: 24px 16px;
+  }
+}


### PR DESCRIPTION
## ✦ Description

Fix the README Table of Contents by adding 3 missing section links and quick-install sub-links under Quick Start. The TOC currently omits `Alternative CDN Providers`, `Issue Labels 🏷️`, and `Accessibility` — all of which are unreachable from the top navigation.

Also adds indented sub-entries for common install methods (CDN, npm, granular imports, modular animations, full bundle) so developers can jump directly to their preferred setup.

The submission in `submissions/core_changes/readme-toc-fix-ss/` includes:
- `README.md` — Analyzes the 3 missing sections and provides the corrected TOC block
- `demo.html` — Before/after visual comparison
- `style.css` — Demo page styling

Fixes #12465

---

## ⟡ Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.
- [x] I have verified that my changes work correctly on both desktop and mobile viewports.
- [x] All changes are inside `submissions/core_changes/readme-toc-fix-ss/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## ⟡ Screenshots / Screen Recordings

N/A — documentation fix, open `demo.html` for before/after comparison.

| Before | After |
| :--- | :--- |
| 18 TOC entries, 3 sections missing | 22 TOC entries, all sections linked + sub-navigation |

---

## Description

### Missing sections added to TOC
1. `Alternative CDN Providers` — links to jsDelivr, unpkg, and GitHub Raw CDN details (line 234)
2. `Issue Labels 🏷️` — links to the label reference table (line 886)
3. `Accessibility` — links to the prefers-reduced-motion docs (line 1024)

### Sub-links added under Quick Start
- CDN (recommended)
- npm
- Granular imports
- Modular animation imports
- Full bundle

### Verification
- All 19 existing TOC anchor links match their GitHub-generated heading IDs
- No anchors are broken — the fix adds only missing entries
- The corrected TOC block is provided in `README.md` for the maintainer to apply

### Affected file (for maintainer)
- `README.md` — lines 48-67: replace the current TOC block

---

## Type of change

- [x] Documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

---

## Additional Notes
- No core framework files were modified.
- Branch pushed: Pcmhacker-piro/EaseMotion-css:feat/core-changes-readme-toc-fix-ss
- Compare URL: https://github.com/Pcmhacker-piro/EaseMotion-css/compare/main...feat/core-changes-readme-toc-fix-ss?expand=1
