### PR TITLE
Add workspace invite role picker example

### DIFF
--- a/submissions/examples/workspace-invite-role-picker-ts/README.md
+++ b/submissions/examples/workspace-invite-role-picker-ts/README.md
@@ -1,0 +1,18 @@
+# Workspace Invite Role Picker
+
+## What does this do?
+
+Shows selected, available, and disabled role options for inviting teammates.
+
+## How is it used?
+
+```html
+<label class="role-option is-selected">
+  <input type="radio" checked>
+  <span>Editor</span>
+</label>
+```
+
+## Why is it useful?
+
+Invite flows need role choices that are compact, readable, and hard to misread before access is granted.

--- a/submissions/examples/workspace-invite-role-picker-ts/demo.html
+++ b/submissions/examples/workspace-invite-role-picker-ts/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Workspace Invite Role Picker</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="role-shell">
+    <section class="role-panel" aria-labelledby="role-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Invite teammate</p>
+        <h1 id="role-title">Choose a role</h1>
+      </div>
+
+      <div class="role-picker">
+        <label class="role-option">
+          <input type="radio" name="role">
+          <span><strong>Owner</strong><small>Full account access</small></span>
+        </label>
+        <label class="role-option">
+          <input type="radio" name="role">
+          <span><strong>Admin</strong><small>Manage team settings</small></span>
+        </label>
+        <label class="role-option is-selected">
+          <input type="radio" name="role" checked>
+          <span><strong>Editor</strong><small>Create and update records</small></span>
+        </label>
+        <label class="role-option is-disabled">
+          <input type="radio" name="role" disabled>
+          <span><strong>Viewer</strong><small>Temporarily unavailable</small></span>
+        </label>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/workspace-invite-role-picker-ts/style.css
+++ b/submissions/examples/workspace-invite-role-picker-ts/style.css
@@ -1,0 +1,149 @@
+:root {
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --blue: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.role-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.role-panel {
+  width: min(720px, 100%);
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12);
+}
+
+.panel-heading {
+  margin-bottom: 22px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.35rem);
+}
+
+.role-picker {
+  display: grid;
+  gap: 10px;
+}
+
+.role-option {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 76px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcff;
+  cursor: pointer;
+  transition: border-color 180ms ease, background-color 180ms ease, transform 180ms ease;
+}
+
+.role-option:hover {
+  transform: translateY(-2px);
+  border-color: rgba(37, 99, 235, 0.45);
+}
+
+.role-option input {
+  width: 20px;
+  height: 20px;
+  accent-color: var(--blue);
+}
+
+.role-option strong,
+.role-option small {
+  display: block;
+}
+
+.role-option small {
+  margin-top: 3px;
+  color: var(--muted);
+}
+
+.role-option.is-selected {
+  border-color: rgba(37, 99, 235, 0.6);
+  background: #eff6ff;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.1);
+}
+
+.role-option.is-selected::after {
+  content: "Selected";
+  margin-left: auto;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: var(--blue);
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.role-option.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  background: #f1f5f9;
+}
+
+.role-option.is-disabled:hover {
+  transform: none;
+  border-color: var(--line);
+}
+
+@media (max-width: 560px) {
+  .role-shell {
+    padding: 18px;
+  }
+
+  .role-panel {
+    padding: 20px;
+  }
+
+  .role-option {
+    align-items: flex-start;
+  }
+
+  .role-option.is-selected::after {
+    position: absolute;
+    right: 14px;
+    bottom: 14px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive workspace invite role picker example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14259

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/workspace-invite-role-picker-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
