### PR TITLE
fix: ensure spinner contrast on ghost and link button loading states

### DIFF
--- a/submissions/examples/ghost-link-spinner-contrast/README.md
+++ b/submissions/examples/ghost-link-spinner-contrast/README.md
@@ -1,0 +1,19 @@
+# Spinner Contrast Fix on Ghost & Link Buttons
+
+An interactive repair patch targeting the inner loading spinner components nested inside secondary button actions (`.ease-btn-ghost`, `.ease-btn-link`). This ensures complete contrast compliance during async processing cycles.
+
+## Bug Resolution Analysis
+
+- **The Problem:** The loading spinner asset previously carried hardcoded semi-transparent border color definitions built for solid primary color surfaces. When embedded within white or transparent background elements, the spinner lacked sufficient contrast against the layout background, violating WCAG 2.1 AA contrast thresholds.
+- **The Solution:** Modifies `.ease-spinner` border channels to leverage CSS `currentColor`. This causes the spinner tracking lines to dynamically inherit the precise color of the active parent element text across all structural interactions (default state values, hover elevations, and muted disabled paths).
+
+## Usage Layout Structure
+```html
+
+<button class="ease-btn ease-btn-ghost">
+  <span class="ease-spinner"></span>
+  Loading Data
+</button>
+```
+
+Closes #13260

--- a/submissions/examples/ghost-link-spinner-contrast/demo.html
+++ b/submissions/examples/ghost-link-spinner-contrast/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spinner Contrast Fix — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 5rem 1rem; margin: 0; font-family: sans-serif;">
+
+  <div style="max-width: 500px; margin: 0 auto; background: #ffffff; border: 1px solid #e2e8f0; border-radius: 0.75rem; padding: 2.5rem; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);">
+    
+    <div style="margin-bottom: 2rem;">
+      <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.25rem;">Loader Contrast Validation</h3>
+      <p style="margin: 0; color: #64748b; font-size: 0.9rem; line-height: 1.4;">
+        Hover over and inspect the interactive button actions to verify spinner color synchronization across states.
+      </p>
+    </div>
+
+    <div style="margin-bottom: 2rem;">
+      <span style="display: block; font-size: 0.75rem; font-weight: 700; color: #94a3b8; text-transform: uppercase; margin-bottom: 0.75rem;">Ghost Action Loading States</span>
+      <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
+        <button class="ease-btn ease-btn-ghost">
+          <span class="ease-spinner"></span> Processing
+        </button>
+        <button class="ease-btn ease-btn-ghost" disabled>
+          <span class="ease-spinner"></span> Locked
+        </button>
+      </div>
+    </div>
+
+    <div>
+      <span style="display: block; font-size: 0.75rem; font-weight: 700; color: #94a3b8; text-transform: uppercase; margin-bottom: 0.75rem;">Link Action Loading States</span>
+      <div style="display: flex; gap: 1.5rem; flex-wrap: wrap;">
+        <button class="ease-btn ease-btn-link">
+          <span class="ease-spinner"></span> Fetching Updates
+        </button>
+        <button class="ease-btn ease-btn-link" disabled>
+          <span class="ease-spinner"></span> Restricted
+        </button>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ghost-link-spinner-contrast/style.css
+++ b/submissions/examples/ghost-link-spinner-contrast/style.css
@@ -1,0 +1,83 @@
+/* ============================================================
+   ease-btn-spinner (Contrast Fix) — Contextual Color Mapping
+
+   Features interactive repairs including:
+     - Mapping spinner borders to currentColor for clean inheritance
+     - Enforcing strict contrast across ghost and link surfaces
+     - Safeguarding opacity rules for disabled loader streams
+   ============================================================ */
+
+/* --- Base Structural Component Dependencies --- */
+.ease-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-family: var(--ease-font-sans, sans-serif);
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.15s ease;
+}
+
+/* --- Ghost Variant Base --- */
+.ease-btn-ghost {
+  background-color: transparent;
+  color: #475569; /* Slate-600 */
+}
+.ease-btn-ghost:hover {
+  background-color: #f1f5f9; /* Slate-100 */
+  color: #0f172a; /* Slate-900 */
+}
+.ease-btn-ghost:disabled {
+  color: #94a3b8 !important;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* --- Link Variant Base --- */
+.ease-btn-link {
+  background-color: transparent;
+  color: #2563eb; /* Blue-600 */
+  padding: 0.5rem 0;
+}
+.ease-btn-link:hover {
+  color: #1d4ed8; /* Blue-700 */
+  text-decoration: underline;
+}
+.ease-btn-link:disabled {
+  color: #94a3b8 !important;
+  text-decoration: none !important;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* --- THE FIX: Spinner Engine & Contextual Contrast Updates --- */
+.ease-spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid cubic-bezier(0.4, 0, 0.2, 1);
+  
+  /* CORE REPAIR: Force spinner tracking lines to inherit the parent button text color */
+  border-color: currentColor;
+  border-right-color: transparent;
+  
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: easeSpinRotation 0.75s linear infinite;
+}
+
+@keyframes easeSpinRotation {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* Opacity modifier when buttons enter disabled processing loops */
+.ease-btn:disabled .ease-spinner {
+  opacity: 0.6;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves an inline asset contrast bug under issue #13260 affecting spinner layout paths nested inside secondary actions (`.ease-btn-ghost` and `.ease-btn-link`). Replaces absolute color boundaries with a dynamic `currentColor` configuration to ensure spinners remain visible across all text variations and component states.

---

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

Closes #13260

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this repair add?**
- System-wide utility convergence tracking via `border-color: currentColor` on loading rings.
- Automated color mapping updates that synchronize spinner borders with parent text alterations during `:hover` actions.
- Explicit opacity protections (`0.6`) applied directly to spinners inside disabled containers to prevent confusing user interactions.

**How does a developer use it?**
```html
<button class="ease-btn ease-btn-link">
  <span class="ease-spinner"></span>
  Syncing
</button>