### PR TITLE
docs: add HTML dialog modal animation starting-style fix under submis…

### DIFF
--- a/submissions/examples/dialog-animation-fix-naresh/README.md
+++ b/submissions/examples/dialog-animation-fix-naresh/README.md
@@ -1,0 +1,72 @@
+# HTML Dialog Animation Fix
+
+## 1. What does this do?
+This submission serves as a developer guide documenting why CSS animations fail to trigger on children inside the native HTML `<dialog>` element when opened via `showModal()`, and details the modern CSS `@starting-style` solution to animate top-layer elements smoothly.
+
+## 2. Root Cause of the Bug
+The `<dialog>` element is rendered in a special browser layer called the **top-layer**. When `dialog.showModal()` is called, the element's CSS `display` changes instantly from `none` to `block` (or similar), and it is appended to the top-layer. 
+
+Because this state change is instantaneous and discrete, standard CSS transitions and animations applied to children fail to recognize the entry transition state, rendering the dialog instantly with zero animation.
+
+---
+
+## 3. The Fix: `@starting-style` & `allow-discrete`
+
+Modern browsers support animating discrete properties (like `display` and `overlay`) using the `allow-discrete` transition behavior coupled with the `@starting-style` block. This allows developers to declare the visual starting styles of an element when it first renders:
+
+### CSS Implementation
+
+```css
+/* 1. Set the initial closed/hidden visual properties and transitions */
+dialog {
+  opacity: 0;
+  transform: scale(0.92) translateY(12px);
+  
+  /* Crucial: transition display and overlay with allow-discrete */
+  transition: 
+    opacity 0.4s ease,
+    transform 0.4s ease,
+    overlay 0.4s ease allow-discrete,
+    display 0.4s ease allow-discrete;
+}
+
+/* 2. Set the target opened visual properties */
+dialog[open] {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+}
+
+/* 3. Declare starting styles for when the top-layer/display changes */
+@starting-style {
+  dialog[open] {
+    opacity: 0;
+    transform: scale(0.92) translateY(12px);
+  }
+}
+
+/* 4. Animate the dialog backdrop similarly */
+dialog::backdrop {
+  opacity: 0;
+  background: rgba(11, 17, 33, 0.8);
+  backdrop-filter: blur(6px);
+  transition: 
+    opacity 0.4s ease,
+    overlay 0.4s ease allow-discrete,
+    display 0.4s ease allow-discrete;
+}
+
+dialog[open]::backdrop {
+  opacity: 1;
+}
+
+@starting-style {
+  dialog[open]::backdrop {
+    opacity: 0;
+  }
+}
+```
+
+---
+
+## 4. Why is it useful?
+Using native `<dialog>` elements is a best practice for web accessibility (providing keyboard trapping, focus management, and escape-close behavior). By resolving the entry animation bug using native CSS `@starting-style` instead of large JavaScript modal libraries, developers can build fast, accessible, and high-fidelity overlays.

--- a/submissions/examples/dialog-animation-fix-naresh/demo.html
+++ b/submissions/examples/dialog-animation-fix-naresh/demo.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - HTML Dialog Animation Fix Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <h1>HTML Dialog Animation Fix</h1>
+      <p class="subtitle">Understand why CSS animations fail to trigger on top-layer <code>&lt;dialog&gt;</code> elements and see the modern CSS <code>@starting-style</code> fix.</p>
+    </header>
+
+    <!-- Trigger Panel -->
+    <section class="showcase-section" style="text-align: center; padding: 3rem;">
+      <h3 class="section-title" style="justify-content: center;"><span>🚀</span> Open Dialog Modals</h3>
+      <p style="margin-bottom: 2rem;">Compare the instant popup behavior of the standard dialog with the smooth transition of the fixed dialog:</p>
+      
+      <button class="btn-trigger" onclick="openDialog('buggy')">
+        🔴 Buggy Dialog (Instant)
+      </button>
+      <button class="btn-trigger" style="background: linear-gradient(135deg, #06b6d4, #3b82f6); box-shadow: 0 4px 15px rgba(6, 182, 212, 0.3);" onclick="openDialog('fixed')">
+        🟢 Fixed Dialog (Smooth Transition)
+      </button>
+    </section>
+
+    <!-- BUGGY DIALOG -->
+    <dialog id="dialog-buggy" class="dialog-buggy">
+      <h3>Buggy Modal</h3>
+      <p>This modal appears instantly because the browser moves it to the top-layer with <code>display: block</code> immediately, which bypasses normal entry CSS transitions.</p>
+      <button class="btn-close" onclick="closeDialog('buggy')">Close Modal</button>
+    </dialog>
+
+    <!-- FIXED DIALOG -->
+    <dialog id="dialog-fixed" class="dialog-fixed">
+      <h3>Fixed Modal</h3>
+      <p>This modal scales and fades in smoothly! By using modern CSS <code>@starting-style</code>, we define the starting visual frames of the entry state when the element transitions from <code>display: none</code>.</p>
+      <button class="btn-close" onclick="closeDialog('fixed')">Close Modal</button>
+    </dialog>
+
+    <!-- Code Block -->
+    <section class="showcase-section">
+      <h3 class="section-title"><span>🛠️</span> Code Implementation</h3>
+      <p>Use the new <code>allow-discrete</code> transition properties alongside <code>@starting-style</code> to animate elements entering the top-layer natively:</p>
+      
+      <pre><code>/* Define transition including display and overlay allow-discrete */
+dialog {
+  opacity: 0;
+  transform: scale(0.92);
+  transition: 
+    opacity 0.4s ease,
+    transform 0.4s ease,
+    overlay 0.4s ease allow-discrete,
+    display 0.4s ease allow-discrete;
+}
+
+/* Open State */
+dialog[open] {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Define starting style rules for entry state */
+@starting-style {
+  dialog[open] {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+}</code></pre>
+    </section>
+  </div>
+
+  <script>
+    function openDialog(type) {
+      const dialog = document.getElementById(`dialog-${type}`);
+      if (dialog) {
+        dialog.showModal();
+      }
+    }
+
+    function closeDialog(type) {
+      const dialog = document.getElementById(`dialog-${type}`);
+      if (dialog) {
+        dialog.close();
+      }
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/dialog-animation-fix-naresh/style.css
+++ b/submissions/examples/dialog-animation-fix-naresh/style.css
@@ -1,0 +1,243 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:root {
+  --ease-font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
+  --ease-font-mono: 'JetBrains Mono', monospace;
+
+  /* HSL Palette */
+  --ease-primary: 250, 100%, 69%;
+  --ease-secondary: 260, 95%, 66%;
+  --ease-accent: 190, 90%, 50%;
+  
+  --ease-bg: #0b1121;
+  --ease-surface: #141e33;
+  --ease-text-main: #f8fafc;
+  --ease-text-muted: #94a3b8;
+  --ease-border: rgba(255, 255, 255, 0.08);
+  
+  --ease-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+}
+
+body {
+  font-family: var(--ease-font-sans);
+  background-color: var(--ease-bg);
+  background-image: radial-gradient(circle at top left, #0e122b, #05060f);
+  color: var(--ease-text-main);
+  margin: 0;
+  padding: 4rem 1.5rem;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 4rem;
+  animation: easeDialogFadeInDown 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  background: linear-gradient(135deg, #fff 40%, hsl(var(--ease-primary)) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: var(--ease-text-muted);
+  font-size: 1.125rem;
+}
+
+/* Sections */
+.showcase-section {
+  background: rgba(20, 30, 51, 0.4);
+  border: 1px solid var(--ease-border);
+  backdrop-filter: blur(12px);
+  border-radius: 16px;
+  padding: 2.5rem;
+  margin-bottom: 2.5rem;
+  box-shadow: var(--ease-shadow);
+  animation: easeDialogFadeInUp 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.2s both;
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  color: hsl(var(--ease-primary));
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.btn-trigger {
+  background: linear-gradient(135deg, hsl(var(--ease-primary)), hsl(var(--ease-secondary)));
+  color: white;
+  border: none;
+  padding: 0.8rem 1.6rem;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 15px rgba(108, 99, 255, 0.3);
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  font-family: var(--ease-font-sans);
+  margin-right: 1rem;
+  margin-bottom: 1rem;
+}
+
+.btn-trigger:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(108, 99, 255, 0.45);
+}
+
+.btn-trigger:active {
+  transform: translateY(0);
+}
+
+.btn-close {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--ease-border);
+  color: var(--ease-text-main);
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-weight: 600;
+  font-family: var(--ease-font-sans);
+  margin-top: 1.5rem;
+}
+
+.btn-close:hover {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+/* ────────────────────────────────────────────────────────────
+   HTML DIALOG STYLING
+   ──────────────────────────────────────────────────────────── */
+
+dialog {
+  background: #141e33;
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  padding: 2.5rem;
+  color: var(--ease-text-main);
+  max-width: 450px;
+  box-shadow: var(--ease-shadow);
+}
+
+dialog::backdrop {
+  background: rgba(11, 17, 33, 0.8);
+  backdrop-filter: blur(6px);
+}
+
+dialog h3 {
+  margin-top: 0;
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+dialog p {
+  color: var(--ease-text-muted);
+  margin-bottom: 0;
+}
+
+/* ── 1. The Buggy Dialog ── */
+/* Standard dialog with no transition configurations */
+.dialog-buggy {
+  /* Default browser styling instantly overrides visibility */
+}
+
+/* ── 2. The Fixed Dialog (using starting-style) ── */
+.dialog-fixed {
+  opacity: 0;
+  transform: scale(0.92) translateY(12px);
+  transition: 
+    opacity 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+    overlay 0.4s cubic-bezier(0.16, 1, 0.3, 1) allow-discrete,
+    display 0.4s cubic-bezier(0.16, 1, 0.3, 1) allow-discrete;
+}
+
+/* Open State */
+.dialog-fixed[open] {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+}
+
+/* Starting Style (Triggers animation from display: none to block / entry to top-layer) */
+@starting-style {
+  .dialog-fixed[open] {
+    opacity: 0;
+    transform: scale(0.92) translateY(12px);
+  }
+}
+
+/* Backdrop Transition */
+.dialog-fixed::backdrop {
+  opacity: 0;
+  transition: 
+    opacity 0.4s ease,
+    overlay 0.4s ease allow-discrete,
+    display 0.4s ease allow-discrete;
+}
+
+.dialog-fixed[open]::backdrop {
+  opacity: 1;
+}
+
+@starting-style {
+  .dialog-fixed[open]::backdrop {
+    opacity: 0;
+  }
+}
+
+pre {
+  background: rgba(10, 15, 30, 0.95);
+  border: 1px solid var(--ease-border);
+  padding: 1.25rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin-top: 1.5rem;
+}
+
+code {
+  font-family: var(--ease-font-mono);
+  font-size: 0.875rem;
+  color: #a78bfa;
+}
+
+pre code {
+  color: #e2e8f0;
+}
+
+/* Keyframes */
+@keyframes easeDialogFadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes easeDialogFadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION

## Pull Request Description
This pull request introduces the `dialog-animation-fix` documentation guide: a developer reference detailing why CSS transition and animation entry frames fail to trigger on top-layer HTML `<dialog>` elements and how to resolve it using CSS `@starting-style` and `allow-discrete` properties.
---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)
---
## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
---
## Feature Description
**What does this add?**
A developer reference guide detailing the top-layer dialog transition bug and providing code examples for the CSS `@starting-style` fix.
**How does a developer use it?**
```css
dialog {
  opacity: 0;
  transition: opacity 0.4s ease, display 0.4s ease allow-discrete;
}
dialog[open] {
  opacity: 1;
}
@starting-style {
  dialog[open] {
    opacity: 0;
  }
}
Why does it fit EaseMotion CSS?

Because the core repository restricts direct modifications to core files, documenting native top-layer entry frame boundaries and resolving them using modern pure-CSS standards (like @starting-style) provides immediately actionable guidance to users.

Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge
 Safari (optional but appreciated)
Notes for Maintainer
Requires zero changes to the core or components folders.
Clearly illustrates why standard animation triggers fail on modal initialization.
Provides copy-pasteable solutions that developers can adopt in their projects.
