### PR TITLE
feat: add top-positioned modal variant (#13259)

### DIFF
--- a/components/modals.css
+++ b/components/modals.css
@@ -65,6 +65,12 @@
     opacity: 1;
   }
 
+  /* ── Modal Positioning Variations ───────────────────────────────────────── */
+  .ease-modal-overlay.ease-modal-top {
+    align-items: flex-start;
+    padding-top: var(--ease-space-8, 2rem);
+  }
+
   /* ── Modal Sizing Variations ────────────────────────────────────────────── */
   .ease-modal-sm {
     max-width: 400px;


### PR DESCRIPTION
## Pull Request Description

Resolves #13259. This PR adds the .ease-modal-top variant in components/modals.css. It positions the modal at the top center of the viewport using lign-items: flex-start and additional top padding.

---

## Type of Change

- [x] ? New animation / hover effect
- [ ] ?? New component
- [ ] ?? Documentation improvement
- [x] ?? Bug fix in an existing submission (Core feature requested in issue)
- [ ] Other (describe below)

---

## Submission Checklist

> ?? PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside submissions/examples/your-feature-name/ (N/A - Requested core change)
- [x] Includes demo.html — self-contained, opens in browser with no server (N/A)
- [x] Includes style.css — raw CSS for the proposed feature (N/A)
- [x] Includes README.md — what it does, how to use it, why it fits EaseMotion CSS (N/A)
- [ ] **No changes to core/**
- [ ] **No changes to components/** (This PR modifies components/modals.css as requested in #13259)
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds .ease-modal-top to display modals at the top.

**How does a developer use it?**

`html
<div class="ease-modal-overlay ease-modal-top" id="modal">
  <div class="ease-modal">...</div>
</div>
`

**Why does it fit EaseMotion CSS?**

Provides layout flexibility without custom overrides.

---

## Demo

- [ ] Demo added (demo.html works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Modifies components/modals.css directly as requested in Issue #13259.
