### PR TITLE
feat: add focus-visible ring to outline button variant

### DIFF
--- a/submissions/examples/outline-button-focus-ring/README.md
+++ b/submissions/examples/outline-button-focus-ring/README.md
@@ -1,0 +1,18 @@
+# Outline Button Focus-Visible Ring Update
+
+An accessibility upgrade pack targeting the `.ease-btn-outline` component class. This update addresses critical WCAG success criteria regarding focus visibility by incorporating standard `:focus-visible` ring tracking profiles.
+
+## Functional Controls
+- **Isolated Interaction Vectors:** Uses native `:focus-visible` pseudo-selectors to display focus outlines exclusively during keyboard interaction streams, keeping mouse-driven focus indicators minimal.
+- **Dual-Layer Shadow Rings:** Composes focus rings via complex layered `box-shadow` values (`0 0 0 2px #ffffff, 0 0 0 4px #2563eb`). This creates an explicit high-contrast white buffer gap to ensure the blue ring remains highly visible across varying container background tones.
+- **WCAG 2.2 AA Compliance:** Satisfies strict target focus visibility requirements, improving readability parameters for assistive hardware interfaces.
+
+## Usage Layout Structure
+```html
+
+<button class="ease-btn ease-btn-outline">
+  Accessible Outline Button
+</button>
+```
+
+Closes #13249

--- a/submissions/examples/outline-button-focus-ring/demo.html
+++ b/submissions/examples/outline-button-focus-ring/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Outline Button Focus Ring — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 5rem 1rem; margin: 0; font-family: sans-serif;">
+
+  <div style="max-width: 500px; margin: 0 auto; background: #ffffff; border: 1px solid #e2e8f0; border-radius: 0.75rem; padding: 2.5rem; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);">
+    
+    <div style="margin-bottom: 2rem;">
+      <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.25rem;">Keyboard Focus Indicators</h3>
+      <p style="margin: 0; color: #64748b; font-size: 0.9rem; line-height: 1.5;">
+        Test the behavior: clicking the button with a mouse keeps the layout clean. Using the <strong>[TAB]</strong> key on your keyboard safely triggers a high-contrast dual ring.
+      </p>
+    </div>
+
+    <div style="display: flex; gap: 1rem; align-items: center;">
+      <button class="ease-btn ease-btn-outline">
+        Focus Target One
+      </button>
+
+      <button class="ease-btn ease-btn-outline">
+        Focus Target Two
+      </button>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/outline-button-focus-ring/style.css
+++ b/submissions/examples/outline-button-focus-ring/style.css
@@ -1,0 +1,54 @@
+/* ============================================================
+   ease-btn-outline (Focus Update) — High-Contrast Focus Ring Implementation
+
+   Features interaction tokens including:
+     - Standard structural dimension defaults for outline components
+     - Native :focus-visible hook isolating keyboard focus states
+     - Dual-ring composition utilizing box-shadow layers for clarity
+   ============================================================ */
+
+/* --- Base Structural Component Reset --- */
+.ease-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--ease-font-sans, sans-serif);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25rem;
+  padding: 0.5rem 1rem;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  border: 1px solid transparent;
+  cursor: pointer;
+  user-select: none;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+/* --- Outline Variant Core Token --- */
+.ease-btn-outline {
+  background-color: transparent;
+  border-color: #cbd5e1; /* Slate-300 */
+  color: #334155;        /* Slate-700 */
+}
+
+.ease-btn-outline:hover {
+  background-color: #f8fafc; /* Slate-50 */
+  border-color: #94a3b8;     /* Slate-400 */
+  color: #0f172a;            /* Slate-900 */
+}
+
+/* --- THE FEATURE: Native Keyboard Focus Ring Overrides --- */
+
+/* Suppress default browser outline rings across all focus actions */
+.ease-btn-outline:focus,
+.ease-btn-outline:focus-visible {
+  outline: none;
+}
+
+/* Apply dual-ring composition explicitly on keyboard-driven focus rings */
+.ease-btn-outline:focus-visible {
+  /* Inner Ring: Creates a crisp 2px white gap separating the button border from the outer ring */
+  /* Outer Ring: Generates a highly visible 2px thick primary colored indicator (Blue-600) */
+  box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #2563eb;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the focus interaction accessibility update for `.ease-btn-outline`. Delivers a highly structured, native `:focus-visible` implementation configured via dual-layer layered `box-shadow` structures. This implementation safeguards keyboard navigation outlines while keeping normal pointer clicks minimal and clean.

Closes #13249

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- Dedicated keyboard-first accessibility indicators via `.ease-btn-outline:focus-visible`.
- Safe multi-tier shadow properties generating an absolute white separation gap between button bounding lines and high-contrast blue tracking states.
- Global cleanup rules disabling default, unstyled browser outline vectors to ensure unified across-browser layout continuity.

**How does a developer use it?**
```html
<button class="ease-btn ease-btn-outline">Tab to see focus ring</button>