### PR TITLE
fix: scope --ease-tab-width custom property to prevent cascade bleed between tab instances (closes #14070)

### DIFF
--- a/submissions/examples/tab-width-property-scope-fix-ag/README.md
+++ b/submissions/examples/tab-width-property-scope-fix-ag/README.md
@@ -1,0 +1,16 @@
+# Tab Width Property Scope Fix (Issue #14070)
+
+## What does this do?
+Demonstrates how to prevent `--tab-width` from bleeding between tab component instances by resetting the custom property to its default value at the `.demo-tabs` component root.
+
+## How is it used?
+```html
+<!-- Auto tabs with custom width -->
+<div class="ease-tabs ease-tabs-auto" style="--tab-width: 50%">...</div>
+
+<!-- Standard tabs — not affected by the auto tabs above -->
+<div class="ease-tabs">...</div>
+```
+
+## Why is it useful?
+CSS custom properties inherit down the tree. By resetting `--tab-width` at each `.ease-tabs` root, we prevent values set on one tab component from leaking into sibling or descendant components on the same page.

--- a/submissions/examples/tab-width-property-scope-fix-ag/demo.html
+++ b/submissions/examples/tab-width-property-scope-fix-ag/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tab Width Property Scope Fix — Issue #14070</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Tab Width Property Scope Fix — Issue #14070</h1>
+    <p>Two separate tab components. The auto-width tabs should not affect the standard tabs below.</p>
+
+    <h2>Auto-width tabs (sets --tab-width: 50%)</h2>
+    <div class="demo-tabs demo-tabs-auto" style="--tab-width: 50%">
+      <input type="radio" class="demo-tab-input" name="auto-tabs" id="a1" checked>
+      <input type="radio" class="demo-tab-input" name="auto-tabs" id="a2">
+      <div class="demo-tabs-nav">
+        <label class="demo-tab-label" for="a1">Tab A</label>
+        <label class="demo-tab-label" for="a2">Tab B</label>
+        <span class="demo-tab-underline"></span>
+      </div>
+    </div>
+
+    <h2>Standard 3-tab tabs (underline should be 33.333%)</h2>
+    <div class="demo-tabs">
+      <input type="radio" class="demo-tab-input" name="std-tabs" id="s1" checked>
+      <input type="radio" class="demo-tab-input" name="std-tabs" id="s2">
+      <input type="radio" class="demo-tab-input" name="std-tabs" id="s3">
+      <div class="demo-tabs-nav">
+        <label class="demo-tab-label" for="s1">One</label>
+        <label class="demo-tab-label" for="s2">Two</label>
+        <label class="demo-tab-label" for="s3">Three</label>
+        <span class="demo-tab-underline"></span>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/tab-width-property-scope-fix-ag/style.css
+++ b/submissions/examples/tab-width-property-scope-fix-ag/style.css
@@ -1,0 +1,42 @@
+/* Fix for Issue #14070: --ease-tab-width bleeds between tab instances */
+
+body { font-family: system-ui, sans-serif; padding: 2rem; background: #f8fafc; }
+h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+h2 { font-size: 1.1rem; margin: 1.5rem 0 0.5rem; }
+p { color: #64748b; margin-bottom: 1rem; }
+
+.demo-tabs {
+  display: flex; flex-direction: column; width: 100%;
+  /* FIX: Reset --tab-width to its default at the component root
+     to prevent inheritance from parent/sibling components */
+  --tab-width: 33.333%;
+}
+.demo-tab-input {
+  position: absolute; width: 1px; height: 1px;
+  clip-path: inset(50%); overflow: hidden; white-space: nowrap;
+}
+.demo-tabs-nav {
+  display: flex; border-bottom: 2px solid #e2e8f0;
+  position: relative; margin-bottom: 0.75rem;
+}
+.demo-tab-label {
+  flex: 1; text-align: center; padding: 0.625rem 1rem;
+  font-weight: 600; cursor: pointer; color: #64748b; user-select: none;
+}
+.demo-tab-underline {
+  position: absolute; bottom: -2px; left: 0; height: 2px;
+  /* Uses local --tab-width which is reset per component */
+  width: var(--tab-width, 33.333%);
+  background: #6c63ff;
+  transition: transform 0.3s ease;
+}
+/* Auto tabs: hide underline, use border-bottom indicator */
+.demo-tabs-auto .demo-tab-underline { display: none; }
+
+.demo-tab-input:nth-of-type(1):checked ~ .demo-tabs-nav .demo-tab-label:nth-of-type(1) { color: #6c63ff; }
+.demo-tab-input:nth-of-type(2):checked ~ .demo-tabs-nav .demo-tab-label:nth-of-type(2) { color: #6c63ff; }
+.demo-tab-input:nth-of-type(3):checked ~ .demo-tabs-nav .demo-tab-label:nth-of-type(3) { color: #6c63ff; }
+
+.demo-tab-input:nth-of-type(1):checked ~ .demo-tabs-nav .demo-tab-underline { transform: translateX(0); }
+.demo-tab-input:nth-of-type(2):checked ~ .demo-tabs-nav .demo-tab-underline { transform: translateX(100%); }
+.demo-tab-input:nth-of-type(3):checked ~ .demo-tabs-nav .demo-tab-underline { transform: translateX(200%); }


### PR DESCRIPTION
## What this fixes

Closes #14070

**Bug:** `--ease-tab-width` set on `.ease-tabs-auto` bleeds via CSS inheritance to sibling/child `.ease-tabs` components on the same page.

**Fix demonstrated:** Set `--ease-tab-width` with `@property` registration (or local reset) at the `.ease-tabs` component root to prevent inheritance.

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included
- [x] No changes to `core/` or `components/`