### PR TITLE
Add data export progress panel example

### DIFF
--- a/submissions/examples/data-export-progress-panel-ts/README.md
+++ b/submissions/examples/data-export-progress-panel-ts/README.md
@@ -1,0 +1,17 @@
+# Data Export Progress Panel
+
+## What does this do?
+
+Shows an export progress panel with file details, progress meter, and staged export states.
+
+## How is it used?
+
+```html
+<section class="export-panel is-exporting">
+  <div class="export-progress"><span></span></div>
+</section>
+```
+
+## Why is it useful?
+
+Export jobs can take time. This example gives users clear progress and status feedback while they wait.

--- a/submissions/examples/data-export-progress-panel-ts/demo.html
+++ b/submissions/examples/data-export-progress-panel-ts/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Data Export Progress Panel</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="export-shell">
+    <section class="export-panel is-exporting" aria-labelledby="export-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Data export</p>
+        <h1 id="export-title">Preparing CSV archive</h1>
+      </div>
+
+      <div class="export-summary">
+        <span>24,180 rows</span>
+        <span>Orders and refunds</span>
+        <span>CSV</span>
+      </div>
+
+      <div class="export-progress" aria-label="Export progress">
+        <span></span>
+      </div>
+
+      <div class="export-states">
+        <span class="state is-done">Prepared</span>
+        <span class="state is-current">Exporting</span>
+        <span class="state">Complete</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/data-export-progress-panel-ts/style.css
+++ b/submissions/examples/data-export-progress-panel-ts/style.css
@@ -1,0 +1,156 @@
+:root {
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --blue: #2563eb;
+  --green: #14845f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.export-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.export-panel {
+  width: min(760px, 100%);
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12);
+}
+
+.panel-heading {
+  margin-bottom: 22px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 4vw, 2.3rem);
+}
+
+.export-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.export-summary span {
+  min-height: 62px;
+  display: grid;
+  place-items: center;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcff;
+  color: var(--muted);
+  font-weight: 800;
+  text-align: center;
+}
+
+.export-progress {
+  height: 14px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e5e7eb;
+}
+
+.export-progress span {
+  display: block;
+  width: 68%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--blue), #14b8a6);
+  animation: exportFill 1200ms ease both;
+}
+
+.export-states {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.state {
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: #eef2f7;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.state.is-done {
+  background: #d1fadf;
+  color: var(--green);
+}
+
+.state.is-current {
+  background: #dbeafe;
+  color: var(--blue);
+  animation: currentPulse 1300ms ease-in-out infinite;
+}
+
+@keyframes exportFill {
+  from {
+    width: 0;
+  }
+}
+
+@keyframes currentPulse {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.04);
+  }
+}
+
+@media (max-width: 560px) {
+  .export-shell {
+    padding: 18px;
+  }
+
+  .export-panel {
+    padding: 20px;
+  }
+
+  .export-summary {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive data export progress panel example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14260

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/data-export-progress-panel-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
