### PR TITLE
feat: add css accordion and tabs example

### DIFF
--- a/submissions/examples/css-accordion-tabs-kp/README.md
+++ b/submissions/examples/css-accordion-tabs-kp/README.md
@@ -1,0 +1,21 @@
+# CSS Accordion and Tabs
+
+## What does this do?
+
+This adds a dependency-free accordion and tab component demo using semantic HTML and CSS state selectors.
+
+## How is it used?
+
+```html
+<details class="accordion-item">
+  <summary>Accordion title</summary>
+  <p>Accordion content</p>
+</details>
+
+<input class="tab-input" type="radio" name="featureTabs" id="tab-motion" checked>
+<label class="tab-label" for="tab-motion">Motion</label>
+```
+
+## Why is it useful?
+
+It fits EaseMotion CSS by showing interactive UI patterns that remain lightweight, accessible, responsive, and free from JavaScript dependencies.

--- a/submissions/examples/css-accordion-tabs-kp/demo.html
+++ b/submissions/examples/css-accordion-tabs-kp/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Accordion and Tabs</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="component-page">
+    <section class="intro">
+      <p class="eyebrow">Zero JavaScript pattern</p>
+      <h1>CSS-only accordion and tabs</h1>
+      <p>
+        This demo uses semantic details elements and radio-button tab state so interactive panels work without a script dependency.
+      </p>
+    </section>
+
+    <section class="layout-grid" aria-label="CSS component examples">
+      <article class="demo-panel">
+        <div class="panel-heading">
+          <span>Accordion</span>
+          <h2>FAQ stack</h2>
+        </div>
+
+        <div class="accordion-stack">
+          <details class="accordion-item" open>
+            <summary>How does this accordion open?</summary>
+            <p>The browser manages the expanded state through the semantic details element, while CSS handles the motion.</p>
+          </details>
+
+          <details class="accordion-item">
+            <summary>Does it need JavaScript?</summary>
+            <p>No. The interaction is native, keyboard accessible, and works when scripts are blocked.</p>
+          </details>
+
+          <details class="accordion-item">
+            <summary>Where can it be used?</summary>
+            <p>It works well for FAQs, release notes, settings panels, and compact documentation sections.</p>
+          </details>
+        </div>
+      </article>
+
+      <article class="demo-panel">
+        <div class="panel-heading">
+          <span>Tabs</span>
+          <h2>Feature switcher</h2>
+        </div>
+
+        <div class="tabs">
+          <input class="tab-input" type="radio" name="featureTabs" id="tab-motion" checked>
+          <label class="tab-label" for="tab-motion">Motion</label>
+
+          <input class="tab-input" type="radio" name="featureTabs" id="tab-access">
+          <label class="tab-label" for="tab-access">Access</label>
+
+          <input class="tab-input" type="radio" name="featureTabs" id="tab-theme">
+          <label class="tab-label" for="tab-theme">Theme</label>
+
+          <div class="tab-panels">
+            <section class="tab-panel tab-panel--motion">
+              <h3>Smooth transitions</h3>
+              <p>Panels fade and slide into place with a short transition that keeps the interface responsive.</p>
+            </section>
+
+            <section class="tab-panel tab-panel--access">
+              <h3>Keyboard friendly</h3>
+              <p>Radio inputs keep the selected tab reachable through native form controls and labels.</p>
+            </section>
+
+            <section class="tab-panel tab-panel--theme">
+              <h3>Token ready</h3>
+              <p>Colors and spacing are defined with custom properties so the component can be themed quickly.</p>
+            </section>
+          </div>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-accordion-tabs-kp/style.css
+++ b/submissions/examples/css-accordion-tabs-kp/style.css
@@ -1,0 +1,243 @@
+:root {
+  --page: #f7f3ef;
+  --surface: #ffffff;
+  --ink: #18202f;
+  --muted: #606b7b;
+  --line: #dadfe8;
+  --primary: #22577a;
+  --primary-soft: #d8edf7;
+  --accent: #c0522d;
+  --shadow: 0 20px 50px rgba(24, 32, 47, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.component-page {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.eyebrow,
+.panel-heading span {
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  margin-top: 8px;
+  font-size: clamp(2rem, 6vw, 4.6rem);
+  line-height: 1;
+}
+
+.intro p {
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.demo-panel {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  padding: 22px;
+}
+
+.panel-heading {
+  margin-bottom: 18px;
+}
+
+.panel-heading h2 {
+  margin-top: 4px;
+  font-size: 1.35rem;
+}
+
+.accordion-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.accordion-item {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fbfcff;
+}
+
+.accordion-item summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 16px 48px 16px 16px;
+  position: relative;
+  font-weight: 800;
+}
+
+.accordion-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.accordion-item summary::after {
+  content: "+";
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--primary-soft);
+  color: var(--primary);
+  transform: translateY(-50%);
+  transition: transform 180ms ease;
+}
+
+.accordion-item[open] summary::after {
+  content: "-";
+  transform: translateY(-50%) rotate(180deg);
+}
+
+.accordion-item p {
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  line-height: 1.6;
+  padding: 16px;
+  animation: accordionRevealKp 180ms ease both;
+}
+
+.tabs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.tab-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.tab-label {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 12px;
+  text-align: center;
+  transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.tab-label:hover {
+  border-color: var(--primary);
+}
+
+.tab-input:focus-visible + .tab-label {
+  outline: 3px solid rgba(34, 87, 122, 0.22);
+  outline-offset: 2px;
+}
+
+#tab-motion:checked + .tab-label,
+#tab-access:checked + .tab-label,
+#tab-theme:checked + .tab-label {
+  border-color: var(--primary);
+  background: var(--primary);
+  color: #ffffff;
+}
+
+.tab-panels {
+  grid-column: 1 / -1;
+  min-height: 190px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcff;
+  overflow: hidden;
+  position: relative;
+}
+
+.tab-panel {
+  inset: 0;
+  opacity: 0;
+  padding: 26px;
+  pointer-events: none;
+  position: absolute;
+  transform: translateY(12px);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.tab-panel h3 {
+  margin-bottom: 10px;
+}
+
+.tab-panel p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+#tab-motion:checked ~ .tab-panels .tab-panel--motion,
+#tab-access:checked ~ .tab-panels .tab-panel--access,
+#tab-theme:checked ~ .tab-panels .tab-panel--theme {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+@keyframes accordionRevealKp {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 820px) {
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .tabs {
+    grid-template-columns: 1fr;
+  }
+
+  .tab-panels {
+    min-height: 230px;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained CSS-only accordion and tabs example under submissions/examples/css-accordion-tabs-kp
- Uses semantic details/summary for the accordion and radio inputs for tab state
- Includes responsive styling and dependency-free interaction patterns

## Related Issue
Closes #12761

## Validation
- Confirmed submission folder contains exactly demo.html, style.css, and README.md
- npm test could not run meaningful checks because current config reports no test files found
- stylelint ignores submissions/ via .stylelintignore, so submission CSS is not linted by repo config

## Checklist
- [x] I added files only inside submissions/examples/
- [x] I included demo.html, style.css, and README.md
- [x] I kept this PR focused on one feature