### PR TITLE
feat: add sidebar toggle top demo

### DIFF
--- a/submissions/examples/sidebar-toggle-top-demo/README.md
+++ b/submissions/examples/sidebar-toggle-top-demo/README.md
@@ -1,0 +1,19 @@
+readme
+
+# Sidebar Toggle Top Demo
+
+## What does this do?
+This demo shows a sidebar with a top-mounted toggle button that opens and closes the sidebar panel.
+
+## How is it used?
+Use the `.demo-sidebar` container for the sidebar and place a `.sidebar-panel-toggle` button at the top of the sidebar.
+
+```html
+<aside class="demo-sidebar" id="demoSidebar">
+  <button class="sidebar-panel-toggle" id="demoSidebarToggle">Toggle sidebar</button>
+  <!-- sidebar content -->
+</aside>
+```
+
+## Why is it useful?
+It demonstrates a compact, accessible sidebar control pattern that matches EaseMotion CSS’s focus on simple, animation-friendly UI components and can be adapted to documentation or dashboard layouts.

--- a/submissions/examples/sidebar-toggle-top-demo/demo.html
+++ b/submissions/examples/sidebar-toggle-top-demo/demo.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sidebar Toggle Top Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="page-shell">
+      <aside class="demo-sidebar" id="demoSidebar">
+        <div class="sidebar-top">
+          <div class="sidebar-brand">Docs</div>
+          <button
+            type="button"
+            class="sidebar-toggle-btn"
+            id="demoSidebarToggle"
+            aria-expanded="true"
+            aria-controls="demoSidebar"
+            aria-label="Toggle sidebar"
+          >
+            ☰
+          </button>
+        </div>
+
+        <div class="sidebar-group">
+          <div class="sidebar-group-label">Introduction</div>
+          <ul class="sidebar-nav">
+            <li><a href="#section-1" class="active">Getting Started</a></li>
+            <li><a href="#section-2">Design Philosophy</a></li>
+            <li><a href="#section-3">Installation</a></li>
+          </ul>
+        </div>
+
+        <div class="sidebar-group">
+          <div class="sidebar-group-label">Core</div>
+          <ul class="sidebar-nav">
+            <li><a href="#section-1">Variables</a></li>
+            <li><a href="#section-2">Dark Mode</a></li>
+            <li><a href="#section-3">Utilities</a></li>
+            <li><a href="#section-3">Animation Builder</a></li>
+          </ul>
+        </div>
+
+        <div class="sidebar-group">
+          <div class="sidebar-group-label">Components</div>
+          <ul class="sidebar-nav">
+            <li><a href="#section-1">Buttons</a></li>
+            <li><a href="#section-2">Cards</a></li>
+            <li><a href="#section-3">Scroll Progress</a></li>
+          </ul>
+        </div>
+      </aside>
+
+      <main class="demo-content">
+        <header class="demo-header">
+          <h1>Docs Sidebar Demo</h1>
+          <p>Preview a sidebar layout with nested sections, active state styling, and a top-right sidebar toggle.</p>
+        </header>
+
+        <section id="section-1">
+          <h2>Getting Started</h2>
+          <p>This demo mirrors the actual docs sidebar structure and styling closely.</p>
+        </section>
+
+        <section id="section-2">
+          <h2>Design Philosophy</h2>
+          <p>The sidebar includes section headings and active link states like the docs site.</p>
+        </section>
+
+        <section id="section-3">
+          <h2>Installation</h2>
+          <p>Use the toggle button to collapse and reopen the sidebar without leaving the page.</p>
+        </section>
+      </main>
+    </div>
+
+    <script>
+      const demoToggle = document.getElementById('demoSidebarToggle');
+      const demoSidebar = document.getElementById('demoSidebar');
+
+      function setSidebarState(isOpen) {
+        demoSidebar.classList.toggle('sidebar-closed', !isOpen);
+        demoToggle.setAttribute('aria-expanded', String(isOpen));
+        demoToggle.setAttribute('aria-label', isOpen ? 'Close sidebar' : 'Open sidebar');
+        demoToggle.textContent = '☰';
+      }
+
+      demoToggle.addEventListener('click', () => {
+        const isOpen = !demoSidebar.classList.contains('sidebar-closed');
+        setSidebarState(!isOpen);
+      });
+
+      setSidebarState(true);
+    </script>
+  </body>
+</html>

--- a/submissions/examples/sidebar-toggle-top-demo/style.css
+++ b/submissions/examples/sidebar-toggle-top-demo/style.css
@@ -1,0 +1,215 @@
+style.css
+
+:root {
+  color-scheme: dark;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.page-shell {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  min-height: 100vh;
+}
+
+.demo-sidebar {
+  background: rgba(15, 23, 42, 0.96);
+  border-right: 1px solid rgba(148, 163, 184, 0.16);
+  padding: 24px 20px 20px;
+  position: relative;
+  min-height: 100vh;
+  width: 280px;
+  transition: width 0.3s ease, padding 0.3s ease, opacity 0.25s ease;
+  overflow: hidden;
+}
+
+.sidebar-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.sidebar-brand {
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #f8fafc;
+}
+
+.demo-sidebar.sidebar-closed {
+  width: 60px;
+  padding: 18px 0;
+}
+
+.sidebar-toggle-btn {
+  width: 36px;
+  height: 36px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(148, 163, 184, 0.12);
+  color: #f8fafc;
+  border-radius: 999px;
+  font-size: 1.05rem;
+  line-height: 1;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  position: absolute;
+  top: 16px;
+  right: 16px;
+}
+
+.demo-sidebar.sidebar-closed .sidebar-toggle-btn {
+  left: 50%;
+  right: auto;
+  transform: translateX(-50%);
+}
+
+.demo-sidebar.sidebar-closed .sidebar-brand,
+.demo-sidebar.sidebar-closed .sidebar-group-label,
+.demo-sidebar.sidebar-closed .sidebar-nav {
+  opacity: 0;
+  height: 0;
+  overflow: hidden;
+  transition: opacity 0.2s ease, height 0.2s ease;
+}
+
+.demo-sidebar.sidebar-closed .sidebar-top {
+  min-height: 48px;
+  width: 100%;
+}
+
+.sidebar-group {
+  margin-bottom: 28px;
+}
+
+.sidebar-group-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  margin-bottom: 24px;
+}
+
+.sidebar-nav {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.sidebar-nav a {
+  display: block;
+  color: #e2e8f0;
+  text-decoration: none;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: rgba(148, 163, 184, 0.04);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sidebar-nav a:hover,
+.sidebar-nav a:focus-visible {
+  background: rgba(148, 163, 184, 0.14);
+}
+
+.sidebar-nav a.active {
+  color: #fff;
+  background: rgba(108, 99, 255, 0.16);
+  border-left: 3px solid #6c63ff;
+  box-shadow: inset 15px 0 15px -15px rgba(108, 99, 255, 0.25);
+}
+
+.sidebar-nav li {
+  list-style: none;
+}
+
+.demo-content {
+  padding: 48px 60px;
+}
+
+.sidebar-group-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  margin-bottom: 12px;
+}
+
+.sidebar-nav {
+  display: grid;
+  gap: 14px;
+}
+
+.sidebar-nav a {
+  color: #e2e8f0;
+  text-decoration: none;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: rgba(148, 163, 184, 0.04);
+  transition: background 0.2s ease;
+}
+
+.sidebar-nav a:hover,
+.sidebar-nav a:focus-visible {
+  background: rgba(148, 163, 184, 0.14);
+}
+
+.demo-content {
+  padding: 48px 60px;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.96), #090b16 90%);
+  color: #f8fafc;
+}
+
+.demo-header h1 {
+  margin: 0 0 12px;
+  font-size: clamp(2rem, 3vw, 2.8rem);
+}
+
+.demo-header p {
+  margin: 0 0 32px;
+  color: #cbd5e1;
+  max-width: 720px;
+}
+
+section {
+  margin-bottom: 36px;
+}
+
+section h2 {
+  margin: 0 0 12px;
+  font-size: 1.3rem;
+}
+
+section p {
+  margin: 0;
+  line-height: 1.75;
+  color: #cbd5e1;
+}
+
+@media (max-width: 900px) {
+  .page-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-sidebar {
+    position: sticky;
+    top: 0;
+    transform: translateX(0);
+  }
+}


### PR DESCRIPTION
Hi,

Added the toggle button inside the sidebar itself that opens and closes it. clicking it collapses the sidebar and clicking it again brings it back


Built this as a lightweight, self-contained sidebar toggle demo with smooth transitions. Everything is contained within submissions/examples/sidebar-toggle-top-demo. Feel free to make any changes or refinements needed to match the framework's conventions.

Please review the demo folder and merge my pull request. Kindly close this issue: #13236