### PR TITLE
feat: add copy code snippets example

### DIFF
--- a/submissions/examples/copy-code-snippets-kp/README.md
+++ b/submissions/examples/copy-code-snippets-kp/README.md
@@ -1,0 +1,16 @@
+# Copy Code Snippets
+
+## What does this do?
+
+This adds a self-contained copy button pattern for CSS and HTML snippets.
+
+## How is it used?
+
+```html
+<button class="copy-button" type="button" data-copy-target="fadeSnippet">Copy CSS</button>
+<pre id="fadeSnippet" class="code-block"><code>.ease-fade-in-kp { ... }</code></pre>
+```
+
+## Why is it useful?
+
+It improves the developer experience for EaseMotion CSS examples by letting users copy reusable animation code with one click while keeping the demo responsive and dependency-free.

--- a/submissions/examples/copy-code-snippets-kp/demo.html
+++ b/submissions/examples/copy-code-snippets-kp/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Copy Code Snippets</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="snippet-page">
+    <section class="snippet-panel">
+      <p class="eyebrow">EaseMotion utility</p>
+      <h1>Copy CSS snippets faster</h1>
+      <p class="intro">
+        Add a small copy action to reusable code examples so developers can grab animation classes without selecting text manually.
+      </p>
+
+      <article class="code-card">
+        <header class="code-card__header">
+          <div>
+            <span class="code-card__label">CSS</span>
+            <h2>Fade in utility</h2>
+          </div>
+          <button class="copy-button" type="button" data-copy-target="fadeSnippet">Copy CSS</button>
+        </header>
+
+        <pre id="fadeSnippet" class="code-block"><code>.ease-fade-in-kp {
+  animation: easeFadeInKp 0.55s ease both;
+}
+
+@keyframes easeFadeInKp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}</code></pre>
+      </article>
+
+      <article class="code-card code-card--accent">
+        <header class="code-card__header">
+          <div>
+            <span class="code-card__label">HTML</span>
+            <h2>Usage example</h2>
+          </div>
+          <button class="copy-button" type="button" data-copy-target="htmlSnippet">Copy HTML</button>
+        </header>
+
+        <pre id="htmlSnippet" class="code-block"><code>&lt;div class="ease-fade-in-kp"&gt;
+  Animated content
+&lt;/div&gt;</code></pre>
+      </article>
+    </section>
+  </main>
+
+  <script>
+    document.querySelectorAll(".copy-button").forEach((button) => {
+      button.addEventListener("click", async () => {
+        const target = document.getElementById(button.dataset.copyTarget);
+        const originalText = button.textContent;
+
+        try {
+          await navigator.clipboard.writeText(target.textContent.trim());
+          button.textContent = "Copied";
+          button.classList.add("is-copied");
+        } catch (error) {
+          button.textContent = "Select text";
+        }
+
+        window.setTimeout(() => {
+          button.textContent = originalText;
+          button.classList.remove("is-copied");
+        }, 1600);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/copy-code-snippets-kp/style.css
+++ b/submissions/examples/copy-code-snippets-kp/style.css
@@ -1,0 +1,145 @@
+:root {
+  color-scheme: light;
+  --page-bg: #f4f7fb;
+  --panel-bg: #ffffff;
+  --ink: #172033;
+  --muted: #5b677a;
+  --line: #d8e0ec;
+  --brand: #116466;
+  --brand-dark: #0b3d3f;
+  --accent: #d99a28;
+  --code-bg: #101522;
+  --code-ink: #dce8ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    linear-gradient(135deg, rgba(17, 100, 102, 0.1), transparent 42%),
+    var(--page-bg);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.snippet-page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px 16px;
+}
+
+.snippet-panel {
+  width: min(920px, 100%);
+  display: grid;
+  gap: 18px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--brand);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+.intro {
+  margin: 0;
+}
+
+h1 {
+  max-width: 760px;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 660px;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.code-card {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  box-shadow: 0 18px 45px rgba(23, 32, 51, 0.1);
+}
+
+.code-card--accent {
+  border-color: rgba(217, 154, 40, 0.45);
+}
+
+.code-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.code-card__label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.code-card h2 {
+  font-size: 1.05rem;
+}
+
+.copy-button {
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 6px;
+  background: var(--brand);
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 800;
+  min-width: 96px;
+  padding: 10px 14px;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.copy-button:hover,
+.copy-button:focus-visible {
+  background: var(--brand-dark);
+  transform: translateY(-1px);
+}
+
+.copy-button.is-copied {
+  background: var(--accent);
+}
+
+.code-block {
+  margin: 0;
+  overflow-x: auto;
+  background: var(--code-bg);
+  color: var(--code-ink);
+  font: 0.94rem/1.65 "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  padding: 20px;
+}
+
+@media (max-width: 620px) {
+  .code-card__header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .copy-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained copy-to-clipboard code snippet example under submissions/examples/copy-code-snippets-kp
- Includes demo.html, style.css, and README.md only
- Provides responsive snippet cards with copied-state feedback

## Related Issue
Closes #12779

## Validation
- Confirmed submission folder contains exactly demo.html, style.css, and README.md
- npm test could not run meaningful checks because current config reports no test files found
- stylelint ignores submissions/ via .stylelintignore, so submission CSS is not linted by repo config

## Checklist
- [x] I added files only inside submissions/examples/
- [x] I included demo.html, style.css, and README.md
- [x] I kept this PR focused on one feature