### PR TITLE
feat: add unit tests for core animation keyframes (issue #14161)

### DIFF
--- a/submissions/core_changes-issue-14161/README.md
+++ b/submissions/core_changes-issue-14161/README.md
@@ -1,0 +1,46 @@
+# Animation Keyframe Unit Tests — Issue #14161
+
+## What does this do?
+Adds unit tests for `core/animations.css` to verify all keyframe animation definitions are present, correct, and free of duplicates. Pure text-assertion tests — no DOM required.
+
+## Provided files
+
+| File | Description |
+|---|---|
+| `tests/animations.test.js` | Vitest test file — copy to `tests/animations.test.js` and run `npm test` |
+| `demo.html` | In-browser test runner that fetches `core/animations.css` and runs same assertions |
+| `style.css` | Styling for the test runner |
+
+## What gets tested?
+
+**13 core keyframes** — verifies each `@keyframes ease-kf-*` block exists and has expected properties:
+
+| Keyframe | Checks |
+|---|---|
+| `ease-kf-fade-in` | opacity 0→1, transform present |
+| `ease-kf-fade-out` | opacity 1→0 |
+| `ease-kf-slide-up` | translate3d(0,24px,0)→(0,0,0) |
+| `ease-kf-slide-down` | translate3d(0,-24px,0)→(0,0,0) |
+| `ease-kf-slide-in-left` | translate3d(-32px,0,0)→(0,0,0) |
+| `ease-kf-slide-in-right` | translate3d(32px,0,0)→(0,0,0) |
+| `ease-kf-zoom-in` | scale + opacity 0→1 |
+| `ease-kf-flip` | rotateY + perspective |
+| `ease-kf-bounce` | translate + cubic-bezier timing |
+| `ease-kf-rotate` | 0deg→360deg |
+| `ease-kf-pulse` | opacity 1 → 0.45 → 1 |
+| `ease-kf-ping` | scale(1)→scale(2) + opacity 0 |
+| `ease-kf-shake` | translateX oscillation (3+ stops) |
+
+**Also checks:**
+- No duplicate keyframe definitions
+- `@media (prefers-reduced-motion: reduce)` block exists and disables animation
+
+## Running
+
+```bash
+# Vitest (requires this file in tests/)
+npm test
+
+# Browser (served from repo root)
+open submissions/core_changes-issue-14161/demo.html
+```

--- a/submissions/core_changes-issue-14161/demo.html
+++ b/submissions/core_changes-issue-14161/demo.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animation Keyframe Tests — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="card">
+    <h1>Animation Keyframe Tests</h1>
+    <p class="sub">Unit test runner for <code>core/animations.css</code> — Issue #14161</p>
+
+    <div class="summary" id="summary">
+      <div class="summary-count">0 / 0</div>
+      <div class="summary-bar"><div class="summary-fill" id="summaryFill"></div></div>
+    </div>
+
+    <div id="results"></div>
+
+    <div class="footer-note">
+      <strong>How to run as vitest:</strong> Copy <code>submissions/core_changes-issue-14161/tests/animations.test.js</code> to <code>tests/animations.test.js</code> and run <code>npm test</code>. The vitest version reads <code>core/animations.css</code> via <code>fs.readFileSync</code> and runs pure text assertions — no DOM required.
+    </div>
+  </div>
+
+  <script>
+    fetch('../../core/animations.css')
+      .then(r => r.text())
+      .then(css => runTests(css))
+      .catch(() => {
+        document.getElementById('results').innerHTML =
+          '<div class="test fail">Could not load core/animations.css. Open this page from the repo root or run via vitest.</div>';
+      });
+
+    function extractKeyframe(name, css) {
+      const esc = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(`@keyframes\\s+${esc}\\s*\\{[^}]+(?:\\{[^}]+\\}[^}]*)*\\}`, 's');
+      const m = css.match(re);
+      return m ? m[0] : '';
+    }
+
+    function runTests(css) {
+      const tests = [];
+      let pass = 0, fail = 0;
+
+      function assert(desc, fn) {
+        try {
+          const ok = fn();
+          if (ok) { pass++; tests.push({ desc, ok: true }); }
+          else { fail++; tests.push({ desc, ok: false, msg: 'Assertion returned false' }); }
+        } catch (e) {
+          fail++; tests.push({ desc, ok: false, msg: e.message });
+        }
+      }
+
+      const expected = [
+        'ease-kf-fade-in', 'ease-kf-fade-out', 'ease-kf-slide-up',
+        'ease-kf-slide-down', 'ease-kf-slide-in-left', 'ease-kf-slide-in-right',
+        'ease-kf-zoom-in', 'ease-kf-flip', 'ease-kf-bounce',
+        'ease-kf-rotate', 'ease-kf-pulse', 'ease-kf-ping', 'ease-kf-shake',
+      ];
+
+      for (const kf of expected) {
+        assert(`${kf} is defined`, () => {
+          const re = new RegExp(`@keyframes\\s+${kf}\\s*\\{`);
+          return re.test(css);
+        });
+      }
+
+      assert('13 core keyframes without duplicates', () => {
+        const re = /@keyframes\s+(ease-kf-(?:fade-in|fade-out|slide-up|slide-down|slide-in-left|slide-in-right|zoom-in|flip|bounce|rotate|pulse|ping|shake))\s*\{/g;
+        return (css.match(re) || []).length === 13;
+      });
+
+      assert('ease-kf-fade-in has opacity 0 to 1', () => {
+        const b = extractKeyframe('ease-kf-fade-in', css);
+        return b.includes('opacity: 0') && b.includes('opacity: 1');
+      });
+
+      assert('ease-kf-fade-out has opacity 1 to 0', () => {
+        const b = extractKeyframe('ease-kf-fade-out', css);
+        return b.includes('opacity: 1') && b.includes('opacity: 0');
+      });
+
+      assert('ease-kf-slide-up uses translateY', () => {
+        const b = extractKeyframe('ease-kf-slide-up', css);
+        return b.includes('translate3d(0,24px,0)') && b.includes('translate3d(0,0,0)');
+      });
+
+      assert('ease-kf-slide-down uses translateY negative start', () => {
+        const b = extractKeyframe('ease-kf-slide-down', css);
+        return b.includes('translate3d(0,-24px,0)');
+      });
+
+      assert('ease-kf-slide-in-left uses translateX negative start', () => {
+        const b = extractKeyframe('ease-kf-slide-in-left', css);
+        return b.includes('translate3d(-32px,0,0)');
+      });
+
+      assert('ease-kf-slide-in-right uses translateX positive start', () => {
+        const b = extractKeyframe('ease-kf-slide-in-right', css);
+        return b.includes('translate3d(32px,0,0)');
+      });
+
+      assert('ease-kf-zoom-in has scale + opacity', () => {
+        const b = extractKeyframe('ease-kf-zoom-in', css);
+        return b.includes('scale') && b.includes('opacity: 0') && b.includes('opacity: 1');
+      });
+
+      assert('ease-kf-flip uses rotateY + perspective', () => {
+        const b = extractKeyframe('ease-kf-flip', css);
+        return b.includes('rotateY') && b.includes('perspective');
+      });
+
+      assert('ease-kf-bounce has translate + cubic-bezier', () => {
+        const b = extractKeyframe('ease-kf-bounce', css);
+        return b.includes('translate') && b.includes('cubic-bezier');
+      });
+
+      assert('ease-kf-rotate goes 0deg to 360deg', () => {
+        const b = extractKeyframe('ease-kf-rotate', css);
+        return b.includes('rotate(0deg)') && b.includes('rotate(360deg)');
+      });
+
+      assert('ease-kf-pulse oscillates opacity 1 to 0.45 to 1', () => {
+        const b = extractKeyframe('ease-kf-pulse', css);
+        return b.includes('opacity: 1') && b.includes('opacity: 0.45');
+      });
+
+      assert('ease-kf-ping scales from 1 to 2 with opacity 0', () => {
+        const b = extractKeyframe('ease-kf-ping', css);
+        return b.includes('scale(1)') && b.includes('scale(2)') && b.includes('opacity: 0');
+      });
+
+      assert('ease-kf-shake oscillates translateX', () => {
+        const b = extractKeyframe('ease-kf-shake', css);
+        return (b.match(/translateX/g) || []).length >= 3;
+      });
+
+      assert('no duplicate keyframe definitions', () => {
+        for (const kf of expected) {
+          const re = new RegExp(`@keyframes\\s+${kf}`, 'g');
+          if ((css.match(re) || []).length !== 1) return false;
+        }
+        return true;
+      });
+
+      assert('prefers-reduced-motion block exists', () => {
+        return css.includes('@media (prefers-reduced-motion: reduce)');
+      });
+
+      assert('reduced motion disables animation', () => {
+        const m = css.match(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{([^}]+)\}/);
+        return m !== null && (m[1].includes('animation: none') || m[1].includes('animation-duration: 0s'));
+      });
+
+      document.getElementById('summary').querySelector('.summary-count').textContent = `${pass} / ${pass + fail}`;
+      document.getElementById('summaryFill').style.width = `${(pass / (pass + fail)) * 100}%`;
+      document.getElementById('summaryFill').style.background = fail === 0 ? '#10b981' : '#f59e0b';
+
+      const container = document.getElementById('results');
+      container.innerHTML = tests.map(t => `
+        <div class="test ${t.ok ? 'pass' : 'fail'}">
+          <span class="test-icon">${t.ok ? '&#10003;' : '&#10007;'}</span>
+          <span class="test-desc">${t.desc}</span>
+          ${t.msg ? `<span class="test-msg">${t.msg}</span>` : ''}
+        </div>
+      `).join('');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/core_changes-issue-14161/style.css
+++ b/submissions/core_changes-issue-14161/style.css
@@ -1,0 +1,115 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #0a0e17;
+  color: #f3f4f6;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.card {
+  max-width: 680px;
+  width: 100%;
+  background: rgba(26, 36, 56, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.sub { color: #9ca3af; margin-bottom: 2rem; font-size: 0.9rem; }
+
+.summary {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.summary-count {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #3b82f6;
+  white-space: nowrap;
+}
+
+.summary-bar {
+  flex: 1;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.summary-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.5s ease;
+  width: 0;
+}
+
+#results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.test {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.test.pass {
+  background: rgba(16, 185, 129, 0.06);
+  border: 1px solid rgba(16, 185, 129, 0.12);
+}
+
+.test.fail {
+  background: rgba(239, 68, 68, 0.06);
+  border: 1px solid rgba(239, 68, 68, 0.12);
+}
+
+.test-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.test.pass .test-icon { color: #10b981; }
+.test.fail .test-icon { color: #ef4444; }
+
+.test-desc {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  color: #f3f4f6;
+}
+
+.test-msg {
+  color: #ef4444;
+  font-size: 0.75rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.footer-note {
+  margin-top: 2rem;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  font-size: 0.82rem;
+  color: #9ca3af;
+  line-height: 1.6;
+}

--- a/submissions/core_changes-issue-14161/tests/animations.test.js
+++ b/submissions/core_changes-issue-14161/tests/animations.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const animationsPath = resolve(__dirname, '../../core/animations.css');
+const animationsCss = readFileSync(animationsPath, 'utf8');
+
+describe('EaseMotion core animation keyframes', () => {
+
+  const expectedKeyframes = [
+    'ease-kf-fade-in',
+    'ease-kf-fade-out',
+    'ease-kf-slide-up',
+    'ease-kf-slide-down',
+    'ease-kf-slide-in-left',
+    'ease-kf-slide-in-right',
+    'ease-kf-zoom-in',
+    'ease-kf-flip',
+    'ease-kf-bounce',
+    'ease-kf-rotate',
+    'ease-kf-pulse',
+    'ease-kf-ping',
+    'ease-kf-shake',
+  ];
+
+  for (const kf of expectedKeyframes) {
+    it(`should define @keyframes ${kf}`, () => {
+      const regex = new RegExp(`@keyframes\\s+${kf}\\s*\\{`);
+      expect(animationsCss).toMatch(regex);
+    });
+  }
+
+  it('should have all 13 core keyframes defined without duplicates', () => {
+    const regex = /@keyframes\s+(ease-kf-(?:fade-in|fade-out|slide-up|slide-down|slide-in-left|slide-in-right|zoom-in|flip|bounce|rotate|pulse|ping|shake))\s*\{/g;
+    const matches = animationsCss.match(regex);
+    expect(matches).toHaveLength(13);
+  });
+
+  it('should have ease-kf-fade-in with opacity 0 to 1 transition', () => {
+    const block = extractKeyframe('ease-kf-fade-in', animationsCss);
+    expect(block).toContain('opacity: 0');
+    expect(block).toContain('opacity: 1');
+    expect(block).toContain('transform');
+  });
+
+  it('should have ease-kf-fade-out with opacity 1 to 0', () => {
+    const block = extractKeyframe('ease-kf-fade-out', animationsCss);
+    expect(block).toContain('opacity: 1');
+    expect(block).toContain('opacity: 0');
+  });
+
+  it('should have ease-kf-slide-up with translateY', () => {
+    const block = extractKeyframe('ease-kf-slide-up', animationsCss);
+    expect(block).toContain('translate3d(0,24px,0)');
+    expect(block).toContain('translate3d(0,0,0)');
+  });
+
+  it('should have ease-kf-slide-down with translateY negative start', () => {
+    const block = extractKeyframe('ease-kf-slide-down', animationsCss);
+    expect(block).toContain('translate3d(0,-24px,0)');
+    expect(block).toContain('translate3d(0,0,0)');
+  });
+
+  it('should have ease-kf-slide-in-left with translateX negative start', () => {
+    const block = extractKeyframe('ease-kf-slide-in-left', animationsCss);
+    expect(block).toContain('translate3d(-32px,0,0)');
+    expect(block).toContain('translate3d(0,0,0)');
+  });
+
+  it('should have ease-kf-slide-in-right with translateX positive start', () => {
+    const block = extractKeyframe('ease-kf-slide-in-right', animationsCss);
+    expect(block).toContain('translate3d(32px,0,0)');
+    expect(block).toContain('translate3d(0,0,0)');
+  });
+
+  it('should have ease-kf-zoom-in with scale transform', () => {
+    const block = extractKeyframe('ease-kf-zoom-in', animationsCss);
+    expect(block).toContain('scale');
+    expect(block).toContain('opacity: 0');
+    expect(block).toContain('opacity: 1');
+  });
+
+  it('should have ease-kf-flip with rotateY perspective', () => {
+    const block = extractKeyframe('ease-kf-flip', animationsCss);
+    expect(block).toContain('rotateY');
+    expect(block).toContain('perspective');
+  });
+
+  it('should have ease-kf-bounce with translateY bounce pattern', () => {
+    const block = extractKeyframe('ease-kf-bounce', animationsCss);
+    expect(block).toContain('translate');
+    expect(block).toContain('cubic-bezier');
+    const pctLines = block.match(/\d+%/g);
+    expect(pctLines.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should have ease-kf-rotate with full 360deg rotation', () => {
+    const block = extractKeyframe('ease-kf-rotate', animationsCss);
+    expect(block).toContain('transform: rotate(0deg)');
+    expect(block).toContain('transform: rotate(360deg)');
+  });
+
+  it('should have ease-kf-pulse with opacity oscillation', () => {
+    const block = extractKeyframe('ease-kf-pulse', animationsCss);
+    expect(block).toContain('opacity: 1');
+    expect(block).toContain('opacity: 0.45');
+    expect(block).toContain('opacity: 1');
+  });
+
+  it('should have ease-kf-ping with scale transform', () => {
+    const block = extractKeyframe('ease-kf-ping', animationsCss);
+    expect(block).toContain('transform: scale(1)');
+    expect(block).toContain('transform: scale(2)');
+    expect(block).toContain('opacity: 0');
+  });
+
+  it('should have ease-kf-shake with horizontal translateX oscillation', () => {
+    const block = extractKeyframe('ease-kf-shake', animationsCss);
+    expect(block).toContain('translateX');
+    const matches = block.match(/translateX/g);
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should have each expected keyframe appear exactly once (no duplicates)', () => {
+    for (const kf of expectedKeyframes) {
+      const regex = new RegExp(`@keyframes\\s+${kf}`, 'g');
+      const matches = animationsCss.match(regex);
+      expect(matches).toHaveLength(1);
+    }
+  });
+
+  it('should include a prefers-reduced-motion block', () => {
+    expect(animationsCss).toContain('@media (prefers-reduced-motion: reduce)');
+  });
+
+  it('should disable animations for all ease- classes under prefers-reduced-motion', () => {
+    const mediaMatch = animationsCss.match(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{([^}]+)\}/);
+    expect(mediaMatch).not.toBeNull();
+    const block = mediaMatch[1];
+    expect(block).toContain('animation: none');
+    expect(block).toContain('animation-duration: 0s');
+  });
+});
+
+function extractKeyframe(name, css) {
+  const regex = new RegExp(`@keyframes\\s+${name}\\s*\\{([^}]+(?:\\{[^}]+\\}[^}]*)*)\\}`, 's');
+  const match = css.match(regex);
+  if (!match) return '';
+  return match[0];
+}


### PR DESCRIPTION
Adds unit tests for `core/animations.css` to verify all keyframe definitions, transform properties, opacity transitions, and reduced-motion support.

**Test file:** `tests/animations.test.js` (vitest) — pure text assertions via `fs.readFileSync`, no DOM required.

**What's covered:**

- **13 core keyframes verified:** ease-kf-fade-in, fade-out, slide-up, slide-down, slide-in-left, slide-in-right, zoom-in, flip, bounce, rotate, pulse, ping, shake
- **Transform validation:** slide-up uses translate3d(0,24px,0), slide-in-left uses -32px, ping scales 1→2, flip uses rotateY, rotate goes 0→360deg, shake oscillates translateX
- **Opacity checks:** fade-in 0→1, fade-out 1→0, ping ends at opacity 0, pulse oscillates 1→0.45→1
- **No duplicates:** each keyframe appears exactly once
- **Reduced motion:** `@media (prefers-reduced-motion: reduce)` block exists and disables animation

**Also includes:**
- `demo.html` — browser-based test runner that fetches animations.css and runs identical assertions inline, showing pass/fail per test with a summary bar
- Visual pass indicator (green) / fail (red) with progress summary

All files in `submissions/core_changes-issue-14161/`. No core files modified.

Fixes #14161