### PR TITLE
Add permission matrix toggle grid example

### DIFF
--- a/submissions/examples/permission-matrix-toggle-grid-ts/README.md
+++ b/submissions/examples/permission-matrix-toggle-grid-ts/README.md
@@ -1,0 +1,19 @@
+# Permission Matrix Toggle Grid
+
+## What does this do?
+
+Displays role permissions in a compact grid with enabled, disabled, and off states.
+
+## How is it used?
+
+```html
+<div class="grid-row">
+  <strong>Admin</strong>
+  <span class="toggle is-on"></span>
+  <span class="toggle"></span>
+</div>
+```
+
+## Why is it useful?
+
+Permission screens need dense state presentation. This example shows how EaseMotion CSS can make role access easier to scan.

--- a/submissions/examples/permission-matrix-toggle-grid-ts/demo.html
+++ b/submissions/examples/permission-matrix-toggle-grid-ts/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Permission Matrix Toggle Grid</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="matrix-shell">
+    <section class="matrix-card" aria-labelledby="matrix-title">
+      <div class="matrix-heading">
+        <p class="eyebrow">Access control</p>
+        <h1 id="matrix-title">Permission matrix</h1>
+      </div>
+
+      <div class="permission-grid" role="table" aria-label="Role permissions">
+        <div class="grid-row grid-head" role="row">
+          <span role="columnheader">Role</span>
+          <span role="columnheader">View</span>
+          <span role="columnheader">Edit</span>
+          <span role="columnheader">Invite</span>
+          <span role="columnheader">Billing</span>
+        </div>
+
+        <div class="grid-row" role="row">
+          <strong role="rowheader">Owner</strong>
+          <span class="toggle is-on"></span>
+          <span class="toggle is-on"></span>
+          <span class="toggle is-on"></span>
+          <span class="toggle is-on"></span>
+        </div>
+
+        <div class="grid-row" role="row">
+          <strong role="rowheader">Admin</strong>
+          <span class="toggle is-on"></span>
+          <span class="toggle is-on"></span>
+          <span class="toggle is-on"></span>
+          <span class="toggle"></span>
+        </div>
+
+        <div class="grid-row" role="row">
+          <strong role="rowheader">Editor</strong>
+          <span class="toggle is-on"></span>
+          <span class="toggle is-on"></span>
+          <span class="toggle"></span>
+          <span class="toggle is-disabled"></span>
+        </div>
+
+        <div class="grid-row" role="row">
+          <strong role="rowheader">Viewer</strong>
+          <span class="toggle is-on"></span>
+          <span class="toggle"></span>
+          <span class="toggle"></span>
+          <span class="toggle is-disabled"></span>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/permission-matrix-toggle-grid-ts/style.css
+++ b/submissions/examples/permission-matrix-toggle-grid-ts/style.css
@@ -1,0 +1,156 @@
+:root {
+  --bg: #f7f6f2;
+  --surface: #ffffff;
+  --text: #20222a;
+  --muted: #667085;
+  --line: #d8dce5;
+  --active: #0f766e;
+  --active-soft: #ccfbf1;
+  --off: #e4e7ec;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.matrix-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.matrix-card {
+  width: min(860px, 100%);
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 22px 55px rgba(25, 33, 46, 0.12);
+}
+
+.matrix-heading {
+  margin-bottom: 22px;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: var(--active);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.permission-grid {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.grid-row {
+  display: grid;
+  grid-template-columns: 1.4fr repeat(4, minmax(72px, 1fr));
+  align-items: center;
+  min-height: 64px;
+  border-top: 1px solid var(--line);
+  background: #fff;
+  transition: background-color 180ms ease;
+}
+
+.grid-row:first-child {
+  border-top: 0;
+}
+
+.grid-row:hover:not(.grid-head) {
+  background: #f8fafc;
+}
+
+.grid-row > * {
+  padding: 14px 16px;
+}
+
+.grid-head {
+  min-height: 48px;
+  background: #f1f5f9;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.toggle {
+  justify-self: center;
+  position: relative;
+  display: inline-block;
+  width: 46px;
+  height: 26px;
+  padding: 0;
+  border-radius: 999px;
+  background: var(--off);
+  transition: background-color 180ms ease, transform 180ms ease;
+}
+
+.toggle::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.22);
+  transition: transform 180ms ease;
+}
+
+.toggle.is-on {
+  background: var(--active);
+}
+
+.toggle.is-on::after {
+  transform: translateX(20px);
+}
+
+.toggle.is-disabled {
+  opacity: 0.38;
+  background: repeating-linear-gradient(45deg, #e5e7eb 0 5px, #cbd5e1 5px 10px);
+}
+
+.toggle:hover {
+  transform: scale(1.04);
+}
+
+@media (max-width: 640px) {
+  .matrix-card {
+    padding: 20px;
+  }
+
+  .permission-grid {
+    overflow-x: auto;
+  }
+
+  .grid-row {
+    min-width: 640px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive permission matrix toggle grid example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14252

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/permission-matrix-toggle-grid-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
