### PR TITLE
CSS will-change Performance Example

### DIFF
--- a/submissions/examples/will-change-gpu-patterns/README.md
+++ b/submissions/examples/will-change-gpu-patterns/README.md
@@ -1,0 +1,62 @@
+# will-change GPU patterns
+
+A self-contained example showing how to use the CSS `will-change` property to
+get smooth, GPU-accelerated animations — and the usage patterns that keep it
+from hurting performance.
+
+## What does this do?
+
+`will-change` hints to the browser that an element is about to change, so it can
+promote the element to its own GPU compositing layer ahead of time. When paired
+with composited properties (`transform`, `opacity`), animations run on the GPU
+and avoid main-thread layout/paint jank.
+
+## How is it used?
+
+Add the relevant class to an element you intend to animate:
+
+```html
+<div class="will-change-good">Scoped hint on hover</div>
+<div class="gpu-layer">Forced GPU compositing layer</div>
+```
+
+## Proper usage patterns
+
+| Pattern | Class | Why |
+|---|---|---|
+| Hint only when needed | `will-change-good` | Promotes the layer on `:hover`/`:focus-visible`, then auto-resets when idle |
+| Force a GPU layer | `gpu-layer` | `transform: translateZ(0)` + `backface-visibility: hidden` for transform animations |
+| Reset after animating | `will-change-reset` | Set this back (e.g. via JS) when an animation ends to release layer memory |
+
+### Do
+
+- Hint `will-change` **just before** an element animates, not permanently.
+- Only hint **`transform`** and **`opacity`** — the properties the GPU composites cheaply.
+- **Remove/reset** the hint once the element is idle.
+- Apply it to a **few key elements**, not everything.
+
+### Don't
+
+- Don't leave `will-change` on permanently — it keeps a compositing layer (and its
+  memory) alive forever. The `will-change-bad` box in the demo shows this anti-pattern.
+- Don't use `will-change: all` or hint layout-triggering properties — there's no GPU benefit.
+
+## Why is it useful?
+
+Transform- and opacity-heavy animations (cards, hover lifts, modals, carousels)
+can stutter when the browser composites them on the fly. These patterns give
+EaseMotion CSS users a correct, memory-safe way to opt into GPU acceleration.
+
+## Tech Stack
+
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+
+Open `demo.html` directly in your browser and hover the boxes to see the effect.
+
+## Contribution Notes
+
+- Class naming was handled by the contributor
+- Maintainer will rename to `ease-*` convention before merging

--- a/submissions/examples/will-change-gpu-patterns/demo.html
+++ b/submissions/examples/will-change-gpu-patterns/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>will-change GPU patterns — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 2rem;
+      background: #0f0f0f;
+      color: #f5f5f5;
+      gap: 2.5rem;
+    }
+    h1 { margin-bottom: 0; }
+    .intro { max-width: 560px; text-align: center; color: #bdbdbd; line-height: 1.5; }
+    .section { display: flex; flex-direction: column; align-items: center; gap: 0.75rem; }
+    .label { font-size: 0.8rem; color: #9ca3af; text-align: center; max-width: 420px; }
+    .label.do { color: #86efac; }
+    .label.dont { color: #fca5a5; }
+    .box {
+      width: 140px;
+      height: 140px;
+      border-radius: 14px;
+      background: #6366f1;
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      font-size: 0.8rem;
+      font-weight: 600;
+      padding: 0.75rem;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>will-change GPU Patterns</h1>
+  <p class="intro">
+    <code>will-change</code> tells the browser to promote an element to its own
+    GPU compositing layer so <code>transform</code> and <code>opacity</code>
+    animations stay smooth. Hover each box to animate it.
+  </p>
+
+  <div class="section">
+    <div class="label do">✅ DO — hint only on hover, animate transform/opacity, then auto-reset</div>
+    <div class="box will-change-good">Scoped hint</div>
+  </div>
+
+  <div class="section">
+    <div class="label do">✅ DO — force a GPU layer with translateZ(0) for transform animations</div>
+    <div class="box gpu-layer">GPU layer</div>
+  </div>
+
+  <div class="section">
+    <div class="label dont">❌ DON'T — leave <code>will-change: all</code> on permanently (wastes memory, no GPU gain)</div>
+    <div class="box will-change-bad">Always-on hint</div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/will-change-gpu-patterns/style.css
+++ b/submissions/examples/will-change-gpu-patterns/style.css
@@ -1,0 +1,64 @@
+/* ============================================================
+   EaseMotion CSS — will-change GPU-acceleration patterns
+   Description: Demonstrates CSS `will-change` for promoting
+                animated elements to their own GPU compositing
+                layer, using the recommended usage patterns.
+
+   PROPER USAGE PATTERNS demonstrated here:
+   1. Hint `will-change` only while the element is about to
+      animate (scoped to :hover) — not permanently.
+   2. Only hint the properties the GPU composites cheaply:
+      `transform` and `opacity`.
+   3. Remove / reset the hint when the element is idle so the
+      browser can reclaim the extra memory.
+   4. Apply it sparingly — to a few key elements, not everything.
+   ============================================================ */
+
+/* ----- PATTERN 1: scoped hint (recommended) -------------------
+   Idle state keeps will-change at `auto`. The hint is only
+   promoted just before the transform/opacity change happens,
+   then automatically dropped again when the pointer leaves. */
+.will-change-good {
+  will-change: auto;
+  transition: transform 300ms ease, opacity 300ms ease;
+}
+.will-change-good:hover,
+.will-change-good:focus-visible {
+  will-change: transform, opacity;
+  transform: translateY(-10px) scale(1.05);
+  opacity: 0.92;
+}
+
+/* ----- PATTERN 2: GPU compositing layer ----------------------
+   `translateZ(0)` forces the element onto its own GPU layer.
+   Pair with `backface-visibility: hidden` to avoid flicker.
+   Only animate composited properties (transform/opacity). */
+.gpu-layer {
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  will-change: transform;
+  transition: transform 300ms ease;
+}
+.gpu-layer:hover,
+.gpu-layer:focus-visible {
+  transform: translateZ(0) rotate(6deg) scale(1.08);
+}
+
+/* ----- PATTERN 3: explicit reset -----------------------------
+   When toggling will-change via JS, set it back to this class
+   after the animation ends so the layer memory is released. */
+.will-change-reset {
+  will-change: auto;
+}
+
+/* ----- ANTI-PATTERN (for contrast in the demo) ---------------
+   Do NOT do this: a permanently-on hint on an idle element
+   keeps a compositing layer alive forever, wasting memory, and
+   hinting `all`/layout properties gives no GPU benefit. */
+.will-change-bad {
+  will-change: all;
+  transition: transform 300ms ease;
+}
+.will-change-bad:hover {
+  transform: translateY(-10px) scale(1.05);
+}


### PR DESCRIPTION
Closes #9155 

Add will-change GPU-acceleration example with proper usage patterns
What
Adds a new self-contained example under submissions/examples/will-change-gpu-patterns/ demonstrating how to use the CSS will-change property for smooth, GPU-accelerated animations — including the usage patterns that keep it from hurting performance.

Why
will-change is easy to misuse: leaving it on permanently or hinting the wrong properties keeps compositing layers (and their memory) alive with no GPU benefit. This example gives EaseMotion CSS users a correct, memory-safe reference for opting into GPU acceleration on transform/opacity-heavy UI (cards, hover lifts, modals, carousels).

What's included
style.css — Demonstrates the recommended patterns:
Scoped will-change activation on :hover/:focus-visible that auto-resets when idle
A translateZ(0) + backface-visibility: hidden GPU compositing layer
An explicit reset class for JS-driven toggling
A labeled anti-pattern (will-change: all always-on) for contrast
demo.html — Runnable demo with DO / DON'T-labeled boxes you hover to see the GPU-accelerated transform/opacity animations. Links the core stylesheet per the project TEMPLATE.
README.md — Explains what it does, how to use it, and a DO/DON'T patterns table.
Notes
Additive only — no existing files modified.
HTML + CSS only, no frameworks or JavaScript.
Follows the repo's one-folder-per-submission convention (README.md + demo.html + style.css).
Class naming left for the maintainer to rename to the ease-* convention before merge.
Testing
Open demo.html directly in a browser and hover each box to verify the animations.