### PR TITLE
fix: prevent .ease-field label color change when child input is disabled (closes #14067)

### DIFF
--- a/submissions/examples/field-focus-within-disabled-fix-ag/README.md
+++ b/submissions/examples/field-focus-within-disabled-fix-ag/README.md
@@ -1,0 +1,15 @@
+# Field Focus-Within Disabled Input Fix (Issue #14067)
+
+## What does this do?
+Demonstrates the corrected `:focus-within` label color rule using `:not(:has(:disabled))` to prevent the label from turning primary color when the field contains a disabled input.
+
+## How is it used?
+```html
+<div class="demo-field">
+  <label class="demo-field-label">Label</label>
+  <input class="demo-input" disabled>
+</div>
+```
+
+## Why is it useful?
+The `:has()` pseudo-class allows checking child state from a parent selector. By adding `:not(:has(:disabled))`, the focus-within label color only activates for fields with focusable, non-disabled inputs — preventing unexpected label color changes on disabled form fields.

--- a/submissions/examples/field-focus-within-disabled-fix-ag/demo.html
+++ b/submissions/examples/field-focus-within-disabled-fix-ag/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Field Focus-Within Disabled Fix — Issue #14067</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Field Focus-Within Disabled Fix — Issue #14067</h1>
+    <p>The label of a disabled field should NOT turn purple on focus.</p>
+
+    <div class="demo-field">
+      <label class="demo-field-label">Active Input (label turns purple on focus)</label>
+      <input class="demo-input" placeholder="Click me">
+    </div>
+
+    <div class="demo-field">
+      <label class="demo-field-label">Disabled Input (label stays grey)</label>
+      <input class="demo-input" disabled value="Cannot focus">
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/field-focus-within-disabled-fix-ag/style.css
+++ b/submissions/examples/field-focus-within-disabled-fix-ag/style.css
@@ -1,0 +1,36 @@
+/* Fix for Issue #14067: :focus-within label color on disabled input */
+
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f8fafc; }
+h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+p { color: #64748b; margin-bottom: 1.5rem; }
+
+.demo-field {
+  display: flex; flex-direction: column;
+  gap: 0.5rem; margin-bottom: 1.25rem;
+}
+
+.demo-field-label {
+  font-size: 0.875rem; font-weight: 500;
+  color: #1e293b;
+  transition: color 0.15s ease;
+}
+
+.demo-input {
+  padding: 0.625rem 0.875rem; font-size: 1rem;
+  border: 1.5px solid #cbd5e1; border-radius: 0.5rem;
+  outline: none;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.demo-input:focus {
+  border-color: #6c63ff;
+  box-shadow: 0 0 0 3px rgba(108,99,255,0.18);
+}
+.demo-input:disabled {
+  background: #f1f5f9; color: #64748b;
+  border-color: #e2e8f0; cursor: not-allowed; opacity: 0.8;
+}
+
+/* FIX: Exclude fields containing a disabled input from focus-within label styling */
+.demo-field:focus-within:not(:has(:disabled)) .demo-field-label {
+  color: #6c63ff;
+}


### PR DESCRIPTION
## What this fixes

Closes #14067

**Bug:** `.ease-field:focus-within .ease-field-label` triggers label color change even when the focused input is disabled.

**Fix demonstrated:** Add `:not(:has(:disabled))` to the `:focus-within` selector to exclude fields with disabled inputs from the color change.

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included
- [x] No changes to `core/` or `components/`