### PR TITLE
fix: normalize repository, bugs, and homepage fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SAPTARSHI-coder/EaseMotion-css.git"
+    "url": "git+https://github.com/saptarshi-coder/easemotion-css.git"
   },
   "keywords": [
     "css",
@@ -48,9 +48,9 @@
   "author": "Saptarshi Sadhu (https://github.com/SAPTARSHI-coder)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/SAPTARSHI-coder/EaseMotion-css/issues"
+    "url": "https://github.com/saptarshi-coder/easemotion-css/issues"
   },
-  "homepage": "https://saptarshi-coder.github.io/EaseMotion-css/",
+  "homepage": "https://github.com/saptarshi-coder/easemotion-css#readme",
   "engines": {
     "node": ">=18"
   },

--- a/submissions/examples/fix-package-json-metadata/README.md
+++ b/submissions/examples/fix-package-json-metadata/README.md
@@ -1,0 +1,11 @@
+# Fix: package.json Metadata
+
+Corrects the `repository`, `bugs`, and `homepage` fields in root `package.json`.
+
+## Changes
+- `repository.url` normalized to lowercase
+- `bugs.url` normalized to lowercase
+- `homepage` points to GitHub repo README
+
+## Related Issue
+Fixes #13201

--- a/submissions/examples/fix-package-json-metadata/demo.html
+++ b/submissions/examples/fix-package-json-metadata/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Fix: package.json Metadata</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>package.json Metadata Fix</h1>
+    <p>Fixes <code>repository</code>, <code>bugs</code>, and <code>homepage</code> fields.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-package-json-metadata/style.css
+++ b/submissions/examples/fix-package-json-metadata/style.css
@@ -1,0 +1,22 @@
+body {
+  font-family: sans-serif;
+  background: #0d1117;
+  color: #c9d1d9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+.container {
+  text-align: center;
+  padding: 2rem;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+}
+code {
+  background: #161b22;
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: #79c0ff;
+}


### PR DESCRIPTION
## 📌 Related Issue
Fixes #13201

## 🐛 What was wrong?
The `package.json` at the repo root had incorrect metadata fields:
- `repository.url` used mixed-case (`SAPTARSHI-coder/EaseMotion-css`) instead of lowercase
- `bugs.url` used mixed-case instead of lowercase
- `homepage` was pointing to GitHub Pages site instead of the GitHub repo README

## ✅ What was fixed?

| Field | Before | After |
|---|---|---|
| `repository.url` | `git+https://github.com/SAPTARSHI-coder/EaseMotion-css.git` | `git+https://github.com/saptarshi-coder/easemotion-css.git` |
| `bugs.url` | `https://github.com/SAPTARSHI-coder/EaseMotion-css/issues` | `https://github.com/saptarshi-coder/easemotion-css/issues` |
| `homepage` | `https://saptarshi-coder.github.io/EaseMotion-css/` | `https://github.com/saptarshi-coder/easemotion-css#readme` |

## 🧪 Verified with
```bash
npm pkg get repository bugs homepage
```

## 📁 Files Changed
- `package.json` — corrected 3 metadata fields
- `submissions/examples/fix-package-json-metadata/` — added required demo files