### PR TITLE
feat: add code documentation page with sidebar nav, search, and syntax highlight

### DIFF
--- a/submissions/examples/code-docs-page/README.md
+++ b/submissions/examples/code-docs-page/README.md
@@ -1,0 +1,22 @@
+# Technical Code Documentation Page Component
+
+An encapsulated documentation layout system pairing a lock-scrolled side navigation panel with tokenized code presentation grids and interactive sidebar searching lists.
+
+## Functional Controls
+- **Sticky Sidebar Bounding Rails:** Independent view height parameters tracking viewports without breaking global scrolling tracking.
+- **Semantic Token Highlights:** Preformatted style classes parsing code block literals into distinct paint layers safely.
+- **Interactive String Filtering:** JavaScript loops matching inline nav listings dynamically without causing text reflow shifts.
+
+## Usage Layout Structure
+```html
+<div class="ease-docs-viewport">
+  <aside class="ease-docs-sidebar"> ... </aside>
+  <main class="ease-docs-main">
+    <div class="ease-code-block-wrapper">
+      <pre class="ease-code-content"> ... </pre>
+    </div>
+  </main>
+</div>
+```
+
+Closes #12486

--- a/submissions/examples/code-docs-page/demo.html
+++ b/submissions/examples/code-docs-page/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Documentation Workspace — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #ffffff; margin: 0; padding: 0;">
+
+  <div class="ease-docs-viewport">
+    
+    <aside class="ease-docs-sidebar">
+      <div class="ease-docs-search-box">
+        <span class="ease-search-icon">🔍</span>
+        <input type="text" class="ease-docs-search-input" id="docsSearch" placeholder="Filter sections..." oninput="handleSearch()" />
+      </div>
+      
+      <nav class="ease-docs-nav-menu">
+        <div class="ease-nav-header">Core Overview</div>
+        <a href="#introduction" class="ease-nav-link is-active">Introduction</a>
+        <a href="#installation" class="ease-nav-link">Installation</a>
+        
+        <div class="ease-nav-header">API Interfaces</div>
+        <a href="#app-factory" class="ease-nav-link">Application Factory</a>
+        <a href="#context-hooks" class="ease-nav-link">Context Hooks</a>
+      </nav>
+    </aside>
+
+    <main class="ease-docs-main">
+      <article class="ease-docs-article">
+        
+        <h1 class="ease-docs-h1" id="introduction">Application Factory</h1>
+        <p class="ease-docs-p">
+          Initialize dynamic context frames cleanly without colliding with concurrent paint loops. The application factory design configuration keeps isolated setups decoupled.
+        </p>
+
+        <div class="ease-code-block-wrapper">
+          <pre class="ease-code-content"><span class="ease-token-keyword">import</span> { createMatrix } <span class="ease-token-keyword">from</span> <span class="ease-token-string">'@easemotion/core'</span>;
+
+<span class="ease-token-comment">// Construct an isolated canvas frame reference parameters</span>
+<span class="ease-token-keyword">export</span> <span class="ease-token-keyword">const</span> <span class="ease-token-function">initPipeline</span> = (selector) => {
+  <span class="ease-token-keyword">const</span> surface = <span class="ease-token-function">createMatrix</span>(selector);
+  
+  <span class="ease-token-keyword">return</span> surface.<span class="ease-token-function">mount</span>({
+    stagger: <span class="ease-token-string">'fluid-linear'</span>
+  });
+};</pre>
+        </div>
+
+        <p class="ease-docs-p">
+          Pass explicit string configuration hooks to align transitions along hardware-accelerated rendering pipelines safely.
+        </p>
+
+      </article>
+    </main>
+
+  </div>
+
+  <script>
+    // Handle inline item structural filtering on the link list
+    function handleSearch() {
+      const query = document.getElementById('docsSearch').value.toLowerCase();
+      const navLinks = document.querySelectorAll('.ease-nav-link');
+
+      navLinks.forEach(link => {
+        const text = link.textContent.toLowerCase();
+        if (text.includes(query)) {
+          link.style.display = 'block';
+        } else {
+          link.style.display = 'none';
+        }
+      });
+    }
+
+    // Highlighting dynamic click target anchors swaps
+    const links = document.querySelectorAll('.ease-nav-link');
+    links.forEach(link => {
+      link.addEventListener('click', () => {
+        links.forEach(l => l.classList.remove('is-active'));
+        link.classList.add('is-active');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/code-docs-page/style.css
+++ b/submissions/examples/code-docs-page/style.css
@@ -1,0 +1,158 @@
+/* ============================================================
+   ease-code-docs — Technical Documentation & Code Viewport UI
+
+   Features micro-interactions including:
+     - Independent scrolling master-navigation sidebar rail
+     - Tokenized semantic code blocks with custom syntax color sets
+     - Inline layout text search match item filtering
+   ============================================================ */
+
+.ease-docs-viewport {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+  background: var(--ease-color-surface, #ffffff);
+  font-family: var(--ease-font-sans, sans-serif);
+}
+
+@media (max-width: 768px) {
+  .ease-docs-viewport {
+    grid-template-columns: 1fr;
+  }
+  .ease-docs-sidebar {
+    display: none; /* Collapsed for mobile implementation baseline */
+  }
+}
+
+/* Left Nav Sidebar Frame Track */
+.ease-docs-sidebar {
+  background: #f8fafc;
+  border-right: 1px solid #e2e8f0;
+  padding: 1.5rem 1rem;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  overflow-y: auto;
+}
+
+.ease-docs-search-box {
+  position: relative;
+}
+
+.ease-docs-search-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem 0.5rem 2rem;
+  font-size: 0.85rem;
+  border: 1px solid #cbd5e1;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  outline: none;
+  background: #ffffff;
+  box-sizing: border-box;
+  transition: border-color 0.15s ease;
+}
+.ease-docs-search-input:focus {
+  border-color: #2563eb;
+}
+
+.ease-search-icon {
+  position: absolute;
+  left: 0.65rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.ease-docs-nav-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.ease-nav-header {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.5rem 0.75rem;
+  margin: 0.5rem 0 0.25rem 0;
+}
+
+.ease-nav-link {
+  display: block;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #475569;
+  text-decoration: none;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.ease-nav-link:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+.ease-nav-link.is-active {
+  background: #eff6ff;
+  color: #2563eb;
+}
+
+/* Right Content Main Container Layout */
+.ease-docs-main {
+  padding: 2.5rem 3rem;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+.ease-docs-article {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-docs-h1 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: #0f172a;
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.ease-docs-p {
+  font-size: 1rem;
+  color: #334155;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Syntax Highlight Preformatted Text Elements */
+.ease-code-block-wrapper {
+  background: #0f172a;
+  border-radius: var(--ease-radius-lg, 0.5rem);
+  padding: 1.25rem;
+  margin: 0.5rem 0;
+  overflow-x: auto;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.ease-code-content {
+  margin: 0;
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #e2e8f0;
+}
+
+/* Token Colors Syntax Rules Mapping */
+.ease-token-keyword { color: #f43f5e; font-weight: 700; }  /* const, return, import */
+.ease-token-function { color: #38bdf8; }                 /* function names */
+.ease-token-string { color: #34d399; }                   /* literals */
+.ease-token-comment { color: #64748b; font-style: italic; } /* documentation lines */


### PR DESCRIPTION
## Pull Request Description
Submits the complete `code-docs-page` template layout structure. Delivers a clean, multi-column reading interface separating sticky sidebar link panels (supporting fast lookahead lookups) from technical documentation grids that include syntax token styles.

Closes #12486

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- Column navigation frames structured using `position: sticky` and `height: 100vh` to enable independent sidebar scrolls.
- Code token sets separating block structures (`.ease-token-keyword`, `.ease-token-string`) to make code snippets highly readable.
- Clean text matching filters that safely prune out nav items without breaking element aspect containers.

**How does a developer use it?**
```html
<div class="ease-docs-viewport">
  <aside class="ease-docs-sidebar">...</aside>
  <main class="ease-docs-main">...</main>
</div>

Demo
[x] Demo added (demo.html grouping active selectors, mock tokens, and nav overrides)

Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

[x] Safari