### PR TITLE
Add reconnecting status banner example

### DIFF
--- a/submissions/examples/reconnecting-status-banner-ts/README.md
+++ b/submissions/examples/reconnecting-status-banner-ts/README.md
@@ -1,0 +1,7 @@
+# Reconnecting Status Banner
+
+**What does this do?** Shows distinct offline, reconnecting, and restored connection banners.
+
+**How is it used?** Combine the base `banner` class with `offline`, `reconnecting`, or `restored` for the current state.
+
+**Why is it useful?** It communicates transient network states with text, shape, color, responsive layout, and motion that can be disabled.

--- a/submissions/examples/reconnecting-status-banner-ts/demo.html
+++ b/submissions/examples/reconnecting-status-banner-ts/demo.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Connection Status Banners</title><link rel="stylesheet" href="style.css"></head>
+<body><main><p class="eyebrow">Workspace status</p><h1>Connection feedback</h1><section aria-label="Connection status examples">
+<div class="banner offline" role="status"><span class="signal" aria-hidden="true">×</span><span><strong>You are offline</strong><small>Changes are saved on this device.</small></span><button type="button">Retry</button></div>
+<div class="banner reconnecting" role="status"><span class="spinner" aria-hidden="true"></span><span><strong>Reconnecting</strong><small>Trying to restore a secure connection…</small></span></div>
+<div class="banner restored" role="status"><span class="signal" aria-hidden="true">✓</span><span><strong>Connection restored</strong><small>All changes are now synced.</small></span></div>
+</section></main></body></html>

--- a/submissions/examples/reconnecting-status-banner-ts/style.css
+++ b/submissions/examples/reconnecting-status-banner-ts/style.css
@@ -1,0 +1,25 @@
+:root { font-family: Inter, system-ui, sans-serif; background: #f2f4f7; color: #182231; }
+* { box-sizing: border-box; }
+body { min-height: 100vh; margin: 0; display: grid; place-items: center; padding: 24px; }
+main { width: min(660px, 100%); }
+.eyebrow { margin: 0 0 4px; color: #647286; font-size: .78rem; font-weight: 800; text-transform: uppercase; }
+h1 { margin: 0 0 20px; }
+section { display: grid; gap: 12px; }
+.banner { display: grid; grid-template-columns: 38px minmax(0, 1fr) auto; align-items: center; gap: 12px; padding: 14px 16px; border: 1px solid; border-radius: 8px; background: #fff; box-shadow: 0 8px 22px rgb(24 34 49 / 7%); animation: banner-in .35s ease both; }
+.banner:nth-child(2) { animation-delay: .08s; }
+.banner:nth-child(3) { animation-delay: .16s; }
+.offline { border-color: #e0b4ad; background: #fff7f5; }
+.reconnecting { border-color: #dfca8e; background: #fffaf0; }
+.restored { border-color: #a9d5bc; background: #f2fbf5; }
+.signal, .spinner { display: grid; width: 34px; aspect-ratio: 1; place-items: center; border-radius: 50%; font-weight: 900; }
+.offline .signal { background: #f4d7d2; color: #902b20; }
+.restored .signal { background: #d6efdf; color: #16623a; }
+.spinner { border: 3px solid #e5d9b8; border-top-color: #9a6c08; animation: spin .9s linear infinite; }
+.banner strong, .banner small { display: block; overflow-wrap: anywhere; }
+.banner small { margin-top: 3px; color: #617085; }
+button { min-height: 36px; padding: 6px 12px; border: 1px solid #c58f86; border-radius: 6px; background: #fff; color: #7e261d; font: inherit; font-weight: 800; }
+button:focus-visible { outline: 3px solid #286ac4; outline-offset: 2px; }
+@keyframes spin { to { transform: rotate(1turn); } }
+@keyframes banner-in { from { opacity: 0; transform: translateY(8px); } }
+@media (max-width: 480px) { .banner { grid-template-columns: 38px minmax(0, 1fr); } button { grid-column: 2; justify-self: start; } }
+@media (prefers-reduced-motion: reduce) { .banner, .spinner { animation: none; } .reconnecting .spinner { border-style: dotted; } }


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive reconnecting status banner example with CSS-only interaction states and reduced-motion support.

Closes #12999

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/reconnecting-status-banner-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
