### PR TITLE
Add audit log diff highlight example

### DIFF
--- a/submissions/examples/audit-log-diff-highlight-ts/README.md
+++ b/submissions/examples/audit-log-diff-highlight-ts/README.md
@@ -1,0 +1,18 @@
+# Audit Log Diff Highlight
+
+## What does this do?
+
+Highlights old and new values in audit log entries with reviewed and unreviewed states.
+
+## How is it used?
+
+```html
+<article class="audit-diff">
+  <span class="old-value">Viewer</span>
+  <span class="new-value">Editor</span>
+</article>
+```
+
+## Why is it useful?
+
+Audit trails are easier to understand when field-level changes are grouped and visually distinct.

--- a/submissions/examples/audit-log-diff-highlight-ts/demo.html
+++ b/submissions/examples/audit-log-diff-highlight-ts/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Audit Log Diff Highlight</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="audit-shell">
+    <section class="audit-panel" aria-labelledby="audit-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Audit log</p>
+        <h1 id="audit-title">Field changes</h1>
+      </div>
+
+      <article class="audit-diff">
+        <div class="audit-meta">
+          <strong>Role updated</strong>
+          <span>Riley changed teammate access</span>
+        </div>
+        <div class="diff-grid">
+          <span class="field-name">Role</span>
+          <span class="old-value">Viewer</span>
+          <span class="new-value">Editor</span>
+        </div>
+      </article>
+
+      <article class="audit-diff is-reviewed">
+        <div class="audit-meta">
+          <strong>Owner reassigned</strong>
+          <span>Change reviewed by compliance</span>
+        </div>
+        <div class="diff-grid">
+          <span class="field-name">Owner</span>
+          <span class="old-value">Sam</span>
+          <span class="new-value">Morgan</span>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/audit-log-diff-highlight-ts/style.css
+++ b/submissions/examples/audit-log-diff-highlight-ts/style.css
@@ -1,0 +1,170 @@
+:root {
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --red: #dc2626;
+  --green: #14845f;
+  --blue: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.audit-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.audit-panel {
+  width: min(820px, 100%);
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12);
+}
+
+.panel-heading {
+  margin-bottom: 22px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.35rem);
+}
+
+.audit-diff {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcff;
+  transition: border-color 200ms ease, transform 200ms ease;
+}
+
+.audit-diff + .audit-diff {
+  margin-top: 12px;
+}
+
+.audit-diff:hover {
+  transform: translateY(-2px);
+  border-color: rgba(37, 99, 235, 0.45);
+}
+
+.audit-meta strong,
+.audit-meta span {
+  display: block;
+}
+
+.audit-meta span {
+  margin-top: 4px;
+  color: var(--muted);
+}
+
+.diff-grid {
+  display: grid;
+  grid-template-columns: 120px 1fr 1fr;
+  gap: 10px;
+  align-items: center;
+}
+
+.diff-grid span {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 6px;
+}
+
+.field-name {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.old-value {
+  color: var(--red);
+  background: #fee2e2;
+  text-decoration: line-through;
+  animation: oldFade 700ms ease both;
+}
+
+.new-value {
+  color: var(--green);
+  background: #d1fadf;
+  font-weight: 900;
+  animation: newSlide 700ms ease both;
+}
+
+.is-reviewed {
+  border-color: rgba(20, 132, 95, 0.35);
+}
+
+.is-reviewed .audit-meta::after {
+  content: "Reviewed";
+  display: inline-flex;
+  margin-top: 10px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: #d1fadf;
+  color: var(--green);
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+@keyframes oldFade {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes newSlide {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+
+@media (max-width: 620px) {
+  .audit-shell {
+    padding: 18px;
+  }
+
+  .audit-panel {
+    padding: 20px;
+  }
+
+  .diff-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive audit log diff highlight example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14258

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/audit-log-diff-highlight-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
