### PR TITLE
Add overflow-wrap utility classes

### DIFF
--- a/submissions/examples/overflow-wrap-utilities-mq/README.md
+++ b/submissions/examples/overflow-wrap-utilities-mq/README.md
@@ -1,0 +1,17 @@
+# Overflow Wrap Utilities
+
+**What does this do?**  
+Adds overflow wrap utilities CSS utility classes to EaseMotion CSS.
+
+**How is it used?**  
+Apply any of these classes directly to HTML elements:
+
+```html
+<div class="ease-overflow-wrap-normal">Content</div>
+```
+
+**Why is it useful?**  
+These utility classes fill a gap in the current EaseMotion CSS framework, making common CSS patterns available as single-purpose classes for rapid prototyping and consistent design.
+
+## gssoc26
+This is a GSSoC 2026 contribution.

--- a/submissions/examples/overflow-wrap-utilities-mq/demo.html
+++ b/submissions/examples/overflow-wrap-utilities-mq/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Overflow Wrap Utilities Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; padding: 2rem; background: var(--ease-color-bg); color: var(--ease-color-text); }
+    .demo-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+    .demo-box { background: var(--ease-color-surface); border-radius: var(--ease-radius-md); padding: 1rem; border: 1px solid var(--ease-color-neutral-200); }
+    .demo-box h3 { margin: 0 0 0.5rem; font-size: var(--ease-text-sm); color: var(--ease-color-muted); }
+    .demo-box p { margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>Overflow Wrap Utilities</h1>
+  <p>Utility classes demonstrated below.</p>
+  <div class="demo-grid">
+
+    <div class="demo-box">
+      <h3>ease-overflow-wrap-normal</h3>
+      <p><code>overflow-wrap: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-overflow-wrap-normal" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+    <div class="demo-box">
+      <h3>ease-overflow-wrap-break-word</h3>
+      <p><code>overflow-wrap: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-overflow-wrap-break-word" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+    <div class="demo-box">
+      <h3>ease-overflow-wrap-anywhere</h3>
+      <p><code>overflow-wrap: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-overflow-wrap-anywhere" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/overflow-wrap-utilities-mq/style.css
+++ b/submissions/examples/overflow-wrap-utilities-mq/style.css
@@ -1,0 +1,6 @@
+/* overflow-wrap-utilities - Utility Classes */
+/* Unique suffix: mq */
+
+.ease-overflow-wrap-normal { overflow-wrap: normal !important; }
+.ease-overflow-wrap-break-word { overflow-wrap: break-word !important; }
+.ease-overflow-wrap-anywhere { overflow-wrap: anywhere !important; }


### PR DESCRIPTION
Add overflow-wrap utility classes (normal, break-word, anywhere) for controlling inline element wrapping behavior.

## Related Issue
Fixes #13317

## gssoc26
This is a GSSoC 2026 contribution.