### PR TITLE
feat(examples): add ease-hover-scale-y — stretches vertically on hover

### DIFF
--- a/submissions/examples/ease-hover-scale-y/README.md
+++ b/submissions/examples/ease-hover-scale-y/README.md
@@ -1,0 +1,30 @@
+# ease-hover-scale-y
+
+## What does it do?
+Element stretches taller on hover using `scaleY` — pure CSS, no JavaScript.
+
+## Features
+- `scaleY(1.15)` on `:hover`
+- Smooth 0.3s transition
+- Good for bars, indicators, and cards
+
+## Usage
+```css
+.element {
+  transition: transform 0.3s ease;
+  transform-origin: bottom center;
+}
+
+.element:hover {
+  transform: scaleY(1.15);
+}
+```
+
+## Browser Support
+- `transform` + `transition` — Chrome 36+, Firefox 16+, Safari 9+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-scale-y/demo.html
+++ b/submissions/examples/ease-hover-scale-y/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-scale-y — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-scale-y</h1>
+  <p class="subtitle">Element stretches taller on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Indicators</h2>
+    <p class="sec-desc">Hover each bar to see it grow vertically</p>
+    <div class="bars-container">
+      <div class="bar-wrapper"><div class="bar bar-1 scale-y"></div><span>25%</span></div>
+      <div class="bar-wrapper"><div class="bar bar-2 scale-y"></div><span>50%</span></div>
+      <div class="bar-wrapper"><div class="bar bar-3 scale-y"></div><span>75%</span></div>
+      <div class="bar-wrapper"><div class="bar bar-4 scale-y"></div><span>100%</span></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Cards</h2>
+    <p class="sec-desc">Hover to stretch vertically</p>
+    <div class="card-row">
+      <div class="v-card scale-y">Card 1</div>
+      <div class="v-card scale-y">Card 2</div>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-hover-scale-y/style.css
+++ b/submissions/examples/ease-hover-scale-y/style.css
@@ -1,0 +1,62 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-scale-y
+   Stretches taller on hover
+   ============================================================ */
+
+.bars-container {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 1.5rem;
+  height: 160px;
+  padding: 1rem 0;
+}
+
+.bar-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bar-wrapper span {
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+.bar {
+  width: 48px;
+  border-radius: 8px 8px 0 0;
+  transition: transform 0.3s ease;
+  transform-origin: bottom center;
+}
+
+.bar-1 { height: 40px; background: #ef4444; }
+.bar-2 { height: 80px; background: #f59e0b; }
+.bar-3 { height: 120px; background: #22c55e; }
+.bar-4 { height: 160px; background: #3b82f6; }
+
+.scale-y:hover {
+  transform: scaleY(1.15);
+}
+
+.card-row {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.v-card {
+  width: 140px;
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #a78bfa, #6366f1);
+  border-radius: 12px;
+  font-weight: 600;
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+  transform-origin: bottom center;
+}


### PR DESCRIPTION
## Description

Element stretches taller on hover using `scaleY` — pure CSS, no JavaScript. Good for bars and indicators.

## Acceptance Criteria
- [x] `scaleY(1.15)` on `:hover`
- [x] Smooth 0.3s transition
- [x] Good for bars and indicators

## Files

| File | Description |
|------|-------------|
| `demo.html` | Bar indicators + card demo |
| `style.css` | scaleY transform with bottom origin |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12543

<!-- re-trigger label sync -->