### PR TITLE
feat(examples): add ease-hover-opacity-brighten — element brightens on hover

### DIFF
--- a/submissions/examples/ease-hover-opacity-brighten/README.md
+++ b/submissions/examples/ease-hover-opacity-brighten/README.md
@@ -1,0 +1,36 @@
+# ease-hover-opacity-brighten
+
+## What does it do?
+Element goes from dimmed to full opacity on hover — pure CSS, no JavaScript. The inverse of ease-hover-opacity-dim.
+
+## Features
+- Items start at reduced opacity (0.7 by default)
+- Hover transitions to full opacity (1.0)
+- Custom property `--ease-brighten-from` controls starting opacity
+- Perfect for highlight/selection models in grids
+
+## Usage
+```css
+.item {
+  opacity: var(--ease-brighten-from, 0.7);
+  transition: opacity 0.3s;
+}
+
+.item:hover {
+  opacity: 1;
+}
+```
+
+## Customisation
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-brighten-from` | `0.7` | Starting opacity for non-hovered items |
+
+## Browser Support
+- `opacity` + `transition` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-opacity-brighten/demo.html
+++ b/submissions/examples/ease-hover-opacity-brighten/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-opacity-brighten — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-opacity-brighten</h1>
+  <p class="subtitle">Element goes from dim to full opacity on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Grid Items — Dim by default, brighten on hover</h2>
+    <p class="sec-desc">Items start at 0.7 opacity and transition to 1.0 on hover</p>
+    <div class="brighten-grid">
+      <div class="brighten-card"><div class="b-thumb" style="background:#ef4444;"></div><span>Red</span></div>
+      <div class="brighten-card"><div class="b-thumb" style="background:#3b82f6;"></div><span>Blue</span></div>
+      <div class="brighten-card"><div class="b-thumb" style="background:#22c55e;"></div><span>Green</span></div>
+      <div class="brighten-card"><div class="b-thumb" style="background:#f59e0b;"></div><span>Amber</span></div>
+      <div class="brighten-card"><div class="b-thumb" style="background:#a78bfa;"></div><span>Purple</span></div>
+      <div class="brighten-card"><div class="b-thumb" style="background:#ec4899;"></div><span>Pink</span></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>With Custom Starting Opacity</h2>
+    <p class="sec-desc"><code>--ease-brighten-from</code> controls the starting opacity</p>
+    <div class="brighten-grid">
+      <div class="brighten-card" style="--ease-brighten-from: 0.5;"><div class="b-thumb" style="background:#6366f1;"></div><span>from 0.5</span></div>
+      <div class="brighten-card" style="--ease-brighten-from: 0.3;"><div class="b-thumb" style="background:#6366f1;"></div><span>from 0.3</span></div>
+      <div class="brighten-card" style="--ease-brighten-from: 0.1;"><div class="b-thumb" style="background:#6366f1;"></div><span>from 0.1</span></div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-opacity-brighten/style.css
+++ b/submissions/examples/ease-hover-opacity-brighten/style.css
@@ -1,0 +1,40 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-opacity-brighten
+   Element brightens from dim to full opacity on hover
+   ============================================================ */
+
+.brighten-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 1rem;
+}
+
+.brighten-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: #2a2a2a;
+  border-radius: 10px;
+  cursor: pointer;
+  opacity: var(--ease-brighten-from, 0.7);
+  transition: opacity 0.3s;
+  user-select: none;
+}
+
+.brighten-card span {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  font-weight: 500;
+}
+
+.brighten-card .b-thumb {
+  width: 60px;
+  height: 60px;
+  border-radius: 8px;
+}
+
+.brighten-card:hover {
+  opacity: 1;
+}


### PR DESCRIPTION
## Description

Element goes from dimmed to full opacity on hover using pure CSS. The inverse of ease-hover-opacity-dim.

## Acceptance Criteria
- [x] Start at `opacity: 0.7`, go to `1` on `:hover`
- [x] Smooth 0.3s transition
- [x] `--ease-brighten-from` custom property for starting opacity
- [x] Good for grid items in an active selection model

## Files

| File | Description |
|------|-------------|
| `demo.html` | Grid demo with brighten-on-hover effect |
| `style.css` | Transitions with --ease-brighten-from variable |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12573

<!-- re-trigger label sync -->