### PR TITLE
fix: demonstrate correct .ease-card-image padding pattern when classes are on separate elements (closes #14068)

### DIFF
--- a/submissions/examples/card-image-padding-specificity-fix-ag/README.md
+++ b/submissions/examples/card-image-padding-specificity-fix-ag/README.md
@@ -1,0 +1,21 @@
+# Card Image Padding Specificity Fix (Issue #14068)
+
+## What does this do?
+Demonstrates the correct usage of `.ease-card-image` where both the base and modifier classes must be on the same element for the `padding: 0` override and its mobile counterpart to work correctly.
+
+## How is it used?
+```html
+<!-- CORRECT: Both classes on same element -->
+<div class="ease-card ease-card-image">
+  <img class="ease-card-img" src="photo.jpg" alt="">
+  <div class="ease-card-body">Text</div>
+</div>
+
+<!-- WRONG: Classes on separate elements — padding override fails on mobile -->
+<div class="ease-card">
+  <div class="ease-card-image">...</div>
+</div>
+```
+
+## Why is it useful?
+Documents the correct class co-location requirement so developers know both classes must be on the same DOM element for the mobile padding override to function correctly.

--- a/submissions/examples/card-image-padding-specificity-fix-ag/demo.html
+++ b/submissions/examples/card-image-padding-specificity-fix-ag/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Card Image Padding Fix — Issue #14068</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Card Image Padding Fix — Issue #14068</h1>
+    <p>Both classes must be on the same element for padding overrides to work correctly on mobile.</p>
+
+    <div class="demo-card demo-card-image">
+      <div class="demo-card-img-wrapper">
+        <div class="demo-card-img-placeholder">Image Area</div>
+      </div>
+      <div class="demo-card-body">
+        <h2>Correct Usage</h2>
+        <p>Both <code>.ease-card</code> and <code>.ease-card-image</code> on the same element.</p>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/card-image-padding-specificity-fix-ag/style.css
+++ b/submissions/examples/card-image-padding-specificity-fix-ag/style.css
@@ -1,0 +1,43 @@
+/* Fix for Issue #14068: .ease-card-image padding specificity when classes on separate elements */
+
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f8fafc; }
+h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+p { color: #64748b; margin-bottom: 1.5rem; }
+code { background: #e2e8f0; padding: 0.1em 0.4em; border-radius: 3px; font-size: 0.875em; }
+
+/* Base card — padding applied */
+.demo-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  overflow: hidden;
+  max-width: 380px;
+  background: #fff;
+}
+
+/* FIX: When .ease-card-image is on THE SAME element as .ease-card,
+   padding: 0 correctly removes all padding from the wrapper */
+.demo-card.demo-card-image {
+  padding: 0;
+}
+
+.demo-card-img-placeholder {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: linear-gradient(135deg, #6c63ff, #a09af8);
+  display: flex; align-items: center; justify-content: center;
+  color: #fff; font-weight: 600; font-size: 1.125rem;
+}
+
+.demo-card-body {
+  padding: 1.5rem;
+}
+.demo-card-body h2 { margin: 0 0 0.5rem; font-size: 1.125rem; }
+.demo-card-body p { margin: 0; color: #64748b; font-size: 0.9rem; }
+
+/* Mobile: combined selector still works because classes are on same element */
+@media (max-width: 640px) {
+  .demo-card.demo-card-image {
+    padding: 0; /* safe — both classes on same element */
+  }
+}


### PR DESCRIPTION
## What this fixes

Closes #14068

**Bug:** `.ease-card-image` `padding: 0` relies on both classes being on the same element. When structure separates them, mobile override `.ease-card.ease-card-image` doesn't apply.

**Fix demonstrated:** Uses the correct single-element class pattern and documents the limitation.

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included
- [x] No changes to `core/` or `components/`