### PR TITLE
feat: add hover neon glow example

### DIFF
--- a/submissions/examples/hover-neon-glow-kp/README.md
+++ b/submissions/examples/hover-neon-glow-kp/README.md
@@ -1,0 +1,18 @@
+# Hover Neon Glow
+
+## What does this do?
+
+This adds a CSS-only neon glow effect that appears when a card or button is hovered or focused.
+
+## How is it used?
+
+```html
+<a class="neon-card" href="#">
+  <span>Launch</span>
+  <strong>Glow CTA</strong>
+</a>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a high-contrast hover treatment for interactive cards and calls to action while keeping the animation lightweight and dependency-free.

--- a/submissions/examples/hover-neon-glow-kp/demo.html
+++ b/submissions/examples/hover-neon-glow-kp/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hover Neon Glow</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="neon-page">
+    <section class="copy">
+      <p class="eyebrow">Hover animation</p>
+      <h1>Neon glow appears on hover</h1>
+      <p>A CSS-only glow treatment for action cards and buttons with keyboard focus support.</p>
+    </section>
+
+    <section class="neon-grid" aria-label="Neon hover examples">
+      <a class="neon-card" href="#">
+        <span>Launch</span>
+        <strong>Glow CTA</strong>
+      </a>
+      <a class="neon-card pink" href="#">
+        <span>Preview</span>
+        <strong>Pulse Card</strong>
+      </a>
+      <a class="neon-card green" href="#">
+        <span>Status</span>
+        <strong>Active State</strong>
+      </a>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hover-neon-glow-kp/style.css
+++ b/submissions/examples/hover-neon-glow-kp/style.css
@@ -1,0 +1,133 @@
+:root {
+  --page: #0b1020;
+  --surface: #111827;
+  --ink: #f8fbff;
+  --muted: #9ca3af;
+  --cyan: #22d3ee;
+  --pink: #f472b6;
+  --green: #34d399;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(34, 211, 238, 0.16), transparent 34%),
+    var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.neon-page {
+  width: min(1040px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 52px 0;
+}
+
+.copy {
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--cyan);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 4.5rem);
+  line-height: 1;
+}
+
+.copy p:last-child {
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.neon-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.neon-card {
+  --glow: var(--cyan);
+  min-height: 210px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  color: var(--ink);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 22px;
+  position: relative;
+  text-decoration: none;
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.neon-card::before {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 6px;
+  box-shadow: 0 0 0 rgba(34, 211, 238, 0);
+  opacity: 0;
+  transition: opacity 180ms ease, box-shadow 180ms ease;
+}
+
+.neon-card:hover,
+.neon-card:focus-visible {
+  border-color: var(--glow);
+  box-shadow: 0 0 28px color-mix(in srgb, var(--glow) 42%, transparent);
+  transform: translateY(-4px);
+  outline: 0;
+}
+
+.neon-card:hover::before,
+.neon-card:focus-visible::before {
+  opacity: 1;
+  box-shadow: inset 0 0 24px color-mix(in srgb, var(--glow) 38%, transparent);
+}
+
+.neon-card span {
+  color: var(--glow);
+  font-size: 0.82rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.neon-card strong {
+  margin-top: 8px;
+  font-size: 1.55rem;
+}
+
+.neon-card.pink {
+  --glow: var(--pink);
+}
+
+.neon-card.green {
+  --glow: var(--green);
+}
+
+@media (max-width: 800px) {
+  .neon-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained hover neon glow example under submissions/examples/hover-neon-glow-kp
- Uses CSS-only hover/focus states with configurable glow colors
- Includes responsive card examples for CTA-style interactions

## Related Issue
Closes #12551

## Validation
- Confirmed submission folder contains exactly demo.html, style.css, and README.md

## Checklist
- [x] I added files only inside submissions/examples/
- [x] I included demo.html, style.css, and README.md
- [x] I kept this PR focused on one feature