### PR TITLE
feat: add dark background card variant

### DIFF
--- a/submissions/examples/dark-card-variant/README.md
+++ b/submissions/examples/dark-card-variant/README.md
@@ -1,0 +1,19 @@
+# Dark Background Card Variant
+
+An isolated component layout submission introducing the `.ease-card-dark` design option preset. This variant provides container panels styled with deep background tones, perfectly optimized for dark mode interfaces, high-visibility dashboard grids, and prominent layout accents.
+
+## Functional Controls
+- **High-Contrast Surface Colors:** Applies a sharp Slate-900 background (`#0f172a`) paired with automated internal typography color rules to keep layouts readable.
+- **Optional Interactive Elevations:** Includes an operational utility class hook (`.is-interactive`) enabling fluid translation animation scaling and surface lift transitions upon user hover actions.
+- **Compliant Dark Focus Halos:** Implements targeted `:focus-visible` parameters configuring a specialized high-contrast Amber ring layer (`0 0 0 2px #0f172a, 0 0 0 4px #f59e0b`) that stays visible over dark elements.
+
+## Usage Layout Structure
+```html
+
+<div class="ease-card ease-card-dark">
+  <h4>Static Structural Title</h4>
+  <p>Standard text paragraph summary.</p>
+</div>
+```
+
+Closes #13255

--- a/submissions/examples/dark-card-variant/demo.html
+++ b/submissions/examples/dark-card-variant/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dark Card Variant — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 5rem 1rem; margin: 0;">
+
+  <div style="max-width: 800px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 2rem;">
+    
+    <div class="ease-card">
+      <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-size: 1.15rem; font-weight: 700;">Light Mode Default</h3>
+      <p style="margin: 0; font-size: 0.9rem; line-height: 1.5; color: #475569;">
+        Standard system layout backing card deploying light background surfaces and standard low-contrast borders.
+      </p>
+    </div>
+
+    <a class="ease-card ease-card-dark is-interactive" href="#featured-track">
+      <h3 style="margin: 0 0 0.5rem 0; font-size: 1.15rem; font-weight: 700;">Featured Dark Node</h3>
+      <p style="margin: 0; font-size: 0.9rem; line-height: 1.5;">
+        High-contrast dark card option utilizing deep backgrounds. Tab into this element via keyboard to check the custom amber focus halo.
+      </p>
+    </a>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/dark-card-variant/style.css
+++ b/submissions/examples/dark-card-variant/style.css
@@ -1,0 +1,63 @@
+/* ============================================================
+   ease-card-dark — Dark Mode Surface Component Variant
+
+   Features structural design tokens including:
+     - Deep slate backing surface (#0f172a) pairing with high-contrast text
+     - Muted, low-intensity interior border grids separating contents
+     - High-contrast focus indicator rings accommodating keyboard paths
+   ============================================================ */
+
+/* --- Base Structural Component Dependency Reset --- */
+.ease-card {
+  display: block;
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 1.5rem;
+  font-family: var(--ease-font-sans, sans-serif);
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+}
+
+/* --- THE FEATURE: Dark Surface Variant Token --- */
+.ease-card-dark {
+  background-color: #0f172a !important; /* Slate-900 */
+  border-color: #1e293b !important;     /* Slate-800 */
+  color: #f8fafc;                        /* Slate-50 Text */
+}
+
+/* Internal typography contextual matching overrides */
+.ease-card-dark h1, 
+.ease-card-dark h2, 
+.ease-card-dark h3, 
+.ease-card-dark h4 {
+  color: #ffffff !important;
+}
+
+.ease-card-dark p {
+  color: #94a3b8 !important;            /* Slate-400 structural copy */
+}
+
+/* --- Interactive Hover Extension Support --- */
+.ease-card-dark.is-interactive {
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-card-dark.is-interactive:hover {
+  transform: translateY(-2px);
+  background-color: #1e293b !important; /* Lifts surface tone slightly to Slate-800 */
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.3);
+}
+
+/* --- High-Contrast Focus Ring Accessibility Paths --- */
+.ease-card-dark.is-interactive:focus,
+.ease-card-dark.is-interactive:focus-visible {
+  outline: none;
+}
+
+.ease-card-dark.is-interactive:focus-visible {
+  /* Inner Layer: Uses deep Slate-900 color to generate a distinct mask track */
+  /* Outer Layer: Pins a vivid high-contrast Amber ring for dark background compliance visibility */
+  box-shadow: 0 0 0 2px #0f172a, 0 0 0 4px #f59e0b;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the design variant package for `.ease-card-dark`. Delivers a self-contained layout container option styled with a deep background. This implementation provides cascading dark typography resets and custom high-contrast keyboard focus indicators to support dark mode sections smoothly.

Closes #13255

---

## Type of Change
- [x] ✨ New component submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
- Dedicated high-contrast component overrides (`.ease-card-dark`) running clean `Slate-900` background states.
- Automated contextual text style rules adjusting nested titles and body paragraphs to responsive dark mode visibility standards natively.
- Specialized alternative focus rings configuration (`#f59e0b` Amber) mapping accessible target orientation paths across dark background layers.

**How does a developer use it?**
```html
<div class="ease-card ease-card-dark">
  <h3>Dark Card</h3>
</div>