### PR TITLE
feat: add animation-composition utilities for stacking animations

### DIFF
--- a/submissions/examples/anim-composition-pk/README.md
+++ b/submissions/examples/anim-composition-pk/README.md
@@ -1,0 +1,59 @@
+# EaseMotion — `animation-composition` Utilities
+
+Control how multiple animations that target the same CSS property combine.
+
+## The Problem
+
+When two animations both modify `transform` (e.g., a zoom-in and a rotation), the default `animation-composition: replace` means the last animation's `transform` value wins — the first is discarded.
+
+## The Solution
+
+Three utility classes:
+
+| Class | Value | Behavior |
+|-------|-------|----------|
+| `.ease-compose-replace` | `replace` | Last animation's value wins (default) |
+| `.ease-compose-add` | `add` | Transform functions are appended in order |
+| `.ease-compose-accumulate` | `accumulate` | Numeric values are summed |
+
+## Demo
+
+Three boxes run the same two animations (`ease-kf-zoom-in` + `ease-kf-rotate`) with different composition modes:
+
+- **replace**: only rotation visible (zoom-in is discarded)
+- **add**: both zoom-in and rotation visible
+- **accumulate**: values summed (scale 0→2 when two scales combine)
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Three-card comparison: replace vs add vs accumulate |
+| `style.css` | Demo grid, animation boxes, explanation table |
+
+## Usage
+
+```html
+<div class="
+  ease-anim-infinite
+  ease-kf-zoom-in
+  ease-kf-rotate
+  ease-compose-add
+">
+  Both zoom and rotation applied
+</div>
+```
+
+## Browser Support
+
+| Chrome | Firefox | Safari |
+|--------|---------|--------|
+| 115+ | 118+ | 17.2+ |
+
+## Adding to `core/utilities.css`
+
+```css
+.ease-compose-replace { animation-composition: replace; }
+.ease-compose-add { animation-composition: add; }
+.ease-compose-accumulate { animation-composition: accumulate; }
+```

--- a/submissions/examples/anim-composition-pk/demo.html
+++ b/submissions/examples/anim-composition-pk/demo.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — animation-composition</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1 class="title"><code>animation-composition</code> Utilities</h1>
+    <p class="subtitle">
+      Control how multiple animations stacking on the same property combine —
+      <code>replace</code> (default), <code>add</code>, or <code>accumulate</code>.
+      <span class="badge">Chrome 115+</span>
+    </p>
+
+    <div class="browser-note">
+      ⚡ Requires Chrome 115+. In unsupported browsers, all three behave as <code>replace</code>.
+    </div>
+
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h2>replace (default)</h2>
+        <p class="desc">Last animation wins — <code>rotate</code> replaces <code>zoom-in</code>.</p>
+        <div class="preview-box">
+          <div class="anim-box ease-compose-replace" id="demo-replace">
+            <span>replace</span>
+          </div>
+        </div>
+        <div class="anim-tags"><code>ease-kf-zoom-in</code> + <code>ease-kf-rotate</code></div>
+      </div>
+
+      <div class="demo-card">
+        <h2>add</h2>
+        <p class="desc">Transforms are appended — <code>rotate</code> adds to <code>zoom-in</code>.</p>
+        <div class="preview-box">
+          <div class="anim-box ease-compose-add" id="demo-add">
+            <span>add</span>
+          </div>
+        </div>
+        <div class="anim-tags"><code>ease-kf-zoom-in</code> + <code>ease-kf-rotate</code></div>
+      </div>
+
+      <div class="demo-card">
+        <h2>accumulate</h2>
+        <p class="desc">Values are added together — 0.5 + 0.5 = 1.0 scale, 0 + 360 = 360deg.</p>
+        <div class="preview-box">
+          <div class="anim-box ease-compose-accumulate" id="demo-accumulate">
+            <span>accumulate</span>
+          </div>
+        </div>
+        <div class="anim-tags"><code>ease-kf-zoom-in</code> + <code>ease-kf-rotate</code></div>
+      </div>
+    </div>
+
+    <div class="explanation">
+      <h2>How It Works</h2>
+      <p>When two animations target the same property (e.g., <code>transform</code>):</p>
+      <table class="guide-table">
+        <tr><th>Mode</th><th>Behavior</th><th>Example</th></tr>
+        <tr>
+          <td><code>replace</code></td>
+          <td>Last declared animation's value wins</td>
+          <td><code>rotate(360deg)</code> replaces <code>scale(0→1)</code> → only rotation visible</td>
+        </tr>
+        <tr>
+          <td><code>add</code></td>
+          <td>Transform functions are appended in order</td>
+          <td><code>scale(0→1)</code> then <code>rotate(360deg)</code> → both visible</td>
+        </tr>
+        <tr>
+          <td><code>accumulate</code></td>
+          <td>Numeric values are summed</td>
+          <td><code>scale(0.5)</code> + <code>scale(0.5)</code> = <code>scale(1.0)</code></td>
+        </tr>
+      </table>
+    </div>
+
+    <div class="code-section">
+      <h2>Proposed Utility Classes</h2>
+      <p>In <code>core/utilities.css</code>:</p>
+      <div class="code-block">
+        <pre><code>.ease-compose-replace {
+  animation-composition: replace;
+}
+.ease-compose-add {
+  animation-composition: add;
+}
+.ease-compose-accumulate {
+  animation-composition: accumulate;
+}</code></pre>
+      </div>
+    </div>
+
+    <div class="code-section">
+      <h2>Demo Usage</h2>
+      <div class="code-block">
+        <pre><code>&lt;div class="
+  ease-anim-infinite
+  ease-kf-zoom-in
+  ease-kf-rotate
+  ease-compose-add
+"&gt;
+  Both zoom and rotation applied
+&lt;/div&gt;</code></pre>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/anim-composition-pk/style.css
+++ b/submissions/examples/anim-composition-pk/style.css
@@ -1,0 +1,167 @@
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 40px 24px 80px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #1e293b;
+}
+
+.title {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: #0f172a;
+}
+
+.title code {
+  font-size: 24px;
+  background: #eef2ff;
+  color: #4f46e5;
+  padding: 0 8px;
+  border-radius: 4px;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: #64748b;
+  margin: 0 0 12px;
+}
+
+.subtitle code { background: #f1f5f9; padding: 2px 6px; border-radius: 4px; }
+
+.badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  background: #fefce8;
+  color: #a16207;
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-left: 6px;
+}
+
+.browser-note {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: #475569;
+  margin-bottom: 28px;
+}
+
+/* --- Demo grid --- */
+.demo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.demo-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+  background: #fff;
+}
+
+.demo-card h2 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 4px;
+  color: #0f172a;
+  font-family: monospace;
+}
+
+.desc {
+  font-size: 13px;
+  color: #64748b;
+  margin: 0 0 12px;
+  line-height: 1.4;
+}
+
+.preview-box {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+.anim-box {
+  width: 90px;
+  height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #fff;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  animation-duration: 2s;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+  animation-name: ease-kf-zoom-in, ease-kf-rotate;
+}
+
+.anim-tags {
+  font-size: 12px;
+  color: #94a3b8;
+  font-family: monospace;
+}
+
+.anim-tags code { font-size: 11px; }
+
+/* --- Explanation --- */
+.explanation {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 28px;
+}
+
+.explanation h2 { font-size: 16px; font-weight: 600; margin: 0 0 8px; color: #0f172a; }
+.explanation > p { font-size: 14px; color: #475569; margin: 0 0 16px; }
+
+.guide-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+
+.guide-table th,
+.guide-table td { padding: 10px 12px; text-align: left; border-bottom: 1px solid #f1f5f9; }
+
+.guide-table th {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #64748b;
+}
+
+.guide-table tr:last-child td { border-bottom: none; }
+.guide-table td:first-child { font-family: monospace; font-weight: 600; }
+
+/* --- Code --- */
+.code-section { margin-bottom: 24px; }
+.code-section h2 { font-size: 16px; font-weight: 600; margin: 0 0 4px; color: #0f172a; }
+.code-section > p { font-size: 14px; color: #475569; margin: 0 0 12px; }
+
+.code-block {
+  background: #0f172a;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.code-block pre { padding: 16px 20px; margin: 0; overflow-x: auto; font-size: 13px; line-height: 1.6; color: #e2e8f0; }
+.code-block code { font-family: 'JetBrains Mono', 'Fira Code', monospace; }
+
+@media (max-width: 700px) {
+  .demo-grid { grid-template-columns: 1fr; }
+  .container { padding: 24px 16px; }
+}


### PR DESCRIPTION
## Description

Adds a self-contained demo showing how `animation-composition` controls multi-animation stacking. Three cards compare `replace`, `add`, and `accumulate` using `ease-kf-zoom-in` + `ease-kf-rotate`.

All changes are in `submissions/examples/anim-composition-pk/`. No existing files were modified or deleted.

Fixes #13879

---

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)

---

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] My changes are entirely new files — no existing code was modified or deleted

---

## What was added

| File | Purpose |
|------|---------|
| `submissions/examples/anim-composition-pk/demo.html` | Three-card comparison of replace/add/accumulate |
| `submissions/examples/anim-composition-pk/style.css` | Demo grid, animation boxes, explanation table |
| `submissions/examples/anim-composition-pk/README.md` | Browser support, proposed utility classes, usage |

## Policy Compliance
- All files are newly created under `submissions/examples/anim-composition-pk/`
- No existing files were modified, deleted, or overwritten
- No core framework files were touched
