### PR TITLE
Add ease-splash-screen-fade animation example for issue #14044

### DIFF
--- a/submissions/examples/u-ease-splash-screen-fade/README.md
+++ b/submissions/examples/u-ease-splash-screen-fade/README.md
@@ -1,0 +1,48 @@
+# ease-splash-screen-fade
+
+A splash screen animation that smoothly fades away to reveal application content underneath.
+
+## Features
+
+- Full-screen splash overlay
+- Opacity fade-out effect
+- Logo scale-down animation
+- Animated loading indicator
+- Smooth content reveal
+- Responsive design
+- Pure HTML and CSS
+
+## Acceptance Criteria Covered
+
+- opacity(1) → opacity(0)
+- Logo scales down during fade
+- Main content appears after splash
+- Common app launch UX pattern
+
+## Files
+
+- demo.html
+- style.css
+- README.md
+
+## Use Cases
+
+- Mobile applications
+- Web dashboards
+- SaaS platforms
+- Startup landing pages
+- Product launch screens
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari
+
+## Customization
+
+Change splash duration:
+
+```css
+animation: fadeSplash 5s forwards;

--- a/submissions/examples/u-ease-splash-screen-fade/demo.html
+++ b/submissions/examples/u-ease-splash-screen-fade/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Splash Screen Fade</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="splash-screen">
+    <div class="logo-wrapper">
+        <div class="logo">EM</div>
+        <h1>EaseMotion CSS</h1>
+        <p>Loading your experience...</p>
+
+        <div class="loader">
+            <span></span>
+            <span></span>
+            <span></span>
+        </div>
+    </div>
+</div>
+
+<div class="app-content">
+
+    <header>
+        <h1>Dashboard</h1>
+        <p>Main application content revealed after splash animation.</p>
+    </header>
+
+    <section class="cards">
+
+        <div class="card">
+            <h3>Analytics</h3>
+            <p>View reports and performance metrics.</p>
+        </div>
+
+        <div class="card">
+            <h3>Projects</h3>
+            <p>Manage active tasks and workflows.</p>
+        </div>
+
+        <div class="card">
+            <h3>Settings</h3>
+            <p>Customize your application preferences.</p>
+        </div>
+
+        <div class="card">
+            <h3>Notifications</h3>
+            <p>Track updates and alerts.</p>
+        </div>
+
+    </section>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/u-ease-splash-screen-fade/style.css
+++ b/submissions/examples/u-ease-splash-screen-fade/style.css
@@ -1,0 +1,174 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    font-family:Arial,sans-serif;
+    background:#f8fafc;
+    overflow:hidden;
+}
+
+/* Splash Screen */
+
+.splash-screen{
+    position:fixed;
+    inset:0;
+    background:linear-gradient(135deg,#0f172a,#1e293b);
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    z-index:999;
+    animation:fadeSplash 3.5s forwards;
+}
+
+.logo-wrapper{
+    text-align:center;
+    color:white;
+    animation:scaleLogo 3.5s forwards;
+}
+
+.logo{
+    width:120px;
+    height:120px;
+    margin:auto;
+    border-radius:50%;
+    background:#3b82f6;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-size:2.5rem;
+    font-weight:bold;
+    margin-bottom:20px;
+}
+
+.logo-wrapper h1{
+    margin-bottom:10px;
+}
+
+.logo-wrapper p{
+    opacity:.8;
+    margin-bottom:25px;
+}
+
+/* Loader */
+
+.loader{
+    display:flex;
+    justify-content:center;
+    gap:10px;
+}
+
+.loader span{
+    width:12px;
+    height:12px;
+    border-radius:50%;
+    background:white;
+    animation:bounce 1s infinite;
+}
+
+.loader span:nth-child(2){
+    animation-delay:.2s;
+}
+
+.loader span:nth-child(3){
+    animation-delay:.4s;
+}
+
+/* Main Content */
+
+.app-content{
+    min-height:100vh;
+    padding:40px;
+    opacity:0;
+    animation:showContent 1s forwards;
+    animation-delay:3s;
+}
+
+header{
+    text-align:center;
+    margin-bottom:40px;
+}
+
+.cards{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(250px,1fr));
+    gap:25px;
+}
+
+.card{
+    background:white;
+    padding:25px;
+    border-radius:18px;
+    box-shadow:0 10px 25px rgba(0,0,0,.08);
+    transition:transform .3s ease;
+}
+
+.card:hover{
+    transform:translateY(-6px);
+}
+
+.card h3{
+    margin-bottom:10px;
+}
+
+/* Animations */
+
+@keyframes fadeSplash{
+    0%{
+        opacity:1;
+    }
+
+    80%{
+        opacity:1;
+    }
+
+    100%{
+        opacity:0;
+        visibility:hidden;
+    }
+}
+
+@keyframes scaleLogo{
+    0%{
+        transform:scale(1);
+    }
+
+    100%{
+        transform:scale(.7);
+    }
+}
+
+@keyframes showContent{
+    from{
+        opacity:0;
+    }
+
+    to{
+        opacity:1;
+    }
+}
+
+@keyframes bounce{
+    0%,100%{
+        transform:translateY(0);
+    }
+
+    50%{
+        transform:translateY(-8px);
+    }
+}
+
+@media(max-width:768px){
+
+    .app-content{
+        padding:20px;
+    }
+
+    .logo{
+        width:90px;
+        height:90px;
+        font-size:2rem;
+    }
+}


### PR DESCRIPTION
## Related Issue

Closes #14044

## Description

Added a new `ease-splash-screen-fade` component that demonstrates a smooth splash/loading screen transition commonly used in modern applications.

### Features

* Full-screen splash screen overlay
* Smooth opacity fade-out animation
* Logo scale-down effect during transition
* Animated loading indicator
* Main content reveal animation
* Responsive layout
* Pure HTML and CSS implementation

## Files Added

submissions/examples/u-ease-splash-screen-fade/
├── demo.html
├── style.css
└── README.md

## Acceptance Criteria Covered

### Splash Fade Animation

The splash screen transitions smoothly from:

* opacity(1)
* opacity(0)

before revealing the application content.

### Logo Scale Animation

The logo scales down during the fade sequence for a polished launch experience.

### Content Reveal

The main dashboard content becomes visible after the splash screen animation completes.

## Use Cases

* Mobile apps
* SaaS dashboards
* Product launch screens
* Web applications
* Admin panels

## Checklist

* [x] HTML and CSS only
* [x] Responsive design
* [x] README included
* [x] Original implementation
* [x] Splash screen fade animation
* [x] Logo scale-down transition
* [x] Content reveal effect
* [x] Follows project structure
