### PR TITLE
fix: add focus-visible ring to interactive card elements

### DIFF
--- a/submissions/examples/card-focus-visible-ring/README.md
+++ b/submissions/examples/card-focus-visible-ring/README.md
@@ -1,0 +1,19 @@
+# Interactive Card Focus-Visible Fix
+
+An interaction repair patch targeting the `.ease-card-interactive` component structure block. This fix implements native accessibility bounds ensuring clickable multi-element containers show clear focus indications under alternative inputs.
+
+## Bug Resolution Analysis
+
+- **The Problem:** When cards function as keyboard-interactive anchors or button surfaces, they require clear focus paths to orient users. Missing focus properties leave keyboard trackers unable to perceive target items visually, failing WCAG 2.2 focus presentation guidelines.
+- **The Solution:** Implements explicit native `:focus-visible` parameters configured through dual-layer layered `box-shadow` styles (`0 0 0 2px #ffffff, 0 0 0 4px #2563eb`). This isolates keyboard tracking loops without generating visual clutter for standard pointer clicks.
+
+## Usage Layout Structure
+```html
+
+<a class="ease-card-interactive" href="#">
+  <h3>Clickable Dashboard Title</h3>
+  <p>Description text rows inside container.</p>
+</a>
+```
+
+Closes #13251

--- a/submissions/examples/card-focus-visible-ring/demo.html
+++ b/submissions/examples/card-focus-visible-ring/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Interactive Card Focus Rings — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 5rem 1rem; margin: 0;">
+
+  <div style="max-width: 800px; margin: 0 auto 3rem auto; text-align: center; font-family: sans-serif;">
+    <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.5rem;">Interactive Focus Containers</h3>
+    <p style="margin: 0; color: #64748b; font-size: 0.95rem;">
+      Clicking the cards with a mouse preserves clean visual state lines. Use your keyboard <strong>[TAB]</strong> tracking key to test the prominent focus rings.
+    </p>
+  </div>
+
+  <div class="ease-card-matrix-grid">
+    
+    <a class="ease-card-interactive" href="#documentation">
+      <h4 class="ease-card-heading">API Documentation</h4>
+      <p class="ease-card-body-text">Explore structured schemas, code snippet guidelines, and deployment hooks mapping modular platform systems.</p>
+    </a>
+
+    <a class="ease-card-interactive" href="#components">
+      <h4 class="ease-card-heading">Design Tokens</h4>
+      <p class="ease-card-body-text">Review systematic layout values, responsive variables, typography bounds, and color scales.</p>
+    </a>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/card-focus-visible-ring/style.css
+++ b/submissions/examples/card-focus-visible-ring/style.css
@@ -1,0 +1,74 @@
+/* ============================================================
+   ease-card-interactive (Focus Fix) — Accessible Focus Rings
+
+   Features interactive repairs including:
+     - Resetting native browser outline rings across focused elements
+     - Native :focus-visible pseudo-state filtering to prevent click glow shifts
+     - Dual-layer box-shadow rings ensuring contrast across background planes
+   ============================================================ */
+
+/* --- Base Structural Card Component (Dependency Reset) --- */
+.ease-card-interactive {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid #e2e8f0; /* Slate-200 */
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 1.5rem;
+  cursor: pointer;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Subtle elevation lift on standard cursor hover pointer */
+.ease-card-interactive:hover {
+  transform: translateY(-2px);
+  border-color: #cbd5e1; /* Slate-300 */
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -4px rgba(0, 0, 0, 0.05);
+}
+
+/* --- THE FIX: High-Contrast Keyboard Focus Ring Overrides --- */
+
+/* Mute default browser focus behavior across standard pointer interactions */
+.ease-card-interactive:focus,
+.ease-card-interactive:focus-visible {
+  outline: none;
+}
+
+/* Trigger explicit dual-layer halo rings strictly on keyboard tab indexing hooks */
+.ease-card-interactive:focus-visible {
+  /* Inner Layer: Generates a crisp 2px solid white margin to isolate the card border edge */
+  /* Outer Layer: Projects a prominent 2px thick vivid primary focus ring (Blue-600) */
+  box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #2563eb;
+  border-color: #2563eb;
+}
+
+
+/* ============================================================
+   PRESENTATION WORKSPACE DECK (Demo Specific)
+   ============================================================ */
+
+.ease-card-matrix-grid {
+  max-width: 800px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  padding: 1rem;
+  font-family: var(--ease-font-sans, sans-serif);
+}
+
+.ease-card-heading {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.ease-card-body-text {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #64748b;
+  line-height: 1.5;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves an accessibility focus indicator bug under issue #13251 affecting interactive block cards (`.ease-card-interactive`). Adds a native, highly structured `:focus-visible` framework using layered dual shadow properties to guarantee high-contrast indicator visibility for keyboard navigation users.

Closes #13251

---

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this repair add?**
- Targeted keyboard-focus visibility states via `.ease-card-interactive:focus-visible`.
- Protective double-ring configurations preventing focus indicators from washing out against complex background fields or imagery content templates.
- Unified behavior that disables standard browser focus rings while providing a cross-browser styling baseline for alternative device interactions.

**How does a developer use it?**
```html
<a class="ease-card-interactive" href="#target">Card Content</a>
