### PR TITLE
feat(examples): add ease-hover-static — static noise on hover

### DIFF
--- a/submissions/examples/ease-hover-static/README.md
+++ b/submissions/examples/ease-hover-static/README.md
@@ -1,0 +1,35 @@
+# ease-hover-static
+
+## What does it do?
+TV static noise briefly flashes across element on hover using pseudo-elements with rapid opacity and translate jitter — pure CSS, no JavaScript.
+
+## Features
+- `::before` pseudo-element with checkerboard static pattern
+- Rapid opacity and translate jitter via keyframes
+- Only active during hover
+- Short burst (0.3s) then stops
+
+## Usage
+```css
+.element::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: /* checkerboard pattern */;
+  background-size: 4px 4px;
+  pointer-events: none;
+}
+
+.element:hover::before {
+  animation: static-noise 0.3s steps(4) 1;
+}
+```
+
+## Browser Support
+- `::before` + `@keyframes` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-static/demo.html
+++ b/submissions/examples/ease-hover-static/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-static — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-static</h1>
+  <p class="subtitle">TV static noise flashes on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Static Cards</h2>
+    <p class="sec-desc">Hover each card to see the static noise effect</p>
+    <div class="static-grid">
+      <div class="static-card">TV 1</div>
+      <div class="static-card">TV 2</div>
+      <div class="static-card">TV 3</div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-static/style.css
+++ b/submissions/examples/ease-hover-static/style.css
@@ -1,0 +1,87 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-static
+   TV static noise flashes on hover
+   ============================================================ */
+
+.static-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.static-card {
+  position: relative;
+  width: 180px;
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #1e293b, #334155);
+  border-radius: 16px;
+  font-weight: 600;
+  color: #94a3b8;
+  font-size: 1rem;
+  cursor: pointer;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.static-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(255,255,255,0.15) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(255,255,255,0.15) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(255,255,255,0.15) 75%);
+  background-size: 4px 4px;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.static-card:hover::before {
+  animation: static-noise 0.3s steps(4) 1;
+}
+
+@keyframes static-noise {
+  0% {
+    opacity: 0;
+    transform: translate(0, 0);
+  }
+  10% {
+    opacity: 0.8;
+    transform: translate(-2px, 1px);
+  }
+  25% {
+    opacity: 0.5;
+    transform: translate(3px, -2px);
+  }
+  40% {
+    opacity: 0.9;
+    transform: translate(-1px, 3px);
+  }
+  55% {
+    opacity: 0.3;
+    transform: translate(2px, -1px);
+  }
+  70% {
+    opacity: 0.7;
+    transform: translate(-3px, 2px);
+  }
+  85% {
+    opacity: 0.4;
+    transform: translate(1px, -3px);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(0, 0);
+  }
+}
+
+.static-card span {
+  position: relative;
+  z-index: 2;
+}


### PR DESCRIPTION
## Description

TV static noise briefly flashes across element on hover using pseudo-elements with rapid opacity and translate jitter — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] Pseudo-element with rapid opacity and translate jitter
- [x] Only active during hover
- [x] Short burst (0.3s) then stops

## Files

| File | Description |
|------|-------------|
| `demo.html` | Three cards with static noise overlay on hover |
| `style.css` | ::before with checkerboard pattern and static keyframes |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12556

<!-- re-trigger label sync -->