### PR TITLE
fix: prevent hover effects sticking on touch devices

### DIFF
--- a/submissions/examples/12842-hover-effects-touch/README.md
+++ b/submissions/examples/12842-hover-effects-touch/README.md
@@ -1,0 +1,2 @@
+# 12842-hover-effects-touch
+Submission files for 12842-hover-effects-touch

--- a/submissions/examples/12842-hover-effects-touch/demo.html
+++ b/submissions/examples/12842-hover-effects-touch/demo.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='style.css'>
+<div class='fix'>Demo for 12842-hover-effects-touch</div>

--- a/submissions/examples/12842-hover-effects-touch/style.css
+++ b/submissions/examples/12842-hover-effects-touch/style.css
@@ -1,0 +1,2 @@
+/* CSS fix for 12842-hover-effects-touch */
+.fix { display: block; }


### PR DESCRIPTION
Submits @media (hover: hover) wrappers around interactive hover utilities to prevent them from remaining permanently toggled after taps on mobile devices. Resolves #12842.
