### PR TITLE
feat: add CHANGELOG badge and release notes auto-generation workflow

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,190 @@
+name: Auto-generate Release Notes
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate Release Notes & Update Changelog
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const currentRelease = context.payload.release;
+            const versionName = currentRelease.tag_name;
+            const releaseDate = new Date(currentRelease.published_at);
+            const dateString = releaseDate.toISOString().split('T')[0];
+
+            console.log(`Current release: ${versionName} published at ${releaseDate}`);
+
+            // Fetch releases to identify the previous release
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner,
+              repo,
+              per_page: 100
+            });
+
+            const previousRelease = releases.find(r => r.id !== currentRelease.id && !r.draft);
+            const previousReleaseDate = previousRelease ? new Date(previousRelease.published_at) : new Date(0);
+            console.log(`Previous release date: ${previousReleaseDate}`);
+
+            // Fetch merged pull requests
+            let prs = [];
+            let page = 1;
+            let keepFetching = true;
+            while (keepFetching) {
+              const { data: closedPRs } = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'closed',
+                sort: 'updated',
+                direction: 'desc',
+                per_page: 100,
+                page: page
+              });
+
+              if (closedPRs.length === 0) {
+                break;
+              }
+
+              for (const pr of closedPRs) {
+                if (pr.merged_at) {
+                  const mergedAt = new Date(pr.merged_at);
+                  if (mergedAt > previousReleaseDate && mergedAt <= releaseDate) {
+                    prs.push(pr);
+                  } else {
+                    const updatedAt = new Date(pr.updated_at);
+                    if (updatedAt < previousReleaseDate) {
+                      keepFetching = false;
+                      break;
+                    }
+                  }
+                }
+              }
+              page++;
+            }
+
+            console.log(`Found ${prs.length} PRs merged since the last release.`);
+
+            // Group PRs/changes by label (component, bug, docs)
+            const groups = {
+              component: [],
+              bug: [],
+              docs: [],
+              other: []
+            };
+
+            // Read existing CHANGELOG.md to extract manual items in [Unreleased]
+            let changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+
+            const versionHeaderRegex = /##\s+\[v?\d+\.\d+\.\d+\]/;
+            const match = changelog.match(versionHeaderRegex);
+
+            if (match) {
+              const index = match.index;
+              const before = changelog.substring(0, index);
+              const after = changelog.substring(index);
+
+              // Extract manually-added changes in [Unreleased]
+              const unreleasedRegex = /(##\s+\[Unreleased\])([\s\S]*?)(?=##\s+\[v?\d+\.\d+\.\d+\]|---|$)/;
+              const unreleasedMatch = before.match(unreleasedRegex);
+              if (unreleasedMatch) {
+                const unreleasedContent = unreleasedMatch[2].trim();
+                const lines = unreleasedContent.split(/\r?\n/);
+                let currentHeader = '';
+                for (const line of lines) {
+                  const trimmed = line.trim();
+                  if (trimmed.startsWith('###')) {
+                    currentHeader = trimmed.replace('###', '').trim().toLowerCase();
+                  } else if (trimmed.startsWith('-') || trimmed.startsWith('*')) {
+                    if (currentHeader === 'added' || currentHeader === 'components') {
+                      groups.component.push(trimmed);
+                    } else if (currentHeader === 'fixed' || currentHeader === 'bug fixes') {
+                      groups.bug.push(trimmed);
+                    } else if (currentHeader === 'docs' || currentHeader === 'documentation') {
+                      groups.docs.push(trimmed);
+                    } else {
+                      groups.other.push(trimmed);
+                    }
+                  }
+                }
+              }
+
+              // Process merged PRs and add them to the categories
+              for (const pr of prs) {
+                const labels = pr.labels.map(l => l.name.toLowerCase());
+                
+                const isBug = labels.some(l => l.includes('bug') || l === 'fix' || l.includes('type:bug'));
+                const isDocs = labels.some(l => l.includes('doc') || l.includes('readme') || l.includes('type:docs') || l.includes('documentation'));
+                const isComponent = labels.some(l => l.includes('component') || l === 'animation' || l.includes('type:feature'));
+                
+                const prItem = `- ${pr.title} (#${pr.number}) by @${pr.user.login}`;
+                
+                // Avoid duplicating if already present (e.g. from manual extraction)
+                if (isComponent) {
+                  if (!groups.component.includes(prItem)) groups.component.push(prItem);
+                } else if (isBug) {
+                  if (!groups.bug.includes(prItem)) groups.bug.push(prItem);
+                } else if (isDocs) {
+                  if (!groups.docs.includes(prItem)) groups.docs.push(prItem);
+                } else {
+                  if (!groups.other.includes(prItem)) groups.other.push(prItem);
+                }
+              }
+
+              // Generate release notes markdown
+              let notes = '';
+              if (groups.component.length > 0) {
+                notes += '### Added\n\n' + groups.component.join('\n') + '\n\n';
+              }
+              if (groups.bug.length > 0) {
+                notes += '### Fixed\n\n' + groups.bug.join('\n') + '\n\n';
+              }
+              if (groups.docs.length > 0) {
+                notes += '### Documentation\n\n' + groups.docs.join('\n') + '\n\n';
+              }
+              if (groups.other.length > 0) {
+                notes += '### Changed\n\n' + groups.other.join('\n') + '\n\n';
+              }
+
+              if (!notes) {
+                notes = 'No notable changes.\n\n';
+              }
+
+              // Clear the Unreleased section content to reset it for the next version
+              let updatedBefore = before;
+              if (unreleasedRegex.test(before)) {
+                updatedBefore = before.replace(unreleasedRegex, '$1\n\n### Added\n\n');
+              }
+
+              const releaseMarkdown = `## [${versionName}] — ${dateString}\n\n${notes}---\n\n`;
+              changelog = updatedBefore + releaseMarkdown + after;
+              
+              fs.writeFileSync('CHANGELOG.md', changelog);
+              console.log(`Successfully updated CHANGELOG.md for version ${versionName}`);
+            } else {
+              console.log('Error: Could not find previous version header in CHANGELOG.md');
+            }
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore: update CHANGELOG.md for ${{ github.event.release.tag_name }} [skip ci]" || echo "No changes to commit"
+          git push

--- a/README.bn.md
+++ b/README.bn.md
@@ -24,6 +24,7 @@ UI লেখো যেভাবে ইংরেজিতে বলো। কো�
 [![Open PRs](https://flat.badgen.net/github/open-prs/SAPTARSHI-coder/EaseMotion-css?color=a78bfa&label=open%20PRs)](https://github.com/SAPTARSHI-coder/EaseMotion-css/pulls)
 [![Open Issues](https://flat.badgen.net/github/open-issues/SAPTARSHI-coder/EaseMotion-css?color=ef4444&label=issues)](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues)
 [![License: MIT](https://img.shields.io/badge/License-MIT-6c63ff?style=flat-square)](./LICENSE)
+[![Changelog](https://img.shields.io/badge/Changelog-Keep%20a%20Changelog-6c63ff?style=flat-square)](./CHANGELOG.md)
 [![GSSoC](https://img.shields.io/badge/GSSoC-2026-orange?style=flat-square)](https://gssoc.girlscript.tech/)
 [![Maintainer](https://img.shields.io/badge/Maintainer-Saptarshi%20Sadhu-a78bfa?style=flat-square)](https://github.com/SAPTARSHI-coder)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ EaseMotion CSS lets you build polished interfaces with readable class names such
 [![Open PRs](https://flat.badgen.net/github/open-prs/SAPTARSHI-coder/EaseMotion-css?color=a78bfa&label=open%20PRs)](https://github.com/SAPTARSHI-coder/EaseMotion-css/pulls)
 [![Open Issues](https://flat.badgen.net/github/open-issues/SAPTARSHI-coder/EaseMotion-css?color=ef4444&label=issues)](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues)
 [![License: MIT](https://img.shields.io/badge/License-MIT-6c63ff?style=flat-square)](./LICENSE)
+[![Changelog](https://img.shields.io/badge/Changelog-Keep%20a%20Changelog-6c63ff?style=flat-square)](./CHANGELOG.md)
 [![GSSoC](https://img.shields.io/badge/GSSoC-2026-orange?style=flat-square)](https://gssoc.girlscript.tech/)
 [![Maintainer](https://img.shields.io/badge/Maintainer-Saptarshi%20Sadhu-a78bfa?style=flat-square)](https://github.com/SAPTARSHI-coder)
 


### PR DESCRIPTION
This PR resolves the issue: Add a badge [Changelog] to README and create a GitHub Actions workflow `release-notes.yml` to auto-generate release notes from merged PR titles grouped by label (component, bug, docs) and append them to CHANGELOG.md via a commit on release publish.