### PR TITLE
feat : added 13833-outline-offset-tm utilities for issue #13833

### DIFF
--- a/submissions/examples/13833-outline-offset-tm/README.md
+++ b/submissions/examples/13833-outline-offset-tm/README.md
@@ -1,0 +1,2 @@
+# 13833-outline-offset
+Submission files for 13833-outline-offset

--- a/submissions/examples/13833-outline-offset-tm/demo.html
+++ b/submissions/examples/13833-outline-offset-tm/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>13833-outline-offset Demo</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      padding: 2rem;
+      color: #334155;
+    }
+    h2 {
+      font-size: 1.1rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: #1e293b;
+    }
+    .demo-section {
+      margin-bottom: 1.5rem;
+    }
+    .demo-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+    }
+    /* Import the utility styles */
+    :root {
+      --ease-color-primary: #6c63ff;
+      --ease-color-secondary: #8b5cf6;
+      --ease-color-surface: #ffffff;
+      --ease-color-text: #334155;
+      --ease-color-neutral-100: #f1f5f9;
+      --ease-color-neutral-200: #e2e8f0;
+      --ease-color-neutral-300: #cbd5e1;
+    }
+  </style>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h2>outline-offset utilities for controlling focus ring distance</h2>
+  <div class="demo-section">
+    <h2>Utilities available:</h2>
+    <div class="demo-grid">
+      <div class="demo-box ease-outline-offset-sm"></div>
+      <div class="demo-box ease-outline-offset-md"></div>
+      <div class="demo-box ease-outline-offset-lg"></div>
+      <p style="font-size:0.85rem;color:#64748b;width:100%;">outline-offset utilities push the focus ring outward.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/13833-outline-offset-tm/style.css
+++ b/submissions/examples/13833-outline-offset-tm/style.css
@@ -1,0 +1,15 @@
+/** outline-offset utilities */
+.ease-outline-offset-none { outline-offset: 0px !important; }
+.ease-outline-offset-sm   { outline-offset: 2px !important; }
+.ease-outline-offset-md   { outline-offset: 4px !important; }
+.ease-outline-offset-lg   { outline-offset: 8px !important; }
+.ease-outline-offset-xl   { outline-offset: 12px !important; }
+
+/* Demo: focus ring at different offsets */
+.demo-box {
+  padding: 0.75rem 1.5rem;
+  border: 2px solid var(--ease-color-neutral-300, #cbd5e1);
+  border-radius: 6px;
+  outline: 3px solid var(--ease-color-primary, #6c63ff);
+  background: var(--ease-color-surface, #fff);
+}


### PR DESCRIPTION
Closes #13833.

Summary of What Has Been Done:
Added five outline-offset utility classes (`.ease-outline-offset-none`, `.ease-outline-offset-sm`, `.ease-outline-offset-md`, `.ease-outline-offset-lg`, `.ease-outline-offset-xl`) to control the space between an element outline and its border.

Changes Made:
Added `submissions/examples/13833-outline-offset-tm/` containing README.md, demo.html, and style.css with all five outline-offset utilities.

Impact it Made:
These utilities fill gaps in the EaseMotion CSS framework, enabling developers to control additional CSS properties without writing custom styles. Each utility follows the existing `.ease-` naming convention and uses `!important` flags consistent with the framework's utility-first approach.

Please assign this task to me (@tmdeveloper007).