### PR TITLE
feat: add ease-truncate-2 utility for 2-line text truncation

### DIFF
--- a/submissions/examples/truncate-2-utility/README.md
+++ b/submissions/examples/truncate-2-utility/README.md
@@ -1,0 +1,17 @@
+# 2-Line Text Truncation Utility
+
+An isolated utility design token component implementation that wraps modern WebKit box constraints to truncate long descriptive text blocks precisely after two lines.
+
+## Functional Controls
+- **Box Orientation Restraints:** Forcing vertical block layout rendering boundaries using `-webkit-box-orient: vertical` definitions.
+- **Ellipsis Overflow Management:** Triggers trailing characters to drop into ellipsis rendering layers automatically via `overflow: hidden` boundaries.
+- **Layout Protection Layouts:** Keeps grid content flows uniform and guards cards from erratic height spikes during data hydration passes.
+
+## Usage Layout Structure
+```html
+<p class="ease-truncate-2">
+  Long copy that needs to stay limited to exactly two rows max goes here...
+</p>
+```
+
+Closes #13482

--- a/submissions/examples/truncate-2-utility/demo.html
+++ b/submissions/examples/truncate-2-utility/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>2-Line Truncation Utility — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 5rem 1rem; margin: 0;">
+
+  <div class="ease-truncate-showcase">
+    
+    <div class="ease-preview-card">
+      <span style="font-size: 0.7rem; font-weight: 700; color: #2563eb; text-transform: uppercase; letter-spacing: 0.05em;">Utility: .ease-truncate-2</span>
+      <h3 class="ease-card-headline">Dynamic Feed Integration</h3>
+      
+      <p class="ease-card-snippet ease-truncate-2">
+        This descriptive text content block is purposely elongated to test how the browser clips string endings. By leveraging native box formatting constraints, the text is cleanly sliced at the end of the second row, rendering a neat trailing ellipsis without forcing manual JavaScript substring manipulation or breaking card dimensions.
+      </p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/truncate-2-utility/style.css
+++ b/submissions/examples/truncate-2-utility/style.css
@@ -1,0 +1,51 @@
+/* ============================================================
+   ease-truncate-2 — 2-Line Text Truncation Utility
+
+   Features structural tokens including:
+     - Webkit-box layout constraints restricting content to exactly two rows
+     - Non-destructive overflow clipping hides characters outside limits
+     - Standard rendering layer boundaries mapping trailing ellipsis blocks
+   ============================================================ */
+
+.ease-truncate-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;  
+  overflow: hidden;
+}
+
+
+/* ============================================================
+   LAYOUT PRESENTATION DECK (Demo Specific)
+   ============================================================ */
+
+.ease-truncate-showcase {
+  max-width: 400px;
+  margin: 0 auto;
+  font-family: var(--ease-font-sans, sans-serif);
+}
+
+.ease-preview-card {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 1.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ease-card-headline {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.ease-card-snippet {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #475569;
+  line-height: 1.5;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the utility class configuration for `.ease-truncate-2`. Delivers a highly performant typography shortcut token that limits multi-line text blocks to exactly two rows max, protecting grid aspect constraints from breaking when processing variable server-side strings.

Closes #13482

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- Dedicated multi-line shorthand layout token (`.ease-truncate-2`) leveraging performance-optimized native box formatting masks.
- Automated layout capping that guarantees typography nodes never exceed two rows, preserving alignment across adjacent dashboard summary components.
- Native rendering-thread handling that fully replaces custom string truncation logic or DOM recalculation loops.

**How does a developer use it?**
```html
<p class="ease-truncate-2">Elongated description strings clamp flawlessly to two lines...</p>