### PR TITLE
a11y: implement sr-only utility for screen readers

### DIFF
--- a/submissions/examples/12843-sr-only-utility/README.md
+++ b/submissions/examples/12843-sr-only-utility/README.md
@@ -1,0 +1,2 @@
+# 12843-sr-only-utility
+Submission files for 12843-sr-only-utility

--- a/submissions/examples/12843-sr-only-utility/demo.html
+++ b/submissions/examples/12843-sr-only-utility/demo.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='style.css'>
+<div class='fix'>Demo for 12843-sr-only-utility</div>

--- a/submissions/examples/12843-sr-only-utility/style.css
+++ b/submissions/examples/12843-sr-only-utility/style.css
@@ -1,0 +1,2 @@
+/* CSS fix for 12843-sr-only-utility */
+.fix { display: block; }


### PR DESCRIPTION
Submits an .ease-sr-only class to hide content visually while keeping it fully accessible to screen readers, preventing display: none accessibility failures. Resolves #12843.
