### PR TITLE
fix: exclude disabled and hidden nodes from modal keyboard focus trap…

### DIFF
--- a/submissions/examples/modal-keyboard-focus-trap/README.md
+++ b/submissions/examples/modal-keyboard-focus-trap/README.md
@@ -1,0 +1,47 @@
+# Modal Keyboard Focus Trap Fix
+
+Fixes modal keyboard focus trap to exclude disabled and hidden elements from tab iteration targets.
+
+## Problem
+Modal keyboard trap query selectors catch disabled inputs and buttons, locking tab loops on non-interactive components.
+
+## Solution
+A focus trap helper that dynamically filters out disabled nodes and hidden elements from tab iteration targets.
+
+## Usage
+
+```html
+<div class="ease-modal-overlay" id="modal" role="dialog" aria-modal="true">
+  <div class="ease-modal" id="modal-box">
+    <input type="text" placeholder="Focusable" />
+    <input type="text" placeholder="Skipped" disabled />
+    <button onclick="closeModal()">Cancel</button>
+    <button disabled>Skipped</button>
+    <button onclick="closeModal()">Confirm</button>
+  </div>
+</div>
+```
+
+```js
+function trapFocus(element) {
+  function getFocusable() {
+    return Array.from(element.querySelectorAll(
+      'a, button, input, select, textarea, [tabindex]'
+    )).filter(el =>
+      !el.disabled &&
+      !el.hidden &&
+      el.style.display !== 'none' &&
+      el.tabIndex !== -1
+    );
+  }
+  // Tab key handler loops only through focusable elements
+}
+```
+
+## Features
+- Excludes disabled inputs and buttons from focus loop
+- Excludes hidden elements (display:none, hidden attribute)
+- Loops focus between first and last focusable elements
+- Shift+Tab reverse navigation supported
+- Closes on Escape key and overlay click
+- Smooth open/close animation

--- a/submissions/examples/modal-keyboard-focus-trap/demo.html
+++ b/submissions/examples/modal-keyboard-focus-trap/demo.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Modal Keyboard Focus Trap Fix</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 16px;
+      background: #0f172a;
+      font-family: sans-serif;
+      color: white;
+    }
+    .info {
+      background: #1e293b;
+      border-radius: 10px;
+      padding: 16px 24px;
+      max-width: 480px;
+      width: 90%;
+      font-size: 0.9rem;
+      color: #94a3b8;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+
+  <h2>Modal Focus Trap Demo</h2>
+  <div class="info">
+    Press <strong>Tab</strong> inside the modal — disabled and hidden elements are excluded from the focus loop.
+  </div>
+
+  <button class="ease-btn ease-btn-primary" onclick="openModal()">Open Modal</button>
+
+  <!-- Modal -->
+  <div class="ease-modal-overlay" id="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="ease-modal" id="modal-box">
+      <h2 id="modal-title">Confirm Action</h2>
+      <p>This modal traps keyboard focus correctly, excluding disabled inputs and hidden elements from the tab loop.</p>
+
+      <div style="display:flex; flex-direction:column; gap:10px; margin-bottom:20px;">
+        <input type="text" placeholder="Active input (focusable)" style="padding:10px; border-radius:8px; border:1px solid #e2e8f0;" />
+        <input type="text" placeholder="Disabled input (skipped)" disabled style="padding:10px; border-radius:8px; border:1px solid #e2e8f0;" />
+        <input type="text" placeholder="Another active input (focusable)" style="padding:10px; border-radius:8px; border:1px solid #e2e8f0;" />
+        <input type="text" placeholder="Hidden input (skipped)" style="display:none;" />
+      </div>
+
+      <div class="ease-modal-actions">
+        <button class="ease-btn ease-btn-secondary" id="cancel-btn" onclick="closeModal()">Cancel</button>
+        <button class="ease-btn ease-btn-primary" disabled>Disabled Button (skipped)</button>
+        <button class="ease-btn ease-btn-primary" id="confirm-btn" onclick="closeModal()">Confirm</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function openModal() {
+      const modal = document.getElementById('modal');
+      modal.classList.add('is-open');
+      trapFocus(document.getElementById('modal-box'));
+    }
+
+    function closeModal() {
+      document.getElementById('modal').classList.remove('is-open');
+      document.removeEventListener('keydown', handleFocusTrap);
+    }
+
+    let handleFocusTrap;
+
+    function trapFocus(element) {
+      // Get all focusable elements, excluding disabled and hidden
+      function getFocusable() {
+        return Array.from(element.querySelectorAll(
+          'a, button, input, select, textarea, [tabindex]'
+        )).filter(el =>
+          !el.disabled &&
+          !el.hidden &&
+          el.style.display !== 'none' &&
+          el.style.visibility !== 'hidden' &&
+          el.tabIndex !== -1
+        );
+      }
+
+      handleFocusTrap = function(e) {
+        if (e.key !== 'Tab') return;
+        const focusable = getFocusable();
+        if (!focusable.length) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      };
+
+      document.addEventListener('keydown', handleFocusTrap);
+
+      // Focus first focusable element
+      getFocusable()[0]?.focus();
+    }
+
+    // Close on overlay click
+    document.getElementById('modal').addEventListener('click', function(e) {
+      if (e.target === this) closeModal();
+    });
+
+    // Close on Escape
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') closeModal();
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/modal-keyboard-focus-trap/style.css
+++ b/submissions/examples/modal-keyboard-focus-trap/style.css
@@ -1,0 +1,79 @@
+/* ===== MODAL KEYBOARD FOCUS TRAP FIX ===== */
+
+/* Modal overlay */
+.ease-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.ease-modal-overlay.is-open {
+  opacity: 1;
+  pointer-events: all;
+}
+
+/* Modal box */
+.ease-modal {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 32px;
+  max-width: 480px;
+  width: 90%;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  transform: translateY(20px) scale(0.97);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-modal-overlay.is-open .ease-modal {
+  transform: translateY(0) scale(1);
+}
+
+.ease-modal h2 {
+  margin: 0 0 12px;
+  font-size: 1.3rem;
+  color: #0f172a;
+}
+
+.ease-modal p {
+  color: #475569;
+  margin: 0 0 24px;
+  line-height: 1.6;
+}
+
+.ease-modal-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+/* Buttons */
+.ease-btn {
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: opacity 0.2s ease;
+}
+
+.ease-btn:hover { opacity: 0.85; }
+
+.ease-btn-primary { background: #6366f1; color: white; }
+.ease-btn-secondary { background: #e2e8f0; color: #0f172a; }
+
+/* Disabled elements — excluded from focus trap */
+.ease-btn:disabled,
+input:disabled,
+select:disabled,
+textarea:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Pull Request Description
Fixes modal keyboard focus trap to exclude disabled inputs, buttons, and hidden elements from tab iteration targets, preventing focus from locking on non-interactive components. Closes #12445

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)
---
## Submission Checklist
- [x] All changes are inside `submissions/examples/modal-keyboard-focus-trap/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
---
## Feature Description
**What does this add?**
A focus trap helper that dynamically filters out disabled and hidden elements from tab iteration targets inside modals, fixing the broken keyboard navigation loop.

**How does a developer use it?**
```html
<div class="ease-modal-overlay" id="modal" role="dialog" aria-modal="true">
  <div class="ease-modal" id="modal-box">
    <input type="text" placeholder="Focusable" />
    <input type="text" placeholder="Skipped" disabled />
    <button onclick="closeModal()">Cancel</button>
    <button disabled>Skipped</button>
    <button onclick="closeModal()">Confirm</button>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Accessibility is core to good UI components. This fix ensures modal components work correctly for keyboard-only users by properly scoping the focus trap to only interactive elements.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)
---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*
---
## Notes for Maintainer
Closes #12445. Focus trap filters by: not disabled, not hidden, display !== none, tabIndex !== -1. Supports Shift+Tab reverse navigation, Escape to close, and overlay click to close.