### PR TITLE
feat: add responsive navbar with mobile hamburger toggle (issue #14164)

### DIFF
--- a/submissions/core_changes-issue-14164/README.md
+++ b/submissions/core_changes-issue-14164/README.md
@@ -1,0 +1,41 @@
+# Responsive Navbar with Mobile Hamburger — Issue #14164
+
+## What does this do?
+Adds mobile-responsive behavior to `.ease-navbar`. On viewports below 768px, the nav links collapse behind a hamburger toggle button. Pure CSS — no JavaScript required — using the checkbox hack (`:checked ~ .ease-navbar-links`).
+
+## How is it used?
+```html
+<nav class="ease-navbar">
+  <a href="#" class="ease-navbar-brand">Brand</a>
+  <input type="checkbox" class="ease-navbar-checkbox" id="navToggle">
+  <label for="navToggle" class="ease-navbar-toggle" aria-label="Menu">
+    <span class="ease-navbar-toggle-icon">
+      <span></span><span></span><span></span>
+    </span>
+  </label>
+  <ul class="ease-navbar-links">
+    <li><a href="#" class="ease-nav-link active">Dashboard</a></li>
+    <li><a href="#" class="ease-nav-link">Projects</a></li>
+  </ul>
+</nav>
+```
+
+## Key classes
+| Class | Description |
+|---|---|
+| `.ease-navbar` | Flex container, sticky top bar with backdrop blur |
+| `.ease-navbar-brand` | Brand text/logo link |
+| `.ease-navbar-links` | Nav link list — inline on desktop, hidden on mobile |
+| `.ease-nav-link` | Individual link with hover/focus and active state |
+| `.ease-navbar-toggle` | Hamburger button (hidden on desktop, visible on mobile) |
+| `.ease-navbar-checkbox` | Hidden checkbox — `:checked` shows links and animates hamburger to X |
+| `.ease-navbar-toggle-icon` | Three `<span>` bars that rotate into an X on checked |
+
+## Mobile behavior
+- At `max-width: 768px`: links hidden, hamburger visible
+- On toggle click: `@keyframes easeSlideDown` animates links in (translateY -8px → 0, opacity 0→1)
+- Hamburger bars animate to X via `rotate(45deg)` / `rotate(-45deg)` with middle bar fading out
+- `prefers-reduced-motion: reduce` disables all transitions
+
+## Why is it useful for EaseMotion CSS?
+Responsive navigation is a fundamental requirement for any UI framework. This provides a drop-in mobile navbar with zero JavaScript dependency.

--- a/submissions/core_changes-issue-14164/demo.html
+++ b/submissions/core_changes-issue-14164/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Responsive Navbar — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="ease-navbar">
+    <a href="#" class="ease-navbar-brand">Ease<span>Motion</span></a>
+
+    <input type="checkbox" class="ease-navbar-checkbox" id="navToggle" autocomplete="off">
+
+    <label for="navToggle" class="ease-navbar-toggle" aria-label="Toggle navigation menu">
+      <span class="ease-navbar-toggle-icon">
+        <span></span>
+        <span></span>
+        <span></span>
+      </span>
+    </label>
+
+    <ul class="ease-navbar-links">
+      <li><a href="#" class="ease-nav-link active">Dashboard</a></li>
+      <li><a href="#" class="ease-nav-link">Projects</a></li>
+      <li><a href="#" class="ease-nav-link">Analytics</a></li>
+      <li><a href="#" class="ease-nav-link">Settings</a></li>
+      <li><a href="#" class="ease-nav-link">Profile</a></li>
+    </ul>
+  </nav>
+
+  <main class="content">
+    <h1>Dashboard</h1>
+    <p>Resize your browser to below 768px to see the navbar collapse into a hamburger menu. No JavaScript required — the toggle uses the checkbox hack (<code>:checked ~ .ease-navbar-links</code>).</p>
+
+    <div class="card-grid">
+      <div class="card">
+        <h3>Page Views</h3>
+        <p>24,591 &uarr; 12% this week</p>
+      </div>
+      <div class="card">
+        <h3>Active Users</h3>
+        <p>1,842 &uarr; 8% this week</p>
+      </div>
+      <div class="card">
+        <h3>Bounce Rate</h3>
+        <p>32.4% &darr; 3% this week</p>
+      </div>
+      <div class="card">
+        <h3>Avg. Session</h3>
+        <p>4m 12s &uarr; 6% this week</p>
+      </div>
+    </div>
+
+    <p style="margin-top:2rem;padding:1.25rem;background:rgba(0,0,0,0.2);border:1px solid rgba(255,255,255,0.06);border-radius:10px;font-size:0.85rem;line-height:1.6;color:#9ca3af;">
+      <strong>How the mobile menu works:</strong> The hidden <code>.ease-navbar-checkbox</code> sits between the brand/toggle and the links. When checked (via the toggle label), <code>:checked ~ .ease-navbar-links</code> switches from <code>display: none</code> to <code>display: flex</code> with an <code>easeSlideDown</code> animation. The hamburger icon animates to an X using <code>rotate()</code> transforms on the three spans. On desktop (&gt;768px), the toggle is hidden and links are shown inline.
+    </p>
+  </main>
+</body>
+</html>

--- a/submissions/core_changes-issue-14164/style.css
+++ b/submissions/core_changes-issue-14164/style.css
@@ -1,0 +1,193 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #0a0e17;
+  color: #f3f4f6;
+  min-height: 100vh;
+}
+
+.ease-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+  height: 60px;
+  background: rgba(26, 36, 56, 0.8);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(12px);
+  position: relative;
+}
+
+.ease-navbar-brand {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #f3f4f6;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.ease-navbar-brand span { color: #3b82f6; }
+
+.ease-navbar-links {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  list-style: none;
+}
+
+.ease-nav-link {
+  padding: 0.45rem 1rem;
+  border-radius: 8px;
+  color: #9ca3af;
+  text-decoration: none;
+  font-size: 0.88rem;
+  font-weight: 500;
+  transition: background 0.15s, color 0.15s;
+  outline: none;
+}
+
+.ease-nav-link:hover,
+.ease-nav-link:focus-visible {
+  background: rgba(255, 255, 255, 0.06);
+  color: #f3f4f6;
+}
+
+.ease-nav-link.active {
+  color: #3b82f6;
+  background: rgba(59, 130, 246, 0.1);
+}
+
+.ease-navbar-toggle {
+  display: none;
+  position: relative;
+  width: 36px;
+  height: 36px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  outline: none;
+  z-index: 10;
+}
+
+.ease-navbar-toggle:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+.ease-navbar-toggle-icon {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  justify-content: center;
+}
+
+.ease-navbar-toggle-icon span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: #f3f4f6;
+  border-radius: 2px;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.ease-navbar-checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+@keyframes easeSlideDown {
+  0% { transform: translateY(-8px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+
+@media (max-width: 768px) {
+  .ease-navbar {
+    flex-wrap: wrap;
+    height: auto;
+    padding: 0 1rem;
+  }
+
+  .ease-navbar-brand {
+    height: 60px;
+    display: flex;
+    align-items: center;
+  }
+
+  .ease-navbar-toggle {
+    display: flex;
+  }
+
+  .ease-navbar-links {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    padding: 0.5rem 0 1rem;
+    gap: 0.15rem;
+  }
+
+  .ease-nav-link {
+    width: 100%;
+    padding: 0.65rem 0.75rem;
+  }
+
+  .ease-navbar-checkbox:checked ~ .ease-navbar-links {
+    display: flex;
+    animation: easeSlideDown 0.25s ease-out;
+  }
+
+  .ease-navbar-checkbox:checked ~ .ease-navbar-toggle .ease-navbar-toggle-icon span:nth-child(1) {
+    transform: translateY(6px) rotate(45deg);
+  }
+
+  .ease-navbar-checkbox:checked ~ .ease-navbar-toggle .ease-navbar-toggle-icon span:nth-child(2) {
+    opacity: 0;
+  }
+
+  .ease-navbar-checkbox:checked ~ .ease-navbar-toggle .ease-navbar-toggle-icon span:nth-child(3) {
+    transform: translateY(-6px) rotate(-45deg);
+  }
+}
+
+.content {
+  max-width: 720px;
+  margin: 3rem auto;
+  padding: 0 2rem;
+}
+
+.content h1 { font-size: 1.75rem; margin-bottom: 0.75rem; }
+.content p { color: #9ca3af; line-height: 1.7; margin-bottom: 1rem; }
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.card {
+  padding: 1.25rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+.card h3 { font-size: 0.95rem; margin-bottom: 0.4rem; }
+.card p { font-size: 0.82rem; color: #6b7280; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-nav-link { transition: none; }
+  .ease-navbar-toggle-icon span { transition: none; }
+  .ease-navbar-checkbox:checked ~ .ease-navbar-links { animation: none; }
+}


### PR DESCRIPTION
CSS-only responsive navbar with mobile hamburger menu. At viewports below 768px, nav links collapse behind a toggle. Zero JavaScript — uses the checkbox hack.

**Features:**
- `.ease-navbar` — flex container with glass backdrop blur and bottom border
- `.ease-navbar-links` — inline row on desktop, hidden on mobile via `display: none`
- `.ease-navbar-checkbox` — hidden input; `:checked ~ .ease-navbar-links` shows links with `@keyframes easeSlideDown` (translateY -8px→0, opacity 0→1, 0.25s ease-out)
- `.ease-navbar-toggle` — hamburger button with three `<span>` bars; on `:checked` they rotate into an X (top: +45deg, middle: fade out, bottom: -45deg)
- `.ease-nav-link` — hover/focus states, `.active` class with blue tint
- `prefers-reduced-motion: reduce` disables all transitions and animation
- Demo page includes a dashboard layout with cards to show the full page context

All files in `submissions/core_changes-issue-14164/`. No core files modified.

Fixes #14164