### PR TITLE
Add inline validation message example

### DIFF
--- a/submissions/examples/inline-validation-message-ts/README.md
+++ b/submissions/examples/inline-validation-message-ts/README.md
@@ -1,0 +1,5 @@
+# Inline Validation Message Transition
+
+1. What does this do? Demonstrates stable inline success and error feedback for form fields.
+2. How is it used? Apply the showcased class names to the matching HTML pattern in the demo.
+3. Why is it useful? It gives EaseMotion CSS a focused, reusable motion pattern that stays small and accessible.

--- a/submissions/examples/inline-validation-message-ts/demo.html
+++ b/submissions/examples/inline-validation-message-ts/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inline Validation Message Transition</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="demo-header" aria-labelledby="demo-title">
+      <p class="eyebrow">EaseMotion CSS example</p>
+      <h1 id="demo-title">Inline Validation Message Transition</h1>
+      <p>Demonstrates stable inline success and error feedback for form fields.</p>
+    </section>
+    <form class="validation-form" aria-label="Validation state examples">
+      <label class="validated-field">
+        <span>Username</span>
+        <input class="is-valid" value="motion-user" aria-describedby="username-help">
+        <small id="username-help" class="field-message success-message">Username is available.</small>
+      </label>
+      <label class="validated-field">
+        <span>Email address</span>
+        <input class="is-invalid" value="motion@example" aria-invalid="true" aria-describedby="email-help">
+        <small id="email-help" class="field-message error-message">Enter a complete email address.</small>
+      </label>
+    </form>
+  </main>
+</body>
+</html>

--- a/submissions/examples/inline-validation-message-ts/style.css
+++ b/submissions/examples/inline-validation-message-ts/style.css
@@ -1,0 +1,132 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f6f8fb;
+  color: #151b2c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  width: min(960px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 46px 0;
+}
+
+.demo-header {
+  margin-bottom: 26px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #4f46e5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  max-width: 720px;
+  color: #111827;
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.demo-header p:last-child {
+  max-width: 680px;
+  margin: 16px 0 0;
+  color: #5f6879;
+  line-height: 1.65;
+}
+
+@media (max-width: 680px) {
+  .demo-shell {
+    width: min(100% - 24px, 960px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+}
+.validation-form {
+  display: grid;
+  gap: 18px;
+  max-width: 560px;
+  border: 1px solid #dce3ef;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 45px rgba(17, 24, 39, 0.08);
+  padding: 24px;
+}
+
+.validated-field {
+  display: grid;
+  gap: 8px;
+  color: #374151;
+  font-weight: 800;
+}
+
+.validated-field input {
+  width: 100%;
+  border: 2px solid #d1d8e5;
+  border-radius: 8px;
+  color: #111827;
+  font: inherit;
+  padding: 13px 14px;
+  transition: border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.validated-field input:focus {
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.12);
+  outline: 0;
+}
+
+.validated-field input.is-valid {
+  border-color: #16a34a;
+}
+
+.validated-field input.is-invalid {
+  border-color: #dc2626;
+}
+
+.field-message {
+  min-height: 1.3rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.validated-field:focus-within .field-message,
+.validated-field input.is-valid + .field-message,
+.validated-field input.is-invalid + .field-message {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.success-message {
+  color: #15803d;
+}
+
+.error-message {
+  color: #b91c1c;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .validated-field input,
+  .field-message {
+    transition-duration: 1ms;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds the Inline Validation Message Transition submission under `submissions/examples/inline-validation-message-ts`.

Closes #12899

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## What changed

Added a self-contained demo with local CSS and README documentation for the requested pattern.

---

## Validation

- [x] Ran stylelint on the new stylesheet
