### PR TITLE
Add inline edit save state example

### DIFF
--- a/submissions/examples/inline-edit-save-state-ts/README.md
+++ b/submissions/examples/inline-edit-save-state-ts/README.md
@@ -1,0 +1,18 @@
+# Inline Edit Save State Row
+
+## What does this do?
+
+Shows static inline edit rows for viewing, editing, saving, and saved states.
+
+## How is it used?
+
+```html
+<article class="edit-row is-saving">
+  <span>Billing contact</span>
+  <span class="state-chip">Saving</span>
+</article>
+```
+
+## Why is it useful?
+
+Inline editing is common in settings and admin tools. This example gives EaseMotion CSS a clear pattern for communicating edit progress without JavaScript.

--- a/submissions/examples/inline-edit-save-state-ts/demo.html
+++ b/submissions/examples/inline-edit-save-state-ts/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inline Edit Save State Row</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="edit-shell">
+    <section class="edit-panel" aria-labelledby="edit-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Settings</p>
+        <h1 id="edit-title">Inline edit states</h1>
+      </div>
+
+      <div class="edit-list" aria-label="Workspace settings">
+        <article class="edit-row is-viewing">
+          <div>
+            <span class="field-label">Workspace name</span>
+            <strong>Northstar Ops</strong>
+          </div>
+          <span class="state-chip">Viewing</span>
+        </article>
+
+        <article class="edit-row is-editing">
+          <div>
+            <span class="field-label">Default region</span>
+            <strong>Asia Pacific</strong>
+          </div>
+          <span class="state-chip">Editing</span>
+        </article>
+
+        <article class="edit-row is-saving">
+          <div>
+            <span class="field-label">Billing contact</span>
+            <strong>finance@example.com</strong>
+          </div>
+          <span class="state-chip">Saving</span>
+        </article>
+
+        <article class="edit-row is-saved">
+          <div>
+            <span class="field-label">Security policy</span>
+            <strong>Required SSO</strong>
+          </div>
+          <span class="state-chip">Saved</span>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/inline-edit-save-state-ts/style.css
+++ b/submissions/examples/inline-edit-save-state-ts/style.css
@@ -1,0 +1,170 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #d9e1ec;
+  --blue: #2563eb;
+  --green: #12805c;
+  --amber: #b45309;
+  --shadow: 0 24px 60px rgba(24, 32, 51, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.edit-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+}
+
+.edit-panel {
+  width: min(760px, 100%);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  padding: 28px;
+}
+
+.panel-heading {
+  margin-bottom: 22px;
+}
+
+.eyebrow,
+.field-label {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 4px 0 0;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  line-height: 1.1;
+}
+
+.edit-list {
+  display: grid;
+  gap: 10px;
+}
+
+.edit-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 78px;
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcfe;
+  transition: border-color 220ms ease, background-color 220ms ease, transform 220ms ease;
+}
+
+.edit-row strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 1rem;
+}
+
+.edit-row:hover {
+  transform: translateY(-2px);
+}
+
+.state-chip {
+  display: inline-flex;
+  align-items: center;
+  min-width: 82px;
+  justify-content: center;
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: #eef2f7;
+  color: #344054;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.is-editing {
+  border-color: rgba(37, 99, 235, 0.45);
+  background: #eff6ff;
+}
+
+.is-editing .state-chip {
+  background: #dbeafe;
+  color: var(--blue);
+}
+
+.is-saving {
+  border-color: rgba(180, 83, 9, 0.45);
+}
+
+.is-saving .state-chip::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  margin-right: 8px;
+  border-radius: 50%;
+  background: var(--amber);
+  animation: savePulse 900ms ease-in-out infinite;
+}
+
+.is-saved {
+  border-color: rgba(18, 128, 92, 0.45);
+  background: #ecfdf3;
+}
+
+.is-saved .state-chip {
+  background: #d1fadf;
+  color: var(--green);
+}
+
+@keyframes savePulse {
+  0%, 100% {
+    opacity: 0.35;
+    transform: scale(0.75);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 560px) {
+  .edit-shell {
+    padding: 18px;
+  }
+
+  .edit-panel {
+    padding: 20px;
+  }
+
+  .edit-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive inline edit save state row example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14251

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/inline-edit-save-state-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
