### PR TITLE
feat(examples): add ease-hover-shadow-pop — dramatic shadow on hover

### DIFF
--- a/submissions/examples/ease-hover-shadow-pop/README.md
+++ b/submissions/examples/ease-hover-shadow-pop/README.md
@@ -1,0 +1,36 @@
+# ease-hover-shadow-pop
+
+## What does it do?
+Element gains a large dramatic shadow on hover — pure CSS, no JavaScript.
+
+## Features
+- `box-shadow: 0 20px 60px` on `:hover`
+- Combined with slight lift (`translateY(-4px)`)
+- Custom property `--ease-shadow-pop-color` for shadow tint
+- Smooth 0.3s transition
+
+## Usage
+```css
+.element {
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.element:hover {
+  box-shadow: 0 20px 60px var(--ease-shadow-pop-color, rgba(0,0,0,0.4));
+  transform: translateY(-4px);
+}
+```
+
+## Customisation
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-shadow-pop-color` | `rgba(0,0,0,0.4)` | Shadow color with opacity |
+
+## Browser Support
+- `box-shadow` + `transition` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-shadow-pop/demo.html
+++ b/submissions/examples/ease-hover-shadow-pop/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-shadow-pop — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-hover-shadow-pop</h1>
+  <p class="subtitle">Dramatic shadow pops on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Cards</h2>
+    <p class="sec-desc">Hover to see the shadow dramatically increase</p>
+    <div class="shadow-grid">
+      <div class="shadow-card">Default</div>
+      <div class="shadow-card" style="--ease-shadow-pop-color: rgba(99, 102, 241, 0.3);">Purple</div>
+      <div class="shadow-card" style="--ease-shadow-pop-color: rgba(34, 197, 94, 0.3);">Green</div>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-hover-shadow-pop/style.css
+++ b/submissions/examples/ease-hover-shadow-pop/style.css
@@ -1,0 +1,31 @@
+/* ============================================================
+   EaseMotion CSS — ease-hover-shadow-pop
+   Dramatic shadow pops on hover
+   ============================================================ */
+
+.shadow-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.shadow-card {
+  width: 180px;
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2a2a2a;
+  border-radius: 16px;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.shadow-card:hover {
+  box-shadow: 0 20px 60px var(--ease-shadow-pop-color, rgba(0, 0, 0, 0.4));
+  transform: translateY(-4px);
+}


### PR DESCRIPTION
## Description

Element gains a large dramatic shadow on hover with a slight lift — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] `box-shadow: 0 20px 60px rgba(0,0,0,0.3)` on `:hover`
- [x] Smooth 0.3s transition
- [x] `--ease-shadow-pop-color` custom property

## Files

| File | Description |
|------|-------------|
| `demo.html` | Three cards with shadow color variants |
| `style.css` | box-shadow transition with lift |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12549

<!-- re-trigger label sync -->