### PR TITLE
feat: add CSS-only Avatar component (#12694)

### DIFF
--- a/submissions/core_changes-issue-12694/README.md
+++ b/submissions/core_changes-issue-12694/README.md
@@ -1,0 +1,78 @@
+# ease-avatar
+
+## What does this do?
+
+Provides a CSS-only Avatar component for user profile pictures, initials fallback, team member cards, and online/offline/busy status indicators. Supports five sizes, three shapes, overlapping groups, and status dots.
+
+## How is it used?
+
+**Image avatar:**
+
+```html
+<div class="ease-avatar">
+  <img src="photo.jpg" alt="User name" />
+</div>
+```
+
+**Initials fallback:**
+
+```html
+<span class="ease-avatar ease-avatar-initials">JD</span>
+```
+
+**With status dot:**
+
+```html
+<span class="ease-avatar ease-avatar-initials
+  ease-avatar-status ease-avatar-status-online">JD</span>
+```
+
+**Avatar group:**
+
+```html
+<div class="ease-avatar-group">
+  <span class="ease-avatar ease-avatar-initials ease-avatar-sm">JD</span>
+  <span class="ease-avatar ease-avatar-initials ease-avatar-sm">AB</span>
+  <span class="ease-avatar ease-avatar-initials ease-avatar-sm">MK</span>
+</div>
+```
+
+### Variants
+
+| Modifier | Effect |
+|---|---|
+| (none) | Circle, 40px, initials background |
+| `.ease-avatar-initials` | Brand background + white text |
+| `.ease-avatar-xs` | 24px |
+| `.ease-avatar-sm` | 32px |
+| `.ease-avatar-lg` | 56px |
+| `.ease-avatar-xl` | 80px |
+| `.ease-avatar-rounded` | Full circle (default) |
+| `.ease-avatar-square` | 0.5rem radius |
+| `.ease-avatar-soft` | 0.75rem radius |
+| `.ease-avatar-status` | Enables status indicator dot |
+| `.ease-avatar-status-online` | Green dot |
+| `.ease-avatar-status-away` | Yellow dot |
+| `.ease-avatar-status-busy` | Red dot |
+| `.ease-avatar-group` | Overlapping stack container |
+
+### CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--asize` | `2.5rem` | Width & height |
+| `--afont` | `0.875rem` | Initials font size |
+
+## Why is it useful?
+
+Avatars are essential for user profiles, team pages, comment sections, chat UIs, and any multi-user interface. This component provides a consistent set of avatar styles that integrate with EaseMotion's design language.
+
+## Features
+
+- Image avatar with auto-sizing and object-fit
+- Initials fallback with brand background
+- Five sizes: xs, sm, md, lg, xl
+- Three shapes: rounded (circle), square, soft
+- Status dot indicator: online, away, busy
+- Overlapping avatar group
+- Dark mode support via `prefers-color-scheme`

--- a/submissions/core_changes-issue-12694/demo.html
+++ b/submissions/core_changes-issue-12694/demo.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-avatar — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      min-height: 100vh;
+      padding: 3rem 1.5rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .demo-header p {
+      margin-top: 0.75rem;
+      color: #64748b;
+      font-size: 1rem;
+      max-width: 520px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .demo-section { max-width: 640px; margin: 0 auto 2.5rem; }
+
+    .demo-section h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 1rem;
+    }
+
+    .demo-section > p {
+      font-size: 0.875rem; color: #64748b; margin-bottom: 1rem;
+    }
+
+    .class-tag {
+      display: inline-block; font-size: 0.65rem; font-family: monospace;
+      background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 999px;
+      padding: 0.3em 0.75em; color: #6c63ff; margin-top: 0.5rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .class-tag { background: #1e293b; border-color: #334155; }
+    }
+
+    .demo-card {
+      background: #ffffff; border: 1px solid #e2e8f0;
+      border-radius: 0.75rem; padding: 1.25rem; margin-bottom: 1rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .demo-card { background: #1e293b; border-color: #334155; }
+    }
+
+    .demo-grid {
+      display: flex; gap: 1rem; flex-wrap: wrap; align-items: center;
+    }
+
+    .demo-item {
+      display: flex; flex-direction: column; align-items: center; gap: 0.375rem;
+    }
+
+    .demo-item > span { font-size: 0.75rem; color: #64748b; }
+
+    .avatar-img-placeholder {
+      width: 100%; height: 100%; object-fit: cover;
+      background: linear-gradient(135deg, #6c63ff, #a78bfa);
+    }
+  </style>
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>ease-avatar</h1>
+    <p>CSS-only avatar component for user profile pictures, initials fallback, and status indicators.</p>
+  </header>
+
+  <section class="demo-section">
+    <h2>Image Avatar</h2>
+    <p>Wrap an <code>&lt;img&gt;</code> with <code>.ease-avatar</code> for automatic rounding and sizing.</p>
+    <div class="demo-card">
+      <div class="demo-grid">
+        <div class="demo-item">
+          <div class="ease-avatar">
+            <div class="avatar-img-placeholder"></div>
+          </div>
+          <span class="class-tag">.ease-avatar</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Initials</h2>
+    <p>Add <code>.ease-avatar-initials</code> for text-based fallback with brand background.</p>
+    <div class="demo-card">
+      <div class="demo-grid">
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials">JD</span>
+          <span class="class-tag">.ease-avatar-initials</span>
+        </div>
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials">AB</span>
+        </div>
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials">MK</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Sizes</h2>
+    <div class="demo-card">
+      <div class="demo-grid">
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-xs">XS</span>
+          <span>xs (24px)</span>
+          <span class="class-tag">.ease-avatar-xs</span>
+        </div>
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-sm">SM</span>
+          <span>sm (32px)</span>
+          <span class="class-tag">.ease-avatar-sm</span>
+        </div>
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials">MD</span>
+          <span>md (40px)</span>
+          <span class="class-tag">.ease-avatar (default)</span>
+        </div>
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-lg">LG</span>
+          <span>lg (56px)</span>
+          <span class="class-tag">.ease-avatar-lg</span>
+        </div>
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-xl">XL</span>
+          <span>xl (80px)</span>
+          <span class="class-tag">.ease-avatar-xl</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Shapes</h2>
+    <div class="demo-card">
+      <div class="demo-grid">
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-rounded">R</span>
+          <span>Rounded (circle)</span>
+          <span class="class-tag">.ease-avatar-rounded</span>
+        </div>
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-square">S</span>
+          <span>Square</span>
+          <span class="class-tag">.ease-avatar-square</span>
+        </div>
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-soft">S</span>
+          <span>Soft</span>
+          <span class="class-tag">.ease-avatar-soft</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Status Dot</h2>
+    <p>Add <code>.ease-avatar-status</code> with <code>-online</code>, <code>-away</code>, or <code>-busy</code>.</p>
+    <div class="demo-card">
+      <div class="demo-grid">
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-status ease-avatar-status-online">JD</span>
+          <span>Online</span>
+          <span class="class-tag">.ease-avatar-status-online</span>
+        </div>
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-status ease-avatar-status-away">AB</span>
+          <span>Away</span>
+          <span class="class-tag">.ease-avatar-status-away</span>
+        </div>
+        <div class="demo-item">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-status ease-avatar-status-busy">MK</span>
+          <span>Busy</span>
+          <span class="class-tag">.ease-avatar-status-busy</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-card" style="margin-top:0.5rem;">
+      <p style="font-size:0.875rem;color:#64748b;margin-bottom:0.75rem;">With image avatar:</p>
+      <div class="demo-grid">
+        <div class="demo-item">
+          <div class="ease-avatar ease-avatar-status ease-avatar-status-online">
+            <div class="avatar-img-placeholder"></div>
+          </div>
+          <span>Online</span>
+        </div>
+        <div class="demo-item">
+          <div class="ease-avatar ease-avatar-status ease-avatar-status-away">
+            <div class="avatar-img-placeholder"></div>
+          </div>
+          <span>Away</span>
+        </div>
+        <div class="demo-item">
+          <div class="ease-avatar ease-avatar-status ease-avatar-status-busy">
+            <div class="avatar-img-placeholder"></div>
+          </div>
+          <span>Busy</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Group</h2>
+    <p>Overlapping avatars using <code>.ease-avatar-group</code>.</p>
+    <div class="demo-card">
+      <div class="demo-item" style="align-items:flex-start;">
+        <div class="ease-avatar-group">
+          <span class="ease-avatar ease-avatar-initials ease-avatar-sm">JD</span>
+          <span class="ease-avatar ease-avatar-initials ease-avatar-sm">AB</span>
+          <span class="ease-avatar ease-avatar-initials ease-avatar-sm">MK</span>
+          <span class="ease-avatar ease-avatar-initials ease-avatar-sm">+4</span>
+        </div>
+        <span class="class-tag">.ease-avatar-group</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Usage</h2>
+    <pre style="background:#f1f5f9;border:1px solid #e2e8f0;border-radius:0.5rem;padding:1rem;font-size:0.8125rem;overflow-x:auto;white-space:pre-wrap;color:#1e293b;">&lt;!-- Image avatar --&gt;
+&lt;div class="ease-avatar"&gt;
+  &lt;img src="photo.jpg" alt="User name" /&gt;
+&lt;/div&gt;
+
+&lt;!-- Initials fallback --&gt;
+&lt;span class="ease-avatar ease-avatar-initials"&gt;JD&lt;/span&gt;
+
+&lt;!-- Sizes: .ease-avatar-xs, -sm, -lg, -xl --&gt;
+&lt;!-- Shapes: .ease-avatar-square, .ease-avatar-soft --&gt;
+
+&lt;!-- Status dot --&gt;
+&lt;span class="ease-avatar ease-avatar-initials
+  ease-avatar-status ease-avatar-status-online"&gt;JD&lt;/span&gt;
+
+&lt;!-- Group --&gt;
+&lt;div class="ease-avatar-group"&gt;
+  &lt;span class="ease-avatar ease-avatar-initials ease-avatar-sm"&gt;JD&lt;/span&gt;
+  &lt;span class="ease-avatar ease-avatar-initials ease-avatar-sm"&gt;AB&lt;/span&gt;
+&lt;/div&gt;</pre>
+  </section>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-12694/style.css
+++ b/submissions/core_changes-issue-12694/style.css
@@ -1,0 +1,145 @@
+/* ============================================================
+   ease-avatar — Avatar Component
+   Submission for EaseMotion CSS · Issue #12694
+   ============================================================ */
+
+/* ── Base ─────────────────────────────────────────────────── */
+
+.ease-avatar {
+  --asize: 2.5rem;
+  --afont: 0.875rem;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--asize);
+  height: var(--asize);
+  border-radius: 9999px;
+  overflow: hidden;
+  flex-shrink: 0;
+  font-size: var(--afont);
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+.ease-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* ── Initials ─────────────────────────────────────────────── */
+
+.ease-avatar-initials {
+  background: #6c63ff;
+  color: #fff;
+  user-select: none;
+}
+
+/* ── Sizes ────────────────────────────────────────────────── */
+
+.ease-avatar-xs {
+  --asize: 1.5rem;
+  --afont: 0.625rem;
+}
+
+.ease-avatar-sm {
+  --asize: 2rem;
+  --afont: 0.75rem;
+}
+
+.ease-avatar-lg {
+  --asize: 3.5rem;
+  --afont: 1.125rem;
+}
+
+.ease-avatar-xl {
+  --asize: 5rem;
+  --afont: 1.5rem;
+}
+
+/* ── Shape Variants ───────────────────────────────────────── */
+
+.ease-avatar-rounded {
+  border-radius: 9999px;
+}
+
+.ease-avatar-square {
+  border-radius: 0.5rem;
+}
+
+.ease-avatar-soft {
+  border-radius: 0.75rem;
+}
+
+/* ── Status Dot ───────────────────────────────────────────── */
+
+.ease-avatar-status {
+  position: relative;
+}
+
+.ease-avatar-status::after {
+  content: "";
+  position: absolute;
+  bottom: 4%;
+  right: 4%;
+  width: 28%;
+  height: 28%;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  background: #94a3b8;
+  box-sizing: border-box;
+}
+
+.ease-avatar-status-online::after {
+  background: #22c55e;
+}
+
+.ease-avatar-status-away::after {
+  background: #f59e0b;
+}
+
+.ease-avatar-status-busy::after {
+  background: #ef4444;
+}
+
+/* ── Group ────────────────────────────────────────────────── */
+
+.ease-avatar-group {
+  display: inline-flex;
+  align-items: center;
+}
+
+.ease-avatar-group .ease-avatar {
+  margin-inline-start: -0.5rem;
+  border: 2px solid #fff;
+}
+
+.ease-avatar-group .ease-avatar:first-child {
+  margin-inline-start: 0;
+}
+
+.ease-avatar-group .ease-avatar-initials:nth-child(2) {
+  background: #22c55e;
+}
+
+.ease-avatar-group .ease-avatar-initials:nth-child(3) {
+  background: #f59e0b;
+}
+
+.ease-avatar-group .ease-avatar-initials:nth-child(4) {
+  background: #06b6d4;
+}
+
+/* ── Dark Mode ────────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .ease-avatar-group .ease-avatar {
+    border-color: #0f172a;
+  }
+
+  .ease-avatar-status::after {
+    border-color: #0f172a;
+  }
+}


### PR DESCRIPTION
### Description

This PR adds a CSS-only Avatar component to the EaseMotion CSS library for user profile pictures, initials fallback, and status indicators.

### Changes Made

- Created `submissions/core_changes-issue-12694/style.css` with the complete avatar implementation
- Created `submissions/core_changes-issue-12694/demo.html` with visual demo preview
- Created `submissions/core_changes-issue-12694/README.md` with documentation and usage examples

### Features

- **Image avatar**: `ease-avatar` wrapping `<img>` — rounds and sizes automatically with `object-fit: cover`
- **Initials**: `ease-avatar-initials` — up to 2 letters with brand background
- **Sizes**: `ease-avatar-xs` (24px), `-sm` (32px), `-md` (40px, default), `-lg` (56px), `-xl` (80px)
- **Shapes**: `ease-avatar-rounded` (circle), `ease-avatar-square` (0.5rem), `ease-avatar-soft` (0.75rem)
- **Status dots**: `ease-avatar-status` with `-online` (green), `-away` (yellow), `-busy` (red)
- **Group**: `ease-avatar-group` — overlapping stack with negative margin and border
- **Dark mode** support via `prefers-color-scheme`

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes in the demo HTML

### Additional Notes

- The component uses CSS custom properties (`--asize`, `--afont`) for easy customization
- Status dots use `::after` pseudo-element with percentage-based sizing for consistent positioning across all avatar sizes
- Group avatars use `margin-inline-start` (logical property) for proper RTL support