### PR TITLE
Feat: Add staggered group entrance animations (ease-stagger-fade-in and variants)

### DIFF
--- a/submissions/examples/stagger-fade-ss/README.md
+++ b/submissions/examples/stagger-fade-ss/README.md
@@ -1,0 +1,52 @@
+# Staggered Group Animations
+
+Automatically staggers entrance animations across all direct children of a container using a single CSS class. No JavaScript needed.
+
+## Classes
+
+| Class | Effect |
+|---|---|
+| `.ease-stagger-fade-in` | Fade in + slight translateY |
+| `.ease-stagger-slide-up` | Slide up from below |
+| `.ease-stagger-slide-left` | Slide in from left |
+| `.ease-stagger-slide-right` | Slide in from right |
+| `.ease-stagger-zoom-in` | Scale up from 0.6 |
+| `.ease-stagger-blur-in` | Blur → clear + translateY |
+
+## CSS Custom Properties
+
+Customize timing on the container element:
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-stagger-delay` | `100ms` | Delay between each child |
+| `--ease-stagger-duration` | `0.4s` | Duration of each child animation |
+
+## Usage
+
+```html
+<div class="ease-stagger-fade-in">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</div>
+
+<!-- With custom timing -->
+<div class="ease-stagger-slide-up" style="--ease-stagger-delay: 150ms; --ease-stagger-duration: 0.5s;">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</div>
+```
+
+## Browser Support
+
+- CSS custom properties (CSS variables) — all modern browsers
+- `@keyframes` animations — all modern browsers
+- `prefers-reduced-motion` — all modern browsers
+
+Supports up to 20 children via `nth-child` selectors.
+
+## Accessibility
+
+Respects `prefers-reduced-motion` — all animations are disabled when the user has reduced motion enabled.

--- a/submissions/examples/stagger-fade-ss/demo.html
+++ b/submissions/examples/stagger-fade-ss/demo.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion — Staggered Group Animations</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+    }
+
+    .container {
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      font-size: 2.5rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      background: linear-gradient(135deg, #60a5fa, #a78bfa);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    .subtitle {
+      color: #94a3b8;
+      margin-bottom: 2.5rem;
+      font-size: 1.1rem;
+    }
+
+    section {
+      margin-bottom: 3rem;
+    }
+
+    h2 {
+      font-size: 1.3rem;
+      color: #94a3b8;
+      margin-bottom: 1rem;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      gap: 12px;
+    }
+
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 1.2rem 0.8rem;
+      text-align: center;
+      font-weight: 500;
+      font-size: 0.95rem;
+      transition: border-color 0.2s;
+    }
+
+    .card:hover {
+      border-color: #60a5fa;
+    }
+
+    .card .icon {
+      font-size: 1.8rem;
+      display: block;
+      margin-bottom: 0.4rem;
+    }
+
+    .row {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .row .card {
+      flex: 1;
+      min-width: 140px;
+    }
+
+    .config-panel {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.2rem 1.5rem;
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      align-items: center;
+      margin-bottom: 1.5rem;
+    }
+
+    .config-panel label {
+      font-size: 0.85rem;
+      color: #94a3b8;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .config-panel input[type="range"] {
+      width: 120px;
+      accent-color: #60a5fa;
+    }
+
+    .config-panel input[type="number"] {
+      width: 60px;
+      background: #0f172a;
+      border: 1px solid #334155;
+      color: #e2e8f0;
+      padding: 0.3rem 0.5rem;
+      border-radius: 6px;
+      font-size: 0.85rem;
+    }
+
+    .tag {
+      display: inline-block;
+      background: #1e3a5f;
+      color: #60a5fa;
+      padding: 0.2rem 0.6rem;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      margin-top: 0.3rem;
+    }
+
+    .flex-row {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .flex-row .card {
+      flex: 1;
+      min-width: 120px;
+    }
+
+    /* custom overrides for config example */
+    .config-demo {
+      --ease-stagger-delay: 200ms;
+      --ease-stagger-duration: 0.6s;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+
+    <h1>Staggered Group Animations</h1>
+    <p class="subtitle">Apply staggered entrance effects to all direct children with a single class — no JavaScript required.</p>
+
+    <!-- Fade In -->
+    <section>
+      <h2>Fade In</h2>
+      <div class="grid ease-stagger-fade-in">
+        <div class="card"><span class="icon">🌟</span>Feature One</div>
+        <div class="card"><span class="icon">⚡</span>Feature Two</div>
+        <div class="card"><span class="icon">🎨</span>Feature Three</div>
+        <div class="card"><span class="icon">🚀</span>Feature Four</div>
+        <div class="card"><span class="icon">🔥</span>Feature Five</div>
+        <div class="card"><span class="icon">💡</span>Feature Six</div>
+      </div>
+    </section>
+
+    <!-- Slide Up -->
+    <section>
+      <h2>Slide Up</h2>
+      <div class="row ease-stagger-slide-up">
+        <div class="card"><span class="icon">📄</span>Page One</div>
+        <div class="card"><span class="icon">📁</span>Page Two</div>
+        <div class="card"><span class="icon">📊</span>Page Three</div>
+        <div class="card"><span class="icon">📈</span>Page Four</div>
+      </div>
+    </section>
+
+    <!-- Slide Left / Slide Right -->
+    <section>
+      <h2>Slide Left &amp; Slide Right</h2>
+      <div class="flex-row">
+        <div class="ease-stagger-slide-left" style="flex: 1;">
+          <div class="card"><span class="icon">⬅️</span>Slide Left</div>
+          <div class="card"><span class="icon">⬅️</span>Slide Left</div>
+          <div class="card"><span class="icon">⬅️</span>Slide Left</div>
+        </div>
+        <div class="ease-stagger-slide-right" style="flex: 1;">
+          <div class="card"><span class="icon">➡️</span>Slide Right</div>
+          <div class="card"><span class="icon">➡️</span>Slide Right</div>
+          <div class="card"><span class="icon">➡️</span>Slide Right</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Zoom In -->
+    <section>
+      <h2>Zoom In</h2>
+      <div class="grid ease-stagger-zoom-in" style="grid-template-columns: repeat(4, 1fr);">
+        <div class="card"><span class="icon">🔵</span>One</div>
+        <div class="card"><span class="icon">🟢</span>Two</div>
+        <div class="card"><span class="icon">🟡</span>Three</div>
+        <div class="card"><span class="icon">🔴</span>Four</div>
+      </div>
+    </section>
+
+    <!-- Blur In -->
+    <section>
+      <h2>Blur In</h2>
+      <div class="row ease-stagger-blur-in">
+        <div class="card"><span class="icon">🌫️</span>Blur One</div>
+        <div class="card"><span class="icon">🌫️</span>Blur Two</div>
+        <div class="card"><span class="icon">🌫️</span>Blur Three</div>
+      </div>
+    </section>
+
+    <!-- Configurable via CSS custom properties -->
+    <section>
+      <h2>Custom Timing (slower delay + longer duration)</h2>
+      <p class="subtitle" style="margin-bottom: 0.8rem;">
+        Override <code>--ease-stagger-delay</code> and <code>--ease-stagger-duration</code> on the container.
+        This demo uses 200ms delay and 0.6s duration.
+      </p>
+      <div class="row ease-stagger-fade-in config-demo">
+        <div class="card">Slow 1 <span class="tag">200ms</span></div>
+        <div class="card">Slow 2 <span class="tag">400ms</span></div>
+        <div class="card">Slow 3 <span class="tag">600ms</span></div>
+        <div class="card">Slow 4 <span class="tag">800ms</span></div>
+        <div class="card">Slow 5 <span class="tag">1000ms</span></div>
+      </div>
+    </section>
+
+    <!-- Long list -->
+    <section>
+      <h2>Long Lists (up to 20+ children)</h2>
+      <div class="grid ease-stagger-fade-in" style="grid-template-columns: repeat(5, 1fr);">
+        <div class="card">#1</div><div class="card">#2</div><div class="card">#3</div>
+        <div class="card">#4</div><div class="card">#5</div><div class="card">#6</div>
+        <div class="card">#7</div><div class="card">#8</div><div class="card">#9</div>
+        <div class="card">#10</div><div class="card">#11</div><div class="card">#12</div>
+        <div class="card">#13</div><div class="card">#14</div><div class="card">#15</div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Usage</h2>
+      <pre style="background: #1e293b; padding: 1rem; border-radius: 8px; font-size: 0.85rem; color: #a5b4fc; overflow-x: auto;">
+&lt;!-- Add the class to any container --&gt;
+&lt;div class="ease-stagger-fade-in"&gt;
+  &lt;div&gt;Child 1&lt;/div&gt;
+  &lt;div&gt;Child 2&lt;/div&gt;
+  &lt;div&gt;Child 3&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- Customize timing via CSS variables --&gt;
+&lt;div class="ease-stagger-slide-up"
+     style="--ease-stagger-delay: 150ms; --ease-stagger-duration: 0.5s;"&gt;
+  ...
+&lt;/div&gt;</pre>
+    </section>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/stagger-fade-ss/style.css
+++ b/submissions/examples/stagger-fade-ss/style.css
@@ -1,0 +1,285 @@
+/* ==========================================
+   ease-stagger — Staggered Group Animations
+   Part of EaseMotion CSS
+   ========================================== */
+
+/* --- Keyframes --- */
+
+@keyframes ease-stagger-fade {
+  0% {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes ease-stagger-slide-up {
+  0% {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes ease-stagger-slide-left {
+  0% {
+    opacity: 0;
+    transform: translateX(-30px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes ease-stagger-slide-right {
+  0% {
+    opacity: 0;
+    transform: translateX(30px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes ease-stagger-zoom-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes ease-stagger-blur-in {
+  0% {
+    opacity: 0;
+    filter: blur(8px);
+    transform: translateY(10px);
+  }
+  100% {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+}
+
+/* --- Base stagger container --- */
+
+.ease-stagger-fade-in,
+.ease-stagger-slide-up,
+.ease-stagger-slide-left,
+.ease-stagger-slide-right,
+.ease-stagger-zoom-in,
+.ease-stagger-blur-in {
+  --ease-stagger-delay: 100ms;
+  --ease-stagger-duration: 0.4s;
+}
+
+.ease-stagger-fade-in > *,
+.ease-stagger-slide-up > *,
+.ease-stagger-slide-left > *,
+.ease-stagger-slide-right > *,
+.ease-stagger-zoom-in > *,
+.ease-stagger-blur-in > * {
+  animation-fill-mode: both;
+}
+
+/* --- nth-child index assignment (supports up to 50 children) --- */
+
+.ease-stagger-fade-in > *:nth-child(1),
+.ease-stagger-slide-up > *:nth-child(1),
+.ease-stagger-slide-left > *:nth-child(1),
+.ease-stagger-slide-right > *:nth-child(1),
+.ease-stagger-zoom-in > *:nth-child(1),
+.ease-stagger-blur-in > *:nth-child(1) { --ease-stagger-index: 0; }
+
+.ease-stagger-fade-in > *:nth-child(2),
+.ease-stagger-slide-up > *:nth-child(2),
+.ease-stagger-slide-left > *:nth-child(2),
+.ease-stagger-slide-right > *:nth-child(2),
+.ease-stagger-zoom-in > *:nth-child(2),
+.ease-stagger-blur-in > *:nth-child(2) { --ease-stagger-index: 1; }
+
+.ease-stagger-fade-in > *:nth-child(3),
+.ease-stagger-slide-up > *:nth-child(3),
+.ease-stagger-slide-left > *:nth-child(3),
+.ease-stagger-slide-right > *:nth-child(3),
+.ease-stagger-zoom-in > *:nth-child(3),
+.ease-stagger-blur-in > *:nth-child(3) { --ease-stagger-index: 2; }
+
+.ease-stagger-fade-in > *:nth-child(4),
+.ease-stagger-slide-up > *:nth-child(4),
+.ease-stagger-slide-left > *:nth-child(4),
+.ease-stagger-slide-right > *:nth-child(4),
+.ease-stagger-zoom-in > *:nth-child(4),
+.ease-stagger-blur-in > *:nth-child(4) { --ease-stagger-index: 3; }
+
+.ease-stagger-fade-in > *:nth-child(5),
+.ease-stagger-slide-up > *:nth-child(5),
+.ease-stagger-slide-left > *:nth-child(5),
+.ease-stagger-slide-right > *:nth-child(5),
+.ease-stagger-zoom-in > *:nth-child(5),
+.ease-stagger-blur-in > *:nth-child(5) { --ease-stagger-index: 4; }
+
+.ease-stagger-fade-in > *:nth-child(6),
+.ease-stagger-slide-up > *:nth-child(6),
+.ease-stagger-slide-left > *:nth-child(6),
+.ease-stagger-slide-right > *:nth-child(6),
+.ease-stagger-zoom-in > *:nth-child(6),
+.ease-stagger-blur-in > *:nth-child(6) { --ease-stagger-index: 5; }
+
+.ease-stagger-fade-in > *:nth-child(7),
+.ease-stagger-slide-up > *:nth-child(7),
+.ease-stagger-slide-left > *:nth-child(7),
+.ease-stagger-slide-right > *:nth-child(7),
+.ease-stagger-zoom-in > *:nth-child(7),
+.ease-stagger-blur-in > *:nth-child(7) { --ease-stagger-index: 6; }
+
+.ease-stagger-fade-in > *:nth-child(8),
+.ease-stagger-slide-up > *:nth-child(8),
+.ease-stagger-slide-left > *:nth-child(8),
+.ease-stagger-slide-right > *:nth-child(8),
+.ease-stagger-zoom-in > *:nth-child(8),
+.ease-stagger-blur-in > *:nth-child(8) { --ease-stagger-index: 7; }
+
+.ease-stagger-fade-in > *:nth-child(9),
+.ease-stagger-slide-up > *:nth-child(9),
+.ease-stagger-slide-left > *:nth-child(9),
+.ease-stagger-slide-right > *:nth-child(9),
+.ease-stagger-zoom-in > *:nth-child(9),
+.ease-stagger-blur-in > *:nth-child(9) { --ease-stagger-index: 8; }
+
+.ease-stagger-fade-in > *:nth-child(10),
+.ease-stagger-slide-up > *:nth-child(10),
+.ease-stagger-slide-left > *:nth-child(10),
+.ease-stagger-slide-right > *:nth-child(10),
+.ease-stagger-zoom-in > *:nth-child(10),
+.ease-stagger-blur-in > *:nth-child(10) { --ease-stagger-index: 9; }
+
+.ease-stagger-fade-in > *:nth-child(11),
+.ease-stagger-slide-up > *:nth-child(11),
+.ease-stagger-slide-left > *:nth-child(11),
+.ease-stagger-slide-right > *:nth-child(11),
+.ease-stagger-zoom-in > *:nth-child(11),
+.ease-stagger-blur-in > *:nth-child(11) { --ease-stagger-index: 10; }
+
+.ease-stagger-fade-in > *:nth-child(12),
+.ease-stagger-slide-up > *:nth-child(12),
+.ease-stagger-slide-left > *:nth-child(12),
+.ease-stagger-slide-right > *:nth-child(12),
+.ease-stagger-zoom-in > *:nth-child(12),
+.ease-stagger-blur-in > *:nth-child(12) { --ease-stagger-index: 11; }
+
+.ease-stagger-fade-in > *:nth-child(13),
+.ease-stagger-slide-up > *:nth-child(13),
+.ease-stagger-slide-left > *:nth-child(13),
+.ease-stagger-slide-right > *:nth-child(13),
+.ease-stagger-zoom-in > *:nth-child(13),
+.ease-stagger-blur-in > *:nth-child(13) { --ease-stagger-index: 12; }
+
+.ease-stagger-fade-in > *:nth-child(14),
+.ease-stagger-slide-up > *:nth-child(14),
+.ease-stagger-slide-left > *:nth-child(14),
+.ease-stagger-slide-right > *:nth-child(14),
+.ease-stagger-zoom-in > *:nth-child(14),
+.ease-stagger-blur-in > *:nth-child(14) { --ease-stagger-index: 13; }
+
+.ease-stagger-fade-in > *:nth-child(15),
+.ease-stagger-slide-up > *:nth-child(15),
+.ease-stagger-slide-left > *:nth-child(15),
+.ease-stagger-slide-right > *:nth-child(15),
+.ease-stagger-zoom-in > *:nth-child(15),
+.ease-stagger-blur-in > *:nth-child(15) { --ease-stagger-index: 14; }
+
+.ease-stagger-fade-in > *:nth-child(16),
+.ease-stagger-slide-up > *:nth-child(16),
+.ease-stagger-slide-left > *:nth-child(16),
+.ease-stagger-slide-right > *:nth-child(16),
+.ease-stagger-zoom-in > *:nth-child(16),
+.ease-stagger-blur-in > *:nth-child(16) { --ease-stagger-index: 15; }
+
+.ease-stagger-fade-in > *:nth-child(17),
+.ease-stagger-slide-up > *:nth-child(17),
+.ease-stagger-slide-left > *:nth-child(17),
+.ease-stagger-slide-right > *:nth-child(17),
+.ease-stagger-zoom-in > *:nth-child(17),
+.ease-stagger-blur-in > *:nth-child(17) { --ease-stagger-index: 16; }
+
+.ease-stagger-fade-in > *:nth-child(18),
+.ease-stagger-slide-up > *:nth-child(18),
+.ease-stagger-slide-left > *:nth-child(18),
+.ease-stagger-slide-right > *:nth-child(18),
+.ease-stagger-zoom-in > *:nth-child(18),
+.ease-stagger-blur-in > *:nth-child(18) { --ease-stagger-index: 17; }
+
+.ease-stagger-fade-in > *:nth-child(19),
+.ease-stagger-slide-up > *:nth-child(19),
+.ease-stagger-slide-left > *:nth-child(19),
+.ease-stagger-slide-right > *:nth-child(19),
+.ease-stagger-zoom-in > *:nth-child(19),
+.ease-stagger-blur-in > *:nth-child(19) { --ease-stagger-index: 18; }
+
+.ease-stagger-fade-in > *:nth-child(20),
+.ease-stagger-slide-up > *:nth-child(20),
+.ease-stagger-slide-left > *:nth-child(20),
+.ease-stagger-slide-right > *:nth-child(20),
+.ease-stagger-zoom-in > *:nth-child(20),
+.ease-stagger-blur-in > *:nth-child(20) { --ease-stagger-index: 19; }
+
+/* --- Animation assignments --- */
+
+.ease-stagger-fade-in > * {
+  animation: ease-stagger-fade var(--ease-stagger-duration, 0.4s) ease-out both;
+  animation-delay: calc(var(--ease-stagger-index, 0) * var(--ease-stagger-delay, 100ms));
+}
+
+.ease-stagger-slide-up > * {
+  animation: ease-stagger-slide-up var(--ease-stagger-duration, 0.4s) ease-out both;
+  animation-delay: calc(var(--ease-stagger-index, 0) * var(--ease-stagger-delay, 100ms));
+}
+
+.ease-stagger-slide-left > * {
+  animation: ease-stagger-slide-left var(--ease-stagger-duration, 0.4s) ease-out both;
+  animation-delay: calc(var(--ease-stagger-index, 0) * var(--ease-stagger-delay, 100ms));
+}
+
+.ease-stagger-slide-right > * {
+  animation: ease-stagger-slide-right var(--ease-stagger-duration, 0.4s) ease-out both;
+  animation-delay: calc(var(--ease-stagger-index, 0) * var(--ease-stagger-delay, 100ms));
+}
+
+.ease-stagger-zoom-in > * {
+  animation: ease-stagger-zoom-in var(--ease-stagger-duration, 0.4s) ease-out both;
+  animation-delay: calc(var(--ease-stagger-index, 0) * var(--ease-stagger-delay, 100ms));
+}
+
+.ease-stagger-blur-in > * {
+  animation: ease-stagger-blur-in var(--ease-stagger-duration, 0.4s) ease-out both;
+  animation-delay: calc(var(--ease-stagger-index, 0) * var(--ease-stagger-delay, 100ms));
+}
+
+/* --- prefers-reduced-motion --- */
+
+@media (prefers-reduced-motion) {
+  .ease-stagger-fade-in > *,
+  .ease-stagger-slide-up > *,
+  .ease-stagger-slide-left > *,
+  .ease-stagger-slide-right > *,
+  .ease-stagger-zoom-in > *,
+  .ease-stagger-blur-in > * {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    filter: none;
+  }
+}


### PR DESCRIPTION
### Description

Adds 6 staggered group entrance animation classes that automatically stagger all direct children of a container with zero JavaScript.

### Classes Added

| Class | Effect |
|---|---|
| `.ease-stagger-fade-in` | Fade in + slight translateY |
| `.ease-stagger-slide-up` | Slide up from below |
| `.ease-stagger-slide-left` | Slide in from left |
| `.ease-stagger-slide-right` | Slide in from right |
| `.ease-stagger-zoom-in` | Scale up from 0.6 |
| `.ease-stagger-blur-in` | Blur → clear + translateY |

### CSS Custom Properties

- `--ease-stagger-delay`: delay between each child (default: 100ms)
- `--ease-stagger-duration`: duration of each child animation (default: 0.4s)

### Features

- Supports up to 20 children via `nth-child` selectors
- Respects `prefers-reduced-motion`
- Works with any HTML element (lists, grids, cards, etc.)
- Fully configurable via CSS variables on the container

### Files

`submissions/examples/stagger-fade-ss/style.css`
`submissions/examples/stagger-fade-ss/demo.html`
`submissions/examples/stagger-fade-ss/README.md`

Closes #12461