### PR TITLE
feat: add top-positioned modal submission (#13259)

### DIFF
--- a/submissions/examples/top-positioned-modal/README.md
+++ b/submissions/examples/top-positioned-modal/README.md
@@ -1,0 +1,20 @@
+# Top-Positioned Modal
+
+This submission adds a top-aligned variant for modal dialogs. 
+
+## What does this add?
+By default, modals in EaseMotion CSS center both vertically and horizontally. This adds an `.ease-modal-top` class to position the modal at the top center of the viewport, which is a common UI pattern for notifications, confirmations, and lightweight prompts.
+
+## How to use it?
+Simply add the `ease-modal-top` class alongside `ease-modal-overlay`:
+
+```html
+<div class="ease-modal-overlay ease-modal-top" id="demo-modal">
+  <div class="ease-modal">
+    <!-- Modal content -->
+  </div>
+</div>
+```
+
+## Why does it fit EaseMotion CSS?
+EaseMotion CSS focuses on lightweight, reusable UI components. This top-positioned variant adds significant layout flexibility for different types of dialogs without requiring developers to write custom CSS overrides or complex structural changes.

--- a/submissions/examples/top-positioned-modal/demo.html
+++ b/submissions/examples/top-positioned-modal/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Top-Positioned Modal Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div style="padding: 2rem; text-align: center;">
+    <h1>Top-Positioned Modal Demo</h1>
+    <p>This demonstrates a modal that aligns to the top of the screen instead of the center.</p>
+    <a href="#demo-modal" class="btn btn-primary">Open Top Modal</a>
+  </div>
+
+  <!-- Top-positioned Modal -->
+  <div class="ease-modal-overlay ease-modal-top" id="demo-modal">
+    <div class="ease-modal">
+      <div class="ease-modal-header">
+        <h2>Notification</h2>
+        <a href="#" class="ease-modal-close" aria-label="Close modal">&times;</a>
+      </div>
+      
+      <div class="ease-modal-body">
+        <p>This modal is positioned at the top of the viewport. It's useful for notifications, alerts, or lightweight dialogs that shouldn't obscure the center of the screen.</p>
+        <p>Click the close button or any action button below to dismiss.</p>
+      </div>
+      
+      <div class="ease-modal-footer">
+        <a href="#" class="btn btn-secondary">Cancel</a>
+        <a href="#" class="btn btn-primary">Understood</a>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/top-positioned-modal/style.css
+++ b/submissions/examples/top-positioned-modal/style.css
@@ -1,0 +1,123 @@
+/* ==========================================================================
+   TOP-POSITIONED MODAL COMPONENT EXTENSION
+   ========================================================================== */
+
+/* This CSS provides a top-positioned variant for standard modals */
+.ease-modal-overlay.ease-modal-top {
+  align-items: flex-start;
+  padding-top: var(--ease-space-8, 2rem);
+}
+
+/* Base styles for the demo purposes (if the main stylesheet is not loaded) */
+.ease-modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  justify-content: center;
+  z-index: 1000;
+  
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+}
+
+.ease-modal-overlay:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.ease-modal {
+  background: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  max-width: 500px;
+  width: 90%;
+  max-height: 90vh;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  font-family: system-ui, sans-serif;
+  
+  transform: scale(0.9) translateY(-20px);
+  opacity: 0;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.25s ease;
+}
+
+.ease-modal-overlay:target .ease-modal {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+}
+
+.ease-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.ease-modal-header h2 {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.ease-modal-close {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.5rem;
+  background: transparent;
+  color: #6b7280;
+  font-size: 1.25rem;
+  text-decoration: none;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ease-modal-close:hover {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.ease-modal-body {
+  padding: 1.5rem;
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+.ease-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #e5e7eb;
+  background: #f9fafb;
+  border-radius: 0 0 1rem 1rem;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  border: none;
+}
+
+.btn-primary {
+  background: #6c63ff;
+  color: white;
+}
+
+.btn-secondary {
+  background: #e5e7eb;
+  color: #374151;
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #13259. This PR submits an example of the .ease-modal-top variant for top-positioned modals. It uses lign-items: flex-start to push the modal to the top of the viewport for notifications or lightweight dialogs.

---

## Type of Change

- [ ] ? New animation / hover effect
- [x] ?? New component
- [ ] ?? Documentation improvement
- [ ] ?? Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ?? PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside submissions/examples/your-feature-name/
- [x] Includes demo.html — self-contained, opens in browser with no server
- [x] Includes style.css — raw CSS for the proposed feature
- [x] Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to core/**
- [x] **No changes to components/**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A top-aligned modal dialog variant.

**How does a developer use it?**

`html
<div class="ease-modal-overlay ease-modal-top" id="modal">
  <div class="ease-modal">...</div>
</div>
`

**Why does it fit EaseMotion CSS?**

It provides layout flexibility for different dialog types (e.g. notifications) without custom CSS overrides.

---

## Demo

- [x] Demo added (demo.html works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission demonstrates the top-positioned modal feature requested in #13259 since modifications to components/modals.css are not permitted for external contributors.
