### PR TITLE
Add box-decoration-slice utility classes

### DIFF
--- a/submissions/examples/box-decoration-slice-utilities-df/README.md
+++ b/submissions/examples/box-decoration-slice-utilities-df/README.md
@@ -1,0 +1,17 @@
+# Box Decoration Slice Utilities
+
+**What does this do?**  
+Adds box decoration slice utilities CSS utility classes to EaseMotion CSS.
+
+**How is it used?**  
+Apply any of these classes directly to HTML elements:
+
+```html
+<div class="ease-box-decoration-slice">Content</div>
+```
+
+**Why is it useful?**  
+These utility classes fill a gap in the current EaseMotion CSS framework, making common CSS patterns available as single-purpose classes for rapid prototyping and consistent design.
+
+## gssoc26
+This is a GSSoC 2026 contribution.

--- a/submissions/examples/box-decoration-slice-utilities-df/demo.html
+++ b/submissions/examples/box-decoration-slice-utilities-df/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Box Decoration Slice Utilities Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; padding: 2rem; background: var(--ease-color-bg); color: var(--ease-color-text); }
+    .demo-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+    .demo-box { background: var(--ease-color-surface); border-radius: var(--ease-radius-md); padding: 1rem; border: 1px solid var(--ease-color-neutral-200); }
+    .demo-box h3 { margin: 0 0 0.5rem; font-size: var(--ease-text-sm); color: var(--ease-color-muted); }
+    .demo-box p { margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>Box Decoration Slice Utilities</h1>
+  <p>Utility classes demonstrated below.</p>
+  <div class="demo-grid">
+
+    <div class="demo-box">
+      <h3>ease-box-decoration-slice</h3>
+      <p><code>box-decoration-break: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-box-decoration-slice" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+    <div class="demo-box">
+      <h3>ease-box-decoration-clone</h3>
+      <p><code>box-decoration-break: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-box-decoration-clone" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/box-decoration-slice-utilities-df/style.css
+++ b/submissions/examples/box-decoration-slice-utilities-df/style.css
@@ -1,0 +1,5 @@
+/* box-decoration-slice-utilities - Utility Classes */
+/* Unique suffix: df */
+
+.ease-box-decoration-slice { box-decoration-break: slice !important; -webkit-box-decoration-break: slice !important; }
+.ease-box-decoration-clone { box-decoration-break: clone !important; -webkit-box-decoration-break: clone !important; }


### PR DESCRIPTION
Add box-decoration-slice utility classes (slice, clone) for controlling background/border rendering across broken boxes.

## Related Issue
Fixes #13355

## gssoc26
This is a GSSoC 2026 contribution.