### PR TITLE
feat: add outline-offset utilities for controlling focus ring distance

### DIFF
--- a/submissions/examples/outline-offset-utilities/README.md
+++ b/submissions/examples/outline-offset-utilities/README.md
@@ -1,0 +1,18 @@
+# Outline Offset Spacing Utilities
+
+An isolated utility submission package adding programmatic control over keyboard accessibility borders (`.ease-outline-offset-0`, `.ease-outline-offset-1`, `.ease-outline-offset-2`, and `.ease-outline-offset-4`) under issue #13833.
+
+## Functional Mechanics
+
+- **The Problem:** By default, native browser focus outline highlights overlay immediately against element bounding rectangles. When items feature custom backgrounds or round pill edges, this tight binding frequently clips tracking vectors or causes visually muddy color interactions.
+- **The Solution:** Taps into native browser engine offset properties (`outline-offset`). This forces focus indicators to render shifted outward by explicit spacing metrics, keeping visual design boundaries pristine without adding complex hidden inner box-shadow rings.
+
+## Usage Layout Structure
+```html
+
+<button class="custom-btn ease-outline-offset-2">
+  Interactive Target Anchor
+</button>
+```
+
+Closes #13833

--- a/submissions/examples/outline-offset-utilities/demo.html
+++ b/submissions/examples/outline-offset-utilities/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Outline Offset Utilities — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f1f5f9; padding: 5rem 1rem; margin: 0;">
+
+  <div style="max-width: 900px; margin: 0 auto 3rem auto; text-align: center; font-family: sans-serif;">
+    <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.6rem;">Focus Outline Offset Utility Matrix</h3>
+    <p style="margin: 0; color: #475569; font-size: 1rem; max-width: 650px; margin-left: auto; margin-right: auto;">
+      Use the <strong>Tab key</strong> to step focus through the inputs below. Notice how the blue highlight rings sit at varying distances outside the button border limits.
+    </p>
+  </div>
+
+  <div class="ease-focus-grid">
+    
+    <div class="ease-focus-card">
+      <h4 style="margin: 0 0 0.25rem 0; font-size: 1.1rem; color: #0f172a; font-weight: 700;">Flush Ring</h4>
+      <code style="font-size: 0.8rem; color: #2563eb;">.ease-outline-offset-0</code>
+      <div class="ease-interactive-container">
+        <button class="ease-accessible-btn ease-outline-offset-0">Button Alpha</button>
+      </div>
+    </div>
+
+    <div class="ease-focus-card">
+      <h4 style="margin: 0 0 0.25rem 0; font-size: 1.1rem; color: #0f172a; font-weight: 700;">Standard Gap</h4>
+      <code style="font-size: 0.8rem; color: #2563eb;">.ease-outline-offset-2</code>
+      <div class="ease-interactive-container">
+        <button class="ease-accessible-btn ease-outline-offset-2">Button Beta</button>
+      </div>
+    </div>
+
+    <div class="ease-focus-card">
+      <h4 style="margin: 0 0 0.25rem 0; font-size: 1.1rem; color: #0f172a; font-weight: 700;">Enhanced Space</h4>
+      <code style="font-size: 0.8rem; color: #2563eb;">.ease-outline-offset-4</code>
+      <div class="ease-interactive-container">
+        <button class="ease-accessible-btn ease-outline-offset-4">Button Gamma</button>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/outline-offset-utilities/style.css
+++ b/submissions/examples/outline-offset-utilities/style.css
@@ -1,0 +1,69 @@
+/* ============================================================
+   ease-outline-offset-* — Focus Ring Spacing Utilities
+
+   Features utility configurations including:
+     - Tight focus ring tracking via 0px offset bounds
+     - Standard structural separation gaps (1px, 2px)
+     - High-visibility accessibility boundaries (4px)
+   ============================================================ */
+
+/* --- THE FEATURE: Core Outline Offset Tokens --- */
+
+.ease-outline-offset-0 { outline-offset: 0px; }
+.ease-outline-offset-1 { outline-offset: 1px; }
+.ease-outline-offset-2 { outline-offset: 2px; }
+.ease-outline-offset-4 { outline-offset: 4px; }
+
+
+/* ============================================================
+   ACCESSIBILITY FOCUS LAB DESK (Demo Specific)
+   ============================================================ */
+
+.ease-focus-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+  font-family: var(--ease-font-sans, sans-serif);
+}
+
+.ease-focus-card {
+  flex: 1;
+  min-width: 200px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 2rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
+  text-align: center;
+}
+
+.ease-interactive-container {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  background: #f8fafc;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Base button setup establishing a clear solid border layout */
+.ease-accessible-btn {
+  background-color: #ffffff;
+  color: #0f172a;
+  border: 2px solid #0f172a;
+  padding: 0.6rem 1.2rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: background-color 0.1s ease;
+}
+
+/* Force a distinct solid focus ring state across all sample triggers */
+.ease-accessible-btn:focus-visible {
+  outline: 2px solid #2563eb;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout utility tokens for fine-tuning accessibility focus ring gaps under issue #13833. Introduces metrics including `.ease-outline-offset-0` through `.ease-outline-offset-4` to give developers explicit control over how far native focus outlines stand out from an element's edge, enhancing modern user interfaces without cluttering components with custom box-shadow hacks.

Closes #13833

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Targeted spacing modifiers (`.ease-outline-offset-2`) establishing clean air gaps between container borders and focus rings.
- Flush baseline overrides (`.ease-outline-offset-0`) to securely snap indicators down to sharp bounding boundaries.
- Fluid layout protection preventing active border colors from mixing negatively with neighboring container paths.

**How does a developer use it?**
```html
<a href="#" class="ease-outline-offset-2">
  Accessible Nav Link
</a>