### PR TITLE
feat(examples): add ease-hover-pixelate — element pixelates on hover

### DIFF
--- a/submissions/examples/ease-hover-pixelate/README.md
+++ b/submissions/examples/ease-hover-pixelate/README.md
@@ -1,0 +1,33 @@
+# ease-hover-pixelate
+
+## What does it do?
+Element appears to pixelate on hover using the CSS `blur + contrast` filter trick — pure CSS, no JavaScript.
+
+## Features
+- `filter: blur(1.5px) contrast(8)` creates pixelation effect
+- Smooth 0.35s transition
+- Fun for retro/game-themed UIs
+- Works with gradients and solid colors
+
+## Usage
+```css
+.element {
+  transition: filter 0.35s ease;
+}
+
+.element:hover {
+  filter: blur(1.5px) contrast(8);
+}
+```
+
+## How it works
+The `blur()` smooths adjacent pixels while `contrast()` hardens the edges back, creating a blocky pixelated appearance.
+
+## Browser Support
+- `filter` + `transition` — Chrome 53+, Firefox 49+, Safari 9.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-pixelate/demo.html
+++ b/submissions/examples/ease-hover-pixelate/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-pixelate — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-pixelate</h1>
+  <p class="subtitle">Element pixelates on hover using CSS filter trick — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Pixelate on Hover</h2>
+    <p class="sec-desc">Hover the cards to see them pixelate via <code>blur + contrast</code></p>
+    <div class="pixel-grid">
+      <div class="pixel-card pixel-1">Gradient 1</div>
+      <div class="pixel-card pixel-2">Gradient 2</div>
+      <div class="pixel-card pixel-3">Gradient 3</div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-pixelate/style.css
+++ b/submissions/examples/ease-hover-pixelate/style.css
@@ -1,0 +1,41 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-pixelate
+   Element pixelates on hover using blur+contrast trick
+   ============================================================ */
+
+.pixel-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.pixel-card {
+  width: 180px;
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: filter 0.35s ease;
+}
+
+.pixel-1 {
+  background: linear-gradient(135deg, #ef4444, #f97316, #eab308);
+}
+
+.pixel-2 {
+  background: linear-gradient(135deg, #6366f1, #a78bfa, #c084fc);
+}
+
+.pixel-3 {
+  background: linear-gradient(135deg, #06b6d4, #22c55e, #10b981);
+}
+
+.pixel-card:hover {
+  filter: blur(1.5px) contrast(8);
+}


### PR DESCRIPTION
## Description

Element appears to pixelate on hover using the CSS `blur + contrast` filter trick — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] `filter: blur(1px) + contrast(10)` trick
- [x] Subtle 0.35s transition
- [x] Fun for retro/game-themed UIs

## Files

| File | Description |
|------|-------------|
| `demo.html` | Three gradient cards that pixelate on hover |
| `style.css` | filter: blur() + contrast() transition |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12558

<!-- re-trigger label sync -->