### PR TITLE
feat: add hover sweep down example

### DIFF
--- a/submissions/examples/hover-sweep-bg-down-kp/README.md
+++ b/submissions/examples/hover-sweep-bg-down-kp/README.md
@@ -1,0 +1,15 @@
+# Hover Sweep Background Down
+
+## What does this do?
+
+This adds a CSS-only hover effect where a background layer sweeps downward behind a button label.
+
+## How is it used?
+
+```html
+<a class="sweep-down-button" href="#">Explore docs</a>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a compact, reusable hover interaction for links and buttons without JavaScript or external assets.

--- a/submissions/examples/hover-sweep-bg-down-kp/demo.html
+++ b/submissions/examples/hover-sweep-bg-down-kp/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hover Sweep Background Down</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="demo-copy">
+      <p class="eyebrow">Hover animation</p>
+      <h1>Background sweeps down on hover</h1>
+      <p>A lightweight CSS-only button effect where the highlight layer drops from the top edge and settles behind the label.</p>
+    </section>
+
+    <section class="button-stage" aria-label="Sweep down examples">
+      <a class="sweep-down-button" href="#">Explore docs</a>
+      <a class="sweep-down-button alt" href="#">View examples</a>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hover-sweep-bg-down-kp/style.css
+++ b/submissions/examples/hover-sweep-bg-down-kp/style.css
@@ -1,0 +1,115 @@
+:root {
+  --page: #f4f8f7;
+  --ink: #172033;
+  --muted: #64748b;
+  --primary: #0f766e;
+  --primary-dark: #134e4a;
+  --accent: #f59e0b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.demo-shell {
+  width: min(900px, calc(100% - 32px));
+  display: grid;
+  gap: 30px;
+  padding: 48px 0;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--primary);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  max-width: 720px;
+  font-size: clamp(2rem, 6vw, 4.4rem);
+  line-height: 1;
+}
+
+.demo-copy p:last-child {
+  max-width: 620px;
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.button-stage {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.sweep-down-button {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  min-width: 180px;
+  border: 2px solid var(--primary);
+  border-radius: 8px;
+  color: var(--primary);
+  display: inline-flex;
+  justify-content: center;
+  padding: 16px 22px;
+  text-decoration: none;
+  font-weight: 900;
+  transition: color 180ms ease, transform 180ms ease;
+}
+
+.sweep-down-button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: var(--primary);
+  transform: translateY(-105%);
+  transition: transform 220ms ease;
+}
+
+.sweep-down-button:hover,
+.sweep-down-button:focus-visible {
+  color: #ffffff;
+  transform: translateY(-2px);
+}
+
+.sweep-down-button:hover::before,
+.sweep-down-button:focus-visible::before {
+  transform: translateY(0);
+}
+
+.sweep-down-button.alt {
+  border-color: var(--accent);
+  color: var(--primary-dark);
+}
+
+.sweep-down-button.alt::before {
+  background: var(--accent);
+}
+
+@media (max-width: 520px) {
+  .sweep-down-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained hover sweep background down example under submissions/examples/hover-sweep-bg-down-kp
- Uses a pseudo-element highlight layer that drops from the top on hover/focus
- Keeps the interaction CSS-only, responsive, and dependency-free

## Related Issue
Closes #12565

## Validation
- Confirmed submission folder contains exactly demo.html, style.css, and README.md

## Checklist
- [x] I added files only inside submissions/examples/
- [x] I included demo.html, style.css, and README.md
- [x] I kept this PR focused on one feature