### PR TITLE
CSS quotes Smart Typography Example

### DIFF
--- a/submissions/examples/css-quotes-smart-typography-am/README.md
+++ b/submissions/examples/css-quotes-smart-typography-am/README.md
@@ -1,0 +1,30 @@
+# CSS Quotes — Smart Typography
+
+## What does this do?
+Demonstrates the CSS `quotes` property automatically inserting the correct, language-specific quotation marks (including nested levels) without typing any quote characters into the HTML.
+
+## How is it used?
+Set a language with the `lang` attribute and wrap text in a `<q>` element. The `quotes` rule for that language supplies the marks:
+
+    <p lang="fr"><q>Le web est pour <q>tout le monde</q>, partout.</q></p>
+
+The matching CSS defines the open/close pairs per language and renders them through `::before` / `::after`:
+
+    :lang(fr) {
+        quotes: "\00AB\00A0" "\00A0\00BB" "\2039\00A0" "\00A0\203A";
+    }
+
+    q::before { content: open-quote; }
+    q::after  { content: close-quote; }
+
+Included languages: English, French, German, Russian, and Japanese.
+
+## Why is it useful?
+Internationalized, motion-first interfaces still need correct typography. Letting CSS generate quotation marks keeps the content language-agnostic, produces proper nested quotes automatically, and ensures quoted text stays visually polished across locales — all with pure HTML and CSS, no JavaScript.
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open `demo.html` directly in your browser to see the effect.

--- a/submissions/examples/css-quotes-smart-typography-am/demo.html
+++ b/submissions/examples/css-quotes-smart-typography-am/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Quotes Smart Typography</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="quotes-demo">
+        <h1>Smart Quotation Marks with CSS <code>quotes</code></h1>
+        <p class="intro">
+            The same markup produces correct, language-specific quotation marks.
+            The marks below are generated entirely by CSS using the
+            <code>quotes</code> property together with the
+            <code>open-quote</code> / <code>close-quote</code> keywords &mdash;
+            no characters are typed into the text.
+        </p>
+
+        <ul class="quote-list">
+            <li class="quote-card">
+                <span class="lang-tag">English</span>
+                <p lang="en"><q>The web is for <q>everyone</q>, everywhere.</q></p>
+            </li>
+
+            <li class="quote-card">
+                <span class="lang-tag">French</span>
+                <p lang="fr"><q>Le web est pour <q>tout le monde</q>, partout.</q></p>
+            </li>
+
+            <li class="quote-card">
+                <span class="lang-tag">German</span>
+                <p lang="de"><q>Das Web ist f&uuml;r <q>alle</q>, &uuml;berall.</q></p>
+            </li>
+
+            <li class="quote-card">
+                <span class="lang-tag">Russian</span>
+                <p lang="ru"><q>&#1057;&#1077;&#1090;&#1100; &#1076;&#1083;&#1103; <q>&#1074;&#1089;&#1077;&#1093;</q>, &#1087;&#1086;&#1074;&#1089;&#1102;&#1076;&#1091;.</q></p>
+            </li>
+
+            <li class="quote-card">
+                <span class="lang-tag">Japanese</span>
+                <p lang="ja"><q>&#12454;&#12455;&#12502;&#12399;<q>&#12415;&#12435;&#12394;</q>&#12398;&#12418;&#12398;</q></p>
+            </li>
+        </ul>
+    </main>
+</body>
+</html>

--- a/submissions/examples/css-quotes-smart-typography-am/style.css
+++ b/submissions/examples/css-quotes-smart-typography-am/style.css
@@ -1,0 +1,108 @@
+/*
+ * Smart Typography with the CSS `quotes` property.
+ *
+ * The browser inserts the correct opening and closing quotation marks
+ * based on the element's language (the `lang` attribute). The text in the
+ * HTML stays plain; CSS supplies the punctuation. Two pairs are given per
+ * language so that nested quotes automatically use the secondary marks.
+ */
+
+/* Default (English): "double" then 'single' for the nested level */
+:lang(en) {
+    quotes: "\201C" "\201D" "\2018" "\2019";
+}
+
+/* French: « guillemets » with thin spaces, then ‹ inner › */
+:lang(fr) {
+    quotes: "\00AB\00A0" "\00A0\00BB" "\2039\00A0" "\00A0\203A";
+}
+
+/* German: „low-9 opening“ then ‚single‘ */
+:lang(de) {
+    quotes: "\201E" "\201C" "\201A" "\2018";
+}
+
+/* Russian: « guillemets » then „low-9“ for nesting */
+:lang(ru) {
+    quotes: "\00AB" "\00BB" "\201E" "\201C";
+}
+
+/* Japanese: 「corner brackets」 then 『double corner brackets』 */
+:lang(ja) {
+    quotes: "\300C" "\300D" "\300E" "\300F";
+}
+
+/* The <q> element renders the marks from the `quotes` list automatically.
+   open-quote / close-quote pick the right level as quotes nest. */
+q::before {
+    content: open-quote;
+}
+
+q::after {
+    content: close-quote;
+}
+
+/* ---- Presentation only (not required for the quotes behaviour) ---- */
+
+.quotes-demo {
+    max-width: 760px;
+    margin: 2.5rem auto;
+    padding: 0 1.25rem;
+    font-family: Georgia, "Times New Roman", serif;
+    color: #1f2933;
+    line-height: 1.6;
+}
+
+.quotes-demo h1 {
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
+.quotes-demo code {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    font-size: 0.85em;
+    background: #eef2f7;
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+}
+
+.intro {
+    color: #52606d;
+}
+
+.quote-list {
+    list-style: none;
+    margin: 2rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.quote-card {
+    border: 1px solid #e4e7eb;
+    border-left: 4px solid #3182ce;
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    background: #ffffff;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.quote-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+}
+
+.lang-tag {
+    display: inline-block;
+    font-family: "SFMono-Regular", Consolas, monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #3182ce;
+    margin-bottom: 0.4rem;
+}
+
+.quote-card p {
+    margin: 0;
+    font-size: 1.15rem;
+}


### PR DESCRIPTION
Add CSS quotes smart typography example

Closes #9161

Adds a self-contained example demonstrating the CSS quotes property for automatic, language-aware quotation marks.

What it does: The same <q> markup produces correct opening/closing quotes per language — driven entirely by CSS via :lang() + quotes and open-quote/close-quote. No quote characters are typed into the HTML, and nested <q> elements automatically use the secondary marks.

Languages covered: English, French, German, Russian, Japanese.

Files added (under submissions/examples/css-quotes-smart-typography-am/):

demo.html — self-contained demo, opens directly in a browser (no server/CDN)
style.css — :lang() quote pairs + presentation styling
README.md — what / how / why
Notes:

Pure HTML + CSS, no JavaScript, frameworks, or external dependencies
New folder only; no existing files, core/, components/, docs/, or other examples were touched
Unique -am suffix per the naming convention to avoid conflicts