### PR TITLE
Add ease-hover-crack animation example for issue #12555

### DIFF
--- a/submissions/examples/u-ease-hover-crack/README.md
+++ b/submissions/examples/u-ease-hover-crack/README.md
@@ -1,0 +1,51 @@
+# ease-hover-crack
+
+Element appears to crack on hover using animated SVG paths.
+
+## Features
+
+- SVG crack overlay
+- stroke-dashoffset animation
+- Center outward crack drawing
+- Hover interaction
+- Responsive design
+- Pure HTML and CSS
+
+## How It Works
+
+Each crack line is an SVG path.
+
+Initially:
+
+- stroke-dasharray is set
+- stroke-dashoffset hides the path
+
+On hover:
+
+- stroke-dashoffset animates to 0
+- crack lines appear to draw outward
+
+## Files
+
+- demo.html
+- style.css
+- README.md
+
+## Use Cases
+
+- Delete buttons
+- Warning panels
+- Danger actions
+- Game UI
+- Glitch effects
+
+## Browser Support
+
+- Chrome
+- Edge
+- Firefox
+- Safari
+
+## License
+
+MIT

--- a/submissions/examples/u-ease-hover-crack/demo.html
+++ b/submissions/examples/u-ease-hover-crack/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ease-hover-crack</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<h1>ease-hover-crack</h1>
+<p class="subtitle">Element appears to crack on hover</p>
+
+<div class="demos">
+
+    <div class="crack-box circle">
+        <span>CRACK</span>
+
+        <svg class="crack-overlay" viewBox="0 0 200 200">
+            <path d="M100 100 L100 20"/>
+            <path d="M100 100 L170 40"/>
+            <path d="M100 100 L180 100"/>
+            <path d="M100 100 L160 170"/>
+            <path d="M100 100 L100 180"/>
+            <path d="M100 100 L40 160"/>
+            <path d="M100 100 L20 100"/>
+            <path d="M100 100 L40 40"/>
+        </svg>
+    </div>
+
+    <div class="crack-box delete">
+        <span>DELETE</span>
+
+        <svg class="crack-overlay" viewBox="0 0 300 120">
+            <path d="M150 60 L20 20"/>
+            <path d="M150 60 L280 20"/>
+            <path d="M150 60 L20 100"/>
+            <path d="M150 60 L280 100"/>
+            <path d="M150 60 L150 10"/>
+            <path d="M150 60 L150 110"/>
+        </svg>
+    </div>
+
+    <div class="crack-box warning">
+        <span>WARNING</span>
+
+        <svg class="crack-overlay" viewBox="0 0 300 120">
+            <path d="M150 60 L40 30"/>
+            <path d="M150 60 L260 30"/>
+            <path d="M150 60 L40 90"/>
+            <path d="M150 60 L260 90"/>
+        </svg>
+    </div>
+
+</div>
+
+<div class="info-grid">
+
+    <div class="info-card">
+        <h2>How it Works</h2>
+
+        <ul>
+            <li>SVG crack lines positioned at center</li>
+            <li>stroke-dashoffset animation</li>
+            <li>Lines draw outward on hover</li>
+            <li>Pure HTML & CSS</li>
+        </ul>
+    </div>
+
+    <div class="info-card">
+        <h2>Usage</h2>
+
+<pre>
+&lt;div class="crack-box"&gt;
+  Content
+  &lt;svg class="crack-overlay"&gt;
+  &lt;/svg&gt;
+&lt;/div&gt;
+</pre>
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/u-ease-hover-crack/style.css
+++ b/submissions/examples/u-ease-hover-crack/style.css
@@ -1,0 +1,133 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background: #0f1115;
+    color: white;
+    font-family: Arial, sans-serif;
+    min-height: 100vh;
+    padding: 40px 20px;
+    text-align: center;
+}
+
+h1 {
+    font-size: 3rem;
+    margin-bottom: 10px;
+}
+
+.subtitle {
+    color: #a0a7b4;
+    margin-bottom: 40px;
+}
+
+.demos {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px,1fr));
+    gap: 30px;
+    max-width: 1200px;
+    margin: auto;
+}
+
+.crack-box {
+    position: relative;
+    overflow: hidden;
+    height: 220px;
+    border-radius: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.crack-box span {
+    font-size: 2rem;
+    font-weight: bold;
+    z-index: 2;
+}
+
+.circle {
+    border-radius: 50%;
+    width: 220px;
+    margin: auto;
+    background: radial-gradient(circle, #444, #111);
+}
+
+.delete {
+    background: linear-gradient(135deg,#ff4d4d,#b30000);
+}
+
+.warning {
+    background: #111;
+    border: 2px solid #2196f3;
+    color: #2196f3;
+}
+
+.crack-overlay {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.crack-overlay path {
+    fill: none;
+    stroke: rgba(255,255,255,0.9);
+    stroke-width: 2;
+    stroke-dasharray: 250;
+    stroke-dashoffset: 250;
+    transition: stroke-dashoffset 0.8s ease;
+}
+
+.crack-box:hover path {
+    stroke-dashoffset: 0;
+}
+
+.crack-box:hover {
+    transform: scale(1.03);
+}
+
+.info-grid {
+    max-width: 1200px;
+    margin: 50px auto 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit,minmax(320px,1fr));
+    gap: 25px;
+}
+
+.info-card {
+    background: #171a21;
+    padding: 25px;
+    border-radius: 16px;
+    text-align: left;
+}
+
+.info-card h2 {
+    margin-bottom: 15px;
+}
+
+.info-card ul {
+    padding-left: 20px;
+}
+
+.info-card li {
+    margin-bottom: 10px;
+}
+
+pre {
+    overflow-x: auto;
+    color: #7ee787;
+}
+
+@media (max-width: 768px) {
+    h1 {
+        font-size: 2rem;
+    }
+
+    .circle {
+        width: 180px;
+        height: 180px;
+    }
+}


### PR DESCRIPTION
## Related Issue

Closes #12555

## Description

Added a new `ease-hover-crack` animation example that creates a broken-glass cracking effect on hover using SVG paths and CSS animations.

### Features

* SVG crack overlay
* Animated stroke-dashoffset effect
* Crack lines draw from center outward
* Multiple crack effect demonstrations
* Circular button example
* Delete action example
* Warning panel example
* Responsive layout
* Pure HTML and CSS implementation

## Files Added

submissions/examples/u-ease-hover-crack/
├── demo.html
├── style.css
└── README.md

## Animation Details

### SVG Crack Overlay

Crack lines are created using SVG paths positioned from the center of the element.

### Stroke Animation

Each path uses `stroke-dasharray` and `stroke-dashoffset` to create a line-drawing effect.

### Hover Interaction

On hover, crack lines animate outward, producing a broken-glass appearance.

### Use Cases

* Delete buttons
* Warning states
* Danger actions
* Game UI effects
* Glitch-themed interfaces

## Checklist

* [x] HTML and CSS only
* [x] Responsive design
* [x] README included
* [x] Original implementation
* [x] SVG-based crack animation
* [x] Follows project structure
