### PR TITLE
fix: prevent scrollbar flicker on Chrome during zoom-in animations

### DIFF
--- a/submissions/examples/chrome-zoom-scrollbar-flicker/README.md
+++ b/submissions/examples/chrome-zoom-scrollbar-flicker/README.md
@@ -1,0 +1,18 @@
+# Chrome Zoom-In Scrollbar Flicker Fix
+
+An interaction repair patch targeting layout paint bugs under issue #13302. This fix stabilizes scrollbar margins in Chromium engines when scale transformation transitions execute immediately on page initialization.
+
+## Bug Resolution Analysis
+
+- **The Problem:** During initialization loops, elements running traditional structural scale transformations (`transform: scale()`) prompt standard browsers to compute transitional bounding geometry parameters. Chrome occasionally registers these micro-second matrix spans as content overflowing active display envelopes, spawning temporary layout scrollbar tracks that trigger layout jumps.
+- **The Solution:** Modifies the baseline animation layer composition by introducing isolated 3D hardware-accelerated parameters (`backface-visibility: hidden` and `transform-style: preserve-3d`). This separates element transformation mechanics cleanly into dedicated compositor execution sequences, preventing parent element repaint calculations entirely.
+
+## Usage Layout Structure
+```html
+
+<div class="ease-animate-zoom-in">
+  <h3>Stable Modal Container</h3>
+</div>
+```
+
+Closes #13302

--- a/submissions/examples/chrome-zoom-scrollbar-flicker/demo.html
+++ b/submissions/examples/chrome-zoom-scrollbar-flicker/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chrome Zoom Flicker Diagnostic — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f8fafc; padding: 6rem 1rem; margin: 0; overflow-x: hidden;">
+
+  <div class="ease-showcase-wrapper">
+    
+    <div class="ease-viewport-edge-card ease-animate-zoom-in">
+      <div style="font-size: 2.5rem; margin-bottom: 1rem;">🎯</div>
+      <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.5rem;">Flicker Isolation Audit</h3>
+      <p style="margin: 0; color: #64748b; font-size: 0.95rem; line-height: 1.5;">
+        This container triggers an entrance scale right at the window layout frame boundaries. Watch the browser margins closely—the scrollbar tracks remain frozen and free of quick jumps.
+      </p>
+      
+      <button class="ease-action-btn" onclick="window.location.reload();">Re-trigger Entrance</button>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/chrome-zoom-scrollbar-flicker/style.css
+++ b/submissions/examples/chrome-zoom-scrollbar-flicker/style.css
@@ -1,0 +1,67 @@
+/* ============================================================
+   ease-zoom-in (Chrome Scrollbar Flicker Fix)
+   
+   Features layout fixes including:
+     - Isolating scaling boundaries via hardware layer promotion
+     - Eliminating sudden compositor dimension recalculation steps
+     - Ensuring clean layout paint bounds at structural view edges
+   ============================================================ */
+
+/* --- THE FIX: Standardized Hardware-Accelerated Zoom Utility --- */
+.ease-animate-zoom-in {
+  animation: easeZoomInKeyframe 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  
+  /* Promotes the layer to the GPU immediately on paint init.
+     This stops Chrome from recalculating baseline body overflow margins
+     during micro-second scale transformations. */
+  backface-visibility: hidden;
+  transform-style: preserve-3d;
+  will-change: transform, opacity;
+}
+
+@keyframes easeZoomInKeyframe {
+  from {
+    opacity: 0;
+    transform: scale3d(0.96, 0.96, 1);
+  }
+  to {
+    opacity: 1;
+    transform: scale3d(1, 1, 1);
+  }
+}
+
+
+/* ============================================================
+   SANDBOX SCREEN BOUNDARY CANVAS (Demo Specific)
+   ============================================================ */
+
+.ease-showcase-wrapper {
+  max-width: 600px;
+  margin: 0 auto;
+  font-family: var(--ease-font-sans, sans-serif);
+}
+
+.ease-viewport-edge-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 2.5rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.02);
+  text-align: center;
+}
+
+.ease-action-btn {
+  background: #0f172a;
+  color: #ffffff;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.375rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 1.5rem;
+  transition: background 0.15s ease;
+}
+
+.ease-action-btn:hover {
+  background: #1e293b;
+}


### PR DESCRIPTION
## Pull Request Description
Resolves a recurring page-load scrollbar flicker and visual layout jump under issue #13302 affecting the scale animation class (`.ease-animate-zoom-in`) inside Google Chrome. Leverages immediate hardware compositor layer promotion to prevent the main layout thread from tracking geometric intermediate bounds against viewport overflow margins.

Closes #13302

---

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this repair add?**
- Safe composite layer rendering overrides utilizing `backface-visibility: hidden` and `transform-style: preserve-3d` parameters.
- Standardized implementation using `will-change: transform, opacity` properties to instruct Chromium to bypass main-thread rendering loops during initial runtime cycles.
- Multi-dimensional layout protection structures maintaining stable body layout bounds during deep entrance scale transitions.

**How does a developer use it?**
```html
<div class="ease-animate-zoom-in">Flicker-Free Content</div>