### PR TITLE
Add command palette focus example

### DIFF
--- a/submissions/examples/command-palette-focus-ts/README.md
+++ b/submissions/examples/command-palette-focus-ts/README.md
@@ -1,0 +1,5 @@
+# Command Palette Result Focus Pattern
+
+1. What does this do? Demonstrates keyboard-friendly command rows with selected, hover, and focus states.
+2. How is it used? Apply the showcased classes to the matching semantic HTML pattern.
+3. Why is it useful? It adds a focused, reusable interaction pattern while keeping motion accessible and layout stable.

--- a/submissions/examples/command-palette-focus-ts/demo.html
+++ b/submissions/examples/command-palette-focus-ts/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Command Palette Result Focus Pattern</title><link rel="stylesheet" href="./style.css"></head>
+<body><main class="demo-shell"><header class="demo-header"><p class="eyebrow">EaseMotion CSS example</p><h1>Command Palette Result Focus Pattern</h1><p>Demonstrates keyboard-friendly command rows with selected, hover, and focus states.</p></header>
+    <section class="command-palette" role="dialog" aria-label="Command palette">
+      <label class="command-search">Search commands<input type="search" placeholder="Type a command"></label>
+      <p class="command-label">Navigation</p>
+      <button class="command-row is-selected" type="button"><span>Open settings</span><kbd>Ctrl K</kbd></button>
+      <button class="command-row" type="button"><span>View shortcuts</span><kbd>?</kbd></button>
+      <button class="command-row" type="button"><span>Switch workspace</span><kbd>Ctrl W</kbd></button>
+    </section>
+</main></body></html>

--- a/submissions/examples/command-palette-focus-ts/style.css
+++ b/submissions/examples/command-palette-focus-ts/style.css
@@ -1,0 +1,18 @@
+:root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f5f7fb; color: #172033; }
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; }
+.demo-shell { width: min(920px, calc(100% - 32px)); margin: 0 auto; padding: 46px 0; }
+.demo-header { margin-bottom: 26px; }
+.eyebrow { margin: 0 0 10px; color: #4f46e5; font-size: 0.78rem; font-weight: 800; letter-spacing: 0; text-transform: uppercase; }
+h1 { margin: 0; max-width: 720px; color: #111827; font-size: 3rem; line-height: 1; }
+.demo-header p:last-child { max-width: 680px; margin: 16px 0 0; color: #5f6879; line-height: 1.65; }
+@media (max-width: 680px) { .demo-shell { width: min(100% - 24px, 920px); padding: 30px 0; } h1 { font-size: 2rem; } }
+.command-palette { max-width: 680px; border: 1px solid #dce3ef; border-radius: 8px; background: #fff; box-shadow: 0 24px 65px rgba(17,24,39,.14); padding: 16px; }
+.command-search { display: grid; gap: 8px; color: #374151; font-weight: 800; }
+.command-search input { border: 1px solid #cfd7e5; border-radius: 8px; font: inherit; padding: 13px 14px; }
+.command-search input:focus { border-color: #4f46e5; box-shadow: 0 0 0 4px rgba(79,70,229,.12); outline: 0; }
+.command-label { margin: 18px 8px 8px; color: #7c8799; font-size: .76rem; font-weight: 900; text-transform: uppercase; }
+.command-row { width: 100%; min-height: 50px; border: 0; border-radius: 8px; background: transparent; color: #374151; cursor: pointer; display: flex; align-items: center; justify-content: space-between; gap: 16px; font: inherit; font-weight: 800; padding: 10px 12px; text-align: left; transition: background-color 160ms ease, color 160ms ease, transform 160ms ease; }
+.command-row:is(:hover,:focus-visible), .command-row.is-selected { background: #eef2ff; color: #312e81; outline: 0; transform: translateX(4px); }
+kbd { border: 1px solid #cbd5e1; border-bottom-width: 2px; border-radius: 6px; background: #fff; color: #64748b; font-family: inherit; font-size: .75rem; padding: 4px 7px; white-space: nowrap; }
+@media (prefers-reduced-motion: reduce) { .command-row { transition-duration: 1ms; } .command-row:is(:hover,:focus-visible), .command-row.is-selected { transform: none; } }


### PR DESCRIPTION
## Pull Request Description

Adds the Command Palette Result Focus Pattern submission under `submissions/examples/command-palette-focus-ts`.

Closes #12971

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission

---

## What changed

Added a self-contained demo, local stylesheet, and README documentation for the requested pattern.

---

## Validation

- [x] Ran stylelint on the new stylesheet
