### PR TITLE
[FEATURE] Add single-pass typewriter animation with configurable speed and cursor colors

### DIFF
--- a/submissions/core_changes/typewriter-ss/README.md
+++ b/submissions/core_changes/typewriter-ss/README.md
@@ -1,0 +1,21 @@
+# Typewriter Effect (ss)
+
+1. **What does this do?**  
+   A single-pass typewriter animation that types text character-by-character with a blinking cursor, using CSS `steps()` timing.
+
+2. **How is it used?**  
+
+   ```html
+   <span class="typewriter-ss" id="hero">Build beautiful UIs</span>
+   <script>
+     document.querySelectorAll('.typewriter-ss').forEach(function (el) {
+       el.style.setProperty('--tw-chars', el.textContent.trim().length);
+     });
+   </script>
+   ```
+
+   Variants: `typewriter-ss-fast`, `typewriter-ss-slow`, `typewriter-ss-info`/`-success`/`-warning`/`-danger`, `typewriter-ss-multi`.  
+   Custom properties: `--tw-speed`, `--tw-chars`, `--tw-delay`, `--tw-primary` (cursor color).
+
+3. **Why is it useful?**  
+   EaseMotion CSS has `ease-typewriter-loop` (infinite) but no single-pass typewriter for hero sections. This fills the gap with configurable speed, delay, cursor colors, and an optional JS helper for auto-detecting character counts.

--- a/submissions/core_changes/typewriter-ss/demo.html
+++ b/submissions/core_changes/typewriter-ss/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Typewriter — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Typewriter Effect</h1>
+    <p>Single-pass typing · Blinking cursor · Configurable speed/delay · Cursor colors</p>
+  </header>
+
+  <div class="demo-section">
+    <h2>Hero Headline</h2>
+    <div class="demo-box">
+      <span class="typewriter-ss" id="tw-hero">
+        Build beautiful UIs with EaseMotion CSS
+      </span>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Fast speed + Info cursor</h2>
+    <div class="demo-box">
+      <span class="typewriter-ss typewriter-ss-fast typewriter-ss-info" id="tw-fast">
+        Zero dependencies · Animation-first · Human-readable
+      </span>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Cursor Color Variants</h2>
+    <div class="demo-box" style="flex-direction:column; align-items:flex-start; gap:16px;">
+      <span class="typewriter-ss" id="tw-c1" style="font-size:1rem;">Default (indigo) cursor</span>
+      <span class="typewriter-ss typewriter-ss-info" id="tw-c2" style="font-size:1rem;">Info (cyan) cursor</span>
+      <span class="typewriter-ss typewriter-ss-success" id="tw-c3" style="font-size:1rem;">Success (green) cursor</span>
+      <span class="typewriter-ss typewriter-ss-warning" id="tw-c4" style="font-size:1rem;">Warning (yellow) cursor</span>
+      <span class="typewriter-ss typewriter-ss-danger" id="tw-c5" style="font-size:1rem;">Danger (red) cursor</span>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>Delayed Start (1.5s)</h2>
+    <div class="demo-box">
+      <span class="typewriter-ss" id="tw-delay" style="--tw-delay:1.5s;">
+        This appears after a 1.5 second pause
+      </span>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.typewriter-ss').forEach(function (el) {
+      el.style.setProperty('--tw-chars', el.textContent.trim().length);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/core_changes/typewriter-ss/style.css
+++ b/submissions/core_changes/typewriter-ss/style.css
@@ -1,0 +1,89 @@
+:root {
+  --tw-primary: #6366f1;
+  --tw-bg: #0f172a;
+  --tw-text: #f1f5f9;
+  --tw-muted: #64748b;
+  --tw-font: "Inter", "SF Mono", "Fira Code", "Consolas", monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--tw-bg);
+  color: var(--tw-text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.page-header { text-align: center; margin-bottom: 60px; }
+
+.page-header h1 {
+  font-size: 1.75rem; font-weight: 700; margin: 0 0 8px;
+  background: linear-gradient(135deg, var(--tw-primary), #a855f7, #ec4899);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+
+.page-header p { color: var(--tw-muted); margin: 0; font-size: 0.95rem; }
+
+.demo-section { width: 100%; max-width: 700px; margin-bottom: 48px; }
+
+.demo-section h2 {
+  font-size: 0.85rem; font-weight: 600; color: var(--tw-muted);
+  text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 16px;
+}
+
+.demo-box {
+  background: #1e293b; border: 1px solid #334155; border-radius: 12px;
+  padding: 32px; min-height: 80px; display: flex; align-items: center;
+  font-size: 1.25rem; font-family: var(--tw-font); overflow: hidden;
+}
+
+/* ─── Typewriter Core ─── */
+
+.typewriter-ss {
+  display: inline-block; overflow: hidden; white-space: nowrap;
+  border-right: 3px solid var(--tw-primary); width: 0;
+  animation:
+    tw-type var(--tw-speed, 0.08s) steps(var(--tw-chars, 20)) forwards,
+    tw-blink 0.75s step-end infinite;
+  animation-delay: var(--tw-delay, 0s);
+  min-width: 100%;
+}
+
+@keyframes tw-type {
+  from { width: 0; }
+  to { width: 100%; }
+}
+
+@keyframes tw-blink {
+  50% { border-color: transparent; }
+}
+
+/* Cursor colors */
+.typewriter-ss-info { --tw-primary: #06b6d4; }
+.typewriter-ss-success { --tw-primary: #22c55e; }
+.typewriter-ss-warning { --tw-primary: #eab308; }
+.typewriter-ss-danger { --tw-primary: #ef4444; }
+
+/* Speed */
+.typewriter-ss-fast { --tw-speed: 0.04s; }
+.typewriter-ss-slow { --tw-speed: 0.15s; }
+
+/* Multi-line (code) */
+.typewriter-ss-multi { white-space: pre; line-height: 1.6; }
+
+@media (prefers-reduced-motion: reduce) {
+  .typewriter-ss {
+    animation: none; width: 100%; border-right-color: transparent;
+  }
+}
+
+@media (max-width: 480px) {
+  .demo-box { padding: 20px; font-size: 1rem; }
+  .page-header h1 { font-size: 1.35rem; }
+}


### PR DESCRIPTION
## ✦ Description

Add a single-pass typewriter effect using CSS `steps()` timing for character-by-character text reveal with a blinking cursor, configurable speed/delay, 5 cursor color variants, and optional JS helper for auto-detecting character counts.

Submission in `submissions/core_changes/typewriter-ss/`:
- `demo.html` — 4 demo sections: hero headline, fast speed with info cursor, cursor color variants, delayed start
- `style.css` — `@keyframes` for typing and blink, `--tw-*` custom properties, cursor color/speed/multiline variants, prefers-reduced-motion
- `README.md` — Usage docs

Fixes #12463

---

## ⟡ Type of Change
- [x] New feature

---

## ✦ Checklist
- [x] All changes inside `submissions/core_changes/typewriter-ss/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] **No changes to `core/` or `components/`**
- [x] One feature per PR

---

## Description

### Keyframes
- `tw-type` — width 0 to 100% via `steps(var(--tw-chars))`
- `tw-blink` — border-color toggle for cursor flash

### Configurable via CSS vars
- `--tw-speed` (default 0.08s), `--tw-chars`, `--tw-delay`, `--tw-primary`

### Variants
- Speed: `typewriter-ss-fast` (0.04s), `typewriter-ss-slow` (0.15s)
- Cursor: `-info` (cyan), `-success` (green), `-warning` (yellow), `-danger` (red)
- `typewriter-ss-multi` for code blocks

---

## Additional Notes
- Branch: Pcmhacker-piro:fix/typewriter-effect-ss
- Compare: https://github.com/Pcmhacker-piro/EaseMotion-css/compare/main...fix/typewriter-effect-ss?expand=1
