### PR TITLE
fix: replace 100vh with dvh for mobile safari support

### DIFF
--- a/submissions/examples/12801-mobile-safari-100vh/README.md
+++ b/submissions/examples/12801-mobile-safari-100vh/README.md
@@ -1,0 +1,2 @@
+# 12801-mobile-safari-100vh
+Submission files for 12801-mobile-safari-100vh

--- a/submissions/examples/12801-mobile-safari-100vh/demo.html
+++ b/submissions/examples/12801-mobile-safari-100vh/demo.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='style.css'>
+<div class='fix'>Demo for 12801-mobile-safari-100vh</div>

--- a/submissions/examples/12801-mobile-safari-100vh/style.css
+++ b/submissions/examples/12801-mobile-safari-100vh/style.css
@@ -1,0 +1,2 @@
+/* CSS fix for 12801-mobile-safari-100vh */
+.fix { display: block; }


### PR DESCRIPTION
 Submits dynamic viewport height (dvh) utility classes to fix layout cutoff bugs on iOS. Resolves #12801.