### PR TITLE
[FEATURE] Add single-pass typewriter animation with configurable speed and cursor colors

### DIFF
--- a/submissions/core_changes/typewriter-ss/README.md
+++ b/submissions/core_changes/typewriter-ss/README.md
@@ -1,0 +1,33 @@
+# Typewriter Effect (ss)
+
+1. **What does this do?**  
+   A single-pass typewriter animation that types out text character by character with a blinking cursor, using CSS `steps()` timing for precise character-by-character reveal.
+
+2. **How is it used?**  
+
+   ```html
+   <span class="typewriter-ss" id="hero-text">
+     Build beautiful UIs with EaseMotion CSS
+   </span>
+
+   <script>
+     document.querySelectorAll('.typewriter-ss').forEach(function (el) {
+       el.style.setProperty('--tw-chars', el.textContent.trim().length);
+     });
+   </script>
+   ```
+
+   Variants:
+   - `typewriter-ss-fast` — faster typing (0.04s per char)
+   - `typewriter-ss-slow` — slower typing (0.15s per char)
+   - `typewriter-ss-multi` — preserves whitespace for code/multiline
+   - Cursor colors: `.typewriter-ss-cursor-info`, `-success`, `-warning`, `-danger`
+
+   Custom properties:
+   - `--tw-speed`: seconds per character (default: 0.08s)
+   - `--tw-chars`: total character count (required for `steps()`)
+   - `--tw-delay`: delay before typing starts (default: 0s)
+   - `--tw-primary`: cursor color (default: #6366f1)
+
+3. **Why is it useful?**  
+   EaseMotion CSS has `ease-typewriter-loop` (infinite loop) but no single-pass typewriter for hero sections and landing pages. This fills that gap with configurable speed, delay, cursor color variants, and an optional JS helper for auto-detecting character counts — all while staying animation-first and respecting `prefers-reduced-motion`.

--- a/submissions/core_changes/typewriter-ss/demo.html
+++ b/submissions/core_changes/typewriter-ss/demo.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Typewriter — EaseMotion CSS Submission</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Typewriter Effect</h1>
+    <p>Single-pass typing &middot; Blinking cursor &middot; Speed/delay control &middot; Cursor color variants</p>
+  </header>
+
+  <!-- Hero-style headline -->
+  <div class="demo-section">
+    <h2>Hero Headline</h2>
+    <div class="demo-box">
+      <span class="typewriter-ss" id="headline-typewriter">
+        Build beautiful UIs with EaseMotion CSS
+      </span>
+    </div>
+  </div>
+
+  <!-- Subtitle -->
+  <div class="demo-section">
+    <h2>Subtitle with custom speed</h2>
+    <div class="demo-box">
+      <span class="typewriter-ss typewriter-ss-fast" id="subtitle-typewriter">
+        Zero dependencies · Animation-first · Human-readable
+      </span>
+    </div>
+  </div>
+
+  <!-- Cursor color variants -->
+  <div class="demo-section">
+    <h2>Cursor Color Variants</h2>
+    <div class="demo-box" style="flex-direction:column; align-items:flex-start; gap:16px;">
+      <span class="typewriter-ss typewriter-ss-cursor" id="color-1" style="font-size:1rem;">
+        Default (indigo) cursor
+      </span>
+      <span class="typewriter-ss typewriter-ss-cursor typewriter-ss-cursor-info" id="color-2" style="font-size:1rem;">
+        Info (cyan) cursor
+      </span>
+      <span class="typewriter-ss typewriter-ss-cursor typewriter-ss-cursor-success" id="color-3" style="font-size:1rem;">
+        Success (green) cursor
+      </span>
+      <span class="typewriter-ss typewriter-ss-cursor typewriter-ss-cursor-warning" id="color-4" style="font-size:1rem;">
+        Warning (yellow) cursor
+      </span>
+      <span class="typewriter-ss typewriter-ss-cursor typewriter-ss-cursor-danger" id="color-5" style="font-size:1rem;">
+        Danger (red) cursor
+      </span>
+    </div>
+  </div>
+
+  <!-- Delayed start -->
+  <div class="demo-section">
+    <h2>Delayed Start (1.5s delay)</h2>
+    <div class="demo-box">
+      <span class="typewriter-ss" id="delayed-typewriter" style="--tw-delay: 1.5s;">
+        This text appears after a 1.5 second pause
+      </span>
+    </div>
+  </div>
+
+  <!-- Code snippet style -->
+  <div class="demo-section">
+    <h2>Code Block Style</h2>
+    <div class="demo-box">
+      <span class="typewriter-ss typewriter-ss-multi" id="code-typewriter">const ease = new EaseMotion();  ease.animate(".hero", "fade-in");</span>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      // Auto-detect character count for each .typewriter-ss element
+      function setupTypewriter(el) {
+        var text = el.textContent.trim();
+        var charCount = text.length;
+
+        // Handle multi-line (preserve whitespace)
+        if (el.classList.contains('typewriter-ss-multi')) {
+          charCount = text.length;
+        }
+
+        el.style.setProperty('--tw-chars', String(charCount));
+
+        // Fix for Firefox: ensure width animation works
+        // by giving it an explicit starting width
+        el.style.width = '0';
+      }
+
+      var elements = document.querySelectorAll('.typewriter-ss');
+      elements.forEach(setupTypewriter);
+
+      // Re-trigger animation on click (for demo purposes)
+      elements.forEach(function (el) {
+        el.addEventListener('click', function () {
+          el.style.animation = 'none';
+          el.style.width = '0';
+          // Force reflow
+          void el.offsetWidth;
+          el.style.animation = '';
+          setupTypewriter(el);
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/core_changes/typewriter-ss/style.css
+++ b/submissions/core_changes/typewriter-ss/style.css
@@ -1,0 +1,162 @@
+:root {
+  --tw-primary: #6366f1;
+  --tw-bg: #0f172a;
+  --tw-text: #f1f5f9;
+  --tw-muted: #64748b;
+  --tw-font: "Inter", "SF Mono", "Fira Code", "Consolas", monospace;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--tw-bg);
+  color: var(--tw-text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 60px;
+}
+
+.page-header h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+  background: linear-gradient(135deg, var(--tw-primary), #a855f7, #ec4899);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.page-header p {
+  color: var(--tw-muted);
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.demo-section {
+  width: 100%;
+  max-width: 700px;
+  margin-bottom: 48px;
+}
+
+.demo-section h2 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--tw-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 16px;
+}
+
+.demo-box {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 32px;
+  min-height: 80px;
+  display: flex;
+  align-items: center;
+  font-size: 1.25rem;
+  font-family: var(--tw-font);
+  overflow: hidden;
+}
+
+/* ─── Typewriter Core ─── */
+
+.typewriter-ss {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 3px solid var(--tw-primary);
+  width: 0;
+  animation:
+    tw-type var(--tw-speed, 0.08s) steps(var(--tw-chars, 20)) forwards,
+    tw-blink 0.75s step-end infinite;
+  animation-delay: var(--tw-delay, 0s);
+  min-width: 100%;
+}
+
+@keyframes tw-type {
+  from { width: 0; }
+  to { width: 100%; }
+}
+
+@keyframes tw-blink {
+  50% { border-color: transparent; }
+}
+
+/* Variant: No cursor after typing stops */
+.typewriter-ss-end {
+  animation:
+    tw-type var(--tw-speed, 0.08s) steps(var(--tw-chars, 20)) forwards,
+    tw-blink 0.75s step-end 3;
+  animation-delay: var(--tw-delay, 0s);
+  border-right-color: transparent;
+}
+
+/* Variant: Keep cursor blinking */
+.typewriter-ss-cursor {
+  animation:
+    tw-type var(--tw-speed, 0.08s) steps(var(--tw-chars, 20)) forwards,
+    tw-blink 0.75s step-end infinite;
+  animation-delay: var(--tw-delay, 0s);
+}
+
+/* Different cursor colors */
+.typewriter-ss-cursor-info { --tw-primary: #06b6d4; }
+.typewriter-ss-cursor-success { --tw-primary: #22c55e; }
+.typewriter-ss-cursor-warning { --tw-primary: #eab308; }
+.typewriter-ss-cursor-danger { --tw-primary: #ef4444; }
+
+/* Speed variants */
+.typewriter-ss-fast { --tw-speed: 0.04s; }
+.typewriter-ss-slow { --tw-speed: 0.15s; }
+
+/* Multi-line (for code examples) */
+.typewriter-ss-multi {
+  white-space: pre;
+  line-height: 1.6;
+}
+
+/* ─── Static demos with JS-set chars ─── */
+
+.demo-box .static-type {
+  font-family: var(--tw-font);
+  font-size: 1.25rem;
+  color: var(--tw-text);
+}
+
+/* ─── Reduced motion ─── */
+
+@media (prefers-reduced-motion: reduce) {
+  .typewriter-ss {
+    animation: none;
+    width: 100%;
+    border-right-color: transparent;
+  }
+}
+
+/* ─── Responsive ─── */
+
+@media (max-width: 480px) {
+  .demo-box {
+    padding: 20px;
+    font-size: 1rem;
+  }
+
+  .page-header h1 {
+    font-size: 1.35rem;
+  }
+}


### PR DESCRIPTION
## ✦ Description

Add a single-pass typewriter effect using CSS `steps()` timing for character-by-character text reveal with a blinking cursor, configurable speed/delay, cursor color variants, and optional JS helper for auto-detecting character counts.

The submission is in `submissions/core_changes/typewriter-ss/`:
- `demo.html` — 5 demo sections: hero headline, subtitle, cursor colors, delayed start, code block
- `style.css` — Raw CSS with `@keyframes` for typing and blink, `--tw-*` custom properties, 5 cursor color variants, speed variants, multiline support, and prefers-reduced-motion
- `README.md` — Usage docs following the 3-question format

Fixes #12463

---

## ⟡ Type of Change
- [x] New feature

---

## ✦ Checklist
- [x] All changes inside `submissions/core_changes/typewriter-ss/`
- [x] Includes `demo.html` — opens in browser with no server
- [x] Includes `style.css` — raw CSS
- [x] Includes `README.md` — what, how, why
- [x] **No changes to `core/` or `components/`**
- [x] One feature per PR

---

## Description

### Keyframes
- `tw-type` — animates width from 0 to 100% using `steps(var(--tw-chars))`
- `tw-blink` — toggles border-color transparency for cursor blink

### Features
- Configurable: `--tw-speed` (sec/char), `--tw-chars` (count), `--tw-delay`, `--tw-primary` (cursor color)
- Cursor variants: info (cyan), success (green), warning (yellow), danger (red)
- Speed variants: `typewriter-ss-fast` (0.04s), `typewriter-ss-slow` (0.15s)
- `typewriter-ss-multi` for code blocks (preserves whitespace)
- JS helper auto-sets `--tw-chars` from textContent.length
- Click-to-replay demo functionality
- `prefers-reduced-motion` — disables animation, shows full text

---

## Additional Notes
- No core or components files modified.
- Branch: Pcmhacker-piro:feat/core-changes-typewriter-ss
- Compare: https://github.com/Pcmhacker-piro/EaseMotion-css/compare/main...feat/core-changes-typewriter-ss?expand=1
