### PR TITLE
feat(examples): add ease-hover-glitch — glitch distortion on hover

### DIFF
--- a/submissions/examples/ease-hover-glitch/README.md
+++ b/submissions/examples/ease-hover-glitch/README.md
@@ -1,0 +1,46 @@
+# ease-hover-glitch
+
+## What does it do?
+Element glitches with color channel separation on hover using \`::before\` and \`::after\` pseudo-elements — pure CSS, no JavaScript.
+
+## Features
+- `::before` and `::after` clones shift horizontally on hover
+- Different translateX distances per clone
+- Red (left-shift) and blue (right-shift) color channels
+- Fast 0.2s animation that runs twice then stops
+
+## Usage
+```css
+.element {
+  position: relative;
+}
+
+.element::before,
+.element::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0; left: 0;
+  pointer-events: none;
+  opacity: 0;
+}
+
+.element:hover::before {
+  color: red;
+  animation: glitch-left 0.2s ease 2;
+}
+
+.element:hover::after {
+  color: blue;
+  animation: glitch-right 0.2s ease 2;
+}
+```
+
+## Browser Support
+- `::before`/`::after` + `@keyframes` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+- Uses `data-text` attribute for pseudo-element content
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-glitch/demo.html
+++ b/submissions/examples/ease-hover-glitch/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-glitch — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-glitch</h1>
+  <p class="subtitle">Glitch distortion with color channel separation on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Glitch Text</h2>
+    <p class="sec-desc">Hover the text to see red/blue channel separation</p>
+    <div class="glitch-wrapper">
+      <h2 class="glitch-text" data-text="GLITCH EFFECT">GLITCH EFFECT</h2>
+    </div>
+  </section>
+
+  <section>
+    <h2>More Examples</h2>
+    <p class="sec-desc">Hover to trigger the glitch</p>
+    <div class="glitch-row">
+      <span class="glitch-text" data-text="CYBER">CYBER</span>
+      <span class="glitch-text" data-text="PUNK">PUNK</span>
+      <span class="glitch-text" data-text="RETRO">RETRO</span>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-glitch/style.css
+++ b/submissions/examples/ease-hover-glitch/style.css
@@ -1,0 +1,72 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-glitch
+   Glitch distortion with color channel separation on hover
+   ============================================================ */
+
+.glitch-wrapper {
+  text-align: center;
+  padding: 1rem 0;
+}
+
+.glitch-text {
+  position: relative;
+  font-size: 2.5rem;
+  font-weight: 800;
+  color: #ffffff;
+  cursor: pointer;
+  display: inline-block;
+  letter-spacing: 2px;
+}
+
+.glitch-text::before,
+.glitch-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0s;
+}
+
+.glitch-text:hover::before,
+.glitch-text:hover::after {
+  opacity: 1;
+}
+
+.glitch-text:hover::before {
+  color: #ef4444;
+  animation: glitch-shift-left 0.2s ease 2;
+}
+
+.glitch-text:hover::after {
+  color: #3b82f6;
+  animation: glitch-shift-right 0.2s ease 2;
+}
+
+@keyframes glitch-shift-left {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-4px); }
+  50% { transform: translateX(-2px); }
+  75% { transform: translateX(-6px); }
+}
+
+@keyframes glitch-shift-right {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(3px); }
+  50% { transform: translateX(5px); }
+  75% { transform: translateX(2px); }
+}
+
+.glitch-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.glitch-row .glitch-text {
+  font-size: 1.5rem;
+}


### PR DESCRIPTION
## Description

Element glitches with color channel separation on hover using `::before` and `::after` pseudo-elements — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] `::before` and `::after` clones shift horizontally
- [x] Different translateX per clone
- [x] Fast 0.2s animation then stops
- [x] Red/blue color channels

## Files

| File | Description |
|------|-------------|
| `demo.html` | Glitch text examples with data-text attribute |
| `style.css` | ::before/::after with red/blue channel shift keyframes |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12557

<!-- re-trigger label sync -->