### PR TITLE
feat: add small and large size variants to badges

### DIFF
--- a/submissions/examples/badge-size-variants/README.md
+++ b/submissions/examples/badge-size-variants/README.md
@@ -1,0 +1,23 @@
+# Badge Size Utility Variants
+
+An isolated sizing modification package expanding the core `.ease-badge` token framework. This update establishes uniform padding scales and proportional type scaling definitions (`.ease-badge-sm` and `.ease-badge-lg`) to suit high-density tables and layout blocks alike.
+
+## Utility Roster API
+
+- `.ease-badge-sm`: Triggers a tight `11px` micro-font layout layer with compressed padding geometry. Engineered exclusively for inline table rows, grid filters, or nested numbers inside card titles.
+- `Default (Base)`: Runs standard `12px` typography. Represents the baseline option for global categorization and standard property labels.
+- `.ease-badge-lg`: Triggers an expanded `14px` type frame bound by deep padding boundaries. Optimized for primary title flags, page header accents, and loud status indicators.
+
+## Usage Layout Structure
+```html
+
+<span class="ease-badge ease-badge-sm">
+  Table Meta
+</span>
+
+<span class="ease-badge ease-badge-lg">
+  Hero Flag
+</span>
+```
+
+Closes #13254

--- a/submissions/examples/badge-size-variants/demo.html
+++ b/submissions/examples/badge-size-variants/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Badge Size Variants — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 5rem 1rem; margin: 0;">
+
+  <div class="ease-badge-canvas-box">
+    
+    <div style="margin-bottom: 2rem;">
+      <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.25rem;">Component Scale Framework</h3>
+      <p style="margin: 0; color: #64748b; font-size: 0.9rem;">Observe how padding ratios and typography track cleanly across geometric scales.</p>
+    </div>
+
+    <div class="ease-badge-scale-stack">
+      
+      <div class="ease-badge-demo-row">
+        <span class="ease-badge-demo-label">.ease-badge-sm</span>
+        <span class="ease-badge ease-badge-sm" style="background-color: #eff6ff; color: #2563eb;">New Update</span>
+        <span class="ease-badge ease-badge-sm">Compact</span>
+      </div>
+
+      <div class="ease-badge-demo-row">
+        <span class="ease-badge-demo-label">Default (Base)</span>
+        <span class="ease-badge" style="background-color: #f0fdf4; color: #16a34a;">Published</span>
+        <span class="ease-badge">Standard</span>
+      </div>
+
+      <div class="ease-badge-demo-row">
+        <span class="ease-badge-demo-label">.ease-badge-lg</span>
+        <span class="ease-badge ease-badge-lg" style="background-color: #fff1f2; color: #e11d48;">Critical Risk</span>
+        <span class="ease-badge ease-badge-lg">Prominent</span>
+      </div>
+
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/badge-size-variants/style.css
+++ b/submissions/examples/badge-size-variants/style.css
@@ -1,0 +1,74 @@
+/* ============================================================
+   ease-badge-* (Size Variants) — Typographic Dimension Scale
+
+   Features structural geometry overrides including:
+     - Compact micro-padding layers for table metadata density
+     - Heightened scale balances for primary section indexing
+     - Proportional font-size tracking keeping text ratios clean
+   ============================================================ */
+
+/* --- Base Structural Component Dependency Reset --- */
+.ease-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: var(--ease-font-sans, sans-serif);
+  font-size: 0.75rem; /* Default size benchmark (12px) */
+  font-weight: 600;
+  line-height: 1rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  background-color: #e2e8f0; /* Slate-200 */
+  color: #334155;            /* Slate-700 */
+  white-space: nowrap;
+}
+
+/* --- THE FEATURE: Compact Size Token (Small) --- */
+.ease-badge-sm {
+  font-size: 0.6875rem; /* 11px micro-type */
+  line-height: 0.875rem;
+  padding: 0.0625rem 0.375rem;
+}
+
+/* --- THE FEATURE: Prominent Size Token (Large) --- */
+.ease-badge-lg {
+  font-size: 0.875rem; /* 14px body-equivalent scale */
+  line-height: 1.25rem;
+  padding: 0.25rem 0.75rem;
+}
+
+
+/* ============================================================
+   PRESENTATION WORKSPACE MODULE (Demo Specific)
+   ============================================================ */
+
+.ease-badge-canvas-box {
+  max-width: 550px;
+  margin: 0 auto;
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 2.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
+  font-family: var(--ease-font-sans, sans-serif);
+}
+
+.ease-badge-scale-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.ease-badge-demo-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.ease-badge-demo-label {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.8rem;
+  color: #94a3b8;
+  width: 140px;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the size optimization suite for badge components under issue #13254. Delivers targeted modifier classes (`.ease-badge-sm` and `.ease-badge-lg`) that scale type layers and geometric padding cleanly, supporting high-density item displays as well as loud hero heading accents without affecting outer layouts.

Closes #13254

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- Compact status tokens (`.ease-badge-sm`) implementing sharp `11px` type configurations optimized for data grids.
- Prominent heading variants (`.ease-badge-lg`) optimizing baseline tracking heights up to `14px` metrics for callout visibility.
- Fluid padding scaling matrices preserving visual center points when elements are integrated within active navigational tables.

**How does a developer use it?**
```html
<span class="ease-badge ease-badge-sm">Mini Tag</span>