### PR TITLE
feat: add CSS sticky section headers example

### DIFF
--- a/submissions/examples/sticky-section-headers/README.md
+++ b/submissions/examples/sticky-section-headers/README.md
@@ -1,0 +1,43 @@
+# CSS Sticky Section Headers
+
+## What does it do?
+Demonstrates `position: sticky` for section headers that stick
+to the top while scrolling through grouped content — like a
+contacts list or settings page.
+
+## How is it used?
+```html
+<div class="ease-sticky-section">
+  <div class="ease-sticky-header ease-sticky-header-blue">A</div>
+
+  <div class="ease-sticky-item">
+    <div class="ease-sticky-avatar">👤</div>
+    <div>
+      <p class="ease-sticky-item-title">Alice Johnson</p>
+      <p class="ease-sticky-item-sub">alice@example.com</p>
+    </div>
+    <span class="ease-sticky-item-meta">2m ago</span>
+  </div>
+</div>
+```
+
+## Classes
+- `.ease-sticky-section` — section group wrapper
+- `.ease-sticky-header` — sticky header bar
+- `.ease-sticky-header-blue/purple/green/orange/red` — color variants
+- `.ease-sticky-item` — list row
+- `.ease-sticky-avatar` — circular avatar
+- `.ease-sticky-item-title` — item heading
+- `.ease-sticky-item-sub` — item subtitle
+- `.ease-sticky-item-meta` — right-aligned metadata
+
+## Features
+- Pure CSS `position: sticky`
+- Shadow appears when header is stuck (via IntersectionObserver)
+- 5 accent color variants
+- Hover highlight on items
+- Respects prefers-reduced-motion
+- Minimal vanilla JS for stuck detection only
+
+## Preview
+Open `demo.html` directly in browser and scroll down.

--- a/submissions/examples/sticky-section-headers/demo.html
+++ b/submissions/examples/sticky-section-headers/demo.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sticky Section Headers — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0f172a;
+      color: #e2e8f0;
+      font-family: 'Segoe UI', sans-serif;
+      min-height: 100vh;
+    }
+    .page-header {
+      padding: 2rem 1rem 1rem;
+      max-width: 680px;
+      margin: 0 auto;
+    }
+    .page-header h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .page-header p  { color: #64748b; font-size: 0.85rem; }
+    .card {
+      background: #1a2744;
+      border: 1px solid #1e293b;
+      border-radius: 12px;
+      overflow: hidden;
+      margin-bottom: 1rem;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="page-header">
+    <h1>Contacts</h1>
+    <p>Scroll down to see sticky section headers in action</p>
+  </div>
+
+  <div class="ease-sticky-page">
+
+    <div class="card">
+      <!-- Section A -->
+      <div class="ease-sticky-section">
+        <div class="ease-sticky-header ease-sticky-header-blue" data-sticky>A</div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#3b82f6">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Alice Johnson</p>
+            <p class="ease-sticky-item-sub">alice@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">2m ago</span>
+        </div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#3b82f6">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Andrew Smith</p>
+            <p class="ease-sticky-item-sub">andrew@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">1h ago</span>
+        </div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#3b82f6">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Amy Chen</p>
+            <p class="ease-sticky-item-sub">amy@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">3h ago</span>
+        </div>
+      </div>
+
+      <!-- Section B -->
+      <div class="ease-sticky-section">
+        <div class="ease-sticky-header ease-sticky-header-purple" data-sticky>B</div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#8b5cf6">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Bob Williams</p>
+            <p class="ease-sticky-item-sub">bob@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">Yesterday</span>
+        </div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#8b5cf6">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Brenda Lee</p>
+            <p class="ease-sticky-item-sub">brenda@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">2 days ago</span>
+        </div>
+      </div>
+
+      <!-- Section C -->
+      <div class="ease-sticky-section">
+        <div class="ease-sticky-header ease-sticky-header-green" data-sticky>C</div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#10b981">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Carlos Rivera</p>
+            <p class="ease-sticky-item-sub">carlos@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">3 days ago</span>
+        </div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#10b981">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Claire Dubois</p>
+            <p class="ease-sticky-item-sub">claire@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">1 week ago</span>
+        </div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#10b981">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Chris Park</p>
+            <p class="ease-sticky-item-sub">chris@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">1 week ago</span>
+        </div>
+      </div>
+
+      <!-- Section D -->
+      <div class="ease-sticky-section">
+        <div class="ease-sticky-header ease-sticky-header-orange" data-sticky>D</div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#f59e0b">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Diana Prince</p>
+            <p class="ease-sticky-item-sub">diana@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">2 weeks ago</span>
+        </div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#f59e0b">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">David Kim</p>
+            <p class="ease-sticky-item-sub">david@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">2 weeks ago</span>
+        </div>
+      </div>
+
+      <!-- Section E -->
+      <div class="ease-sticky-section">
+        <div class="ease-sticky-header ease-sticky-header-red" data-sticky>E</div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#ef4444">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Emma Watson</p>
+            <p class="ease-sticky-item-sub">emma@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">1 month ago</span>
+        </div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#ef4444">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Ethan Brown</p>
+            <p class="ease-sticky-item-sub">ethan@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">1 month ago</span>
+        </div>
+        <div class="ease-sticky-item">
+          <div class="ease-sticky-avatar" style="background:#ef4444">👤</div>
+          <div>
+            <p class="ease-sticky-item-title">Eva Martinez</p>
+            <p class="ease-sticky-item-sub">eva@example.com</p>
+          </div>
+          <span class="ease-sticky-item-meta">1 month ago</span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <script>
+    // Add shadow when header is stuck
+    const headers = document.querySelectorAll('[data-sticky]');
+    const observer = new IntersectionObserver(
+      entries => entries.forEach(e => {
+        e.target.classList.toggle('is-stuck', e.intersectionRatio < 1);
+      }),
+      { threshold: [1], rootMargin: '-1px 0px 0px 0px' }
+    );
+    headers.forEach(h => observer.observe(h));
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/sticky-section-headers/style.css
+++ b/submissions/examples/sticky-section-headers/style.css
@@ -1,0 +1,105 @@
+/* ============================================================
+   EaseMotion CSS — CSS Sticky Section Headers
+   ============================================================ */
+
+/* Page layout */
+.ease-sticky-page {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+/* Section group */
+.ease-sticky-section {
+  margin-bottom: 2rem;
+}
+
+/* Sticky header */
+.ease-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding: 0.625rem 1rem;
+  background: var(--ease-sticky-bg, #1e293b);
+  color: var(--ease-sticky-color, #94a3b8);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-left: 3px solid var(--ease-sticky-accent, #6366f1);
+  backdrop-filter: blur(8px);
+  transition: box-shadow 0.2s ease;
+}
+
+/* Shadow when stuck */
+.ease-sticky-header.is-stuck {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* Section items */
+.ease-sticky-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  border-bottom: 1px solid #1e293b;
+  transition: background 0.15s ease;
+}
+
+.ease-sticky-item:hover {
+  background: rgba(99, 102, 241, 0.05);
+}
+
+.ease-sticky-item:last-child {
+  border-bottom: none;
+}
+
+/* Item avatar */
+.ease-sticky-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  flex-shrink: 0;
+  background: var(--ease-sticky-accent, #6366f1);
+  opacity: 0.8;
+}
+
+/* Item content */
+.ease-sticky-item-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #f1f5f9;
+  margin-bottom: 2px;
+}
+
+.ease-sticky-item-sub {
+  font-size: 0.78rem;
+  color: #64748b;
+}
+
+/* Item meta */
+.ease-sticky-item-meta {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: #475569;
+  white-space: nowrap;
+}
+
+/* Color variants for section headers */
+.ease-sticky-header-blue   { --ease-sticky-accent: #3b82f6; }
+.ease-sticky-header-purple { --ease-sticky-accent: #8b5cf6; }
+.ease-sticky-header-green  { --ease-sticky-accent: #10b981; }
+.ease-sticky-header-orange { --ease-sticky-accent: #f59e0b; }
+.ease-sticky-header-red    { --ease-sticky-accent: #ef4444; }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-sticky-header,
+  .ease-sticky-item {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #8796

## Pull Request Description
Adds a CSS sticky section headers example using position: sticky,
demonstrated with a contacts list layout with 5 color variants.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] Files inside `submissions/examples/sticky-section-headers/`
- [x] `demo.html` works by opening directly in browser
- [x] `style.css` contains all styles
- [x] `README.md` documents usage
- [x] No edits to `core/` or `components/`
- [x] Respects prefers-reduced-motion
- [x] Pure CSS + minimal vanilla JS