### PR TITLE
fix: ensure slide-left and slide-right maintain correct directions in RTL layouts

### DIFF
--- a/submissions/examples/rtl-slide-animations/README.md
+++ b/submissions/examples/rtl-slide-animations/README.md
@@ -1,0 +1,18 @@
+# Bi-Directional RTL Slide Animations Repair
+
+An interaction repair patch targeting directional animation tokens (`.ease-animate-slide-left` and `.ease-animate-slide-right`) under issue #13300. This fixes broken transitions in localized international configurations.
+
+## Bug Resolution Analysis
+
+- **The Problem:** The existing slide-left and slide-right utilities used standard rigid `translateX` percentages. Under an RTL language context (`dir="rtl"`), moving an item by a positive percentage pushes it out the wrong side of the layout, reversing the logical animation flow.
+- **The Solution:** Implements context-aware keyframe modifiers keyed to the `[dir="rtl"]` layout selector. This configuration re-maps the transformation boundaries, ensuring that regardless of whether a page is rendered in English or Arabic, "slide-left" consistently matches structural expectations across viewports.
+
+## Usage Layout Structure
+```html
+
+<div dir="rtl">
+  <div class="ease-animate-slide-left">Logical Safe Content</div>
+</div>
+```
+
+Closes #13300

--- a/submissions/examples/rtl-slide-animations/demo.html
+++ b/submissions/examples/rtl-slide-animations/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>RTL Slide Direction Validation — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 5rem 1rem; margin: 0;">
+
+  <div class="ease-split-container">
+    
+    <div class="ease-sandbox-column" dir="ltr">
+      <h3 style="margin: 0 0 0.25rem 0; color: #0f172a; font-size: 1.25rem; font-weight: 800;">Left-to-Right (LTR)</h3>
+      <p style="margin: 0; color: #64748b; font-size: 0.85rem;">Standard English/Western formatting layout alignment.</p>
+      
+      <div class="ease-preview-box ease-animate-slide-left">← Sliding Left (Into View)</div>
+      <div class="ease-preview-box ease-animate-slide-right">Sliding Right (Into View) →</div>
+    </div>
+
+    <div class="ease-sandbox-column" dir="rtl">
+      <h3 style="margin: 0 0 0.25rem 0; color: #0f172a; font-size: 1.25rem; font-weight: 800;">Right-to-Left (RTL)</h3>
+      <p style="margin: 0; color: #64748b; font-size: 0.85rem;">Mirrored Arabic/Hebrew system reading flow context.</p>
+      
+      <div class="ease-preview-box ease-animate-slide-left">← Sliding Left (Into View)</div>
+      <div class="ease-preview-box ease-animate-slide-right">Sliding Right (Into View) →</div>
+    </div>
+
+  </div>
+
+  <div style="text-align: center; margin-top: 3rem; font-family: sans-serif;">
+    <button onclick="window.location.reload();" style="background: #0f172a; color: #ffffff; border: none; padding: 0.6rem 1.2rem; border-radius: 0.375rem; font-weight: 600; cursor: pointer;">Replay Animations</button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/rtl-slide-animations/style.css
+++ b/submissions/examples/rtl-slide-animations/style.css
@@ -1,0 +1,81 @@
+/* ============================================================
+   ease-slide-* (RTL Direction Fix) — Logical Positioning
+   
+   Features layout fixes including:
+     - Bi-directional axis tracking preserving relative entry vectors
+     - HTML attribute selector targeting [dir="rtl"] core rules
+     - Smooth 3D hardware translation transitions
+   ============================================================ */
+
+/* --- Default LTR / Logical Keyframe Initializations --- */
+.ease-animate-slide-left {
+  animation: easeSlideLeftKeyframe 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.ease-animate-slide-right {
+  animation: easeSlideRightKeyframe 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* LTR Standard Keyframes */
+@keyframes easeSlideLeftKeyframe {
+  from { transform: translate3d(100%, 0, 0); opacity: 0; }
+  to { transform: translate3d(0, 0, 0); opacity: 1; }
+}
+
+@keyframes easeSlideRightKeyframe {
+  from { transform: translate3d(-100%, 0, 0); opacity: 0; }
+  to { transform: translate3d(0, 0, 0); opacity: 1; }
+}
+
+/* --- THE FIX: Right-To-Left (RTL) Explicit Context Inversions --- */
+[dir="rtl"] .ease-animate-slide-left {
+  animation-name: easeSlideLeftRTLKeyframe;
+}
+
+[dir="rtl"] .ease-animate-slide-right {
+  animation-name: easeSlideRightRTLKeyframe;
+}
+
+/* Flipped RTL Direction Sets */
+@keyframes easeSlideLeftRTLKeyframe {
+  from { transform: translate3d(-100%, 0, 0); opacity: 0; }
+  to { transform: translate3d(0, 0, 0); opacity: 1; }
+}
+
+@keyframes easeSlideRightRTLKeyframe {
+  from { transform: translate3d(100%, 0, 0); opacity: 0; }
+  to { transform: translate3d(0, 0, 0); opacity: 1; }
+}
+
+
+/* ============================================================
+   TESTING INTERFACE DECK ENVIRONMENT (Demo Specific)
+   ============================================================ */
+
+.ease-split-container {
+  display: flex;
+  gap: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+  font-family: var(--ease-font-sans, sans-serif);
+}
+
+.ease-sandbox-column {
+  flex: 1;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 2rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
+}
+
+.ease-preview-box {
+  background: #f1f5f9;
+  border: 1px dashed #cbd5e1;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  padding: 1.25rem;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1e293b;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves a localized translation vector bug under issue #13300 affecting directional sliding classes (`.ease-animate-slide-left` and `.ease-animate-slide-right`). Employs attribute target matching to redefine transformation tracking lines when initialized inside `[dir="rtl"]` wrappers, keeping UI animations in sync with reading layouts.

Closes #13300

---

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this repair add?**
- Dedicated multi-context keyframe maps (`easeSlideLeftRTLKeyframe`, etc.) matching inverted orientation criteria perfectly.
- Clean component lifecycle rendering that shields localized layout panels from visual shifting out of boundaries.
- Precise hardware acceleration using `translate3d` matrices to optimize frame painting during localized rendering.

**How does a developer use it?**
```html
<div dir="rtl" class="ease-animate-slide-left">RTL Content</div>