### PR TITLE
Add floating label error state example

### DIFF
--- a/submissions/examples/floating-label-error-ts/README.md
+++ b/submissions/examples/floating-label-error-ts/README.md
@@ -1,0 +1,5 @@
+# Floating Label Input With Error State
+
+1. What does this do? Demonstrates floating input labels with focused, filled, and invalid field states.
+2. How is it used? Apply the showcased class names to the matching HTML pattern in the demo.
+3. Why is it useful? It gives EaseMotion CSS a focused, reusable motion pattern that stays small and accessible.

--- a/submissions/examples/floating-label-error-ts/demo.html
+++ b/submissions/examples/floating-label-error-ts/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Floating Label Input With Error State</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="demo-header" aria-labelledby="demo-title">
+      <p class="eyebrow">EaseMotion CSS example</p>
+      <h1 id="demo-title">Floating Label Input With Error State</h1>
+      <p>Demonstrates floating input labels with focused, filled, and invalid field states.</p>
+    </section>
+    <form class="floating-form" aria-label="Floating label form">
+      <label class="floating-field">
+        <input type="text" placeholder=" " value="Ari Motion">
+        <span>Full name</span>
+      </label>
+      <label class="floating-field">
+        <input type="email" placeholder=" " value="ari@example" aria-invalid="true" aria-describedby="email-error">
+        <span>Email address</span>
+        <small id="email-error">Please enter a valid email address.</small>
+      </label>
+    </form>
+  </main>
+</body>
+</html>

--- a/submissions/examples/floating-label-error-ts/style.css
+++ b/submissions/examples/floating-label-error-ts/style.css
@@ -1,0 +1,133 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f6f8fb;
+  color: #151b2c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  width: min(960px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 46px 0;
+}
+
+.demo-header {
+  margin-bottom: 26px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #4f46e5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  max-width: 720px;
+  color: #111827;
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.demo-header p:last-child {
+  max-width: 680px;
+  margin: 16px 0 0;
+  color: #5f6879;
+  line-height: 1.65;
+}
+
+@media (max-width: 680px) {
+  .demo-shell {
+    width: min(100% - 24px, 960px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+}
+.floating-form {
+  display: grid;
+  gap: 22px;
+  max-width: 560px;
+  border: 1px solid #dce3ef;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 45px rgba(17, 24, 39, 0.08);
+  padding: 28px;
+}
+
+.floating-field {
+  position: relative;
+  display: grid;
+  gap: 8px;
+}
+
+.floating-field input {
+  width: 100%;
+  border: 2px solid #d1d8e5;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #111827;
+  font: inherit;
+  padding: 18px 14px 10px;
+  transition: border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.floating-field span {
+  position: absolute;
+  top: 15px;
+  left: 14px;
+  background: #ffffff;
+  color: #6b7280;
+  padding: 0 4px;
+  pointer-events: none;
+  transform-origin: left center;
+  transition: color 180ms ease, transform 180ms ease;
+}
+
+.floating-field input:focus {
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.12);
+  outline: 0;
+}
+
+.floating-field input:focus + span,
+.floating-field input:not(:placeholder-shown) + span {
+  color: #4f46e5;
+  transform: translateY(-22px) scale(0.82);
+}
+
+.floating-field input[aria-invalid="true"] {
+  border-color: #dc2626;
+}
+
+.floating-field input[aria-invalid="true"] + span,
+.floating-field small {
+  color: #b91c1c;
+}
+
+.floating-field small {
+  min-height: 1.25rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .floating-field input,
+  .floating-field span {
+    transition-duration: 1ms;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds the Floating Label Input With Error State submission under `submissions/examples/floating-label-error-ts`.

Closes #12904

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## What changed

Added a self-contained demo with local CSS and README documentation for the requested pattern.

---

## Validation

- [x] Ran stylelint on the new stylesheet
