### PR TITLE
[FEATURE] Add text truncation and line-clamp utility classes

### DIFF
--- a/submissions/examples/ease-line-clamp/README.md
+++ b/submissions/examples/ease-line-clamp/README.md
@@ -1,0 +1,26 @@
+# Text Truncation & Line-Clamp Utilities
+
+Utility classes for single-line truncation and multi-line line-clamp for EaseMotion CSS.
+
+## Classes
+
+| Class | Description |
+|---|---|
+| `.ease-truncate` | Single-line text truncation with ellipsis |
+| `.ease-line-clamp-1` | Clamp text to 1 line |
+| `.ease-line-clamp-2` | Clamp text to 2 lines |
+| `.ease-line-clamp-3` | Clamp text to 3 lines |
+| `.ease-line-clamp-4` | Clamp text to 4 lines |
+| `.ease-line-clamp-5` | Clamp text to 5 lines |
+| `.ease-line-clamp-6` | Clamp text to 6 lines |
+
+## Usage
+
+```html
+<p class="ease-truncate">Long text that will be truncated...</p>
+<p class="ease-line-clamp-3">Multi-line text clamped to 3 lines...</p>
+```
+
+Uses both `-webkit-line-clamp` (broad compatibility) and standard `line-clamp` (modern browsers).
+
+Fixes #12455

--- a/submissions/examples/ease-line-clamp/demo.html
+++ b/submissions/examples/ease-line-clamp/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Text Truncation & Line-Clamp - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<h1>Text Truncation &amp; Line-Clamp Utilities</h1>
+
+<p>Utility classes for single-line truncation and multi-line line-clamp.</p>
+
+<!-- Single-line truncation -->
+<h2>.ease-truncate</h2>
+<div class="card">
+    <p class="ease-truncate">
+        This is a very long text that should be truncated with an ellipsis at the end because it exceeds the available width of its container and cannot fit on a single line without overflowing.
+    </p>
+</div>
+
+<!-- Line-clamp examples -->
+<h2>.ease-line-clamp-1</h2>
+<div class="card">
+    <p class="ease-line-clamp-1">
+        This text is clamped to a single line. Any overflow beyond one line will be hidden with an ellipsis. This is very useful for headlines and titles.
+    </p>
+</div>
+
+<h2>.ease-line-clamp-2</h2>
+<div class="card">
+    <p class="ease-line-clamp-2">
+        This text is clamped to two lines. Any content beyond that gets truncated with an ellipsis. Perfect for card descriptions, article previews, and list item summaries where you want to show a preview without taking too much space.
+    </p>
+</div>
+
+<h2>.ease-line-clamp-3</h2>
+<div class="card">
+    <p class="ease-line-clamp-3">
+        This text is clamped to three lines. Great for longer previews where you want to show more context. The line-clamp utility gracefully handles multi-line text truncation using the CSS line-clamp property with \-webkit prefix for broad compatibility. This ensures your content stays within bounds while indicating there is more to read.
+    </p>
+</div>
+
+<h2>.ease-line-clamp-4</h2>
+<div class="card">
+    <p class="ease-line-clamp-4">
+        This text is clamped to four lines. Use this when you need to show a substantial preview while still constraining the height. It works well for blog post excerpts, product descriptions, and comment previews where you want to balance information density with visual consistency across a grid or list layout.
+    </p>
+</div>
+
+<h2>.ease-line-clamp-5</h2>
+<div class="card">
+    <p class="ease-line-clamp-5">
+        This text is clamped to five lines. This provides even more content visibility while maintaining a clean, consistent layout. Suitable for detailed previews, abstract snippets, or any scenario where you need to show a significant amount of text without letting individual items dominate the available space on the page.
+    </p>
+</div>
+
+<h2>.ease-line-clamp-6</h2>
+<div class="card">
+    <p class="ease-line-clamp-6">
+        This text is clamped to six lines, allowing for a generous preview while still enforcing a limit. This is the maximum line-clamp value provided by the utility set. Use it for longer excerpts, multi-line summaries, or any content area where you want to show substantial text without losing control over your layout and spacing.
+    </p>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/ease-line-clamp/style.css
+++ b/submissions/examples/ease-line-clamp/style.css
@@ -1,0 +1,114 @@
+/* ============================================================
+   EaseMotion CSS — Text Truncation & Line-Clamp Utilities
+   ============================================================ */
+@layer easemotion-utilities {
+  .ease-truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .ease-line-clamp-1 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
+  }
+
+  .ease-line-clamp-2 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+  }
+
+  .ease-line-clamp-3 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+  }
+
+  .ease-line-clamp-4 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    line-clamp: 4;
+  }
+
+  .ease-line-clamp-5 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 5;
+    line-clamp: 5;
+  }
+
+  .ease-line-clamp-6 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 6;
+    line-clamp: 6;
+  }
+}
+
+/* Demo page styling */
+@import url("https://cdn.jsdelivr.net/npm/easemotion-css@latest/easemotion.min.css");
+
+body {
+  font-family: var(--ease-font-sans, "Inter", system-ui, -apple-system, sans-serif);
+  max-width: 640px;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  line-height: 1.6;
+}
+
+h1 {
+  font-size: var(--ease-text-3xl, 1.875rem);
+  margin-bottom: 0.5rem;
+}
+
+h2 {
+  font-size: var(--ease-text-lg, 1.125rem);
+  margin: 1.5rem 0 0.5rem;
+  font-family: var(--ease-font-mono, "JetBrains Mono", monospace);
+}
+
+.card {
+  width: 100%;
+  max-width: 400px;
+  padding: var(--ease-space-4, 1rem);
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  margin-bottom: 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: var(--ease-color-bg, #0b1121);
+    color: var(--ease-color-text, #e2e8f0);
+  }
+
+  .card {
+    background: var(--ease-color-surface, #141e33);
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+}
+
+[data-theme="dark"] body {
+  background: var(--ease-color-bg, #0b1121);
+  color: var(--ease-color-text, #e2e8f0);
+}
+
+[data-theme="dark"] .card {
+  background: var(--ease-color-surface, #141e33);
+  border-color: var(--ease-color-neutral-700, #334155);
+}


### PR DESCRIPTION
## ✦ Description
Adds `.ease-truncate` (single-line ellipsis) and `.ease-line-clamp-1` through `.ease-line-clamp-6` utility classes for text overflow handling. Uses both `-webkit-line-clamp` for broad compatibility and standard `line-clamp` for modern browsers.

Fixes #12455

## ⟡ Type of Change
- [x] New feature

## ✦ Checklist
- [x] My code follows the style guidelines.
- [x] I have performed a self-review.

## Changes
- `submissions/examples/ease-line-clamp/demo.html` — Interactive demo
- `submissions/examples/ease-line-clamp/style.css` — Utility classes + demo styling
- `submissions/examples/ease-line-clamp/README.md` — Documentation

Branch: feat/line-clamp