### PR TITLE
feat: add scroll reveal utility under submissions/examples/ease-scrol…

### DIFF
--- a/submissions/examples/ease-scroll-reveal-naresh/README.md
+++ b/submissions/examples/ease-scroll-reveal-naresh/README.md
@@ -1,0 +1,64 @@
+# Scroll Reveal Utility
+
+## 1. What does this do?
+This utility allows elements to animate smoothly into view as the user scrolls down a page. It sets an initial invisible, offset state and reveals the element with custom transitions once it crosses a configurable viewport threshold.
+
+## 2. How is it used?
+Add the `.ease-scroll-reveal` class and any desired direction/delay helpers to your HTML elements:
+
+```html
+<div class="ease-scroll-reveal ease-reveal--slide-up ease-delay-200">
+  <h3>Scroll Revealed Card</h3>
+  <p>Animates when visible.</p>
+</div>
+```
+
+### Configurable CSS Variables
+- `--ease-reveal-threshold`: The percentage of the element that must be visible in the viewport before animating (defaults to `0.1` or 10%).
+- `--ease-reveal-duration`: Transition duration (defaults to `800ms`).
+- `--ease-reveal-delay`: Delay before the transition runs (defaults to `0ms`).
+
+### JavaScript Trigger Script (<10 lines)
+Include this tiny observer script in your project to activate the scroll triggers:
+
+```javascript
+document.querySelectorAll('.ease-scroll-reveal').forEach(el => {
+  const threshold = parseFloat(getComputedStyle(el).getPropertyValue('--ease-reveal-threshold')) || 0.1;
+  const observer = new IntersectionObserver(([entry]) => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('ease-revealed');
+      observer.unobserve(entry.target);
+    }
+  }, { threshold });
+  observer.observe(el);
+});
+```
+
+---
+
+## 3. Pure CSS Alternative: `animation-timeline: view()`
+For modern browsers that support scroll-driven animations natively without any JavaScript, you can achieve the exact same effect using pure CSS:
+
+```css
+@keyframes reveal {
+  from {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ease-scroll-reveal-css {
+  animation: reveal both;
+  animation-timeline: view();
+  animation-range: entry 10% cover 30%;
+}
+```
+
+---
+
+## 4. Why is it useful?
+Scroll-triggered reveals make long landing pages, portfolios, and product sites feel dynamic and engaging. This utility balances classic compatibility (via a tiny performance-optimized IntersectionObserver JS snippet) with modern standards (supporting native Scroll-Driven CSS timelines).

--- a/submissions/examples/ease-scroll-reveal-naresh/demo.html
+++ b/submissions/examples/ease-scroll-reveal-naresh/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - Scroll Reveal Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <h1>Scroll Reveal Animations</h1>
+      <p class="subtitle">Animate elements dynamically as they enter the viewport using pure CSS transitions powered by IntersectionObserver.</p>
+    </header>
+
+    <div class="scroll-hint">
+      👇 Scroll down to see the effects
+    </div>
+
+    <!-- Section 1: Slide Up (Default) -->
+    <div class="scroll-section">
+      <div class="section-label">Default Transition</div>
+      <div class="reveal-card ease-scroll-reveal ease-reveal--slide-up">
+        <h3>Slide Up Reveal</h3>
+        <p>The standard scroll reveal slides upward as it fades into view. Excellent for standard body content, blocks, and dashboard cards.</p>
+      </div>
+    </div>
+
+    <!-- Section 2: Slide Left & Slide Right -->
+    <div class="scroll-section" style="width: 100%;">
+      <div class="section-label">Directional Reveals</div>
+      <div style="display: flex; gap: 2rem; flex-wrap: wrap; justify-content: center; width: 100%;">
+        <div class="reveal-card ease-scroll-reveal ease-reveal--slide-right" style="max-width: 360px;">
+          <h3>Slide Right</h3>
+          <p>Reveals by sliding in from the left side.</p>
+        </div>
+        <div class="reveal-card ease-scroll-reveal ease-reveal--slide-left" style="max-width: 360px;">
+          <h3>Slide Left</h3>
+          <p>Reveals by sliding in from the right side.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Section 3: Zoom / Scale In -->
+    <div class="scroll-section">
+      <div class="section-label">Zoom Entrance</div>
+      <div class="reveal-card ease-scroll-reveal ease-reveal--scale-in" style="--ease-reveal-threshold: 0.2;">
+        <h3>Scale In Reveal</h3>
+        <p>This element has a custom <code>--ease-reveal-threshold: 0.2</code> variable, meaning it will only animate once 20% of it is visible in the viewport.</p>
+      </div>
+    </div>
+
+    <!-- Section 4: Blur In -->
+    <div class="scroll-section">
+      <div class="section-label">Cinematic Blur</div>
+      <div class="reveal-card ease-scroll-reveal ease-reveal--blur-in ease-duration-1000">
+        <h3>Blur In Reveal</h3>
+        <p>Uses a cinematic blur-in effect with a slower 1000ms duration (using the <code>.ease-duration-1000</code> helper class).</p>
+      </div>
+    </div>
+
+    <!-- Section 5: Staggered Grid Reveal -->
+    <div class="scroll-section">
+      <div class="section-label">Staggered Grid</div>
+      <div class="stagger-grid">
+        <div class="stagger-card ease-scroll-reveal ease-reveal--slide-up">
+          <div class="icon">🚀</div>
+          <h4>Feature Alpha</h4>
+          <p>Reveals immediately when visible.</p>
+        </div>
+        <div class="stagger-card ease-scroll-reveal ease-reveal--slide-up ease-delay-200">
+          <div class="icon">🎨</div>
+          <h4>Feature Beta</h4>
+          <p>Delayed by 200ms for staggered effect.</p>
+        </div>
+        <div class="stagger-card ease-scroll-reveal ease-reveal--slide-up ease-delay-400">
+          <div class="icon">🔒</div>
+          <h4>Feature Gamma</h4>
+          <p>Delayed by 400ms for staggered effect.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Intersection Observer Script (< 10 lines) -->
+  <script>
+    document.querySelectorAll('.ease-scroll-reveal').forEach(el => {
+      const threshold = parseFloat(getComputedStyle(el).getPropertyValue('--ease-reveal-threshold')) || 0.1;
+      const observer = new IntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('ease-revealed');
+          observer.unobserve(entry.target);
+        }
+      }, { threshold });
+      observer.observe(el);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-reveal-naresh/style.css
+++ b/submissions/examples/ease-scroll-reveal-naresh/style.css
@@ -1,0 +1,272 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:root {
+  --ease-font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
+  --ease-font-mono: 'JetBrains Mono', monospace;
+
+  /* HSL Colors */
+  --ease-primary: 250, 100%, 69%;
+  --ease-secondary: 260, 95%, 66%;
+  --ease-accent: 190, 90%, 50%;
+  
+  --ease-bg: #0b1121;
+  --ease-surface: #141e33;
+  --ease-text-main: #f8fafc;
+  --ease-text-muted: #94a3b8;
+  --ease-border: rgba(255, 255, 255, 0.08);
+  
+  --ease-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+  
+  /* Scroll reveal defaults */
+  --ease-reveal-duration: 800ms;
+  --ease-reveal-timing: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-reveal-delay: 0ms;
+  --ease-reveal-distance: 40px;
+}
+
+body {
+  font-family: var(--ease-font-sans);
+  background-color: var(--ease-bg);
+  background-image: radial-gradient(circle at top left, #0e122b, #05060f);
+  color: var(--ease-text-main);
+  margin: 0;
+  padding: 4rem 1.5rem;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 8vh;
+  animation: easeRevealFadeInDown 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  background: linear-gradient(135deg, #fff 40%, hsl(var(--ease-primary)) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: var(--ease-text-muted);
+  font-size: 1.125rem;
+}
+
+/* Scroll indicator banner */
+.scroll-hint {
+  text-align: center;
+  margin: 3rem 0;
+  color: hsl(var(--ease-accent));
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  animation: easeRevealPulse 2s infinite ease-in-out;
+}
+
+/* Spacer sections for scrolling demo */
+.scroll-section {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 4rem;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.05);
+  padding-bottom: 4rem;
+}
+
+.scroll-section:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+}
+
+.section-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: hsl(var(--ease-accent));
+  letter-spacing: 0.1em;
+  margin-bottom: 1rem;
+}
+
+/* Visual Card for Reveal Demo */
+.reveal-card {
+  background: rgba(20, 30, 51, 0.5);
+  border: 1px solid var(--ease-border);
+  backdrop-filter: blur(12px);
+  padding: 2.5rem;
+  border-radius: 16px;
+  box-shadow: var(--ease-shadow);
+  max-width: 500px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.reveal-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, hsl(var(--ease-primary)), hsl(var(--ease-secondary)));
+}
+
+.reveal-card h3 {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.reveal-card p {
+  color: var(--ease-text-muted);
+  margin-bottom: 0;
+}
+
+/* Grid layout for staggered cards */
+.stagger-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 800px;
+}
+
+.stagger-card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--ease-border);
+  padding: 2rem;
+  border-radius: 12px;
+  text-align: center;
+}
+
+.stagger-card .icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.stagger-card h4 {
+  margin: 0.5rem 0;
+  font-size: 1.15rem;
+}
+
+.stagger-card p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ease-text-muted);
+}
+
+/* ────────────────────────────────────────────────────────────
+   SCROLL REVEAL COMPONENT
+   ──────────────────────────────────────────────────────────── */
+
+.ease-scroll-reveal {
+  opacity: 0;
+  pointer-events: none; /* Prevent interaction while hidden */
+  will-change: transform, opacity;
+  transition: 
+    opacity var(--ease-reveal-duration) var(--ease-reveal-timing) var(--ease-reveal-delay),
+    transform var(--ease-reveal-duration) var(--ease-reveal-timing) var(--ease-reveal-delay),
+    filter var(--ease-reveal-duration) var(--ease-reveal-timing) var(--ease-reveal-delay);
+}
+
+/* Default reveals (slide up) */
+.ease-scroll-reveal {
+  transform: translateY(var(--ease-reveal-distance));
+}
+
+/* Revealed State */
+.ease-scroll-reveal.ease-revealed {
+  opacity: 1 !important;
+  pointer-events: auto !important;
+  transform: translate(0) scale(1) rotate(0) !important;
+}
+
+/* ── Direction / Effect Modifiers ── */
+
+/* Slide Up (default modifier) */
+.ease-reveal--slide-up {
+  transform: translateY(var(--ease-reveal-distance));
+}
+
+/* Slide Down */
+.ease-reveal--slide-down {
+  transform: translateY(calc(-1 * var(--ease-reveal-distance)));
+}
+
+/* Slide Left */
+.ease-reveal--slide-left {
+  transform: translateX(var(--ease-reveal-distance));
+}
+
+/* Slide Right */
+.ease-reveal--slide-right {
+  transform: translateX(calc(-1 * var(--ease-reveal-distance)));
+}
+
+/* Zoom / Scale In */
+.ease-reveal--scale-in {
+  transform: scale(0.92);
+}
+
+/* Blur In */
+.ease-reveal--blur-in {
+  filter: blur(8px);
+  transform: translateY(15px);
+}
+.ease-scroll-reveal.ease-revealed.ease-reveal--blur-in {
+  filter: blur(0) !important;
+}
+
+/* ── Delay Utilities ── */
+.ease-delay-100 { --ease-reveal-delay: 100ms; }
+.ease-delay-200 { --ease-reveal-delay: 200ms; }
+.ease-delay-300 { --ease-reveal-delay: 300ms; }
+.ease-delay-400 { --ease-reveal-delay: 400ms; }
+.ease-delay-500 { --ease-reveal-delay: 500ms; }
+
+/* ── Duration Utilities ── */
+.ease-duration-500 { --ease-reveal-duration: 500ms; }
+.ease-duration-1000 { --ease-reveal-duration: 1000ms; }
+.ease-duration-1500 { --ease-reveal-duration: 1500ms; }
+
+/* Keyframe animations */
+@keyframes easeRevealPulse {
+  0%, 100% {
+    opacity: 0.5;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(6px);
+  }
+}
+
+@keyframes easeRevealFadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes easeRevealFadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION

## Pull Request Description
This pull request introduces the `ease-scroll-reveal` utility: a responsive scroll-triggered reveal utility combining pure CSS transitions with a micro IntersectionObserver script (under 10 lines) that dynamically honors threshold CSS variables.
---
## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)
---
## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
---
## Feature Description
**What does this add?**
An accessible scroll-reveal utility allowing elements to slide and fade dynamically into the viewport as the user scrolls.
**How does a developer use it?**
```html
<div class="ease-scroll-reveal ease-reveal--slide-up ease-delay-200">
  <h3>Revealed Card</h3>
  <p>Animates when visible.</p>
</div>
Why does it fit EaseMotion CSS?

It bridges classic browser compatibility (using a tiny performance-optimized IntersectionObserver snippet) with cutting-edge CSS standards (supporting native Scroll-Driven CSS view timelines), matching EaseMotion's high-fidelity animation-first values.

Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge
 Safari (optional but appreciated)
Notes for Maintainer
Includes a micro JS observer block under 10 lines.
Honors --ease-reveal-threshold inline properties so developers can adjust triggers in stylesheets.
Documents native animation-timeline: view() alternatives inside README.md.
