### PR TITLE
Add disclosure card stack example

### DIFF
--- a/submissions/examples/disclosure-card-stack-ts/README.md
+++ b/submissions/examples/disclosure-card-stack-ts/README.md
@@ -1,0 +1,5 @@
+# CSS-Only Disclosure Card Stack
+
+1. What does this do? Uses native details and summary elements with a compact animated indicator.
+2. How is it used? Apply the showcased class names to the matching HTML pattern in the demo.
+3. Why is it useful? It gives EaseMotion CSS a focused, reusable motion pattern that stays small and accessible.

--- a/submissions/examples/disclosure-card-stack-ts/demo.html
+++ b/submissions/examples/disclosure-card-stack-ts/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Disclosure Card Stack</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="demo-header" aria-labelledby="demo-title">
+      <p class="eyebrow">EaseMotion CSS example</p>
+      <h1 id="demo-title">CSS-Only Disclosure Card Stack</h1>
+      <p>Uses native details and summary elements with a compact animated indicator.</p>
+    </section>
+    <section class="disclosure-stack" aria-label="Frequently asked questions">
+      <details class="disclosure-card" open>
+        <summary>What is this pattern for?</summary>
+        <p>Use it for FAQs, settings groups, and compact documentation sections.</p>
+      </details>
+      <details class="disclosure-card">
+        <summary>Does it need JavaScript?</summary>
+        <p>No. The native details element handles disclosure behavior.</p>
+      </details>
+      <details class="disclosure-card">
+        <summary>How is motion handled?</summary>
+        <p>The indicator rotates while the content area stays readable and stable.</p>
+      </details>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/disclosure-card-stack-ts/style.css
+++ b/submissions/examples/disclosure-card-stack-ts/style.css
@@ -1,0 +1,127 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f6f8fb;
+  color: #151b2c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  width: min(960px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 46px 0;
+}
+
+.demo-header {
+  margin-bottom: 26px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #4f46e5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  max-width: 720px;
+  color: #111827;
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.demo-header p:last-child {
+  max-width: 680px;
+  margin: 16px 0 0;
+  color: #5f6879;
+  line-height: 1.65;
+}
+
+@media (max-width: 680px) {
+  .demo-shell {
+    width: min(100% - 24px, 960px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+}
+.disclosure-stack {
+  display: grid;
+  gap: 12px;
+  max-width: 680px;
+}
+
+.disclosure-card {
+  border: 1px solid #dce3ef;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 14px 36px rgba(17, 24, 39, 0.07);
+  overflow: hidden;
+}
+
+.disclosure-card summary {
+  position: relative;
+  cursor: pointer;
+  list-style: none;
+  padding: 18px 56px 18px 20px;
+  color: #111827;
+  font-weight: 900;
+}
+
+.disclosure-card summary::-webkit-details-marker {
+  display: none;
+}
+
+.disclosure-card summary::after {
+  content: "+";
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #4f46e5;
+  display: grid;
+  place-items: center;
+  transform: translateY(-50%) rotate(0deg);
+  transition: background-color 180ms ease, transform 180ms ease;
+}
+
+.disclosure-card[open] summary::after {
+  background: #4f46e5;
+  color: #ffffff;
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.disclosure-card summary:focus-visible {
+  outline: 3px solid rgba(79, 70, 229, 0.28);
+  outline-offset: -3px;
+}
+
+.disclosure-card p {
+  margin: 0;
+  border-top: 1px solid #eef2f7;
+  color: #5f6879;
+  line-height: 1.65;
+  padding: 0 20px 20px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .disclosure-card summary::after {
+    transition-duration: 1ms;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds the CSS-Only Disclosure Card Stack submission under `submissions/examples/disclosure-card-stack-ts`.

Closes #12900

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## What changed

Added a self-contained demo with local CSS and README documentation for the requested pattern.

---

## Validation

- [x] Ran stylelint on the new stylesheet
