### PR TITLE
feat: add CSS-only Pagination component (#12696)

### DIFF
--- a/submissions/core_changes-issue-12696/README.md
+++ b/submissions/core_changes-issue-12696/README.md
@@ -1,0 +1,70 @@
+# ease-pagination
+
+## What does this do?
+
+Provides a CSS-only Pagination component for navigating multi-page content. Supports a full page-number list with active highlight, disabled states for boundaries, three sizes, and a simple Prev/Next variant.
+
+## How is it used?
+
+**Default pagination:**
+
+```html
+<nav aria-label="Pagination">
+  <ul class="ease-pagination">
+    <li class="is-disabled"><span>&laquo; Prev</span></li>
+    <li class="is-active"><span>1</span></li>
+    <li><a href="#">2</a></li>
+    <li><a href="#">3</a></li>
+    <li><a href="#">Next &raquo;</a></li>
+  </ul>
+</nav>
+```
+
+**Simple variant (Prev / Next + counter):**
+
+```html
+<ul class="ease-pagination ease-pagination-simple">
+  <li class="is-disabled"><span>&laquo; Previous</span></li>
+  <li><span>Page 3 of 10</span></li>
+  <li><a href="#">Next &raquo;</a></li>
+</ul>
+```
+
+### Variants
+
+| Modifier | Effect |
+|---|---|
+| (none) | Default pill-style page buttons |
+| `.ease-pagination-sm` | Smaller buttons (1.75rem) |
+| `.ease-pagination-lg` | Larger buttons (2.75rem) |
+| `.ease-pagination-simple` | Minimal: Prev / counter / Next |
+
+### States
+
+| Class | Effect |
+|---|---|
+| `.is-active` | Current page — brand background, white text |
+| `.is-disabled` | Disabled action — reduced opacity, no pointer events |
+
+### CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--psize` | `2.25rem` | Min-width & height |
+| `--pfont` | `0.875rem` | Font size |
+| `--pradius` | `0.5rem` | Border radius |
+
+## Why is it useful?
+
+Pagination is essential for blog listings, search results, data tables, and any paginated content. This component provides a consistent pagination pattern that integrates with EaseMotion's design language.
+
+## Features
+
+- Full page-number list with Previous/Next navigation
+- Active page highlighted with brand color
+- Disabled state for boundary buttons (reduced opacity, no pointer events)
+- Three sizes: sm, md (default), lg
+- Simple variant with only Prev/Next and page counter
+- Subtle hover scale animation on links
+- Dark mode support via `prefers-color-scheme`
+- CSS custom properties for easy customization

--- a/submissions/core_changes-issue-12696/demo.html
+++ b/submissions/core_changes-issue-12696/demo.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-pagination — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      min-height: 100vh;
+      padding: 3rem 1.5rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+
+    .demo-header { text-align: center; margin-bottom: 3rem; }
+
+    .demo-header h1 {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .demo-header p {
+      margin-top: 0.75rem;
+      color: #64748b;
+      font-size: 1rem;
+      max-width: 520px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .demo-section { max-width: 640px; margin: 0 auto 2.5rem; }
+
+    .demo-section h2 {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #6c63ff; margin-bottom: 1rem;
+    }
+
+    .demo-section > p {
+      font-size: 0.875rem; color: #64748b; margin-bottom: 1rem;
+    }
+
+    .class-tag {
+      display: inline-block; font-size: 0.65rem; font-family: monospace;
+      background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 999px;
+      padding: 0.3em 0.75em; color: #6c63ff; margin-top: 0.5rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .class-tag { background: #1e293b; border-color: #334155; }
+    }
+
+    .demo-card {
+      background: #ffffff; border: 1px solid #e2e8f0;
+      border-radius: 0.75rem; padding: 1.25rem; margin-bottom: 1rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .demo-card { background: #1e293b; border-color: #334155; }
+    }
+
+    .demo-group {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+  </style>
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>ease-pagination</h1>
+    <p>CSS-only pagination component for navigating multi-page content.</p>
+  </header>
+
+  <section class="demo-section">
+    <h2>Default</h2>
+    <p>Full page-number list with Previous/Next, active highlight, and disabled boundaries.</p>
+    <div class="demo-card">
+      <nav aria-label="Pagination">
+        <ul class="ease-pagination">
+          <li class="is-disabled"><span>&laquo; Prev</span></li>
+          <li class="is-active"><span>1</span></li>
+          <li><a href="#">2</a></li>
+          <li><a href="#">3</a></li>
+          <li><a href="#">4</a></li>
+          <li><a href="#">5</a></li>
+          <li><span>&hellip;</span></li>
+          <li><a href="#">10</a></li>
+          <li><a href="#">Next &raquo;</a></li>
+        </ul>
+      </nav>
+      <span class="class-tag">.ease-pagination</span>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Sizes</h2>
+    <div class="demo-card">
+      <div class="demo-group">
+        <div>
+          <nav aria-label="Pagination">
+            <ul class="ease-pagination ease-pagination-sm">
+              <li class="is-disabled"><span>&laquo;</span></li>
+              <li class="is-active"><span>1</span></li>
+              <li><a href="#">2</a></li>
+              <li><a href="#">3</a></li>
+              <li><a href="#">4</a></li>
+              <li><a href="#">5</a></li>
+              <li><a href="#">&raquo;</a></li>
+            </ul>
+          </nav>
+          <span class="class-tag">.ease-pagination-sm</span>
+        </div>
+        <div>
+          <nav aria-label="Pagination">
+            <ul class="ease-pagination">
+              <li class="is-disabled"><span>&laquo;</span></li>
+              <li class="is-active"><span>1</span></li>
+              <li><a href="#">2</a></li>
+              <li><a href="#">3</a></li>
+              <li><a href="#">4</a></li>
+              <li><a href="#">5</a></li>
+              <li><a href="#">&raquo;</a></li>
+            </ul>
+          </nav>
+          <span class="class-tag">.ease-pagination (md)</span>
+        </div>
+        <div>
+          <nav aria-label="Pagination">
+            <ul class="ease-pagination ease-pagination-lg">
+              <li class="is-disabled"><span>&laquo;</span></li>
+              <li class="is-active"><span>1</span></li>
+              <li><a href="#">2</a></li>
+              <li><a href="#">3</a></li>
+              <li><a href="#">4</a></li>
+              <li><a href="#">5</a></li>
+              <li><a href="#">&raquo;</a></li>
+            </ul>
+          </nav>
+          <span class="class-tag">.ease-pagination-lg</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Active Page (Middle)</h2>
+    <p>Active page does not have to be the first — works at any position.</p>
+    <div class="demo-card">
+      <nav aria-label="Pagination">
+        <ul class="ease-pagination">
+          <li><a href="#">&laquo; Prev</a></li>
+          <li><a href="#">1</a></li>
+          <li><a href="#">2</a></li>
+          <li class="is-active"><span>3</span></li>
+          <li><a href="#">4</a></li>
+          <li><a href="#">5</a></li>
+          <li><span>&hellip;</span></li>
+          <li><a href="#">10</a></li>
+          <li><a href="#">Next &raquo;</a></li>
+        </ul>
+      </nav>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Active Page (Last) + Disabled Next</h2>
+    <p>When on the last page, the Next button becomes disabled.</p>
+    <div class="demo-card">
+      <nav aria-label="Pagination">
+        <ul class="ease-pagination">
+          <li><a href="#">&laquo; Prev</a></li>
+          <li><a href="#">1</a></li>
+          <li><a href="#">2</a></li>
+          <li><a href="#">3</a></li>
+          <li><a href="#">4</a></li>
+          <li class="is-active"><span>5</span></li>
+          <li class="is-disabled"><span>Next &raquo;</span></li>
+        </ul>
+      </nav>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Simple Variant</h2>
+    <p>Previous / Next only with page counter — for minimal pagination.</p>
+    <div class="demo-card">
+      <nav aria-label="Pagination">
+        <ul class="ease-pagination ease-pagination-simple">
+          <li class="is-disabled"><span>&laquo; Previous</span></li>
+          <li><span>Page 3 of 10</span></li>
+          <li><a href="#">Next &raquo;</a></li>
+        </ul>
+      </nav>
+      <span class="class-tag">.ease-pagination-simple</span>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <h2>Usage</h2>
+    <pre style="background:#f1f5f9;border:1px solid #e2e8f0;border-radius:0.5rem;padding:1rem;font-size:0.8125rem;overflow-x:auto;white-space:pre-wrap;color:#1e293b;">&lt;nav aria-label="Pagination"&gt;
+  &lt;ul class="ease-pagination"&gt;
+    &lt;li class="is-disabled"&gt;&lt;span&gt;&amp;laquo; Prev&lt;/span&gt;&lt;/li&gt;
+    &lt;li class="is-active"&gt;&lt;span&gt;1&lt;/span&gt;&lt;/li&gt;
+    &lt;li&gt;&lt;a href="#"&gt;2&lt;/a&gt;&lt;/li&gt;
+    &lt;li&gt;&lt;a href="#"&gt;3&lt;/a&gt;&lt;/li&gt;
+    &lt;li&gt;&lt;a href="#"&gt;Next &amp;raquo;&lt;/a&gt;&lt;/li&gt;
+  &lt;/ul&gt;
+&lt;/nav&gt;
+
+&lt;!-- Sizes: .ease-pagination-sm, .ease-pagination-lg --&gt;
+&lt;!-- Simple: .ease-pagination-simple (Prev / Page X of Y / Next) --&gt;
+
+&lt;!-- is-active — highlight current page --&gt;
+&lt;!-- is-disabled — gray out unavailable actions --&gt;</pre>
+  </section>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-12696/style.css
+++ b/submissions/core_changes-issue-12696/style.css
@@ -1,0 +1,115 @@
+/* ============================================================
+   ease-pagination — Pagination Component
+   Submission for EaseMotion CSS · Issue #12696
+   ============================================================ */
+
+/* ── Base ─────────────────────────────────────────────────── */
+
+.ease-pagination {
+  --psize: 2.25rem;
+  --pfont: 0.875rem;
+  --pradius: 0.5rem;
+
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ease-pagination li {
+  display: flex;
+}
+
+.ease-pagination li a,
+.ease-pagination li span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--psize);
+  height: var(--psize);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--pradius);
+  font-size: var(--pfont);
+  color: #1e293b;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  user-select: none;
+}
+
+.ease-pagination li a:hover {
+  background: #f1f5f9;
+  transform: scale(1.05);
+}
+
+/* ── Active ───────────────────────────────────────────────── */
+
+.ease-pagination .is-active,
+.ease-pagination .is-active span {
+  background: #6c63ff;
+  color: #fff;
+  font-weight: 600;
+}
+
+/* ── Disabled ─────────────────────────────────────────────── */
+
+.ease-pagination .is-disabled span {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* ── Sizes ────────────────────────────────────────────────── */
+
+.ease-pagination-sm {
+  --psize: 1.75rem;
+  --pfont: 0.75rem;
+  --pradius: 0.375rem;
+}
+
+.ease-pagination-lg {
+  --psize: 2.75rem;
+  --pfont: 1rem;
+  --pradius: 0.625rem;
+}
+
+/* ── Simple Variant ───────────────────────────────────────── */
+
+.ease-pagination-simple li:not(:first-child):not(:last-child) {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: #64748b;
+  font-size: var(--pfont);
+}
+
+.ease-pagination-simple li:not(:first-child):not(:last-child) span {
+  min-width: auto;
+  height: auto;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+  cursor: default;
+}
+
+/* ── Dark Mode ────────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .ease-pagination li a,
+  .ease-pagination li span {
+    color: #f1f5f9;
+  }
+
+  .ease-pagination li a:hover {
+    background: #334155;
+  }
+
+  .ease-pagination-simple li:not(:first-child):not(:last-child) {
+    color: #94a3b8;
+  }
+
+  .ease-pagination .is-disabled span {
+    color: #64748b;
+  }
+}


### PR DESCRIPTION
### Description

This PR adds a CSS-only Pagination component to the EaseMotion CSS library for navigating multi-page content.

### Changes Made

- Created `submissions/core_changes-issue-12696/style.css` with the complete pagination implementation
- Created `submissions/core_changes-issue-12696/demo.html` with visual demo preview
- Created `submissions/core_changes-issue-12696/README.md` with documentation and usage examples

### Features

- **Default**: `ease-pagination` — horizontal list of page buttons with active state
- **Active**: `.is-active` on the current page — brand background + white text + bold
- **Disabled**: `.is-disabled` on boundary buttons — reduced opacity, no pointer events
- **Sizes**: `ease-pagination-sm`, `ease-pagination-lg` (md is default)
- **Simple variant**: `ease-pagination-simple` — only Prev/Next buttons with page counter
- **Hover effect**: Subtle `scale(1.05)` transform and background change on links
- **Dark mode** support via `prefers-color-scheme`

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes in the demo HTML

### Additional Notes

- Uses CSS custom properties (`--psize`, `--pfont`, `--pradius`) for easy customization
- Semantic `<nav aria-label="Pagination">` wrapping an `<ul>` for accessibility
- Links are `<a>` elements for SEO/accessibility; current page uses `<span>` inside the active item