### PR TITLE
feat: add Ctrl+K global documentation search command palette

### DIFF
--- a/submissions/examples/ctrl-k-command-palette/README.md
+++ b/submissions/examples/ctrl-k-command-palette/README.md
@@ -1,0 +1,59 @@
+# Global Documentation Search — Ctrl+K Command Palette
+
+## What does it do?
+A Ctrl+K command palette for documentation search with real-time
+filtering, keyboard navigation, grouped results, and smooth
+open/close animations.
+
+## How is it used?
+```html
+<!-- Trigger button -->
+<button class="ease-palette-trigger" id="trigger">
+  🔍 Search...
+  <kbd class="ease-palette-kbd">Ctrl K</kbd>
+</button>
+
+<!-- Backdrop -->
+<div class="ease-palette-backdrop" id="backdrop"></div>
+
+<!-- Palette -->
+<div class="ease-palette" id="palette">
+  <div class="ease-palette-input-wrap">
+    <input class="ease-palette-input" type="text" placeholder="Search...">
+  </div>
+  <div class="ease-palette-results" id="results"></div>
+  <div class="ease-palette-footer">
+    <span><kbd>↑↓</kbd> Navigate</span>
+    <span><kbd>Enter</kbd> Select</span>
+    <span><kbd>Esc</kbd> Close</span>
+  </div>
+</div>
+```
+
+## Keyboard Shortcuts
+- `Ctrl+K` / `Cmd+K` — open palette
+- `↑↓` — navigate results
+- `Enter` — select item
+- `Esc` — close palette
+
+## Classes
+- `.ease-palette-backdrop` — blurred overlay
+- `.ease-palette` — modal container
+- `.ease-palette-input` — search input
+- `.ease-palette-results` — results container
+- `.ease-palette-group` — section label
+- `.ease-palette-item` — result row
+- `.ease-palette-trigger` — trigger button
+- `.is-open` — active state
+
+## Features
+- Ctrl+K keyboard shortcut
+- Real-time search filtering
+- Grouped results by category
+- Arrow key navigation
+- Smooth open/close animations
+- Respects prefers-reduced-motion
+- Pure HTML + CSS + vanilla JS
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ctrl-k-command-palette/demo.html
+++ b/submissions/examples/ctrl-k-command-palette/demo.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ctrl+K Command Palette — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0f172a;
+      color: #e2e8f0;
+      font-family: 'Segoe UI', sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1.5rem;
+      padding: 2rem;
+    }
+    h1 { font-size: 1.75rem; }
+    p  { color: #64748b; font-size: 0.9rem; text-align: center; }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion CSS Docs</h1>
+  <p>Press <strong>Ctrl+K</strong> or click the button to open the command palette</p>
+
+  <button class="ease-palette-trigger" id="trigger">
+    🔍 Search documentation...
+    <kbd class="ease-palette-kbd">Ctrl K</kbd>
+  </button>
+
+  <!-- Backdrop -->
+  <div class="ease-palette-backdrop" id="backdrop"></div>
+
+  <!-- Palette -->
+  <div class="ease-palette" id="palette" role="dialog" aria-modal="true" aria-label="Search">
+    <div class="ease-palette-input-wrap">
+      <span class="ease-palette-icon">🔍</span>
+      <input
+        class="ease-palette-input"
+        id="search-input"
+        type="text"
+        placeholder="Search animations, components, utilities..."
+        autocomplete="off"
+      >
+      <kbd class="ease-palette-kbd">Esc</kbd>
+    </div>
+
+    <div class="ease-palette-results" id="results"></div>
+
+    <div class="ease-palette-footer">
+      <span><kbd>↑↓</kbd> Navigate</span>
+      <span><kbd>Enter</kbd> Select</span>
+      <span><kbd>Esc</kbd> Close</span>
+    </div>
+  </div>
+
+  <script>
+    const data = [
+      { group: 'Animations', icon: '✨', title: 'ease-fade-in', sub: 'Fade element into view', tag: 'entrance' },
+      { group: 'Animations', icon: '✨', title: 'ease-slide-up', sub: 'Slide element up while fading in', tag: 'entrance' },
+      { group: 'Animations', icon: '✨', title: 'ease-zoom-in', sub: 'Scale element up with bounce', tag: 'entrance' },
+      { group: 'Animations', icon: '✨', title: 'ease-bounce', sub: 'Continuously bouncing loop', tag: 'looping' },
+      { group: 'Animations', icon: '✨', title: 'ease-pulse', sub: 'Pulsating opacity animation', tag: 'looping' },
+      { group: 'Animations', icon: '✨', title: 'ease-shake', sub: 'Horizontal shake for errors', tag: 'looping' },
+      { group: 'Hover', icon: '🖱️', title: 'ease-hover-grow', sub: 'Scale up on hover', tag: 'hover' },
+      { group: 'Hover', icon: '🖱️', title: 'ease-hover-lift', sub: 'Lift with shadow on hover', tag: 'hover' },
+      { group: 'Hover', icon: '🖱️', title: 'ease-hover-glow', sub: 'Glow effect on hover', tag: 'hover' },
+      { group: 'Hover', icon: '🖱️', title: 'ease-hover-shimmer', sub: 'Light sweep on hover', tag: 'hover' },
+      { group: 'Utilities', icon: '🛠️', title: 'ease-delay-100', sub: 'Add 100ms animation delay', tag: 'delay' },
+      { group: 'Utilities', icon: '🛠️', title: 'ease-duration-slow', sub: 'Slow animation duration', tag: 'duration' },
+      { group: 'Utilities', icon: '🛠️', title: 'ease-blur-to-focus', sub: 'Blur to sharp focus entrance', tag: 'entrance' },
+      { group: 'Skeleton', icon: '💀', title: 'ease-skeleton-shimmer', sub: 'Shimmer loading skeleton', tag: 'loading' },
+      { group: 'Skeleton', icon: '💀', title: 'ease-skeleton-pulse', sub: 'Pulse loading skeleton', tag: 'loading' },
+    ];
+
+    const palette   = document.getElementById('palette');
+    const backdrop  = document.getElementById('backdrop');
+    const input     = document.getElementById('search-input');
+    const results   = document.getElementById('results');
+    const trigger   = document.getElementById('trigger');
+    let activeIdx   = -1;
+
+    function open() {
+      palette.classList.add('is-open');
+      backdrop.classList.add('is-open');
+      input.focus();
+      renderResults('');
+    }
+
+    function close() {
+      palette.classList.remove('is-open');
+      backdrop.classList.remove('is-open');
+      input.value = '';
+      activeIdx = -1;
+    }
+
+    function renderResults(query) {
+      const q = query.toLowerCase();
+      const filtered = data.filter(d =>
+        d.title.toLowerCase().includes(q) ||
+        d.sub.toLowerCase().includes(q) ||
+        d.tag.toLowerCase().includes(q)
+      );
+
+      if (!filtered.length) { results.innerHTML = ''; return; }
+
+      const groups = [...new Set(filtered.map(d => d.group))];
+      results.innerHTML = groups.map(g => `
+        <p class="ease-palette-group">${g}</p>
+        ${filtered.filter(d => d.group === g).map((d, i) => `
+          <div class="ease-palette-item" data-idx="${data.indexOf(d)}">
+            <div class="ease-palette-item-icon">${d.icon}</div>
+            <div>
+              <p class="ease-palette-item-title">${d.title}</p>
+              <p class="ease-palette-item-sub">${d.sub}</p>
+            </div>
+            <span class="ease-palette-item-tag">${d.tag}</span>
+          </div>
+        `).join('')}
+      `).join('');
+
+      activeIdx = -1;
+    }
+
+    function getItems() {
+      return [...results.querySelectorAll('.ease-palette-item')];
+    }
+
+    function setActive(idx) {
+      getItems().forEach((el, i) => el.classList.toggle('is-active', i === idx));
+      activeIdx = idx;
+    }
+
+    trigger.addEventListener('click', open);
+    backdrop.addEventListener('click', close);
+    input.addEventListener('input', () => renderResults(input.value));
+
+    document.addEventListener('keydown', e => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') { e.preventDefault(); open(); return; }
+      if (!palette.classList.contains('is-open')) return;
+      const items = getItems();
+      if (e.key === 'Escape') { close(); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); setActive(Math.min(activeIdx + 1, items.length - 1)); }
+      if (e.key === 'ArrowUp')   { e.preventDefault(); setActive(Math.max(activeIdx - 1, 0)); }
+      if (e.key === 'Enter' && activeIdx >= 0) { close(); }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ctrl-k-command-palette/style.css
+++ b/submissions/examples/ctrl-k-command-palette/style.css
@@ -1,0 +1,211 @@
+/* ============================================================
+   EaseMotion CSS — Ctrl+K Command Palette
+   ============================================================ */
+
+/* Backdrop */
+.ease-palette-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  z-index: 999;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.ease-palette-backdrop.is-open {
+  opacity: 1;
+  pointer-events: all;
+}
+
+/* Palette modal */
+.ease-palette {
+  position: fixed;
+  top: 20%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-12px);
+  width: min(640px, 92vw);
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 16px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.ease-palette.is-open {
+  opacity: 1;
+  pointer-events: all;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Search input */
+.ease-palette-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #334155;
+}
+
+.ease-palette-icon {
+  color: #64748b;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.ease-palette-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 1rem;
+  color: #f1f5f9;
+  caret-color: #6366f1;
+}
+
+.ease-palette-input::placeholder { color: #475569; }
+
+.ease-palette-kbd {
+  font-size: 0.7rem;
+  color: #475569;
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-family: monospace;
+  flex-shrink: 0;
+}
+
+/* Results */
+.ease-palette-results {
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.ease-palette-results:empty::after {
+  content: 'No results found';
+  display: block;
+  text-align: center;
+  color: #475569;
+  font-size: 0.85rem;
+  padding: 2rem;
+}
+
+/* Group label */
+.ease-palette-group {
+  font-size: 0.68rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.5rem 0.75rem 0.25rem;
+}
+
+/* Result item */
+.ease-palette-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.1s ease;
+  text-decoration: none;
+  color: inherit;
+}
+
+.ease-palette-item:hover,
+.ease-palette-item.is-active {
+  background: rgba(99, 102, 241, 0.12);
+}
+
+.ease-palette-item-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: rgba(99, 102, 241, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.ease-palette-item-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #f1f5f9;
+}
+
+.ease-palette-item-sub {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.ease-palette-item-tag {
+  margin-left: auto;
+  font-size: 0.68rem;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  background: rgba(99, 102, 241, 0.15);
+  color: #818cf8;
+  white-space: nowrap;
+}
+
+/* Footer */
+.ease-palette-footer {
+  display: flex;
+  gap: 1rem;
+  padding: 0.625rem 1.25rem;
+  border-top: 1px solid #1e293b;
+  font-size: 0.7rem;
+  color: #475569;
+}
+
+.ease-palette-footer kbd {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-family: monospace;
+  color: #64748b;
+}
+
+/* Trigger button */
+.ease-palette-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  color: #64748b;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.ease-palette-trigger:hover {
+  border-color: #6366f1;
+  color: #f1f5f9;
+}
+
+/* Scrollbar */
+.ease-palette-results::-webkit-scrollbar { width: 4px; }
+.ease-palette-results::-webkit-scrollbar-track { background: transparent; }
+.ease-palette-results::-webkit-scrollbar-thumb { background: #334155; border-radius: 2px; }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-palette,
+  .ease-palette-backdrop,
+  .ease-palette-item {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #8268

## Pull Request Description
Adds a Ctrl+K command palette for documentation search with
real-time filtering, keyboard navigation, and grouped results.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] Files inside `submissions/examples/ctrl-k-command-palette/`
- [x] `demo.html` works by opening directly in browser
- [x] `style.css` contains all styles
- [x] `README.md` documents usage
- [x] No edits to `core/` or `components/`
- [x] Respects prefers-reduced-motion
- [x] Pure HTML + CSS + vanilla JS