### PR TITLE
feat: add ease-zoom-in-down entrance animation #11823

### DIFF
--- a/submissions/examples/ease-zoom-in-down-aaniya/README.md
+++ b/submissions/examples/ease-zoom-in-down-aaniya/README.md
@@ -1,0 +1,55 @@
+# ease-zoom-in-down: Zoom In While Sliding Down
+
+A CSS entrance animation where an element fades in while scaling up and moving downward — a direction variant of `ease-zoom-in-up`. Great for dropdown entrances.
+
+## Classes
+
+| Class | Effect |
+|-------|--------|
+| `ease-zoom-in-down` | Triggers zoom-in-down on class add |
+| `ease-zoom-in-down-hover` | Triggers zoom-in-down on hover |
+| `ease-zoom-in-down-trigger` | Wraps a trigger element (e.g. dropdown button) |
+| `ease-zoom-in-down-target` | The element that animates in when the trigger is hovered/focused |
+
+## Usage
+
+```html
+<!-- Class trigger -->
+<div class="ease-zoom-in-down">
+  Zooms in and slides down
+</div>
+
+<!-- Dropdown entrance -->
+<div class="ease-zoom-in-down-trigger">
+  <button>Menu ▾</button>
+  <div class="ease-zoom-in-down-target">
+    <a href="#">Profile</a>
+    <a href="#">Settings</a>
+  </div>
+</div>
+```
+
+## Animation
+
+```css
+@keyframes ease-zoom-in-down {
+  from { transform: scale(0.5) translateY(-40px); opacity: 0; }
+  to   { transform: scale(1) translateY(0);        opacity: 1; }
+}
+```
+
+## Customization
+
+```css
+:root {
+  --ease-zoom-in-down-duration: 0.5s;
+  --ease-zoom-in-down-easing: ease-out;
+}
+```
+
+## Features
+- scale(0.5) + translateY(-40px) + opacity(0) → normal
+- Smooth ease-out timing
+- Class, hover, and dropdown-trigger variants
+- Customizable duration and easing
+- Respects prefers-reduced-motion

--- a/submissions/examples/ease-zoom-in-down-aaniya/demo.html
+++ b/submissions/examples/ease-zoom-in-down-aaniya/demo.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-zoom-in-down Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      background: #0f172a;
+      font-family: sans-serif;
+      color: white;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 60px;
+      padding: 40px 20px;
+    }
+    h1 { font-size: 1.8rem; margin: 0; }
+    h2 { font-size: 0.85rem; color: #64748b; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 16px; }
+    .demo-section { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 24px 32px;
+      text-align: center;
+      min-width: 160px;
+    }
+    .card h3 { margin: 0 0 8px; font-size: 1rem; }
+    .card p  { margin: 0; font-size: 0.85rem; color: #94a3b8; }
+    button {
+      padding: 8px 18px;
+      background: #6366f1;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85rem;
+      margin-top: 10px;
+    }
+
+    /* Dropdown demo */
+    .dropdown-wrap {
+      position: relative;
+      display: inline-block;
+    }
+    .dropdown-btn {
+      padding: 10px 20px;
+      background: #6366f1;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 0.95rem;
+    }
+    .dropdown-menu {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      margin-top: 8px;
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 8px;
+      min-width: 160px;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+    }
+    .dropdown-menu a {
+      display: block;
+      padding: 8px 12px;
+      color: white;
+      text-decoration: none;
+      font-size: 0.9rem;
+      border-radius: 6px;
+    }
+    .dropdown-menu a:hover { background: #334155; }
+  </style>
+</head>
+<body>
+
+  <h1>ease-zoom-in-down</h1>
+
+  <!-- Click trigger -->
+  <div class="demo-section">
+    <h2>Click Trigger</h2>
+    <div class="card" id="card1">
+      <h3>Click to Animate</h3>
+      <p>Zooms in while sliding down</p>
+      <button onclick="zoomIn('card1')">Animate</button>
+    </div>
+  </div>
+
+  <!-- Dropdown entrance demo -->
+  <div class="demo-section">
+    <h2>Dropdown Entrance (hover)</h2>
+    <div class="dropdown-wrap ease-zoom-in-down-trigger">
+      <button class="dropdown-btn">Hover Menu ▾</button>
+      <div class="dropdown-menu ease-zoom-in-down-target">
+        <a href="#">Profile</a>
+        <a href="#">Settings</a>
+        <a href="#">Logout</a>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function zoomIn(id) {
+      const card = document.getElementById(id);
+      card.classList.remove('ease-zoom-in-down');
+      void card.offsetWidth;
+      card.classList.add('ease-zoom-in-down');
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-zoom-in-down-aaniya/style.css
+++ b/submissions/examples/ease-zoom-in-down-aaniya/style.css
@@ -1,0 +1,67 @@
+/* ===== EASE-ZOOM-IN-DOWN: Zoom In While Sliding Down ===== */
+
+:root {
+  --ease-zoom-in-down-duration: 0.5s;
+  --ease-zoom-in-down-easing: ease-out;
+}
+
+/* Base entrance animation */
+.ease-zoom-in-down {
+  animation: ease-zoom-in-down var(--ease-zoom-in-down-duration) var(--ease-zoom-in-down-easing) forwards;
+}
+
+/* Hover trigger variant (e.g. dropdown entrance) */
+.ease-zoom-in-down-hover {
+  transform: scale(0.5) translateY(-40px);
+  opacity: 0;
+  transition: transform var(--ease-zoom-in-down-duration) var(--ease-zoom-in-down-easing),
+              opacity var(--ease-zoom-in-down-duration) var(--ease-zoom-in-down-easing);
+  transform-origin: top center;
+}
+
+.ease-zoom-in-down-hover:hover,
+.ease-zoom-in-down-hover.is-active {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+}
+
+/* Dropdown helper — parent triggers child entrance */
+.ease-zoom-in-down-trigger:hover .ease-zoom-in-down-target,
+.ease-zoom-in-down-trigger:focus-within .ease-zoom-in-down-target {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+  pointer-events: all;
+}
+
+.ease-zoom-in-down-target {
+  transform: scale(0.5) translateY(-40px);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform var(--ease-zoom-in-down-duration) var(--ease-zoom-in-down-easing),
+              opacity var(--ease-zoom-in-down-duration) var(--ease-zoom-in-down-easing);
+  transform-origin: top center;
+}
+
+/* Keyframes */
+@keyframes ease-zoom-in-down {
+  from {
+    transform: scale(0.5) translateY(-40px);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-zoom-in-down,
+  .ease-zoom-in-down-hover:hover,
+  .ease-zoom-in-down-hover.is-active,
+  .ease-zoom-in-down-target {
+    animation: none;
+    transform: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds ease-zoom-in-down, a CSS entrance animation where an element fades in while scaling up and moving downward — a direction variant of ease-zoom-in-up. Closes #11823

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)
---
## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-zoom-in-down-aaniya/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
---
## Feature Description
**What does this add?**
Adds ease-zoom-in-down with scale(0.5) + translateY(-40px) + opacity(0) to normal animation, plus hover and dropdown-trigger variants. Good for dropdown entrances.

**How does a developer use it?**
<div class="ease-zoom-in-down">Zooms in and slides down</div>
<div class="ease-zoom-in-down-trigger">
  <button>Menu</button>
  <div class="ease-zoom-in-down-target">
    <a href="#">Profile</a>
  </div>
</div>

**Why does it fit EaseMotion CSS?**
Pure CSS animation with human-readable class names, follows the existing ease-zoom-in-up naming convention as its direction variant. Customizable duration/easing, respects prefers-reduced-motion.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)
---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*
---
## Notes for Maintainer
Closes #11823. Used ease-zoom-in-down-aaniya/ folder as ease-zoom-in-down-pr/ already exists in main. Includes a dropdown-entrance demo variant alongside the base class/keyframe animation.