### PR TITLE
fix: resolve .ease-modal-slide visibility flash during overlay close transition (closes #14062)

### DIFF
--- a/submissions/examples/modal-slide-opacity-fix-ag/demo.html
+++ b/submissions/examples/modal-slide-opacity-fix-ag/demo.html
@@ -10,13 +10,13 @@
   <main>
     <h1>Modal Slide Fix — Issue #14062</h1>
     <p>Demonstrates the corrected slide modal that does not flash during close.</p>
-    <button class="demo-btn" onclick="document.getElementById(\"m\").classList.add(\"is-active\")">Open Slide Modal</button>
+    <button class="demo-btn" onclick="document.getElementById('m').classList.add('is-active')">Open Slide Modal</button>
     <div id="m" class="demo-modal-overlay">
       <div class="demo-modal demo-modal-slide">
         <div class="demo-modal-header"><h2>Slide Modal</h2></div>
         <div class="demo-modal-body"><p>No opacity flash on close. Transition is smooth.</p></div>
         <div class="demo-modal-footer">
-          <button type="button" class="demo-btn" onclick="document.getElementById(\"m\").classList.remove(\"is-active\")">Close</button>
+          <button type="button" class="demo-btn" onclick="document.getElementById('m').classList.remove('is-active')">Close</button>
         </div>
       </div>
     </div>

--- a/submissions/examples/modal-slide-opacity-fix-ag/style.css
+++ b/submissions/examples/modal-slide-opacity-fix-ag/style.css
@@ -1,7 +1,13 @@
-/* Fix for Issue #14062: .ease-modal-slide opacity flash */
+body {
+  font-family: system-ui, sans-serif;
+  padding: 2rem;
+  background: #f8fafc;
+}
 
-body { font-family: system-ui, sans-serif; padding: 2rem; background: #f8fafc; }
-h1 { font-size: 1.5rem; margin-bottom: 1rem; }
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
 
 .demo-btn {
   padding: 0.5rem 1.25rem;
@@ -14,36 +20,60 @@ h1 { font-size: 1.5rem; margin-bottom: 1rem; }
 }
 
 .demo-modal-overlay {
-  position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
   background: rgba(15, 23, 42, 0.6);
-  display: flex; justify-content: center; align-items: flex-end;
-  opacity: 0; visibility: hidden; pointer-events: none;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
   transition: opacity 0.25s ease, visibility 0.25s ease;
   z-index: 1000;
 }
+
 .demo-modal-overlay.is-active {
-  opacity: 1; visibility: visible; pointer-events: auto;
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }
 
-/* FIX: slide variant carries its own opacity + transform closed state */
 .demo-modal {
-  background: #fff; border-radius: 1rem 1rem 0 0;
-  width: 100%; max-width: 500px;
+  background: #fff;
+  border-radius: 1rem 1rem 0 0;
+  width: 100%;
+  max-width: 500px;
   box-shadow: 0 -4px 24px rgba(0,0,0,0.15);
 }
+
 .demo-modal-slide {
-  /* KEY FIX: Both transform AND opacity in closed state */
   transform: translateY(100%);
   opacity: 0;
-  transition:
-    transform 0.3s cubic-bezier(0.4,0,0.2,1),
-    opacity 0.3s ease;
+  transition: transform 0.3s cubic-bezier(0.4,0,0.2,1), opacity 0.3s ease;
 }
+
 .demo-modal-overlay.is-active .demo-modal-slide {
   transform: translateY(0);
   opacity: 1;
 }
-.demo-modal-header { padding: 1rem 1.5rem; border-bottom: 1px solid #e2e8f0; }
-.demo-modal-header h2 { margin: 0; font-size: 1.125rem; }
-.demo-modal-body { padding: 1.5rem; }
-.demo-modal-footer { padding: 1rem 1.5rem; text-align: right; border-top: 1px solid #e2e8f0; }
+
+.demo-modal-header {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.demo-modal-header h2 {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.demo-modal-body {
+  padding: 1.5rem;
+}
+
+.demo-modal-footer {
+  padding: 1rem 1.5rem;
+  text-align: right;
+  border-top: 1px solid #e2e8f0;
+}


### PR DESCRIPTION
Closes #14062

**Bug:** `.ease-modal-slide` flashes briefly during close transitions because the slide variant sets `transform: translateY(100%)` but doesn't carry its own `opacity: 0` in the closed state — relying solely on the overlay's `visibility: hidden` for concealment.

**Fix demonstrated:** This submission shows a corrected slide modal pattern where the closed state includes both `transform: translateY(100%)` and an explicit `opacity: 0` on the modal itself, ensuring no flash regardless of overlay transition timing.

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included (`demo.html`, `style.css`, `README.md`)
- [x] PR is focused on one fix
- [x] No changes to `core/` or `components/`