### PR TITLE
[FEATURE] Add Speed Dial / Quick Action FAB Menu component with 4 direction variants

### DIFF
--- a/submissions/core_changes/speed-dial-ss/README.md
+++ b/submissions/core_changes/speed-dial-ss/README.md
@@ -1,0 +1,30 @@
+# Speed Dial — Quick Action FAB Menu (ss)
+
+1. **What does this do?**  
+   A floating action button that expands into multiple secondary action buttons with staggered entrance animation, 4 direction variants, tooltip labels, click-outside and Escape-to-close, and proper ARIA attributes.
+
+2. **How is it used?**  
+
+   ```html
+   <div class="speed-dial-ss speed-dial-ss-up" role="group" aria-label="Quick actions">
+     <button class="speed-dial-ss-trigger"
+             aria-expanded="false"
+             aria-haspopup="true"
+             aria-label="Open actions">
+       <span class="icon-plus" aria-hidden="true">+</span>
+     </button>
+     <div class="speed-dial-ss-actions" role="menu">
+       <button class="speed-dial-ss-action" role="menuitem" aria-label="Add file">
+         <span aria-hidden="true">📄</span>
+         <span class="speed-dial-ss-label">Add file</span>
+       </button>
+       <!-- more action buttons -->
+     </div>
+   </div>
+   ```
+
+   Change direction by replacing `speed-dial-ss-up` with `-down`, `-left`, or `-right`.\
+   Toggle the `.open` class via JavaScript to show/hide actions.
+
+3. **Why is it useful?**  
+   EaseMotion CSS has a single-action FAB but no multi-action speed dial. This component fills that gap with the framework's animation-first philosophy — staggered scale+fade entrance, smooth icon rotation, and tooltip reveals — while keeping the code fully CSS-driven with just a small JS toggle handler.

--- a/submissions/core_changes/speed-dial-ss/demo.html
+++ b/submissions/core_changes/speed-dial-ss/demo.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Speed Dial — EaseMotion CSS Submission</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Speed Dial — Quick Action FAB Menu</h1>
+    <p>4 direction variants &middot; Staggered animation &middot; Tooltips &middot; Keyboard accessible</p>
+  </header>
+
+  <div class="demo-grid">
+
+    <!-- Up (default) -->
+    <div class="demo-cell">
+      <h2>Up (default)</h2>
+      <div class="speed-dial-stage">
+        <div class="speed-dial-ss speed-dial-ss-up" id="dial-up" role="group" aria-label="Quick actions">
+          <button class="speed-dial-ss-trigger"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Open actions">
+            <span class="icon-plus" aria-hidden="true">+</span>
+          </button>
+          <div class="speed-dial-ss-actions" role="menu">
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Add file">
+              <span aria-hidden="true">📄</span>
+              <span class="speed-dial-ss-label">Add file</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Add folder">
+              <span aria-hidden="true">📁</span>
+              <span class="speed-dial-ss-label">Add folder</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Upload">
+              <span aria-hidden="true">☁️</span>
+              <span class="speed-dial-ss-label">Upload</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Settings">
+              <span aria-hidden="true">⚙️</span>
+              <span class="speed-dial-ss-label">Settings</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Down -->
+    <div class="demo-cell">
+      <h2>Down</h2>
+      <div class="speed-dial-stage">
+        <div class="speed-dial-ss speed-dial-ss-down" id="dial-down" role="group" aria-label="Quick actions">
+          <button class="speed-dial-ss-trigger"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Open actions">
+            <span class="icon-plus" aria-hidden="true">+</span>
+          </button>
+          <div class="speed-dial-ss-actions" role="menu">
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Edit">
+              <span aria-hidden="true">✏️</span>
+              <span class="speed-dial-ss-label">Edit</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Copy">
+              <span aria-hidden="true">📋</span>
+              <span class="speed-dial-ss-label">Copy</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Delete">
+              <span aria-hidden="true">🗑️</span>
+              <span class="speed-dial-ss-label">Delete</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Share">
+              <span aria-hidden="true">🔗</span>
+              <span class="speed-dial-ss-label">Share</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Left -->
+    <div class="demo-cell">
+      <h2>Left</h2>
+      <div class="speed-dial-stage">
+        <div class="speed-dial-ss speed-dial-ss-left" id="dial-left" role="group" aria-label="Quick actions">
+          <button class="speed-dial-ss-trigger"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Open actions">
+            <span class="icon-plus" aria-hidden="true">+</span>
+          </button>
+          <div class="speed-dial-ss-actions" role="menu">
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Search">
+              <span aria-hidden="true">🔍</span>
+              <span class="speed-dial-ss-label">Search</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Filter">
+              <span aria-hidden="true">🔽</span>
+              <span class="speed-dial-ss-label">Filter</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Sort">
+              <span aria-hidden="true">↕️</span>
+              <span class="speed-dial-ss-label">Sort</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Refresh">
+              <span aria-hidden="true">🔄</span>
+              <span class="speed-dial-ss-label">Refresh</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Right -->
+    <div class="demo-cell">
+      <h2>Right</h2>
+      <div class="speed-dial-stage">
+        <div class="speed-dial-ss speed-dial-ss-right" id="dial-right" role="group" aria-label="Quick actions">
+          <button class="speed-dial-ss-trigger"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Open actions">
+            <span class="icon-plus" aria-hidden="true">+</span>
+          </button>
+          <div class="speed-dial-ss-actions" role="menu">
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Save">
+              <span aria-hidden="true">💾</span>
+              <span class="speed-dial-ss-label">Save</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Export">
+              <span aria-hidden="true">📤</span>
+              <span class="speed-dial-ss-label">Export</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Print">
+              <span aria-hidden="true">🖨️</span>
+              <span class="speed-dial-ss-label">Print</span>
+            </button>
+            <button class="speed-dial-ss-action" role="menuitem" aria-label="Bookmark">
+              <span aria-hidden="true">🔖</span>
+              <span class="speed-dial-ss-label">Bookmark</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <script>
+    (function () {
+      var dials = document.querySelectorAll('.speed-dial-ss');
+
+      function closeAll(except) {
+        dials.forEach(function (d) {
+          if (d !== except) {
+            d.classList.remove('open');
+            var btn = d.querySelector('.speed-dial-ss-trigger');
+            if (btn) btn.setAttribute('aria-expanded', 'false');
+          }
+        });
+      }
+
+      function toggleDial(dial) {
+        var isOpen = dial.classList.contains('open');
+        closeAll(dial);
+        if (!isOpen) {
+          dial.classList.add('open');
+          var btn = dial.querySelector('.speed-dial-ss-trigger');
+          if (btn) btn.setAttribute('aria-expanded', 'true');
+        }
+      }
+
+      // Click on trigger to toggle
+      dials.forEach(function (dial) {
+        var trigger = dial.querySelector('.speed-dial-ss-trigger');
+        if (trigger) {
+          trigger.addEventListener('click', function (e) {
+            e.stopPropagation();
+            toggleDial(dial);
+          });
+        }
+
+        // Click on action item
+        var actions = dial.querySelectorAll('.speed-dial-ss-action');
+        actions.forEach(function (action) {
+          action.addEventListener('click', function (e) {
+            e.stopPropagation();
+            var label = action.getAttribute('aria-label') || 'Action clicked';
+            console.log('Speed Dial action:', label);
+            dial.classList.remove('open');
+            var btn = dial.querySelector('.speed-dial-ss-trigger');
+            if (btn) btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      });
+
+      // Click outside closes all
+      document.addEventListener('click', function (e) {
+        var clickedDial = e.target.closest('.speed-dial-ss');
+        if (!clickedDial) {
+          closeAll();
+        }
+      });
+
+      // Escape key closes all
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') {
+          closeAll();
+          // Focus back to the last active trigger
+          var openDial = document.querySelector('.speed-dial-ss.open');
+          if (openDial) {
+            var btn = openDial.querySelector('.speed-dial-ss-trigger');
+            if (btn) btn.focus();
+          }
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/core_changes/speed-dial-ss/style.css
+++ b/submissions/core_changes/speed-dial-ss/style.css
@@ -1,0 +1,351 @@
+:root {
+  --sd-primary: #6366f1;
+  --sd-primary-hover: #4f46e5;
+  --sd-bg: #ffffff;
+  --sd-bg-secondary: #f1f5f9;
+  --sd-text: #0f172a;
+  --sd-text-secondary: #475569;
+  --sd-text-muted: #94a3b8;
+  --sd-border: #e2e8f0;
+  --sd-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --sd-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.15);
+  --sd-radius: 999px;
+  --sd-size: 56px;
+  --sd-action-size: 44px;
+  --sd-gap: 12px;
+  --sd-transition: 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  --sd-transition-linear: 0.2s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 40px 20px;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--sd-bg-secondary);
+  color: var(--sd-text);
+  min-height: 100vh;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 60px;
+}
+
+.page-header h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+  background: linear-gradient(135deg, var(--sd-primary), #a855f7);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.page-header p {
+  color: var(--sd-text-secondary);
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+/* ─── Demo area ─── */
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 40px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.demo-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.demo-cell h2 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--sd-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.speed-dial-stage {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--sd-bg);
+  border: 1px solid var(--sd-border);
+  border-radius: 16px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+/* ─── Speed Dial ─── */
+
+.speed-dial-ss {
+  position: relative;
+  display: inline-flex;
+}
+
+/* Main FAB trigger */
+.speed-dial-ss-trigger {
+  width: var(--sd-size);
+  height: var(--sd-size);
+  border-radius: var(--sd-radius);
+  background: var(--sd-primary);
+  color: white;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  box-shadow: var(--sd-shadow);
+  transition: background var(--sd-transition-linear), transform var(--sd-transition-linear), box-shadow var(--sd-transition-linear);
+  z-index: 2;
+  position: relative;
+}
+
+.speed-dial-ss-trigger:hover {
+  background: var(--sd-primary-hover);
+  transform: scale(1.05);
+  box-shadow: var(--sd-shadow-lg);
+}
+
+.speed-dial-ss-trigger:active {
+  transform: scale(0.95);
+}
+
+.speed-dial-ss-trigger:focus-visible {
+  outline: 2px solid var(--sd-primary);
+  outline-offset: 3px;
+}
+
+.speed-dial-ss-trigger .icon-plus {
+  transition: transform var(--sd-transition);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.speed-dial-ss.open .speed-dial-ss-trigger .icon-plus {
+  transform: rotate(45deg);
+}
+
+/* Action items container */
+.speed-dial-ss-actions {
+  position: absolute;
+  display: flex;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--sd-transition-linear), visibility var(--sd-transition-linear);
+  z-index: 1;
+}
+
+.speed-dial-ss.open .speed-dial-ss-actions {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Individual action button */
+.speed-dial-ss-action {
+  width: var(--sd-action-size);
+  height: var(--sd-action-size);
+  border-radius: 50%;
+  background: var(--sd-bg);
+  border: 1px solid var(--sd-border);
+  color: var(--sd-text-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  transition: all var(--sd-transition-linear);
+  position: relative;
+  transform: scale(0);
+  opacity: 0;
+}
+
+.speed-dial-ss.open .speed-dial-ss-action {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.speed-dial-ss-action:hover {
+  background: var(--sd-primary);
+  color: white;
+  border-color: var(--sd-primary);
+  transform: scale(1.1) !important;
+  box-shadow: var(--sd-shadow);
+}
+
+.speed-dial-ss-action:focus-visible {
+  outline: 2px solid var(--sd-primary);
+  outline-offset: 2px;
+}
+
+/* Tooltip label */
+.speed-dial-ss-label {
+  position: absolute;
+  white-space: nowrap;
+  background: var(--sd-text);
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 6px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--sd-transition-linear);
+}
+
+.speed-dial-ss-action:hover .speed-dial-ss-label {
+  opacity: 1;
+}
+
+/* ─── Direction variants ─── */
+
+/* Up (default) */
+.speed-dial-ss-up .speed-dial-ss-actions {
+  bottom: calc(100% + var(--sd-gap));
+  left: 50%;
+  transform: translateX(-50%);
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sd-gap);
+}
+
+.speed-dial-ss-up .speed-dial-ss-label {
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* Down */
+.speed-dial-ss-down .speed-dial-ss-actions {
+  top: calc(100% + var(--sd-gap));
+  left: 50%;
+  transform: translateX(-50%);
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sd-gap);
+}
+
+.speed-dial-ss-down .speed-dial-ss-label {
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* Left */
+.speed-dial-ss-left .speed-dial-ss-actions {
+  right: calc(100% + var(--sd-gap));
+  top: 50%;
+  transform: translateY(-50%);
+  flex-direction: row;
+  align-items: center;
+  gap: var(--sd-gap);
+}
+
+.speed-dial-ss-left .speed-dial-ss-label {
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+/* Right */
+.speed-dial-ss-right .speed-dial-ss-actions {
+  left: calc(100% + var(--sd-gap));
+  top: 50%;
+  transform: translateY(-50%);
+  flex-direction: row;
+  align-items: center;
+  gap: var(--sd-gap);
+}
+
+.speed-dial-ss-right .speed-dial-ss-label {
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+/* ─── Staggered animation ─── */
+
+.speed-dial-ss.open .speed-dial-ss-action:nth-child(1) { transition-delay: 0ms; }
+.speed-dial-ss.open .speed-dial-ss-action:nth-child(2) { transition-delay: 40ms; }
+.speed-dial-ss.open .speed-dial-ss-action:nth-child(3) { transition-delay: 80ms; }
+.speed-dial-ss.open .speed-dial-ss-action:nth-child(4) { transition-delay: 120ms; }
+.speed-dial-ss.open .speed-dial-ss-action:nth-child(5) { transition-delay: 160ms; }
+
+/* Close stagger (reverse order) */
+.speed-dial-ss:not(.open) .speed-dial-ss-action:nth-child(1) { transition-delay: 120ms; }
+.speed-dial-ss:not(.open) .speed-dial-ss-action:nth-child(2) { transition-delay: 90ms; }
+.speed-dial-ss:not(.open) .speed-dial-ss-action:nth-child(3) { transition-delay: 60ms; }
+.speed-dial-ss:not(.open) .speed-dial-ss-action:nth-child(4) { transition-delay: 30ms; }
+.speed-dial-ss:not(.open) .speed-dial-ss-action:nth-child(5) { transition-delay: 0ms; }
+
+/* ─── Overlay ─── */
+
+.speed-dial-overlay {
+  position: fixed;
+  inset: 0;
+  background: transparent;
+  z-index: 0;
+  display: none;
+}
+
+.speed-dial-ss.open + .speed-dial-overlay,
+.speed-dial-overlay.active {
+  display: block;
+}
+
+/* ─── Reduced motion ─── */
+
+@media (prefers-reduced-motion: reduce) {
+  .speed-dial-ss-trigger .icon-plus,
+  .speed-dial-ss-action,
+  .speed-dial-ss-label,
+  .speed-dial-ss-actions {
+    transition: none;
+  }
+
+  .speed-dial-ss.open .speed-dial-ss-action {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  .speed-dial-ss-action {
+    transform: scale(1);
+    opacity: 0;
+  }
+}
+
+/* ─── Responsive ─── */
+
+@media (max-width: 600px) {
+  .demo-grid {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+
+  .page-header {
+    margin-bottom: 40px;
+  }
+
+  .speed-dial-stage {
+    width: 160px;
+    height: 160px;
+  }
+}


### PR DESCRIPTION
## ✦ Description

Add a Speed Dial / Quick Action FAB Menu component — a primary floating action button that expands into multiple secondary action buttons with staggered entrance animation.

The component supports 4 direction variants (up, down, left, right), tooltip labels on hover, click-outside and Escape-to-close behavior, proper ARIA attributes (aria-expanded, aria-haspopup, role="menu"), and dark mode via CSS custom properties.

The submission is in `submissions/core_changes/speed-dial-ss/`:
- `demo.html` — Self-contained demo with all 4 direction variants in a grid layout
- `style.css` — Raw CSS with staggered scale+fade animation, direction variants, tooltips, responsive design, and prefers-reduced-motion support
- `README.md` — Usage documentation following the required 3-question format

Fixes #12464

---

## ⟡ Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.
- [x] I have verified that my changes work correctly on both desktop and mobile viewports.
- [x] All changes are inside `submissions/core_changes/speed-dial-ss/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## ⟡ Screenshots / Screen Recordings (Required for UI changes)

N/A — open `demo.html` directly in a browser to view. The demo shows 4 direction variants (Up, Down, Left, Right) each with 4 action items.

| Before | After |
| :--- | :--- |
| Only single-action FAB exists (components/fab.css) | Multi-action speed dial with staggered animation, 4 directions, tooltips |

---

## Description

### Features
- **4 direction variants** — up (default), down, left, right
- **Staggered entrance** — actions appear sequentially (40ms delays) with scale+fade animation; reverse stagger on close
- **Tooltip labels** — appear on hover with smooth opacity transition
- **Plus icon rotation** — rotates 45deg to X when open
- **Click-outside close** — clicking anywhere outside closes the dial
- **Escape key** — closes the active dial and refocuses the trigger
- **ARIA attributes** — aria-expanded, aria-haspopup, role="menu", role="menuitem"
- **Dark mode ready** — all colors use CSS custom properties
- **prefers-reduced-motion** — disables transitions when user prefers reduced motion
- **Responsive** — single-column layout on mobile

### CSS Customization
All visual properties can be overridden via CSS variables:
- `--sd-primary`, `--sd-primary-hover`, `--sd-bg`, `--sd-text`, `--sd-border`
- `--sd-shadow`, `--sd-radius`, `--sd-size`, `--sd-action-size`, `--sd-gap`
- `--sd-transition` (bouncy open), `--sd-transition-linear` (close/tooltips)

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

---

## Additional Notes
- No core framework files were modified.
- Branch pushed: Pcmhacker-piro/EaseMotion-css:feat/core-changes-speed-dial-ss
- Compare URL: https://github.com/Pcmhacker-piro/EaseMotion-css/compare/main...feat/core-changes-speed-dial-ss?expand=1
