### PR TITLE
feat(examples): add ease-hover-underline-grow — underline grows left to right on hover

### DIFF
--- a/submissions/examples/ease-hover-underline-grow/README.md
+++ b/submissions/examples/ease-hover-underline-grow/README.md
@@ -1,0 +1,48 @@
+# ease-hover-underline-grow
+
+## What does it do?
+Underline animates from 0 to full width from left to right on hover — pure CSS, no JavaScript. Perfect for navigation links.
+
+## Features
+- `::after` pseudo-element with `width: 0 → 100%` on `:hover`
+- Positioned at text bottom
+- Custom properties for color and thickness
+- Smooth 0.3s transition
+
+## Usage
+```css
+.link {
+  position: relative;
+  text-decoration: none;
+}
+
+.link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: var(--ease-underline-thickness, 2px);
+  background: var(--ease-underline-color, rebeccapurple);
+  transition: width 0.3s ease;
+}
+
+.link:hover::after {
+  width: 100%;
+}
+```
+
+## Customisation
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-underline-color` | `#a78bfa` | Color of the underline |
+| `--ease-underline-thickness` | `2px` | Height of the underline |
+
+## Browser Support
+- `::after` + `transition` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-underline-grow/demo.html
+++ b/submissions/examples/ease-hover-underline-grow/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-underline-grow — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-underline-grow</h1>
+  <p class="subtitle">Underline grows from left to right on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Nav Link Style</h2>
+    <p class="sec-desc">Hover each link to see the underline animate</p>
+    <nav class="grow-nav">
+      <a href="#" class="grow-link">Home</a>
+      <a href="#" class="grow-link">About</a>
+      <a href="#" class="grow-link">Services</a>
+      <a href="#" class="grow-link">Portfolio</a>
+      <a href="#" class="grow-link">Contact</a>
+    </nav>
+  </section>
+
+  <section>
+    <h2>Custom Colors & Thickness</h2>
+    <p class="sec-desc">Using <code>--ease-underline-color</code> and <code>--ease-underline-thickness</code></p>
+    <nav class="grow-nav">
+      <a href="#" class="grow-link" style="--ease-underline-color: #22c55e; --ease-underline-thickness: 3px;">Green Thick</a>
+      <a href="#" class="grow-link" style="--ease-underline-color: #a78bfa; --ease-underline-thickness: 2px;">Purple</a>
+      <a href="#" class="grow-link" style="--ease-underline-color: #f59e0b; --ease-underline-thickness: 4px;">Amber Bold</a>
+    </nav>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-underline-grow/style.css
+++ b/submissions/examples/ease-hover-underline-grow/style.css
@@ -1,0 +1,35 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-underline-grow
+   Underline grows from left to right on hover
+   ============================================================ */
+
+.grow-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.grow-link {
+  position: relative;
+  color: #d1d5db;
+  text-decoration: none;
+  font-size: 1.05rem;
+  font-weight: 500;
+  padding-bottom: 4px;
+  cursor: pointer;
+}
+
+.grow-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: var(--ease-underline-thickness, 2px);
+  background-color: var(--ease-underline-color, #a78bfa);
+  transition: width 0.3s ease;
+}
+
+.grow-link:hover::after {
+  width: 100%;
+}


### PR DESCRIPTION
## Description

Underline animates from 0 to full width from left to right on hover using pure CSS. Perfect for navigation links.

## Acceptance Criteria
- [x] `::after` width: `0 → 100%` on `:hover`
- [x] Positioned at text bottom
- [x] `--ease-underline-color` and `--ease-underline-thickness` custom properties
- [x] Good for nav links

## Files

| File | Description |
|------|-------------|
| `demo.html` | Nav link demo with custom color/thickness variants |
| `style.css` | ::after pseudo-element with width transition |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12574

<!-- re-trigger label sync -->