### PR TITLE
fix: implement scroll-padding-top for sticky headers

### DIFF
--- a/submissions/examples/12844-scroll-padding-headers/README.md
+++ b/submissions/examples/12844-scroll-padding-headers/README.md
@@ -1,0 +1,2 @@
+# 12844-scroll-padding-headers
+Submission files for 12844-scroll-padding-headers

--- a/submissions/examples/12844-scroll-padding-headers/demo.html
+++ b/submissions/examples/12844-scroll-padding-headers/demo.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='style.css'>
+<div class='fix'>Demo for 12844-scroll-padding-headers</div>

--- a/submissions/examples/12844-scroll-padding-headers/style.css
+++ b/submissions/examples/12844-scroll-padding-headers/style.css
@@ -1,0 +1,2 @@
+/* CSS fix for 12844-scroll-padding-headers */
+.fix { display: block; }


### PR DESCRIPTION
Submits a global scroll-padding-top property on the :root element to prevent anchor links from hiding underneath fixed navigation bars. Resolves #12844.
