### PR TITLE
feat: add animated search/expand input component (issue #14186)

### DIFF
--- a/submissions/core_changes-issue-14186/README.md
+++ b/submissions/core_changes-issue-14186/README.md
@@ -1,0 +1,32 @@
+# Animated Search / Expand Input — Issue #14186
+
+## What does this do?
+A CSS-only animated search input with expand-on-focus behavior. The input collapses to a 40px circle by default and smoothly expands to 280px when focused, revealing the placeholder text and a fully faded-in search icon.
+
+## How is it used?
+```html
+<div class="ease-search-wrapper">
+  <svg class="ease-search-icon"><!-- search icon --></svg>
+  <input class="ease-search-input" type="text" placeholder="Search...">
+</div>
+```
+
+## Classes
+| Class | Description |
+|---|---|
+| `.ease-search-wrapper` | Container; controls width via `--ease-search-collapsed` / `--ease-search-expanded` |
+| `.ease-search-input` | The text input; inherits width, border-radius 20px |
+| `.ease-search-icon` | SVG icon; positioned absolutely, fades on wrapper focus |
+| `.ease-search-wrapper-sm` | Small variant: 34px / 220px |
+| `.ease-search-wrapper-lg` | Large variant: 48px / 340px |
+
+## CSS Custom Properties
+| Property | Default | Description |
+|---|---|---|
+| `--ease-speed-medium` | 300ms | Transition duration for width, icon opacity, border |
+| `--ease-ease-out` | cubic-bezier(0.25, 0.46, 0.45, 0.94) | Easing function |
+| `--ease-search-collapsed` | 40px | Width when unfocused |
+| `--ease-search-expanded` | 280px | Width when focused |
+
+## Why is it useful for EaseMotion CSS?
+Animated search inputs are a common UI pattern (navbars, header toolbars). This provides a drop-in component with accessible focus handling, dark mode, and size variants.

--- a/submissions/core_changes-issue-14186/demo.html
+++ b/submissions/core_changes-issue-14186/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Search Input — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="card">
+    <h1>Search Input</h1>
+    <p class="sub">Animated expand-on-focus search bar with embedded icon — Issue #14186</p>
+
+    <div class="controls">
+      <button class="ease-btn" id="themeToggle">&#9788; Light Mode</button>
+    </div>
+
+    <div class="demo-group">
+
+      <div class="demo-row">
+        <span class="demo-row-label">Default</span>
+        <div class="ease-search-wrapper">
+          <svg class="ease-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"/>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+          </svg>
+          <input class="ease-search-input" type="text" placeholder="Search documentation..." aria-label="Search">
+        </div>
+      </div>
+
+      <div class="demo-row">
+        <span class="demo-row-label">Small</span>
+        <div class="ease-search-wrapper ease-search-wrapper-sm">
+          <svg class="ease-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"/>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+          </svg>
+          <input class="ease-search-input" type="text" placeholder="Search..." aria-label="Search small">
+        </div>
+      </div>
+
+      <div class="demo-row">
+        <span class="demo-row-label">Large</span>
+        <div class="ease-search-wrapper ease-search-wrapper-lg">
+          <svg class="ease-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"/>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+          </svg>
+          <input class="ease-search-input" type="text" placeholder="Search products, articles, and more..." aria-label="Search large">
+        </div>
+      </div>
+
+    </div>
+
+    <div class="feature-list">
+      <h3>How it works</h3>
+      <ul>
+        <li>Input collapses to <strong>40px</strong> circle; expands to <strong>280px</strong> on focus via <code>width</code> transition</li>
+        <li>Transition timing uses <code>--ease-speed-medium</code> (300ms) and <code>--ease-ease-out</code> easing</li>
+        <li>Search icon fades in on focus from <code>opacity: 0.4</code> to <code>1</code> and shifts to brand blue</li>
+        <li>Placeholder text fades in with a 100ms delay after expansion starts</li>
+        <li>Focus ring appears via <code>box-shadow</code> on the input</li>
+        <li>Size variants: <code>.ease-search-wrapper-sm</code> (34px / 220px) and <code>.ease-search-wrapper-lg</code> (48px / 340px)</li>
+        <li>Dark and light mode via <code>[data-theme]</code> CSS custom properties</li>
+        <li>Respects <code>prefers-reduced-motion: reduce</code> — disables all transitions</li>
+        <li>Keyboard accessible: native <code>:focus</code> and <code>:focus-within</code> for expansion</li>
+      </ul>
+    </div>
+  </div>
+
+  <script>
+    const toggle = document.getElementById('themeToggle');
+    toggle.addEventListener('click', () => {
+      const isLight = document.body.getAttribute('data-theme') === 'light';
+      document.body.setAttribute('data-theme', isLight ? 'dark' : 'light');
+      toggle.textContent = isLight ? '\u2600 Light Mode' : '\u2600 Light Mode';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/core_changes-issue-14186/style.css
+++ b/submissions/core_changes-issue-14186/style.css
@@ -1,0 +1,273 @@
+:root {
+  --ease-speed-fast: 150ms;
+  --ease-speed-medium: 300ms;
+  --ease-speed-slow: 500ms;
+  --ease-ease-out: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  --ease-search-collapsed: 40px;
+  --ease-search-expanded: 280px;
+  --ease-search-bg: rgba(255, 255, 255, 0.06);
+  --ease-search-border: rgba(255, 255, 255, 0.12);
+  --ease-search-color: #f3f4f6;
+  --ease-search-placeholder: #6b7280;
+  --ease-search-icon: #9ca3af;
+  --ease-search-focus: #3b82f6;
+}
+
+[data-theme="light"] {
+  --ease-search-bg: #f3f4f6;
+  --ease-search-border: #d1d5db;
+  --ease-search-color: #1f2937;
+  --ease-search-placeholder: #9ca3af;
+  --ease-search-icon: #6b7280;
+  --ease-search-focus: #3b82f6;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #0a0e17;
+  color: #f3f4f6;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  transition: background var(--ease-speed-slow) var(--ease-ease-out);
+}
+
+body[data-theme="light"] {
+  background: #f9fafb;
+  color: #1f2937;
+}
+
+.card {
+  max-width: 640px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+body[data-theme="light"] .card {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+}
+
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.sub { color: #9ca3af; margin-bottom: 2rem; font-size: 0.9rem; }
+
+.ease-search-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: var(--ease-search-collapsed);
+  transition: width var(--ease-speed-medium) var(--ease-ease-out);
+}
+
+.ease-search-wrapper:focus-within {
+  width: var(--ease-search-expanded);
+}
+
+.ease-search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  pointer-events: none;
+  color: var(--ease-search-icon);
+  opacity: 0.4;
+  transition: opacity var(--ease-speed-medium) var(--ease-ease-out);
+}
+
+.ease-search-wrapper:focus-within .ease-search-icon {
+  opacity: 1;
+  color: var(--ease-search-focus);
+}
+
+.ease-search-input {
+  width: 100%;
+  height: 40px;
+  padding: 0 12px 0 36px;
+  border: 1px solid var(--ease-search-border);
+  border-radius: 20px;
+  background: var(--ease-search-bg);
+  color: var(--ease-search-color);
+  font-size: 0.9rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color var(--ease-speed-medium) var(--ease-ease-out),
+              box-shadow var(--ease-speed-medium) var(--ease-ease-out);
+}
+
+.ease-search-input::placeholder {
+  color: var(--ease-search-placeholder);
+  opacity: 0;
+  transition: opacity var(--ease-speed-fast) var(--ease-ease-out);
+}
+
+.ease-search-wrapper:focus-within .ease-search-input::placeholder {
+  opacity: 1;
+  transition-delay: 0.1s;
+}
+
+.ease-search-wrapper:focus-within .ease-search-input {
+  border-color: var(--ease-search-focus);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.ease-search-wrapper-sm {
+  --ease-search-collapsed: 34px;
+  --ease-search-expanded: 220px;
+}
+
+.ease-search-wrapper-sm .ease-search-input {
+  height: 34px;
+  font-size: 0.8rem;
+  padding: 0 10px 0 32px;
+  border-radius: 17px;
+}
+
+.ease-search-wrapper-sm .ease-search-icon {
+  width: 15px;
+  height: 15px;
+  left: 9px;
+}
+
+.ease-search-wrapper-lg {
+  --ease-search-collapsed: 48px;
+  --ease-search-expanded: 340px;
+}
+
+.ease-search-wrapper-lg .ease-search-input {
+  height: 48px;
+  font-size: 1rem;
+  padding: 0 16px 0 44px;
+  border-radius: 24px;
+}
+
+.ease-search-wrapper-lg .ease-search-icon {
+  width: 22px;
+  height: 22px;
+  left: 12px;
+}
+
+.demo-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin: 1.5rem 0;
+}
+
+.demo-row {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.demo-row-label {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  min-width: 72px;
+}
+
+body[data-theme="light"] .demo-row-label {
+  color: #6b7280;
+}
+
+.feature-list {
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+body[data-theme="light"] .feature-list {
+  background: rgba(0, 0, 0, 0.02);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+.feature-list h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+body[data-theme="light"] .feature-list h3 { color: #6b7280; }
+
+.feature-list ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.feature-list li {
+  font-size: 0.85rem;
+  color: #9ca3af;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+body[data-theme="light"] .feature-list li { color: #6b7280; }
+
+.feature-list li::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #3b82f6;
+  flex-shrink: 0;
+}
+
+.controls {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.ease-btn {
+  padding: 0.5rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #f3f4f6;
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background var(--ease-speed-fast) var(--ease-ease-out);
+  outline: none;
+}
+
+.ease-btn:hover { background: rgba(255, 255, 255, 0.12); }
+.ease-btn:focus-visible { outline: 2px solid var(--ease-search-focus); outline-offset: 2px; }
+
+body[data-theme="light"] .ease-btn {
+  border-color: rgba(0, 0, 0, 0.15);
+  background: rgba(0, 0, 0, 0.04);
+  color: #1f2937;
+}
+
+body[data-theme="light"] .ease-btn:hover { background: rgba(0, 0, 0, 0.08); }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-search-wrapper { transition: none; }
+  .ease-search-input { transition: none; }
+  .ease-search-icon { transition: none; }
+  .ease-search-input::placeholder { transition: none; }
+}


### PR DESCRIPTION
This PR adds an animated search input component to EaseMotion CSS — a compact circle that expands into a full-width search bar on focus.

**How it behaves:**
- Collapsed state: a 40px rounded pill showing only the search icon at low opacity
- On focus (or focus-within on the wrapper): smoothly scales width to 280px, the icon shifts to brand blue at full opacity, and the placeholder text fades in
- On blur: animates back to the collapsed circle
- Three sizes: default (40px/280px), small (34px/220px), large (48px/340px)

**Implementation details:**
- CSS-only: uses `.ease-search-wrapper:focus-within` to toggle width, icon opacity, and placeholder visibility — no JavaScript required for the animation
- Transition properties: width on the wrapper, opacity on the icon and placeholder, border-color and box-shadow on the input — all timed with 300ms `cubic-bezier(0.25, 0.46, 0.45, 0.94)`
- Placeholder text uses a delayed opacity transition (100ms delay) so it only appears after the pill has begun expanding
- Size variants override `--ease-search-collapsed` and `--ease-search-expanded` CSS custom properties per wrapper
- Dark and light themes via `[data-theme]` attribute switching on body — changes background, border, text, and icon colors
- Reduced motion: all transitions disabled at `prefers-reduced-motion: reduce`

**Demo page:**
- Three live examples (default, small, large) side by side
- Theme toggle button
- Feature list explaining each behavioral detail

All files are in `submissions/core_changes-issue-14186/`. No core files were touched.

Fixes #14186