### PR TITLE
feat: add hover 3d push example

### DIFF
--- a/submissions/examples/hover-3d-push-kp/README.md
+++ b/submissions/examples/hover-3d-push-kp/README.md
@@ -1,0 +1,18 @@
+# Hover 3D Push
+
+## What does this do?
+
+This adds a CSS-only hover effect where an element appears to push into the screen.
+
+## How is it used?
+
+```html
+<button class="push-card" type="button">
+  <span>01</span>
+  <strong>Press card</strong>
+</button>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a tactile 3D interaction for cards and buttons while staying lightweight and dependency-free.

--- a/submissions/examples/hover-3d-push-kp/demo.html
+++ b/submissions/examples/hover-3d-push-kp/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hover 3D Push</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="push-page">
+    <section class="copy">
+      <p class="eyebrow">Hover animation</p>
+      <h1>Element pushes into the screen on hover</h1>
+      <p>A CSS-only 3D press effect for cards and action buttons with focus-visible support.</p>
+    </section>
+
+    <section class="push-grid" aria-label="3D push examples">
+      <button class="push-card" type="button">
+        <span>01</span>
+        <strong>Press card</strong>
+      </button>
+      <button class="push-card blue" type="button">
+        <span>02</span>
+        <strong>Depth CTA</strong>
+      </button>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hover-3d-push-kp/style.css
+++ b/submissions/examples/hover-3d-push-kp/style.css
@@ -1,0 +1,123 @@
+:root {
+  --page: #f3f6fb;
+  --surface: #ffffff;
+  --ink: #182033;
+  --muted: #64748b;
+  --line: #d7dfeb;
+  --primary: #7c3aed;
+  --blue: #0ea5e9;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.push-page {
+  width: min(980px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 52px 0;
+}
+
+.copy {
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--primary);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 4.5rem);
+  line-height: 1;
+}
+
+.copy p:last-child {
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.push-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 22px;
+  perspective: 900px;
+}
+
+.push-card {
+  min-height: 220px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--ink);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 24px;
+  text-align: left;
+  transform: translateZ(36px);
+  transform-style: preserve-3d;
+  transition: box-shadow 180ms ease, transform 180ms ease;
+  box-shadow:
+    0 24px 0 -14px color-mix(in srgb, var(--primary) 28%, transparent),
+    0 28px 42px rgba(24, 32, 51, 0.14);
+}
+
+.push-card:hover,
+.push-card:focus-visible {
+  outline: 0;
+  transform: translateZ(6px) scale(0.98);
+  box-shadow:
+    0 8px 0 -6px color-mix(in srgb, var(--primary) 45%, transparent),
+    0 14px 26px rgba(24, 32, 51, 0.18);
+}
+
+.push-card span {
+  color: var(--primary);
+  font-size: 0.82rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.push-card strong {
+  margin-top: 10px;
+  font-size: 1.7rem;
+}
+
+.push-card.blue {
+  box-shadow:
+    0 24px 0 -14px color-mix(in srgb, var(--blue) 28%, transparent),
+    0 28px 42px rgba(24, 32, 51, 0.14);
+}
+
+.push-card.blue span {
+  color: var(--blue);
+}
+
+@media (max-width: 720px) {
+  .push-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained hover 3D push example under submissions/examples/hover-3d-push-kp
- Uses CSS perspective, translateZ, and shadow compression to create a press-into-screen effect
- Includes keyboard focus-visible support and responsive card layout

## Related Issue
Closes #12563

## Validation
- Confirmed submission folder contains exactly demo.html, style.css, and README.md

## Checklist
- [x] I added files only inside submissions/examples/
- [x] I included demo.html, style.css, and README.md
- [x] I kept this PR focused on one feature