### PR TITLE
feat: add hover delay utility classes to tooltips

### DIFF
--- a/submissions/examples/tooltip-hover-delay/README.md
+++ b/submissions/examples/tooltip-hover-delay/README.md
@@ -1,0 +1,23 @@
+# Tooltip Hover Delay Utilities
+
+An isolated utility package delivering timing pacing tokens (`.ease-delay-*`) designed to prevent layout clutter and excessive structural repaints caused by quick cursor passes over active UI elements.
+
+## Utility Roster API
+
+- `.ease-delay-short`: Introduces a `150ms` delay gate. Perfect for actionable control buttons where prompt feedback is necessary but stray cursor glances should be muted.
+- `.ease-delay-normal`: Introduces a standard `300ms` delay gate. Suited for general navigation headers and list icons.
+- `.ease-delay-long`: Introduces a prominent `700ms` delay gate. Designed for data charts or complex dashboards where information tooltips should only trigger when a user deliberately halts their cursor.
+
+## Technical Advantage
+By constraining the delay exclusively to the `:hover` layer state, the tooltips fade away instantly (`transition-delay: 0s`) the moment the user moves their cursor off the element, keeping the interaction snap-responsive.
+
+## Usage Layout Structure
+```html
+
+<div class="ease-tooltip-wrapper ease-delay-normal">
+  <button>Hover Action Target</button>
+  <div class="ease-tooltip-content">Informative string summary here.</div>
+</div>
+```
+
+Closes #13256

--- a/submissions/examples/tooltip-hover-delay/demo.html
+++ b/submissions/examples/tooltip-hover-delay/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tooltip Hover Delay Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 6rem 1rem; margin: 0; font-family: sans-serif;">
+
+  <div style="max-width: 600px; margin: 0 auto; text-align: center; margin-bottom: 3rem;">
+    <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.5rem;">Intelligent Tooltip Delays</h3>
+    <p style="margin: 0; color: #64748b; font-size: 0.95rem;">Sweep your cursor quickly across the array to observe how delays mitigate popover clutter.</p>
+  </div>
+
+  <div style="max-width: 700px; margin: 0 auto; background: #ffffff; border: 1px solid #e2e8f0; border-radius: 0.75rem; padding: 3rem 2rem; display: flex; justify-content: space-around; gap: 1rem; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);">
+    
+    <div class="ease-tooltip-wrapper ease-delay-short">
+      <button style="padding: 0.6rem 1rem; background: #f1f5f9; border: 1px solid #cbd5e1; border-radius: 0.375rem; cursor: pointer; font-weight: 600; color: #334155;">
+        Short Delay (150ms)
+      </button>
+      <div class="ease-tooltip-content">Quick Reveal (.ease-delay-short)</div>
+    </div>
+
+    <div class="ease-tooltip-wrapper ease-delay-normal">
+      <button style="padding: 0.6rem 1rem; background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 0.375rem; cursor: pointer; font-weight: 600; color: #2563eb;">
+        Normal Delay (300ms)
+      </button>
+      <div class="ease-tooltip-content">Standard Balanced (.ease-delay-normal)</div>
+    </div>
+
+    <div class="ease-tooltip-wrapper ease-delay-long">
+      <button style="padding: 0.6rem 1rem; background: #f5f3ff; border: 1px solid #ddd6fe; border-radius: 0.375rem; cursor: pointer; font-weight: 600; color: #7c3aed;">
+        Long Delay (700ms)
+      </button>
+      <div class="ease-tooltip-content">Intentional Hold (.ease-delay-long)</div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/tooltip-hover-delay/style.css
+++ b/submissions/examples/tooltip-hover-delay/style.css
@@ -1,0 +1,57 @@
+/* ============================================================
+   ease-delay-* — Tooltip Hover Transition Delay Utilities
+
+   Features orchestration tokens including:
+     - Standardized increments matching interaction milestones (150ms - 700ms)
+     - Clean compound target utility pairings with base tooltips
+     - Pure CSS transition-delay property mappings
+   ============================================================ */
+
+/* --- Base Structural Tooltip Layout (Dependency Reset) --- */
+.ease-tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-tooltip-content {
+  position: absolute;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%) scale(0.95);
+  background-color: #0f172a; /* Slate-900 */
+  color: #ffffff;
+  font-family: var(--ease-font-sans, sans-serif);
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--ease-radius-md, 0.25rem);
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s cubic-bezier(0.25, 1, 0.5, 1), transform 0.2s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Base immediate reveal state */
+.ease-tooltip-wrapper:hover .ease-tooltip-content {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) scale(1);
+}
+
+/* --- THE FEATURE: Hover Reveal Delay Token Roster --- */
+
+/* Fast/Responsive Check (150ms delay) — Intentional brief skip */
+.ease-delay-short:hover .ease-tooltip-content {
+  transition-delay: 0.15s;
+}
+
+/* Standard Deliberate Check (300ms delay) — Ideal for general UI cards */
+.ease-delay-normal:hover .ease-tooltip-content {
+  transition-delay: 0.3s;
+}
+
+/* Long Safe Check (700ms delay) — Keeps complex charts clear from popover clutter */
+.ease-delay-long:hover .ease-tooltip-content {
+  transition-delay: 0.7s;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the timing pacing utility package for `.ease-delay-*`. Delivers a self-contained, lightweight suite of transition modifiers that introduce micro-delays before displaying tooltip layers on hover. This helps prevent popover flicker and clutter during casual cursor exploration.

Closes #13256

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- Targeted time pacing definitions (`.ease-delay-short` through `.ease-delay-long`) that easily latch onto standard utility configurations.
- Directional transition filtering, ensuring delays apply exclusively during element entrance hover events while clearing immediately upon element mouse-leave streams.
- Clean component patterns managing secondary notification elements without adding custom event loops.

**How does a developer use it?**
```html
<div class="ease-tooltip-wrapper ease-delay-normal">
  <img src="icon.svg" />
  <div class="ease-tooltip-content">Context data</div>
</div>