### PR TITLE
fix: prevent scrollbar layout shift on modal open

### DIFF
--- a/submissions/examples/12816-scrollbar-layout-shifting/README.md
+++ b/submissions/examples/12816-scrollbar-layout-shifting/README.md
@@ -1,0 +1,2 @@
+# 12816-scrollbar-layout-shifting
+Submission files for 12816-scrollbar-layout-shifting

--- a/submissions/examples/12816-scrollbar-layout-shifting/demo.html
+++ b/submissions/examples/12816-scrollbar-layout-shifting/demo.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='style.css'>
+<div class='fix'>Demo for 12816-scrollbar-layout-shifting</div>

--- a/submissions/examples/12816-scrollbar-layout-shifting/style.css
+++ b/submissions/examples/12816-scrollbar-layout-shifting/style.css
@@ -1,0 +1,2 @@
+/* CSS fix for 12816-scrollbar-layout-shifting */
+.fix { display: block; }


### PR DESCRIPTION
Submits right-padding compensation logic for the <body> to prevent horizontal jumping when scrolling is disabled. Resolves #12816.