### PR TITLE
[BUG] Theme toggle button does not persist dark mode preference across page reloads

### DIFF
--- a/submissions/core_changes/README.md
+++ b/submissions/core_changes/README.md
@@ -1,0 +1,38 @@
+# Theme Toggle Persistence with localStorage
+
+## What does this do?
+Persists the user's dark/light theme preference across page reloads using `localStorage`. On page load, an inline script checks `localStorage` before the page renders to prevent Flash of Unstyled Content (FOUC), falling back to `prefers-color-scheme` if no saved preference exists.
+
+## How is it used?
+Add this inline script synchronously in `<head>` before any CSS that depends on `data-theme`:
+```html
+<script>
+  (function() {
+    var key = "easemotion-theme";
+    var saved = localStorage.getItem(key);
+    var theme = saved || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+    document.documentElement.setAttribute("data-theme", theme);
+  })();
+</script>
+```
+
+Toggle button handler:
+```js
+document.querySelector(".ease-theme-toggle").addEventListener("click", function() {
+  var html = document.documentElement;
+  var current = html.getAttribute("data-theme") || "light";
+  var next = current === "dark" ? "light" : "dark";
+  html.setAttribute("data-theme", next);
+  localStorage.setItem("easemotion-theme", next);
+});
+```
+
+## Why is it useful?
+Without persistence, users must toggle the theme on every page visit, creating poor UX. This fix:
+- Saves preference to `localStorage` on every toggle
+- Reads saved preference before render (no FOUC)
+- Falls back to system `prefers-color-scheme` if no saved preference
+- Updates toggle button ARIA label for accessibility
+- Requires no external dependencies
+
+Fixes #12448

--- a/submissions/core_changes/demo.html
+++ b/submissions/core_changes/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Theme Persistence Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <script>
+    (function() {
+      var key = "easemotion-theme";
+      var saved = localStorage.getItem(key);
+      var theme = saved || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+      document.documentElement.setAttribute("data-theme", theme);
+    })();
+  </script>
+</head>
+<body>
+  <header>
+    <h1>Theme Persistence Demo</h1>
+    <button class="ease-theme-toggle" aria-label="Switch to dark mode">
+      <span class="ease-theme-icon sun">&#9728;</span>
+      <span class="ease-theme-icon moon" hidden>&#9790;</span>
+    </button>
+  </header>
+
+  <main>
+    <p>Issue #12448 — The theme toggle button persists dark/light preference across page reloads using <code>localStorage</code>.</p>
+
+    <hr>
+
+    <h2>How It Works</h2>
+    <ol>
+      <li>Inline script in <code>&lt;head&gt;</code> reads <code>localStorage</code> before rendering (prevents FOUC)</li>
+      <li>If no saved preference, falls back to <code>prefers-color-scheme</code></li>
+      <li>Toggle button updates <code>data-theme</code> on <code>&lt;html&gt;</code> and saves to <code>localStorage</code></li>
+      <li>Toggle icon switches between sun (light) and moon (dark)</li>
+    </ol>
+
+    <hr>
+
+    <h2>Test It</h2>
+    <p>Click the toggle button (sun/moon) in the header. Reload the page — your preference is preserved!</p>
+
+    <div class="card">
+      <h3>Sample Card</h3>
+      <p>This card adapts to the active theme. Switch themes and reload to verify persistence.</p>
+      <button class="demo-btn">Sample Button</button>
+    </div>
+  </main>
+
+  <script>
+    (function() {
+      var STORAGE_KEY = "easemotion-theme";
+      var html = document.documentElement;
+      var btn = document.querySelector(".ease-theme-toggle");
+      var sun = btn && btn.querySelector(".sun");
+      var moon = btn && btn.querySelector(".moon");
+
+      function setTheme(theme) {
+        html.setAttribute("data-theme", theme);
+        localStorage.setItem(STORAGE_KEY, theme);
+        if (btn) btn.setAttribute("aria-label", "Switch to " + (theme === "dark" ? "light" : "dark") + " mode");
+        if (sun) sun.hidden = theme === "dark";
+        if (moon) moon.hidden = theme === "light";
+      }
+
+      if (btn) {
+        btn.addEventListener("click", function() {
+          var current = html.getAttribute("data-theme") || "light";
+          setTheme(current === "dark" ? "light" : "dark");
+        });
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/core_changes/style.css
+++ b/submissions/core_changes/style.css
@@ -1,0 +1,108 @@
+/* Theme Persistence — Issue #12448 */
+
+/* Light theme (default) */
+:root,
+[data-theme="light"] {
+  --bg: #ffffff;
+  --text: #1e293b;
+  --card-bg: #f8fafc;
+  --card-border: #e2e8f0;
+  --accent: #6c63ff;
+  --btn-bg: #6c63ff;
+  --btn-text: #ffffff;
+}
+
+[data-theme="dark"] {
+  --bg: #0f172a;
+  --text: #e2e8f0;
+  --card-bg: #1e293b;
+  --card-border: #334155;
+  --accent: #8b83ff;
+  --btn-bg: #8b83ff;
+  --btn-text: #0f172a;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: var(--card-bg);
+  border-bottom: 1px solid var(--card-border);
+}
+
+header h1 { margin: 0; font-size: 1.25rem; }
+
+main {
+  max-width: 720px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  line-height: 1.6;
+}
+
+/* Theme toggle button */
+.ease-theme-toggle {
+  background: none;
+  border: 2px solid var(--card-border);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  font-size: 1.25rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.ease-theme-toggle:hover {
+  border-color: var(--accent);
+  transform: scale(1.1);
+}
+
+.ease-theme-icon { line-height: 1; }
+
+/* Card */
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-top: 1rem;
+  transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+.card h3 { margin: 0 0 0.5rem; }
+
+.demo-btn {
+  background: var(--btn-bg);
+  color: var(--btn-text);
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.demo-btn:hover { opacity: 0.9; }
+
+hr { border: none; border-top: 1px solid var(--card-border); margin: 1.5rem 0; }
+code { background: var(--card-bg); padding: 0.125rem 0.375rem; border-radius: 0.25rem; font-size: 0.9em; }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  body, .card, .ease-theme-toggle { transition: none; }
+}


### PR DESCRIPTION
## ✦ Description
Persists the user's dark/light theme preference across page reloads using `localStorage`. Previously the `.ease-theme-toggle` button switched themes via `data-theme` on `<html>` but the preference was lost on reload, forcing users to toggle on every page visit.

An inline script in `<head>` reads saved preference before rendering to prevent Flash of Unstyled Content (FOUC), with a fallback to `prefers-color-scheme`.

Fixes #12448

---

## ⟡ Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.

## Description

### Root Cause
The theme toggle updated `data-theme` on `<html>` but never saved the preference, so it was lost on page reload.

### Changes Made
Added 3 files to `submissions/core_changes/`:
- `demo.html` - Full demo with inline FOUC-prevention script and toggle handler
- `style.css` - Light/dark theme variables and toggle button styling
- `README.md` - Usage documentation

### Key Implementation Details
- Synchronous inline script in `<head>` reads `localStorage` before render
- Falls back to `prefers-color-scheme` media query
- Saves preference on every toggle via `localStorage.setItem`
- Updates toggle button ARIA label and sun/moon icon visibility

---

## Additional Notes
- No core files modified.
- Branch: `fix/theme-persistence`