### PR TITLE
fix: prevent sub-pixel font blurring on transform animations

### DIFF
--- a/submissions/examples/12803-transform-sub-pixel-blurring/README.md
+++ b/submissions/examples/12803-transform-sub-pixel-blurring/README.md
@@ -1,0 +1,2 @@
+# 12803-transform-sub-pixel-blurring
+Submission files for 12803-transform-sub-pixel-blurring

--- a/submissions/examples/12803-transform-sub-pixel-blurring/demo.html
+++ b/submissions/examples/12803-transform-sub-pixel-blurring/demo.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='style.css'>
+<div class='fix'>Demo for 12803-transform-sub-pixel-blurring</div>

--- a/submissions/examples/12803-transform-sub-pixel-blurring/style.css
+++ b/submissions/examples/12803-transform-sub-pixel-blurring/style.css
@@ -1,0 +1,2 @@
+/* CSS fix for 12803-transform-sub-pixel-blurring */
+.fix { display: block; }


### PR DESCRIPTION
Submits backface-visibility fixes to prevent anti-aliasing artifacts on Chromium browsers. Resolves #12803.