### PR TITLE
feat: add backface-visibility utilities for controlling element visibility during 3D transforms

### DIFF
--- a/submissions/examples/backface-visibility-utilities/README.md
+++ b/submissions/examples/backface-visibility-utilities/README.md
@@ -1,0 +1,18 @@
+# CSS Backface Visibility 3D Transform Utilities
+
+An isolated rendering layout utility package introducing spatial plane visibility modifiers (`.ease-backface-visible` and `.ease-backface-hidden`) under issue #13832.
+
+## Functional Mechanics
+
+- **The Problem:** When rotating structural boxes along spatial coordinates (such as a 180-degree turn via `rotateY`), browsers by default render a mirrored, backward projection of the front face. This causes the front contents to bleed through and clash visually with any real background layout panels you place underneath.
+- **The Solution:** Interfaces cleanly with native browser graphics composition routines via `backface-visibility`. Applying `.ease-backface-hidden` instructs the hardware painter to clip the reverse side immediately when its orientation vectors point away from the viewport, leaving your custom background panels perfectly pristine.
+
+## Usage Layout Structure
+```html
+
+<div class="front-face ease-backface-hidden">
+  <span>Front Side Template</span>
+</div>
+```
+
+Closes #13832

--- a/submissions/examples/backface-visibility-utilities/demo.html
+++ b/submissions/examples/backface-visibility-utilities/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Backface Visibility Labs — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="background: #f1f5f9; padding: 5rem 1rem; margin: 0;">
+
+  <div style="max-width: 800px; margin: 0 auto 3rem auto; text-align: center; font-family: sans-serif;">
+    <h3 style="margin: 0 0 0.5rem 0; color: #0f172a; font-weight: 800; font-size: 1.6rem;">3D Backface Visibility Sandbox</h3>
+    <p style="margin: 0; color: #475569; font-size: 1rem;">
+      Hover over the decks below to flip them 180 degrees and verify reverse-face clipping properties.
+    </p>
+  </div>
+
+  <div class="ease-spatial-grid">
+    
+    <div class="ease-lab-card">
+      <h4 style="margin: 0 0 0.25rem 0; font-size: 1.1rem; color: #0f172a; font-weight: 700;">Clean Clipping</h4>
+      <code style="font-size: 0.8rem; color: #10b981;">.ease-backface-hidden</code>
+      
+      <div class="ease-stage-3d">
+        <div class="ease-flipping-hull">
+          <div class="ease-card-face ease-face-front ease-backface-hidden">FRONT</div>
+          <div class="ease-card-face ease-face-back ease-backface-hidden">BACK</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="ease-lab-card">
+      <h4 style="margin: 0 0 0.25rem 0; font-size: 1.1rem; color: #0f172a; font-weight: 700;">Bleed-Through Mirror</h4>
+      <code style="font-size: 0.8rem; color: #ef4444;">.ease-backface-visible</code>
+      
+      <div class="ease-stage-3d">
+        <div class="ease-flipping-hull">
+          <div class="ease-card-face ease-face-front ease-backface-visible">FRONT</div>
+          <div class="ease-card-face ease-face-back ease-backface-visible">BACK</div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/backface-visibility-utilities/style.css
+++ b/submissions/examples/backface-visibility-utilities/style.css
@@ -1,0 +1,88 @@
+/* ============================================================
+   ease-backface-* — 3D Transform Mirror Visibility Utilities
+
+   Features utility configurations including:
+     - Visible reverse rendering maps via backface-visibility: visible
+     - Hidden reverse face clipping via backface-visibility: hidden
+   ============================================================ */
+
+/* --- THE FEATURE: Core Backface Visibility Utilities --- */
+
+.ease-backface-visible {
+  backface-visibility: visible; /* Default: Shows a mirrored, flipped version of the element face when rotated */
+}
+
+.ease-backface-hidden {
+  backface-visibility: hidden; /* Clips the reverse face entirely, leaving the element invisible when flipped */
+}
+
+
+/* ============================================================
+   3D CARD FLIP LAB STAGE (Demo Specific)
+   ============================================================ */
+
+.ease-spatial-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3rem;
+  max-width: 800px;
+  margin: 0 auto;
+  font-family: var(--ease-font-sans, sans-serif);
+  justify-content: center;
+}
+
+.ease-lab-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--ease-radius-xl, 0.75rem);
+  padding: 2rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.02);
+  text-align: center;
+}
+
+/* Perspective Wrapper establishing 3D depth field */
+.ease-stage-3d {
+  width: 200px;
+  height: 260px;
+  perspective: 600px;
+  margin-top: 1.5rem;
+}
+
+/* The structural card tracking rotational degrees */
+.ease-flipping-hull {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Rotate card 180 degrees continuously on hover */
+.ease-stage-3d:hover .ease-flipping-hull {
+  transform: rotateY(180deg);
+}
+
+/* Face sheets sharing mutual geometric positions */
+.ease-card-face {
+  position: absolute;
+  inset: 0;
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.ease-face-front {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  z-index: 2;
+}
+
+.ease-face-back {
+  background: linear-gradient(135deg, #10b981, #047857);
+  color: #ffffff;
+  transform: rotateY(180deg); /* Pre-flipped background positioning */
+}


### PR DESCRIPTION
## Pull Request Description
Submits the system interaction utility tokens for setting 3D layer visibility parameters under issue #13832. Introduces `.ease-backface-visible` and `.ease-backface-hidden` to provide exact control over whether an element's reverse side remains rendered or cleanly clipped when rotated in 3D spatial environments.

Closes #13832

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Visual clipping switches (`.ease-backface-hidden`) to hide mirrored background elements completely when they face away from the viewport camera.
- Default projection toggles (`.ease-backface-visible`) to let element paths render fluidly across multi-directional depth transformations.
- Clean coordination matrices that stop double-sided interfaces from bleeding into one another during intensive CSS rotations.

**How does a developer use it?**
```html
<div class="card-face ease-backface-hidden">
  </div>