### PR TITLE
feat(examples): add ease-hover-desaturate — fades to grayscale on hover

### DIFF
--- a/submissions/examples/ease-hover-desaturate/README.md
+++ b/submissions/examples/ease-hover-desaturate/README.md
@@ -1,0 +1,35 @@
+# ease-hover-desaturate
+
+## What does it do?
+Element transitions toward grayscale on hover using `filter: saturate()` — pure CSS, no JavaScript.
+
+## Features
+- `filter: saturate(0.2)` on `:hover`
+- Smooth 0.3s transition
+- Can combine with brightness for reduced visual weight
+- Good for 'disabled' hover states or de-emphasis
+
+## Usage
+```css
+.element {
+  transition: filter 0.3s ease;
+}
+
+.element:hover {
+  filter: saturate(0.2);
+}
+
+/* Combined with brightness */
+.element:hover {
+  filter: saturate(0.2) brightness(1.1);
+}
+```
+
+## Browser Support
+- CSS Filters — Chrome 53+, Firefox 49+, Safari 9.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-desaturate/demo.html
+++ b/submissions/examples/ease-hover-desaturate/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-desaturate — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-desaturate</h1>
+  <p class="subtitle">Element fades to grayscale on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Cards</h2>
+    <p class="sec-desc">Hover to desaturate using <code>filter: saturate()</code></p>
+    <div class="desat-grid">
+      <div class="desat-card" style="background: linear-gradient(135deg, #ef4444, #f97316);">Desaturate</div>
+      <div class="desat-card" style="background: linear-gradient(135deg, #22c55e, #059669);">+ brightness</div>
+      <div class="desat-card desat-combo" style="background: linear-gradient(135deg, #6366f1, #a78bfa);">Combined</div>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-hover-desaturate/style.css
+++ b/submissions/examples/ease-hover-desaturate/style.css
@@ -1,0 +1,33 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-desaturate
+   Fades to grayscale on hover
+   ============================================================ */
+
+.desat-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.desat-card {
+  width: 180px;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: filter 0.3s ease;
+}
+
+.desat-card:hover {
+  filter: saturate(0.2);
+}
+
+.desat-combo:hover {
+  filter: saturate(0.2) brightness(1.1);
+}


### PR DESCRIPTION
## Description

Element transitions toward grayscale on hover using `filter: saturate()` — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] `filter: saturate(0.2)` on `:hover`
- [x] Smooth 0.3s transition
- [x] Can combine with brightness for reduced visual weight

## Files

| File | Description |
|------|-------------|
| `demo.html` | Three cards with desaturate + combined variant |
| `style.css` | filter: saturate() with optional brightness |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12547

<!-- re-trigger label sync -->