### PR TITLE
Add expandable data table row example

### DIFF
--- a/submissions/examples/expandable-data-table-row-ts/README.md
+++ b/submissions/examples/expandable-data-table-row-ts/README.md
@@ -1,0 +1,7 @@
+# Expandable Data Table Row
+
+**What does this do?** Shows a data table row with a visually connected, animated detail region.
+
+**How is it used?** Add `active` to the parent row and place its expanded content in the following `detail` row.
+
+**Why is it useful?** It reveals secondary data without leaving the table, while preserving semantic markup, focus visibility, responsive behavior, and reduced-motion support.

--- a/submissions/examples/expandable-data-table-row-ts/demo.html
+++ b/submissions/examples/expandable-data-table-row-ts/demo.html
@@ -1,0 +1,7 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Expandable Data Table Row</title><link rel="stylesheet" href="style.css"></head>
+<body><main><p class="eyebrow">Quarterly accounts</p><h1>Expandable row details</h1><div class="table-wrap"><table><thead><tr><th>Account</th><th>Owner</th><th>Revenue</th><th><span class="sr-only">Details</span></th></tr></thead><tbody>
+<tr><td><strong>Northstar</strong></td><td>Maya Chen</td><td>$48,200</td><td><button aria-label="Expand Northstar details">+</button></td></tr>
+<tr class="active"><td><strong>Highline</strong></td><td>Sam Ortiz</td><td>$36,840</td><td><button aria-expanded="true" aria-label="Collapse Highline details">−</button></td></tr>
+<tr class="detail"><td colspan="4"><div><span><small>Renewal</small>18 Sep 2026</span><span><small>Health</small><b>On track</b></span><span><small>Next step</small>Review proposal</span></div></td></tr>
+<tr><td><strong>Fieldwork</strong></td><td>Nia Bell</td><td>$29,500</td><td><button aria-label="Expand Fieldwork details">+</button></td></tr>
+</tbody></table></div></main></body></html>

--- a/submissions/examples/expandable-data-table-row-ts/style.css
+++ b/submissions/examples/expandable-data-table-row-ts/style.css
@@ -1,0 +1,23 @@
+:root { font-family: Inter, system-ui, sans-serif; background: #f3f5f7; color: #17212f; }
+* { box-sizing: border-box; }
+body { min-height: 100vh; margin: 0; display: grid; place-items: center; padding: 24px; }
+main { width: min(760px, 100%); }
+.eyebrow { margin: 0 0 4px; color: #59697c; font-size: .78rem; font-weight: 800; text-transform: uppercase; }
+h1 { margin: 0 0 20px; font-size: clamp(1.6rem, 5vw, 2.25rem); }
+.table-wrap { overflow-x: auto; border: 1px solid #ccd5df; border-radius: 8px; background: #fff; box-shadow: 0 16px 40px rgb(27 39 56 / 9%); }
+table { width: 100%; min-width: 560px; border-collapse: collapse; }
+th, td { padding: 14px 16px; border-bottom: 1px solid #e3e8ed; text-align: left; }
+th { background: #f7f9fb; color: #536174; font-size: .78rem; text-transform: uppercase; }
+th:last-child, td:last-child { width: 64px; text-align: right; }
+tr.active { background: #eef5ff; box-shadow: inset 3px 0 #2768c7; }
+button { width: 34px; aspect-ratio: 1; border: 1px solid #aebccd; border-radius: 6px; background: #fff; color: #235a9d; font: 700 1.2rem/1 system-ui; cursor: pointer; transition: transform .2s ease, background-color .2s ease; }
+button:hover { background: #e7f0ff; transform: rotate(8deg); }
+button:focus-visible { outline: 3px solid #1e63c6; outline-offset: 2px; }
+.detail td { padding: 0; background: #f8fbff; }
+.detail td > div { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; padding: 18px 22px 20px; animation: detail-in .35s ease both; transform-origin: top; }
+.detail span, .detail small { display: block; }
+.detail small { margin-bottom: 5px; color: #69798e; font-size: .72rem; font-weight: 700; text-transform: uppercase; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0, 0, 0, 0); }
+@keyframes detail-in { from { opacity: 0; transform: translateY(-8px) scaleY(.92); } }
+@media (max-width: 600px) { .detail td > div { grid-template-columns: 1fr; gap: 12px; } }
+@media (prefers-reduced-motion: reduce) { button { transition: none; } .detail td > div { animation: none; } }


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive expandable data table row example with CSS-only interaction states and reduced-motion support.

Closes #12997

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/expandable-data-table-row-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
