### PR TITLE
feat: add email inbox with list, preview pane, and compose modal

### DIFF
--- a/submissions/examples/email-inbox/README.md
+++ b/submissions/examples/email-inbox/README.md
@@ -1,0 +1,19 @@
+# Email Inbox Master-Detail Component
+
+An interactive client multi-pane split layout module handling independent panel scroll bounding, row-based selection borders, and layered lightbox overlay modals.
+
+## Functional Controls
+- **Isolated Scroll Rails:** Layout container controls locking vertical overflow rules on column feeds independently.
+- **Compensation Borders:** Selection indicators using inset spacing geometry to safeguard elements from width reflow shifts.
+- **Hardware Scale Modals:** Overlay panels using scaling transitions (`transform` and `opacity`) to stay decoupled from base document paint trees.
+
+## Usage Layout Structure
+```html
+<div class="ease-inbox-viewport">
+  <aside class="ease-inbox-sidebar"> ... </aside>
+  <div class="ease-message-list-feed"> ... </div>
+  <main class="ease-preview-pane"> ... </main>
+</div>
+```
+
+Closes #12485

--- a/submissions/examples/email-inbox/demo.html
+++ b/submissions/examples/email-inbox/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Email Client Shell — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f1f5f9; padding: 3rem 1rem; margin: 0;">
+
+  <div class="ease-inbox-viewport">
+    
+    <aside class="ease-inbox-sidebar">
+      <button class="ease-btn-compose" onclick="toggleCompose(true)">✏️ Compose</button>
+      <nav class="ease-sidebar-menu">
+        <button class="ease-sidebar-item is-active">📥 Inbox</button>
+        <button class="ease-sidebar-item">📤 Sent</button>
+        <button class="ease-sidebar-item">📝 Drafts</button>
+      </nav>
+    </aside>
+
+    <div class="ease-message-list-feed">
+      
+      <div class="ease-msg-item-row is-active" onclick="viewMail('Elena Rostova', '10:42 AM', 'Global Context Providers', 'Hey team, I just pushed the structural modifications to the frame parameters. Let me know your thoughts.')">
+        <div class="ease-msg-meta-top">
+          <span class="ease-msg-sender">Elena Rostova</span>
+          <span class="ease-msg-time">10:42 AM</span>
+        </div>
+        <h4 class="ease-msg-subject">Global Context Providers</h4>
+        <p class="ease-msg-snippet">Hey team, I just pushed the structural modifications to the frame parameters.</p>
+      </div>
+
+      <div class="ease-msg-item-row" onclick="viewMail('David Chen', 'Yesterday', 'Hardware Acceleration Curves', 'We need to verify if the matrix shifts stay paint-safe under continuous transform streams on narrow break-frames.')">
+        <div class="ease-msg-meta-top">
+          <span class="ease-msg-sender">David Chen</span>
+          <span class="ease-msg-time">Yesterday</span>
+        </div>
+        <h4 class="ease-msg-subject">Hardware Acceleration Curves</h4>
+        <p class="ease-msg-snippet">We need to verify if the matrix shifts stay paint-safe under continuous transform streams.</p>
+      </div>
+
+    </div>
+
+    <main class="ease-preview-pane" id="previewWindow">
+      <div class="ease-preview-header">
+        <h2 class="ease-preview-subject" id="previewSubject">Global Context Providers</h2>
+        <div style="font-size: 0.85rem; color: #64748b;">
+          From: <strong style="color: #0f172a;" id="previewSender">Elena Rostova</strong> &bull; <span id="previewTime">10:42 AM</span>
+        </div>
+      </div>
+      <p class="ease-preview-body" id="previewBody">
+        Hey team, I just pushed the structural modifications to the frame parameters. Let me know your thoughts on how it behaves with layout isolated containers before we cut the main release.
+      </p>
+    </main>
+
+  </div>
+
+  <div class="ease-modal-overlay" id="composeModal">
+    <div class="ease-compose-box">
+      <div class="ease-compose-header">
+        <h3 class="ease-compose-title">New Message</h3>
+        <button class="ease-btn-modal-close" onclick="toggleCompose(false)">✕</button>
+      </div>
+      <form class="ease-compose-body-form" onsubmit="event.preventDefault(); toggleCompose(false);">
+        <input type="text" class="ease-input-field" placeholder="To" required />
+        <input type="text" class="ease-input-field" placeholder="Subject" required />
+        <textarea class="ease-input-field" style="height: 160px; resize: none; font-family: inherit;" placeholder="Write your message..."></textarea>
+        <button class="ease-btn-compose" type="submit" style="align-self: flex-end; padding: 0.5rem 1.5rem;">Send</button>
+      </form>
+    </div>
+  </div>
+
+  <script>
+    // Handle inline row list data routing
+    function viewMail(sender, time, subject, body) {
+      // Manage active element row highlight resets
+      const rows = document.querySelectorAll('.ease-msg-item-row');
+      rows.forEach(r => r.classList.remove('is-active'));
+      
+      // Look up target contextual pointer item
+      const clickedRow = Array.from(rows).find(r => r.querySelector('.ease-msg-sender').textContent === sender);
+      if (clickedRow) clickedRow.classList.add('is-active');
+
+      document.getElementById('previewSubject').textContent = subject;
+      document.getElementById('previewSender').textContent = sender;
+      document.getElementById('previewTime').textContent = time;
+      document.getElementById('previewBody').textContent = body;
+    }
+
+    // Toggle overlay view states
+    function toggleCompose(visible) {
+      const modal = document.getElementById('composeModal');
+      if (visible) {
+        modal.classList.add('is-visible');
+      } else {
+        modal.classList.remove('is-visible');
+      }
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/email-inbox/style.css
+++ b/submissions/examples/email-inbox/style.css
@@ -1,0 +1,253 @@
+/* ============================================================
+   ease-email-inbox — Interactive Email Client Split-Pane UI
+
+   Features micro-interactions including:
+     - Flex-split master-detail panels with independent scroll frames
+     - Active message selection highlights without border reflows
+     - Layered viewport overlay compose modal transitions
+   ============================================================ */
+
+.ease-inbox-viewport {
+  max-width: 1200px;
+  margin: 0 auto;
+  height: 600px;
+  display: grid;
+  grid-template-columns: 240px 380px 1fr;
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-2xl, 1rem);
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05);
+  font-family: var(--ease-font-sans, sans-serif);
+  overflow: hidden;
+}
+
+@media (max-width: 968px) {
+  .ease-inbox-viewport {
+    grid-template-columns: 80px 1fr;
+  }
+  .ease-preview-pane {
+    display: none;
+  }
+}
+
+/* Left Sidebar Layout Navigation */
+.ease-inbox-sidebar {
+  background: #f8fafc;
+  border-right: 1px solid #e2e8f0;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ease-btn-compose {
+  background: #2563eb;
+  color: #ffffff;
+  border: none;
+  padding: 0.75rem 1rem;
+  font-weight: 700;
+  font-size: 0.9rem;
+  border-radius: var(--ease-radius-lg, 0.5rem);
+  cursor: pointer;
+  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.2);
+  transition: background 0.15s ease;
+}
+.ease-btn-compose:hover {
+  background: #1d4ed8;
+}
+
+.ease-sidebar-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.ease-sidebar-item {
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #475569;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  cursor: pointer;
+}
+.ease-sidebar-item.is-active {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+/* Center Column: Message List Feed */
+.ease-message-list-feed {
+  border-right: 1px solid #e2e8f0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-msg-item-row {
+  padding: 1.25rem;
+  border-bottom: 1px solid #f1f5f9;
+  cursor: pointer;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  transition: background 0.15s ease;
+}
+.ease-msg-item-row:hover:not(.is-active) {
+  background: #f8fafc;
+}
+.ease-msg-item-row.is-active {
+  background: #eff6ff;
+  border-left: 3px solid #2563eb;
+  padding-left: calc(1.25rem - 3px);
+}
+
+.ease-msg-meta-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ease-msg-sender {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.ease-msg-time {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.ease-msg-subject {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0;
+}
+
+.ease-msg-snippet {
+  font-size: 0.8rem;
+  color: #64748b;
+  line-height: 1.4;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Right Column: Detailed Preview Panel */
+.ease-preview-pane {
+  overflow-y: auto;
+  background: #ffffff;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.ease-preview-header {
+  border-bottom: 1px solid #f1f5f9;
+  padding-bottom: 1.25rem;
+}
+
+.ease-preview-subject {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #0f172a;
+  margin: 0 0 0.5rem 0;
+}
+
+.ease-preview-body {
+  font-size: 0.95rem;
+  color: #334155;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Compose Lightbox Viewport Modals */
+.ease-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(4px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.ease-modal-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ease-compose-box {
+  background: #ffffff;
+  width: 100%;
+  max-width: 500px;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  transform: scale(0.95) translateY(12px);
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-modal-overlay.is-visible .ease-compose-box {
+  transform: scale(1) translateY(0);
+}
+
+.ease-compose-header {
+  background: #0f172a;
+  color: #ffffff;
+  padding: 1rem 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top-left-radius: var(--ease-radius-xl, 0.75rem);
+  border-top-right-radius: var(--ease-radius-xl, 0.75rem);
+}
+
+.ease-compose-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.ease-btn-modal-close {
+  background: transparent;
+  border: none;
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+.ease-btn-modal-close:hover {
+  color: #ffffff;
+}
+
+.ease-compose-body-form {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ease-input-field {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  font-size: 0.9rem;
+  box-sizing: border-box;
+  outline: none;
+}
+.ease-input-field:focus {
+  border-color: #2563eb;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the complete `email-inbox` feature application block. Delivers a clean grid structure separating sidebar navigational triggers, item list scrolling cards, and detailed read viewports alongside an animated modal form layer.

Closes #12485

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- Column-bound layouts using CSS grid alignments to safely collapse downstream viewports on mobile devices.
- Anti-shift active rules ensuring row highlights (`border-left`) adjust content widths inline without generating layout displacement.
- Hardware-accelerated presentation overlays (`.ease-modal-overlay`) modifying transform scaling inside decoupled repaint chains.

**How does a developer use it?**
```html
<div class="ease-inbox-viewport">
  <aside class="ease-inbox-sidebar">...</aside>
  <div class="ease-message-list-feed">...</div>
  <main class="ease-preview-pane">...</main>
</div>

Demo
[x] Demo added (demo.html implementing split-routing text injections and toggle drawers)

Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

[x] Safari