### PR TITLE
feat(examples): add ease-hover-vintage — vintage color grade on hover

### DIFF
--- a/submissions/examples/ease-hover-vintage/README.md
+++ b/submissions/examples/ease-hover-vintage/README.md
@@ -1,0 +1,38 @@
+# ease-hover-vintage
+
+## What does it do?
+Element gets a vintage film color grade on hover using a combination of CSS filters — pure CSS, no JavaScript.
+
+## Features
+- `sepia + contrast + brightness` filter combination
+- Smooth 0.4s transition
+- Custom property `--ease-vintage-intensity` controls effect strength
+- Works with any background color or gradient
+
+## Usage
+```css
+.element {
+  transition: filter 0.4s ease;
+}
+
+.element:hover {
+  filter:
+    sepia(calc(var(--ease-vintage-intensity, 1) * 0.6))
+    contrast(calc(var(--ease-vintage-intensity, 1) * 1.1))
+    brightness(calc(var(--ease-vintage-intensity, 1) * 0.95));
+}
+```
+
+## Customisation
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-vintage-intensity` | `1` | Multiplier for filter values (0.5–1.5) |
+
+## Browser Support
+- CSS Filters + `transition` — Chrome 53+, Firefox 49+, Safari 9.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-vintage/demo.html
+++ b/submissions/examples/ease-hover-vintage/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-vintage — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-vintage</h1>
+  <p class="subtitle">Vintage film color grade on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Vintage Hover Cards</h2>
+    <p class="sec-desc">Hover each card to apply sepia + contrast + brightness film grade</p>
+    <div class="vintage-grid">
+      <div class="vintage-card" style="background: linear-gradient(135deg, #ef4444, #f97316);">Warm</div>
+      <div class="vintage-card" style="background: linear-gradient(135deg, #3b82f6, #06b6d4);">Cool</div>
+      <div class="vintage-card" style="background: linear-gradient(135deg, #22c55e, #059669);">Nature</div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Custom Intensity</h2>
+    <p class="sec-desc">Using <code>--ease-vintage-intensity</code> to control the effect strength</p>
+    <div class="vintage-grid">
+      <div class="vintage-card" style="--ease-vintage-intensity: 0.5; background: linear-gradient(135deg, #a78bfa, #6366f1);">50%</div>
+      <div class="vintage-card" style="--ease-vintage-intensity: 1; background: linear-gradient(135deg, #a78bfa, #6366f1);">100%</div>
+      <div class="vintage-card" style="--ease-vintage-intensity: 1.5; background: linear-gradient(135deg, #a78bfa, #6366f1);">150%</div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-vintage/style.css
+++ b/submissions/examples/ease-hover-vintage/style.css
@@ -1,0 +1,32 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-vintage
+   Vintage film color grade on hover
+   ============================================================ */
+
+.vintage-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.vintage-card {
+  width: 180px;
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: filter 0.4s ease;
+}
+
+.vintage-card:hover {
+  filter:
+    sepia(calc(var(--ease-vintage-intensity, 1) * 0.6))
+    contrast(calc(var(--ease-vintage-intensity, 1) * 1.1))
+    brightness(calc(var(--ease-vintage-intensity, 1) * 0.95));
+}


### PR DESCRIPTION
## Description

Element gets a vintage film color grade on hover using `sepia + contrast + brightness` filter combination — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] Combination of sepia + contrast + brightness filters
- [x] Smooth 0.4s transition
- [x] `--ease-vintage-intensity` custom property

## Files

| File | Description |
|------|-------------|
| `demo.html` | Three preset cards + three intensity variants |
| `style.css` | Filter combination with --ease-vintage-intensity |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12569

<!-- re-trigger label sync -->