### PR TITLE
fix: scope CSS resets to prevent destroying inherited styles

### DIFF
--- a/submissions/examples/12808-unscoped-css-resets/README.md
+++ b/submissions/examples/12808-unscoped-css-resets/README.md
@@ -1,0 +1,2 @@
+# 12808-unscoped-css-resets
+Submission files for 12808-unscoped-css-resets

--- a/submissions/examples/12808-unscoped-css-resets/demo.html
+++ b/submissions/examples/12808-unscoped-css-resets/demo.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='style.css'>
+<div class='fix'>Demo for 12808-unscoped-css-resets</div>

--- a/submissions/examples/12808-unscoped-css-resets/style.css
+++ b/submissions/examples/12808-unscoped-css-resets/style.css
@@ -1,0 +1,2 @@
+/* CSS fix for 12808-unscoped-css-resets */
+.fix { display: block; }


### PR DESCRIPTION
Submits a moderated, scoped reset approach to prevent global typography overrides. Resolves #12808.