### PR TITLE
fix: enforce aspect-ratio on .ease-card-image

### DIFF
--- a/submissions/core_changes-issue-14158/README.md
+++ b/submissions/core_changes-issue-14158/README.md
@@ -1,0 +1,54 @@
+# Card Image Aspect Ratio Fix
+
+## Issue #14158
+
+Fixes inconsistent card heights when `ease-card` contains images with varying natural aspect ratios.
+
+## Problem
+
+Images inside `.ease-card` had no fixed aspect ratio, causing:
+- Cards in the same grid to have different heights
+- Tall portrait images pushed card content down
+- The grid layout appeared broken
+
+## Solution
+
+Add `aspect-ratio` and `object-fit` to `.ease-card-image`:
+
+```css
+.ease-card-image {
+  width: 100%;
+  aspect-ratio: var(--ease-card-image-ratio, 16 / 9);
+  object-fit: cover;
+  display: block;
+}
+```
+
+### Key Properties
+
+| Property | Value | Effect |
+|----------|-------|--------|
+| `aspect-ratio` | `16 / 9` (default) | Forces uniform height across images |
+| `object-fit: cover` | crops to fill | Prevents distortion, centers content |
+| `display: block` | removes gap | Eliminates inline whitespace below image |
+
+### Custom Ratio
+
+Override per grid via CSS custom property:
+
+```css
+.my-grid {
+  --ease-card-image-ratio: 4 / 3;
+}
+```
+
+Or per image via inline style:
+
+```html
+<img class="ease-card-image" src="..." style="aspect-ratio: 1/1">
+```
+
+## Files
+
+- `demo.html` — Side-by-side comparison of broken vs fixed behavior
+- `style.css` — Demo styles with dark/light theme support

--- a/submissions/core_changes-issue-14158/demo.html
+++ b/submissions/core_changes-issue-14158/demo.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Card Image Aspect Ratio — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Card Image Aspect Ratio</h1>
+    <p class="sub">Fixing inconsistent card heights with <code>aspect-ratio: 16/9</code> and <code>object-fit: cover</code> — Issue #14158</p>
+
+    <div class="controls">
+      <button class="ease-btn" id="themeToggle">&#9788; Light Mode</button>
+    </div>
+
+    <div class="section-label">Broken &mdash; No aspect-ratio enforcement</div>
+
+    <div class="card-grid" id="brokenGrid">
+      <div class="ease-card">
+        <img class="ease-card-image broken" src="https://picsum.photos/id/15/400/300" alt="Landscape" loading="lazy">
+        <div class="ease-card-body">
+          <div class="ease-card-title">Landscape (4:3)</div>
+          <div class="ease-card-text">Images with different natural aspect ratios stretch or shrink, causing uneven card heights in a grid.</div>
+        </div>
+      </div>
+      <div class="ease-card">
+        <img class="ease-card-image broken" src="https://picsum.photos/id/18/300/400" alt="Portrait" loading="lazy">
+        <div class="ease-card-body">
+          <div class="ease-card-title">Portrait (3:4)</div>
+          <div class="ease-card-text">Tall images push the card content down. The grid alignment breaks.</div>
+        </div>
+      </div>
+      <div class="ease-card">
+        <img class="ease-card-image broken" src="https://picsum.photos/id/24/300/300" alt="Square" loading="lazy">
+        <div class="ease-card-body">
+          <div class="ease-card-title">Square (1:1)</div>
+          <div class="ease-card-text">Each card has a different height because image dimensions are not constrained.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="section-label">Fixed &mdash; With <code>aspect-ratio: 16/9</code> + <code>object-fit: cover</code></div>
+
+    <div class="card-grid" id="fixedGrid">
+      <div class="ease-card">
+        <img class="ease-card-image fixed" src="https://picsum.photos/id/15/400/300" alt="Landscape" loading="lazy">
+        <div class="ease-card-body">
+          <div class="ease-card-title">Landscape (4:3)</div>
+          <div class="ease-card-text">Forced to 16:9, content area fills remaining space. Cards align perfectly.</div>
+        </div>
+      </div>
+      <div class="ease-card">
+        <img class="ease-card-image fixed" src="https://picsum.photos/id/18/300/400" alt="Portrait" loading="lazy">
+        <div class="ease-card-body">
+          <div class="ease-card-title">Portrait (3:4)</div>
+          <div class="ease-card-text">Cropped to fit 16:9. Card height matches its neighbors.</div>
+        </div>
+      </div>
+      <div class="ease-card">
+        <img class="ease-card-image fixed" src="https://picsum.photos/id/24/300/300" alt="Square" loading="lazy">
+        <div class="ease-card-body">
+          <div class="ease-card-title">Square (1:1)</div>
+          <div class="ease-card-text">Uniform card grid maintained regardless of original image dimensions.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="section-label">Configurable Ratio</div>
+
+    <div class="card-grid" id="ratioGrid">
+      <div class="ease-card">
+        <img class="ease-card-image fixed" src="https://picsum.photos/id/48/400/300" alt="Demo" loading="lazy" style="aspect-ratio:1/1">
+        <div class="ease-card-body">
+          <div class="ease-card-title">1:1 Square</div>
+          <div class="ease-card-text">Override per image: <code>style="aspect-ratio:1/1"</code></div>
+        </div>
+      </div>
+      <div class="ease-card">
+        <img class="ease-card-image fixed" src="https://picsum.photos/id/60/400/200" alt="Demo" loading="lazy" style="aspect-ratio:21/9">
+        <div class="ease-card-body">
+          <div class="ease-card-title">21:9 Ultrawide</div>
+          <div class="ease-card-text"><code>style="aspect-ratio:21/9"</code></div>
+        </div>
+      </div>
+      <div class="ease-card">
+        <img class="ease-card-image fixed" src="https://picsum.photos/id/63/400/400" alt="Demo" loading="lazy" style="aspect-ratio:4/3">
+        <div class="ease-card-body">
+          <div class="ease-card-title">4:3 Classic</div>
+          <div class="ease-card-text"><code>style="aspect-ratio:4/3"</code></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="code-block">
+<span style="color:#6b7280">/* Proposed fix for components/cards.css */</span>
+.ease-card-image {
+  width: 100%;
+  aspect-ratio: var(--ease-card-image-ratio, 16 / 9);
+  object-fit: cover;
+  display: block;
+}
+
+<span style="color:#6b7280">/* Configurable per card grid */</span>
+.card-grid {
+  --ease-card-image-ratio: 4 / 3;
+}
+    </div>
+  </div>
+
+  <script>
+    document.getElementById('themeToggle').addEventListener('click', () => {
+      const isLight = document.body.getAttribute('data-theme') === 'light';
+      document.body.setAttribute('data-theme', isLight ? 'dark' : 'light');
+    });
+
+    const ratioButtons = document.querySelectorAll('.ease-card-ratio-btn');
+    ratioButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        ratioButtons.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const ratio = btn.dataset.ratio;
+        document.querySelectorAll('#ratioGrid .ease-card-image').forEach(img => {
+          img.style.aspectRatio = ratio;
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/core_changes-issue-14158/style.css
+++ b/submissions/core_changes-issue-14158/style.css
@@ -1,0 +1,182 @@
+:root {
+  --ease-card-image-ratio: 16 / 9;
+  --ease-card-bg: rgba(255, 255, 255, 0.03);
+  --ease-card-border: rgba(255, 255, 255, 0.08);
+  --ease-card-text: #f3f4f6;
+  --ease-card-muted: #9ca3af;
+}
+
+[data-theme="light"] {
+  --ease-card-bg: #ffffff;
+  --ease-card-border: rgba(0, 0, 0, 0.1);
+  --ease-card-text: #1f2937;
+  --ease-card-muted: #6b7280;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #0a0e17;
+  color: #f3f4f6;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+body[data-theme="light"] {
+  background: #f9fafb;
+  color: #1f2937;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.sub { color: #9ca3af; margin-bottom: 2rem; font-size: 0.9rem; }
+
+.controls {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.ease-btn {
+  padding: 0.5rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #f3f4f6;
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s;
+  outline: none;
+}
+
+.ease-btn:hover { background: rgba(255, 255, 255, 0.12); }
+.ease-btn:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
+
+body[data-theme="light"] .ease-btn {
+  border-color: rgba(0, 0, 0, 0.15);
+  background: rgba(0, 0, 0, 0.04);
+  color: #1f2937;
+}
+
+body[data-theme="light"] .ease-btn:hover { background: rgba(0, 0, 0, 0.08); }
+
+.section-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #9ca3af;
+  margin: 2rem 0 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.ease-card {
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-card-border);
+  border-radius: 14px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-card-image {
+  width: 100%;
+  display: block;
+}
+
+.ease-card-image.broken {
+}
+
+.ease-card-image.fixed {
+  aspect-ratio: var(--ease-card-image-ratio, 16 / 9);
+  object-fit: cover;
+}
+
+.ease-card-body {
+  padding: 1rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-card-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+  color: var(--ease-card-text);
+}
+
+.ease-card-text {
+  font-size: 0.82rem;
+  color: var(--ease-card-muted);
+  line-height: 1.5;
+  flex: 1;
+}
+
+.ease-card-ratio-select {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.ease-card-ratio-btn {
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--ease-card-border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ease-card-muted);
+  font-size: 0.75rem;
+  font-family: inherit;
+  cursor: pointer;
+  outline: none;
+}
+
+.ease-card-ratio-btn:hover { border-color: #3b82f6; color: #3b82f6; }
+.ease-card-ratio-btn:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
+.ease-card-ratio-btn.active { border-color: #3b82f6; background: rgba(59,130,246,0.1); color: #3b82f6; }
+
+.demo-note {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  font-size: 0.85rem;
+  color: var(--ease-card-muted);
+  line-height: 1.6;
+}
+
+.code-block {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  padding: 1rem;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.82rem;
+  line-height: 1.7;
+  overflow-x: auto;
+  white-space: pre;
+  color: #9ca3af;
+}
+
+.code-add { color: #10b981; }
+
+@media (max-width: 640px) {
+  .card-grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary

Enforces a consistent aspect ratio on `.ease-card-image` to prevent uneven card heights when images have varying natural dimensions.

## Changes

Adds three CSS properties to `.ease-card-image`:

- `width: 100%` — ensures image fills container width
- `aspect-ratio: var(--ease-card-image-ratio, 16 / 9)` — forces uniform height via CSS custom property (defaults to 16:9)
- `object-fit: cover` — crops image without distortion
- `display: block` — removes inline whitespace gap below image

## Configurability

Override per grid:
```css
.my-grid {
  --ease-card-image-ratio: 4 / 3;
}
```

Override per image:
```html
<img class="ease-card-image" src="..." style="aspect-ratio: 1/1">
```

## Submission

`submissions/core_changes-issue-14158/` containing:
- `demo.html` — Interactive comparison of broken vs fixed behavior
- `style.css` — Demo styles with dark/light theme
- `README.md` — Usage documentation

Fixes #14158