### PR TITLE
feat: add ease-placeholder-shown styling utilities for form inputs

### DIFF
--- a/submissions/examples/placeholder-shown-utilities/README.md
+++ b/submissions/examples/placeholder-shown-utilities/README.md
@@ -1,0 +1,23 @@
+# Placeholder Shown Styling Utilities
+
+An isolated styling utility configuration leveraging the native CSS `:placeholder-shown` pseudo-class to track input layer hydration states dynamically without script dependencies.
+
+## Utility Roster API
+
+- `.ease-input-empty:placeholder-shown`: Applies style states (such as background tints or italic structural text) exclusively while the input canvas remains unpopulated.
+- `.ease-floating-input:not(:placeholder-shown) ~ .ease-floating-label`: Combines with sibling CSS combinators to transform, reposition, and scale adjacent label text strings into advanced floating structures when form values exist.
+
+## Technical Benefits
+- **Zero Script Runtime Overheads:** Bypasses DOM event listeners (`input`, `change`, `blur`), reducing main-thread overhead during dense database form hydration cycles.
+- **Flawless SSR/Pre-hydration Execution:** Operates immediately during browser paint loops, preventing visual flashing or label collisions on server-side rendered inputs containing default values.
+
+## Usage Layout Structure
+```html
+<div class="ease-floating-group">
+  
+  <input type="text" class="ease-floating-input" placeholder=" " />
+  <label class="ease-floating-label">Label Element Text</label>
+</div>
+```
+
+Closes #13476

--- a/submissions/examples/placeholder-shown-utilities/demo.html
+++ b/submissions/examples/placeholder-shown-utilities/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Placeholder Shown Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 5rem 1rem; margin: 0; font-family: sans-serif;">
+
+  <div style="max-width: 400px; margin: 0 auto;">
+    
+    <div style="margin-bottom: 2rem; text-align: center;">
+      <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800;">CSS State Floating Labels</h3>
+      <p style="margin: 0; color: #64748b; font-size: 0.9rem;">Type into the input fields to see the labels adapt natively without JavaScript.</p>
+    </div>
+
+    <div style="margin-bottom: 2rem;">
+      <label style="display: block; font-size: 0.85rem; font-weight: 700; color: #475569; margin-bottom: 0.5rem;">Conditional Utility Input</label>
+      <input type="text" class="ease-input-empty" placeholder="Empty state styling..." style="width: 100%; padding: 0.75rem; border: 1px solid #cbd5e1; border-radius: 0.375rem; box-sizing: border-box; outline: none;" />
+    </div>
+
+    <div class="ease-floating-group">
+      <input type="email" class="ease-floating-input" placeholder=" " autocomplete="off" />
+      <label class="ease-floating-label">Email Address</label>
+    </div>
+
+    <div class="ease-floating-group">
+      <input type="text" class="ease-floating-input" placeholder=" " value="Kaparthy Reddy" autocomplete="off" />
+      <label class="ease-floating-label">Full Name</label>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/placeholder-shown-utilities/style.css
+++ b/submissions/examples/placeholder-shown-utilities/style.css
@@ -1,0 +1,57 @@
+/* ============================================================
+   ease-placeholder-shown — Conditional State Input Utilities
+
+   Features interactive hooks including:
+     - Input border and background styling when placeholder is visible
+     - Floating label interactions driven by sibling combinators
+     - Smooth transitions to eliminate sudden visual layout snapping
+   ============================================================ */
+
+/* --- Core Sibling Combinator Utilities --- */
+
+/* Mutes input text configuration when unpopulated */
+.ease-input-empty:placeholder-shown {
+  border-color: #cbd5e1;
+  background-color: #f8fafc;
+  font-style: italic;
+}
+
+/* Floating Label Engine: Coordinates transformation scaling when placeholder vanishes */
+.ease-floating-group {
+  position: relative;
+  margin-bottom: 1.5rem;
+}
+
+.ease-floating-input {
+  width: 100%;
+  padding: 1rem 0.75rem 0.5rem 0.75rem;
+  font-size: 1rem;
+  border: 1px solid #cbd5e1;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  outline: none;
+  background: transparent;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.ease-floating-input:focus {
+  border-color: #2563eb;
+}
+
+.ease-floating-label {
+  position: absolute;
+  left: 0.75rem;
+  top: 0.75rem;
+  color: #94a3b8;
+  font-size: 1rem;
+  pointer-events: none;
+  transition: transform 0.2s ease, font-size 0.2s ease, color 0.2s ease;
+  transform-origin: left top;
+}
+
+/* When the placeholder is NOT shown (user typed text) OR the input is focused, float the label up */
+.ease-floating-input:focus ~ .ease-floating-label,
+.ease-floating-input:not(:placeholder-shown) ~ .ease-floating-label {
+  transform: translateY(-0.5rem) scale(0.75);
+  color: #2563eb;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the form interaction style package for `:placeholder-shown` operations. Delivers a clean suite of layout utility states that monitor input value footprints natively, enabling pure-CSS floating labels and unpopulated container highlights without relying on input loop event handler scripts.

Closes #13476

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- Conditional fallback token structures (`.ease-input-empty:placeholder-shown`) that isolate empty template states natively.
- Sibling tracking patterns (`.ease-floating-input`) that cleanly scale, shift, and color contextual label tags as content hydration occurs.
- Highly performant macro-interactions that compute position rules natively inside the browser paint pipeline, fully bypassing JS execution thread layers.

**How does a developer use it?**
```html
<div class="ease-floating-group">
  <input class="ease-floating-input" placeholder=" " />
  <label class="ease-floating-label">First Name</label>
</div>