### PR TITLE
Add shortcut keypress feedback example

### DIFF
--- a/submissions/examples/shortcut-keypress-feedback-ts/README.md
+++ b/submissions/examples/shortcut-keypress-feedback-ts/README.md
@@ -1,0 +1,7 @@
+# Keyboard Shortcut Keypress Feedback
+
+**What does this do?** Demonstrates idle, pressed, completed, and unavailable keyboard shortcut states.
+
+**How is it used?** Group `kbd` elements in `keys` and apply `pressed`, `complete`, or `unavailable` to the containing shortcut row.
+
+**Why is it useful?** It makes shortcut feedback tangible without resembling form inputs and keeps long combinations responsive with reduced-motion support.

--- a/submissions/examples/shortcut-keypress-feedback-ts/demo.html
+++ b/submissions/examples/shortcut-keypress-feedback-ts/demo.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Keyboard Shortcut Feedback</title><link rel="stylesheet" href="style.css"></head><body><main><header><p>Editor shortcuts</p><h1>Keypress feedback</h1></header><section aria-label="Keyboard shortcut states">
+<article><div class="keys"><kbd>Ctrl</kbd><span>+</span><kbd>K</kbd></div><div><strong>Open command menu</strong><small>Ready</small></div></article>
+<article class="pressed"><div class="keys"><kbd>Ctrl</kbd><span>+</span><kbd>S</kbd></div><div><strong>Save document</strong><small>Keys pressed</small></div></article>
+<article class="complete"><div class="keys"><kbd>Ctrl</kbd><span>+</span><kbd>Enter</kbd></div><div><strong>Publish changes</strong><small>Completed</small></div><i>✓</i></article>
+<article class="unavailable" aria-disabled="true"><div class="keys"><kbd>Alt</kbd><span>+</span><kbd>R</kbd></div><div><strong>Review mode</strong><small>Unavailable offline</small></div><i>×</i></article>
+</section></main></body></html>

--- a/submissions/examples/shortcut-keypress-feedback-ts/style.css
+++ b/submissions/examples/shortcut-keypress-feedback-ts/style.css
@@ -1,0 +1,18 @@
+:root { font-family: Inter, system-ui, sans-serif; background: #eef2f5; color: #182230; }
+* { box-sizing: border-box; }
+body { min-height: 100vh; margin: 0; display: grid; place-items: center; padding: 24px; }
+main { width: min(680px, 100%); overflow: hidden; border: 1px solid #ccd5dd; border-radius: 8px; background: #fff; box-shadow: 0 18px 45px rgb(24 34 48 / 10%); }
+header { padding: 20px; border-bottom: 1px solid #e1e6eb; } header p, h1 { margin: 0; } header p { color: #68788b; font-size: .78rem; font-weight: 800; text-transform: uppercase; } h1 { margin-top: 4px; }
+section { padding: 8px; }
+article { display: grid; grid-template-columns: 190px minmax(0, 1fr) 28px; align-items: center; gap: 16px; min-height: 78px; padding: 12px; border-bottom: 1px solid #e5e9ed; border-radius: 6px; }
+article:last-child { border-bottom: 0; }
+.keys { display: flex; align-items: center; gap: 7px; }
+kbd { display: inline-grid; min-width: 42px; min-height: 36px; place-items: center; padding: 5px 9px; border: 1px solid #aebac6; border-bottom-width: 4px; border-radius: 6px; background: #f9fafb; color: #33465d; font: 800 .78rem/1 system-ui; transition: transform .14s ease, border-bottom-width .14s ease, background-color .14s ease; }
+article strong, article small { display: block; } article small { margin-top: 4px; color: #6a798c; }
+.pressed { background: #eef5ff; }
+.pressed kbd { border-bottom-width: 1px; background: #dceaff; color: #174d91; transform: translateY(3px); }
+.complete { background: #f2faf5; } .complete i { color: #1e7348; font-size: 1.2rem; font-style: normal; font-weight: 900; }
+.unavailable { background: repeating-linear-gradient(135deg, #fafafa 0 8px, #f2f3f4 8px 16px); color: #707b88; } .unavailable kbd { color: #7e8791; } .unavailable i { color: #99433a; font-style: normal; font-weight: 900; }
+article:focus-within { outline: 3px solid #276ac0; outline-offset: -1px; }
+@media (max-width: 560px) { article { grid-template-columns: 1fr 28px; } .keys { grid-column: 1 / -1; } }
+@media (prefers-reduced-motion: reduce) { kbd { transition: none; } }


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive shortcut keypress feedback example with CSS-only interaction states and reduced-motion support.

Closes #13004

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/shortcut-keypress-feedback-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
