### PR TITLE
feat: add elevation profile draw example

### DIFF
--- a/submissions/examples/14021-ease-elevation-profile-draw-kp/README.md
+++ b/submissions/examples/14021-ease-elevation-profile-draw-kp/README.md
@@ -1,0 +1,17 @@
+# Elevation Profile Draw
+
+## What does this do?
+It draws a route elevation profile line and then fades in the filled mountain area beneath it.
+
+## How is it used?
+```html
+<div class="profile-chart" aria-hidden="true">
+  <svg viewBox="0 0 360 160">
+    <path class="profile-area" d="M20 132 L66 118 L103 124 L144 88 L189 104 L232 54 L278 78 L330 34 L340 132 Z"></path>
+    <path class="profile-line" d="M20 132 L66 118 L103 124 L144 88 L189 104 L232 54 L278 78 L330 34"></path>
+  </svg>
+</div>
+```
+
+## Why is it useful?
+It gives outdoor, fitness, and travel interfaces a lightweight CSS motion pattern for showing route difficulty and terrain shape.

--- a/submissions/examples/14021-ease-elevation-profile-draw-kp/demo.html
+++ b/submissions/examples/14021-ease-elevation-profile-draw-kp/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Elevation Profile Draw</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="elevation-stage">
+    <section class="elevation-card" aria-label="Elevation profile draw demo">
+      <p class="route-label">Trail elevation</p>
+      <strong class="route-title">Summit Loop</strong>
+      <div class="profile-chart" aria-hidden="true">
+        <svg viewBox="0 0 360 160" role="img">
+          <path class="profile-area" d="M20 132 L66 118 L103 124 L144 88 L189 104 L232 54 L278 78 L330 34 L340 132 Z"></path>
+          <path class="profile-line" d="M20 132 L66 118 L103 124 L144 88 L189 104 L232 54 L278 78 L330 34"></path>
+        </svg>
+      </div>
+      <div class="route-stats">
+        <span>12.6 km</span>
+        <span>850 m gain</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/14021-ease-elevation-profile-draw-kp/style.css
+++ b/submissions/examples/14021-ease-elevation-profile-draw-kp/style.css
@@ -1,0 +1,124 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Arial, sans-serif;
+  color: #1e293b;
+  background: #f1f5f9;
+}
+
+.elevation-stage {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.elevation-card {
+  width: min(32rem, 100%);
+  padding: 1.6rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1.4rem 2.8rem rgba(15, 23, 42, 0.12);
+}
+
+.route-label {
+  margin: 0 0 0.25rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #0f766e;
+  text-transform: uppercase;
+}
+
+.route-title {
+  display: block;
+  margin-bottom: 1rem;
+  font-size: clamp(1.8rem, 7vw, 3.2rem);
+  line-height: 1;
+}
+
+.profile-chart {
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.85rem;
+  background:
+    linear-gradient(180deg, rgba(14, 165, 233, 0.12), rgba(20, 184, 166, 0.1)),
+    repeating-linear-gradient(0deg, transparent 0 1.9rem, rgba(15, 23, 42, 0.07) 1.9rem 2rem);
+}
+
+.profile-chart svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.profile-area {
+  fill: rgba(20, 184, 166, 0.18);
+  opacity: 0;
+  animation: area-rise 1s ease-out 1.05s forwards;
+}
+
+.profile-line {
+  fill: none;
+  stroke: #0f766e;
+  stroke-width: 7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 420;
+  stroke-dashoffset: 420;
+  filter: drop-shadow(0 0.25rem 0.35rem rgba(15, 118, 110, 0.2));
+  animation: profile-draw 1.4s ease-out forwards;
+}
+
+.route-stats {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+  color: #475569;
+  font-weight: 700;
+}
+
+@keyframes profile-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes area-rise {
+  from {
+    opacity: 0;
+    transform: translateY(1rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 30rem) {
+  .route-stats {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .profile-line,
+  .profile-area {
+    animation: none;
+  }
+
+  .profile-line {
+    stroke-dashoffset: 0;
+  }
+
+  .profile-area {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained elevation profile draw demo under submissions/examples
- animate the route line and filled profile area with reduced-motion fallback
- document usage in README

Closes #14021

## Validation
- git diff --check