### PR TITLE
feat(examples): add ease-hover-underline-center — underline grows from center on hover

### DIFF
--- a/submissions/examples/ease-hover-underline-center/README.md
+++ b/submissions/examples/ease-hover-underline-center/README.md
@@ -1,0 +1,48 @@
+# ease-hover-underline-center
+
+## What does it do?
+Underline expands from center outward on hover — pure CSS, no JavaScript. A center-origin variant of the underline animation effect.
+
+## Features
+- `::after` with `left: 50%` and `translateX(-50%)` for center origin
+- `width: 0 → 100%` on `:hover`
+- Custom property `--ease-underline-color` for color
+- Perfect for navigation links
+
+## Usage
+```css
+.link {
+  position: relative;
+  text-decoration: none;
+}
+
+.link::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: var(--ease-underline-color, rebeccapurple);
+  transform: translateX(-50%);
+  transition: width 0.3s ease;
+}
+
+.link:hover::after {
+  width: 100%;
+}
+```
+
+## Customisation
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-underline-color` | `#a78bfa` | Color of the underline |
+
+## Browser Support
+- `::after` + `transition` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-underline-center/demo.html
+++ b/submissions/examples/ease-hover-underline-center/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-underline-center — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-underline-center</h1>
+  <p class="subtitle">Underline expands from center outward on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Nav Link Style</h2>
+    <p class="sec-desc">Hover each link to see the underline expand from the center</p>
+    <nav class="center-nav">
+      <a href="#" class="center-link">Home</a>
+      <a href="#" class="center-link">About</a>
+      <a href="#" class="center-link">Services</a>
+      <a href="#" class="center-link">Portfolio</a>
+      <a href="#" class="center-link">Contact</a>
+    </nav>
+  </section>
+
+  <section>
+    <h2>Custom Color</h2>
+    <p class="sec-desc">Using <code>--ease-underline-color</code> to customize</p>
+    <nav class="center-nav">
+      <a href="#" class="center-link" style="--ease-underline-color: #22c55e;">Green</a>
+      <a href="#" class="center-link" style="--ease-underline-color: #f59e0b;">Amber</a>
+      <a href="#" class="center-link" style="--ease-underline-color: #ef4444;">Red</a>
+      <a href="#" class="center-link" style="--ease-underline-color: #a78bfa;">Purple</a>
+    </nav>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-underline-center/style.css
+++ b/submissions/examples/ease-hover-underline-center/style.css
@@ -1,0 +1,36 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-underline-center
+   Underline expands from center outward on hover
+   ============================================================ */
+
+.center-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.center-link {
+  position: relative;
+  color: #d1d5db;
+  text-decoration: none;
+  font-size: 1.05rem;
+  font-weight: 500;
+  padding-bottom: 4px;
+  cursor: pointer;
+}
+
+.center-link::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background-color: var(--ease-underline-color, #a78bfa);
+  transform: translateX(-50%);
+  transition: width 0.3s ease;
+}
+
+.center-link:hover::after {
+  width: 100%;
+}


### PR DESCRIPTION
## Description

Underline expands from center outward on hover using pure CSS. A center-origin variant of the underline animation.

## Acceptance Criteria
- [x] `::after` with `left: 50%`, `width: 0 → 100%`, `translateX(-50%)`
- [x] `--ease-underline-color` custom property
- [x] Smooth 0.3s transition
- [x] Center-origin underline effect

## Files

| File | Description |
|------|-------------|
| `demo.html` | Nav link demo with center-expanding underline |
| `style.css` | ::after pseudo-element with translateX centering |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12575

<!-- re-trigger label sync -->