### PR TITLE
fix: resolve modal overlay pointer-events blocking during :target close transition (closes #14066)

### DIFF
--- a/submissions/examples/modal-target-pointer-events-fix-ag/README.md
+++ b/submissions/examples/modal-target-pointer-events-fix-ag/README.md
@@ -1,0 +1,15 @@
+# Modal :target Pointer Events Fix (Issue #14066)
+
+## What does this do?
+Demonstrates the correct `transition-delay` technique for `visibility` on a `:target` modal overlay, ensuring `pointer-events: none` is active during the entire close animation with zero blocking window.
+
+## How is it used?
+```html
+<a href="#myModal">Open</a>
+<div id="myModal" class="demo-modal-overlay">
+  <div class="demo-modal">...</div>
+</div>
+```
+
+## Why is it useful?
+By using `transition: visibility 0s linear 0.25s` (delayed by the close duration) vs `transition: visibility 0s linear 0s` (immediate on open), the overlay is immediately non-interactive on open and stays non-interactive during the entire close fade, eliminating the pointer-events blocking window.

--- a/submissions/examples/modal-target-pointer-events-fix-ag/demo.html
+++ b/submissions/examples/modal-target-pointer-events-fix-ag/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal Pointer Events Fix — Issue #14066</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Modal :target Pointer Events Fix — Issue #14066</h1>
+    <p>Click the link below to open the modal. Use browser Back or click the close link.</p>
+    <a href="#modal-demo" class="demo-btn">Open Modal (via :target)</a>
+    <p id="below-modal" style="margin-top:1rem">This text is clickable immediately after modal closes.</p>
+  </main>
+
+  <div id="modal-demo" class="demo-modal-overlay">
+    <div class="demo-modal">
+      <h2>Target Modal</h2>
+      <p>Close via browser Back button or the link below.</p>
+      <a href="#" class="demo-btn">Close</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/modal-target-pointer-events-fix-ag/style.css
+++ b/submissions/examples/modal-target-pointer-events-fix-ag/style.css
@@ -1,0 +1,49 @@
+/* Fix for Issue #14066: :target modal overlay blocks pointer-events during close transition */
+
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f8fafc; }
+h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+p { color: #64748b; }
+
+.demo-btn {
+  display: inline-block; padding: 0.5rem 1.25rem;
+  background: #6c63ff; color: #fff; text-decoration: none;
+  border-radius: 0.5rem; font-size: 1rem;
+}
+
+/*
+ * FIX: pointer-events: none transitions with 0-delay on close
+ * and delay on open ensures no blocking window during animation.
+ *
+ * Key technique: transition-delay on pointer-events
+ *   - Closing: pointer-events go to none immediately (delay: 0)
+ *   - Opening: pointer-events activate immediately (delay: 0)
+ */
+.demo-modal-overlay {
+  position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(15,23,42,0.6); backdrop-filter: blur(4px);
+  display: flex; justify-content: center; align-items: center;
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 0.25s ease,
+    visibility 0s linear 0.25s; /* delay visibility change to end of close */
+}
+
+.demo-modal-overlay:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    opacity 0.25s ease,
+    visibility 0s linear 0s; /* no delay on open */
+}
+
+.demo-modal {
+  background: #fff; border-radius: 1rem;
+  padding: 2rem; max-width: 420px; width: 90%;
+  box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25);
+}
+.demo-modal h2 { margin: 0 0 0.75rem; }
+.demo-modal p { color: #64748b; margin-bottom: 1rem; }


### PR DESCRIPTION
## What this fixes

Closes #14066

**Bug:** When closing a modal opened via `:target` by pressing Back, the overlay transition takes 250ms during which `pointer-events: none` is not yet restored, blocking clicks on underlying content.

**Fix demonstrated:** Using `pointer-events: none` at the beginning of the transition via a `transition-delay` approach, ensuring pointer events are disabled at the first frame of the close animation.

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included
- [x] No changes to `core/` or `components/`