### PR TITLE
feat: add logical properties for RTL/internationalization support

### DIFF
--- a/submissions/examples/logical-props-pk/README.md
+++ b/submissions/examples/logical-props-pk/README.md
@@ -1,0 +1,53 @@
+# EaseMotion — Logical Properties for RTL Support
+
+Replace physical directional properties with logical equivalents for automatic RTL/LTR adaptation.
+
+## The Problem
+
+Physical properties like `left`, `right`, `margin-left`, `border-right` are direction-specific. In RTL languages (Arabic, Hebrew, Urdu), `left` should become `right`, but the browser doesn't auto-flip physical properties.
+
+## The Solution
+
+Logical properties like `inset-inline-start`, `margin-inline-end`, `border-inline-start` automatically adapt to the writing direction (`dir="ltr"` or `dir="rtl"`).
+
+## Demo
+
+Toggles `dir="rtl"` on the page to show how physical properties break and logical properties adapt.
+
+- **Physical sidebar**: `float: left`, `border-right` — stays on left even in RTL
+- **Logical sidebar**: `float: inline-start`, `border-inline-end` — flips to right in RTL
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Side-by-side physical vs logical with RTL toggle |
+| `style.css` | Both component variants, mapping table, code samples |
+
+## Physical → Logical Mapping
+
+| Physical | Logical |
+|----------|---------|
+| `left` | `inset-inline-start` |
+| `right` | `inset-inline-end` |
+| `margin-left` | `margin-inline-start` |
+| `margin-right` | `margin-inline-end` |
+| `padding-left` | `padding-inline-start` |
+| `padding-right` | `padding-inline-end` |
+| `border-left` | `border-inline-start` |
+| `border-right` | `border-inline-end` |
+| `text-align: left` | `text-align: start` |
+| `float: left` | `float: inline-start` |
+
+## Affected Components
+
+| Component | Physical Properties | Convert To |
+|-----------|-------------------|------------|
+| Sidebar | `left`, `right`, `transform: translateX` | `inset-inline-start/end`, `translate()` |
+| Navbar | `margin-right: auto` (brand push) | `margin-inline-end: auto` |
+| Tooltip | `left: 100%`, `margin-left` | `inset-inline-start: 100%`, `margin-inline-start` |
+| Modal | `left: 50%`, `transform: translateX(-50%)` | `inset-inline-start: 50%`, `translate(-50%, 0)` |
+| Toast | `right: 20px` | `inset-inline-end: 20px` |
+| Breadcrumb | `margin: 0 4px` | `margin-inline: 4px` |
+| Pagination | `margin-left` | `margin-inline-start` |
+| Tabs | `border-bottom`, `margin-right` | `border-block-end`, `margin-inline-end` |

--- a/submissions/examples/logical-props-pk/demo.html
+++ b/submissions/examples/logical-props-pk/demo.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Logical Properties for RTL</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1 class="title">Logical Properties for RTL Support</h1>
+    <p class="subtitle">
+      Replace physical <code>left</code>/<code>right</code> with logical
+      <code>inset-inline-start</code>/<code>inset-inline-end</code>
+      for automatic RTL adaptation.
+    </p>
+
+    <div class="toggle-bar">
+      <label class="toggle">
+        <input type="checkbox" id="toggle-rtl">
+        <span class="toggle-track"></span>
+        <span class="toggle-label"><code>dir=&quot;rtl&quot;</code></span>
+      </label>
+      <span class="toggle-hint">Toggle to see how logical properties auto-adapt</span>
+    </div>
+
+    <div class="demo-grid">
+      <div class="demo-col">
+        <h2 class="col-heading col-heading-bad">Physical Properties</h2>
+        <p class="col-desc">Uses <code>left</code>, <code>right</code>, <code>margin-left</code> — <strong>broken in RTL</strong>.</p>
+        <div class="component-demo" id="phys-sidebar">
+          <div class="phys-sidebar">
+            <div class="phys-sidebar-header">Sidebar</div>
+            <a class="phys-sidebar-link active">Home</a>
+            <a class="phys-sidebar-link">Dashboard</a>
+            <a class="phys-sidebar-link">Settings</a>
+          </div>
+          <div class="phys-content">
+            <div class="phys-navbar">
+              <span class="phys-nav-brand">Logo</span>
+              <div class="phys-nav-links">
+                <a>Home</a><a>About</a><a>Contact</a>
+              </div>
+            </div>
+            <div class="phys-tooltip-demo">
+              <span class="phys-tooltip-trigger">Hover me</span>
+              <div class="phys-tooltip">Tooltip on the right</div>
+            </div>
+            <p class="phys-text">Content area. The sidebar uses <code>left: 0</code>. In RTL, it should be on the right but stays on the left — <strong>broken</strong>.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="demo-col">
+        <h2 class="col-heading col-heading-good">Logical Properties</h2>
+        <p class="col-desc">Uses <code>inset-inline-start</code>, <code>margin-inline</code> — <strong>adapts to RTL</strong>.</p>
+        <div class="component-demo" id="logi-sidebar">
+          <div class="logi-sidebar">
+            <div class="logi-sidebar-header">Sidebar</div>
+            <a class="logi-sidebar-link active">Home</a>
+            <a class="logi-sidebar-link">Dashboard</a>
+            <a class="logi-sidebar-link">Settings</a>
+          </div>
+          <div class="logi-content">
+            <div class="logi-navbar">
+              <span class="logi-nav-brand">Logo</span>
+              <div class="logi-nav-links">
+                <a>Home</a><a>About</a><a>Contact</a>
+              </div>
+            </div>
+            <div class="logi-tooltip-demo">
+              <span class="logi-tooltip-trigger">Hover me</span>
+              <div class="logi-tooltip">Tooltip at inline-start</div>
+            </div>
+            <p class="logi-text">Content area. The sidebar uses <code>inset-inline-start: 0</code>. In RTL, it automatically flips to the right side — <strong>correct</strong>.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="mapping">
+      <h2>Physical → Logical Mapping</h2>
+      <table class="guide-table">
+        <tr><th>Physical</th><th>Logical</th></tr>
+        <tr><td><code>left</code></td><td><code>inset-inline-start</code></td></tr>
+        <tr><td><code>right</code></td><td><code>inset-inline-end</code></td></tr>
+        <tr><td><code>margin-left</code></td><td><code>margin-inline-start</code></td></tr>
+        <tr><td><code>margin-right</code></td><td><code>margin-inline-end</code></td></tr>
+        <tr><td><code>padding-left</code></td><td><code>padding-inline-start</code></td></tr>
+        <tr><td><code>padding-right</code></td><td><code>padding-inline-end</code></td></tr>
+        <tr><td><code>border-left</code></td><td><code>border-inline-start</code></td></tr>
+        <tr><td><code>border-right</code></td><td><code>border-inline-end</code></td></tr>
+        <tr><td><code>text-align: left</code></td><td><code>text-align: start</code></td></tr>
+        <tr><td><code>translateX(-100%)</code></td><td><code>translate(-100%, 0)</code> (LTR/RTL aware via logical)</td></tr>
+      </table>
+    </div>
+
+    <div class="code-section">
+      <h2>Sidebar Conversion Example</h2>
+      <div class="code-block">
+        <div class="code-header">Before (physical)</div>
+        <pre><code>.ease-sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 260px;
+  transform: translateX(-100%);
+}
+
+.ease-sidebar-right {
+  left: auto;
+  right: 0;
+  transform: translateX(100%);
+}</code></pre>
+      </div>
+      <div class="code-block">
+        <div class="code-header">After (logical)</div>
+        <pre><code>.ease-sidebar {
+  position: fixed;
+  inset-inline-start: 0;
+  inset-block: 0;
+  width: 260px;
+  transform: translate(-100%, 0);
+}
+
+.ease-sidebar-right {
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: translate(100%, 0);
+}</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.getElementById('toggle-rtl').addEventListener('change', (e) => {
+      document.documentElement.dir = e.target.checked ? 'rtl' : 'ltr';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/logical-props-pk/style.css
+++ b/submissions/examples/logical-props-pk/style.css
@@ -1,0 +1,316 @@
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 40px 24px 80px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #1e293b;
+}
+
+.title {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: #0f172a;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: #64748b;
+  margin: 0 0 20px;
+}
+
+.subtitle code { background: #f1f5f9; padding: 2px 6px; border-radius: 4px; }
+
+/* --- Toggle --- */
+.toggle-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.toggle input { display: none; }
+
+.toggle-track {
+  width: 44px;
+  height: 24px;
+  background: #cbd5e1;
+  border-radius: 12px;
+  position: relative;
+  transition: background 0.2s;
+}
+
+.toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.toggle input:checked + .toggle-track { background: #6366f1; }
+.toggle input:checked + .toggle-track::after { transform: translateX(20px); }
+
+.toggle-hint {
+  font-size: 13px;
+  color: #94a3b8;
+}
+
+.toggle-hint code { font-size: 12px; }
+
+/* --- Demo grid --- */
+.demo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+.col-heading {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 4px;
+  padding: 8px 12px;
+  border-radius: 6px;
+}
+
+.col-heading-bad { background: #fef2f2; color: #dc2626; }
+.col-heading-good { background: #f0fdf4; color: #16a34a; }
+
+.col-desc {
+  font-size: 12px;
+  color: #64748b;
+  margin: 0 0 12px;
+}
+
+.col-desc code { background: #f1f5f9; padding: 1px 4px; border-radius: 3px; }
+
+/* --- Component demo --- */
+.component-demo {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #fff;
+}
+
+/* --- Physical sidebar --- */
+.phys-sidebar {
+  float: left;
+  width: 120px;
+  background: #f1f5f9;
+  padding: 12px;
+  min-height: 200px;
+  border-right: 1px solid #e2e8f0;
+}
+
+.phys-sidebar-header { font-weight: 700; font-size: 14px; margin-bottom: 10px; color: #0f172a; }
+
+.phys-sidebar-link {
+  display: block;
+  padding: 6px 10px;
+  font-size: 13px;
+  color: #475569;
+  text-decoration: none;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}
+
+.phys-sidebar-link.active { background: #6366f1; color: #fff; }
+
+.phys-content { overflow: hidden; padding: 12px; }
+
+.phys-navbar {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+.phys-nav-brand { font-weight: 700; margin-right: auto; font-size: 14px; }
+
+.phys-nav-links { display: flex; gap: 12px; font-size: 13px; }
+.phys-nav-links a { color: #475569; cursor: pointer; }
+.phys-nav-links a:hover { color: #6366f1; }
+
+.phys-tooltip-demo {
+  position: relative;
+  padding: 10px 0;
+}
+
+.phys-tooltip-trigger {
+  display: inline-block;
+  padding: 4px 12px;
+  background: #e2e8f0;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: default;
+}
+
+.phys-tooltip {
+  display: none;
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 8px;
+  padding: 6px 10px;
+  background: #0f172a;
+  color: #f8fafc;
+  font-size: 12px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.phys-tooltip-trigger:hover + .phys-tooltip { display: block; }
+
+.phys-text { font-size: 13px; color: #64748b; line-height: 1.5; margin-top: 12px; }
+.phys-text code { background: #f1f5f9; padding: 1px 4px; border-radius: 3px; }
+
+/* --- Logical sidebar --- */
+.logi-sidebar {
+  float: inline-start;
+  width: 120px;
+  background: #f1f5f9;
+  padding: 12px;
+  min-height: 200px;
+  border-inline-end: 1px solid #e2e8f0;
+}
+
+.logi-sidebar-header { font-weight: 700; font-size: 14px; margin-bottom: 10px; color: #0f172a; }
+
+.logi-sidebar-link {
+  display: block;
+  padding: 6px 10px;
+  font-size: 13px;
+  color: #475569;
+  text-decoration: none;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}
+
+.logi-sidebar-link.active { background: #6366f1; color: #fff; }
+
+.logi-content { overflow: hidden; padding: 12px; }
+
+.logi-navbar {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+.logi-nav-brand { font-weight: 700; margin-inline-end: auto; font-size: 14px; }
+
+.logi-nav-links { display: flex; gap: 12px; font-size: 13px; }
+.logi-nav-links a { color: #475569; cursor: pointer; }
+.logi-nav-links a:hover { color: #6366f1; }
+
+.logi-tooltip-demo {
+  position: relative;
+  padding: 10px 0;
+}
+
+.logi-tooltip-trigger {
+  display: inline-block;
+  padding: 4px 12px;
+  background: #e2e8f0;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: default;
+}
+
+.logi-tooltip {
+  display: none;
+  position: absolute;
+  inset-inline-start: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-inline-start: 8px;
+  padding: 6px 10px;
+  background: #0f172a;
+  color: #f8fafc;
+  font-size: 12px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.logi-tooltip-trigger:hover + .logi-tooltip { display: block; }
+
+.logi-text { font-size: 13px; color: #64748b; line-height: 1.5; margin-top: 12px; }
+.logi-text code { background: #f1f5f9; padding: 1px 4px; border-radius: 3px; }
+
+/* --- Mapping --- */
+.mapping {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 28px;
+}
+
+.mapping h2 { font-size: 16px; font-weight: 600; margin: 0 0 16px; color: #0f172a; }
+
+.guide-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+
+.guide-table th,
+.guide-table td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #f1f5f9; }
+
+.guide-table th {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #64748b;
+}
+
+.guide-table tr:last-child td { border-bottom: none; }
+.guide-table td code { font-size: 13px; }
+
+/* --- Code --- */
+.code-section { margin-bottom: 32px; }
+.code-section h2 { font-size: 16px; font-weight: 600; margin: 0 0 12px; color: #0f172a; }
+
+.code-block {
+  background: #0f172a;
+  border-radius: 10px;
+  margin-bottom: 12px;
+  overflow: hidden;
+}
+
+.code-header {
+  padding: 10px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #94a3b8;
+  background: #1e293b;
+  border-bottom: 1px solid #334155;
+}
+
+.code-block pre { padding: 16px 20px; margin: 0; overflow-x: auto; font-size: 13px; line-height: 1.6; color: #e2e8f0; }
+.code-block code { font-family: 'JetBrains Mono', 'Fira Code', monospace; }
+
+@media (max-width: 700px) {
+  .demo-grid { grid-template-columns: 1fr; }
+  .container { padding: 24px 16px; }
+}


### PR DESCRIPTION
## Description

Adds a self-contained demo showing physical vs logical CSS properties for RTL support. Toggles `dir="rtl"` to demonstrate how physical properties break and logical properties auto-adapt. Includes sidebar, navbar, and tooltip components in both variants.

All changes are in `submissions/examples/logical-props-pk/`. No existing files were modified or deleted.

Fixes #13884

---

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)

---

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] My changes are entirely new files — no existing code was modified or deleted

---

## What was added

| File | Purpose |
|------|---------|
| `submissions/examples/logical-props-pk/demo.html` | Side-by-side physical vs logical with RTL toggle |
| `submissions/examples/logical-props-pk/style.css` | Both component variants using physical vs logical properties |
| `submissions/examples/logical-props-pk/README.md` | Full physical→logical mapping table, affected components |

## Policy Compliance
- All files are newly created under `submissions/examples/logical-props-pk/`
- No existing files were modified, deleted, or overwritten
- No core framework files were touched
