### PR TITLE
fix: add @supports guard for color-mix in .ease-card-glass dark mode (closes #14063)

### DIFF
--- a/submissions/examples/card-glass-colormix-fallback-ag/README.md
+++ b/submissions/examples/card-glass-colormix-fallback-ag/README.md
@@ -1,0 +1,12 @@
+# Glass Card color-mix Fallback Fix (Issue #14063)
+
+## What does this do?
+Demonstrates a corrected `.ease-card-glass` dark mode pattern that wraps `color-mix()` in a `@supports` guard with a solid dark background fallback.
+
+## How is it used?
+```html
+<div class="demo-card-glass">Glass content</div>
+```
+
+## Why is it useful?
+Without `@supports`, the `color-mix()` dark background silently drops in Firefox < 113 and Safari < 16.2, rendering the glass card fully transparent. The fix ensures all browsers get a visible dark background.

--- a/submissions/examples/card-glass-colormix-fallback-ag/demo.html
+++ b/submissions/examples/card-glass-colormix-fallback-ag/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Glass Card color-mix Fix — Issue #14063</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Glass Card Dark Mode Fix — Issue #14063</h1>
+    <p>Enable dark mode to see the corrected frosted glass background.</p>
+    <div class="demo-card-glass">
+      <h2>Glass Card</h2>
+      <p>Dark mode background now has a proper @supports fallback for browsers without color-mix support.</p>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/card-glass-colormix-fallback-ag/style.css
+++ b/submissions/examples/card-glass-colormix-fallback-ag/style.css
@@ -1,0 +1,42 @@
+/* Fix for Issue #14063: .ease-card-glass dark-mode color-mix without @supports */
+
+body {
+  font-family: system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 3rem 2rem;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+h1 { color: #fff; font-size: 1.5rem; margin-bottom: 1.5rem; }
+
+.demo-card-glass {
+  background: rgba(255,255,255,0.35);
+  border: 1px solid rgba(255,255,255,0.3);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  color: #1e293b;
+  max-width: 400px;
+}
+
+/* FIX: @supports guard for color-mix in dark mode */
+@media (prefers-color-scheme: dark) {
+  body { background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%); }
+
+  /* Fallback for browsers WITHOUT color-mix support */
+  .demo-card-glass {
+    background: rgba(30, 41, 59, 0.85);
+    color: #f8fafc;
+    border-color: rgba(255,255,255,0.12);
+  }
+
+  /* Enhanced background for browsers WITH color-mix support */
+  @supports (background: color-mix(in srgb, red 50%, blue)) {
+    .demo-card-glass {
+      background: color-mix(in srgb, #1e293b 50%, transparent);
+    }
+  }
+}
+
+.demo-card-glass h2 { margin: 0 0 0.75rem; font-size: 1.25rem; }
+.demo-card-glass p { margin: 0; line-height: 1.6; }


### PR DESCRIPTION
## What this fixes

Closes #14063

**Bug:** Dark mode `.ease-card-glass` uses `color-mix()` without an `@supports` guard. In Firefox < 113 and Safari < 16.2 the background becomes fully transparent.

**Fix demonstrated:** Adds a proper `@supports (background: color-mix(in srgb, red 50%, blue))` guard with a solid dark fallback for browsers that don't support `color-mix`.

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included
- [x] No changes to `core/` or `components/`