### PR TITLE
fix: align .ease-card-shadow hardcoded fallback values with design system shadow token (closes #14072)

### DIFF
--- a/submissions/examples/card-shadow-token-alignment-fix-ag/README.md
+++ b/submissions/examples/card-shadow-token-alignment-fix-ag/README.md
@@ -1,0 +1,12 @@
+# Card Shadow Token Alignment Fix (Issue #14072)
+
+## What does this do?
+Demonstrates corrected `.ease-card-shadow` fallback values that match the `--ease-shadow-lg` design token (`rgba(0,0,0,0.10)` and `rgba(0,0,0,0.05)`) instead of the overly dark `0.40`/`0.25` values.
+
+## How is it used?
+```html
+<div class="ease-card ease-card-shadow">Shadow card</div>
+```
+
+## Why is it useful?
+Consistent fallback values ensure that in environments where CSS custom properties are not resolved (SSR, IE11 polyfills, CSS-in-JS stripping), the shadow appearance matches the rest of the design system.

--- a/submissions/examples/card-shadow-token-alignment-fix-ag/demo.html
+++ b/submissions/examples/card-shadow-token-alignment-fix-ag/demo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Card Shadow Token Fix — #14072</title><link rel="stylesheet" href="style.css"></head>
+<body><main>
+  <h1>Card Shadow Token Alignment — Issue #14072</h1>
+  <p>Both cards should have identical shadow intensity.</p>
+  <div class="demo-cards">
+    <div class="demo-card demo-card-shadow-corrected"><h2>Corrected Shadow</h2><p>Fallback rgba matches the design token values.</p></div>
+    <div class="demo-card"><h2>Base Card</h2><p>No shadow modifier applied.</p></div>
+  </div>
+</main></body></html>

--- a/submissions/examples/card-shadow-token-alignment-fix-ag/style.css
+++ b/submissions/examples/card-shadow-token-alignment-fix-ag/style.css
@@ -1,0 +1,13 @@
+/* Fix for Issue #14072: .ease-card-shadow hardcoded rgba mismatches token */
+body{font-family:system-ui,sans-serif;padding:2rem;background:#f8fafc}
+h1{font-size:1.4rem;margin-bottom:.5rem}p{color:#64748b;margin-bottom:1.5rem}
+.demo-cards{display:flex;gap:1.5rem;flex-wrap:wrap}
+.demo-card{background:#fff;border:1px solid #e2e8f0;border-radius:1rem;padding:1.5rem;flex:1;min-width:220px}
+.demo-card h2{margin:0 0 .5rem;font-size:1.125rem}
+.demo-card p{margin:0;color:#64748b;font-size:.9rem}
+/* FIX: Use standard shadow values that match --ease-shadow-lg token
+   (0 10px 15px -3px rgba(0,0,0,.1) and 0 4px 6px -2px rgba(0,0,0,.05)) */
+.demo-card-shadow-corrected{
+  box-shadow:var(--ease-shadow-lg,0 10px 15px -3px rgba(0,0,0,.1),0 4px 6px -2px rgba(0,0,0,.05));
+  border-color:transparent;
+}


### PR DESCRIPTION
## What this fixes

Closes #14072

**Bug:** `.ease-card-shadow` fallback rgba values `(0,0,0,0.40)` and `(0,0,0,0.25)` don't match the `--ease-shadow-lg` token definition, causing inconsistency when custom properties aren't resolved.

**Fix demonstrated:** Corrected shadow values aligned with the design system token.

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included
- [x] No changes to `core/` or `components/`