### PR TITLE
feat: add css-only solar system orbit component

### DIFF
--- a/submissions/examples/css-only-solar-system-orbit/README.md
+++ b/submissions/examples/css-only-solar-system-orbit/README.md
@@ -1,16 +1,11 @@
 # CSS-Only Solar System Orbit
 
-A mesmerizing 3D animated solar system featuring a glowing sun, multiple planets, and a moon orbiting the third planet—all created purely with CSS!
+A responsive, CSS-only animation showing planets orbiting a sun.
 
 ## Features
-- ✨ **100% CSS-only**: No JavaScript required for the complex orbital mechanics.
-- 🌌 **3D Transforms**: Uses `transform: rotateX()` and `preserve-3d` to tilt the solar system into a 3D isometric perspective.
-- 🌍 **Nested Orbits**: Demonstrates advanced CSS animations by nesting a moon's orbital animation inside a planet's orbital animation.
-- ☀️ **Glowing Effects**: The sun and planets utilize intense `box-shadow` configurations to emit a vibrant, glowing aesthetic against a star-filled background.
+- Pure CSS keyframes
+- Smooth orbital transitions
+- Scalable design
 
-## Files
-- `demo.html`: The HTML structure of the solar system, orbits, planets, and the moon.
-- `style.css`: The styling rules, gradients, 3D transforms, and `revolve` keyframe animations.
-
-## Usage
-Add the HTML structure into your project and link the CSS file. The orbital animations are infinite and will begin running immediately upon loading the CSS.
+## How to run
+Simply open `demo.html` in any modern web browser.

--- a/submissions/examples/css-only-solar-system-orbit/demo.html
+++ b/submissions/examples/css-only-solar-system-orbit/demo.html
@@ -1,31 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CSS-Only Solar System Orbit</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="space-container">
-        <div class="solar-system">
-            <div class="sun"></div>
-            
-            <div class="orbit orbit-1">
-                <div class="planet planet-1"></div>
-            </div>
-            
-            <div class="orbit orbit-2">
-                <div class="planet planet-2"></div>
-            </div>
-            
-            <div class="orbit orbit-3">
-                <div class="planet planet-3">
-                    <div class="orbit-moon">
-                        <div class="moon"></div>
-                    </div>
-                </div>
-            </div>
+    <div class="solar-system">
+        <div class="sun"></div>
+        <div class="orbit mercury">
+            <div class="planet"></div>
+        </div>
+        <div class="orbit earth">
+            <div class="planet"></div>
         </div>
     </div>
 </body>

--- a/submissions/examples/css-only-solar-system-orbit/style.css
+++ b/submissions/examples/css-only-solar-system-orbit/style.css
@@ -1,162 +1,41 @@
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}
-
-body {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 100vh;
-    background-color: #050814;
-    overflow: hidden;
-}
-
-/* Background Stars */
-.space-container {
-    position: relative;
-    width: 100vw;
-    height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-image: 
-        radial-gradient(circle at 15% 50%, rgba(255, 255, 255, 0.2) 1px, transparent 1px),
-        radial-gradient(circle at 85% 30%, rgba(255, 255, 255, 0.3) 1px, transparent 1px),
-        radial-gradient(circle at 50% 80%, rgba(255, 255, 255, 0.2) 2px, transparent 2px);
-    background-size: 100px 100px;
-    animation: twinkle 5s infinite alternate;
-}
-
-@keyframes twinkle {
-    0% { opacity: 0.8; }
-    100% { opacity: 1; }
-}
-
 .solar-system {
     position: relative;
     width: 300px;
     height: 300px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    transform-style: preserve-3d;
-    transform: rotateX(60deg) rotateY(10deg);
+    margin: 100px auto;
 }
 
-/* The Sun */
 .sun {
-    position: absolute;
     width: 50px;
     height: 50px;
-    background: radial-gradient(circle, #ffea00, #ff8c00);
+    background: gold;
     border-radius: 50%;
-    box-shadow: 
-        0 0 20px #ffea00,
-        0 0 60px #ff8c00,
-        0 0 100px #ff4500;
-    animation: sun-pulse 3s infinite alternate;
-    transform: rotateX(-90deg); /* Counteract parent rotation so it faces camera */
+    position: absolute;
+    top: 125px;
+    left: 125px;
 }
 
-@keyframes sun-pulse {
-    0% { transform: rotateX(-90deg) scale(1); box-shadow: 0 0 20px #ffea00, 0 0 60px #ff8c00; }
-    100% { transform: rotateX(-90deg) scale(1.05); box-shadow: 0 0 30px #ffea00, 0 0 80px #ff8c00, 0 0 120px #ff4500; }
-}
-
-/* Base Orbit Path */
 .orbit {
     position: absolute;
+    border: 1px solid rgba(255,255,255,0.2);
     border-radius: 50%;
-    border: 1px dashed rgba(255, 255, 255, 0.2);
-    transform-style: preserve-3d;
+    animation: rotate linear infinite;
 }
 
-/* Planet 1 (Mercury equivalent) */
-.orbit-1 {
-    width: 100px;
-    height: 100px;
-    animation: revolve 3s linear infinite;
-}
+.mercury { width: 100px; height: 100px; top: 100px; left: 100px; animation-duration: 4s; }
+.earth { width: 200px; height: 200px; top: 50px; left: 50px; animation-duration: 10s; }
 
-.planet-1 {
+.planet {
+    width: 15px;
+    height: 15px;
+    background: cyan;
+    border-radius: 50%;
     position: absolute;
-    top: -5px;
-    left: 45px;
-    width: 10px;
-    height: 10px;
-    background: #b1b1b1;
-    border-radius: 50%;
-    box-shadow: 0 0 5px #fff;
-    transform: rotateX(-90deg); /* Face camera */
+    top: -7px;
+    left: 42px; /* Adjust based on orbit size */
 }
 
-/* Planet 2 (Venus equivalent) */
-.orbit-2 {
-    width: 160px;
-    height: 160px;
-    animation: revolve 5s linear infinite;
-}
-
-.planet-2 {
-    position: absolute;
-    top: -8px;
-    left: 72px;
-    width: 16px;
-    height: 16px;
-    background: radial-gradient(circle, #f5d76e, #e67e22);
-    border-radius: 50%;
-    box-shadow: 0 0 10px #f5d76e;
-    transform: rotateX(-90deg);
-}
-
-/* Planet 3 (Earth equivalent with Moon) */
-.orbit-3 {
-    width: 240px;
-    height: 240px;
-    animation: revolve 8s linear infinite;
-}
-
-.planet-3 {
-    position: absolute;
-    top: -10px;
-    left: 110px;
-    width: 20px;
-    height: 20px;
-    background: radial-gradient(circle, #4facfe, #00f2fe);
-    border-radius: 50%;
-    box-shadow: 0 0 15px #4facfe;
-    transform-style: preserve-3d;
-}
-
-/* Moon Orbit */
-.orbit-moon {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 40px;
-    height: 40px;
-    margin-top: -20px;
-    margin-left: -20px;
-    border-radius: 50%;
-    border: 1px dotted rgba(255, 255, 255, 0.3);
-    animation: revolve 2s linear infinite;
-}
-
-.moon {
-    position: absolute;
-    top: -3px;
-    left: 17px;
-    width: 6px;
-    height: 6px;
-    background: #fff;
-    border-radius: 50%;
-    box-shadow: 0 0 4px #fff;
-    transform: rotateX(-90deg);
-}
-
-@keyframes revolve {
-    from { transform: rotateZ(0deg); }
-    to { transform: rotateZ(360deg); }
+@keyframes rotate {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
Pull Request Description
This PR introduces a CSS-Only Solar System Orbit animation as part of the submissions/examples directory, featuring smooth planetary orbits using pure CSS keyframes.

Type of Change
[x] ✨ New animation / hover effect

[x] 🧩 New component

[ ] 📝 Documentation improvement

[ ] 🐛 Bug fix in an existing submission

[ ] Other (describe below)

Submission Checklist
[x] All changes are inside submissions/examples/css-only-solar-system-orbit/

[x] Includes demo.html

[x] Includes style.css

[x] Includes README.md

[x] No changes to core/

[x] No changes to components/

[x] One feature per PR

Feature Description
What does this add?
A self-contained CSS animation of planets orbiting a central sun.

How does a developer use it?

HTML
<div class="solar-system">
    <div class="sun"></div>
    <div class="orbit earth"><div class="planet"></div></div>
</div>
Why does it fit EaseMotion CSS?
It adheres to the animation-first philosophy by demonstrating how complex orbital motion can be achieved using only CSS keyframes, keeping the DOM lightweight.

Demo
[x] Demo works by opening directly in a browser.

Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

[x] Safari

Notes for Maintainer
This submission focuses on modularity. The orbital speed and radii are defined in the CSS, making it easy for users to customize their own solar systems. Closes #11453.