### PR TITLE
feat: add hover spotlight example

### DIFF
--- a/submissions/examples/hover-spotlight-kp/README.md
+++ b/submissions/examples/hover-spotlight-kp/README.md
@@ -1,0 +1,18 @@
+# Hover Spotlight
+
+## What does this do?
+
+This adds a CSS-only hover effect where a soft spotlight appears over a card.
+
+## How is it used?
+
+```html
+<article class="spotlight-card" tabindex="0">
+  <h2>Soft reveal</h2>
+  <p>The light blooms from the top edge.</p>
+</article>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS an atmospheric but lightweight hover pattern for feature cards, previews, and interactive panels.

--- a/submissions/examples/hover-spotlight-kp/demo.html
+++ b/submissions/examples/hover-spotlight-kp/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hover Spotlight</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="spotlight-page">
+    <section class="copy">
+      <p class="eyebrow">Hover animation</p>
+      <h1>Spotlight appears on hover</h1>
+      <p>A CSS-only radial highlight that reveals a soft light spot when users hover or focus the card.</p>
+    </section>
+
+    <section class="spotlight-grid" aria-label="Spotlight hover examples">
+      <article class="spotlight-card" tabindex="0">
+        <span>Docs</span>
+        <h2>Soft reveal</h2>
+        <p>The light blooms from the top edge and makes the card feel active.</p>
+      </article>
+      <article class="spotlight-card violet" tabindex="0">
+        <span>UI</span>
+        <h2>Focus ready</h2>
+        <p>The same spotlight appears for keyboard users through focus-visible.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hover-spotlight-kp/style.css
+++ b/submissions/examples/hover-spotlight-kp/style.css
@@ -1,0 +1,139 @@
+:root {
+  --page: #0f172a;
+  --surface: #172033;
+  --ink: #f8fafc;
+  --muted: #aab5c5;
+  --line: rgba(255, 255, 255, 0.14);
+  --cyan: #67e8f9;
+  --violet: #c4b5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.spotlight-page {
+  width: min(1000px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 52px 0;
+}
+
+.copy {
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--cyan);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 4.5rem);
+  line-height: 1;
+}
+
+.copy p:last-child {
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.spotlight-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.spotlight-card {
+  --spotlight: var(--cyan);
+  min-height: 260px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 50% -20%, color-mix(in srgb, var(--spotlight) 0%, transparent), transparent 38%),
+    var(--surface);
+  overflow: hidden;
+  padding: 24px;
+  position: relative;
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.spotlight-card::before {
+  content: "";
+  position: absolute;
+  inset: -45% -20% auto;
+  height: 72%;
+  background: radial-gradient(circle, color-mix(in srgb, var(--spotlight) 42%, transparent), transparent 62%);
+  opacity: 0;
+  transform: translateY(-18px);
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.spotlight-card:hover,
+.spotlight-card:focus-visible {
+  border-color: color-mix(in srgb, var(--spotlight) 70%, white);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.28);
+  outline: 0;
+  transform: translateY(-4px);
+}
+
+.spotlight-card:hover::before,
+.spotlight-card:focus-visible::before {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.spotlight-card span,
+.spotlight-card h2,
+.spotlight-card p {
+  position: relative;
+}
+
+.spotlight-card span {
+  color: var(--spotlight);
+  font-size: 0.82rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.spotlight-card h2 {
+  margin-top: 92px;
+  font-size: 1.8rem;
+}
+
+.spotlight-card p {
+  margin-top: 10px;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.spotlight-card.violet {
+  --spotlight: var(--violet);
+}
+
+@media (max-width: 760px) {
+  .spotlight-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained hover spotlight example under submissions/examples/hover-spotlight-kp
- Uses a CSS radial highlight layer that appears on hover and keyboard focus
- Includes responsive spotlight card examples with configurable accent colors

## Related Issue
Closes #12554

## Validation
- Confirmed submission folder contains exactly demo.html, style.css, and README.md

## Checklist
- [x] I added files only inside submissions/examples/
- [x] I included demo.html, style.css, and README.md
- [x] I kept this PR focused on one feature