### PR TITLE
feat: add prefers-reduced-data media query support for low-data mode

### DIFF
--- a/submissions/examples/reduced-data-pk/README.md
+++ b/submissions/examples/reduced-data-pk/README.md
@@ -1,0 +1,70 @@
+# EaseMotion — `prefers-reduced-data` Support
+
+Respect users' bandwidth preferences by disabling decorative animations and heavy visual effects on slow or metered connections.
+
+## The Problem
+
+Users on slow or metered connections may want to disable decorative animations and gradients to save bandwidth and improve perceived performance. EaseMotion currently only respects `prefers-reduced-motion` (for accessibility), not `prefers-reduced-data`.
+
+## The Solution
+
+Add a `@media (prefers-reduced-data: reduce)` block alongside the existing reduced-motion section in `easemotion.css`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Before/after comparison with toggle, info cards, proposed implementation |
+| `style.css` | Demo layout, animation simulation, reduced-data toggle styles |
+
+## What Gets Disabled
+
+| Feature | Status |
+|---------|--------|
+| Decorative `@keyframes` (shimmer, ripple, pulse) | ❌ Disabled |
+| Heavy gradients and box-shadows | ❌ Stripped |
+| Non-essential background images | ❌ Removed |
+| Content animations (fade-in, slide-up) | ✅ Kept |
+| Core layout and interaction | ✅ Unchanged |
+
+## Proposed CSS
+
+Add to `easemotion.css`:
+
+```css
+@media (prefers-reduced-motion: reduce),
+       (prefers-reduced-data: reduce) {
+  :root {
+    --ease-speed-fast: 0.01ms;
+    --ease-speed-medium: 0.01ms;
+    --ease-speed-slow: 0.01ms;
+    --ease-animation-iterations: 1;
+  }
+}
+
+@media (prefers-reduced-data: reduce) {
+  .ease-shimmer,
+  .ease-ripple,
+  .ease-pulse,
+  .ease-gradient-bg {
+    animation: none !important;
+    background-image: none !important;
+  }
+}
+```
+
+## Opt-In Override
+
+Add `.ease-no-preference-data` to elements that should animate despite the data preference:
+
+```css
+@media (prefers-reduced-data: reduce) {
+  .ease-no-preference-data .ease-shimmer {
+    animation: ease-shimmer 2s ease infinite !important;
+  }
+}
+```
+
+## Browser Support
+
+`prefers-reduced-data` is an experimental media query. Check [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-data) for current support.

--- a/submissions/examples/reduced-data-pk/demo.html
+++ b/submissions/examples/reduced-data-pk/demo.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — prefers-reduced-data</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1 class="title"><code>prefers-reduced-data</code> Support</h1>
+    <p class="subtitle">
+      Respect users' bandwidth preferences. Disable decorative animations
+      and heavy visuals on slow or metered connections.
+      <span class="badge">Experimental</span>
+    </p>
+
+    <div class="toggle-bar">
+      <label class="toggle">
+        <input type="checkbox" id="toggle-data">
+        <span class="toggle-track"></span>
+        <span class="toggle-label">Simulate reduced-data mode</span>
+      </label>
+    </div>
+
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h2>Full Data Mode</h2>
+        <p class="desc">All animations, gradients, and effects active.</p>
+        <div class="card-body full-data" id="full-data">
+          <div class="anim-piece shimmer"></div>
+          <div class="anim-piece fade"></div>
+          <div class="anim-piece slide"></div>
+          <div class="anim-piece gradient-box"></div>
+        </div>
+        <div class="stats">
+          <span class="stat">🎬 4 animations</span>
+          <span class="stat">🎨 gradients</span>
+          <span class="stat">📦 2.1 KB painted</span>
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h2>Reduced Data Mode</h2>
+        <p class="desc">Decorative animations and gradients removed.</p>
+        <div class="card-body reduced-data" id="reduced-data">
+          <div class="anim-piece static-block"></div>
+          <div class="anim-piece static-block"></div>
+          <div class="anim-piece static-block"></div>
+          <div class="anim-piece flat-box"></div>
+        </div>
+        <div class="stats">
+          <span class="stat">🎬 0 animations</span>
+          <span class="stat">🎨 flat colors</span>
+          <span class="stat">📦 0.3 KB painted</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="info-cards">
+      <div class="info-card">
+        <h3>When It Activates</h3>
+        <ul>
+          <li>🧑‍💻 User enables <strong>Data Saver</strong> in browser (Chrome/Android)</li>
+          <li>🌍 Slow connection detected by OS</li>
+          <li>📱 Metered mobile network</li>
+          <li>⚙️ OS-level reduced data setting</li>
+        </ul>
+      </div>
+      <div class="info-card">
+        <h3>What Gets Disabled</h3>
+        <ul>
+          <li>❌ Decorative <code>@keyframes</code> animations</li>
+          <li>❌ <code>shimmer</code>, <code>ripple</code>, <code>pulse</code> effects</li>
+          <li>❌ Heavy gradients and box-shadows</li>
+          <li>❌ Non-essential background images</li>
+          <li>✅ Content animations (fade-in, slide-up) kept</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="proposed">
+      <h2>Proposed Implementation</h2>
+      <p>Add to <code>easemotion.css</code> alongside the existing reduced-motion block:</p>
+
+      <div class="code-block">
+        <div class="code-header">easemotion.css</div>
+        <pre><code>@media (prefers-reduced-motion: reduce),
+       (prefers-reduced-data: reduce) {
+  :root {
+    --ease-speed-fast: 0.01ms;
+    --ease-speed-medium: 0.01ms;
+    --ease-speed-slow: 0.01ms;
+    --ease-animation-iterations: 1;
+  }
+}
+
+@media (prefers-reduced-data: reduce) {
+  .ease-shimmer,
+  .ease-ripple,
+  .ease-pulse,
+  .ease-gradient-bg {
+    animation: none !important;
+    background-image: none !important;
+  }
+}</code></pre>
+      </div>
+    </div>
+
+    <div class="proposed">
+      <h2>Opt-In Override</h2>
+      <p>For users who want animations despite their data preference:</p>
+      <div class="code-block">
+        <pre><code>.ease-no-preference-data {
+  --ease-reduced-data-override: true;
+}
+
+@media (prefers-reduced-data: reduce) {
+  .ease-no-preference-data .ease-shimmer {
+    animation: ease-shimmer 2s ease infinite !important;
+    background-image: linear-gradient(...) !important;
+  }
+}</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.getElementById('toggle-data').addEventListener('change', (e) => {
+      document.documentElement.classList.toggle('simulate-reduced-data', e.target.checked);
+      document.getElementById('reduced-data').classList.toggle('is-reduced', e.target.checked);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/reduced-data-pk/style.css
+++ b/submissions/examples/reduced-data-pk/style.css
@@ -1,0 +1,237 @@
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 40px 24px 80px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #1e293b;
+}
+
+.title {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: #0f172a;
+}
+
+.title code {
+  font-size: 24px;
+  background: #eef2ff;
+  color: #4f46e5;
+  padding: 0 8px;
+  border-radius: 4px;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: #64748b;
+  margin: 0 0 12px;
+}
+
+.subtitle code { background: #f1f5f9; padding: 2px 6px; border-radius: 4px; }
+
+.badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  background: #fefce8;
+  color: #a16207;
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-left: 6px;
+}
+
+.toggle-bar { margin-bottom: 24px; }
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.toggle input { display: none; }
+
+.toggle-track {
+  width: 44px;
+  height: 24px;
+  background: #cbd5e1;
+  border-radius: 12px;
+  position: relative;
+  transition: background 0.2s;
+}
+
+.toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.toggle input:checked + .toggle-track { background: #6366f1; }
+.toggle input:checked + .toggle-track::after { transform: translateX(20px); }
+
+/* --- Demo grid --- */
+.demo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 28px;
+}
+
+.demo-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+  background: #fff;
+}
+
+.demo-card h2 { font-size: 16px; font-weight: 600; margin: 0 0 4px; }
+.desc { font-size: 13px; color: #64748b; margin: 0 0 12px; }
+
+.card-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  padding: 12px;
+  background: #f8fafc;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  min-height: 120px;
+}
+
+.anim-piece {
+  height: 44px;
+  border-radius: 8px;
+}
+
+.shimmer {
+  background: linear-gradient(90deg, #e2e8f0 25%, #f1f5f9 50%, #e2e8f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer-slide 1.5s ease infinite;
+}
+
+.fade {
+  background: #6366f1;
+  animation: pulse-fade 1.5s ease infinite;
+}
+
+.slide {
+  background: #8b5cf6;
+  animation: slide-sway 2s ease infinite;
+}
+
+.gradient-box {
+  background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
+}
+
+.static-block { background: #e2e8f0; height: 44px; border-radius: 8px; }
+.flat-box { background: #94a3b8; height: 44px; border-radius: 8px; }
+
+.is-reduced .shimmer,
+.is-reduced .fade,
+.is-reduced .slide {
+  animation: none !important;
+  background-image: none !important;
+}
+
+.is-reduced .shimmer { background: #e2e8f0; }
+.is-reduced .fade { background: #6366f1; }
+.is-reduced .slide { background: #8b5cf6; }
+.is-reduced .gradient-box { background: #a855f7; }
+
+@keyframes shimmer-slide {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@keyframes pulse-fade {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+@keyframes slide-sway {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(8px); }
+}
+
+.stats {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.stat { font-size: 12px; color: #64748b; }
+
+/* --- Info cards --- */
+.info-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+.info-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.info-card h3 { font-size: 15px; font-weight: 600; margin: 0 0 10px; color: #0f172a; }
+
+.info-card ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.info-card li {
+  font-size: 13px;
+  color: #475569;
+  padding: 4px 0;
+  line-height: 1.5;
+}
+
+/* --- Proposed --- */
+.proposed {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 20px;
+}
+
+.proposed h2 { font-size: 16px; font-weight: 600; margin: 0 0 4px; color: #0f172a; }
+.proposed > p { font-size: 14px; color: #475569; margin: 0 0 16px; }
+
+.code-block {
+  background: #0f172a;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.code-header {
+  padding: 10px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #94a3b8;
+  background: #1e293b;
+  border-bottom: 1px solid #334155;
+}
+
+.code-block pre { padding: 16px 20px; margin: 0; overflow-x: auto; font-size: 13px; line-height: 1.6; color: #e2e8f0; }
+.code-block code { font-family: 'JetBrains Mono', 'Fira Code', monospace; }
+
+@media (max-width: 640px) {
+  .demo-grid, .info-cards { grid-template-columns: 1fr; }
+  .container { padding: 24px 16px; }
+}


### PR DESCRIPTION
## Description

Adds a self-contained demo showing `prefers-reduced-data` support to disable decorative animations and heavy gradients on slow/metered connections. Includes a toggle to simulate reduced-data mode, proposed CSS for `easemotion.css`, and opt-in override class.

All changes are in `submissions/examples/reduced-data-pk/`. No existing files were modified or deleted.

Fixes #13880

---

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)

---

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] My changes are entirely new files — no existing code was modified or deleted

---

## What was added

| File | Purpose |
|------|---------|
| `submissions/examples/reduced-data-pk/demo.html` | Before/after with toggle, info cards, proposed implementation |
| `submissions/examples/reduced-data-pk/style.css` | Demo layout, animation simulation, reduced-data styles |
| `submissions/examples/reduced-data-pk/README.md` | Browser support, proposed CSS, opt-in override |

## Policy Compliance
- All files are newly created under `submissions/examples/reduced-data-pk/`
- No existing files were modified, deleted, or overwritten
- No core framework files were touched
