### PR TITLE
feat: add achievement streak flame example

### DIFF
--- a/submissions/examples/14025-ease-achievement-streak-flame-kp/README.md
+++ b/submissions/examples/14025-ease-achievement-streak-flame-kp/README.md
@@ -1,0 +1,19 @@
+# Achievement Streak Flame
+
+## What does this do?
+It shows an achievement streak counter with a flame that flickers and glows to reward continued progress.
+
+## How is it used?
+```html
+<section class="streak-card">
+  <div class="flame-wrap" aria-hidden="true">
+    <span class="flame-core"></span>
+    <span class="flame-glow"></span>
+  </div>
+  <p class="streak-label">Current streak</p>
+  <strong class="streak-count">28 days</strong>
+</section>
+```
+
+## Why is it useful?
+It gives dashboards, habit trackers, learning apps, and gamified interfaces a small motion cue that makes achievement streaks feel active without requiring JavaScript.

--- a/submissions/examples/14025-ease-achievement-streak-flame-kp/demo.html
+++ b/submissions/examples/14025-ease-achievement-streak-flame-kp/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Achievement Streak Flame</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="streak-stage" aria-label="Achievement streak flame demo">
+    <section class="streak-card">
+      <div class="flame-wrap" aria-hidden="true">
+        <span class="flame-core"></span>
+        <span class="flame-glow"></span>
+      </div>
+      <p class="streak-label">Current streak</p>
+      <strong class="streak-count">28 days</strong>
+      <p class="streak-copy">Keep the daily habit alive to maintain the animated streak.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/14025-ease-achievement-streak-flame-kp/style.css
+++ b/submissions/examples/14025-ease-achievement-streak-flame-kp/style.css
@@ -1,0 +1,117 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Arial, sans-serif;
+  color: #1f2937;
+  background: #f8fafc;
+}
+
+.streak-stage {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.streak-card {
+  width: min(24rem, 100%);
+  padding: 2rem;
+  border: 1px solid #fed7aa;
+  border-radius: 1rem;
+  text-align: center;
+  background: #fff7ed;
+  box-shadow: 0 1.5rem 3rem rgba(154, 52, 18, 0.14);
+}
+
+.flame-wrap {
+  position: relative;
+  width: 5rem;
+  height: 6rem;
+  margin: 0 auto 1.2rem;
+}
+
+.flame-core,
+.flame-glow {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%) rotate(45deg);
+  border-radius: 70% 15% 70% 40%;
+}
+
+.flame-glow {
+  width: 5rem;
+  height: 5rem;
+  background: #fdba74;
+  filter: blur(1rem);
+  opacity: 0.55;
+  animation: streak-glow 1.4s ease-in-out infinite;
+}
+
+.flame-core {
+  width: 3.3rem;
+  height: 3.3rem;
+  background: linear-gradient(135deg, #f97316 15%, #facc15 58%, #fff7ad 100%);
+  box-shadow: inset -0.35rem -0.35rem 0 rgba(194, 65, 12, 0.24);
+  animation: streak-flame 1.1s ease-in-out infinite;
+}
+
+.streak-label {
+  margin: 0 0 0.25rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #c2410c;
+  text-transform: uppercase;
+}
+
+.streak-count {
+  display: block;
+  font-size: clamp(2.2rem, 8vw, 4rem);
+  line-height: 1;
+  color: #7c2d12;
+}
+
+.streak-copy {
+  margin: 1rem auto 0;
+  max-width: 18rem;
+  line-height: 1.55;
+  color: #7c2d12;
+}
+
+@keyframes streak-flame {
+  0%, 100% {
+    transform: translateX(-50%) rotate(45deg) scale(1);
+  }
+
+  45% {
+    transform: translateX(-50%) rotate(39deg) scale(1.08, 0.95);
+  }
+
+  70% {
+    transform: translateX(-50%) rotate(50deg) scale(0.96, 1.08);
+  }
+}
+
+@keyframes streak-glow {
+  0%, 100% {
+    opacity: 0.45;
+    transform: translateX(-50%) rotate(45deg) scale(0.96);
+  }
+
+  50% {
+    opacity: 0.72;
+    transform: translateX(-50%) rotate(45deg) scale(1.08);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flame-core,
+  .flame-glow {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained achievement streak flame demo under submissions/examples
- include flicker/glow CSS animation and reduced-motion fallback
- document usage in README

Closes #14025

## Validation
- git diff --check