### PR TITLE
feat(examples): add ease-hover-opacity-dim — element dims on hover

### DIFF
--- a/submissions/examples/ease-hover-opacity-dim/README.md
+++ b/submissions/examples/ease-hover-opacity-dim/README.md
@@ -1,0 +1,35 @@
+# ease-hover-opacity-dim
+
+## What does it do?
+Element dims to lower opacity on hover — pure CSS, no JavaScript. Ideal for image grids where hovering one item subtly de-emphasises the rest.
+
+## Features
+- Hovered card stays at full opacity, siblings dim
+- Custom property `--ease-dim-amount` controls dim level
+- Smooth 0.3s transition
+- Perfect for galleries and grid layouts
+
+## Usage
+```css
+.grid:hover .item {
+  opacity: var(--ease-dim-amount, 0.7);
+}
+
+.item:hover {
+  opacity: 1 !important;
+}
+```
+
+## Customisation
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-dim-amount` | `0.7` | Opacity of non-hovered siblings |
+
+## Browser Support
+- `opacity` + `transition` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-opacity-dim/demo.html
+++ b/submissions/examples/ease-hover-opacity-dim/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-opacity-dim — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-opacity-dim</h1>
+  <p class="subtitle">Element dims to lower opacity on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Image Grid Dim Effect</h2>
+    <p class="sec-desc">Hover any card to dim others using <code>--ease-dim-amount</code></p>
+    <div class="dim-grid">
+      <div class="dim-card"><div class="dim-thumb" style="background:#ef4444;"></div><span>Red</span></div>
+      <div class="dim-card"><div class="dim-thumb" style="background:#3b82f6;"></div><span>Blue</span></div>
+      <div class="dim-card"><div class="dim-thumb" style="background:#22c55e;"></div><span>Green</span></div>
+      <div class="dim-card"><div class="dim-thumb" style="background:#f59e0b;"></div><span>Amber</span></div>
+      <div class="dim-card"><div class="dim-thumb" style="background:#a78bfa;"></div><span>Purple</span></div>
+      <div class="dim-card"><div class="dim-thumb" style="background:#ec4899;"></div><span>Pink</span></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Custom Dim Amount</h2>
+    <p class="sec-desc">Override <code>--ease-dim-amount</code> per card</p>
+    <div class="dim-grid">
+      <div class="dim-card" style="--ease-dim-amount: 0.5;"><div class="dim-thumb" style="background:#6366f1;"></div><span>0.5</span></div>
+      <div class="dim-card" style="--ease-dim-amount: 0.3;"><div class="dim-thumb" style="background:#6366f1;"></div><span>0.3</span></div>
+      <div class="dim-card" style="--ease-dim-amount: 0.1;"><div class="dim-thumb" style="background:#6366f1;"></div><span>0.1</span></div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-opacity-dim/style.css
+++ b/submissions/examples/ease-hover-opacity-dim/style.css
@@ -1,0 +1,43 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-opacity-dim
+   Element dims to lower opacity on hover
+   ============================================================ */
+
+.dim-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 1rem;
+}
+
+.dim-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: #2a2a2a;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: opacity 0.3s;
+  user-select: none;
+}
+
+.dim-card span {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  font-weight: 500;
+}
+
+.dim-card .dim-thumb {
+  width: 60px;
+  height: 60px;
+  border-radius: 8px;
+}
+
+.dim-grid:hover .dim-card {
+  opacity: var(--ease-dim-amount, 0.7);
+}
+
+.dim-card:hover {
+  opacity: 1 !important;
+}


### PR DESCRIPTION
## Description

Element dims to lower opacity on hover using pure CSS. Hovered item stays at full opacity while siblings dim.

## Acceptance Criteria
- [x] `opacity: 0.7` on non-hovered siblings
- [x] Smooth 0.3s transition
- [x] `--ease-dim-amount` custom property
- [x] Good for image grids

## Files

| File | Description |
|------|-------------|
| `demo.html` | Grid demo with sibling dimming effect |
| `style.css` | Transitions with --ease-dim-amount variable |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12572

<!-- re-trigger label sync -->