### PR TITLE
fix: add missing box-shadow focus style to warning input state

### DIFF
--- a/submissions/examples/warning-input-focus-shadow/README.md
+++ b/submissions/examples/warning-input-focus-shadow/README.md
@@ -1,0 +1,16 @@
+# Warning Input Focus Glow Fix
+
+An interaction repair patch targeting the `.ease-input-warning` validation state token. This fix ensures that fields flagged with system alerts generate a compliant visual indicator upon user focus.
+
+## Bug Resolution Analysis
+
+- **The Problem:** The warning utility override completely locked the input field border color without configuring a corresponding `:focus` ruleset. When an end-user selected a problematic input, the component lacked visual feedback, violating strict interactive layout orientation principles.
+- **The Solution:** Appends an isolated `.ease-input-warning:focus` declaration that steps up border-shading depths to Amber-600 while distributing a modern translucent soft ring via an optimized `box-shadow` mask (`0 0 0 4px rgba(217, 119, 6, 0.2)`).
+
+## Usage Layout Structure
+```html
+
+<input type="text" class="ease-input ease-input-warning" />
+```
+
+Closes #13252

--- a/submissions/examples/warning-input-focus-shadow/demo.html
+++ b/submissions/examples/warning-input-focus-shadow/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Warning Input Focus Fix — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 5rem 1rem; margin: 0; font-family: sans-serif;">
+
+  <div style="max-width: 440px; margin: 0 auto; background: #ffffff; border: 1px solid #e2e8f0; border-radius: 0.75rem; padding: 2.5rem; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);">
+    
+    <div style="margin-bottom: 2rem;">
+      <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.25rem;">Form Validation Interaction</h3>
+      <p style="margin: 0; color: #64748b; font-size: 0.9rem; line-height: 1.4;">
+        Click or tab directly into the caution input layout below to preview the corrected, high-contrast focus ring.
+      </p>
+    </div>
+
+    <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+      <label style="font-size: 0.85rem; font-weight: 700; color: #b45309;">Password Vulnerability Check</label>
+      
+      <input type="text" class="ease-input ease-input-warning" value="weakpassword123" />
+      
+      <span style="font-size: 0.75rem; color: #d97706; font-weight: 500;">
+        ⚠️ This string appears in public credential dumps.
+      </span>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/warning-input-focus-shadow/style.css
+++ b/submissions/examples/warning-input-focus-shadow/style.css
@@ -1,0 +1,44 @@
+/* ============================================================
+   ease-input-warning (Focus Fix) — High-Contrast Glow Ring
+
+   Features interactive repairs including:
+     - Warning state input field border default token mappings
+     - Native :focus state overrides binding explicit box-shadow layers
+     - Micro-timed border transitions preventing sudden frame jumps
+   ============================================================ */
+
+/* --- Base Structural Input Core Preset Dependencies --- */
+.ease-input {
+  width: 100%;
+  padding: 0.625rem 0.875rem;
+  font-family: var(--ease-font-sans, sans-serif);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #0f172a;        /* Slate-900 */
+  background-color: #ffffff;
+  border: 1px solid #cbd5e1; /* Slate-300 */
+  border-radius: var(--ease-radius-md, 0.375rem);
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+/* Base focus state for normal fields */
+.ease-input:focus {
+  border-color: #2563eb; /* Blue-600 */
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+/* --- THE FIX: Warning Input Variant State Upgrades --- */
+.ease-input-warning {
+  border-color: #f59e0b !important; /* Amber-500 default state border override */
+  background-color: #fffdfa;        /* Soft amber tint to signify localized caution */
+}
+
+/* Restores missing focus shadow explicitly upon input field targeting loop */
+.ease-input-warning:focus {
+  border-color: #d97706 !important; /* Darker Amber-600 border for sharp legibility */
+  
+  /* Composes a soft high-contrast glow using an alpha-channel translucent Amber hue */
+  box-shadow: 0 0 0 4px rgba(217, 119, 6, 0.2) !important;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves an interactive state bug under issue #13252 affecting `.ease-input-warning`. Delivers a clean `:focus` state modifier that introduces a proportional, high-contrast translucent amber halo ring, restoring necessary visual confirmation paths during input hydration validation loops.

Closes #13252

---

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this repair add?**
- Dedicated interactive target handling via `.ease-input-warning:focus`.
- Standard alpha-channel glowing variables (`rgba(217, 119, 6, 0.2)`) scaling layout consistency across established component validation models.
- Deepened line bounds ensuring form readability matches accessible AA usability thresholds cleanly under active data manipulation conditions.

**How does a developer use it?**
```html
<input type="text" class="ease-input ease-input-warning" />