### PR TITLE
feat: add ease-bounce-in-left entrance animation #11819

### DIFF
--- a/submissions/examples/ease-bounce-in-left-aaniya/README.md
+++ b/submissions/examples/ease-bounce-in-left-aaniya/README.md
@@ -1,0 +1,51 @@
+# ease-bounce-in-left: Slides In From Left With Elastic Overshoot
+
+A CSS entrance animation where an element slides in from the left, overshoots slightly, then settles into place — part of the `ease-bounce-in` direction family alongside `ease-bounce-in-down`.
+
+## Classes
+
+| Class | Effect |
+|-------|--------|
+| `ease-bounce-in-left` | Triggers bounce-in-left on class add |
+
+## Usage
+
+```html
+<!-- Class trigger -->
+<div class="ease-bounce-in-left">
+  Slides in from left with overshoot
+</div>
+
+<!-- List items with stagger -->
+<div class="list-item ease-bounce-in-left" style="animation-delay:0.1s;">
+  New message
+</div>
+```
+
+## Animation
+
+```css
+@keyframes ease-bounce-in-left {
+  0%   { transform: translateX(-120%); opacity: 0; }
+  60%  { transform: translateX(8%);    opacity: 1; }
+  80%  { transform: translateX(-4%); }
+  100% { transform: translateX(0%);    opacity: 1; }
+}
+```
+
+## Customization
+
+```css
+:root {
+  --ease-bounce-in-left-duration: 0.7s;
+  --ease-bounce-in-left-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+```
+
+## Features
+- translateX(-120%) → overshoot → settle motion path
+- Springy cubic-bezier(0.34, 1.56, 0.64, 1) easing
+- Consistent with the ease-bounce-in-down family
+- Works well for notification lists and toasts
+- Customizable duration and easing
+- Respects prefers-reduced-motion

--- a/submissions/examples/ease-bounce-in-left-aaniya/demo.html
+++ b/submissions/examples/ease-bounce-in-left-aaniya/demo.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-bounce-in-left Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      background: #0f172a;
+      font-family: sans-serif;
+      color: white;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 60px;
+      padding: 40px 20px;
+    }
+    h1 { font-size: 1.8rem; margin: 0; }
+    h2 { font-size: 0.85rem; color: #64748b; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 16px; }
+    .demo-section { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 24px 32px;
+      text-align: center;
+      min-width: 200px;
+    }
+    .card h3 { margin: 0 0 8px; font-size: 1rem; }
+    .card p  { margin: 0; font-size: 0.85rem; color: #94a3b8; }
+    button {
+      padding: 8px 18px;
+      background: #6366f1;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85rem;
+      margin-top: 10px;
+    }
+    .list-demo {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      width: 280px;
+    }
+    .list-item {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 12px 16px;
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>ease-bounce-in-left</h1>
+
+  <!-- Click trigger -->
+  <div class="demo-section">
+    <h2>Click Trigger</h2>
+    <div class="card" id="card1">
+      <h3>Click to Animate</h3>
+      <p>Slides in from left with overshoot</p>
+      <button onclick="bounceIn('card1')">Animate</button>
+    </div>
+  </div>
+
+  <!-- List demo -->
+  <div class="demo-section">
+    <h2>Notification List</h2>
+    <div class="list-demo">
+      <div class="list-item ease-bounce-in-left" style="animation-delay:0s;">New message from Sam</div>
+      <div class="list-item ease-bounce-in-left" style="animation-delay:0.1s;">Order #4821 shipped</div>
+      <div class="list-item ease-bounce-in-left" style="animation-delay:0.2s;">Payment received</div>
+    </div>
+  </div>
+
+  <script>
+    function bounceIn(id) {
+      const card = document.getElementById(id);
+      card.classList.remove('ease-bounce-in-left');
+      void card.offsetWidth;
+      card.classList.add('ease-bounce-in-left');
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-bounce-in-left-aaniya/style.css
+++ b/submissions/examples/ease-bounce-in-left-aaniya/style.css
@@ -1,0 +1,45 @@
+/* ===== EASE-BOUNCE-IN-LEFT: Slides In From Left With Elastic Overshoot ===== */
+
+:root {
+  --ease-bounce-in-left-duration: 0.7s;
+  --ease-bounce-in-left-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Base entrance animation */
+.ease-bounce-in-left {
+  animation: ease-bounce-in-left var(--ease-bounce-in-left-duration) var(--ease-bounce-in-left-easing) forwards;
+}
+
+/* Class re-trigger helper (toggle via JS) */
+.ease-bounce-in-left.is-active {
+  animation: ease-bounce-in-left var(--ease-bounce-in-left-duration) var(--ease-bounce-in-left-easing) forwards;
+}
+
+/* Keyframes — translateX(-120%) -> overshoot -> settle */
+@keyframes ease-bounce-in-left {
+  0% {
+    transform: translateX(-120%);
+    opacity: 0;
+  }
+  60% {
+    transform: translateX(8%);
+    opacity: 1;
+  }
+  80% {
+    transform: translateX(-4%);
+  }
+  100% {
+    transform: translateX(0%);
+    opacity: 1;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-bounce-in-left,
+  .ease-bounce-in-left.is-active {
+    animation: none;
+    transform: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds ease-bounce-in-left, a CSS entrance animation where an element slides in from the left, overshoots slightly, then settles into place — part of the ease-bounce-in direction family alongside ease-bounce-in-down. Closes #11819

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)
---
## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-bounce-in-left-aaniya/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
---
## Feature Description
**What does this add?**
Adds ease-bounce-in-left with a translateX(-120%) → overshoot → settle motion path using a springy cubic-bezier easing, ideal for notification lists and toasts.

**How does a developer use it?**
<div class="ease-bounce-in-left">Slides in from left with overshoot</div>

**Why does it fit EaseMotion CSS?**
Pure CSS animation with human-readable class name, extends the existing ease-bounce-in direction family (consistent with ease-bounce-in-down). Customizable duration/easing, respects prefers-reduced-motion.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)
---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*
---
## Notes for Maintainer
Closes #11819. Used ease-bounce-in-left-aaniya/ folder as ease-bounce-in-left-pr/ already exists in main. Uses cubic-bezier(0.34, 1.56, 0.64, 1) for the elastic overshoot effect.