### PR TITLE
feat: add CSS-only Toggle Switch component (#12700)

### DIFF
--- a/submissions/core_changes-issue-12700/style.css
+++ b/submissions/core_changes-issue-12700/style.css
@@ -3,6 +3,8 @@
    Submission for EaseMotion CSS · Issue #12700
    ============================================================ */
 
+@layer easemotion-components {
+
 /* ── Base ─────────────────────────────────────────────────── */
 
 .ease-toggle {
@@ -89,6 +91,10 @@
 
 /* ── Color Variants ───────────────────────────────────────── */
 
+.ease-toggle-primary {
+  --ton: #6c63ff;
+}
+
 .ease-toggle-success {
   --ton: #22c55e;
 }
@@ -98,6 +104,11 @@
 }
 
 /* ── Disabled State ───────────────────────────────────────── */
+
+.ease-toggle-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 .ease-toggle input:disabled {
   pointer-events: none;
@@ -136,4 +147,6 @@
   .ease-toggle {
     --toff: #475569;
   }
+}
+
 }


### PR DESCRIPTION
✦ **Description**
Adds a CSS-only Toggle Switch component — checkbox-based toggle for boolean settings, feature flags, and preference toggles.

⟡ **Type of Change**
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

✦ **Checklist**
- [x] My code follows the style guidelines of this project (no core files modified)
- [x] I have performed a self-review of my code
- [x] I have added tests/demo that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally
- [x] I have commented my code, particularly in hard-to-understand areas

⟡ **Screenshots**
Demo page shows color variants (default, primary, success, danger), size variants (sm, md, lg), and states (on, off, disabled).

✦ **Classes**
- Base: `ease-toggle`
- Track: `ease-toggle-track`, Knob: `ease-toggle-knob`, Label: `ease-toggle-label`
- Colors: `ease-toggle-primary`, `-success`, `-danger`
- Sizes: `ease-toggle-sm`, `ease-toggle-lg`
- State: `ease-toggle-disabled`
- Accessibility: `:focus-visible` outline, keyboard-operable

✦ **Additional Context**
Files in `submissions/core_changes-issue-12700/`:
- `style.css` — Toggle styles within `@layer easemotion-components`, CSS custom properties for sizing, reduced motion and dark mode support
- `demo.html` — Interactive demo
- `README.md` — Documentation

Fixes #12700