### PR TITLE
feat: add ease-zoom-in-right-ag feature submission (#11825)

### DIFF
--- a/submissions/examples/ease-zoom-in-right-ag/README.md
+++ b/submissions/examples/ease-zoom-in-right-ag/README.md
@@ -1,0 +1,58 @@
+# Animated Zoom In Right (ease-zoom-in-right-ag)
+
+## What does this do?
+
+Provides a smooth entrance animation where an element scales up from a smaller size while sliding to the right from the left side, fading in concurrently.
+
+## How is it used?
+
+Add the base class `.ease-zoom-in-right` and any desired speed, scale, or distance variants to an HTML element:
+
+```html
+<!-- Default zoom-in-right animation -->
+<div class="ease-zoom-in-right">Your content here</div>
+
+<!-- Fast speed variant with a short slide distance and subtle scale -->
+<div class="ease-zoom-in-right zoom-fast zoom-translate-short zoom-scale-subtle">
+  Your content here
+</div>
+
+<!-- Slow duration with an intense scale scaling up from 0.3 and a long translate distance -->
+<div class="ease-zoom-in-right zoom-scale-intense zoom-translate-long zoom-slow">
+  Your content here
+</div>
+```
+
+### Class Options
+
+- **Base Class**: `.ease-zoom-in-right`
+- **Speed Modifiers**: `.zoom-fast` (0.25s), `.zoom-slow` (0.75s)
+- **Scale Modifiers**: `.zoom-scale-subtle` (scale starts from 0.8), `.zoom-scale-intense` (scale starts from 0.3)
+- **Distance Modifiers**: `.zoom-translate-short` (-15px), `.zoom-translate-long` (-80px)
+
+### Custom Tokens
+
+Customize values directly in your stylesheet or inline styles:
+
+- `--ease-zoom-scale`: Change the initial scale ratio (default: `0.5`)
+- `--ease-zoom-translate`: Adjust the initial horizontal offset (default: `-40px`)
+- `--ease-zoom-duration`: Adjust the speed of the entrance (default: `0.45s`)
+- `--ease-zoom-easing`: Override the transition timing curve (default: `cubic-bezier(0.16, 1, 0.3, 1)`)
+
+## Why is it useful?
+
+It aligns with EaseMotion CSS's philosophy of providing human-readable, lightweight, GPU-accelerated micro-interactions. Specifically designed for side navigation bars, list feeds, panel entries, and slide-in notifications, it decouples the animation parameters into CSS variables. This gives developers local design control without writing extra JavaScript or risking layout jitter, supporting a responsive and high-performance design.
+
+## Tech Stack
+
+- HTML
+- CSS (no frameworks or libraries, fully compliant with modern web standard features)
+
+## Preview
+
+Open `demo.html` directly in your browser to interact with the sandbox and test speed, scale, and translate distance combinations.
+
+## Contribution Notes
+
+- Class naming suffix handled by the contributor (`-ag` for Antigravity)
+- Maintainer will rename classes to standard `ease-*` conventions during final core integration.

--- a/submissions/examples/ease-zoom-in-right-ag/demo.html
+++ b/submissions/examples/ease-zoom-in-right-ag/demo.html
@@ -1,0 +1,708 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ease-zoom-in-right — EaseMotion CSS Demo</title>
+    <!-- Link to the component's stylesheet -->
+    <link rel="stylesheet" href="style.css" />
+
+    <style>
+      /* Dark Theme Premium Showcase Styles */
+      :root {
+        --bg-dark: #070913;
+        --bg-card: rgba(255, 255, 255, 0.03);
+        --border-dark: rgba(255, 255, 255, 0.08);
+        --text-main: #f8fafc;
+        --text-muted: #64748b;
+        --primary: #8b5cf6;
+        --primary-glow: rgba(139, 92, 246, 0.2);
+        --accent: #d946ef;
+        --accent-glow: rgba(217, 70, 239, 0.15);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        background-color: var(--bg-dark);
+        background-image:
+          radial-gradient(
+            circle at 5% 30%,
+            rgba(139, 92, 246, 0.1) 0%,
+            transparent 50%
+          ),
+          radial-gradient(
+            circle at 95% 70%,
+            rgba(217, 70, 239, 0.08) 0%,
+            transparent 50%
+          );
+        color: var(--text-main);
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          Outfit,
+          sans-serif;
+        min-height: 100vh;
+        padding: 4rem 2rem;
+        line-height: 1.5;
+        overflow-x: hidden;
+      }
+
+      .container {
+        max-width: 1000px;
+        margin: 0 auto;
+      }
+
+      header {
+        text-align: center;
+        margin-bottom: 4rem;
+      }
+
+      .badge {
+        display: inline-block;
+        padding: 0.3rem 0.8rem;
+        border-radius: 9999px;
+        background: var(--primary-glow);
+        border: 1px solid rgba(139, 92, 246, 0.4);
+        color: #a78bfa;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin-bottom: 1rem;
+      }
+
+      h1 {
+        font-size: 2.75rem;
+        font-weight: 850;
+        letter-spacing: -0.03em;
+        background: linear-gradient(135deg, #fff 40%, #c084fc 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        margin-bottom: 0.75rem;
+      }
+
+      header p {
+        color: var(--text-muted);
+        font-size: 1.05rem;
+        max-width: 650px;
+        margin: 0 auto;
+      }
+
+      /* Sections */
+      section {
+        margin-bottom: 5rem;
+      }
+
+      .section-title {
+        font-size: 1.35rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--text-muted);
+        margin-bottom: 2rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .section-title::after {
+        content: "";
+        flex-grow: 1;
+        height: 1px;
+        background: var(--border-dark);
+      }
+
+      /* Sandbox Panel Layout */
+      .sandbox-layout {
+        display: grid;
+        grid-template-columns: 1.1fr 1.9fr;
+        gap: 3rem;
+        align-items: start;
+      }
+
+      @media (max-width: 768px) {
+        .sandbox-layout {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .controls-panel {
+        background: rgba(13, 17, 33, 0.75);
+        border: 1px solid var(--border-dark);
+        border-radius: 20px;
+        padding: 2rem;
+        backdrop-filter: blur(8px);
+      }
+
+      .control-group {
+        margin-bottom: 1.5rem;
+      }
+
+      .control-group:last-child {
+        margin-bottom: 0;
+      }
+
+      .control-label {
+        display: block;
+        font-size: 0.8rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--text-muted);
+        margin-bottom: 0.6rem;
+      }
+
+      .btn-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(75px, 1fr));
+        gap: 0.4rem;
+      }
+
+      .btn-select {
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid var(--border-dark);
+        color: var(--text-main);
+        padding: 0.55rem;
+        border-radius: 8px;
+        font-size: 0.85rem;
+        cursor: pointer;
+        font-weight: 500;
+        transition: all 0.2s ease;
+        text-align: center;
+      }
+
+      .btn-select:hover {
+        background: rgba(255, 255, 255, 0.07);
+      }
+
+      .btn-select.active {
+        background: var(--primary-glow);
+        border-color: var(--primary);
+        color: #ddd6fe;
+        font-weight: 600;
+      }
+
+      /* Action Trigger Button */
+      .btn-trigger {
+        display: block;
+        width: 100%;
+        background: var(--primary);
+        color: white;
+        border: none;
+        padding: 0.8rem;
+        border-radius: 10px;
+        font-size: 0.95rem;
+        font-weight: 700;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        box-shadow: 0 4px 14px var(--primary-glow);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-top: 1.5rem;
+      }
+
+      .btn-trigger:hover {
+        background: #7c3aed;
+        transform: translateY(-1px);
+      }
+
+      .preview-panel {
+        background: radial-gradient(
+          circle,
+          rgba(25, 20, 45, 0.4) 0%,
+          rgba(5, 6, 12, 0.8) 100%
+        );
+        border: 1px dashed rgba(255, 255, 255, 0.1);
+        border-radius: 20px;
+        min-height: 380px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        position: relative;
+        overflow: hidden;
+      }
+
+      /* Animation Card Target */
+      .preview-card {
+        width: 300px;
+        padding: 2rem;
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        border-radius: 16px;
+        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+        backdrop-filter: blur(10px);
+        transition: border-color 0.3s ease;
+      }
+
+      .card-icon {
+        width: 48px;
+        height: 48px;
+        background: var(--primary-glow);
+        border-radius: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #c084fc;
+        margin-bottom: 1.25rem;
+        font-size: 1.5rem;
+      }
+
+      .preview-card h3 {
+        font-size: 1.25rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+      }
+
+      .preview-card p {
+        font-size: 0.9rem;
+        color: var(--text-muted);
+        line-height: 1.6;
+      }
+
+      .code-box {
+        margin-top: 2rem;
+        font-family: monospace;
+        font-size: 0.85rem;
+        background: #04050b;
+        padding: 0.8rem 1.2rem;
+        border-radius: 10px;
+        border: 1px solid var(--border-dark);
+        color: #c084fc;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .code-box span {
+        color: var(--text-main);
+        user-select: all;
+      }
+
+      /* Layout Showcase Grid */
+      .demo-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 2rem;
+      }
+
+      .demo-showcase-panel {
+        background: rgba(255, 255, 255, 0.02);
+        border: 1px solid var(--border-dark);
+        border-radius: 20px;
+        padding: 2rem;
+        position: relative;
+        min-height: 320px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        overflow: hidden;
+      }
+
+      /* Slide-in Sidebar Demo */
+      .sidebar-showcase {
+        position: relative;
+        height: 180px;
+        background: rgba(0, 0, 0, 0.3);
+        border-radius: 12px;
+        border: 1px solid var(--border-dark);
+        margin-top: 1rem;
+        overflow: hidden;
+      }
+
+      .sidebar-toggle-btn {
+        background: var(--primary);
+        color: white;
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 6px;
+        font-size: 0.8rem;
+        cursor: pointer;
+        font-weight: 600;
+        margin: 10px;
+      }
+
+      .demo-sidebar {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        width: 140px;
+        background: rgba(13, 11, 28, 0.95);
+        border-right: 1px solid var(--border-dark);
+        padding: 1rem;
+        display: none;
+        flex-direction: column;
+        gap: 0.5rem;
+        box-shadow: 10px 0 25px rgba(0, 0, 0, 0.5);
+        z-index: 20;
+      }
+
+      .sidebar-nav-item {
+        color: var(--text-main);
+        text-decoration: none;
+        font-size: 0.75rem;
+        padding: 0.4rem 0.6rem;
+        border-radius: 4px;
+        background: rgba(255, 255, 255, 0.02);
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        transition: background 0.2s ease;
+      }
+
+      .sidebar-nav-item:hover {
+        background: var(--primary-glow);
+        color: #d8b4fe;
+      }
+
+      /* Staggered items container */
+      .stagger-container {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-top: 1rem;
+      }
+
+      .stagger-item {
+        padding: 0.75rem 1rem;
+        background: rgba(255, 255, 255, 0.03);
+        border-left: 3px solid var(--accent);
+        border-radius: 0 8px 8px 0;
+        font-size: 0.85rem;
+        opacity: 0;
+      }
+
+      /* Toggle Button for Stagger */
+      .btn-stagger-trigger {
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--text-main);
+        border: 1px solid var(--border-dark);
+        padding: 0.5rem 1rem;
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 0.8rem;
+        font-weight: 600;
+        transition: background 0.2s;
+      }
+
+      .btn-stagger-trigger:hover {
+        background: rgba(255, 255, 255, 0.08);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <span class="badge">Scale + Slide Entrance</span>
+        <h1>ease-zoom-in-right</h1>
+        <p>
+          A high-performance entrance animation that combines scaling and
+          rightward translation from the left side. Ideal for side panels, navigation
+          drawers, list feeds, and alert notifications.
+        </p>
+      </header>
+
+      <!-- SECTION 1: SANDBOX PLAYGROUND -->
+      <section>
+        <h2 class="section-title">Interactive Sandbox</h2>
+        <div class="sandbox-layout">
+          <!-- Controls Panel -->
+          <div class="controls-panel">
+            <!-- Scale Intensity -->
+            <div class="control-group">
+              <span class="control-label">Initial Scale</span>
+              <div class="btn-grid">
+                <button class="btn-select btn-scale active" data-class="">
+                  0.5
+                </button>
+                <button
+                  class="btn-select btn-scale"
+                  data-class="zoom-scale-subtle"
+                >
+                  Subtle (0.8)
+                </button>
+                <button
+                  class="btn-select btn-scale"
+                  data-class="zoom-scale-intense"
+                >
+                  Intense (0.3)
+                </button>
+              </div>
+            </div>
+
+            <!-- Speed Variants -->
+            <div class="control-group">
+              <span class="control-label">Speed / Duration</span>
+              <div class="btn-grid">
+                <button class="btn-select btn-speed active" data-class="">
+                  Normal
+                </button>
+                <button class="btn-select btn-speed" data-class="zoom-fast">
+                  Fast
+                </button>
+                <button class="btn-select btn-speed" data-class="zoom-slow">
+                  Slow
+                </button>
+              </div>
+            </div>
+
+            <!-- Distance Variants -->
+            <div class="control-group">
+              <span class="control-label">Left Translate Offset</span>
+              <div class="btn-grid">
+                <button class="btn-select btn-dist active" data-class="">
+                  -40px
+                </button>
+                <button
+                  class="btn-select btn-dist"
+                  data-class="zoom-translate-short"
+                >
+                  Short (-15px)
+                </button>
+                <button
+                  class="btn-select btn-dist"
+                  data-class="zoom-translate-long"
+                >
+                  Long (-80px)
+                </button>
+              </div>
+            </div>
+
+            <!-- Trigger Button -->
+            <button id="btn-replay" class="btn-trigger">
+              Replay Animation
+            </button>
+          </div>
+
+          <!-- Preview Panel -->
+          <div class="preview-panel">
+            <div id="sandbox-card" class="preview-card ease-zoom-in-right">
+              <div class="card-icon">⚡</div>
+              <h3>Entrance Card</h3>
+              <p>
+                This card scales up and slides rightward from the left smoothly,
+                creating a delightful and modern interface transition.
+              </p>
+            </div>
+
+            <div class="code-box">
+              Class:
+              <span id="class-code">&lt;div class="ease-zoom-in-right"&gt;</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SECTION 2: COMMON APPLICATIONS -->
+      <section>
+        <h2 class="section-title">Common Layout Applications</h2>
+        <div class="demo-grid">
+          <!-- App 1: Slide-out Sidebar Menu -->
+          <div class="demo-showcase-panel">
+            <div>
+              <h3>Left Navigation Menu</h3>
+              <p
+                style="
+                  font-size: 0.85rem;
+                  color: var(--text-muted);
+                  margin-top: 0.5rem;
+                  margin-bottom: 1rem;
+                "
+              >
+                Ideal for left navigation drawers. The panel emerges from the screen edge with a combined scale and slide.
+              </p>
+
+              <div class="sidebar-showcase">
+                <button id="btn-toggle-sidebar" class="sidebar-toggle-btn">
+                  Toggle Sidebar
+                </button>
+
+                <div id="demo-sidebar" class="demo-sidebar">
+                  <div style="font-size: 0.65rem; color: var(--text-muted); font-weight: 600; margin-bottom: 0.2rem;">MENU</div>
+                  <a href="#" class="sidebar-nav-item">🏠 Home</a>
+                  <a href="#" class="sidebar-nav-item">📊 Dashboard</a>
+                  <a href="#" class="sidebar-nav-item">⚙️ Settings</a>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- App 2: Staggered Content Feed -->
+          <div class="demo-showcase-panel">
+            <div>
+              <h3>Staggered Content Feed</h3>
+              <p
+                style="
+                  font-size: 0.85rem;
+                  color: var(--text-muted);
+                  margin-top: 0.5rem;
+                  margin-bottom: 1rem;
+                "
+              >
+                Staggered delays can be combined with `.ease-zoom-in-right` to create high-end loading sequences.
+              </p>
+
+              <div style="display: flex; justify-content: space-between; align-items: center;">
+                <span style="font-size: 0.75rem; color: var(--text-muted);">Sequential List</span>
+                <button id="btn-stagger" class="btn-stagger-trigger">Trigger List</button>
+              </div>
+
+              <div class="stagger-container">
+                <div class="stagger-item">🔔 New Notification Received</div>
+                <div class="stagger-item">📧 Email Campaign Sent</div>
+                <div class="stagger-item">📈 Performance Metric Updated</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- Interactive JS Controls -->
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const card = document.getElementById("sandbox-card");
+        const replayBtn = document.getElementById("btn-replay");
+        const classCode = document.getElementById("class-code");
+
+        // Interactive states
+        const state = {
+          scale: "",
+          speed: "",
+          dist: "",
+        };
+
+        // Handler for Scale Selection
+        document.querySelectorAll(".btn-scale").forEach((btn) => {
+          btn.addEventListener("click", (e) => {
+            document
+              .querySelectorAll(".btn-scale")
+              .forEach((b) => b.classList.remove("active"));
+            e.target.classList.add("active");
+            state.scale = e.target.getAttribute("data-class");
+            triggerAnimation();
+          });
+        });
+
+        // Handler for Speed Selection
+        document.querySelectorAll(".btn-speed").forEach((btn) => {
+          btn.addEventListener("click", (e) => {
+            document
+              .querySelectorAll(".btn-speed")
+              .forEach((b) => b.classList.remove("active"));
+            e.target.classList.add("active");
+            state.speed = e.target.getAttribute("data-class");
+            triggerAnimation();
+          });
+        });
+
+        // Handler for Distance Selection
+        document.querySelectorAll(".btn-dist").forEach((btn) => {
+          btn.addEventListener("click", (e) => {
+            document
+              .querySelectorAll(".btn-dist")
+              .forEach((b) => b.classList.remove("active"));
+            e.target.classList.add("active");
+            state.dist = e.target.getAttribute("data-class");
+            triggerAnimation();
+          });
+        });
+
+        // Trigger/Replay function
+        function triggerAnimation() {
+          card.classList.remove("ease-zoom-in-right");
+          void card.offsetWidth; // Force reflow
+
+          card.className = "preview-card ease-zoom-in-right";
+          if (state.scale) card.classList.add(state.scale);
+          if (state.speed) card.classList.add(state.speed);
+          if (state.dist) card.classList.add(state.dist);
+
+          const classNames = Array.from(card.classList).join(" ");
+          classCode.textContent = `<div class="${classNames}">`;
+        }
+
+        replayBtn.addEventListener("click", triggerAnimation);
+
+        // --- Interactive Sidebar Showcase Controls ---
+        const toggleSidebarBtn = document.getElementById("btn-toggle-sidebar");
+        const sidebar = document.getElementById("demo-sidebar");
+
+        toggleSidebarBtn.addEventListener("click", (e) => {
+          e.stopPropagation();
+          const isVisible = sidebar.style.display === "flex";
+          if (isVisible) {
+            sidebar.style.display = "none";
+            sidebar.classList.remove(
+              "ease-zoom-in-right",
+              "zoom-fast",
+              "zoom-translate-short"
+            );
+          } else {
+            sidebar.style.display = "flex";
+            void sidebar.offsetWidth;
+            sidebar.classList.add(
+              "ease-zoom-in-right",
+              "zoom-fast",
+              "zoom-translate-short"
+            );
+          }
+        });
+
+        // Close sidebar when clicking outside
+        document.addEventListener("click", (e) => {
+          if (!sidebar.contains(e.target) && e.target !== toggleSidebarBtn) {
+            sidebar.style.display = "none";
+            sidebar.classList.remove(
+              "ease-zoom-in-right",
+              "zoom-fast",
+              "zoom-translate-short"
+            );
+          }
+        });
+
+        // --- Staggered Feed Demo Controls ---
+        const staggerBtn = document.getElementById("btn-stagger");
+        const staggerItems = document.querySelectorAll(".stagger-item");
+
+        staggerBtn.addEventListener("click", () => {
+          staggerItems.forEach((item) => {
+            item.style.opacity = "0";
+            item.classList.remove(
+              "ease-zoom-in-right",
+              "zoom-fast",
+              "zoom-translate-short"
+            );
+            void item.offsetWidth;
+          });
+
+          staggerItems.forEach((item, index) => {
+            setTimeout(() => {
+              item.style.opacity = "1";
+              item.classList.add(
+                "ease-zoom-in-right",
+                "zoom-fast",
+                "zoom-translate-short"
+              );
+            }, index * 100);
+          });
+        });
+
+        // Initialize stagger trigger automatically once
+        setTimeout(() => {
+          staggerBtn.click();
+        }, 500);
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/ease-zoom-in-right-ag/style.css
+++ b/submissions/examples/ease-zoom-in-right-ag/style.css
@@ -1,0 +1,86 @@
+/* ==========================================================================
+   EaseMotion CSS — Animated Zoom In Right
+   Component: ease-zoom-in-right
+   Contributor: Antigravity (ag)
+   Description: Entrances where an element scales up from a smaller size
+                while smoothly sliding right into place from the left side.
+                Ideal for left navigation, menus, sidebars, tooltips, and content panels.
+                Zero JavaScript for the core animation.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   Keyframes
+   -------------------------------------------------------------------------- */
+@keyframes ease-zoom-in-right-kf {
+  0% {
+    opacity: 0;
+    transform: scale(var(--ease-zoom-scale, 0.5))
+      translateX(var(--ease-zoom-translate, -40px));
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateX(0);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   Base Class: .ease-zoom-in-right
+   -------------------------------------------------------------------------- */
+.ease-zoom-in-right {
+  /* Default configurable tokens */
+  --ease-zoom-scale: 0.5;
+  --ease-zoom-translate: -40px;
+  --ease-zoom-duration: 0.45s;
+  --ease-zoom-easing: cubic-bezier(0.16, 1, 0.3, 1); /* Smooth ultra-ease-out */
+
+  animation: ease-zoom-in-right-kf var(--ease-zoom-duration)
+    var(--ease-zoom-easing) both;
+}
+
+/* --------------------------------------------------------------------------
+   Speed Variants
+   -------------------------------------------------------------------------- */
+.zoom-fast {
+  --ease-zoom-duration: 0.25s;
+}
+
+.zoom-slow {
+  --ease-zoom-duration: 0.75s;
+}
+
+/* --------------------------------------------------------------------------
+   Scale Intensity Variants
+   -------------------------------------------------------------------------- */
+/* Subtle scale entrance */
+.zoom-scale-subtle {
+  --ease-zoom-scale: 0.8;
+}
+
+/* Intense scale entrance */
+.zoom-scale-intense {
+  --ease-zoom-scale: 0.3;
+}
+
+/* --------------------------------------------------------------------------
+   Translate Distance Variants
+   -------------------------------------------------------------------------- */
+/* Short slide distance (great for tooltips and compact items) */
+.zoom-translate-short {
+  --ease-zoom-translate: -15px;
+}
+
+/* Long slide distance (great for prominent sidebars and panels) */
+.zoom-translate-long {
+  --ease-zoom-translate: -80px;
+}
+
+/* --------------------------------------------------------------------------
+   Accessibility - Respect user preferences for reduced motion
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-zoom-in-right {
+    animation: none;
+    transform: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces the `ease-zoom-in-right-ag` component under `submissions/examples/ease-zoom-in-right-ag/`. It implements a combined scale and translation entrance animation that scales up from `0.5` and slides right from `-40px`.

---

## Type of Change

- [x] 🌀 New animation / hover effect
- [ ] 📦 New component
- [ ] 📖 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-zoom-in-right-ag/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Provides a smooth entrance animation where an element scales up from a smaller size (default scale starts from `0.5`) while sliding to the right from the left side (default translate starts from `-40px`), fading in concurrently.

**How does a developer use it?**

```html
<div class="ease-zoom-in-right">Your content here</div>
```

**Why does it fit EaseMotion CSS?**

It aligns with EaseMotion CSS's human-readable, animation-first philosophy by using native CSS keyframes and configurable variables (`--ease-zoom-scale`, `--ease-zoom-translate`, `--ease-zoom-duration`, `--ease-zoom-easing`) to allow developers to easily customize layout transition parameters locally with zero JS overhead.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

None.
