### PR TITLE
feat: add transition-behavior: allow-discrete for discrete property transitions

### DIFF
--- a/submissions/examples/allow-discrete-pk/README.md
+++ b/submissions/examples/allow-discrete-pk/README.md
@@ -1,0 +1,66 @@
+# EaseMotion — `transition-behavior: allow-discrete`
+
+Smoothly transition discrete CSS properties like `display` and `overlay` — no more instant toggles.
+
+## The Problem
+
+Discrete properties (`display`, `visibility`, `overlay`) cannot be smoothly transitioned by default. When you toggle `display: none → block`, it snaps instantly — even with `opacity` and `transform` transitions.
+
+## The Solution
+
+`transition-behavior: allow-discrete` (Chromium 117+) enables transitions on discrete properties. Combined with `@starting-style` for entry animations, components can fade in/out smoothly when toggling `display`.
+
+## Demo
+
+- **normal**: `display` toggles instantly — no transition
+- **allow-discrete**: `display` fades in/out smoothly with `opacity` and `transform`
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Side-by-side comparison: normal vs allow-discrete |
+| `style.css` | Toggle panels, `@starting-style`, `transition-behavior` rules |
+
+## Proposed Utility
+
+In `core/utilities.css`:
+
+```css
+.ease-allow-discrete {
+  transition-behavior: allow-discrete;
+}
+```
+
+## Component Usage
+
+```css
+.ease-modal-panel {
+  transition:
+    opacity 0.3s,
+    transform 0.3s,
+    display 0.3s allow-discrete;
+}
+
+@starting-style {
+  .ease-modal-panel.active {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+```
+
+## Affected Components
+
+| Component | Discrete Property | Transition |
+|-----------|-----------------|------------|
+| `.ease-modal` | `display: none → flex` | opacity + transform + display allow-discrete |
+| `.ease-toast` | `display: none → block` | opacity + translate + display allow-discrete |
+| `.ease-tooltip` | `visibility: hidden → visible` | opacity + visibility allow-discrete |
+| `.ease-sidebar` | `display: none → block` | translate + display allow-discrete |
+
+## Browser Support
+
+| Chrome | Firefox | Safari |
+|--------|---------|--------|
+| 117+ | 129+ | 17.2+ |

--- a/submissions/examples/allow-discrete-pk/demo.html
+++ b/submissions/examples/allow-discrete-pk/demo.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — transition-behavior: allow-discrete</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1 class="title"><code>transition-behavior: allow-discrete</code></h1>
+    <p class="subtitle">
+      Smoothly transition discrete properties like <code>display</code> and <code>overlay</code>.
+      <span class="badge">Chrome 117+</span>
+    </p>
+
+    <div class="browser-note">
+      ⚡ Requires Chrome 117+. The default <code>normal</code> behavior instantly toggles discrete properties — no smooth transition.
+    </div>
+
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h2>normal (default)</h2>
+        <p class="desc"><code>display</code> toggles instantly — no transition.</p>
+        <div class="preview-box">
+          <div class="toggle-panel" id="panel-normal">
+            <div class="panel-inner">I appear instantly</div>
+          </div>
+        </div>
+        <button class="btn" onclick="toggle('panel-normal')">Toggle</button>
+        <div class="prop-label"><code>transition-behavior: normal</code></div>
+      </div>
+
+      <div class="demo-card">
+        <h2>allow-discrete</h2>
+        <p class="desc"><code>display</code> fades in/out smoothly.</p>
+        <div class="preview-box">
+          <div class="toggle-panel allow-discrete" id="panel-discrete">
+            <div class="panel-inner">I fade in smoothly</div>
+          </div>
+        </div>
+        <button class="btn" onclick="toggle('panel-discrete')">Toggle</button>
+        <div class="prop-label"><code>transition-behavior: allow-discrete</code></div>
+      </div>
+    </div>
+
+    <div class="details">
+      <h2>How It Works</h2>
+      <p>Without <code>allow-discrete</code>, the browser cannot interpolate values for discrete properties (like <code>display: none → block</code>). It snaps instantly.</p>
+      <p>With <code>allow-discrete</code>, combined with <code>@starting-style</code>, the browser can interpolate <code>opacity</code> and <code>transform</code> <em>while</em> toggling <code>display</code> — giving a smooth entry/exit.</p>
+    </div>
+
+    <div class="code-section">
+      <h2>Implementation</h2>
+
+      <div class="code-block">
+        <div class="code-header">Proposed .ease-allow-discrete utility</div>
+        <pre><code>.ease-allow-discrete {
+  transition-behavior: allow-discrete;
+}</code></pre>
+      </div>
+
+      <div class="code-block">
+        <div class="code-header">Component usage (modal panel)</div>
+        <pre><code>.ease-modal-panel {
+  transition:
+    opacity 0.3s,
+    transform 0.3s,
+    display 0.3s allow-discrete;
+}
+
+/* Entry state */
+@starting-style {
+  .ease-modal-panel.active {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}</code></pre>
+      </div>
+    </div>
+
+    <div class="components-list">
+      <h2>Affected Components</h2>
+      <table class="guide-table">
+        <tr><th>Component</th><th>Discrete Property</th><th>Transition</th></tr>
+        <tr><td><code>.ease-modal</code></td><td><code>display: none → flex</code></td><td>opacity + transform + display allow-discrete</td></tr>
+        <tr><td><code>.ease-toast</code></td><td><code>display: none → block</code></td><td>opacity + translate + display allow-discrete</td></tr>
+        <tr><td><code>.ease-tooltip</code></td><td><code>visibility: hidden → visible</code></td><td>opacity + visibility allow-discrete</td></tr>
+        <tr><td><code>.ease-sidebar</code></td><td><code>translate: -100% → 0</code></td><td>translate + display allow-discrete</td></tr>
+      </table>
+    </div>
+  </div>
+
+  <script>
+    function toggle(id) {
+      document.getElementById(id).classList.toggle('active');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/allow-discrete-pk/style.css
+++ b/submissions/examples/allow-discrete-pk/style.css
@@ -1,0 +1,216 @@
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 40px 24px 80px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #1e293b;
+}
+
+.title {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: #0f172a;
+}
+
+.title code {
+  font-size: 20px;
+  background: #eef2ff;
+  color: #4f46e5;
+  padding: 0 8px;
+  border-radius: 4px;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: #64748b;
+  margin: 0 0 12px;
+}
+
+.subtitle code { background: #f1f5f9; padding: 2px 6px; border-radius: 4px; }
+
+.badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  background: #fefce8;
+  color: #a16207;
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-left: 6px;
+}
+
+.browser-note {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: #475569;
+  margin-bottom: 28px;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 28px;
+}
+
+.demo-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+  background: #fff;
+}
+
+.demo-card h2 { font-size: 15px; font-weight: 600; margin: 0 0 4px; color: #0f172a; font-family: monospace; }
+
+.desc {
+  font-size: 13px;
+  color: #64748b;
+  margin: 0 0 12px;
+}
+
+.preview-box {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 10px;
+  min-height: 80px;
+}
+
+.toggle-panel {
+  display: none;
+  padding: 16px;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  border-radius: 8px;
+  color: #fff;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease,
+    display 0.3s;
+}
+
+.toggle-panel.allow-discrete {
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease,
+    display 0.3s allow-discrete;
+}
+
+.toggle-panel.active {
+  display: block;
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Without allow-discrete — no @starting-style possible */
+.toggle-panel:not(.allow-discrete).active {
+  display: block;
+}
+
+/* With allow-discrete + @starting-style */
+.toggle-panel.allow-discrete {
+  display: none;
+}
+
+@starting-style {
+  .toggle-panel.allow-discrete.active {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+
+.panel-inner { font-size: 14px; font-weight: 500; }
+
+.btn {
+  padding: 8px 20px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  background: #fff;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-right: 8px;
+}
+
+.btn:hover { background: #f1f5f9; border-color: #94a3b8; }
+
+.prop-label {
+  display: inline-block;
+  font-size: 12px;
+  color: #94a3b8;
+  font-family: monospace;
+}
+
+/* --- Details --- */
+.details {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 28px;
+}
+
+.details h2 { font-size: 16px; font-weight: 600; margin: 0 0 10px; color: #0f172a; }
+.details p { font-size: 14px; color: #475569; margin: 0 0 8px; line-height: 1.6; }
+.details p:last-child { margin-bottom: 0; }
+
+/* --- Code --- */
+.code-section { margin-bottom: 28px; }
+.code-section h2 { font-size: 16px; font-weight: 600; margin: 0 0 16px; color: #0f172a; }
+
+.code-block {
+  background: #0f172a;
+  border-radius: 10px;
+  margin-bottom: 12px;
+  overflow: hidden;
+}
+
+.code-header {
+  padding: 10px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #94a3b8;
+  background: #1e293b;
+  border-bottom: 1px solid #334155;
+}
+
+.code-block pre { padding: 16px 20px; margin: 0; overflow-x: auto; font-size: 13px; line-height: 1.6; color: #e2e8f0; }
+.code-block code { font-family: 'JetBrains Mono', 'Fira Code', monospace; }
+
+/* --- Components list --- */
+.components-list {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+}
+
+.components-list h2 { font-size: 16px; font-weight: 600; margin: 0 0 16px; color: #0f172a; }
+
+.guide-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+
+.guide-table th,
+.guide-table td { padding: 10px 12px; text-align: left; border-bottom: 1px solid #f1f5f9; }
+
+.guide-table th {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #64748b;
+}
+
+.guide-table tr:last-child td { border-bottom: none; }
+.guide-table td code { font-size: 12px; background: #f1f5f9; padding: 1px 5px; border-radius: 3px; }
+
+@media (max-width: 640px) {
+  .demo-grid { grid-template-columns: 1fr; }
+  .container { padding: 24px 16px; }
+}


### PR DESCRIPTION
## Description

Adds a self-contained demo showing `transition-behavior: allow-discrete` for smooth transitions on discrete properties like `display`. Side-by-side comparison of normal (instant toggle) vs allow-discrete (smooth fade). Includes proposed `.ease-allow-discrete` utility class and component mapping.

All changes are in `submissions/examples/allow-discrete-pk/`. No existing files were modified or deleted.

Fixes #13882

---

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)

---

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] My changes are entirely new files — no existing code was modified or deleted

---

## What was added

| File | Purpose |
|------|---------|
| `submissions/examples/allow-discrete-pk/demo.html` | Normal vs allow-discrete comparison with toggle buttons |
| `submissions/examples/allow-discrete-pk/style.css` | Toggle panels, `@starting-style`, `transition-behavior` rules |
| `submissions/examples/allow-discrete-pk/README.md` | Usage, component mapping, browser support |

## Policy Compliance
- All files are newly created under `submissions/examples/allow-discrete-pk/`
- No existing files were modified, deleted, or overwritten
- No core framework files were touched
