### PR TITLE
feat(examples): add ease-hover-darken — darkens on hover

### DIFF
--- a/submissions/examples/ease-hover-darken/README.md
+++ b/submissions/examples/ease-hover-darken/README.md
@@ -1,0 +1,35 @@
+# ease-hover-darken
+
+## What does it do?
+Element darkens on hover using `filter: brightness()` below 1 — pure CSS, no JavaScript.
+
+## Features
+- `filter: brightness(0.8)` on `:hover`
+- GPU-accelerated filter transition
+- Custom property `--ease-darken-amount`
+- Opposite of ease-hover-brightness
+
+## Usage
+```css
+.element {
+  transition: filter 0.3s ease;
+}
+
+.element:hover {
+  filter: brightness(var(--ease-darken-amount, 0.8));
+}
+```
+
+## Customisation
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-darken-amount` | `0.8` | Brightness multiplier (< 1 darkens) |
+
+## Browser Support
+- CSS Filters — Chrome 53+, Firefox 49+, Safari 9.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-darken/demo.html
+++ b/submissions/examples/ease-hover-darken/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-darken — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-darken</h1>
+  <p class="subtitle">Element darkens on hover using CSS filter — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Cards</h2>
+    <p class="sec-desc">Hover to darken using <code>filter: brightness()</code> below 1</p>
+    <div class="dark-grid">
+      <div class="dark-card" style="background: linear-gradient(135deg, #f59e0b, #f97316);">Default</div>
+      <div class="dark-card" style="--ease-darken-amount: 0.6; background: linear-gradient(135deg, #22c55e, #059669);">0.6x</div>
+      <div class="dark-card" style="--ease-darken-amount: 0.4; background: linear-gradient(135deg, #3b82f6, #6366f1);">0.4x</div>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-hover-darken/style.css
+++ b/submissions/examples/ease-hover-darken/style.css
@@ -1,0 +1,29 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-darken
+   Darkens on hover using filter
+   ============================================================ */
+
+.dark-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.dark-card {
+  width: 180px;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: filter 0.3s ease;
+}
+
+.dark-card:hover {
+  filter: brightness(var(--ease-darken-amount, 0.8));
+}


### PR DESCRIPTION
## Description

Element darkens on hover using `filter: brightness()` below 1 — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] `filter: brightness(0.8)` on `:hover`
- [x] Smooth 0.3s transition
- [x] `--ease-darken-amount` custom property

## Files

| File | Description |
|------|-------------|
| `demo.html` | Three cards with darken variants |
| `style.css` | filter: brightness() with custom property |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12545

<!-- re-trigger label sync -->