### PR TITLE
Add saved view preset switcher example

### DIFF
--- a/submissions/examples/saved-view-preset-switcher-ts/README.md
+++ b/submissions/examples/saved-view-preset-switcher-ts/README.md
@@ -1,0 +1,18 @@
+# Saved View Preset Switcher
+
+## What does this do?
+
+Shows saved table or dashboard presets with active, hover, and unsaved-change states.
+
+## How is it used?
+
+```html
+<div class="view-switcher">
+  <button class="view-pill is-active">Assigned</button>
+  <button class="view-pill is-dirty">Custom</button>
+</div>
+```
+
+## Why is it useful?
+
+Saved views help users return to repeated workflows. This example makes preset state changes visible with CSS-only feedback.

--- a/submissions/examples/saved-view-preset-switcher-ts/demo.html
+++ b/submissions/examples/saved-view-preset-switcher-ts/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Saved View Preset Switcher</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="view-shell">
+    <section class="view-card" aria-labelledby="view-title">
+      <div class="view-heading">
+        <p class="eyebrow">Table views</p>
+        <h1 id="view-title">Saved presets</h1>
+      </div>
+
+      <div class="view-switcher" aria-label="Saved views">
+        <button class="view-pill is-active" type="button">Assigned</button>
+        <button class="view-pill" type="button">All work</button>
+        <button class="view-pill is-dirty" type="button">Custom</button>
+        <button class="view-pill" type="button">Archived</button>
+      </div>
+
+      <div class="view-preview">
+        <div class="preview-row"><span>Onboarding audit</span><strong>Due today</strong></div>
+        <div class="preview-row"><span>Renewal review</span><strong>Tomorrow</strong></div>
+        <div class="preview-row"><span>Risk follow-up</span><strong>Friday</strong></div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/saved-view-preset-switcher-ts/style.css
+++ b/submissions/examples/saved-view-preset-switcher-ts/style.css
@@ -1,0 +1,162 @@
+:root {
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --text: #171f31;
+  --muted: #667085;
+  --line: #d9e1ec;
+  --blue: #2563eb;
+  --amber: #b45309;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.view-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.view-card {
+  width: min(820px, 100%);
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 22px 56px rgba(16, 24, 40, 0.12);
+}
+
+.view-heading {
+  margin-bottom: 20px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.3rem);
+}
+
+.view-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #f1f5f9;
+}
+
+.view-pill {
+  position: relative;
+  min-height: 42px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  transition: color 180ms ease, background-color 180ms ease, transform 180ms ease;
+}
+
+.view-pill:hover,
+.view-pill:focus-visible {
+  color: var(--text);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.view-pill.is-active {
+  color: var(--blue);
+  background: #ffffff;
+  box-shadow: 0 8px 24px rgba(37, 99, 235, 0.14);
+}
+
+.view-pill.is-dirty::after {
+  content: "";
+  position: absolute;
+  top: 9px;
+  right: 8px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--amber);
+  animation: dirtyPulse 1300ms ease-in-out infinite;
+}
+
+.view-preview {
+  display: grid;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.preview-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcff;
+}
+
+.preview-row strong {
+  color: var(--blue);
+}
+
+@keyframes dirtyPulse {
+  0%, 100% {
+    transform: scale(0.8);
+    opacity: 0.45;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 560px) {
+  .view-shell {
+    padding: 18px;
+  }
+
+  .view-card {
+    padding: 20px;
+  }
+
+  .view-pill {
+    flex: 1 1 130px;
+  }
+
+  .preview-row {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive saved view preset switcher example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14256

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/saved-view-preset-switcher-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
