### PR TITLE
fix: override spinner border-color for ghost/outline/link loading 

### DIFF
--- a/submissions/examples/loading-btn-contrast-fix-sp/README.md
+++ b/submissions/examples/loading-btn-contrast-fix-sp/README.md
@@ -1,0 +1,18 @@
+# Loading Button Contrast Fix
+
+**What does this do?**
+Overrides the spinner `border-color` for ghost, outline, and link loading buttons to ensure the loading indicator remains visible when the button text color is transparent.
+
+**How is it used?**
+The following CSS should be applied to the framework to ensure contrast:
+```css
+.ease-btn-ghost.ease-btn-loading::after,
+.ease-btn-outline.ease-btn-loading::after,
+.ease-btn-link.ease-btn-loading::after {
+  border-color: var(--ease-color-neutral-400);
+  border-top-color: transparent;
+}
+```
+
+**Why is it useful?**
+For ghost, outline, and link buttons, `currentColor` inherits the transparent text color during the loading state, causing the spinner to become invisible. This fix explicitly sets a fallback neutral color to maintain accessibility and visual feedback for the user.

--- a/submissions/examples/loading-btn-contrast-fix-sp/demo.html
+++ b/submissions/examples/loading-btn-contrast-fix-sp/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loading Button Contrast Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>Loading Button Contrast Fix</h2>
+    <p>When ghost, outline, and link buttons are in a loading state, their text color becomes transparent. Previously, the spinner inherited this transparent color via <code>currentColor</code>, making it invisible. This submission applies a fallback border color to fix it.</p>
+    
+    <div class="button-group">
+      <button class="ease-btn ease-btn-ghost ease-btn-loading">Ghost Loading</button>
+      <button class="ease-btn ease-btn-outline ease-btn-loading">Outline Loading</button>
+      <button class="ease-btn ease-btn-link ease-btn-loading">Link Loading</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/loading-btn-contrast-fix-sp/style.css
+++ b/submissions/examples/loading-btn-contrast-fix-sp/style.css
@@ -1,0 +1,77 @@
+:root {
+  --ease-color-neutral-400: #9ca3af;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+  background-color: #f3f4f6;
+  color: #1f2937;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+p {
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+.button-group {
+  display: flex;
+  gap: 1rem;
+}
+
+/* Base button styles to simulate the issue */
+.ease-btn {
+  position: relative;
+  padding: 10px 20px;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  background: transparent;
+  /* During loading, the framework makes text transparent */
+  color: transparent; 
+}
+
+.ease-btn-ghost { border: 1px solid transparent; }
+.ease-btn-outline { border: 1px solid #d1d5db; }
+.ease-btn-link { border: 1px solid transparent; text-decoration: underline; }
+
+/* Base spinner logic (the bug source) */
+.ease-btn-loading::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 18px;
+  height: 18px;
+  margin-top: -9px;
+  margin-left: -9px;
+  border-radius: 50%;
+  /* Original buggy code relies entirely on currentColor */
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* =========================================
+   THE FIX
+   ========================================= */
+.ease-btn-ghost.ease-btn-loading::after,
+.ease-btn-outline.ease-btn-loading::after,
+.ease-btn-link.ease-btn-loading::after {
+  border-color: var(--ease-color-neutral-400, #9ca3af);
+  border-top-color: transparent;
+}


### PR DESCRIPTION
closes pr https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/13260
### What does this do?
Overrides the spinner `border-color` for ghost, outline, and link loading buttons to ensure the loading indicator remains visible.
### How is it used?
It applies the following CSS override:
```css
.ease-btn-ghost.ease-btn-loading::after,
.ease-btn-outline.ease-btn-loading::after,
.ease-btn-link.ease-btn-loading::after {
  border-color: var(--ease-color-neutral-400);
  border-top-color: transparent;
}
