### PR TITLE
Add notification preference cards example

### DIFF
--- a/submissions/examples/notification-preference-cards-ts/README.md
+++ b/submissions/examples/notification-preference-cards-ts/README.md
@@ -1,0 +1,18 @@
+# Notification Preference Channel Cards
+
+## What does this do?
+
+Shows notification channel cards for enabled, recommended, off, and muted states.
+
+## How is it used?
+
+```html
+<article class="channel-card is-enabled">
+  <h2>Email updates</h2>
+  <span class="status">On</span>
+</article>
+```
+
+## Why is it useful?
+
+Notification settings often contain many choices. This example keeps those choices readable and stateful with CSS-only styling.

--- a/submissions/examples/notification-preference-cards-ts/demo.html
+++ b/submissions/examples/notification-preference-cards-ts/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Notification Preference Channel Cards</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="preference-shell">
+    <section class="preference-panel" aria-labelledby="preference-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Notifications</p>
+        <h1 id="preference-title">Channel preferences</h1>
+      </div>
+
+      <div class="channel-grid">
+        <article class="channel-card is-enabled">
+          <span class="channel-icon">Email</span>
+          <h2>Email updates</h2>
+          <p>Product news, billing receipts, and account alerts.</p>
+          <span class="status">On</span>
+        </article>
+
+        <article class="channel-card is-recommended">
+          <span class="channel-icon">Push</span>
+          <h2>Push alerts</h2>
+          <p>Time-sensitive workspace and security notifications.</p>
+          <span class="status">Recommended</span>
+        </article>
+
+        <article class="channel-card">
+          <span class="channel-icon">SMS</span>
+          <h2>SMS codes</h2>
+          <p>Backup delivery for urgent login and recovery events.</p>
+          <span class="status">Off</span>
+        </article>
+
+        <article class="channel-card is-muted">
+          <span class="channel-icon">Digest</span>
+          <h2>Weekly digest</h2>
+          <p>Summary of team activity and pending approvals.</p>
+          <span class="status">Muted</span>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/notification-preference-cards-ts/style.css
+++ b/submissions/examples/notification-preference-cards-ts/style.css
@@ -1,0 +1,174 @@
+:root {
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --text: #162033;
+  --muted: #667085;
+  --line: #dde3ed;
+  --blue: #2563eb;
+  --green: #15936b;
+  --violet: #7c3aed;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.preference-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 30px;
+}
+
+.preference-panel {
+  width: min(980px, 100%);
+}
+
+.panel-heading {
+  margin-bottom: 20px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.7rem, 4vw, 2.4rem);
+}
+
+.channel-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.channel-card {
+  position: relative;
+  min-height: 230px;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 18px 45px rgba(16, 24, 40, 0.1);
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.channel-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 55px rgba(16, 24, 40, 0.14);
+}
+
+.channel-icon {
+  display: inline-grid;
+  place-items: center;
+  min-width: 58px;
+  height: 34px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: var(--blue);
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+h2 {
+  margin: 18px 0 8px;
+  font-size: 1.05rem;
+}
+
+p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.status {
+  position: absolute;
+  left: 22px;
+  bottom: 20px;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.is-enabled {
+  border-color: rgba(21, 147, 107, 0.5);
+}
+
+.is-enabled .channel-icon,
+.is-enabled .status {
+  color: var(--green);
+}
+
+.is-enabled .channel-icon {
+  background: #d1fadf;
+}
+
+.is-recommended {
+  border-color: rgba(124, 58, 237, 0.5);
+}
+
+.is-recommended::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border: 1px solid rgba(124, 58, 237, 0.22);
+  border-radius: 6px;
+  animation: recommendPulse 1700ms ease-in-out infinite;
+}
+
+.is-recommended .channel-icon,
+.is-recommended .status {
+  color: var(--violet);
+}
+
+.is-muted {
+  opacity: 0.72;
+}
+
+@keyframes recommendPulse {
+  0%, 100% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 860px) {
+  .channel-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .preference-shell {
+    padding: 18px;
+  }
+
+  .channel-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive notification preference channel cards example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14253

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/notification-preference-cards-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
