### PR TITLE
feat: add dark mode token example

### DIFF
--- a/submissions/examples/dark-mode-tokens-kp/README.md
+++ b/submissions/examples/dark-mode-tokens-kp/README.md
@@ -1,0 +1,18 @@
+# Dark Mode Tokens
+
+## What does this do?
+
+This demonstrates a dark mode token system using CSS custom properties and `prefers-color-scheme`.
+
+## How is it used?
+
+```html
+<article class="preview-card">
+  <h2>Surface</h2>
+  <p>Uses semantic tokens for text, borders, shadows, and background.</p>
+</article>
+```
+
+## Why is it useful?
+
+It shows how EaseMotion CSS components can adapt to light and dark themes by changing reusable token values instead of hard-coding colors in each component.

--- a/submissions/examples/dark-mode-tokens-kp/demo.html
+++ b/submissions/examples/dark-mode-tokens-kp/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dark Mode Tokens</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="token-shell">
+    <section class="token-hero">
+      <p class="eyebrow">CSS custom properties</p>
+      <h1>Dark mode tokens that follow system preference</h1>
+      <p class="summary">The same component reads semantic color tokens, while the token values swap through prefers-color-scheme.</p>
+    </section>
+
+    <section class="preview-grid" aria-label="Token previews">
+      <article class="preview-card">
+        <span class="status-dot"></span>
+        <h2>Surface</h2>
+        <p>Cards, text, borders, and shadows use reusable tokens instead of hard-coded colors.</p>
+      </article>
+      <article class="preview-card accent-card">
+        <span class="status-dot"></span>
+        <h2>Accent</h2>
+        <p>Accent colors remain readable in both light and dark mode without changing markup.</p>
+      </article>
+      <article class="preview-card success-card">
+        <span class="status-dot"></span>
+        <h2>State</h2>
+        <p>State tokens make success, warning, and action components easier to theme consistently.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/dark-mode-tokens-kp/style.css
+++ b/submissions/examples/dark-mode-tokens-kp/style.css
@@ -1,0 +1,135 @@
+:root {
+  color-scheme: light;
+  --ease-page-bg-kp: #f4f7fb;
+  --ease-surface-kp: #ffffff;
+  --ease-text-kp: #172033;
+  --ease-muted-kp: #627086;
+  --ease-border-kp: #d9e2ef;
+  --ease-accent-kp: #2563eb;
+  --ease-accent-soft-kp: #dbeafe;
+  --ease-success-kp: #047857;
+  --ease-success-soft-kp: #d1fae5;
+  --ease-shadow-kp: 0 20px 48px rgba(23, 32, 51, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --ease-page-bg-kp: #101820;
+    --ease-surface-kp: #17212d;
+    --ease-text-kp: #edf5ff;
+    --ease-muted-kp: #a8b6c9;
+    --ease-border-kp: #2c3a4c;
+    --ease-accent-kp: #7dd3fc;
+    --ease-accent-soft-kp: #123449;
+    --ease-success-kp: #86efac;
+    --ease-success-soft-kp: #123626;
+    --ease-shadow-kp: 0 22px 52px rgba(0, 0, 0, 0.32);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--ease-page-bg-kp);
+  color: var(--ease-text-kp);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  transition: background 180ms ease, color 180ms ease;
+}
+
+.token-shell {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.token-hero {
+  max-width: 760px;
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--ease-accent-kp);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 4.5rem);
+  line-height: 1;
+}
+
+.summary {
+  margin-top: 14px;
+  color: var(--ease-muted-kp);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.preview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.preview-card {
+  min-height: 220px;
+  border: 1px solid var(--ease-border-kp);
+  border-radius: 8px;
+  background: var(--ease-surface-kp);
+  box-shadow: var(--ease-shadow-kp);
+  padding: 22px;
+  transition: background 180ms ease, border-color 180ms ease, transform 180ms ease;
+}
+
+.preview-card:hover {
+  transform: translateY(-4px);
+}
+
+.preview-card h2 {
+  margin-top: 24px;
+  font-size: 1.35rem;
+}
+
+.preview-card p {
+  margin-top: 10px;
+  color: var(--ease-muted-kp);
+  line-height: 1.6;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+  border: 10px solid var(--ease-accent-soft-kp);
+  border-radius: 50%;
+  background: var(--ease-accent-kp);
+}
+
+.accent-card {
+  background: var(--ease-accent-soft-kp);
+}
+
+.success-card .status-dot {
+  border-color: var(--ease-success-soft-kp);
+  background: var(--ease-success-kp);
+}
+
+@media (max-width: 820px) {
+  .preview-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained dark mode token example under submissions/examples/dark-mode-tokens-kp
- Uses CSS custom properties and prefers-color-scheme to swap semantic token values
- Includes responsive preview cards for surface, accent, and state tokens

## Related Issue
Closes #12760

## Validation
- Confirmed submission folder contains exactly demo.html, style.css, and README.md

## Checklist
- [x] I added files only inside submissions/examples/
- [x] I included demo.html, style.css, and README.md
- [x] I kept this PR focused on one feature