### PR TITLE
fix: ease-marquee resize stutter and tab-visibility speed burst

### DIFF
--- a/submissions/examples/marquee-fix-pk/README.md
+++ b/submissions/examples/marquee-fix-pk/README.md
@@ -1,0 +1,52 @@
+# EaseMotion — Marquee Bug Fix Demo
+
+Demonstrates fixes for two bugs in the `ease-marquee` component:
+
+1. **Resize stutter** — marquee text visibly jumps or restarts when viewport/container width changes
+2. **Tab-visibility speed burst** — marquee runs at incorrect speed (double-time) after switching back to a background tab
+
+## Bugs
+
+| Bug | Root Cause | Fix |
+|-----|-----------|-----|
+| Resize stutter | CSS animation recalculates `translateX` on layout change; percentage-based transform snaps | Pause animation during resize via debounced JS, resume after 150ms |
+| Tab speed burst | `requestAnimationFrame` freezes during tab switch; on return, browser tries to "catch up" the animation | Use `document.visibilitychange` to pause when tab is hidden, resume when visible |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Side-by-side comparison: buggy (CSS-only) vs fixed (JS-enhanced) marquee |
+| `style.css` | Demo page layout and comparison card styles |
+
+## Usage
+
+Open `demo.html` directly in a browser. Use the resize buttons or manually resize the viewport. Switch to another tab and back to see the tab-visibility fix.
+
+## How to Apply the Fix
+
+Add this script to any page using `ease-marquee`:
+
+```javascript
+// Resize fix — pause during resize, resume after 150ms debounce
+let resizeTimer;
+window.addEventListener('resize', () => {
+  document.querySelectorAll('.ease-marquee-track')
+    .forEach(el => el.style.animationPlayState = 'paused');
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => {
+    document.querySelectorAll('.ease-marquee-track')
+      .forEach(el => el.style.animationPlayState = '');
+  }, 150);
+});
+
+// Tab visibility fix — pause when hidden, resume when visible
+document.addEventListener('visibilitychange', () => {
+  document.querySelectorAll('.ease-marquee-track')
+    .forEach(el => {
+      el.style.animationPlayState = document.hidden ? 'paused' : 'running';
+    });
+});
+```
+
+For a `core/marquee.js` integration, save the snippet above as a standalone script loaded after `easemotion.css`.

--- a/submissions/examples/marquee-fix-pk/demo.html
+++ b/submissions/examples/marquee-fix-pk/demo.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Marquee Fix Demo</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container">
+    <h1 class="demo-title">EaseMotion Marquee — Bug Fix Demo</h1>
+    <p class="demo-subtitle">
+      Demonstrates fixes for <strong>resize stutter</strong> and <strong>tab-visibility speed burst</strong>.
+      Resize the viewport or switch tabs to compare behavior.
+    </p>
+
+    <div class="demo-grid">
+      <div class="demo-col">
+        <div class="demo-card demo-card-bug">
+          <div class="demo-card-header">Before (Buggy)</div>
+          <div class="ease-marquee" id="marquee-bug">
+            <div class="ease-marquee-track">
+              <span>✦ CSS-only marquee — resize to see stutter ✦</span>
+              <span>✦ CSS-only marquee — resize to see stutter ✦</span>
+              <span>✦ CSS-only marquee — resize to see stutter ✦</span>
+              <span>✦ CSS-only marquee — resize to see stutter ✦</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="demo-col">
+        <div class="demo-card demo-card-fixed">
+          <div class="demo-card-header">After (Fixed)</div>
+          <div class="ease-marquee" id="marquee-fixed">
+            <div class="ease-marquee-track">
+              <span>✦ JS-enhanced marquee — smooth resize & tab switch ✦</span>
+              <span>✦ JS-enhanced marquee — smooth resize & tab switch ✦</span>
+              <span>✦ JS-enhanced marquee — smooth resize & tab switch ✦</span>
+              <span>✦ JS-enhanced marquee — smooth resize & tab switch ✦</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-stats" id="stats">
+      <span>🔵 Buggy: <strong id="state-bug">running</strong></span>
+      <span>🟢 Fixed: <strong id="state-fixed">running</strong></span>
+      <span>Tab: <strong id="state-tab">visible</strong></span>
+    </div>
+
+    <div class="demo-actions">
+      <button class="demo-btn" id="btn-resize-50">Resize to 50%</button>
+      <button class="demo-btn" id="btn-resize-75">Resize to 75%</button>
+      <button class="demo-btn" id="btn-resize-100">Resize to 100%</button>
+    </div>
+
+    <div class="demo-code">
+      <h2>Implementation</h2>
+      <p>The fixed marquee uses a lightweight JS enhancement (shown below). Paste this into any page to fix both bugs without changing your marquee markup.</p>
+      <pre><code>// Fix #1: Pause marquee during resize
+let resizeTimer;
+window.addEventListener('resize', () => {
+  document.querySelectorAll('.ease-marquee-track')
+    .forEach(el => el.style.animationPlayState = 'paused');
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => {
+    document.querySelectorAll('.ease-marquee-track')
+      .forEach(el => el.style.animationPlayState = '');
+  }, 150);
+});
+
+// Fix #2: Pause marquee when tab is hidden
+document.addEventListener('visibilitychange', () => {
+  document.querySelectorAll('.ease-marquee-track')
+    .forEach(el => {
+      el.style.animationPlayState =
+        document.hidden ? 'paused' : 'running';
+    });
+});</code></pre>
+    </div>
+  </div>
+
+  <script>
+    const bugTrack = document.querySelector('#marquee-bug .ease-marquee-track');
+    const fixedTrack = document.querySelector('#marquee-fixed .ease-marquee-track');
+    const stateBug = document.getElementById('state-bug');
+    const stateFixed = document.getElementById('state-fixed');
+    const stateTab = document.getElementById('state-tab');
+
+    // --- Fix #1: Resize debounce ---
+    let resizeTimer;
+    window.addEventListener('resize', () => {
+      fixedTrack.style.animationPlayState = 'paused';
+      stateFixed.textContent = 'paused (resizing)';
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        fixedTrack.style.animationPlayState = '';
+        stateFixed.textContent = 'running';
+      }, 150);
+    });
+
+    // --- Fix #2: Tab visibility ---
+    document.addEventListener('visibilitychange', () => {
+      stateTab.textContent = document.hidden ? 'hidden' : 'visible';
+      fixedTrack.style.animationPlayState = document.hidden ? 'paused' : 'running';
+      stateFixed.textContent = document.hidden ? 'paused (tab hidden)' : 'running';
+    });
+
+    // --- Resize action buttons ---
+    document.getElementById('btn-resize-50').addEventListener('click', () => {
+      document.querySelector('.demo-container').style.width = '50%';
+    });
+    document.getElementById('btn-resize-75').addEventListener('click', () => {
+      document.querySelector('.demo-container').style.width = '75%';
+    });
+    document.getElementById('btn-resize-100').addEventListener('click', () => {
+      document.querySelector('.demo-container').style.width = '100%';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/marquee-fix-pk/style.css
+++ b/submissions/examples/marquee-fix-pk/style.css
@@ -1,0 +1,148 @@
+.demo-container {
+  max-width: 960px;
+  margin: 40px auto;
+  padding: 0 24px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #1e293b;
+  transition: width 0.3s ease;
+}
+
+.demo-title {
+  font-size: 26px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: #0f172a;
+}
+
+.demo-subtitle {
+  font-size: 14px;
+  color: #64748b;
+  margin: 0 0 28px;
+  line-height: 1.6;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.demo-col {
+  min-width: 0;
+}
+
+.demo-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.demo-card-bug {
+  border-color: #fca5a5;
+}
+
+.demo-card-fixed {
+  border-color: #86efac;
+}
+
+.demo-card-header {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+}
+
+.demo-card-bug .demo-card-header {
+  background: #fef2f2;
+  color: #dc2626;
+}
+
+.demo-card-fixed .demo-card-header {
+  background: #f0fdf4;
+  color: #16a34a;
+}
+
+.demo-card .ease-marquee {
+  padding: 16px;
+  border-top: 1px solid #e2e8f0;
+  font-size: 18px;
+}
+
+.demo-stats {
+  display: flex;
+  gap: 24px;
+  padding: 12px 16px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+
+.demo-actions {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.demo-btn {
+  padding: 8px 18px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.demo-btn:hover {
+  background: #f1f5f9;
+  border-color: #94a3b8;
+}
+
+.demo-code {
+  background: #0f172a;
+  border-radius: 10px;
+  padding: 24px;
+  color: #e2e8f0;
+}
+
+.demo-code h2 {
+  font-size: 16px;
+  margin: 0 0 8px;
+  color: #f8fafc;
+}
+
+.demo-code p {
+  font-size: 13px;
+  color: #94a3b8;
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.demo-code pre {
+  background: #1e293b;
+  padding: 16px 20px;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.demo-code code {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-grid {
+    grid-template-columns: 1fr;
+  }
+  .demo-stats {
+    flex-direction: column;
+    gap: 6px;
+  }
+}


### PR DESCRIPTION
## Description

Fixes two bugs in the `ease-marquee` component:

1. **Resize stutter** — marquee jumps/restarts when viewport or container width changes
2. **Tab-visibility speed burst** — marquee runs at incorrect speed after switching back from a background tab

All changes are self-contained in `submissions/examples/marquee-fix-pk/`. No existing files were modified or deleted.

Fixes #13893

---

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)

---

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] My changes are entirely new files — no existing code was modified or deleted

---

## What was added

| File | Purpose |
|------|---------|
| `submissions/examples/marquee-fix-pk/demo.html` | Side-by-side comparison: buggy (CSS-only) vs fixed (JS-enhanced) marquee |
| `submissions/examples/marquee-fix-pk/style.css` | Demo page styles |
| `submissions/examples/marquee-fix-pk/README.md` | Bug documentation and inline fix code snippet |

## Fixes

### Resize stutter
Debounced resize handler pauses `animation-play-state` during resize, resumes after 150ms.

### Tab-visibility speed burst
`visibilitychange` event listener pauses marquee when tab is hidden, resumes on return.

## Policy Compliance
- All files are newly created under `submissions/examples/marquee-fix-pk/`
- No existing files were modified, deleted, or overwritten
- No core framework files were touched
