### PR TITLE
feat: add hyphens utilities for controlling text hyphenation

### DIFF
--- a/submissions/examples/hyphens-utilities/README.md
+++ b/submissions/examples/hyphens-utilities/README.md
@@ -1,0 +1,18 @@
+# Typographic Text Hyphenation Utilities
+
+An isolated text utility package introducing layout manipulation classes (`.ease-hyphens-none`, `.ease-hyphens-manual`, and `.ease-hyphens-auto`) under issue #13838. These utilities give developers explicit control over line wrapping splits on word boundaries.
+
+## Functional Mechanics
+
+- **The Problem:** In narrow responsive columns, cards, or side sheets, exceptionally long words frequently overflow the bounds of their layout cards or force heavy text raggedness. 
+- **The Solution:** Modifies word-wrap configurations using native browser engine properties. Applying `.ease-hyphens-auto` checks the element's container declaration (e.g., `lang="en"`) to break long strings gracefully at syllables using system-level dictionaries, injecting hyphens automatically.
+
+## Usage Layout Structure
+```html
+
+<p lang="en" class="ease-hyphens-auto">
+  Automating transformational responsive typography shifts fluidly.
+</p>
+```
+
+Closes #13838

--- a/submissions/examples/hyphens-utilities/demo.html
+++ b/submissions/examples/hyphens-utilities/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Typography Hyphenation Diagnostics — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f1f5f9; padding: 5rem 1rem; margin: 0;">
+
+  <div style="max-width: 950px; margin: 0 auto 3rem auto; text-align: center; font-family: sans-serif;">
+    <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.6rem;">Text Hyphenation Utility Matrix</h3>
+    <p style="margin: 0; color: #475569; font-size: 1rem; max-width: 650px; margin-left: auto; margin-right: auto;">
+      Observe how the long word <strong>"transformational"</strong> handles line wrapping when placed into constrained text boxes.
+    </p>
+  </div>
+
+  <div class="ease-hyphens-grid">
+    
+    <div class="ease-text-card">
+      <h4 style="margin: 0 0 0.25rem 0; font-size: 1.1rem; color: #0f172a; font-weight: 700;">Disabled (None)</h4>
+      <code style="font-size: 0.8rem; color: #ef4444;">.ease-hyphens-none</code>
+      
+      <div class="ease-narrow-paragraph ease-hyphens-none">
+        An interactive transformational interface.
+      </div>
+    </div>
+
+    <div class="ease-text-card">
+      <h4 style="margin: 0 0 0.25rem 0; font-size: 1.1rem; color: #0f172a; font-weight: 700;">Manual Break</h4>
+      <code style="font-size: 0.8rem; color: #2563eb;">.ease-hyphens-manual</code>
+      
+      <div class="ease-narrow-paragraph ease-hyphens-manual">
+        An interactive trans&shy;for&shy;ma&shy;tion&shy;al interface.
+      </div>
+    </div>
+
+    <div class="ease-text-card">
+      <h4 style="margin: 0 0 0.25rem 0; font-size: 1.1rem; color: #0f172a; font-weight: 700;">Automated (Auto)</h4>
+      <code style="font-size: 0.8rem; color: #10b981;">.ease-hyphens-auto</code>
+      
+      <div class="ease-narrow-paragraph ease-hyphens-auto">
+        An interactive transformational interface.
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/hyphens-utilities/style.css
+++ b/submissions/examples/hyphens-utilities/style.css
@@ -1,0 +1,61 @@
+/* ============================================================
+   ease-hyphens-* — Text Hyphenation Layout Utilities
+
+   Features utility configurations including:
+     - Prevention of hyphenation overrides via hyphens: none
+     - Soft-hyphen specific breaks via hyphens: manual
+     - Language-driven automated line-breaking via hyphens: auto
+   ============================================================ */
+
+/* --- THE FEATURE: Core Hyphenation Utilities --- */
+
+.ease-hyphens-none {
+  id-hyphens: none;
+  hyphens: none; /* Disables word-breaking hyphen insertion entirely */
+}
+
+.ease-hyphens-manual {
+  id-hyphens: manual;
+  hyphens: manual; /* Only splits lines when explicit &shy; tokens are present */
+}
+
+.ease-hyphens-auto {
+  id-hyphens: auto;
+  hyphens: auto; /* Automatically injects hyphens using language dictionaries */
+}
+
+
+/* ============================================================
+   TYPOGRAPHIC INSIGHT DESK (Demo Specific)
+   ============================================================ */
+
+.ease-hyphens-grid {
+  display: flex;
+  gap: 2rem;
+  max-width: 950px;
+  margin: 0 auto;
+  font-family: var(--ease-font-sans, sans-serif);
+}
+
+.ease-text-card {
+  flex: 1;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 1.75rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
+}
+
+/* Constrained text window layout container to forcefully trigger word wraps */
+.ease-narrow-paragraph {
+  width: 140px;
+  margin: 1.5rem auto 0 auto;
+  padding: 0.75rem;
+  background: #f8fafc;
+  border: 1px dashed #cbd5e1;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #0f172a;
+  text-align: left;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout utility tokens for fine-grained text hyphenation under issue #13838. Introduces `.ease-hyphens-none`, `.ease-hyphens-manual`, and `.ease-hyphens-auto` to give developers explicit control over line-breaks on word boundaries, maximizing typographic layout stability in tight panels or column setups.

Closes #13838

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Targeted word-breaking filters (`.ease-hyphens-auto`) mapping syallable breaks directly into multi-language contexts.
- Manual safety hooks (`.ease-hyphens-manual`) to allow structural parsing only when soft-hyphen markers (`&shy;`) are explicitly specified in HTML code blocks.
- Clean layout overrides safeguarding cards from unaligned visual padding splits or side overflows.

**How does a developer use it?**
```html
<p lang="en" class="ease-hyphens-auto">
  Comprehensive text wrapping structures here.
</p>