### PR TITLE
feat: add hover sweep up example

### DIFF
--- a/submissions/examples/hover-sweep-bg-up-kp/README.md
+++ b/submissions/examples/hover-sweep-bg-up-kp/README.md
@@ -1,0 +1,18 @@
+# Hover Sweep Background Up
+
+## What does this do?
+
+This adds a CSS-only hover effect where a background layer sweeps upward from the bottom of a card.
+
+## How is it used?
+
+```html
+<article class="sweep-up-card">
+  <h2>Fast</h2>
+  <p>Short transition timing keeps the hover state responsive.</p>
+</article>
+```
+
+## Why is it useful?
+
+It provides EaseMotion CSS with a reusable upward fill animation for cards, buttons, and call-to-action blocks.

--- a/submissions/examples/hover-sweep-bg-up-kp/demo.html
+++ b/submissions/examples/hover-sweep-bg-up-kp/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hover Sweep Background Up</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="copy">
+      <p class="eyebrow">Hover animation</p>
+      <h1>Background sweeps up from the bottom</h1>
+      <p>This CSS-only interaction gives cards and calls-to-action a clear upward fill motion on hover and keyboard focus.</p>
+    </section>
+
+    <section class="card-row" aria-label="Sweep up cards">
+      <article class="sweep-up-card">
+        <span>01</span>
+        <h2>Fast</h2>
+        <p>Short transition timing keeps the hover state responsive.</p>
+      </article>
+      <article class="sweep-up-card warm">
+        <span>02</span>
+        <h2>Readable</h2>
+        <p>Text color shifts with the background fill for contrast.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hover-sweep-bg-up-kp/style.css
+++ b/submissions/examples/hover-sweep-bg-up-kp/style.css
@@ -1,0 +1,132 @@
+:root {
+  --page: #f8f5f0;
+  --surface: #ffffff;
+  --ink: #182033;
+  --muted: #667085;
+  --line: #ddd6cc;
+  --primary: #1d4ed8;
+  --warm: #b45309;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.demo-shell {
+  width: min(980px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 52px 0;
+}
+
+.copy {
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--primary);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 4.5rem);
+  line-height: 1;
+}
+
+.copy p:last-child {
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.card-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.sweep-up-card {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  min-height: 230px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 24px;
+  transition: color 200ms ease, transform 200ms ease;
+}
+
+.sweep-up-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: var(--primary);
+  transform: translateY(105%);
+  transition: transform 240ms ease;
+}
+
+.sweep-up-card:hover,
+.sweep-up-card:focus-within {
+  color: #ffffff;
+  transform: translateY(-4px);
+}
+
+.sweep-up-card:hover::before,
+.sweep-up-card:focus-within::before {
+  transform: translateY(0);
+}
+
+.sweep-up-card span {
+  color: currentColor;
+  font-size: 0.85rem;
+  font-weight: 900;
+  opacity: 0.75;
+}
+
+.sweep-up-card h2 {
+  margin-top: 60px;
+  font-size: 2rem;
+}
+
+.sweep-up-card p {
+  margin-top: 10px;
+  color: var(--muted);
+  line-height: 1.65;
+  transition: color 200ms ease;
+}
+
+.sweep-up-card:hover p,
+.sweep-up-card:focus-within p {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.sweep-up-card.warm::before {
+  background: var(--warm);
+}
+
+@media (max-width: 720px) {
+  .card-row {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained hover sweep background up example under submissions/examples/hover-sweep-bg-up-kp
- Uses a pseudo-element fill layer that rises from the bottom on hover/focus
- Includes responsive card examples with contrast-aware text color changes

## Related Issue
Closes #12564

## Validation
- Confirmed submission folder contains exactly demo.html, style.css, and README.md

## Checklist
- [x] I added files only inside submissions/examples/
- [x] I included demo.html, style.css, and README.md
- [x] I kept this PR focused on one feature