### PR TITLE
Add shape-image-threshold utility classes

### DIFF
--- a/submissions/examples/shape-image-threshold-utilities-gh/README.md
+++ b/submissions/examples/shape-image-threshold-utilities-gh/README.md
@@ -1,0 +1,17 @@
+# Shape Image Threshold Utilities
+
+**What does this do?**  
+Adds shape image threshold utilities CSS utility classes to EaseMotion CSS.
+
+**How is it used?**  
+Apply any of these classes directly to HTML elements:
+
+```html
+<div class="ease-shape-threshold-0">Content</div>
+```
+
+**Why is it useful?**  
+These utility classes fill a gap in the current EaseMotion CSS framework, making common CSS patterns available as single-purpose classes for rapid prototyping and consistent design.
+
+## gssoc26
+This is a GSSoC 2026 contribution.

--- a/submissions/examples/shape-image-threshold-utilities-gh/demo.html
+++ b/submissions/examples/shape-image-threshold-utilities-gh/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shape Image Threshold Utilities Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; padding: 2rem; background: var(--ease-color-bg); color: var(--ease-color-text); }
+    .demo-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+    .demo-box { background: var(--ease-color-surface); border-radius: var(--ease-radius-md); padding: 1rem; border: 1px solid var(--ease-color-neutral-200); }
+    .demo-box h3 { margin: 0 0 0.5rem; font-size: var(--ease-text-sm); color: var(--ease-color-muted); }
+    .demo-box p { margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>Shape Image Threshold Utilities</h1>
+  <p>Utility classes demonstrated below.</p>
+  <div class="demo-grid">
+
+    <div class="demo-box">
+      <h3>ease-shape-threshold-0</h3>
+      <p><code>shape-image-threshold: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-shape-threshold-0" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+    <div class="demo-box">
+      <h3>ease-shape-threshold-5</h3>
+      <p><code>shape-image-threshold: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-shape-threshold-5" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+    <div class="demo-box">
+      <h3>ease-shape-threshold-10</h3>
+      <p><code>shape-image-threshold: /* value */</code></p>
+      <p style="margin-top:0.5rem"><span class="ease-shape-threshold-10" style="background:var(--ease-color-neutral-100);padding:0.25rem 0.5rem;border-radius:4px">Sample text</span></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/shape-image-threshold-utilities-gh/style.css
+++ b/submissions/examples/shape-image-threshold-utilities-gh/style.css
@@ -1,0 +1,6 @@
+/* shape-image-threshold-utilities - Utility Classes */
+/* Unique suffix: gh */
+
+.ease-shape-threshold-0 { shape-image-threshold: 0 !important; }
+.ease-shape-threshold-5 { shape-image-threshold: 0.5 !important; }
+.ease-shape-threshold-10 { shape-image-threshold: 1.0 !important; }


### PR DESCRIPTION
Add shape-image-threshold utility classes for controlling alpha channel threshold used by shape-outside.

## Related Issue
Fixes #13357

## gssoc26
This is a GSSoC 2026 contribution.