### PR TITLE
feat : added ease-sr-only-focusable utility for accessible skip links

### DIFF
--- a/submissions/examples/ease-sr-only-focusable-tm/README.md
+++ b/submissions/examples/ease-sr-only-focusable-tm/README.md
@@ -1,17 +1,22 @@
 # ease-sr-only-focusable
 
 ## What does this do?
-The ease-sr-only-focusable utility class provides a reusable CSS pattern following the EaseMotion CSS design system.
+The ease-sr-only-focusable utility provides a screen-reader-only element that becomes visible on keyboard focus. Used for accessible skip navigation links and hidden-but-focusable labels.
 
 ## How is it used?
-    <div class=".ease-sr-only-focusable">Content</div>
+Add the class to any element that should be visually hidden but accessible to keyboard users:
+
+    <a href="#main" class="ease-sr-only-focusable">Skip to main content</a>
+
+## Why is it useful?
+This utility is essential for WCAG 2.1 AA accessibility compliance. It enables skip navigation links without cluttering the visual interface for mouse users.
 
 ## Tech Stack
 - HTML
 - CSS (no frameworks, no JavaScript)
 
 ## Preview
-Open demo.html in your browser.
+Open demo.html in your browser. Tab to the "Skip to main content" link to see the focus state.
 
 ## Contribution Notes
 - Class naming follows the ease-* convention

--- a/submissions/examples/ease-sr-only-focusable-tm/README.md
+++ b/submissions/examples/ease-sr-only-focusable-tm/README.md
@@ -1,0 +1,18 @@
+# ease-sr-only-focusable
+
+## What does this do?
+The ease-sr-only-focusable utility class provides a reusable CSS pattern following the EaseMotion CSS design system.
+
+## How is it used?
+    <div class=".ease-sr-only-focusable">Content</div>
+
+## Tech Stack
+- HTML
+- CSS (no frameworks, no JavaScript)
+
+## Preview
+Open demo.html in your browser.
+
+## Contribution Notes
+- Class naming follows the ease-* convention
+- Uses CSS custom properties for theming

--- a/submissions/examples/ease-sr-only-focusable-tm/demo.html
+++ b/submissions/examples/ease-sr-only-focusable-tm/demo.html
@@ -1,17 +1,58 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="UTF-8"><title>ease-sr-only-focusable Demo</title><style>
-:root{--ease-speed-medium:300ms;--ease-ease-bounce:cubic-bezier(0.34,1.56,0.64,1);--ease-color-primary:#6c63ff;--ease-color-neutral-200:#e2e8f0;--ease-color-neutral-900:#0f172a}
-*{box-sizing:border-box;margin:0;padding:0}
-body{font-family:system-ui,sans-serif;background:#f8fafc;color:var(--ease-color-neutral-900);padding:2rem}
-h1{font-size:1.5rem;font-weight:700;margin-bottom:1.5rem;color:var(--ease-color-primary)}
-.demo-item{background:white;border:1px solid var(--ease-color-neutral-200);border-radius:.75rem;padding:1.5rem;text-align:center;margin-bottom:1rem}
-.demo-box{display:inline-flex;align-items:center;justify-content:center;width:80px;height:80px;background:var(--ease-color-primary);color:white;font-weight:600;font-size:.75rem;border-radius:.5rem;cursor:pointer}
-</style></head><body>
-<h1>ease-sr-only-focusable — Demo</h1>
-<div class="demo-item"><div class="demo-box .ease-sr-only-focusable">.ease-sr-only-focusable</div><p>Hover to see the effect</p></div>
-<style>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ease-sr-only-focusable Demo</title>
+  <style>
+    :root {
+      --ease-color-primary: #6c63ff;
+      --ease-color-neutral-200: #e2e8f0;
+      --ease-color-neutral-900: #0f172a;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #f8fafc; color: var(--ease-color-neutral-900); padding: 2rem; }
+    h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 1rem; color: var(--ease-color-primary); }
+    .demo-item { background: white; border: 1px solid var(--ease-color-neutral-200); border-radius: 0.75rem; padding: 1.5rem; margin-bottom: 1rem; }
+    .demo-skip-link { position: static; width: auto; height: auto; padding: 0.75rem 1.5rem; margin: 0; overflow: visible; clip: auto; white-space: normal; outline: 2px solid var(--ease-color-primary); outline-offset: 2px; border-radius: 0.5rem; background: var(--ease-color-primary); color: white; font-weight: 600; display: inline-block; cursor: pointer; }
+    .sr-only-demo { margin-top: 1rem; }
+    .sr-only-demo-label { font-size: 0.875rem; color: #64748b; margin-bottom: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>ease-sr-only-focusable — Demo</h1>
+  <div class="demo-item">
+    <p class="sr-only-demo-label">Click the skip link below (or Tab to it) to see the focus state:</p>
+    <a href="#main" class="ease-sr-only-focusable">Skip to main content</a>
+    <main id="main" style="margin-top:1rem; padding:1rem; background:#f1f5f9; border-radius:0.5rem;">
+      <strong>Main content area</strong> — reached via skip link
+    </main>
+  </div>
+  <style>
 /* ease-sr-only-focusable utility */
-.ease-sr-only-focusable{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
-.ease-sr-only-focusable:focus,.ease-sr-only-focusable:focus-visible{position:static;width:auto;height:auto;padding:inherit;margin:inherit;overflow:visible;clip:auto;white-space:normal;outline:2px solid var(--ease-color-primary,#6c63ff);outline-offset:2px}
-</style>
-</body></html>
+.ease-sr-only-focusable {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+.ease-sr-only-focusable:focus,
+.ease-sr-only-focusable:focus-visible {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: inherit;
+  margin: inherit;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+  </style>
+</body>
+</html>

--- a/submissions/examples/ease-sr-only-focusable-tm/demo.html
+++ b/submissions/examples/ease-sr-only-focusable-tm/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>ease-sr-only-focusable Demo</title><style>
+:root{--ease-speed-medium:300ms;--ease-ease-bounce:cubic-bezier(0.34,1.56,0.64,1);--ease-color-primary:#6c63ff;--ease-color-neutral-200:#e2e8f0;--ease-color-neutral-900:#0f172a}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,sans-serif;background:#f8fafc;color:var(--ease-color-neutral-900);padding:2rem}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:1.5rem;color:var(--ease-color-primary)}
+.demo-item{background:white;border:1px solid var(--ease-color-neutral-200);border-radius:.75rem;padding:1.5rem;text-align:center;margin-bottom:1rem}
+.demo-box{display:inline-flex;align-items:center;justify-content:center;width:80px;height:80px;background:var(--ease-color-primary);color:white;font-weight:600;font-size:.75rem;border-radius:.5rem;cursor:pointer}
+</style></head><body>
+<h1>ease-sr-only-focusable — Demo</h1>
+<div class="demo-item"><div class="demo-box .ease-sr-only-focusable">.ease-sr-only-focusable</div><p>Hover to see the effect</p></div>
+<style>
+/* ease-sr-only-focusable utility */
+.ease-sr-only-focusable{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+.ease-sr-only-focusable:focus,.ease-sr-only-focusable:focus-visible{position:static;width:auto;height:auto;padding:inherit;margin:inherit;overflow:visible;clip:auto;white-space:normal;outline:2px solid var(--ease-color-primary,#6c63ff);outline-offset:2px}
+</style>
+</body></html>

--- a/submissions/examples/ease-sr-only-focusable-tm/style.css
+++ b/submissions/examples/ease-sr-only-focusable-tm/style.css
@@ -1,0 +1,5 @@
+/* ease-sr-only-focusable — EaseMotion CSS Utility */
+
+/* ease-sr-only-focusable utility */
+.ease-sr-only-focusable{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+.ease-sr-only-focusable:focus,.ease-sr-only-focusable:focus-visible{position:static;width:auto;height:auto;padding:inherit;margin:inherit;overflow:visible;clip:auto;white-space:normal;outline:2px solid var(--ease-color-primary,#6c63ff);outline-offset:2px}


### PR DESCRIPTION
Closes #13474.

## Summary of What Has Been Done
Added the ease-sr-only-focusable utility for accessible skip navigation links. This utility provides a screen-reader-only element that becomes visible on keyboard focus, essential for WCAG 2.1 AA compliance.

## Changes Made
- Added utility classes under submissions/examples/ease-sr-only-focusable-tm/
- Includes README.md, demo.html, and style.css
- Full keyboard accessibility support with focus-visible handling

## Impact it Made
Provides a reusable, themeable CSS utility that enables accessible skip links and hidden-but-focusable labels without JavaScript.

Please assign this task to me (@tmdeveloper007).