### PR TITLE
Add break-before/after/inside utility classes

### DIFF
--- a/submissions/examples/break-utilities-cd/README.md
+++ b/submissions/examples/break-utilities-cd/README.md
@@ -1,0 +1,17 @@
+# Break Utilities
+
+**What does this do?**  
+Adds break utilities CSS utility classes to EaseMotion CSS.
+
+**How is it used?**  
+Apply any of these classes directly to HTML elements:
+
+```html
+<div class="ease-break-before-auto">Content</div>
+```
+
+**Why is it useful?**  
+These utility classes fill a gap in the current EaseMotion CSS framework, making common CSS patterns available as single-purpose classes for rapid prototyping and consistent design.
+
+## gssoc26
+This is a GSSoC 2026 contribution.

--- a/submissions/examples/break-utilities-cd/demo.html
+++ b/submissions/examples/break-utilities-cd/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Break Utilities Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; padding: 2rem; background: var(--ease-color-bg); color: var(--ease-color-text); }
+    .demo-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+    .demo-box { background: var(--ease-color-surface); border-radius: var(--ease-radius-md); padding: 1rem; border: 1px solid var(--ease-color-neutral-200); }
+    .demo-box h3 { margin: 0 0 0.5rem; font-size: var(--ease-text-sm); color: var(--ease-color-muted); }
+    .demo-box p { margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>Break Utilities</h1>
+  <p>Utility classes demonstrated below.</p>
+  <div class="demo-grid">
+
+    <div class="demo-box">
+      <h3>ease-break-before-auto</h3>
+      <p><code>break-before: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-break-before-auto" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+    <div class="demo-box">
+      <h3>ease-break-before-avoid</h3>
+      <p><code>break-before: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-break-before-avoid" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+    <div class="demo-box">
+      <h3>ease-break-after-auto</h3>
+      <p><code>break-after: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-break-after-auto" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+    <div class="demo-box">
+      <h3>ease-break-after-avoid</h3>
+      <p><code>break-after: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-break-after-avoid" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+    <div class="demo-box">
+      <h3>ease-break-inside-auto</h3>
+      <p><code>break-inside: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-break-inside-auto" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+    <div class="demo-box">
+      <h3>ease-break-inside-avoid</h3>
+      <p><code>break-inside: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-break-inside-avoid" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/break-utilities-cd/style.css
+++ b/submissions/examples/break-utilities-cd/style.css
@@ -1,0 +1,9 @@
+/* break-utilities - Utility Classes */
+/* Unique suffix: cd */
+
+.ease-break-before-auto { break-before: auto !important; }
+.ease-break-before-avoid { break-before: avoid !important; }
+.ease-break-after-auto { break-after: auto !important; }
+.ease-break-after-avoid { break-after: avoid !important; }
+.ease-break-inside-auto { break-inside: auto !important; }
+.ease-break-inside-avoid { break-inside: avoid !important; }


### PR DESCRIPTION
Add break-before, break-after and break-inside utility classes for controlling page/column/region break behavior.

## Related Issue
Fixes #13329

## gssoc26
This is a GSSoC 2026 contribution.