### PR TITLE
feat: add tooltip color variant classes (success, warning, danger, info) (issue #14165)

### DIFF
--- a/submissions/core_changes-issue-14165/README.md
+++ b/submissions/core_changes-issue-14165/README.md
@@ -1,0 +1,31 @@
+# Tooltip Color Variants — Issue #14165
+
+## What does this do?
+Adds semantic color variant classes to the tooltip component: `.ease-tooltip-success`, `.ease-tooltip-warning`, `.ease-tooltip-danger`, and `.ease-tooltip-info`. Each variant overrides `--ease-tooltip-bg` and `--ease-tooltip-border` via CSS custom properties, so the arrow pseudo-element inherits the variant color automatically.
+
+## How is it used?
+```html
+<span class="ease-tooltip-wrapper">
+  <button>Save</button>
+  <span class="ease-tooltip ease-tooltip-success">Changes saved</span>
+</span>
+```
+
+## Variants
+| Class | Background | Use case |
+|---|---|---|
+| `.ease-tooltip-default` | Grey (`#1f2937`) | Neutral info |
+| `.ease-tooltip-success` | Green (`--ease-color-success-600`) | Confirmation |
+| `.ease-tooltip-warning` | Amber (`--ease-color-warning-600`) | Caution |
+| `.ease-tooltip-danger` | Red (`--ease-color-danger-600`) | Errors |
+| `.ease-tooltip-info` | Blue (`--ease-color-primary-600`) | General info |
+
+## Positions
+| Class | Placement |
+|---|---|
+| *(none)* | Top-center (above, arrow down) |
+| `.ease-tooltip-bottom` | Bottom-center (below, arrow up) |
+| `.ease-tooltip-right` | Right-center (to the right, arrow left) |
+
+## Why is it useful for EaseMotion CSS?
+Semantic tooltips are essential for form validation, notification toasts, and status indicators. Color variants let developers communicate meaning at a glance without overriding styles manually.

--- a/submissions/core_changes-issue-14165/demo.html
+++ b/submissions/core_changes-issue-14165/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tooltip Color Variants — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="card">
+    <h1>Tooltip Variants</h1>
+    <p class="sub">Color-coded semantic tooltips: default, success, warning, danger, info — Issue #14165</p>
+
+    <div class="section-label">Color Variants</div>
+
+    <div class="demo-grid">
+      <span class="ease-tooltip-wrapper" tabindex="0">
+        <button class="demo-btn">Default</button>
+        <span class="ease-tooltip ease-tooltip-default">Neutral info</span>
+      </span>
+
+      <span class="ease-tooltip-wrapper" tabindex="0">
+        <button class="demo-btn">Success</button>
+        <span class="ease-tooltip ease-tooltip-success">Changes saved</span>
+      </span>
+
+      <span class="ease-tooltip-wrapper" tabindex="0">
+        <button class="demo-btn">Warning</button>
+        <span class="ease-tooltip ease-tooltip-warning">Low disk space</span>
+      </span>
+
+      <span class="ease-tooltip-wrapper" tabindex="0">
+        <button class="demo-btn">Danger</button>
+        <span class="ease-tooltip ease-tooltip-danger">Connection lost</span>
+      </span>
+
+      <span class="ease-tooltip-wrapper" tabindex="0">
+        <button class="demo-btn">Info</button>
+        <span class="ease-tooltip ease-tooltip-info">3 updates ready</span>
+      </span>
+    </div>
+
+    <div class="section-label">Position Variants</div>
+
+    <div class="position-demo">
+      <span class="ease-tooltip-wrapper" tabindex="0">
+        <button class="demo-btn">Top</button>
+        <span class="ease-tooltip ease-tooltip-info">Top tooltip</span>
+      </span>
+
+      <span class="ease-tooltip-wrapper" tabindex="0">
+        <button class="demo-btn">Bottom</button>
+        <span class="ease-tooltip ease-tooltip-info ease-tooltip-bottom">Bottom tooltip</span>
+      </span>
+
+      <span class="ease-tooltip-wrapper" tabindex="0">
+        <button class="demo-btn">Right</button>
+        <span class="ease-tooltip ease-tooltip-success ease-tooltip-right">Right tooltip</span>
+      </span>
+    </div>
+
+    <div class="section-label">Implementation</div>
+
+    <div style="background:rgba(0,0,0,0.2);border:1px solid rgba(255,255,255,0.06);border-radius:10px;padding:1.25rem;font-size:0.82rem;line-height:1.7;text-align:left;font-family:'SF Mono','Fira Code',monospace;color:#9ca3af;">
+      <span style="color:#10b981">/* Each variant sets --ease-tooltip-bg and --ease-tooltip-border */</span>
+      .ease-tooltip-success {
+        --ease-tooltip-bg: var(--ease-color-success-600);
+        --ease-tooltip-border: var(--ease-color-success-700);
+      }
+      .ease-tooltip-warning {
+        --ease-tooltip-bg: var(--ease-color-warning-600);
+        --ease-tooltip-border: var(--ease-color-warning-700);
+      }
+      .ease-tooltip-danger {
+        --ease-tooltip-bg: var(--ease-color-danger-600);
+        --ease-tooltip-border: var(--ease-color-danger-700);
+      }
+      .ease-tooltip-info {
+        --ease-tooltip-bg: var(--ease-color-primary-600);
+        --ease-tooltip-border: var(--ease-color-primary-700);
+      }
+
+      <span style="color:#6b7280">/* Arrow inherits via border-top/border-left color */</span>
+      .ease-tooltip::after {
+        border-top: 6px solid var(--ease-tooltip-bg);
+        <span style="color:#6b7280">/* ...inherits the variant color automatically */</span>
+      }
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/core_changes-issue-14165/style.css
+++ b/submissions/core_changes-issue-14165/style.css
@@ -1,0 +1,200 @@
+:root {
+  --ease-color-primary-600: #3b82f6;
+  --ease-color-primary-700: #2563eb;
+  --ease-color-success-600: #10b981;
+  --ease-color-success-700: #059669;
+  --ease-color-warning-600: #f59e0b;
+  --ease-color-warning-700: #d97706;
+  --ease-color-danger-600: #ef4444;
+  --ease-color-danger-700: #dc2626;
+  --ease-tooltip-bg: #1f2937;
+  --ease-tooltip-border: #374151;
+  --ease-tooltip-text: #f3f4f6;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #0a0e17;
+  color: #f3f4f6;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.card {
+  max-width: 680px;
+  width: 100%;
+  background: rgba(26, 36, 56, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  text-align: center;
+}
+
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.sub { color: #9ca3af; margin-bottom: 2rem; font-size: 0.9rem; }
+
+.ease-tooltip-wrapper {
+  position: relative;
+  display: inline-flex;
+  cursor: pointer;
+}
+
+.ease-tooltip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.5rem 0.85rem;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  transform: translateX(-50%) translateY(4px);
+  background: var(--ease-tooltip-bg, #1f2937);
+  border: 1px solid var(--ease-tooltip-border, #374151);
+  color: var(--ease-tooltip-text, #f3f4f6);
+}
+
+.ease-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid var(--ease-tooltip-bg, #1f2937);
+}
+
+.ease-tooltip-wrapper:hover .ease-tooltip,
+.ease-tooltip-wrapper:focus-within .ease-tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.ease-tooltip-default {
+  --ease-tooltip-bg: #1f2937;
+  --ease-tooltip-border: #374151;
+}
+
+.ease-tooltip-success {
+  --ease-tooltip-bg: var(--ease-color-success-600);
+  --ease-tooltip-border: var(--ease-color-success-700);
+}
+
+.ease-tooltip-warning {
+  --ease-tooltip-bg: var(--ease-color-warning-600);
+  --ease-tooltip-border: var(--ease-color-warning-700);
+}
+
+.ease-tooltip-danger {
+  --ease-tooltip-bg: var(--ease-color-danger-600);
+  --ease-tooltip-border: var(--ease-color-danger-700);
+}
+
+.ease-tooltip-info {
+  --ease-tooltip-bg: var(--ease-color-primary-600);
+  --ease-tooltip-border: var(--ease-color-primary-700);
+}
+
+.ease-tooltip-right {
+  bottom: auto;
+  left: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%) translateX(-4px);
+}
+
+.ease-tooltip-right::after {
+  top: 50%;
+  left: auto;
+  right: 100%;
+  transform: translateY(-50%);
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-right: 6px solid var(--ease-tooltip-bg);
+  border-left: none;
+}
+
+.ease-tooltip-wrapper:hover .ease-tooltip-right,
+.ease-tooltip-wrapper:focus-within .ease-tooltip-right {
+  transform: translateY(-50%) translateX(0);
+}
+
+.ease-tooltip-bottom {
+  top: calc(100% + 10px);
+  bottom: auto;
+}
+
+.ease-tooltip-bottom::after {
+  top: auto;
+  bottom: 100%;
+  border-top: none;
+  border-bottom: 6px solid var(--ease-tooltip-bg);
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+}
+
+.demo-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+  margin: 1.5rem 0;
+}
+
+.demo-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100px;
+  height: 56px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #f3f4f6;
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s;
+  outline: none;
+  position: relative;
+}
+
+.demo-btn:hover { background: rgba(255, 255, 255, 0.1); }
+.demo-btn:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
+
+.section-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #9ca3af;
+  margin: 2rem 0 1rem;
+}
+
+.position-demo {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip { transition: none; }
+}


### PR DESCRIPTION
Adds four semantic color variant classes to the tooltip component — success (green), warning (amber), danger (red), and info (blue) — each overriding `--ease-tooltip-bg` and `--ease-tooltip-border` so the arrow pseudo-element inherits the color automatically.

**Variants:**
- `.ease-tooltip-success` — `--ease-color-success-600` background, `--ease-color-success-700` border
- `.ease-tooltip-warning` — `--ease-color-warning-600` / `--ease-color-warning-700`
- `.ease-tooltip-danger` — `--ease-color-danger-600` / `--ease-color-danger-700`
- `.ease-tooltip-info` — `--ease-color-primary-600` / `--ease-color-primary-700`

**Position variants also included:**
- `.ease-tooltip-bottom` — arrow points up, tooltip below the trigger
- `.ease-tooltip-right` — arrow points left, tooltip to the right of the trigger

All variants work with `:hover` and `:focus-within` (keyboard accessible). The demo shows all 5 color variants plus 3 position variants with semantic text labels.

All files in `submissions/core_changes-issue-14165/`. No core files modified.

Fixes #14165