### PR TITLE
feat: add skeleton shimmer animation (issue #14163)

### DIFF
--- a/submissions/core_changes-issue-14163/README.md
+++ b/submissions/core_changes-issue-14163/README.md
@@ -1,0 +1,39 @@
+# Skeleton Shimmer Animation — Issue #14163
+
+## What does this do?
+Adds a skeleton loading shimmer — a moving gradient highlight that indicates content is loading. Drop `.ease-shimmer` on any block element to turn it into a shimmer placeholder.
+
+## How is it used?
+```html
+<div class="ease-shimmer" style="width:100%;height:12px"></div>
+<div class="ease-shimmer ease-shimmer-circle" style="width:48px;height:48px"></div>
+```
+
+## Classes
+| Class | Description |
+|---|---|
+| `.ease-shimmer` | Base shimmer — gradient background, `background-size: 200% 100%`, `easeShimmer` animation |
+| `.ease-shimmer-sm` | 4px border-radius |
+| `.ease-shimmer-md` | 6px border-radius (default) |
+| `.ease-shimmer-lg` | 10px border-radius |
+| `.ease-shimmer-xl` | 14px border-radius |
+| `.ease-shimmer-circle` | 50% border-radius for avatars/icons |
+
+## Keyframes
+```css
+@keyframes easeShimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+```
+
+## CSS Custom Properties
+| Property | Default (dark) | Default (light) |
+|---|---|---|
+| `--ease-shimmer-base` | `rgba(255,255,255,0.04)` | `#e5e7eb` |
+| `--ease-shimmer-highlight` | `rgba(255,255,255,0.08)` | `#f3f4f6` |
+
+Override per element: `style="--ease-shimmer-base:#1e3a5f;--ease-shimmer-highlight:#2d5a8e"`
+
+## Why is it useful for EaseMotion CSS?
+Skeleton loaders are one of the most common UI patterns — used in every app with async data. This provides a consistent, theme-aware shimmer that works on any element shape.

--- a/submissions/core_changes-issue-14163/demo.html
+++ b/submissions/core_changes-issue-14163/demo.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skeleton Shimmer — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="card">
+    <h1>Skeleton Shimmer</h1>
+    <p class="sub">Loading placeholder with moving gradient highlight — Issue #14163</p>
+
+    <div class="controls">
+      <button class="ease-btn" id="themeToggle">&#9788; Light Mode</button>
+    </div>
+
+    <div class="section-label">Profile Card</div>
+
+    <div class="skel-card">
+      <div class="skel-row">
+        <div class="ease-shimmer ease-shimmer-circle skel-avatar"></div>
+        <div class="skel-lines">
+          <div class="ease-shimmer skel-line"></div>
+          <div class="ease-shimmer skel-line"></div>
+        </div>
+      </div>
+      <div class="ease-shimmer skel-line" style="margin-bottom:0.5rem"></div>
+      <div class="ease-shimmer skel-line"></div>
+    </div>
+
+    <div class="section-label">Card Grid (Loading)</div>
+
+    <div class="skel-grid">
+      <div class="skel-grid-item">
+        <div class="ease-shimmer skel-line"></div>
+        <div class="ease-shimmer skel-line"></div>
+        <div class="ease-shimmer skel-line-short"></div>
+      </div>
+      <div class="skel-grid-item">
+        <div class="ease-shimmer skel-line"></div>
+        <div class="ease-shimmer skel-line"></div>
+        <div class="ease-shimmer skel-line-short"></div>
+      </div>
+      <div class="skel-grid-item">
+        <div class="ease-shimmer skel-line"></div>
+        <div class="ease-shimmer skel-line"></div>
+        <div class="ease-shimmer skel-line-short"></div>
+      </div>
+      <div class="skel-grid-item">
+        <div class="ease-shimmer skel-line"></div>
+        <div class="ease-shimmer skel-line"></div>
+        <div class="ease-shimmer skel-line-short"></div>
+      </div>
+    </div>
+
+    <div class="section-label">Shapes &amp; Radius Variants</div>
+
+    <div class="shape-demo">
+      <div>
+        <div class="ease-shimmer ease-shimmer-sm shape-box"></div>
+        <span>ease-shimmer-sm</span>
+      </div>
+      <div>
+        <div class="ease-shimmer ease-shimmer-md shape-box"></div>
+        <span>ease-shimmer-md</span>
+      </div>
+      <div>
+        <div class="ease-shimmer ease-shimmer-lg shape-box"></div>
+        <span>ease-shimmer-lg</span>
+      </div>
+      <div>
+        <div class="ease-shimmer ease-shimmer-circle shape-circle"></div>
+        <span>ease-shimmer-circle</span>
+      </div>
+      <div>
+        <div class="ease-shimmer ease-shimmer-lg shape-wide"></div>
+        <span>Button / Bar</span>
+      </div>
+    </div>
+
+    <div style="margin-top:2rem;padding:1.25rem;background:rgba(0,0,0,0.2);border:1px solid rgba(255,255,255,0.06);border-radius:10px;font-size:0.82rem;line-height:1.7;font-family:'SF Mono','Fira Code',monospace;color:#9ca3af;">
+      <span style="color:#10b981">/* Usage */</span>
+      &lt;div class="ease-shimmer" style="width:100%;height:12px"&gt;&lt;/div&gt;
+      &lt;div class="ease-shimmer ease-shimmer-circle" style="width:48px;height:48px"&gt;&lt;/div&gt;
+
+      <span style="color:#6b7280;display:block;margin-top:0.5rem">
+        /* Custom colors via --ease-shimmer-base / --ease-shimmer-highlight */
+      </span>
+      &lt;div class="ease-shimmer" style="--ease-shimmer-base:#1e3a5f;--ease-shimmer-highlight:#2d5a8e"&gt;&lt;/div&gt;
+    </div>
+  </div>
+
+  <script>
+    document.getElementById('themeToggle').addEventListener('click', () => {
+      const isLight = document.body.getAttribute('data-theme') === 'light';
+      document.body.setAttribute('data-theme', isLight ? 'dark' : 'light');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/core_changes-issue-14163/style.css
+++ b/submissions/core_changes-issue-14163/style.css
@@ -1,0 +1,219 @@
+:root {
+  --ease-shimmer-base: rgba(255, 255, 255, 0.04);
+  --ease-shimmer-highlight: rgba(255, 255, 255, 0.08);
+  --ease-shimmer-radius: 6px;
+}
+
+[data-theme="light"] {
+  --ease-shimmer-base: #e5e7eb;
+  --ease-shimmer-highlight: #f3f4f6;
+}
+
+@keyframes easeShimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.ease-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--ease-shimmer-base) 25%,
+    var(--ease-shimmer-highlight) 50%,
+    var(--ease-shimmer-base) 75%
+  );
+  background-size: 200% 100%;
+  animation: easeShimmer 2s ease-in-out infinite;
+}
+
+.ease-shimmer-sm { border-radius: 4px; }
+.ease-shimmer-md { border-radius: 6px; }
+.ease-shimmer-lg { border-radius: 10px; }
+.ease-shimmer-xl { border-radius: 14px; }
+
+.ease-shimmer-circle {
+  border-radius: 50%;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #0a0e17;
+  color: #f3f4f6;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  transition: background 0.3s;
+}
+
+body[data-theme="light"] {
+  background: #f9fafb;
+  color: #1f2937;
+}
+
+.card {
+  max-width: 640px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+body[data-theme="light"] .card {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+}
+
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.sub { color: #9ca3af; margin-bottom: 2rem; font-size: 0.9rem; }
+
+.section-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #9ca3af;
+  margin: 2rem 0 1rem;
+}
+
+.controls {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.ease-btn {
+  padding: 0.5rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #f3f4f6;
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s;
+  outline: none;
+}
+
+.ease-btn:hover { background: rgba(255, 255, 255, 0.12); }
+.ease-btn:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
+
+body[data-theme="light"] .ease-btn {
+  border-color: rgba(0, 0, 0, 0.15);
+  background: rgba(0, 0, 0, 0.04);
+  color: #1f2937;
+}
+
+body[data-theme="light"] .ease-btn:hover { background: rgba(0, 0, 0, 0.08); }
+
+/* --- Skeleton demos --- */
+
+.skel-card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+body[data-theme="light"] .skel-card {
+  background: rgba(0, 0, 0, 0.02);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+.skel-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.skel-row:last-child { margin-bottom: 0; }
+
+.skel-avatar {
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+}
+
+.skel-lines {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skel-line {
+  height: 12px;
+  width: 100%;
+}
+
+.skel-line:nth-child(2) { width: 70%; }
+
+.skel-line-short {
+  width: 40%;
+  height: 12px;
+}
+
+.skel-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.skel-grid-item {
+  padding: 1.25rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+body[data-theme="light"] .skel-grid-item {
+  background: rgba(0, 0, 0, 0.02);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+.skel-grid-item .skel-line { margin-bottom: 0.5rem; }
+.skel-grid-item .skel-line-short { margin-top: 0.5rem; }
+
+.skel-badge {
+  display: inline-block;
+  width: 70px;
+  height: 20px;
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.shape-demo {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.shape-demo > div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.shape-box { width: 64px; height: 48px; }
+.shape-circle { width: 48px; height: 48px; }
+.shape-wide { width: 120px; height: 32px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-shimmer { animation: none; }
+}


### PR DESCRIPTION
Adds a skeleton loading shimmer — `@keyframes easeShimmer` (background-position -200%→200%) with a `.ease-shimmer` class for drop-in loading placeholders.

**Features:**
- `@keyframes easeShimmer` — animates `background-position` from -200% to 200% over 2s ease-in-out, infinite
- `.ease-shimmer` — `linear-gradient(90deg, base 25%, highlight 50%, base 75%)` with `background-size: 200% 100%`
- Radius variants: `.ease-shimmer-sm` (4px), `.md` (6px), `.lg` (10px), `.xl` (14px)
- `.ease-shimmer-circle` — `border-radius: 50%` for avatars
- `--ease-shimmer-base` and `--ease-shimmer-highlight` CSS variables, customizable per element
- Dark/light theme via `[data-theme]` switching
- `prefers-reduced-motion: reduce` disables animation
- Works on any block element — just set width/height

**Demo:** Profile card skeleton (avatar + text lines), 2x2 card grid, shape/radius showcase, inline code examples.

All files in `submissions/core_changes-issue-14163/`. No core files modified.

Fixes #14163