### PR TITLE
feat: add break-inside utilities for controlling how elements split across columns or pages

### DIFF
--- a/submissions/examples/break-inside-utilities/README.md
+++ b/submissions/examples/break-inside-utilities/README.md
@@ -1,0 +1,19 @@
+# Multi-Column Element Break Inside Utilities
+
+An isolated text layout and printing utility package introducing fragmentation optimization classes (`.ease-break-inside-auto`, `.ease-break-inside-avoid`, `.ease-break-inside-avoid-page`, and `.ease-break-inside-avoid-column`) under issue #13835.
+
+## Functional Mechanics
+
+- **The Problem:** In rich CSS columns layouts or standard printing sheets, elements (like article cards, quotes, or table rows) can break uncomfortably at structural limits. The browser engine often slices the card in half, placing the header at the bottom of column 1 and pushing the body text to the top of column 2.
+- **The Solution:** Modifies engine block breaking loops natively. Applying `.ease-break-inside-avoid` signals the renderer to keep the targeted boundary box completely intact, pushing the whole element to the next layout track whenever a column or page fracture line intersects it.
+
+## Usage Layout Structure
+```html
+
+<div class="masonry-item-card ease-break-inside-avoid">
+  <h4>Solid UI Card Header Fragment</h4>
+  <p>Solid content text that will never be split in half.</p>
+</div>
+```
+
+Closes #13835

--- a/submissions/examples/break-inside-utilities/demo.html
+++ b/submissions/examples/break-inside-utilities/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Break Inside Layout Metrics — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f1f5f9; padding: 5rem 1rem; margin: 0;">
+
+  <div style="max-width: 950px; margin: 0 auto 2.5rem auto; text-align: center; font-family: sans-serif;">
+    <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.6rem;">Element Fragmentation Utility Arena</h3>
+    <p style="margin: 0; color: #475569; font-size: 1rem; max-width: 700px; margin-left: auto; margin-right: auto;">
+      Observe structural differences within multi-column flow layers. The card marked with <code>.ease-break-inside-avoid</code> will stay intact, gracefully shifting to the next column rather than splitting awkwardly across columns.
+    </p>
+  </div>
+
+  <div class="ease-masonry-wrapper">
+    <div class="ease-column-flow-canvas">
+      
+      <div class="ease-content-card">
+        <h4>01. Foundation Entry</h4>
+        <p>This is standard baseline entry text. It occupies the top layer of the multi-column distribution grid perfectly.</p>
+      </div>
+
+      <div class="ease-content-card ease-break-inside-avoid" style="border-left: 4px solid #2563eb;">
+        <h4 style="color: #2563eb;">02. Integrity Protected Card</h4>
+        <code style="font-size: 0.75rem; color: #2563eb; display: block; margin-bottom: 0.5rem;">.ease-break-inside-avoid</code>
+        <p>By enforcing this utility, the browser engine is forced to treat this block as an indivisible unit. If space runs thin at the tail end of a column line, the entire module drops cleanly to the top of the next column track as a single piece.</p>
+      </div>
+
+      <div class="ease-content-card">
+        <h4>03. Downstream Block Alpha</h4>
+        <p>Additional text string mapping. This block tracks behind the protected unit without throwing off column balancing metrics.</p>
+      </div>
+
+      <div class="ease-content-card">
+        <h4>04. Downstream Block Beta</h4>
+        <p>Final node completing the columns layout verification sequence for the masonry field wrapper.</p>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/break-inside-utilities/style.css
+++ b/submissions/examples/break-inside-utilities/style.css
@@ -1,0 +1,70 @@
+/* ============================================================
+   ease-break-inside-* — Element Fragmentation Layout Utilities
+
+   Features utility configurations including:
+     - Default unconstrained breaking paths via auto
+     - Strict visual unit protection blocks via avoid
+     - Column/Page specific fragmentation avoidance limits
+   ============================================================ */
+
+/* --- THE FEATURE: Core Break Inside Utilities --- */
+
+.ease-break-inside-auto {
+  break-inside: auto; /* Allows content block fragmentation to occur naturally */
+}
+
+.ease-break-inside-avoid {
+  break-inside: avoid; /* Safely locks the element container from slicing across columns/pages */
+}
+
+.ease-break-inside-avoid-page {
+  break-inside: avoid-page; /* Prevents fragmentation exclusively during page breaks / PDF print tracks */
+}
+
+.ease-break-inside-avoid-column {
+  break-inside: avoid-column; /* Prevents layout slicing exclusively during multi-column distributions */
+}
+
+
+/* ============================================================
+   MULTI-COLUMN LAYOUT DESK (Demo Specific)
+   ============================================================ */
+
+.ease-masonry-wrapper {
+  max-width: 950px;
+  margin: 0 auto;
+  font-family: var(--ease-font-sans, sans-serif);
+}
+
+/* Configures a multi-column text canvas layout */
+.ease-column-flow-canvas {
+  column-count: 3;
+  column-gap: 2rem;
+  background: #f8fafc;
+  border: 1px dashed #cbd5e1;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 1.5rem;
+}
+
+.ease-content-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-md, 0.375rem);
+  padding: 1.25rem;
+  margin-bottom: 1.25rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.01);
+}
+
+.ease-content-card h4 {
+  margin: 0 0 0.5rem 0;
+  color: #0f172a;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.ease-content-card p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout utility tokens for fine-tuning layout fragmentation behaviors under issue #13835. Adds `.ease-break-inside-auto`, `.ease-break-inside-avoid`, and targeted platform modifiers to give developers explicit control over how container elements split across columns or page breaks, eliminating messy visual cut-offs in masonry and print layouts.

Closes #13835

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Visual layout stabilizers (`.ease-break-inside-avoid`) forcing individual container grids to stay whole when rendering close to structural column thresholds.
- Specialized document switches (`.ease-break-inside-avoid-page`) safeguarding layout content from being split across page breaks during PDF exports or printing.
- Clean masonry control, letting items shift seamlessly as complete blocks without layout clipping.

**How does a developer use it?**
```html
<div class="ease-break-inside-avoid">
  </div>