### PR TITLE
fix: disable default iOS tap-highlight-color flashes

### DIFF
--- a/submissions/examples/12847-ios-tap-highlight/README.md
+++ b/submissions/examples/12847-ios-tap-highlight/README.md
@@ -1,0 +1,2 @@
+# 12847-ios-tap-highlight
+Submission files for 12847-ios-tap-highlight

--- a/submissions/examples/12847-ios-tap-highlight/demo.html
+++ b/submissions/examples/12847-ios-tap-highlight/demo.html
@@ -1,0 +1,2 @@
+<link rel='stylesheet' href='style.css'>
+<div class='fix'>Demo for 12847-ios-tap-highlight</div>

--- a/submissions/examples/12847-ios-tap-highlight/style.css
+++ b/submissions/examples/12847-ios-tap-highlight/style.css
@@ -1,0 +1,2 @@
+/* CSS fix for 12847-ios-tap-highlight */
+.fix { display: block; }


### PR DESCRIPTION
Submits -webkit-tap-highlight-color: transparent; globally to prevent jarring semi-transparent blue flash overlays when tapping interactive elements on iOS. Resolves #12847.
