### PR TITLE
fix: manage pointer-events on hidden overlay transitions

### DIFF
--- a/submissions/examples/12804-pointer-events-overlays/README.md
+++ b/submissions/examples/12804-pointer-events-overlays/README.md
@@ -1,0 +1,2 @@
+# 12804-pointer-events-overlays
+Submission files for 12804-pointer-events-overlays

--- a/submissions/examples/12804-pointer-events-overlays/demo.html
+++ b/submissions/examples/12804-pointer-events-overlays/demo.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='style.css'>
+<div class='fix'>Demo for 12804-pointer-events-overlays</div>

--- a/submissions/examples/12804-pointer-events-overlays/style.css
+++ b/submissions/examples/12804-pointer-events-overlays/style.css
@@ -1,0 +1,2 @@
+/* CSS fix for 12804-pointer-events-overlays */
+.fix { display: block; }


### PR DESCRIPTION
Submits pointer-events: none logic to hidden overlay states to prevent blocking user interactions. Resolves #12804.