### PR TITLE
Add search suggestion focus example

### DIFF
--- a/submissions/examples/search-suggestion-focus-ts/README.md
+++ b/submissions/examples/search-suggestion-focus-ts/README.md
@@ -1,0 +1,7 @@
+# Search Suggestion Focus States
+
+**What does this do?** Presents a search suggestion panel with a strong active-option treatment and keyboard guidance.
+
+**How is it used?** Apply `active` and `aria-selected="true"` to the current option inside the suggestion list.
+
+**Why is it useful?** It makes keyboard position easy to scan without depending on color alone and remains readable on narrow screens with reduced motion.

--- a/submissions/examples/search-suggestion-focus-ts/demo.html
+++ b/submissions/examples/search-suggestion-focus-ts/demo.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Search Suggestion Focus</title><link rel="stylesheet" href="style.css"></head>
+<body><main><label for="docs-search">Search documentation</label><div class="search"><span aria-hidden="true">⌕</span><input id="docs-search" value="motion" autocomplete="off" aria-controls="suggestions"></div><ul id="suggestions" role="listbox" aria-label="Search suggestions">
+<li role="option"><span><strong>Motion duration tokens</strong><small>Foundations · 4 min read</small></span><kbd>↵</kbd></li>
+<li class="active" role="option" aria-selected="true"><span><strong>Motion accessibility</strong><small>Guides · 7 min read</small></span><kbd>↵</kbd></li>
+<li role="option"><span><strong>Motion choreography</strong><small>Patterns · 5 min read</small></span><kbd>↵</kbd></li>
+</ul><p class="hint"><kbd>↑</kbd><kbd>↓</kbd> Navigate <kbd>Esc</kbd> Close</p></main></body></html>

--- a/submissions/examples/search-suggestion-focus-ts/style.css
+++ b/submissions/examples/search-suggestion-focus-ts/style.css
@@ -1,0 +1,20 @@
+:root { font-family: Inter, system-ui, sans-serif; background: #edf1f5; color: #182231; }
+* { box-sizing: border-box; }
+body { min-height: 100vh; margin: 0; display: grid; place-items: center; padding: 24px; }
+main { width: min(580px, 100%); }
+label { display: block; margin-bottom: 8px; font-weight: 800; }
+.search { display: flex; align-items: center; gap: 10px; padding: 4px 14px; border: 2px solid #316fc2; border-radius: 8px 8px 0 0; background: #fff; box-shadow: 0 0 0 4px rgb(49 111 194 / 14%); }
+.search span { color: #526780; font-size: 1.35rem; }
+input { width: 100%; min-height: 46px; border: 0; outline: 0; color: inherit; font: inherit; font-size: 1.05rem; }
+ul { margin: 0; padding: 6px; border: 1px solid #cbd5df; border-top: 0; border-radius: 0 0 8px 8px; background: #fff; box-shadow: 0 20px 45px rgb(24 34 49 / 12%); list-style: none; }
+li { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 13px 12px 13px 16px; border-radius: 6px; }
+li::before { position: absolute; inset: 7px auto 7px 0; width: 3px; border-radius: 3px; background: #286ac4; content: ""; opacity: 0; transform: scaleY(.3); transition: opacity .18s ease, transform .18s ease; }
+li.active { background: #edf5ff; }
+li.active::before { opacity: 1; transform: scaleY(1); }
+li span, li small { display: block; min-width: 0; }
+li small { margin-top: 4px; color: #657489; }
+kbd { display: inline-grid; min-width: 28px; min-height: 26px; place-items: center; padding: 2px 6px; border: 1px solid #c3ccd7; border-bottom-width: 2px; border-radius: 5px; background: #f9fafb; color: #46556a; font: 700 .72rem/1 system-ui; }
+.hint { display: flex; align-items: center; gap: 6px; margin: 12px 0 0; color: #66758a; font-size: .78rem; }
+.hint kbd:nth-of-type(3) { margin-left: 10px; }
+@media (max-width: 420px) { li > kbd { display: none; } .hint { flex-wrap: wrap; } }
+@media (prefers-reduced-motion: reduce) { li::before { transition: none; } }


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive search suggestion focus example with CSS-only interaction states and reduced-motion support.

Closes #12998

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/search-suggestion-focus-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
