### PR TITLE
Add list-style-image utility classes

### DIFF
--- a/submissions/examples/list-style-image-utilities-zx/README.md
+++ b/submissions/examples/list-style-image-utilities-zx/README.md
@@ -1,0 +1,17 @@
+# List Style Image Utilities
+
+**What does this do?**  
+Adds list style image utilities CSS utility classes to EaseMotion CSS.
+
+**How is it used?**  
+Apply any of these classes directly to HTML elements:
+
+```html
+<div class="ease-list-image-none">Content</div>
+```
+
+**Why is it useful?**  
+These utility classes fill a gap in the current EaseMotion CSS framework, making common CSS patterns available as single-purpose classes for rapid prototyping and consistent design.
+
+## gssoc26
+This is a GSSoC 2026 contribution.

--- a/submissions/examples/list-style-image-utilities-zx/demo.html
+++ b/submissions/examples/list-style-image-utilities-zx/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>List Style Image Utilities Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; padding: 2rem; background: var(--ease-color-bg); color: var(--ease-color-text); }
+    .demo-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+    .demo-box { background: var(--ease-color-surface); border-radius: var(--ease-radius-md); padding: 1rem; border: 1px solid var(--ease-color-neutral-200); }
+    .demo-box h3 { margin: 0 0 0.5rem; font-size: var(--ease-text-sm); color: var(--ease-color-muted); }
+    .demo-box p { margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>List Style Image Utilities</h1>
+  <p>Utility classes demonstrated below.</p>
+  <div class="demo-grid">
+
+    <div class="demo-box">
+      <h3>ease-list-image-none</h3>
+      <p><code>list-style-image: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-list-image-none" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/list-style-image-utilities-zx/style.css
+++ b/submissions/examples/list-style-image-utilities-zx/style.css
@@ -1,0 +1,4 @@
+/* list-style-image-utilities - Utility Classes */
+/* Unique suffix: zx */
+
+.ease-list-image-none { list-style-image: none !important; }


### PR DESCRIPTION
Add list-style-image utility classes for using custom images as list item markers.

## Related Issue
Fixes #13353

## gssoc26
This is a GSSoC 2026 contribution.