### PR TITLE
feat: add animated flame difficulty rating example

### DIFF
--- a/submissions/examples/difficulty-rating-flame-vs/README.md
+++ b/submissions/examples/difficulty-rating-flame-vs/README.md
@@ -1,0 +1,3 @@
+1. What does this do? It shows a reusable recipe difficulty rating component that uses five animated flame icons to represent Very Easy through Extreme.
+2. How is it used? Open demo.html directly in a browser and reuse the flame rating markup and style.css classes in any recipe card.
+3. Why is it useful? It gives recipe interfaces a clear, compact, and accessible way to communicate difficulty with a familiar rating pattern.

--- a/submissions/examples/difficulty-rating-flame-vs/demo.html
+++ b/submissions/examples/difficulty-rating-flame-vs/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>difficulty-rating-flame-vs Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page-shell">
+    <section class="hero" aria-labelledby="page-title">
+      <p class="eyebrow">Recipe difficulty</p>
+      <h1 id="page-title">Flame rating for recipe difficulty</h1>
+      <p class="lede">
+        A reusable, CSS-only component that turns the familiar rating pattern into animated flame icons.
+      </p>
+    </section>
+
+    <section class="rating-grid" aria-label="Recipe difficulty examples">
+      <article class="rating-card">
+        <p class="card-kicker">Recipe</p>
+        <h2>Herb Butter Toast</h2>
+        <div class="flame-rating" role="img" aria-label="Herb Butter Toast difficulty: Very Easy, 1 out of 5 flames">
+          <span class="flame active"></span>
+          <span class="flame inactive"></span>
+          <span class="flame inactive"></span>
+          <span class="flame inactive"></span>
+          <span class="flame inactive"></span>
+        </div>
+        <p class="difficulty-label">Very Easy</p>
+      </article>
+
+      <article class="rating-card">
+        <p class="card-kicker">Recipe</p>
+        <h2>Citrus Couscous</h2>
+        <div class="flame-rating" role="img" aria-label="Citrus Couscous difficulty: Easy, 2 out of 5 flames">
+          <span class="flame active"></span>
+          <span class="flame active"></span>
+          <span class="flame inactive"></span>
+          <span class="flame inactive"></span>
+          <span class="flame inactive"></span>
+        </div>
+        <p class="difficulty-label">Easy</p>
+      </article>
+
+      <article class="rating-card">
+        <p class="card-kicker">Recipe</p>
+        <h2>Skillet Gnocchi</h2>
+        <div class="flame-rating" role="img" aria-label="Skillet Gnocchi difficulty: Medium, 3 out of 5 flames">
+          <span class="flame active"></span>
+          <span class="flame active"></span>
+          <span class="flame active"></span>
+          <span class="flame inactive"></span>
+          <span class="flame inactive"></span>
+        </div>
+        <p class="difficulty-label">Medium</p>
+      </article>
+
+      <article class="rating-card">
+        <p class="card-kicker">Recipe</p>
+        <h2>Harissa Ramen</h2>
+        <div class="flame-rating" role="img" aria-label="Harissa Ramen difficulty: Hard, 4 out of 5 flames">
+          <span class="flame active"></span>
+          <span class="flame active"></span>
+          <span class="flame active"></span>
+          <span class="flame active"></span>
+          <span class="flame inactive"></span>
+        </div>
+        <p class="difficulty-label">Hard</p>
+      </article>
+
+      <article class="rating-card">
+        <p class="card-kicker">Recipe</p>
+        <h2>Volcano Curry</h2>
+        <div class="flame-rating" role="img" aria-label="Volcano Curry difficulty: Extreme, 5 out of 5 flames">
+          <span class="flame active"></span>
+          <span class="flame active"></span>
+          <span class="flame active"></span>
+          <span class="flame active"></span>
+          <span class="flame active"></span>
+        </div>
+        <p class="difficulty-label">Extreme</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/difficulty-rating-flame-vs/style.css
+++ b/submissions/examples/difficulty-rating-flame-vs/style.css
@@ -1,0 +1,323 @@
+/* Root styles */
+:root {
+  color-scheme: light;
+  --page-bg: #fff8f0;
+  --page-bg-deep: #ffe8d3;
+  --card-bg: rgba(255, 255, 255, 0.78);
+  --card-border: rgba(226, 120, 47, 0.14);
+  --text-main: #1f2937;
+  --text-soft: #6b7280;
+  --accent: #ea580c;
+  --accent-deep: #b91c1c;
+  --inactive: #b8c0cc;
+  --inactive-edge: #8a93a1;
+  --shadow: 0 18px 50px rgba(148, 67, 22, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text-main);
+  background:
+    radial-gradient(circle at top, rgba(255, 183, 114, 0.36), transparent 36%),
+    radial-gradient(circle at 20% 20%, rgba(255, 127, 80, 0.14), transparent 24%),
+    linear-gradient(160deg, var(--page-bg) 0%, #fff 55%, var(--page-bg-deep) 100%);
+}
+
+/* Layout */
+.page-shell {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 3rem 0 3.5rem;
+}
+
+.hero {
+  text-align: center;
+  max-width: 44rem;
+  margin: 0 auto 2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--accent-deep);
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 4rem);
+  line-height: 1.02;
+}
+
+.lede {
+  margin: 1rem auto 0;
+  max-width: 36rem;
+  color: var(--text-soft);
+  font-size: 1.02rem;
+  line-height: 1.65;
+}
+
+.rating-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  align-items: stretch;
+}
+
+/* Rating card */
+.rating-card {
+  position: relative;
+  overflow: hidden;
+  padding: 1.4rem 1.25rem 1.2rem;
+  border: 1px solid var(--card-border);
+  border-radius: 22px;
+  background: var(--card-bg);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(16px);
+  text-align: center;
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.rating-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.48), transparent 42%);
+  pointer-events: none;
+}
+
+.rating-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(234, 88, 12, 0.24);
+  box-shadow: 0 24px 60px rgba(148, 67, 22, 0.22);
+}
+
+.card-kicker {
+  position: relative;
+  margin: 0 0 0.45rem;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-deep);
+}
+
+.rating-card h2 {
+  position: relative;
+  margin: 0;
+  font-size: 1.18rem;
+  line-height: 1.2;
+}
+
+.flame-rating {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  justify-content: center;
+  gap: 0.42rem;
+  margin: 1rem 0 0.85rem;
+  padding: 0.9rem 1rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255, 243, 231, 0.92), rgba(255, 234, 216, 0.72));
+  border: 1px solid rgba(248, 162, 90, 0.18);
+}
+
+.difficulty-label {
+  position: relative;
+  margin: 0;
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: var(--accent-deep);
+}
+
+/* Flame styles */
+.flame {
+  --flame-size: 1.18rem;
+  --flame-final-opacity: 1;
+  position: relative;
+  width: var(--flame-size);
+  height: calc(var(--flame-size) * 1.38);
+  flex: 0 0 auto;
+  display: inline-block;
+  transform-origin: center bottom;
+  opacity: 0;
+  will-change: transform, opacity, filter;
+}
+
+.flame::before,
+.flame::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
+.flame::before {
+  inset: 4% 8% 2% 8%;
+  border-radius: 60% 60% 58% 58% / 60% 60% 40% 40%;
+  transform: rotate(45deg) scale(0.96);
+  background: linear-gradient(180deg, #fff5b8 0%, #ffc558 28%, #ff8a1f 60%, #d61f1f 100%);
+  box-shadow: inset 0 -0.22rem 0.45rem rgba(128, 34, 15, 0.28), 0 0 0.9rem rgba(255, 122, 26, 0.18);
+}
+
+.flame::after {
+  inset: 28% 30% 18% 30%;
+  border-radius: 50% 50% 50% 50%;
+  transform: rotate(45deg) scale(0.82);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(255, 241, 183, 0.98) 45%, rgba(255, 198, 88, 0.92) 100%);
+  opacity: 0.9;
+}
+
+.flame.active::before {
+  filter: drop-shadow(0 0 0.45rem rgba(255, 122, 26, 0.38));
+}
+
+.flame.active {
+  --flame-final-opacity: 1;
+}
+
+.flame.inactive::before {
+  background: linear-gradient(180deg, #e5e7eb 0%, #cbd5e1 45%, #94a3b8 100%);
+  box-shadow: inset 0 -0.18rem 0.3rem rgba(71, 85, 105, 0.15);
+}
+
+.flame.inactive {
+  --flame-final-opacity: 0.72;
+}
+
+.flame.inactive::after {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.8) 0%, rgba(226, 232, 240, 0.82) 100%);
+  opacity: 0.55;
+}
+
+.flame:nth-child(1) {
+  --flame-delay: 0ms;
+}
+
+.flame:nth-child(2) {
+  --flame-delay: 120ms;
+}
+
+.flame:nth-child(3) {
+  --flame-delay: 240ms;
+}
+
+.flame:nth-child(4) {
+  --flame-delay: 360ms;
+}
+
+.flame:nth-child(5) {
+  --flame-delay: 480ms;
+}
+
+/* Animations */
+@keyframes flame-pop {
+  0% {
+    transform: translateY(0.75rem) scale(0);
+    opacity: 0;
+    filter: blur(2px);
+  }
+
+  60% {
+    transform: translateY(-0.1rem) scale(1.08);
+    opacity: 1;
+    filter: blur(0);
+  }
+
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: var(--flame-final-opacity);
+    filter: blur(0);
+  }
+}
+
+@keyframes flame-glow {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 0.4rem rgba(255, 122, 26, 0.28));
+  }
+
+  50% {
+    filter: drop-shadow(0 0 0.7rem rgba(255, 122, 26, 0.52));
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .flame.active {
+    animation: flame-pop 720ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation-delay: var(--flame-delay);
+  }
+
+  .flame.inactive {
+    animation: flame-pop 720ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation-delay: var(--flame-delay);
+  }
+
+  .flame.active::before {
+    animation: flame-glow 2.8s ease-in-out infinite;
+  }
+
+  .rating-card:hover .flame.active {
+    transform: translateY(-0.08rem) scale(1.05);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rating-card,
+  .flame,
+  .rating-card:hover {
+    transition: none;
+    transform: none;
+  }
+
+  .flame {
+    opacity: var(--flame-final-opacity);
+  }
+}
+
+/* Responsive styles */
+@media (max-width: 720px) {
+  .page-shell {
+    width: min(100% - 1.25rem, 1120px);
+    padding: 2rem 0 2.5rem;
+  }
+
+  .hero {
+    margin-bottom: 1.5rem;
+  }
+
+  .rating-card {
+    padding: 1.25rem 1rem 1.1rem;
+  }
+
+  .flame-rating {
+    gap: 0.34rem;
+    padding: 0.82rem 0.88rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .hero h1 {
+    font-size: 1.95rem;
+  }
+
+  .lede {
+    font-size: 0.96rem;
+  }
+
+  .rating-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new self-contained animated recipe difficulty rating component using flame icons.

## Changes Made

* Added `demo.html`
* Added `style.css`
* Added `README.md`
* Implemented staggered flame scale-in animation
* Added active/inactive flame states
* Added responsive card layout

## Issue

Closes #14039

## Checklist

* [x] Added files only inside `submissions/examples/`
* [x] No core/component files modified
* [x] No external dependencies used
* [x] Includes `demo.html`, `style.css`, and `README.md`
* [x] Tested locally in browser
