### PR TITLE
feat: add team/about us page with profile cards and staggered reveal

### DIFF
--- a/submissions/examples/team-page/README.md
+++ b/submissions/examples/team-page/README.md
@@ -1,0 +1,20 @@
+# Team / About Us Component
+
+An interactive leadership showcase layout framework combining micro-staggered arrival entry triggers with clean multi-axis item profile hovers.
+
+## Functional Controls
+- **Staggered Entry Disclosures:** Scripted timeout arrays injecting state classes sequentially to build rhythmic animations.
+- **Smooth Image Scaling:** Transforming container scale layers effortlessly via hardware-accelerated transform rules.
+- **Social Tray Hover Transitions:** Translation overlays modifying opacity values cleanly on layout mouse vectors.
+
+## Usage Layout Structure
+```html
+<div class="ease-team-grid">
+  <div class="ease-profile-card">
+    <div class="ease-avatar-wrapper"> ... </div>
+    <div class="ease-profile-socials"> ... </div>
+  </div>
+</div>
+```
+
+Closes #12480

--- a/submissions/examples/team-page/demo.html
+++ b/submissions/examples/team-page/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Team Profile Matrix — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #ffffff; margin: 0; padding: 2rem 0;">
+
+  <section class="ease-team-section">
+    <div class="ease-team-header">
+      <h2 class="ease-team-title">Our Leadership</h2>
+      <p class="ease-team-subtitle">Architects behind the Next-Gen layout framework models</p>
+    </div>
+
+    <div class="ease-team-grid" id="teamGrid">
+      
+      <div class="ease-profile-card">
+        <div class="ease-avatar-wrapper">
+          <img class="ease-avatar-img" src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=200&q=80" alt="Marcus Vance" />
+        </div>
+        <h3 class="ease-profile-name">Elena Rostova</h3>
+        <p class="ease-profile-role">Core Architecture</p>
+        <p class="ease-profile-bio">Pioneering paint cycle optimizations and CSS coordinate grid abstractions inside core viewports.</p>
+        <div class="ease-profile-socials">
+          <a href="#" class="ease-social-link">🌐</a>
+          <a href="#" class="ease-social-link">🐙</a>
+        </div>
+      </div>
+
+      <div class="ease-profile-card">
+        <div class="ease-avatar-wrapper">
+          <img class="ease-avatar-img" src="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&q=80" alt="David Chen" />
+        </div>
+        <h3 class="ease-profile-name">David Chen</h3>
+        <p class="ease-profile-role">Interaction Design</p>
+        <p class="ease-profile-bio">Specializing in fluid hardware-accelerated curves and high-fidelity micro-interactions.</p>
+        <div class="ease-profile-socials">
+          <a href="#" class="ease-social-link">🌐</a>
+          <a href="#" class="ease-social-link">🐦</a>
+        </div>
+      </div>
+
+      <div class="ease-profile-card">
+        <div class="ease-avatar-wrapper">
+          <img class="ease-avatar-img" src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&q=80" alt="Sophia Martinez" />
+        </div>
+        <h3 class="ease-profile-name">Sophia Martinez</h3>
+        <p class="ease-profile-role">DevOps Pipeline</p>
+        <p class="ease-profile-bio">Managing regression test bounds and isolated build verification workflows across matrices.</p>
+        <div class="ease-profile-socials">
+          <a href="#" class="ease-social-link">🐙</a>
+          <a href="#" class="ease-social-link">🐦</a>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <script>
+    const profileCards = document.querySelectorAll('.ease-profile-card');
+
+    function triggerStaggeredReveal() {
+      profileCards.forEach((card, index) => {
+        // Apply micro-incremental disclosure timeouts
+        setTimeout(() => {
+          card.classList.add('is-revealed');
+        }, index * 120);
+      });
+    }
+
+    // Fire presentation immediately on asset mount
+    window.addEventListener('DOMContentLoaded', triggerStaggeredReveal);
+  </script>
+</body>
+</html>

--- a/submissions/examples/team-page/style.css
+++ b/submissions/examples/team-page/style.css
@@ -1,0 +1,150 @@
+/* ============================================================
+   ease-team-page — Interactive Team Profile Showcase
+
+   Features micro-interactions including:
+     - Staggered scale/fade card entries on layout disclosure
+     - Multi-axis social control reveal panels on profile hover
+     - Layout-isolated flex grid maps minimizing repaint costs
+   ============================================================ */
+
+.ease-team-section {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+  font-family: var(--ease-font-sans, sans-serif);
+}
+
+.ease-team-header {
+  text-align: center;
+  margin-bottom: 3.5rem;
+}
+
+.ease-team-title {
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: #0f172a;
+  margin: 0 0 0.5rem 0;
+}
+
+.ease-team-subtitle {
+  font-size: 1.05rem;
+  color: #64748b;
+  margin: 0;
+}
+
+/* Fluid Profile Cards Grid Workspace */
+.ease-team-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+}
+
+@media (max-width: 768px) {
+  .ease-team-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .ease-team-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Staggered Card Entry Configurations */
+.ease-profile-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 1rem);
+  overflow: hidden;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 2rem 1.5rem;
+  opacity: 0;
+  transform: translateY(30px) scale(0.96);
+  transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1), transform 0.6s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.ease-profile-card.is-revealed {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.ease-profile-card:hover {
+  border-color: #cbd5e1;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05);
+}
+
+/* Profile Image Media Frame */
+.ease-avatar-wrapper {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  position: relative;
+  margin-bottom: 1.25rem;
+  overflow: hidden;
+  background: #f1f5f9;
+}
+
+.ease-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-profile-card:hover .ease-avatar-img {
+  transform: scale(1.08);
+}
+
+/* Metadata Text Elements */
+.ease-profile-name {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0 0 0.25rem 0;
+}
+
+.ease-profile-role {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #2563eb;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 1rem 0;
+}
+
+.ease-profile-bio {
+  font-size: 0.9rem;
+  color: #475569;
+  line-height: 1.5;
+  margin: 0 0 1.25rem 0;
+}
+
+/* Hover-Revealed Social Icon Overlays */
+.ease-profile-socials {
+  display: flex;
+  gap: 0.75rem;
+  opacity: 0.4;
+  transform: translateY(4px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.ease-profile-card:hover .ease-profile-socials {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.ease-social-link {
+  color: #64748b;
+  text-decoration: none;
+  font-size: 1.1rem;
+  transition: color 0.15s ease;
+}
+.ease-social-link:hover {
+  color: #0f172a;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the complete `team-page` layout block structure. Delivers a responsive roster overview grouping combining staggered CSS transition-entry delays with contextual icon trays that smoothly slide and fade into focus when profiles are active.

Closes #12480

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- JavaScript timeout sequences applying isolated disclosure classes (`.is-revealed`) on paint timelines.
- CSS transform layer properties (`scale` and `translateY`) preventing layout jitter or content reflow jumps during interactions.
- Completely isolated component spacing models safe from global container styles.

**How does a developer use it?**
```html
<div class="ease-team-grid">
  <div class="ease-profile-card">...</div>
</div>

Demo
[x] Demo added (demo.html managing automated load-ins and internal hover nodes)

Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

[x] Safari

Closes #12480