### PR TITLE
[FEATURE] Add responsive breakpoint utility classes (ease-md-*, ease-lg-*, ease-xl-*, ease-2xl-*)

### DIFF
--- a/submissions/core_changes/README.md
+++ b/submissions/core_changes/README.md
@@ -1,0 +1,49 @@
+# Responsive Breakpoint Utility Classes
+
+Adds responsive utility classes with breakpoint prefixes for building responsive layouts.
+
+## Breakpoints
+
+| Prefix | Min Width | Example |
+|--------|-----------|--------|
+| `sm` | 640px | `.ease-sm-flex` (already exists) |
+| `md` | 768px | `.ease-md-hidden` |
+| `lg` | 1024px | `.ease-lg-grid-cols-3` |
+| `xl` | 1280px | `.ease-xl-flex-row` |
+| `2xl` | 1536px | `.ease-2xl-w-1/2` |
+
+## Utility Categories
+
+| Category | Classes |
+|----------|--------|
+| **Display** | `flex`, `grid`, `block`, `hidden`, `inline`, `inline-block` |
+| **Grid columns** | `grid-cols-1`, `grid-cols-2`, `grid-cols-3`, `grid-cols-4`, `grid-cols-6`, `grid-cols-12` |
+| **Flex direction** | `flex-row`, `flex-col`, `flex-wrap`, `flex-nowrap` |
+| **Gap** | `gap-0` through `gap-8` |
+| **Text alignment** | `text-left`, `text-center`, `text-right` |
+| **Width** | `w-1/2`, `w-1/3`, `w-2/3`, `w-1/4`, `w-3/4`, `w-full` |
+| **Order** | `order-first`, `order-1`, `order-2`, `order-3`, `order-last` |
+| **Alignment** | `items-center`, `items-start`, `items-end`, `justify-center`, `justify-between`, `justify-around`, `justify-end` |
+
+## Usage
+
+```html
+<!-- 2 cols on md, 4 cols on lg -->
+<div class="ease-grid ease-md-grid-cols-2 ease-lg-grid-cols-4">
+  <div>1</div>
+  <div>2</div>
+  <div>3</div>
+  <div>4</div>
+</div>
+
+<!-- Hidden on mobile, flex on md+ -->
+<div class="ease-hidden ease-md-flex">
+  <span>Visible on md+</span>
+</div>
+```
+
+## Generation
+
+Classes are generated via CSS `@media (min-width: ...)` queries for each breakpoint. To regenerate, run the Python/SCSS build script in the submission source.
+
+Fixes #12460

--- a/submissions/core_changes/demo.html
+++ b/submissions/core_changes/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Responsive Breakpoint Utilities - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<h1>Responsive Breakpoint Utilities</h1>
+<p>Resize your browser to see <code>ease-md-*</code>, <code>ease-lg-*</code>, <code>ease-xl-*</code>, <code>ease-2xl-*</code> in action.</p>
+
+<h2>Display: <code>ease-md-flex</code></h2>
+<div class="demo-box">
+    <div class="ease-flex ease-md-flex">
+        <span class="badge">1</span>
+        <span class="badge">2</span>
+        <span class="badge">3</span>
+    </div>
+    <p class="note">Always flex; use <code>ease-md-block</code> / <code>ease-md-hidden</code> at breakpoints.</p>
+</div>
+
+<h2>Grid columns: <code>ease-md-grid-cols-2 ease-lg-grid-cols-4</code></h2>
+<div class="demo-box ease-grid ease-md-grid-cols-2 ease-lg-grid-cols-4">
+    <div class="cell">1</div>
+    <div class="cell">2</div>
+    <div class="cell">3</div>
+    <div class="cell">4</div>
+</div>
+
+<h2>Flex direction: <code>ease-flex-col ease-md-flex-row</code></h2>
+<div class="demo-box ease-flex ease-flex-col ease-md-flex-row">
+    <span class="badge">A</span>
+    <span class="badge">B</span>
+    <span class="badge">C</span>
+</div>
+
+<h2>Text alignment: <code>ease-text-center ease-md-text-left ease-lg-text-right</code></h2>
+<div class="demo-box ease-text-center ease-md-text-left ease-lg-text-right">
+    Align changes at each breakpoint.
+</div>
+
+<h2>Width: <code>ease-w-full ease-md-w-1/2 ease-lg-w-1/3</code></h2>
+<div class="demo-box">
+    <div class="demo-width ease-w-full ease-md-w-1/2 ease-lg-w-1/3">
+        Width responds to breakpoint.
+    </div>
+</div>
+
+<h2>Order: <code>ease-md-order-2</code></h2>
+<div class="demo-box ease-flex">
+    <div class="badge" style="order:2">Second (order:2)</div>
+    <div class="badge" style="order:1">First (order:1)</div>
+    <div class="badge ease-md-order-last">Last on md+</div>
+</div>
+
+<h2>Gap: <code>ease-flex-col ease-md-flex-row ease-gap-2 ease-md-gap-6</code></h2>
+<div class="demo-box ease-flex ease-flex-col ease-md-flex-row ease-gap-2 ease-md-gap-6">
+    <span class="badge">X</span>
+    <span class="badge">Y</span>
+    <span class="badge">Z</span>
+</div>
+
+<h2>Breakpoint Reference</h2>
+<table class="bp-table">
+    <thead>
+        <tr><th>Prefix</th><th>Min Width</th><th>Example</th></tr>
+    </thead>
+    <tbody>
+        <tr><td><code>sm</code></td><td>640px</td><td><code>.ease-sm-flex</code></td></tr>
+        <tr><td><code>md</code></td><td>768px</td><td><code>.ease-md-hidden</code></td></tr>
+        <tr><td><code>lg</code></td><td>1024px</td><td><code>.ease-lg-grid-cols-3</code></td></tr>
+        <tr><td><code>xl</code></td><td>1280px</td><td><code>.ease-xl-flex-row</code></td></tr>
+        <tr><td><code>2xl</code></td><td>1536px</td><td><code>.ease-2xl-w-1/2</code></td></tr>
+    </tbody>
+</table>
+
+</body>
+</html>

--- a/submissions/core_changes/style.css
+++ b/submissions/core_changes/style.css
@@ -1,0 +1,323 @@
+/* ============================================================
+   EaseMotion CSS — Responsive Breakpoint Utility Classes
+   Generated for md (768px), lg (1024px), xl (1280px), 2xl (1536px)
+   ============================================================ */
+
+@media (min-width: 768px) {
+  .ease-md-flex { display: flex; }
+  .ease-md-grid { display: grid; }
+  .ease-md-block { display: block; }
+  .ease-md-hidden { display: none; }
+  .ease-md-inline { display: inline; }
+  .ease-md-inline-block { display: inline-block; }
+  .ease-md-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+  .ease-md-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ease-md-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .ease-md-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .ease-md-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+  .ease-md-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+  .ease-md-flex-row { flex-direction: row; }
+  .ease-md-flex-col { flex-direction: column; }
+  .ease-md-flex-wrap { flex-direction: wrap; }
+  .ease-md-flex-nowrap { flex-direction: nowrap; }
+  .ease-md-gap-0 { gap: 0; }
+  .ease-md-gap-1 { gap: 0.25rem; }
+  .ease-md-gap-2 { gap: 0.5rem; }
+  .ease-md-gap-3 { gap: 0.75rem; }
+  .ease-md-gap-4 { gap: 1rem; }
+  .ease-md-gap-6 { gap: 1.5rem; }
+  .ease-md-gap-8 { gap: 2rem; }
+  .ease-md-text-left { text-align: left; }
+  .ease-md-text-center { text-align: center; }
+  .ease-md-text-right { text-align: right; }
+  .ease-md-w-1\/2 { width: 50%; }
+  .ease-md-w-1\/3 { width: 33.333333%; }
+  .ease-md-w-2\/3 { width: 66.666667%; }
+  .ease-md-w-1\/4 { width: 25%; }
+  .ease-md-w-3\/4 { width: 75%; }
+  .ease-md-w-full { width: 100%; }
+  .ease-md-order-first { order: -1; }
+  .ease-md-order-1 { order: 1; }
+  .ease-md-order-2 { order: 2; }
+  .ease-md-order-3 { order: 3; }
+  .ease-md-order-last { order: 9999; }
+}
+
+@media (min-width: 1024px) {
+  .ease-lg-flex { display: flex; }
+  .ease-lg-grid { display: grid; }
+  .ease-lg-block { display: block; }
+  .ease-lg-hidden { display: none; }
+  .ease-lg-inline { display: inline; }
+  .ease-lg-inline-block { display: inline-block; }
+  .ease-lg-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+  .ease-lg-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ease-lg-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .ease-lg-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .ease-lg-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+  .ease-lg-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+  .ease-lg-flex-row { flex-direction: row; }
+  .ease-lg-flex-col { flex-direction: column; }
+  .ease-lg-flex-wrap { flex-direction: wrap; }
+  .ease-lg-flex-nowrap { flex-direction: nowrap; }
+  .ease-lg-gap-0 { gap: 0; }
+  .ease-lg-gap-1 { gap: 0.25rem; }
+  .ease-lg-gap-2 { gap: 0.5rem; }
+  .ease-lg-gap-3 { gap: 0.75rem; }
+  .ease-lg-gap-4 { gap: 1rem; }
+  .ease-lg-gap-6 { gap: 1.5rem; }
+  .ease-lg-gap-8 { gap: 2rem; }
+  .ease-lg-text-left { text-align: left; }
+  .ease-lg-text-center { text-align: center; }
+  .ease-lg-text-right { text-align: right; }
+  .ease-lg-w-1\/2 { width: 50%; }
+  .ease-lg-w-1\/3 { width: 33.333333%; }
+  .ease-lg-w-2\/3 { width: 66.666667%; }
+  .ease-lg-w-1\/4 { width: 25%; }
+  .ease-lg-w-3\/4 { width: 75%; }
+  .ease-lg-w-full { width: 100%; }
+  .ease-lg-order-first { order: -1; }
+  .ease-lg-order-1 { order: 1; }
+  .ease-lg-order-2 { order: 2; }
+  .ease-lg-order-3 { order: 3; }
+  .ease-lg-order-last { order: 9999; }
+}
+
+@media (min-width: 1280px) {
+  .ease-xl-flex { display: flex; }
+  .ease-xl-grid { display: grid; }
+  .ease-xl-block { display: block; }
+  .ease-xl-hidden { display: none; }
+  .ease-xl-inline { display: inline; }
+  .ease-xl-inline-block { display: inline-block; }
+  .ease-xl-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+  .ease-xl-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ease-xl-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .ease-xl-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .ease-xl-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+  .ease-xl-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+  .ease-xl-flex-row { flex-direction: row; }
+  .ease-xl-flex-col { flex-direction: column; }
+  .ease-xl-flex-wrap { flex-direction: wrap; }
+  .ease-xl-flex-nowrap { flex-direction: nowrap; }
+  .ease-xl-gap-0 { gap: 0; }
+  .ease-xl-gap-1 { gap: 0.25rem; }
+  .ease-xl-gap-2 { gap: 0.5rem; }
+  .ease-xl-gap-3 { gap: 0.75rem; }
+  .ease-xl-gap-4 { gap: 1rem; }
+  .ease-xl-gap-6 { gap: 1.5rem; }
+  .ease-xl-gap-8 { gap: 2rem; }
+  .ease-xl-text-left { text-align: left; }
+  .ease-xl-text-center { text-align: center; }
+  .ease-xl-text-right { text-align: right; }
+  .ease-xl-w-1\/2 { width: 50%; }
+  .ease-xl-w-1\/3 { width: 33.333333%; }
+  .ease-xl-w-2\/3 { width: 66.666667%; }
+  .ease-xl-w-1\/4 { width: 25%; }
+  .ease-xl-w-3\/4 { width: 75%; }
+  .ease-xl-w-full { width: 100%; }
+  .ease-xl-order-first { order: -1; }
+  .ease-xl-order-1 { order: 1; }
+  .ease-xl-order-2 { order: 2; }
+  .ease-xl-order-3 { order: 3; }
+  .ease-xl-order-last { order: 9999; }
+}
+
+@media (min-width: 1536px) {
+  .ease-2xl-flex { display: flex; }
+  .ease-2xl-grid { display: grid; }
+  .ease-2xl-block { display: block; }
+  .ease-2xl-hidden { display: none; }
+  .ease-2xl-inline { display: inline; }
+  .ease-2xl-inline-block { display: inline-block; }
+  .ease-2xl-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+  .ease-2xl-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ease-2xl-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .ease-2xl-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .ease-2xl-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+  .ease-2xl-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+  .ease-2xl-flex-row { flex-direction: row; }
+  .ease-2xl-flex-col { flex-direction: column; }
+  .ease-2xl-flex-wrap { flex-direction: wrap; }
+  .ease-2xl-flex-nowrap { flex-direction: nowrap; }
+  .ease-2xl-gap-0 { gap: 0; }
+  .ease-2xl-gap-1 { gap: 0.25rem; }
+  .ease-2xl-gap-2 { gap: 0.5rem; }
+  .ease-2xl-gap-3 { gap: 0.75rem; }
+  .ease-2xl-gap-4 { gap: 1rem; }
+  .ease-2xl-gap-6 { gap: 1.5rem; }
+  .ease-2xl-gap-8 { gap: 2rem; }
+  .ease-2xl-text-left { text-align: left; }
+  .ease-2xl-text-center { text-align: center; }
+  .ease-2xl-text-right { text-align: right; }
+  .ease-2xl-w-1\/2 { width: 50%; }
+  .ease-2xl-w-1\/3 { width: 33.333333%; }
+  .ease-2xl-w-2\/3 { width: 66.666667%; }
+  .ease-2xl-w-1\/4 { width: 25%; }
+  .ease-2xl-w-3\/4 { width: 75%; }
+  .ease-2xl-w-full { width: 100%; }
+  .ease-2xl-order-first { order: -1; }
+  .ease-2xl-order-1 { order: 1; }
+  .ease-2xl-order-2 { order: 2; }
+  .ease-2xl-order-3 { order: 3; }
+  .ease-2xl-order-last { order: 9999; }
+}
+
+@media (min-width: 768px) {
+  .ease-md-items-center { align-items: center; }
+  .ease-md-items-start { align-items: flex-start; }
+  .ease-md-items-end { align-items: flex-end; }
+  .ease-md-justify-center { justify-content: center; }
+  .ease-md-justify-between { justify-content: space-between; }
+  .ease-md-justify-around { justify-content: space-around; }
+  .ease-md-justify-end { justify-content: flex-end; }
+}
+
+@media (min-width: 1024px) {
+  .ease-lg-items-center { align-items: center; }
+  .ease-lg-items-start { align-items: flex-start; }
+  .ease-lg-items-end { align-items: flex-end; }
+  .ease-lg-justify-center { justify-content: center; }
+  .ease-lg-justify-between { justify-content: space-between; }
+  .ease-lg-justify-around { justify-content: space-around; }
+  .ease-lg-justify-end { justify-content: flex-end; }
+}
+
+@media (min-width: 1280px) {
+  .ease-xl-items-center { align-items: center; }
+  .ease-xl-items-start { align-items: flex-start; }
+  .ease-xl-items-end { align-items: flex-end; }
+  .ease-xl-justify-center { justify-content: center; }
+  .ease-xl-justify-between { justify-content: space-between; }
+  .ease-xl-justify-around { justify-content: space-around; }
+  .ease-xl-justify-end { justify-content: flex-end; }
+}
+
+@media (min-width: 1536px) {
+  .ease-2xl-items-center { align-items: center; }
+  .ease-2xl-items-start { align-items: flex-start; }
+  .ease-2xl-items-end { align-items: flex-end; }
+  .ease-2xl-justify-center { justify-content: center; }
+  .ease-2xl-justify-between { justify-content: space-between; }
+  .ease-2xl-justify-around { justify-content: space-around; }
+  .ease-2xl-justify-end { justify-content: flex-end; }
+}
+
+/* Demo page */
+@import url("https://cdn.jsdelivr.net/npm/easemotion-css@latest/easemotion.min.css");
+
+body {
+  font-family: var(--ease-font-sans, "Inter", system-ui, -apple-system, sans-serif);
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  line-height: 1.6;
+}
+
+h1 {
+  font-size: var(--ease-text-3xl, 1.875rem);
+  margin-bottom: 0.25rem;
+}
+
+h2 {
+  font-size: var(--ease-text-lg, 1.125rem);
+  margin: 2rem 0 0.5rem;
+  font-family: var(--ease-font-mono, "JetBrains Mono", monospace);
+}
+
+.demo-box {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  padding: var(--ease-space-4, 1rem);
+  margin-bottom: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+  font-weight: 700;
+  border-radius: var(--ease-radius-md, 0.5rem);
+}
+
+.cell {
+  background: var(--ease-color-primary-light, #a09af8);
+  color: #fff;
+  padding: var(--ease-space-3, 0.75rem);
+  text-align: center;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  font-weight: 600;
+}
+
+.demo-width {
+  background: var(--ease-color-success-light, #86efac);
+  color: var(--ease-color-success-dark, #15803d);
+  padding: var(--ease-space-3, 0.75rem);
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  font-weight: 600;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.note {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #64748b);
+  margin-top: var(--ease-space-2, 0.5rem);
+  margin-bottom: 0;
+}
+
+.bp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.bp-table th, .bp-table td {
+  padding: var(--ease-space-3, 0.75rem);
+  border-bottom: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  text-align: left;
+}
+
+.bp-table th {
+  font-weight: 600;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+}
+
+code {
+  font-family: var(--ease-font-mono, "JetBrains Mono", monospace);
+  font-size: 0.85em;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: var(--ease-color-bg, #0b1121);
+    color: var(--ease-color-text, #e2e8f0);
+  }
+
+  .demo-box, .bp-table th, code {
+    background: var(--ease-color-surface, #141e33);
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+}
+
+[data-theme="dark"] body {
+  background: var(--ease-color-bg, #0b1121);
+  color: var(--ease-color-text, #e2e8f0);
+}
+
+[data-theme="dark"] .demo-box,
+[data-theme="dark"] .bp-table th,
+[data-theme="dark"] code {
+  background: var(--ease-color-surface, #141e33);
+  border-color: var(--ease-color-neutral-700, #334155);
+}


### PR DESCRIPTION
## ✦ Description
Adds responsive utility classes for md (768px), lg (1024px), xl (1280px), and 2xl (1536px) breakpoints covering display, grid columns, flex direction, gap, text alignment, width, order, and alignment utilities.

Fixes #12460

## ⟡ Type of Change
- [x] New feature

## ✦ Checklist
- [x] My code follows the style guidelines.
- [x] I have performed a self-review.

## Changes
- `submissions/core_changes/demo.html` — Interactive demo showing each utility category at different breakpoints
- `submissions/core_changes/style.css` — Generated responsive CSS for all breakpoints + demo styling
- `submissions/core_changes/README.md` — Breakpoint reference table and usage examples

No core files modified. Branch: feat/responsive-breakpoints