### PR TITLE
feat: add animated toggle switch component (issue #14169)

### DIFF
--- a/submissions/core_changes-issue-14169/README.md
+++ b/submissions/core_changes-issue-14169/README.md
@@ -1,0 +1,33 @@
+# Animated Toggle Switch / Checkbox — Issue #14169
+
+## What does this do?
+A CSS-only animated toggle switch built on a hidden checkbox input. The knob slides smoothly between off (grey) and on (green) states using `transform: translateX` with a 250ms cubic-bezier transition. Pure CSS — no JavaScript required for the toggle animation.
+
+## How is it used?
+```html
+<label class="ease-toggle">
+  <input type="checkbox" class="ease-toggle-input">
+  <span class="ease-toggle-track">
+    <span class="ease-toggle-thumb"></span>
+  </span>
+</label>
+```
+
+## Classes
+| Class | Description |
+|---|---|
+| `.ease-toggle` | Wrapper label; holds input, track, and thumb |
+| `.ease-toggle-input` | Hidden checkbox (`opacity: 0; width: 0; height: 0`) |
+| `.ease-toggle-track` | Pill-shaped background; green when checked, grey when unchecked |
+| `.ease-toggle-thumb` | Circular knob that slides via `translateX` |
+| `.ease-toggle-sm` | Small variant: 36x20px track, 14px thumb |
+| `.ease-toggle-lg` | Large variant: 64x34px track, 26px thumb |
+
+## Behavior
+- **Checked state:** `:checked + .ease-toggle-track` sets background to `--ease-toggle-track-on` (emerald green), and `.ease-toggle-thumb` translates to the right edge
+- **Focus ring:** `.ease-toggle:focus-within .ease-toggle-track` shows a blue box-shadow ring for keyboard navigation
+- **Disabled:** `opacity: 0.4` with `cursor: not-allowed`
+- **Dark/light mode:** CSS custom properties switch via `[data-theme]` on body
+
+## Why is it useful for EaseMotion CSS?
+Toggles are a high-demand pattern for settings pages. This provides a drop-in component with accessible keyboard handling, size variants, and disabled state.

--- a/submissions/core_changes-issue-14169/demo.html
+++ b/submissions/core_changes-issue-14169/demo.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Toggle Switch — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="card">
+    <h1>Toggle Switch</h1>
+    <p class="sub">CSS-only animated toggle using hidden checkbox — Issue #14169</p>
+
+    <div class="controls">
+      <button class="ease-btn" id="themeToggle">&#9788; Light</button>
+      <button class="ease-btn" id="toggleAll">&#9635; Toggle All</button>
+    </div>
+
+    <div class="section-label">Settings</div>
+
+    <div class="demo-group">
+      <label class="demo-row">
+        <span class="ease-toggle-label">Notifications</span>
+        <span class="ease-toggle">
+          <input type="checkbox" class="ease-toggle-input" checked>
+          <span class="ease-toggle-track">
+            <span class="ease-toggle-thumb"></span>
+          </span>
+        </span>
+      </label>
+
+      <label class="demo-row">
+        <span class="ease-toggle-label">Dark Mode</span>
+        <span class="ease-toggle">
+          <input type="checkbox" class="ease-toggle-input">
+          <span class="ease-toggle-track">
+            <span class="ease-toggle-thumb"></span>
+          </span>
+        </span>
+      </label>
+
+      <label class="demo-row">
+        <span class="ease-toggle-label">Auto-save</span>
+        <span class="ease-toggle">
+          <input type="checkbox" class="ease-toggle-input" checked>
+          <span class="ease-toggle-track">
+            <span class="ease-toggle-thumb"></span>
+          </span>
+        </span>
+      </label>
+
+      <label class="demo-row" style="opacity:0.5">
+        <span class="ease-toggle-label">Beta Features</span>
+        <span class="ease-toggle">
+          <input type="checkbox" class="ease-toggle-input" disabled>
+          <span class="ease-toggle-track">
+            <span class="ease-toggle-thumb"></span>
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <div class="section-label">Sizes</div>
+
+    <div class="size-demo">
+      <label class="ease-toggle">
+        <input type="checkbox" class="ease-toggle-input">
+        <span class="ease-toggle-track ease-toggle-sm">
+          <span class="ease-toggle-thumb"></span>
+        </span>
+        <span class="ease-toggle-label">Small</span>
+      </label>
+
+      <label class="ease-toggle">
+        <input type="checkbox" class="ease-toggle-input" checked>
+        <span class="ease-toggle-track">
+          <span class="ease-toggle-thumb"></span>
+        </span>
+        <span class="ease-toggle-label">Default</span>
+      </label>
+
+      <label class="ease-toggle">
+        <input type="checkbox" class="ease-toggle-input" checked>
+        <span class="ease-toggle-track ease-toggle-lg">
+          <span class="ease-toggle-thumb"></span>
+        </span>
+        <span class="ease-toggle-label">Large</span>
+      </label>
+    </div>
+  </div>
+
+  <script>
+    document.getElementById('toggleAll').addEventListener('click', () => {
+      document.querySelectorAll('.ease-toggle-input:not(:disabled)').forEach(cb => {
+        cb.checked = !cb.checked;
+      });
+    });
+    document.getElementById('themeToggle').addEventListener('click', () => {
+      const isLight = document.body.getAttribute('data-theme') === 'light';
+      document.body.setAttribute('data-theme', isLight ? 'dark' : 'light');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/core_changes-issue-14169/style.css
+++ b/submissions/core_changes-issue-14169/style.css
@@ -1,0 +1,219 @@
+:root {
+  --ease-toggle-width: 48px;
+  --ease-toggle-height: 26px;
+  --ease-toggle-thumb-size: 20px;
+  --ease-toggle-track-off: #374151;
+  --ease-toggle-track-on: #10b981;
+  --ease-toggle-thumb-color: #f3f4f6;
+  --ease-toggle-disabled-opacity: 0.4;
+  --ease-toggle-focus-ring: #3b82f6;
+}
+
+[data-theme="light"] {
+  --ease-toggle-track-off: #d1d5db;
+  --ease-toggle-track-on: #10b981;
+  --ease-toggle-thumb-color: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #0a0e17;
+  color: #f3f4f6;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+body[data-theme="light"] {
+  background: #f9fafb;
+  color: #1f2937;
+}
+
+.card {
+  max-width: 560px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+body[data-theme="light"] .card {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+}
+
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.sub { color: #9ca3af; margin-bottom: 2rem; font-size: 0.9rem; }
+
+.ease-toggle {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  gap: 0.75rem;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.ease-toggle-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.ease-toggle-track {
+  position: relative;
+  width: var(--ease-toggle-width);
+  height: var(--ease-toggle-height);
+  background: var(--ease-toggle-track-off);
+  border-radius: calc(var(--ease-toggle-height) / 2);
+  transition: background 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  flex-shrink: 0;
+}
+
+.ease-toggle-thumb {
+  position: absolute;
+  top: calc((var(--ease-toggle-height) - var(--ease-toggle-thumb-size)) / 2);
+  left: calc((var(--ease-toggle-height) - var(--ease-toggle-thumb-size)) / 2);
+  width: var(--ease-toggle-thumb-size);
+  height: var(--ease-toggle-thumb-size);
+  background: var(--ease-toggle-thumb-color);
+  border-radius: 50%;
+  transition: transform 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.ease-toggle-input:checked + .ease-toggle-track {
+  background: var(--ease-toggle-track-on);
+}
+
+.ease-toggle-input:checked + .ease-toggle-track .ease-toggle-thumb {
+  transform: translateX(calc(var(--ease-toggle-width) - var(--ease-toggle-height)));
+}
+
+.ease-toggle:focus-within .ease-toggle-track {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+.ease-toggle-input:disabled + .ease-toggle-track {
+  opacity: var(--ease-toggle-disabled-opacity);
+  cursor: not-allowed;
+}
+
+.ease-toggle-input:disabled ~ .ease-toggle-label {
+  opacity: var(--ease-toggle-disabled-opacity);
+  cursor: not-allowed;
+}
+
+.ease-toggle-sm {
+  --ease-toggle-width: 36px;
+  --ease-toggle-height: 20px;
+  --ease-toggle-thumb-size: 14px;
+}
+
+.ease-toggle-lg {
+  --ease-toggle-width: 64px;
+  --ease-toggle-height: 34px;
+  --ease-toggle-thumb-size: 26px;
+}
+
+.ease-toggle-label {
+  font-size: 0.9rem;
+  user-select: none;
+}
+
+.demo-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin: 1.5rem 0;
+}
+
+.demo-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+}
+
+body[data-theme="light"] .demo-row {
+  background: rgba(0, 0, 0, 0.02);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+.size-demo {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  padding: 1.25rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  margin-top: 1rem;
+}
+
+body[data-theme="light"] .size-demo {
+  background: rgba(0, 0, 0, 0.02);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+.section-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #9ca3af;
+  margin: 1.5rem 0 1rem;
+}
+
+body[data-theme="light"] .section-label { color: #6b7280; }
+
+.controls {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.ease-btn {
+  padding: 0.5rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #f3f4f6;
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s;
+  outline: none;
+}
+
+.ease-btn:hover { background: rgba(255, 255, 255, 0.12); }
+.ease-btn:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
+
+body[data-theme="light"] .ease-btn {
+  border-color: rgba(0, 0, 0, 0.15);
+  background: rgba(0, 0, 0, 0.04);
+  color: #1f2937;
+}
+
+body[data-theme="light"] .ease-btn:hover { background: rgba(0, 0, 0, 0.08); }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-toggle-track { transition: none; }
+  .ease-toggle-thumb { transition: none; }
+}


### PR DESCRIPTION
CSS-only animated toggle switch built on a hidden checkbox. The knob slides between grey (off) and green (on) via `transform: translateX` with a 250ms cubic-bezier transition.

**Features:**
- `.ease-toggle` wrapper with `.ease-toggle-input` (hidden checkbox), `.ease-toggle-track` (pill), `.ease-toggle-thumb` (sliding knob)
- `:checked` state: green background + thumb slides right via `translateX(calc(width - height))`
- `:focus-within` blue focus ring for keyboard accessibility
- Disabled state at 0.4 opacity
- Size variants: `.ease-toggle-sm` (36x20/14px), default (48x26/20px), `.ease-toggle-lg` (64x34/26px)
- Dark/light theme via `[data-theme]` CSS custom properties
- `prefers-reduced-motion: reduce` disables all transitions
- Pure CSS — zero JavaScript needed for the toggle behavior

**Demo:** Three settings rows (notifications, dark mode, auto-save) + disabled variant + size comparison row. "Toggle All" button and theme switcher.

All files in `submissions/core_changes-issue-14169/`. No core files modified.

Fixes #14169