### PR TITLE
feat : added ease-hover-strikethrough hover animation

### DIFF
--- a/submissions/examples/ease-hover-strikethrough-tm/README.md
+++ b/submissions/examples/ease-hover-strikethrough-tm/README.md
@@ -1,0 +1,42 @@
+# ease-hover-strikethrough
+
+**What does this do?**
+Adds a smooth strikethrough animation that sweeps across text (or any inline element) on hover. The line grows from left to right, giving a clean, modern "completed" or "dismissed" visual cue.
+
+**How is it used?**
+
+```html
+<!-- Navigation link -->
+<a href="#" class="strikethrough-link">Home</a>
+
+<!-- Heading -->
+<h3 class="strikethrough-text">Section Title</h3>
+
+<!-- Button -->
+<button class="strikethrough-btn">Submit</button>
+```
+
+```css
+.strikethrough-link {
+  position: relative;
+}
+.strikethrough-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 0;
+  height: 2px;
+  background: #38bdf8;
+  transition: width 0.3s ease;
+  transform: translateY(-50%);
+}
+.strikethrough-link:hover::after {
+  width: 100%;
+}
+```
+
+**Why is it useful?**
+Strikethrough-on-hover is a common pattern for todo lists, navigation highlights, and interactive labels. It is a lightweight, pure-CSS way to communicate state changes without JavaScript.
+
+**Browser support:** All modern browsers (Chrome, Firefox, Safari, Edge). Uses `::after` pseudo-element and `transition`.

--- a/submissions/examples/ease-hover-strikethrough-tm/demo.html
+++ b/submissions/examples/ease-hover-strikethrough-tm/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-strikethrough Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>ease-hover-strikethrough</h1>
+    <p>Hover over each link to see the strikethrough animation.</p>
+
+    <nav class="demo-nav">
+      <a href="#" class="strikethrough-link">Home</a>
+      <a href="#" class="strikethrough-link">About</a>
+      <a href="#" class="strikethrough-link">Services</a>
+      <a href="#" class="strikethrough-link">Blog</a>
+      <a href="#" class="strikethrough-link">Contact</a>
+    </nav>
+
+    <div class="card">
+      <h3 class="strikethrough-text">This heading gets struck through on hover</h3>
+      <p class="strikethrough-text">This paragraph also animates with a clean strikethrough effect on hover.</p>
+    </div>
+
+    <div class="cta-row">
+      <button class="strikethrough-btn">Submit</button>
+      <button class="strikethrough-btn">Cancel</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-hover-strikethrough-tm/style.css
+++ b/submissions/examples/ease-hover-strikethrough-tm/style.css
@@ -1,0 +1,156 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Inter, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 3rem 2rem;
+  min-height: 100vh;
+}
+
+.demo-wrapper {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: #38bdf8;
+}
+
+p {
+  margin-bottom: 2rem;
+  color: #94a3b8;
+  font-size: 0.95rem;
+}
+
+/* Nav link with ease-hover-strikethrough */
+
+.demo-nav {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 2.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #1e293b;
+}
+
+.strikethrough-link {
+  position: relative;
+  color: #e2e8f0;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 1rem;
+  padding-bottom: 2px;
+}
+
+/* The underline that slides in as a strikethrough */
+.strikethrough-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 0;
+  height: 2px;
+  background: #38bdf8;
+  transition: width 0.3s ease;
+  transform: translateY(-50%);
+}
+
+.strikethrough-link:hover::after {
+  width: 100%;
+}
+
+/* Card with ease-hover-strikethrough on headings and paragraphs */
+
+.card {
+  background: #1e293b;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  border: 1px solid #334155;
+}
+
+.strikethrough-text {
+  position: relative;
+  display: inline-block;
+  transition: color 0.3s ease;
+}
+
+.strikethrough-text::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 0;
+  height: 2px;
+  background: #f87171;
+  transition: width 0.35s ease;
+  transform: translateY(-50%);
+}
+
+.strikethrough-text:hover {
+  color: #94a3b8;
+}
+
+.strikethrough-text:hover::after {
+  width: 100%;
+}
+
+.card h3.strikethrough-text {
+  display: block;
+  margin-bottom: 0.75rem;
+  font-size: 1.1rem;
+}
+
+.card p.strikethrough-text {
+  font-size: 0.9rem;
+}
+
+/* Button with ease-hover-strikethrough */
+
+.cta-row {
+  display: flex;
+  gap: 1rem;
+}
+
+.strikethrough-btn {
+  position: relative;
+  overflow: hidden;
+  background: #1e293b;
+  color: #e2e8f0;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 0.6rem 1.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.3s ease, border-color 0.3s ease;
+}
+
+.strikethrough-btn::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 0;
+  height: 2px;
+  background: #38bdf8;
+  transition: width 0.3s ease;
+  transform: translateY(-50%);
+}
+
+.strikethrough-btn:hover {
+  color: #38bdf8;
+  border-color: #38bdf8;
+}
+
+.strikethrough-btn:hover::after {
+  width: 100%;
+}


### PR DESCRIPTION
Closes #12576.

Summary of What Has Been Done:
Added the ease-hover-strikethrough hover animation as an interactive demo. The effect animates a strikethrough line from left to right on hover using CSS ::after pseudo-elements and transitions.

Changes Made:
- submissions/examples/ease-hover-strikethrough-tm/demo.html — interactive demo with nav links, card, and buttons
- submissions/examples/ease-hover-strikethrough-tm/style.css — pure CSS implementation using ::after pseudo-elements
- submissions/examples/ease-hover-strikethrough-tm/README.md — documentation with usage examples and browser support

Impact it Made:
Provides a reusable, pure-CSS strikethrough hover effect for navigation links, headings, and buttons. Contributes to the growing library of ease-hover-* animations in EaseMotion CSS.

Please assign this task to me (@tmdeveloper007).