### PR TITLE
docs: propose fix for issue #9622 (bundler import regex)

### DIFF
--- a/submissions/core_changes-issue-9622/README.md
+++ b/submissions/core_changes-issue-9622/README.md
@@ -1,0 +1,30 @@
+# Core Changes Proposal: Issue 9622
+
+## Problem Description
+Issue [#9622](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/9622) reports that the CSS bundler fails to parse `@import` statements when they include CSS cascade layers or media queries after the URL.
+
+The bug is located in `scripts/build-minified-css.mjs` on line 9:
+```javascript
+const localImportPattern = /@import\s+url\((["']?)(.*?)\1\)\s*;/gi;
+```
+This regex strictly expects a semicolon immediately after the closing parenthesis (with optional whitespace). If a layer or media query is added, such as `@import url("theme.css") layer(base);`, the regex fails to match, and the bundler throws an error or fails to inline the file.
+
+## Why this is submitted here
+PR #9646 originally attempted to fix this by modifying `scripts/build-minified-css.mjs` directly. However, due to the repository's strict Core Framework Protection policy and current Contribution Freeze on core files, the PR was closed automatically.
+
+Following `CONTRIBUTING.md`, this fix is proposed as a formal submission in the `submissions/` directory.
+
+## Proposed Fix
+Update the `localImportPattern` regex in `scripts/build-minified-css.mjs` to allow any characters up to the semicolon.
+
+**Change from:**
+```javascript
+const localImportPattern = /@import\s+url\((["']?)(.*?)\1\)\s*;/gi;
+```
+
+**Change to:**
+```javascript
+const localImportPattern = /@import\s+url\((["']?)(.*?)\1\)[^;]*;/gi;
+```
+
+This ensures that statements like `@import url("...") layer(base);` are correctly matched and processed.

--- a/submissions/core_changes-issue-9622/demo.html
+++ b/submissions/core_changes-issue-9622/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Issue #9622 Core Fix Proposal</title>
+    <!-- Linking the CSS that contains the failing import pattern -->
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <h1>Core Fix Proposal for Issue #9622</h1>
+        <p>This submission proposes a fix to the CSS bundler to support `@import` with cascade layers and media queries.</p>
+        <p>See the <code>README.md</code> for the proposed code changes to <code>scripts/build-minified-css.mjs</code>.</p>
+    </main>
+</body>
+</html>

--- a/submissions/core_changes-issue-9622/style.css
+++ b/submissions/core_changes-issue-9622/style.css
@@ -1,0 +1,21 @@
+/* 
+  Demonstration of Issue #9622 
+  The bundler currently fails to parse @import statements with layers.
+*/
+
+/* This import statement currently breaks the bundler: */
+@import url("base-theme.css") layer(core);
+
+/* 
+  PROPOSED FIX FOR `scripts/build-minified-css.mjs`:
+  
+  Update `localImportPattern` on line 9:
+  
+  - const localImportPattern = /@import\s+url\((["']?)(.*?)\1\)\s*;/gi;
+  + const localImportPattern = /@import\s+url\((["']?)(.*?)\1\)[^;]*;/gi;
+*/
+
+.test-element {
+  color: red;
+  /* Additional styles would go here */
+}


### PR DESCRIPTION
This PR submits a proposal for fixing the CSS bundler failing to parse `@import` statements with layers/media queries (Fixes #9622). As per the contribution guidelines, this is submitted in the `submissions/` directory to comply with the core framework freeze.