### PR TITLE
feat: add animation performance monitoring utility with FPS counter and jank detection

### DIFF
--- a/submissions/examples/animation-perf-monitor-pk/README.md
+++ b/submissions/examples/animation-perf-monitor-pk/README.md
@@ -1,0 +1,50 @@
+# EaseMotion — Animation Performance Monitor
+
+Detect jank and dropped frames in real time. An opt-in floating FPS counter that warns when animations drop below 30 FPS.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Side-by-side comparison: janky (layout-triggering) vs GPU-accelerated animation, with live FPS counter |
+| `style.css` | Demo layout, balls, guide table |
+
+## Features
+
+- **FPS counter** — floating overlay in the top-right corner, updates every second
+- **Color-coded**: green (&ge;50 FPS), amber (30–49 FPS), red (&lt;30 FPS)
+- **Console warnings** — logged up to 3 times when FPS drops below 30
+- **Opt-in** — enabled by adding `.ease-perf-monitor` to `<html>`; no perf cost when absent
+- **Before/after demo** — compare `top`+`left` (layout trigger) vs `translate` (compositor-only)
+
+## Usage
+
+### Enable the monitor
+
+Add the class to `<html>`:
+
+```html
+<html class="ease-perf-monitor">
+```
+
+Include `core/animation-perf.js`:
+
+```html
+<script src="core/animation-perf.js"></script>
+```
+
+The FPS counter appears automatically. Console warnings fire when FPS &lt; 30.
+
+### Disable
+
+Remove the class or the script. The script exits immediately if the class is absent.
+
+## Performance Tips
+
+| Avoid (triggers layout/paint) | Prefer (GPU-accelerated) |
+|-------------------------------|--------------------------|
+| `top`, `left` | `translate` |
+| `width`, `height` | `scale` |
+| `margin` | `translate` |
+| `border-width` | `box-shadow` or pseudo-element |
+| `display: none` (animating) | `visibility: hidden` + `opacity` |

--- a/submissions/examples/animation-perf-monitor-pk/demo.html
+++ b/submissions/examples/animation-perf-monitor-pk/demo.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en" class="ease-perf-monitor">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Animation Performance Monitor</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1 class="title">Animation Performance Monitor</h1>
+    <p class="subtitle">
+      Detect jank and dropped frames in real time.
+      Add <code>.ease-perf-monitor</code> to <code>&lt;html&gt;</code> to enable the FPS counter.
+    </p>
+
+    <div class="toggle-bar">
+      <label class="toggle">
+        <input type="checkbox" id="toggle-perf" checked>
+        <span class="toggle-track"></span>
+        <span class="toggle-label">Perf Monitor</span>
+      </label>
+    </div>
+
+    <div class="demo-grid">
+      <div class="demo-card">
+        <div class="card-header card-header-jank">Janky Animation</div>
+        <div class="card-body">
+          <p class="card-desc">Animates <code>top</code> + <code>left</code> (triggers layout).</p>
+          <div class="ball ball-jank" id="ball-jank"></div>
+          <button class="btn btn-jank" id="btn-jank">Toggle</button>
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <div class="card-header card-header-smooth">GPU-Accelerated</div>
+        <div class="card-body">
+          <p class="card-desc">Animates <code>translate</code> (compositor-only).</p>
+          <div class="ball ball-smooth" id="ball-smooth"></div>
+          <button class="btn btn-smooth" id="btn-smooth">Toggle</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="guide">
+      <h2>Performance Guide</h2>
+      <table class="guide-table">
+        <tr><th>Triggers Layout/Paint</th><th>GPU-Accelerated (Safe)</th></tr>
+        <tr><td><code>top</code>, <code>left</code></td><td><code>translate</code></td></tr>
+        <tr><td><code>width</code>, <code>height</code></td><td><code>scale</code></td></tr>
+        <tr><td><code>opacity</code> (with layout)</td><td><code>opacity</code> (alone)</td></tr>
+        <tr><td><code>display: none</code></td><td><code>visibility: hidden</code></td></tr>
+        <tr><td><code>margin</code>, <code>padding</code></td><td><code>translate</code></td></tr>
+        <tr><td><code>border-width</code></td><td><code>box-shadow</code> or pseudo-element</td></tr>
+      </table>
+    </div>
+
+    <div class="code-section">
+      <h2>Detection Script</h2>
+      <div class="code-block">
+        <div class="code-header">core/animation-perf.js</div>
+        <pre><code>(function () {
+  if (!document.documentElement.classList.contains("ease-perf-monitor")) return;
+
+  let frameCount = 0;
+  let lastTime = performance.now();
+  let lowFpsCount = 0;
+
+  const fpsDisplay = document.createElement("div");
+  fpsDisplay.id = "ease-fps-counter";
+  fpsDisplay.style.cssText =
+    "position:fixed;top:4px;right:4px;z-index:99999;" +
+    "background:#000;color:#0f0;font:14px monospace;" +
+    "padding:4px 8px;border-radius:4px;user-select:none;" +
+    "pointer-events:none;";
+
+  function tick(now) {
+    frameCount++;
+    if (now - lastTime >= 1000) {
+      fpsDisplay.textContent = frameCount + " FPS";
+      if (frameCount < 30) {
+        fpsDisplay.style.color = "#f00";
+        lowFpsCount++;
+        if (lowFpsCount <= 3) {
+          console.warn(
+            "⚠️ EaseMotion: Low FPS (" + frameCount +
+            "). Optimize animations: prefer translate/scale/opacity " +
+            "over top/left/width/height."
+          );
+        }
+      } else if (frameCount < 50) {
+        fpsDisplay.style.color = "#fb0";
+      } else {
+        fpsDisplay.style.color = "#0f0";
+      }
+      frameCount = 0;
+      lastTime = now;
+    }
+    requestAnimationFrame(tick);
+  }
+
+  document.body.appendChild(fpsDisplay);
+  requestAnimationFrame(tick);
+})();</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      if (!document.documentElement.classList.contains('ease-perf-monitor')) return;
+
+      let frameCount = 0;
+      let lastTime = performance.now();
+      let lowFpsCount = 0;
+
+      const fpsDisplay = document.createElement('div');
+      fpsDisplay.id = 'ease-fps-counter';
+      fpsDisplay.style.cssText =
+        'position:fixed;top:4px;right:4px;z-index:99999;' +
+        'background:#000;color:#0f0;font:14px monospace;' +
+        'padding:4px 8px;border-radius:4px;user-select:none;' +
+        'pointer-events:none;';
+
+      function tick(now) {
+        frameCount++;
+        if (now - lastTime >= 1000) {
+          fpsDisplay.textContent = frameCount + ' FPS';
+          if (frameCount < 30) {
+            fpsDisplay.style.color = '#f00';
+            lowFpsCount++;
+            if (lowFpsCount <= 3) {
+              console.warn(
+                '⚠️ EaseMotion: Low FPS (' + frameCount +
+                '). Optimize: prefer translate/scale/opacity ' +
+                'over top/left/width/height.'
+              );
+            }
+          } else if (frameCount < 50) {
+            fpsDisplay.style.color = '#fb0';
+          } else {
+            fpsDisplay.style.color = '#0f0';
+          }
+          frameCount = 0;
+          lastTime = now;
+        }
+        requestAnimationFrame(tick);
+      }
+
+      document.body.appendChild(fpsDisplay);
+      requestAnimationFrame(tick);
+    })();
+
+    // --- Ball animations ---
+    const ballJank = document.getElementById('ball-jank');
+    const ballSmooth = document.getElementById('ball-smooth');
+    let jankRunning = false;
+    let smoothRunning = false;
+    let jankRaf, smoothRaf;
+    let jankT = 0, smoothT = 0;
+
+    function animateJank() {
+      if (!jankRunning) return;
+      jankT += 0.04;
+      const x = Math.sin(jankT) * 120 + 120;
+      const y = Math.cos(jankT * 0.7) * 60 + 60;
+      ballJank.style.left = x + 'px';
+      ballJank.style.top = y + 'px';
+      jankRaf = requestAnimationFrame(animateJank);
+    }
+
+    function animateSmooth() {
+      if (!smoothRunning) return;
+      smoothT += 0.04;
+      const x = Math.sin(smoothT) * 120;
+      const y = Math.cos(smoothT * 0.7) * 60;
+      ballSmooth.style.transform = 'translate(' + x + 'px,' + y + 'px)';
+      smoothRaf = requestAnimationFrame(animateSmooth);
+    }
+
+    document.getElementById('btn-jank').addEventListener('click', () => {
+      jankRunning = !jankRunning;
+      if (jankRunning) { animateJank(); }
+      else { cancelAnimationFrame(jankRaf); }
+      document.getElementById('btn-jank').textContent = jankRunning ? 'Stop' : 'Start';
+    });
+
+    document.getElementById('btn-smooth').addEventListener('click', () => {
+      smoothRunning = !smoothRunning;
+      if (smoothRunning) { animateSmooth(); }
+      else { cancelAnimationFrame(smoothRaf); }
+      document.getElementById('btn-smooth').textContent = smoothRunning ? 'Stop' : 'Start';
+    });
+
+    // --- Toggle perf monitor ---
+    document.getElementById('toggle-perf').addEventListener('change', (e) => {
+      const el = document.getElementById('ease-fps-counter');
+      if (el) el.style.display = e.target.checked ? '' : 'none';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animation-perf-monitor-pk/style.css
+++ b/submissions/examples/animation-perf-monitor-pk/style.css
@@ -1,0 +1,253 @@
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 40px 24px 80px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #1e293b;
+}
+
+.title {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: #0f172a;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: #64748b;
+  margin: 0 0 24px;
+}
+
+.subtitle code {
+  background: #f1f5f9;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: #475569;
+}
+
+/* --- Toggle --- */
+.toggle-bar {
+  margin-bottom: 24px;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.toggle input { display: none; }
+
+.toggle-track {
+  width: 44px;
+  height: 24px;
+  background: #cbd5e1;
+  border-radius: 12px;
+  position: relative;
+  transition: background 0.2s;
+}
+
+.toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.toggle input:checked + .toggle-track {
+  background: #6366f1;
+}
+
+.toggle input:checked + .toggle-track::after {
+  transform: translateX(20px);
+}
+
+/* --- Demo grid --- */
+.demo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+.demo-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.card-header {
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.card-header-jank { background: #fef2f2; color: #dc2626; }
+.card-header-smooth { background: #f0fdf4; color: #16a34a; }
+
+.card-body {
+  padding: 20px;
+}
+
+.card-desc {
+  font-size: 13px;
+  color: #64748b;
+  margin: 0 0 16px;
+}
+
+.card-desc code {
+  background: #f1f5f9;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.ball {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  position: relative;
+  margin-bottom: 12px;
+}
+
+.ball-jank {
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  top: 0;
+  left: 0;
+}
+
+.ball-smooth {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  top: 0;
+  left: 0;
+  will-change: transform;
+}
+
+.btn {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-jank { background: #fca5a5; color: #7f1d1d; }
+.btn-jank:hover { background: #f87171; }
+.btn-smooth { background: #86efac; color: #14532d; }
+.btn-smooth:hover { background: #4ade80; }
+
+/* --- Guide table --- */
+.guide {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 32px;
+}
+
+.guide h2 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 16px;
+  color: #0f172a;
+}
+
+.guide-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.guide-table th,
+.guide-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.guide-table th {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #64748b;
+}
+
+.guide-table td:first-child code {
+  background: #fef2f2;
+  color: #dc2626;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.guide-table td:last-child code {
+  background: #f0fdf4;
+  color: #16a34a;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+
+.guide-table tr:last-child td { border-bottom: none; }
+
+/* --- Code --- */
+.code-section {
+  margin-bottom: 32px;
+}
+
+.code-section h2 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 16px;
+  color: #0f172a;
+}
+
+.code-block {
+  background: #0f172a;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.code-header {
+  padding: 10px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #94a3b8;
+  background: #1e293b;
+  border-bottom: 1px solid #334155;
+}
+
+.code-block pre {
+  padding: 16px 20px;
+  margin: 0;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #e2e8f0;
+}
+
+.code-block code {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+@media (max-width: 640px) {
+  .demo-grid { grid-template-columns: 1fr; }
+  .container { padding: 24px 16px; }
+}


### PR DESCRIPTION
## Description

Adds a self-contained demo of an opt-in animation performance monitoring utility. Includes a floating FPS counter with color-coded thresholds, console warnings for low FPS, and a before/after comparison of janky vs GPU-accelerated animations.

All changes are in `submissions/examples/animation-perf-monitor-pk/`. No existing files were modified or deleted.

Fixes #13890

---

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)

---

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] My changes are entirely new files — no existing code was modified or deleted

---

## What was added

| File | Purpose |
|------|---------|
| `submissions/examples/animation-perf-monitor-pk/demo.html` | Floating FPS counter, before/after ball animation, toggle, performance guide |
| `submissions/examples/animation-perf-monitor-pk/style.css` | Demo layout, balls, guide table, toggle switch |
| `submissions/examples/animation-perf-monitor-pk/README.md` | Usage instructions, performance tips table |

## Features

- **FPS counter**: top-right overlay, updates every second
- **Color-coded**: green (≥50), amber (30–49), red (<30)
- **Console warnings**: up to 3 warnings when FPS < 30
- **Before/after**: `top`+`left` (layout-triggering) vs `translate` (GPU-accelerated)
- **Opt-in**: `.ease-perf-monitor` on `<html>` — no perf cost when absent
- **Performance guide**: which CSS properties trigger layout vs compositor-only

## Policy Compliance
- All files are newly created under `submissions/examples/animation-perf-monitor-pk/`
- No existing files were modified, deleted, or overwritten
- No core framework files were touched
