### PR TITLE
feat: add hover contract text example

### DIFF
--- a/submissions/examples/hover-contract-text-kp/README.md
+++ b/submissions/examples/hover-contract-text-kp/README.md
@@ -1,0 +1,15 @@
+# Hover Contract Text
+
+## What does this do?
+
+This adds a CSS-only hover effect where text visually contracts when a link is hovered or focused.
+
+## How is it used?
+
+```html
+<a class="contract-link" href="#">Explore Motion</a>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a compact typography interaction for navigation links, labels, and call-to-action text without JavaScript.

--- a/submissions/examples/hover-contract-text-kp/demo.html
+++ b/submissions/examples/hover-contract-text-kp/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hover Contract Text</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="contract-page">
+    <section class="copy">
+      <p class="eyebrow">Hover animation</p>
+      <h1>Text contracts on hover</h1>
+      <p>A CSS-only typography effect that tightens letter spacing and scale for compact interactive labels.</p>
+    </section>
+
+    <section class="label-stack" aria-label="Contract text examples">
+      <a class="contract-link" href="#">Explore Motion</a>
+      <a class="contract-link gold" href="#">View Components</a>
+      <a class="contract-link teal" href="#">Read Guide</a>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hover-contract-text-kp/style.css
+++ b/submissions/examples/hover-contract-text-kp/style.css
@@ -1,0 +1,118 @@
+:root {
+  --page: #f7f7fb;
+  --ink: #151b2c;
+  --muted: #64748b;
+  --line: #dce3ef;
+  --primary: #4f46e5;
+  --gold: #b7791f;
+  --teal: #0f766e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.contract-page {
+  width: min(960px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 52px 0;
+}
+
+.copy {
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--primary);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 4.5rem);
+  line-height: 1;
+}
+
+.copy p:last-child {
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.label-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.contract-link {
+  --accent: var(--primary);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--ink);
+  display: block;
+  overflow: hidden;
+  padding: 22px;
+  position: relative;
+  text-decoration: none;
+  font-size: clamp(1.5rem, 5vw, 3.4rem);
+  font-weight: 900;
+  line-height: 1;
+  transition: color 180ms ease, transform 180ms ease;
+}
+
+.contract-link::before {
+  content: "";
+  position: absolute;
+  inset: auto 22px 16px 22px;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--accent);
+  transform: scaleX(0.18);
+  transform-origin: left;
+  transition: transform 180ms ease;
+}
+
+.contract-link:hover,
+.contract-link:focus-visible {
+  color: var(--accent);
+  outline: 0;
+  transform: scaleX(0.96);
+}
+
+.contract-link:hover::before,
+.contract-link:focus-visible::before {
+  transform: scaleX(0.08);
+}
+
+.contract-link.gold {
+  --accent: var(--gold);
+}
+
+.contract-link.teal {
+  --accent: var(--teal);
+}
+
+@media (max-width: 560px) {
+  .contract-link {
+    padding: 18px;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained hover contract text example under submissions/examples/hover-contract-text-kp
- Uses transform and underline compression to create a compact text contraction effect
- Includes hover and keyboard focus states for interactive labels

## Related Issue
Closes #12562

## Validation
- Confirmed submission folder contains exactly demo.html, style.css, and README.md

## Checklist
- [x] I added files only inside submissions/examples/
- [x] I included demo.html, style.css, and README.md
- [x] I kept this PR focused on one feature