### PR TITLE
Statistics Counter Card Component Added

### DIFF
--- a/submissions/examples/statistics-counter-card-ds/README.md
+++ b/submissions/examples/statistics-counter-card-ds/README.md
@@ -1,0 +1,29 @@
+# Statistics Counter Card
+
+## Feature overview
+A responsive statistics section with four modern cards that animate number values as they enter the viewport.
+
+## Preview description
+The demo displays a grid of stat cards for users, projects, satisfaction, and support. Each card fades up into view and counts smoothly from zero to the target value using a requestAnimationFrame-driven animation.
+
+## Folder structure
+- `demo.html` — semantic demo page with cards and inline script.
+- `style.css` — CSS Grid layout, card styling, responsive behavior, and hover motion.
+- `README.md` — explanation of the feature, how it works, and customization options.
+
+## How the counter animation works
+- Each `.stat-card` is observed using the Intersection Observer API.
+- When the card enters the viewport, the card receives the `.is-visible` class to fade up.
+- The counter script triggers once and animates each number from 0 to its target value using `requestAnimationFrame`.
+- The animation uses an ease-out cubic progression for a polished counting motion.
+
+## Customization options
+- `data-target` — change the target statistic value for each card.
+- `--card-duration` — adjust animation timing for hover and fade transitions.
+- `--accent` and `--card-bg` — update the accent color and card surface.
+- `--radius` — change card border radius.
+- `--gap` — modify spacing between cards.
+- Card icons may be replaced with emoji, inline SVG, or icon fonts.
+
+## Browser compatibility
+This component uses modern browser APIs: CSS Grid, custom properties, Intersection Observer, and requestAnimationFrame. It is compatible with current versions of Chrome, Firefox, Edge, and Safari. For older browsers without Intersection Observer support, the counters may not trigger automatically, but the layout remains functional.

--- a/submissions/examples/statistics-counter-card-ds/demo.html
+++ b/submissions/examples/statistics-counter-card-ds/demo.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Statistics Counter Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page-shell">
+    <section class="stats-panel" aria-labelledby="stats-heading">
+      <header class="stats-header">
+        <p class="eyebrow">Performance highlights</p>
+        <h1 id="stats-heading">Statistics Counter Cards</h1>
+        <p class="description">
+          Watch the numbers count up as this responsive stat grid enters the viewport. Each card also fades in with a subtle motion effect.
+        </p>
+      </header>
+
+      <div class="stats-grid" id="statsGrid">
+        <article class="stat-card" data-fade-offset="0">
+          <span class="stat-icon" role="img" aria-label="Users">👥</span>
+          <div class="stat-content">
+            <div class="stat-value" data-target="12000">0</div>
+            <p class="stat-label">Users</p>
+            <p class="stat-description">Trusted by thousands globally.</p>
+          </div>
+        </article>
+
+        <article class="stat-card" data-fade-offset="100">
+          <span class="stat-icon" role="img" aria-label="Projects">📁</span>
+          <div class="stat-content">
+            <div class="stat-value" data-target="350">0</div>
+            <p class="stat-label">Projects</p>
+            <p class="stat-description">Completed across multiple teams.</p>
+          </div>
+        </article>
+
+        <article class="stat-card" data-fade-offset="200">
+          <span class="stat-icon" role="img" aria-label="Satisfaction">⭐</span>
+          <div class="stat-content">
+            <div class="stat-value" data-target="98">0</div>
+            <p class="stat-label">Satisfaction</p>
+            <p class="stat-description">Customer happiness rating.</p>
+          </div>
+        </article>
+
+        <article class="stat-card" data-fade-offset="300">
+          <span class="stat-icon" role="img" aria-label="Support">🕒</span>
+          <div class="stat-content">
+            <div class="stat-value" data-target="24">0</div>
+            <p class="stat-label">Support</p>
+            <p class="stat-description">Available around the clock.</p>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    // Capture the statistic cards and an animation state that ensures counting runs only once.
+    const cards = document.querySelectorAll('.stat-card');
+    let animationTriggered = false;
+
+    const animateValue = (element, start, end, duration, suffix = '') => {
+      const range = end - start;
+      const startTime = performance.now();
+
+      const step = (currentTime) => {
+        const elapsed = Math.min(currentTime - startTime, duration);
+        const progress = elapsed / duration;
+        const eased = 1 - Math.pow(1 - progress, 3); // ease-out cubic
+        const currentValue = Math.floor(start + range * eased);
+
+        element.textContent = `${currentValue}${suffix}`;
+
+        if (elapsed < duration) {
+          requestAnimationFrame(step);
+        } else {
+          element.textContent = `${end}${suffix}`;
+        }
+      };
+
+      requestAnimationFrame(step);
+    };
+
+    const startCounters = () => {
+      if (animationTriggered) return;
+      animationTriggered = true;
+
+      cards.forEach((card) => {
+        const valueElement = card.querySelector('.stat-value');
+        const target = Number(valueElement.dataset.target);
+        const suffix = target >= 1000 ? '+' : '';
+        const displayTarget = target >= 1000 ? Math.floor(target / 1000) : target;
+
+        animateValue(valueElement, 0, displayTarget, 1400, suffix);
+      });
+    };
+
+    const observerOptions = {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0.2,
+    };
+
+    const intersectionCallback = (entries, observer) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          if (!animationTriggered) {
+            startCounters();
+          }
+        } else {
+          // Keep cards visible after they have appeared once.
+          entry.target.classList.add('is-visible');
+        }
+      });
+    };
+
+    const observer = new IntersectionObserver(intersectionCallback, observerOptions);
+    cards.forEach((card) => observer.observe(card));
+  </script>
+</body>
+</html>

--- a/submissions/examples/statistics-counter-card-ds/style.css
+++ b/submissions/examples/statistics-counter-card-ds/style.css
@@ -1,0 +1,152 @@
+/* ============================================================
+   Statistics Counter Card
+   ============================================================ */
+
+:root {
+  --bg: #0f172a;
+  --panel: rgba(15, 23, 42, 0.95);
+  --panel-border: rgba(148, 163, 184, 0.16);
+  --text: #f8fafc;
+  --muted: #cbd5e1;
+  --card-bg: rgba(15, 23, 42, 0.88);
+  --card-border: rgba(148, 163, 184, 0.18);
+  --accent: #7c3aed;
+  --shadow: 0 32px 70px rgba(15, 23, 42, 0.28);
+  --radius: 28px;
+  --gap: 1.5rem;
+  --card-min: 220px;
+  --card-max: 1fr;
+  --card-duration: 420ms;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top, rgba(124, 58, 237, 0.18), transparent 30%),
+              linear-gradient(180deg, #111827 0%, #0f172a 100%);
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.page-shell {
+  width: min(1060px, 100%);
+}
+
+.stats-panel {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 32px;
+  box-shadow: var(--shadow);
+  padding: 3rem;
+}
+
+.stats-header {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 2.5vw, 2.75rem);
+  line-height: 1.05;
+}
+
+.description {
+  margin: 1rem auto 0;
+  max-width: 38rem;
+  color: var(--muted);
+  line-height: 1.75;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(var(--card-max), 240px), 1fr));
+  gap: var(--gap);
+}
+
+.stat-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius);
+  padding: 2rem;
+  display: grid;
+  gap: 1.35rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.14);
+  transform: translateY(32px);
+  opacity: 0;
+  transition: transform var(--card-duration) ease, opacity var(--card-duration) ease, box-shadow var(--card-duration) ease;
+}
+
+.stat-card.is-visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.stat-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(124, 58, 237, 0.16);
+  color: var(--accent);
+  font-size: 1.5rem;
+}
+
+.stat-content {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.stat-value {
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.stat-label {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.stat-description {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.stat-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 32px 70px rgba(15, 23, 42, 0.2);
+}
+
+@media (max-width: 640px) {
+  .stats-panel {
+    padding: 2rem;
+  }
+
+  .stat-card {
+    padding: 1.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

A new `Statistics Counter Card` example is added under statistics-counter-card-ds. It delivers a responsive grid of four stat cards with animated counters, fade-up entrance motion, and hover lift effects.

---
Closes #12592 

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside statistics-counter-card-ds
- [x] Includes demo.html — self-contained, opens in browser with no server
- [x] Includes style.css — raw CSS for the proposed feature
- [x] Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to core**
- [x] **No changes to components**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A polished statistics card section with animated number counters and entrance motion.

**How does a developer use it?**

```html
<link rel="stylesheet" href="style.css" />
<div class="stats-grid">
  <article class="stat-card">...</article>
  <article class="stat-card">...</article>
</div>
```

**Why does it fit EaseMotion CSS?**

It uses semantic markup, CSS custom properties, smooth motion-first animation, and lightweight vanilla JavaScript for a polished interaction without external dependencies.

---

## Demo

- [x] Demo added (demo.html works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- Counters animate from 0 to the target values once when the cards enter the viewport.
- Intersection Observer ensures the animation triggers once and keeps the layout accessible.
- Styling uses CSS Grid, hover lift, and fade-up motion for a modern, lightweight presentation.