### PR TITLE
[FIX] resolve non-fixed header navigation bar on documentation website (13374)

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -1151,7 +1151,6 @@ body > .docs-shell {
   opacity: 0.35;
 }
 
-.docs-header,
 .docs-shell,
 .ease-scroll-progress {
   position: relative;

--- a/submissions/examples/sticky-navbar-dg/README.md
+++ b/submissions/examples/sticky-navbar-dg/README.md
@@ -17,3 +17,7 @@ This component makes a website's navigation header sticky, keeping it locked to 
 </header>
 ```
 
+**Why is it useful?**
+A sticky navigation bar solves a major usability problem where a user must scroll all the way back to the top of a page to access site navigation links. By keeping the header visible, it dramatically improves accessibility and user experience.
+
+This matches EaseMotion CSS's focus on user-centric layouts, offering a reusable structural element that works seamlessly on both desktop (where it is fixed) and mobile/tablet devices (where it acts as a sticky element).

--- a/submissions/examples/sticky-navbar-dg/README.md
+++ b/submissions/examples/sticky-navbar-dg/README.md
@@ -3,3 +3,17 @@
 **What does this do?**
 This component makes a website's navigation header sticky, keeping it locked to the top of the viewport when scrolling, with a modern translucent glass effect (backdrop blur) and a subtle drop shadow to cleanly separate it from background content.
 
+**How is it used?**
+
+```html
+<header class="sticky-navbar">
+  <div class="navbar-logo">BrandLogo</div>
+  <nav class="navbar-links">
+    <a href="#" class="nav-link active">Home</a>
+    <a href="#" class="nav-link">About</a>
+    <a href="#" class="nav-link">Services</a>
+    <a href="#" class="nav-link">Contact</a>
+  </nav>
+</header>
+```
+

--- a/submissions/examples/sticky-navbar-dg/README.md
+++ b/submissions/examples/sticky-navbar-dg/README.md
@@ -1,0 +1,5 @@
+# Sticky Navigation Bar
+
+**What does this do?**
+This component makes a website's navigation header sticky, keeping it locked to the top of the viewport when scrolling, with a modern translucent glass effect (backdrop blur) and a subtle drop shadow to cleanly separate it from background content.
+

--- a/submissions/examples/sticky-navbar-dg/demo.html
+++ b/submissions/examples/sticky-navbar-dg/demo.html
@@ -6,3 +6,14 @@
     <title>Sticky Navigation Bar Demo - EaseMotion CSS</title>
     <link rel="stylesheet" href="style.css" />
   </head>
+  <body>
+    <!-- Sticky Header Navigation -->
+    <header class="sticky-navbar">
+      <div class="navbar-logo">EaseMotion</div>
+
+      <nav class="navbar-links">
+        <a href="#hero" class="nav-link active">Home</a>
+        <a href="#about" class="nav-link">About</a>
+        <a href="#features" class="nav-link">Features</a>
+        <a href="#contact" class="nav-link">Contact</a>
+      </nav>

--- a/submissions/examples/sticky-navbar-dg/demo.html
+++ b/submissions/examples/sticky-navbar-dg/demo.html
@@ -132,3 +132,7 @@
             link.classList.add("active");
           }
         });
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/sticky-navbar-dg/demo.html
+++ b/submissions/examples/sticky-navbar-dg/demo.html
@@ -111,3 +111,24 @@
         const newTheme = currentTheme === "dark" ? "light" : "dark";
         htmlElement.setAttribute("data-theme", newTheme);
       });
+
+      // Add active state to nav links on scroll
+      const sections = document.querySelectorAll("section");
+      const navLinks = document.querySelectorAll(".nav-link");
+
+      window.addEventListener("scroll", () => {
+        let current = "";
+        sections.forEach((section) => {
+          const sectionTop = section.offsetTop;
+          const sectionHeight = section.clientHeight;
+          if (pageYOffset >= sectionTop - 150) {
+            current = section.getAttribute("id");
+          }
+        });
+
+        navLinks.forEach((link) => {
+          link.classList.remove("active");
+          if (link.getAttribute("href").slice(1) === current) {
+            link.classList.add("active");
+          }
+        });

--- a/submissions/examples/sticky-navbar-dg/demo.html
+++ b/submissions/examples/sticky-navbar-dg/demo.html
@@ -70,3 +70,21 @@
         </div>
       </section>
 
+      <section id="about" class="demo-content-block">
+        <h2 class="block-title">Why Sticky Position?</h2>
+        <p class="block-text">
+          In modern web design, keeping navigation accessible is key to high
+          usability. Without sticky navigation, a user on a long page has to
+          scroll all the way back to the top just to find the menu links. Sticky
+          headers solve this by remaining at the top of the viewport, providing
+          instant access.
+        </p>
+      </section>
+
+      <section id="features" class="demo-content-block">
+        <h2 class="block-title">Glassmorphic Aesthetics</h2>
+        <p class="block-text">
+          To prevent the navbar from looking blocky or hiding underlying content
+          entirely, this navbar uses backdrop-filter blur and semi-translucent
+          background colors. As the page scrolls under the header, the content
+          behind it becomes beautifully blurred, giving the interface a layered,

--- a/submissions/examples/sticky-navbar-dg/demo.html
+++ b/submissions/examples/sticky-navbar-dg/demo.html
@@ -33,3 +33,21 @@
           fill="none"
           stroke-linecap="round"
           stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="5"></circle>
+          <line x1="12" y1="1" x2="12" y2="3"></line>
+          <line x1="12" y1="21" x2="12" y2="23"></line>
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+          <line x1="1" y1="12" x2="3" y2="12"></line>
+          <line x1="21" y1="12" x2="23" y2="12"></line>
+          <line x1="4.22" y1="19.72" x2="5.64" y2="18.3"></line>
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+        </svg>
+      </button>
+    </header>
+
+    <!-- Main Scrollable Content -->
+    <main class="demo-container">
+      <section id="hero" class="hero-section">
+        <h1 class="hero-title">Sticky Navigation Bar</h1>

--- a/submissions/examples/sticky-navbar-dg/demo.html
+++ b/submissions/examples/sticky-navbar-dg/demo.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sticky Navigation Bar Demo - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>

--- a/submissions/examples/sticky-navbar-dg/demo.html
+++ b/submissions/examples/sticky-navbar-dg/demo.html
@@ -88,3 +88,26 @@
           entirely, this navbar uses backdrop-filter blur and semi-translucent
           background colors. As the page scrolls under the header, the content
           behind it becomes beautifully blurred, giving the interface a layered,
+          premium depth.
+        </p>
+      </section>
+
+      <section id="contact" class="demo-content-block">
+        <h2 class="block-title">Get In Touch</h2>
+        <p class="block-text">
+          This component is fully responsive and adjusts font sizes, padding,
+          and positioning to fit desktop, tablet, and mobile layouts cleanly.
+        </p>
+      </section>
+    </main>
+
+    <script>
+      // Simple theme toggle logic
+      const themeToggleBtn = document.getElementById("theme-toggle");
+      const htmlElement = document.documentElement;
+
+      themeToggleBtn.addEventListener("click", () => {
+        const currentTheme = htmlElement.getAttribute("data-theme");
+        const newTheme = currentTheme === "dark" ? "light" : "dark";
+        htmlElement.setAttribute("data-theme", newTheme);
+      });

--- a/submissions/examples/sticky-navbar-dg/demo.html
+++ b/submissions/examples/sticky-navbar-dg/demo.html
@@ -17,3 +17,19 @@
         <a href="#features" class="nav-link">Features</a>
         <a href="#contact" class="nav-link">Contact</a>
       </nav>
+
+      <button
+        class="theme-toggle-btn"
+        id="theme-toggle"
+        aria-label="Toggle Theme"
+      >
+        <svg
+          class="sun-icon"
+          viewBox="0 0 24 24"
+          width="20"
+          height="20"
+          stroke="currentColor"
+          stroke-width="2"
+          fill="none"
+          stroke-linecap="round"
+          stroke-linejoin="round"

--- a/submissions/examples/sticky-navbar-dg/demo.html
+++ b/submissions/examples/sticky-navbar-dg/demo.html
@@ -51,3 +51,22 @@
     <main class="demo-container">
       <section id="hero" class="hero-section">
         <h1 class="hero-title">Sticky Navigation Bar</h1>
+        <p class="hero-subtitle">
+          A premium, glassmorphic header that stays anchored to the top of the
+          viewport when scrolling, preventing layout shift and keeping
+          navigation accessible at all times.
+        </p>
+        <div class="scroll-indicator">
+          <span
+            style="
+              font-size: 0.85rem;
+              text-transform: uppercase;
+              letter-spacing: 0.1em;
+              color: var(--nav-accent);
+              margin-bottom: 0.5rem;
+            "
+            >Scroll down to see the effect</span
+          >
+        </div>
+      </section>
+

--- a/submissions/examples/sticky-navbar-dg/style.css
+++ b/submissions/examples/sticky-navbar-dg/style.css
@@ -126,6 +126,9 @@ body {
   position: absolute;
   bottom: 4px;
   left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 2px;
   background-color: var(--nav-accent);
   border-radius: 2px;
   transition: width 0.3s ease;
@@ -176,4 +179,80 @@ body {
 .hero-section {
   text-align: center;
   padding: 6rem 0;
+  position: relative;
+}
+
+.hero-title {
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  background: linear-gradient(135deg, var(--text-primary), var(--nav-accent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 1.5rem;
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  color: var(--text-muted);
+  max-width: 600px;
+  margin: 0 auto 2.5rem auto;
+  line-height: 1.6;
+}
+
+.demo-content-block {
+  margin: 6rem 0;
+  padding: 3rem;
+  background-color: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--nav-border-dark);
+  border-radius: 16px;
+}
+
+[data-theme="light"] .demo-content-block {
+  background-color: #ffffff;
+  border-color: var(--nav-border-light);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.02);
+}
+
+.block-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.block-text {
+  color: var(--text-muted);
+  line-height: 1.8;
+}
+
+/* Scroll indicator dot animation */
+.scroll-indicator {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 2rem;
+}
+
+.scroll-indicator::after {
+  content: "↓";
+  font-size: 1.5rem;
+  color: var(--nav-accent);
+  animation: bounce 2s infinite;
+}
+
+@keyframes bounce {
+  0%,
+  20%,
+  50%,
+  80%,
+  100% {
+    transform: translateY(0);
+  }
+  40% {
+    transform: translateY(-8px);
+  }
+  60% {
+    transform: translateY(-4px);
+  }
 }

--- a/submissions/examples/sticky-navbar-dg/style.css
+++ b/submissions/examples/sticky-navbar-dg/style.css
@@ -1,0 +1,12 @@
+/* ── Modern Premium Sticky Navbar ── */
+
+:root {
+  --nav-bg-dark: rgba(15, 14, 23, 0.85);
+  --nav-bg-light: rgba(248, 250, 252, 0.85);
+  --nav-text-dark: #fffffe;
+  --nav-text-light: #0f172a;
+  --nav-text-muted-dark: rgba(255, 255, 255, 0.6);
+  --nav-text-muted-light: #475569;
+  --nav-accent: #6c63ff;
+  --nav-accent-glow: rgba(108, 99, 255, 0.25);
+  --nav-border-dark: rgba(255, 255, 255, 0.08);

--- a/submissions/examples/sticky-navbar-dg/style.css
+++ b/submissions/examples/sticky-navbar-dg/style.css
@@ -95,3 +95,34 @@ body {
   color: var(--nav-text-muted-dark);
   font-size: 0.9rem;
   font-weight: 500;
+  text-decoration: none;
+  padding: 8px 16px;
+  border-radius: 8px;
+  position: relative;
+  transition:
+    color 0.3s ease,
+    background-color 0.3s ease;
+}
+
+[data-theme="light"] .nav-link {
+  color: var(--nav-text-muted-light);
+}
+
+.nav-link:hover,
+.nav-link.active {
+  color: var(--nav-text-dark);
+  background-color: var(--nav-link-active-bg-dark);
+}
+
+[data-theme="light"] .nav-link:hover,
+[data-theme="light"] .nav-link.active {
+  color: var(--nav-accent);
+  background-color: var(--nav-link-active-bg-light);
+}
+
+/* Underline slide effect on hover/active */
+.nav-link::after {
+  content: "";
+  position: absolute;
+  bottom: 4px;
+  left: 50%;

--- a/submissions/examples/sticky-navbar-dg/style.css
+++ b/submissions/examples/sticky-navbar-dg/style.css
@@ -48,3 +48,26 @@ body {
   position: -webkit-sticky; /* Safari support */
   position: sticky;
   top: 0;
+  left: 0;
+  right: 0;
+  height: 70px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 2rem;
+  background-color: var(--nav-bg-dark);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--nav-border-dark);
+  box-shadow: var(--nav-shadow);
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease,
+    box-shadow 0.3s ease;
+}
+
+[data-theme="light"] .sticky-navbar {
+  background-color: var(--nav-bg-light);
+  border-bottom: 1px solid var(--nav-border-light);
+}

--- a/submissions/examples/sticky-navbar-dg/style.css
+++ b/submissions/examples/sticky-navbar-dg/style.css
@@ -153,4 +153,27 @@ body {
     border-color 0.3s;
 }
 
+[data-theme="light"] .theme-toggle-btn {
+  border-color: var(--nav-border-light);
+}
+
+.theme-toggle-btn:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-color: var(--nav-accent);
+}
+
+[data-theme="light"] .theme-toggle-btn:hover {
+  background-color: rgba(15, 23, 42, 0.06);
+}
+
+/* ── Content Layout to demonstrate scrolling ── */
+.demo-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.hero-section {
+  text-align: center;
+  padding: 6rem 0;
 }

--- a/submissions/examples/sticky-navbar-dg/style.css
+++ b/submissions/examples/sticky-navbar-dg/style.css
@@ -126,3 +126,30 @@ body {
   position: absolute;
   bottom: 4px;
   left: 50%;
+  background-color: var(--nav-accent);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.nav-link:hover::after,
+.nav-link.active::after {
+  width: 40%;
+}
+
+/* ── Theme Toggle Button ── */
+.theme-toggle-btn {
+  background: none;
+  border: 1px solid var(--nav-border-dark);
+  color: var(--text-primary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  transition:
+    background-color 0.3s,
+    border-color 0.3s;
+}
+

--- a/submissions/examples/sticky-navbar-dg/style.css
+++ b/submissions/examples/sticky-navbar-dg/style.css
@@ -29,3 +29,22 @@
 
 * {
   box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  min-height: 200vh; /* Allow scrolling to demonstrate sticky behavior */
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
+}
+
+/* ── Sticky Navbar Core ── */
+.sticky-navbar {
+  position: -webkit-sticky; /* Safari support */
+  position: sticky;
+  top: 0;

--- a/submissions/examples/sticky-navbar-dg/style.css
+++ b/submissions/examples/sticky-navbar-dg/style.css
@@ -153,3 +153,4 @@ body {
     border-color 0.3s;
 }
 
+}

--- a/submissions/examples/sticky-navbar-dg/style.css
+++ b/submissions/examples/sticky-navbar-dg/style.css
@@ -71,3 +71,27 @@ body {
   background-color: var(--nav-bg-light);
   border-bottom: 1px solid var(--nav-border-light);
 }
+
+/* Logo */
+.navbar-logo {
+  font-size: 1.25rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  letter-spacing: -0.02em;
+  cursor: pointer;
+}
+
+/* Navigation Links */
+.navbar-links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.nav-link {
+  color: var(--nav-text-muted-dark);
+  font-size: 0.9rem;
+  font-weight: 500;

--- a/submissions/examples/sticky-navbar-dg/style.css
+++ b/submissions/examples/sticky-navbar-dg/style.css
@@ -10,3 +10,22 @@
   --nav-accent: #6c63ff;
   --nav-accent-glow: rgba(108, 99, 255, 0.25);
   --nav-border-dark: rgba(255, 255, 255, 0.08);
+  --nav-border-light: rgba(15, 23, 42, 0.08);
+  --nav-link-active-bg-dark: rgba(108, 99, 255, 0.15);
+  --nav-link-active-bg-light: rgba(108, 99, 255, 0.1);
+  --nav-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.15);
+
+  /* Page defaults */
+  --bg-primary: #0f0e17;
+  --text-primary: #fffffe;
+  --text-muted: rgba(255, 255, 255, 0.65);
+}
+
+[data-theme="light"] {
+  --bg-primary: #f8fafc;
+  --text-primary: #0f172a;
+  --text-muted: #475569;
+}
+
+* {
+  box-sizing: border-box;


### PR DESCRIPTION
## Pull Request Description

This PR resolves the issue where the top navigation bar scrolled out of view on the documentation website. In addition, it submits a self-contained sticky navigation bar component (`sticky-navbar-dg`) as an example.


Fixes: #13374 
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A premium glassmorphic sticky navigation bar that remains anchored to the top of the viewport when scrolling.

**How does a developer use it?**

```html
<header class="sticky-navbar">
  <div class="navbar-logo">EaseMotion</div>
  <nav class="navbar-links">
    <a href="#" class="nav-link active">Home</a>
    <a href="#" class="nav-link">About</a>
  </nav>
</header>
```

**Why does it fit EaseMotion CSS?**
It provides a high-usability, semantic layout building block focused on accessible styling that naturally complements EaseMotion's human-readable, user-centric design language.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
