### PR TITLE
Add rating stars hover preview example

### DIFF
--- a/submissions/examples/rating-stars-preview-ts/README.md
+++ b/submissions/examples/rating-stars-preview-ts/README.md
@@ -1,0 +1,5 @@
+# CSS-Only Rating Stars Hover Preview
+
+1. What does this do? Uses radio inputs and star labels to provide keyboard-accessible rating previews.
+2. How is it used? Apply the showcased classes to the matching semantic HTML pattern.
+3. Why is it useful? It adds a focused, reusable interaction pattern while keeping motion accessible and layout stable.

--- a/submissions/examples/rating-stars-preview-ts/demo.html
+++ b/submissions/examples/rating-stars-preview-ts/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Rating Stars Hover Preview</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <header class="demo-header">
+      <p class="eyebrow">EaseMotion CSS example</p>
+      <h1>CSS-Only Rating Stars Hover Preview</h1>
+      <p>Uses radio inputs and star labels to provide keyboard-accessible rating previews.</p>
+    </header>
+    <fieldset class="rating-preview">
+      <legend>Rate this component</legend>
+      <div class="stars">
+        <input type="radio" name="rating" id="star-1"><label for="star-1"><span aria-hidden="true">*</span><span class="sr-only">1 star</span></label>
+        <input type="radio" name="rating" id="star-2"><label for="star-2"><span aria-hidden="true">*</span><span class="sr-only">2 stars</span></label>
+        <input type="radio" name="rating" id="star-3"><label for="star-3"><span aria-hidden="true">*</span><span class="sr-only">3 stars</span></label>
+        <input type="radio" name="rating" id="star-4" checked><label for="star-4"><span aria-hidden="true">*</span><span class="sr-only">4 stars</span></label>
+        <input type="radio" name="rating" id="star-5"><label for="star-5"><span aria-hidden="true">*</span><span class="sr-only">5 stars</span></label>
+      </div>
+      <p>Four out of five stars selected</p>
+    </fieldset>
+  </main>
+</body>
+</html>

--- a/submissions/examples/rating-stars-preview-ts/style.css
+++ b/submissions/examples/rating-stars-preview-ts/style.css
@@ -1,0 +1,25 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f5f7fb;
+  color: #172033;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; }
+.demo-shell { width: min(920px, calc(100% - 32px)); margin: 0 auto; padding: 46px 0; }
+.demo-header { margin-bottom: 26px; }
+.eyebrow { margin: 0 0 10px; color: #4f46e5; font-size: 0.78rem; font-weight: 800; letter-spacing: 0; text-transform: uppercase; }
+h1 { margin: 0; max-width: 720px; color: #111827; font-size: 3rem; line-height: 1; }
+.demo-header p:last-child { max-width: 680px; margin: 16px 0 0; color: #5f6879; line-height: 1.65; }
+@media (max-width: 680px) { .demo-shell { width: min(100% - 24px, 920px); padding: 30px 0; } h1 { font-size: 2rem; } }
+.rating-preview { max-width: 520px; border: 1px solid #dce3ef; border-radius: 8px; background: #fff; box-shadow: 0 18px 45px rgba(17,24,39,.08); padding: 26px; }
+.rating-preview legend { padding: 0 8px; color: #111827; font-weight: 900; }
+.stars { display: flex; gap: 8px; }
+.stars input { position: absolute; opacity: 0; }
+.stars label { width: 52px; height: 52px; border: 1px solid #d8deea; border-radius: 8px; color: #9ca3af; cursor: pointer; display: grid; font-size: 2rem; font-weight: 900; place-items: center; transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease; }
+.stars label:is(:hover,:focus-visible), .stars input:checked + label { border-color: #eab308; background: #fef9c3; color: #ca8a04; transform: translateY(-3px) scale(1.04); }
+.stars input:focus-visible + label { outline: 3px solid rgba(79,70,229,.28); outline-offset: 3px; }
+.rating-preview p { margin: 16px 0 0; color: #5f6879; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
+@media (prefers-reduced-motion: reduce) { .stars label { transition-duration: 1ms; } .stars label:is(:hover,:focus-visible), .stars input:checked + label { transform: none; } }


### PR DESCRIPTION
## Pull Request Description

Adds the CSS-Only Rating Stars Hover Preview submission under `submissions/examples/rating-stars-preview-ts`.

Closes #12966

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission

---

## What changed

Added a self-contained demo, local stylesheet, and README documentation for the requested pattern.

---

## Validation

- [x] Ran stylelint on the new stylesheet
