### PR TITLE
fix: add vendor prefixes for older WebKit engines

### DIFF
--- a/submissions/examples/12815-missing-vendor-prefixes/README.md
+++ b/submissions/examples/12815-missing-vendor-prefixes/README.md
@@ -1,0 +1,2 @@
+# 12815-missing-vendor-prefixes
+Submission files for 12815-missing-vendor-prefixes

--- a/submissions/examples/12815-missing-vendor-prefixes/demo.html
+++ b/submissions/examples/12815-missing-vendor-prefixes/demo.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='style.css'>
+<div class='fix'>Demo for 12815-missing-vendor-prefixes</div>

--- a/submissions/examples/12815-missing-vendor-prefixes/style.css
+++ b/submissions/examples/12815-missing-vendor-prefixes/style.css
@@ -1,0 +1,2 @@
+/* CSS fix for 12815-missing-vendor-prefixes */
+.fix { display: block; }


### PR DESCRIPTION
Submits WebKit fallbacks for modern CSS properties like clip-path and backdrop-filter. Resolves #12815.