### PR TITLE
feat: add scroll snap container utilities (ease-snap-*)

### DIFF
--- a/submissions/examples/scroll-snap-utilities/README.md
+++ b/submissions/examples/scroll-snap-utilities/README.md
@@ -1,0 +1,26 @@
+# Scroll Snap Container Utilities
+
+A utility class package containing CSS scroll-snapping design primitives to quickly build high-performance sliders, carousels, and presentation lanes using native thread optimizations.
+
+## Utility Roster API
+
+### Parent Configurations
+- `.ease-snap-x`: Sets up horizontal overflow scroll fields running rigid mandatory locking targets.
+- `.ease-snap-y`: Sets up vertical overflow scroll rails running rigid mandatory locking targets.
+- `.ease-snap-proximity`: Weakens lock thresholds to evaluate alignment purely when stopping nearby.
+
+### Child Alignments
+- `.ease-snap-align-start`: Forces items to lock flush against the leading axis bounds.
+- `.ease-snap-align-center`: Forces items to lock symmetrically into the central axis viewports.
+- `.ease-snap-align-end`: Forces items to lock flush against the trailing axis bounds.
+
+## Usage Layout Structure
+```html
+
+<div class="ease-snap-x">
+  <div class="ease-carousel-card ease-snap-align-center"> Card 1 </div>
+  <div class="ease-carousel-card ease-snap-align-center"> Card 2 </div>
+</div>
+```
+
+Closes #12659

--- a/submissions/examples/scroll-snap-utilities/demo.html
+++ b/submissions/examples/scroll-snap-utilities/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Snap Container Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f1f5f9; padding: 4rem 1rem; margin: 0;">
+
+  <div class="ease-showcase-viewport">
+    
+    <div>
+      <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.25rem;">Horizontal Center Snapping</h3>
+      <p style="margin: 0 0 1rem 0; color: #64748b; font-size: 0.9rem;">Swipe smoothly; tiles lock precisely into the container's center coordinate track.</p>
+      
+      <div class="ease-snap-x ease-snap-pad-md">
+        <div class="ease-carousel-card ease-snap-align-center" style="border-left: 4px solid #3b82f6;">
+          <h4 style="margin: 0 0 0.25rem 0; color: #1e293b;">01 / Asset Stream</h4>
+          <p style="margin: 0; color: #64748b; font-size: 0.85rem;">Hardware-optimized render layer blocks.</p>
+        </div>
+        <div class="ease-carousel-card ease-snap-align-center" style="border-left: 4px solid #8b5cf6;">
+          <h4 style="margin: 0 0 0.25rem 0; color: #1e293b;">02 / Motion Buffer</h4>
+          <p style="margin: 0; color: #64748b; font-size: 0.85rem;">Stagger loops bypassing repaint cycles.</p>
+        </div>
+        <div class="ease-carousel-card ease-snap-align-center" style="border-left: 4px solid #ec4899;">
+          <h4 style="margin: 0 0 0.25rem 0; color: #1e293b;">03 / Matrix State</h4>
+          <p style="margin: 0; color: #64748b; font-size: 0.85rem;">Isolated sibling element calculations.</p>
+        </div>
+        <div class="ease-carousel-card ease-snap-align-center" style="border-left: 4px solid #10b981;">
+          <h4 style="margin: 0 0 0.25rem 0; color: #1e293b;">04 / Pipeline Flush</h4>
+          <p style="margin: 0; color: #64748b; font-size: 0.85rem;">Zero-reflow text adjustments complete.</p>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.25rem;">Vertical Start Snapping</h3>
+      <p style="margin: 0 0 1rem 0; color: #64748b; font-size: 0.9rem;">Scroll vertically; panels lock flush against the top container ceiling.</p>
+      
+      <div class="ease-snap-y ease-vertical-scroller">
+        <div class="ease-vertical-panel ease-snap-align-start">
+          <h4 style="margin: 0 0 0.5rem 0; color: #0f172a;">Overview Paradigm</h4>
+          <p style="margin: 0; color: #334155; font-size: 0.95rem; line-height: 1.5;">
+            By matching rigid container dimension bounds with native alignment keywords, mobile touches maintain uniform fluid travel properties without software positioning lags.
+          </p>
+        </div>
+        <div class="ease-vertical-panel ease-snap-align-start">
+          <h4 style="margin: 0 0 0.5rem 0; color: #0f172a;">Isolation Boundaries</h4>
+          <p style="margin: 0; color: #334155; font-size: 0.95rem; line-height: 1.5;">
+            Each child element enforces structural parameters inside distinct container scopes, keeping sibling frames organized away from outer layout variables.
+          </p>
+        </div>
+        <div class="ease-vertical-panel ease-snap-align-start">
+          <h4 style="margin: 0 0 0.5rem 0; color: #0f172a;">Performance Blueprint</h4>
+          <p style="margin: 0; color: #334155; font-size: 0.95rem; line-height: 1.5;">
+            Enforcing native thread snapping eliminates the need for scroll event listener loops, saving cycles and safeguarding animation frame targets.
+          </p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/scroll-snap-utilities/style.css
+++ b/submissions/examples/scroll-snap-utilities/style.css
@@ -1,0 +1,108 @@
+/* ============================================================
+   ease-snap-* — Scroll Snap Container Layout Utilities
+
+   Features micro-interactions including:
+     - Strict coordinate track snapping definitions (x/y alignment)
+     - Proximity vs mandatory locking threshold overrides
+     - Inset padding alignment guards to prevent boundary cropping
+   ============================================================ */
+
+/* --- Parent Slider Track Containers --- */
+
+.ease-snap-x {
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch; /* Enforce smooth inertia on iOS */
+  gap: 1rem;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.ease-snap-y {
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  -webkit-overflow-scrolling: touch;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  box-sizing: border-box;
+}
+
+/* Proximity override variant */
+.ease-snap-proximity {
+  scroll-snap-type: both proximity;
+}
+
+/* --- Downstream Child Tile Elements --- */
+
+.ease-snap-align-start {
+  scroll-snap-align: start;
+}
+
+.ease-snap-align-center {
+  scroll-snap-align: center;
+}
+
+.ease-snap-align-end {
+  scroll-snap-align: end;
+}
+
+/* --- Inset Scroll Padding Guards --- */
+.ease-snap-pad-md {
+  scroll-padding: 1rem;
+}
+
+.ease-snap-pad-lg {
+  scroll-padding: 2rem;
+}
+
+
+/* ============================================================
+   SHOWCASE AND PRESENTATION CLASSES (Demo Specific)
+   ============================================================ */
+
+.ease-showcase-viewport {
+  max-width: 700px;
+  margin: 0 auto;
+  font-family: var(--ease-font-sans, sans-serif);
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.ease-carousel-card {
+  flex: 0 0 280px; /* Rigid width to allow safe spillover horizontal scrolling */
+  height: 200px;
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 1.5rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
+  transition: transform 0.2s ease;
+}
+
+.ease-vertical-scroller {
+  height: 320px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-2xl, 1rem);
+}
+
+.ease-vertical-panel {
+  width: 100%;
+  height: 260px;
+  flex-shrink: 0;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 2rem;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the utility class additions for `ease-snap-*`. Delivers a self-contained, lightweight design token collection that maps CSS scroll-snapping primitives to let developers assemble responsive carousels, full-height panels, and product grid decks that glide fluidly and lock firmly without depending on JavaScript intersection listeners.

Closes #12659

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- Dedicated parent axis scrollers (`.ease-snap-x`, `.ease-snap-y`) configuring thread-isolated navigation rails.
- Precision coordinate matching components (`.ease-snap-align-center`, `.ease-snap-align-start`) to anchor items cleanly inside viewframes.
- Scroll padding helpers (`.ease-snap-pad-md`) ensuring card spacing rules remain uniform during transition limits.

**How does a developer use it?**
```html
<div class="ease-snap-x ease-snap-pad-md">
  <div class="ease-snap-align-center">Item Node</div>
</div>

Demo
[x] Demo added (demo.html showcasing horizontal multi-card slider rails alongside vertical presentation sheets)

Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

[x] Safari