### PR TITLE
feat: add dark mode aware breadcrumb navigation component

### DIFF
--- a/submissions/examples/themed-breadcrumb/README.md
+++ b/submissions/examples/themed-breadcrumb/README.md
@@ -1,0 +1,19 @@
+# Themed Breadcrumb
+
+## What does this do?
+A dark mode aware breadcrumb navigation component that uses `@media (prefers-color-scheme: dark/light)` to automatically adjust text, link, and separator colors — light text on dark backgrounds, dark text on light backgrounds.
+
+## How is it used?
+```html
+<nav class="ease-breadcrumb" aria-label="Breadcrumb">
+  <a href="#" class="ease-breadcrumb-item">Home</a>
+  <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+  <a href="#" class="ease-breadcrumb-item">Docs</a>
+  <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+  <span class="ease-breadcrumb-item active" aria-current="page">Current</span>
+</nav>
+```
+Wrap items in `.ease-breadcrumb` with `aria-label`. Use `.ease-breadcrumb-item` for links/current page, `.ease-breadcrumb-item.active` with `aria-current="page"` for the current page, and `.ease-breadcrumb-separator` with `aria-hidden="true"` for separators. Add `.ease-breadcrumb-icon` spans for optional icons.
+
+## Why is it useful for EaseMotion CSS?
+Breadcrumbs are a fundamental navigation pattern used across all websites. This component ensures proper dark mode support through automatic `prefers-color-scheme` detection, filling a critical accessibility and theming gap while maintaining keyboard accessibility with `:focus-visible` indicators and smooth link hover transitions.

--- a/submissions/examples/themed-breadcrumb/demo.html
+++ b/submissions/examples/themed-breadcrumb/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Themed Breadcrumb</title>
+  <meta name="description" content="Dark mode aware breadcrumb navigation component with light/dark color overrides via prefers-color-scheme.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="container">
+    <header>
+      <h1>Themed Breadcrumb</h1>
+      <p class="subtitle">Dark mode aware breadcrumb with <code>prefers-color-scheme</code> overrides</p>
+    </header>
+
+    <div class="demo-section">
+      <div class="section-label">Default (follows OS scheme)</div>
+      <nav class="ease-breadcrumb" aria-label="Breadcrumb">
+        <a href="#" class="ease-breadcrumb-item">
+          <span class="ease-breadcrumb-icon">&#127968;</span>Home
+        </a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <a href="#" class="ease-breadcrumb-item">Documentation</a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <a href="#" class="ease-breadcrumb-item">Components</a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <span class="ease-breadcrumb-item active" aria-current="page">Breadcrumb</span>
+      </nav>
+    </div>
+
+    <div class="demo-section">
+      <div class="section-label">With Icons</div>
+      <nav class="ease-breadcrumb" aria-label="Breadcrumb with icons">
+        <a href="#" class="ease-breadcrumb-item">
+          <span class="ease-breadcrumb-icon">&#128193;</span>Projects
+        </a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <a href="#" class="ease-breadcrumb-item">
+          <span class="ease-breadcrumb-icon">&#128196;</span>Web App
+        </a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <a href="#" class="ease-breadcrumb-item">Settings</a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <span class="ease-breadcrumb-item active" aria-current="page">Advanced</span>
+      </nav>
+    </div>
+
+    <div class="demo-section">
+      <div class="section-label">Long Path (wrapping)</div>
+      <nav class="ease-breadcrumb" aria-label="Long breadcrumb path">
+        <a href="#" class="ease-breadcrumb-item">Home</a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <a href="#" class="ease-breadcrumb-item">Products</a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <a href="#" class="ease-breadcrumb-item">Category</a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <a href="#" class="ease-breadcrumb-item">Subcategory</a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <a href="#" class="ease-breadcrumb-item">Item</a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
+        <span class="ease-breadcrumb-item active" aria-current="page">Details</span>
+      </nav>
+    </div>
+
+    <div class="demo-section">
+      <div class="section-label">Custom Separator</div>
+      <nav class="ease-breadcrumb" aria-label="Breadcrumb with custom separator">
+        <a href="#" class="ease-breadcrumb-item">Dashboard</a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#47;</span>
+        <a href="#" class="ease-breadcrumb-item">Analytics</a>
+        <span class="ease-breadcrumb-separator" aria-hidden="true">&#47;</span>
+        <span class="ease-breadcrumb-item active" aria-current="page">Reports</span>
+      </nav>
+    </div>
+
+    <div style="margin-top:2rem; padding:1rem; background:rgba(255,255,255,0.03); border-radius:12px; border:1px solid var(--border-color);">
+      <p style="font-size:0.85rem; color:var(--color-text-muted);">
+        <strong>Note:</strong> Toggle your OS color scheme to see dark/light mode changes. The breadcrumb uses <code>@media (prefers-color-scheme: dark)</code> and <code>@media (prefers-color-scheme: light)</code> to set text, link, and separator colors — light text on dark backgrounds, dark text on light backgrounds. Links have <code>:focus-visible</code> for keyboard accessibility and smooth hover transitions.
+      </p>
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/themed-breadcrumb/style.css
+++ b/submissions/examples/themed-breadcrumb/style.css
@@ -1,0 +1,172 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a0e17;
+  --bg-surface: rgba(26, 36, 56, 0.6);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --color-primary: #3b82f6;
+  --color-text: #f3f4f6;
+  --color-text-muted: #9ca3af;
+  --color-link: #60a5fa;
+  --color-link-hover: #93c5fd;
+  --breadcrumb-separator: rgba(255, 255, 255, 0.25);
+  --breadcrumb-text: var(--color-text-muted);
+  --breadcrumb-active: var(--color-text);
+  --font-sans: 'Outfit', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background-image: radial-gradient(circle at 50% 50%, rgba(59, 130, 246, 0.08) 0%, transparent 60%);
+}
+
+.container {
+  max-width: 650px;
+  width: 100%;
+  backdrop-filter: blur(20px);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  padding: 3rem 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #60a5fa, #818cf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-align: center;
+}
+
+.subtitle {
+  color: var(--color-text-muted);
+  margin-bottom: 2.5rem;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.section-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: 1rem;
+}
+
+.demo-section {
+  margin-bottom: 2.5rem;
+}
+
+.demo-section:last-child {
+  margin-bottom: 0;
+}
+
+.ease-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  font-size: 0.9rem;
+}
+
+.ease-breadcrumb-item {
+  color: var(--breadcrumb-text);
+  text-decoration: none;
+  transition: color 0.2s ease;
+  font-weight: 500;
+}
+
+.ease-breadcrumb-item:hover {
+  color: var(--color-link-hover);
+}
+
+.ease-breadcrumb-item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.ease-breadcrumb-item.active {
+  color: var(--breadcrumb-active);
+  font-weight: 600;
+  pointer-events: none;
+}
+
+.ease-breadcrumb-separator {
+  color: var(--breadcrumb-separator);
+  font-size: 0.8rem;
+  user-select: none;
+  display: inline-flex;
+  align-items: center;
+}
+
+.ease-breadcrumb-icon {
+  margin-right: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.light-scheme {
+  --bg-primary: #f8fafc;
+  --bg-surface: rgba(255, 255, 255, 0.85);
+  --border-color: rgba(0, 0, 0, 0.08);
+  --color-text: #1e293b;
+  --color-text-muted: #64748b;
+  --color-link: #3b82f6;
+  --color-link-hover: #2563eb;
+  --breadcrumb-separator: rgba(0, 0, 0, 0.2);
+  --breadcrumb-text: var(--color-text-muted);
+  --breadcrumb-active: var(--color-text);
+}
+
+.light-scheme h1 {
+  background: linear-gradient(135deg, #3b82f6, #6366f1);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.light-scheme .ease-breadcrumb {
+  background: rgba(0, 0, 0, 0.02);
+  border-color: rgba(0, 0, 0, 0.06);
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-breadcrumb-item { color: #9ca3af; }
+  .ease-breadcrumb-item:hover { color: #f3f4f6; }
+  .ease-breadcrumb-item.active { color: #f3f4f6; }
+  .ease-breadcrumb-separator { color: rgba(255, 255, 255, 0.25); }
+}
+
+@media (prefers-color-scheme: light) {
+  .ease-breadcrumb-item { color: #64748b; }
+  .ease-breadcrumb-item:hover { color: #2563eb; }
+  .ease-breadcrumb-item.active { color: #1e293b; }
+  .ease-breadcrumb-separator { color: rgba(0, 0, 0, 0.25); }
+}
+
+@media (max-width: 600px) {
+  .container { padding: 2rem 1.5rem; }
+  h1 { font-size: 1.5rem; }
+  .ease-breadcrumb { font-size: 0.8rem; gap: 0.35rem; }
+}


### PR DESCRIPTION
## ✦ Description

Add a dark mode aware breadcrumb navigation component that uses `@media (prefers-color-scheme: dark/light)` to automatically adjust text, link, and separator colors — fixing the issue where breadcrumb text was invisible in dark mode.

The component features:

- `.ease-breadcrumb` — flexible container with wrap support for long paths
- `.ease-breadcrumb-item` — link style with smooth hover color transition
- `.ease-breadcrumb-item.active` — current page indicator with `aria-current="page"`
- `.ease-breadcrumb-separator` — customizable separator (default `›`, supports any character)
- `.ease-breadcrumb-icon` — optional icon prefix within items
- `@media (prefers-color-scheme: dark)` — light text (#9ca3af links, #f3f4f6 active, rgba white separator)
- `@media (prefers-color-scheme: light)` — dark text (#64748b links, #1e293b active, rgba black separator)
- `:focus-visible` outline for keyboard accessibility
- Pure CSS — no JavaScript required

All changes are contained within `submissions/examples/themed-breadcrumb/`. No core framework files were modified.

Fixes #14194

---

## ⟡ Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## ✦ Submission Checklist

- [x] All changes are inside `submissions/examples/themed-breadcrumb/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## ✦ Feature Description

**What does this add?**

A dark mode aware breadcrumb navigation component with automatic `prefers-color-scheme` color overrides.

**How does a developer use it?**

```html
<nav class="ease-breadcrumb" aria-label="Breadcrumb">
  <a href="#" class="ease-breadcrumb-item">Home</a>
  <span class="ease-breadcrumb-separator" aria-hidden="true">&#8250;</span>
  <span class="ease-breadcrumb-item active" aria-current="page">Current</span>
</nav>
```

**Why does it fit EaseMotion CSS?**

Breadcrumbs are a fundamental navigation pattern. This component ensures proper dark mode support, filling a critical theming and accessibility gap while maintaining keyboard navigation with `:focus-visible` and smooth hover transitions.

---

## ✦ Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## ✦ Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional)*

---

## ✦ Additional Notes

- No core files were modified.
- Branch pushed: `feature/themed-breadcrumb-pcm`
- Compare URL: https://github.com/Pcmhacker-piro/EaseMotion-css/compare/main...Pcmhacker-piro:feature/themed-breadcrumb-pcm?expand=1