### PR TITLE
feat: add accessible form controls example

### DIFF
--- a/submissions/examples/accessible-form-controls-kp/README.md
+++ b/submissions/examples/accessible-form-controls-kp/README.md
@@ -1,0 +1,18 @@
+# Accessible Form Controls
+
+## What does this do?
+
+This adds a self-contained demo for accessible CSS-only inputs, selects, checkboxes, and toggles.
+
+## How is it used?
+
+```html
+<label class="field">
+  <span>Email address</span>
+  <input type="email" placeholder="you@example.com">
+</label>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a practical form-control pattern with visible labels, keyboard focus states, touch-friendly sizing, and clear checked states.

--- a/submissions/examples/accessible-form-controls-kp/demo.html
+++ b/submissions/examples/accessible-form-controls-kp/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accessible Form Controls</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="form-page">
+    <section class="form-intro">
+      <p class="eyebrow">Accessible controls</p>
+      <h1>CSS-only inputs, checkboxes, and toggles</h1>
+      <p>Form controls use visible labels, focus rings, minimum touch targets, and clear state changes without external dependencies.</p>
+    </section>
+
+    <form class="control-card">
+      <label class="field">
+        <span>Email address</span>
+        <input type="email" placeholder="you@example.com">
+      </label>
+
+      <label class="field">
+        <span>Project type</span>
+        <select>
+          <option>Animation library</option>
+          <option>Design system</option>
+          <option>Documentation site</option>
+        </select>
+      </label>
+
+      <label class="check-row">
+        <input type="checkbox">
+        <span class="check-box"></span>
+        <span>Send weekly contribution summaries</span>
+      </label>
+
+      <label class="switch-row">
+        <span>Enable reduced motion defaults</span>
+        <input type="checkbox">
+        <span class="switch-track"></span>
+      </label>
+
+      <button type="button">Save preferences</button>
+    </form>
+  </main>
+</body>
+</html>

--- a/submissions/examples/accessible-form-controls-kp/style.css
+++ b/submissions/examples/accessible-form-controls-kp/style.css
@@ -1,0 +1,209 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #182033;
+  --muted: #627086;
+  --line: #d8e1ee;
+  --primary: #0f766e;
+  --primary-dark: #0b4f4a;
+  --focus: rgba(15, 118, 110, 0.22);
+  --shadow: 0 22px 50px rgba(24, 32, 51, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.form-page {
+  width: min(940px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.form-intro {
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--primary);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 4.4rem);
+  line-height: 1;
+}
+
+.form-intro p {
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.control-card {
+  display: grid;
+  gap: 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  padding: 24px;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.field input,
+.field select {
+  min-height: 48px;
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fbfcff;
+  color: var(--ink);
+  font: inherit;
+  font-weight: 600;
+  padding: 0 14px;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.field input:focus,
+.field select:focus,
+button:focus-visible,
+.check-row input:focus-visible + .check-box,
+.switch-row input:focus-visible + .switch-track {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px var(--focus);
+  outline: 0;
+}
+
+.check-row,
+.switch-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.check-row input,
+.switch-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.check-box {
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+  border: 2px solid var(--line);
+  border-radius: 6px;
+  display: grid;
+  place-items: center;
+  transition: background 160ms ease, border-color 160ms ease;
+}
+
+.check-box::after {
+  content: "";
+  width: 7px;
+  height: 12px;
+  border: solid #ffffff;
+  border-width: 0 3px 3px 0;
+  opacity: 0;
+  transform: rotate(45deg) scale(0.6);
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.check-row input:checked + .check-box {
+  border-color: var(--primary);
+  background: var(--primary);
+}
+
+.check-row input:checked + .check-box::after {
+  opacity: 1;
+  transform: rotate(45deg) scale(1);
+}
+
+.switch-row {
+  justify-content: space-between;
+}
+
+.switch-track {
+  width: 58px;
+  height: 32px;
+  flex: 0 0 auto;
+  border: 2px solid var(--line);
+  border-radius: 999px;
+  background: #e8edf5;
+  padding: 3px;
+  transition: background 160ms ease, border-color 160ms ease;
+}
+
+.switch-track::before {
+  content: "";
+  display: block;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 4px 12px rgba(24, 32, 51, 0.2);
+  transition: transform 160ms ease;
+}
+
+.switch-row input:checked + .switch-track {
+  border-color: var(--primary);
+  background: var(--primary);
+}
+
+.switch-row input:checked + .switch-track::before {
+  transform: translateX(26px);
+}
+
+button {
+  min-height: 48px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--primary);
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  padding: 0 18px;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+button:hover {
+  background: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+@media (max-width: 560px) {
+  .switch-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained accessible form controls example under submissions/examples/accessible-form-controls-kp
- Demonstrates labeled inputs, select, checkbox, switch, focus rings, and touch-friendly sizing
- Keeps the interaction CSS-only and dependency-free

## Related Issue
Closes #12759

## Validation
- Confirmed submission folder contains exactly demo.html, style.css, and README.md

## Checklist
- [x] I added files only inside submissions/examples/
- [x] I included demo.html, style.css, and README.md
- [x] I kept this PR focused on one feature