### PR TITLE
feat: add traffic light cycle example

### DIFF
--- a/submissions/examples/14019-ease-traffic-light-cycle-kp/README.md
+++ b/submissions/examples/14019-ease-traffic-light-cycle-kp/README.md
@@ -1,0 +1,16 @@
+# Traffic Light Cycle
+
+## What does this do?
+It cycles a traffic light through red, amber, and green states with glowing CSS-only signals.
+
+## How is it used?
+```html
+<div class="traffic-light" aria-hidden="true">
+  <span class="light red"></span>
+  <span class="light amber"></span>
+  <span class="light green"></span>
+</div>
+```
+
+## Why is it useful?
+It provides a reusable signal-state animation for dashboards, map UIs, traffic demos, and status indicators without JavaScript.

--- a/submissions/examples/14019-ease-traffic-light-cycle-kp/demo.html
+++ b/submissions/examples/14019-ease-traffic-light-cycle-kp/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Traffic Light Cycle</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="traffic-stage">
+    <section class="traffic-card" aria-label="Traffic light cycle demo">
+      <div class="traffic-light" aria-hidden="true">
+        <span class="light red"></span>
+        <span class="light amber"></span>
+        <span class="light green"></span>
+      </div>
+      <p class="traffic-label">Signal state</p>
+      <strong class="traffic-status">Cycling</strong>
+      <p class="traffic-copy">Lights transition through stop, ready, and go states.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/14019-ease-traffic-light-cycle-kp/style.css
+++ b/submissions/examples/14019-ease-traffic-light-cycle-kp/style.css
@@ -1,0 +1,131 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Arial, sans-serif;
+  color: #111827;
+  background: #f3f4f6;
+}
+
+.traffic-stage {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.traffic-card {
+  width: min(24rem, 100%);
+  padding: 2rem;
+  border: 1px solid #d1d5db;
+  border-radius: 1rem;
+  text-align: center;
+  background: #ffffff;
+  box-shadow: 0 1.4rem 2.8rem rgba(17, 24, 39, 0.12);
+}
+
+.traffic-light {
+  width: 6rem;
+  margin: 0 auto 1.25rem;
+  padding: 0.8rem;
+  border-radius: 1.6rem;
+  background: linear-gradient(180deg, #374151, #111827);
+  box-shadow:
+    inset 0 0 0 0.25rem rgba(255, 255, 255, 0.08),
+    0 1rem 2rem rgba(17, 24, 39, 0.3);
+}
+
+.light {
+  display: block;
+  width: 4rem;
+  height: 4rem;
+  margin: 0.5rem auto;
+  border-radius: 50%;
+  background: #4b5563;
+  box-shadow: inset 0 0.5rem 0.8rem rgba(255, 255, 255, 0.12);
+}
+
+.red {
+  animation: red-cycle 4.5s linear infinite;
+}
+
+.amber {
+  animation: amber-cycle 4.5s linear infinite;
+}
+
+.green {
+  animation: green-cycle 4.5s linear infinite;
+}
+
+.traffic-label {
+  margin: 0 0 0.25rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #4b5563;
+  text-transform: uppercase;
+}
+
+.traffic-status {
+  display: block;
+  font-size: clamp(2rem, 8vw, 3.4rem);
+  line-height: 1;
+}
+
+.traffic-copy {
+  max-width: 18rem;
+  margin: 1rem auto 0;
+  color: #4b5563;
+  line-height: 1.55;
+}
+
+@keyframes red-cycle {
+  0%, 30% {
+    background: #ef4444;
+    box-shadow: 0 0 1.5rem rgba(239, 68, 68, 0.75), inset 0 0.5rem 0.8rem rgba(255, 255, 255, 0.22);
+  }
+
+  31%, 100% {
+    background: #4b5563;
+    box-shadow: inset 0 0.5rem 0.8rem rgba(255, 255, 255, 0.12);
+  }
+}
+
+@keyframes amber-cycle {
+  0%, 34%, 66%, 100% {
+    background: #4b5563;
+    box-shadow: inset 0 0.5rem 0.8rem rgba(255, 255, 255, 0.12);
+  }
+
+  35%, 50% {
+    background: #f59e0b;
+    box-shadow: 0 0 1.5rem rgba(245, 158, 11, 0.75), inset 0 0.5rem 0.8rem rgba(255, 255, 255, 0.22);
+  }
+}
+
+@keyframes green-cycle {
+  0%, 54%, 100% {
+    background: #4b5563;
+    box-shadow: inset 0 0.5rem 0.8rem rgba(255, 255, 255, 0.12);
+  }
+
+  55%, 88% {
+    background: #22c55e;
+    box-shadow: 0 0 1.5rem rgba(34, 197, 94, 0.75), inset 0 0.5rem 0.8rem rgba(255, 255, 255, 0.22);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .red,
+  .amber,
+  .green {
+    animation: none;
+  }
+
+  .red {
+    background: #ef4444;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained traffic light cycle demo under submissions/examples
- animate red, amber, and green signal states with reduced-motion fallback
- document usage in README

Closes #14019

## Validation
- git diff --check