### PR TITLE
fix: demonstrate correct prefers-reduced-motion handling for dark mode neumorphic hover (closes #14065)

### DIFF
--- a/submissions/examples/neumorphic-dark-reduced-motion-fix-ag/README.md
+++ b/submissions/examples/neumorphic-dark-reduced-motion-fix-ag/README.md
@@ -1,0 +1,12 @@
+# Neumorphic Dark Mode Reduced Motion Fix (Issue #14065)
+
+## What does this do?
+Shows the correct CSS ordering so that `prefers-reduced-motion: reduce` properly suppresses the neumorphic card hover animation in both light AND dark mode.
+
+## How is it used?
+```html
+<div class="demo-card-neumorphic">Card content</div>
+```
+
+## Why is it useful?
+The current implementation nests the dark-mode hover inside `@media (prefers-color-scheme: dark)` but the reduced-motion override is declared before the dark-mode block. By placing the reduced-motion block last and targeting both the default and `:hover` states, the animation is fully suppressed for all users who prefer reduced motion.

--- a/submissions/examples/neumorphic-dark-reduced-motion-fix-ag/demo.html
+++ b/submissions/examples/neumorphic-dark-reduced-motion-fix-ag/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neumorphic Reduced Motion Fix — Issue #14065</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Neumorphic Dark Mode + Reduced Motion Fix — Issue #14065</h1>
+    <p>Hover the card below. With <em>prefers-reduced-motion: reduce</em> enabled, no transform occurs.</p>
+    <div class="demo-card-neumorphic">
+      <h2>Neumorphic Card</h2>
+      <p>Hover me. Reduced motion users see no lift animation in either light or dark mode.</p>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/neumorphic-dark-reduced-motion-fix-ag/style.css
+++ b/submissions/examples/neumorphic-dark-reduced-motion-fix-ag/style.css
@@ -1,0 +1,49 @@
+/* Fix for Issue #14065: neumorphic dark-mode nested hover not suppressed by reduced-motion */
+
+body {
+  font-family: system-ui, sans-serif; padding: 3rem 2rem;
+  background: #f0f4f8; min-height: 100vh;
+}
+h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+p { color: #64748b; margin-bottom: 2rem; }
+
+.demo-card-neumorphic {
+  background: #f0f4f8;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 8px 8px 20px rgba(15,23,42,0.12), -8px -8px 20px rgba(255,255,255,0.78);
+  max-width: 360px;
+  transition: transform 0.3s cubic-bezier(0.4,0,0.2,1), box-shadow 0.3s cubic-bezier(0.4,0,0.2,1);
+}
+.demo-card-neumorphic h2 { margin: 0 0 0.5rem; }
+.demo-card-neumorphic p { margin: 0; font-size: 0.9rem; }
+
+@media (hover: hover) and (pointer: fine) {
+  .demo-card-neumorphic:hover {
+    transform: translateY(-4px);
+    box-shadow: 12px 12px 26px rgba(15,23,42,0.14), -10px -10px 24px rgba(255,255,255,0.86);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body { background: #141e33; }
+  .demo-card-neumorphic {
+    background: #141e33;
+    box-shadow: 8px 8px 20px rgba(0,0,0,0.32), -8px -8px 20px rgba(255,255,255,0.04);
+    color: #f8fafc;
+  }
+  @media (hover: hover) and (pointer: fine) {
+    .demo-card-neumorphic:hover {
+      box-shadow: 12px 12px 26px rgba(0,0,0,0.36), -10px -10px 24px rgba(255,255,255,0.055);
+    }
+  }
+}
+
+/* FIX: Reduced motion override comes LAST and targets ALL hover states */
+@media (prefers-reduced-motion: reduce) {
+  .demo-card-neumorphic,
+  .demo-card-neumorphic:hover {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## What this fixes

Closes #14065

**Bug:** `.ease-card-neumorphic` dark-mode hover is nested inside `@media (prefers-color-scheme: dark) { @media (hover: hover) }` — the outer reduced-motion reset does not correctly suppress this hover animation for dark mode + reduced motion users.

**Fix demonstrated:** Correct ordering places the reduced-motion override after all hover rules and explicitly targets the combined dark-mode hover.

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included
- [x] No changes to `core/` or `components/`