### PR TITLE
Add SLA breach risk indicator example

### DIFF
--- a/submissions/examples/sla-breach-risk-indicator-ts/README.md
+++ b/submissions/examples/sla-breach-risk-indicator-ts/README.md
@@ -1,0 +1,18 @@
+# SLA Breach Risk Indicator
+
+## What does this do?
+
+Shows safe, warning, urgent, and breached SLA risk cards with progress meters.
+
+## How is it used?
+
+```html
+<article class="sla-card is-urgent">
+  <span class="risk-label">Urgent</span>
+  <div class="sla-bar"><span></span></div>
+</article>
+```
+
+## Why is it useful?
+
+Support teams need fast deadline scanning. This example gives EaseMotion CSS a compact visual pattern for SLA risk.

--- a/submissions/examples/sla-breach-risk-indicator-ts/demo.html
+++ b/submissions/examples/sla-breach-risk-indicator-ts/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SLA Breach Risk Indicator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="sla-shell">
+    <section class="sla-panel" aria-labelledby="sla-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Support queue</p>
+        <h1 id="sla-title">SLA breach risk</h1>
+      </div>
+
+      <div class="sla-grid">
+        <article class="sla-card is-safe">
+          <span class="risk-label">Safe</span>
+          <h2>Enterprise onboarding</h2>
+          <p>6h 15m left</p>
+          <div class="sla-bar"><span></span></div>
+        </article>
+        <article class="sla-card is-warning">
+          <span class="risk-label">Warning</span>
+          <h2>Payment escalation</h2>
+          <p>1h 20m left</p>
+          <div class="sla-bar"><span></span></div>
+        </article>
+        <article class="sla-card is-urgent">
+          <span class="risk-label">Urgent</span>
+          <h2>Security review</h2>
+          <p>18m left</p>
+          <div class="sla-bar"><span></span></div>
+        </article>
+        <article class="sla-card is-breached">
+          <span class="risk-label">Breached</span>
+          <h2>Priority outage</h2>
+          <p>12m overdue</p>
+          <div class="sla-bar"><span></span></div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/sla-breach-risk-indicator-ts/style.css
+++ b/submissions/examples/sla-breach-risk-indicator-ts/style.css
@@ -1,0 +1,190 @@
+:root {
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --text: #171f31;
+  --muted: #667085;
+  --line: #dce3ee;
+  --green: #149167;
+  --amber: #b45309;
+  --orange: #ea580c;
+  --red: #dc2626;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.sla-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.sla-panel {
+  width: min(1000px, 100%);
+}
+
+.panel-heading {
+  margin-bottom: 20px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--orange);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.7rem, 4vw, 2.4rem);
+}
+
+.sla-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.sla-card {
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 18px 45px rgba(16, 24, 40, 0.1);
+  transition: transform 200ms ease, border-color 200ms ease;
+}
+
+.sla-card:hover {
+  transform: translateY(-4px);
+}
+
+.risk-label {
+  display: inline-flex;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #eef2f7;
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h2 {
+  margin: 18px 0 8px;
+  font-size: 1.05rem;
+}
+
+p {
+  margin: 0 0 18px;
+  color: var(--muted);
+}
+
+.sla-bar {
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e5e7eb;
+}
+
+.sla-bar span {
+  display: block;
+  height: 100%;
+  width: var(--risk-width);
+  border-radius: inherit;
+  background: var(--risk-color);
+  animation: fillIn 900ms ease both;
+}
+
+.is-safe {
+  --risk-width: 34%;
+  --risk-color: var(--green);
+}
+
+.is-warning {
+  --risk-width: 62%;
+  --risk-color: var(--amber);
+}
+
+.is-urgent {
+  --risk-width: 82%;
+  --risk-color: var(--orange);
+  animation: urgentGlow 1400ms ease-in-out infinite;
+}
+
+.is-breached {
+  --risk-width: 100%;
+  --risk-color: var(--red);
+  border-color: rgba(220, 38, 38, 0.45);
+}
+
+.is-safe .risk-label {
+  color: var(--green);
+  background: #d1fadf;
+}
+
+.is-warning .risk-label {
+  color: var(--amber);
+  background: #fef3c7;
+}
+
+.is-urgent .risk-label {
+  color: var(--orange);
+  background: #ffedd5;
+}
+
+.is-breached .risk-label {
+  color: var(--red);
+  background: #fee2e2;
+}
+
+@keyframes fillIn {
+  from {
+    width: 0;
+  }
+}
+
+@keyframes urgentGlow {
+  0%, 100% {
+    box-shadow: 0 18px 45px rgba(16, 24, 40, 0.1);
+  }
+  50% {
+    box-shadow: 0 18px 45px rgba(234, 88, 12, 0.22);
+  }
+}
+
+@media (max-width: 900px) {
+  .sla-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 540px) {
+  .sla-shell {
+    padding: 18px;
+  }
+
+  .sla-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive SLA breach risk indicator example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14257

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/sla-breach-risk-indicator-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
