### PR TITLE
[FEATURE] Add CSS-only Dropdown/Menu component

### DIFF
--- a/submissions/core_changes/README.md
+++ b/submissions/core_changes/README.md
@@ -1,0 +1,36 @@
+# CSS-only Dropdown / Menu Component
+
+## What does this do?
+Adds a CSS-only dropdown/menu component with hover and click variants, positioning modifiers, animations, dividers, and dark mode support. Uses `.ease-dropdown`, `.ease-dropdown-trigger`, `.ease-dropdown-menu`, and `.ease-dropdown-item` classes.
+
+## How is it used?
+```html
+<div class="ease-dropdown">
+  <button class="ease-dropdown-trigger">
+    Trigger <span class="ease-dropdown-arrow">&#9662;</span>
+  </button>
+  <div class="ease-dropdown-menu">
+    <button class="ease-dropdown-item">Item</button>
+    <div class="ease-dropdown-divider"></div>
+    <button class="ease-dropdown-item">Other</button>
+  </div>
+</div>
+```
+
+### Modifiers
+- `.ease-dropdown-right` — right-aligned dropdown
+- `.ease-dropdown-up` — opens upward
+- `.ease-dropdown-click` — click-to-open variant (requires JS)
+
+## Why is it useful?
+EaseMotion CSS lacked a dropdown component essential for navigation menus, action menus, and context menus. This component provides:
+- **CSS-only hover variant** — works without JavaScript
+- **Click variant** — with keyboard navigation (Escape, Arrow keys, Enter/Space)
+- **4 positions** — default (bottom-left), right, up, with modifier classes
+- **Animations** — fade + slide on open/close
+- **Arrow rotation** — visual indicator rotates when open
+- **Dividers** — separate menu item groups
+- **Dark mode** — adapts via `data-theme` CSS variables
+- **Reduced motion** — respects `prefers-reduced-motion`
+
+Fixes #12449

--- a/submissions/core_changes/demo.html
+++ b/submissions/core_changes/demo.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Dropdown/Menu Component Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>CSS-only Dropdown / Menu Component</h1>
+  <p>Issue #12449 — Hover and click variants with positioning, dividers, animations, and dark mode.</p>
+
+  <hr>
+
+  <div class="demos">
+    <div class="demo-section">
+      <h2>Hover Dropdown</h2>
+      <p>Opens on hover using <code>:hover</code> CSS.</p>
+      <div class="ease-dropdown demo-placed">
+        <button class="ease-dropdown-trigger">
+          Hover me <span class="ease-dropdown-arrow">&#9662;</span>
+        </button>
+        <div class="ease-dropdown-menu">
+          <button class="ease-dropdown-item">Profile</button>
+          <button class="ease-dropdown-item">Settings</button>
+          <div class="ease-dropdown-divider"></div>
+          <button class="ease-dropdown-item">Help</button>
+          <button class="ease-dropdown-item">Logout</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Click Dropdown</h2>
+      <p>Opens on click, closes on click-outside or Escape.</p>
+      <div class="ease-dropdown ease-dropdown-click demo-placed" id="click-dropdown">
+        <button class="ease-dropdown-trigger">
+          Click me <span class="ease-dropdown-arrow">&#9662;</span>
+        </button>
+        <div class="ease-dropdown-menu">
+          <button class="ease-dropdown-item">Dashboard</button>
+          <button class="ease-dropdown-item">Analytics</button>
+          <div class="ease-dropdown-divider"></div>
+          <button class="ease-dropdown-item">Sign out</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Right-aligned</h2>
+      <p>Uses <code>.ease-dropdown-right</code> modifier.</p>
+      <div class="ease-dropdown ease-dropdown-right demo-placed">
+        <button class="ease-dropdown-trigger">
+          Right menu <span class="ease-dropdown-arrow">&#9662;</span>
+        </button>
+        <div class="ease-dropdown-menu">
+          <button class="ease-dropdown-item">New file</button>
+          <button class="ease-dropdown-item">Upload</button>
+          <div class="ease-dropdown-divider"></div>
+          <button class="ease-dropdown-item">Delete</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Drop-up</h2>
+      <p>Uses <code>.ease-dropdown-up</code> modifier.</p>
+      <div class="ease-dropdown ease-dropdown-up demo-placed">
+        <button class="ease-dropdown-trigger">
+          Drop up <span class="ease-dropdown-arrow">&#9652;</span>
+        </button>
+        <div class="ease-dropdown-menu">
+          <button class="ease-dropdown-item">Action 1</button>
+          <button class="ease-dropdown-item">Action 2</button>
+          <div class="ease-dropdown-divider"></div>
+          <button class="ease-dropdown-item">Action 3</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <hr>
+
+  <h2>Usage</h2>
+  <pre><code>&lt;div class="ease-dropdown"&gt;
+  &lt;button class="ease-dropdown-trigger"&gt;
+    Trigger &lt;span class="ease-dropdown-arrow"&gt;&amp;#9662;&lt;/span&gt;
+  &lt;/button&gt;
+  &lt;div class="ease-dropdown-menu"&gt;
+    &lt;button class="ease-dropdown-item"&gt;Item&lt;/button&gt;
+    &lt;div class="ease-dropdown-divider"&gt;&lt;/div&gt;
+    &lt;button class="ease-dropdown-item"&gt;Other&lt;/button&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
+  <h3>Modifiers</h3>
+  <ul>
+    <li><code>.ease-dropdown-right</code> — right-aligned menu</li>
+    <li><code>.ease-dropdown-up</code> — opens upward</li>
+    <li><code>.ease-dropdown-click</code> — JS click-to-open variant</li>
+  </ul>
+
+  <script>
+    (function() {
+      // Click variant: toggle .open class, close on outside click/Escape
+      document.querySelectorAll('.ease-dropdown-click').forEach(function(dd) {
+        var trigger = dd.querySelector('.ease-dropdown-trigger');
+        var menu = dd.querySelector('.ease-dropdown-menu');
+
+        trigger.addEventListener('click', function(e) {
+          e.stopPropagation();
+          dd.classList.toggle('open');
+        });
+
+        document.addEventListener('click', function(e) {
+          if (!dd.contains(e.target)) dd.classList.remove('open');
+        });
+
+        document.addEventListener('keydown', function(e) {
+          if (e.key === 'Escape') dd.classList.remove('open');
+        });
+
+        // Arrow key navigation within menu
+        dd.addEventListener('keydown', function(e) {
+          if (!dd.classList.contains('open')) return;
+          var items = menu.querySelectorAll('.ease-dropdown-item');
+          var focused = document.activeElement;
+          var idx = Array.from(items).indexOf(focused);
+          if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            items[(idx + 1) % items.length].focus();
+          } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            items[(idx - 1 + items.length) % items.length].focus();
+          } else if (e.key === 'Enter' || e.key === ' ') {
+            if (focused && focused.classList.contains('ease-dropdown-item')) {
+              e.preventDefault();
+              focused.click();
+            }
+          }
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/core_changes/style.css
+++ b/submissions/core_changes/style.css
@@ -1,0 +1,183 @@
+/* Dropdown/Menu Component — Issue #12449 */
+
+/* Light theme (default) */
+:root, [data-theme="light"] {
+  --dd-bg: #ffffff;
+  --dd-text: #1e293b;
+  --dd-border: #e2e8f0;
+  --dd-hover: #f1f5f9;
+  --dd-shadow: 0 4px 24px rgba(0,0,0,0.12);
+}
+
+[data-theme="dark"] {
+  --dd-bg: #1e293b;
+  --dd-text: #e2e8f0;
+  --dd-border: #334155;
+  --dd-hover: #0f172a;
+  --dd-shadow: 0 4px 24px rgba(0,0,0,0.4);
+}
+
+/* Dropdown container */
+.ease-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+/* Trigger */
+.ease-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--dd-bg);
+  color: var(--dd-text);
+  border: 1px solid var(--dd-border);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  white-space: nowrap;
+}
+
+.ease-dropdown-trigger:hover {
+  border-color: #6c63ff;
+}
+
+.ease-dropdown-arrow {
+  font-size: 0.75rem;
+  transition: transform 0.2s ease;
+  line-height: 1;
+}
+
+/* Dropdown menu (hidden by default) */
+.ease-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 50;
+  min-width: 200px;
+  background: var(--dd-bg);
+  border: 1px solid var(--dd-border);
+  border-radius: 0.5rem;
+  box-shadow: var(--dd-shadow);
+  padding: 0.375rem 0;
+  margin-top: 0.25rem;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+}
+
+/* Open states */
+.ease-dropdown:hover .ease-dropdown-menu,
+.ease-dropdown:focus-within .ease-dropdown-menu,
+.ease-dropdown.open .ease-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.ease-dropdown:hover .ease-dropdown-arrow { transform: rotate(180deg); }
+.ease-dropdown.open .ease-dropdown-arrow { transform: rotate(180deg); }
+
+/* Menu items */
+.ease-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: var(--dd-text);
+  font-size: 0.875rem;
+  transition: background 0.15s ease;
+}
+
+.ease-dropdown-item:hover,
+.ease-dropdown-item:focus-visible {
+  background: var(--dd-hover);
+  outline: none;
+}
+
+/* Divider */
+.ease-dropdown-divider {
+  height: 1px;
+  background: var(--dd-border);
+  margin: 0.25rem 0;
+}
+
+/* Position variants */
+.ease-dropdown-right .ease-dropdown-menu {
+  left: auto;
+  right: 0;
+}
+
+.ease-dropdown-up .ease-dropdown-menu {
+  top: auto;
+  bottom: 100%;
+  margin-top: 0;
+  margin-bottom: 0.25rem;
+  transform: translateY(4px);
+}
+
+.ease-dropdown-up:hover .ease-dropdown-menu {
+  transform: translateY(0);
+}
+
+.ease-dropdown-up .ease-dropdown-arrow { display: inline-block; }
+
+/* Demo page */
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  line-height: 1.6;
+  color: var(--dd-text);
+  background: #f8fafc;
+}
+
+[data-theme="dark"] body { background: #0f172a; }
+
+h1, h2, h3 { color: inherit; }
+
+.demos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.demo-section {
+  background: var(--dd-bg);
+  border: 1px solid var(--dd-border);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+}
+
+.demo-section h2 { margin: 0 0 0.25rem; font-size: 1.1rem; }
+.demo-section p { margin: 0 0 1rem; font-size: 0.85rem; color: #64748b; }
+
+.demo-placed { margin-top: 0.5rem; }
+
+pre {
+  background: #f1f5f9;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+}
+
+code {
+  background: #f1f5f9;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-size: 0.9em;
+}
+
+hr { border: none; border-top: 1px solid #e2e8f0; margin: 1.5rem 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dropdown-menu, .ease-dropdown-arrow { transition: none; }
+}


### PR DESCRIPTION
## ✦ Description
Adds a CSS-only dropdown/menu component with hover and click variants, positioning modifiers (bottom-left, bottom-right, top-left), fade+slide animations, arrow rotation, dividers, keyboard navigation, and dark mode support.

The hover variant is pure CSS using `:hover`. The click variant uses a lightweight inline script for toggle, click-outside-to-close, Escape-to-close, and Arrow key navigation.

Fixes #12449

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.

## Description

### Changes Made
Added 3 files to `submissions/core_changes/`:
- `demo.html` - Demo with 4 variants (hover, click, right-aligned, drop-up)
- `style.css` - Dropdown styles with CSS variables, positioning, animations, dark mode
- `README.md` - Usage documentation

### Features
- `.ease-dropdown` container with hover-based CSS-only reveal
- `.ease-dropdown-click` for JS click-to-open variant
- `.ease-dropdown-right` and `.ease-dropdown-up` position modifiers
- `.ease-dropdown-arrow` rotates on open
- `.ease-dropdown-divider` for menu section separation
- Keyboard: Arrow keys, Enter/Space, Escape
- Click-outside-to-close
- Dark mode via `data-theme` CSS variables
- `prefers-reduced-motion` support

---

## Additional Notes
- No core files modified.
- Branch: `feat/dropdown-menu`