### PR TITLE
feat: add animated glassmorphism pricing card example (#14273)

### DIFF
--- a/submissions/examples/glassmorphism-pricing-card/README.md
+++ b/submissions/examples/glassmorphism-pricing-card/README.md
@@ -1,0 +1,52 @@
+# Glassmorphism Pricing Card
+
+A self-contained, animated frosted-glass pricing card component for SaaS landing pages and subscription UIs.
+
+## What does it do?
+
+Renders a single pricing tier card using the glassmorphism aesthetic — `backdrop-filter: blur()` on a semi-transparent background to produce a "frosted glass" look against any vivid gradient scene.
+
+**Animations included:**
+
+| Name | Trigger | Keyframe |
+|---|---|---|
+| Card entrance | Page load | `ease-card-in` — fade + slide up |
+| Shimmer sweep | Hover | `ease-shimmer` — diagonal highlight sweep |
+| Badge pulse | Continuous | `ease-pulse` — radiating glow ring |
+| Ambient orbs | Continuous | `ease-float` — slow vertical float |
+
+All animations respect `prefers-reduced-motion`.
+
+## Why is it useful?
+
+Glassmorphism pricing cards are the de-facto standard on modern SaaS landing pages. EaseMotion CSS already ships glow and magnetic card examples; this fills the missing frosted-glass slot and demonstrates how `backdrop-filter` pairs with `@keyframes` in a drop-in, zero-dependency component.
+
+## How to use it
+
+1. Copy the `glassmorphism-pricing-card/` folder into your project.
+2. Open `demo.html` directly in a browser — no build step required.
+3. To customise, edit the CSS variables in `:root` inside `style.css`:
+
+```css
+:root {
+  --accent-primary:   #a78bfa;   /* change to your brand colour */
+  --accent-secondary: #38bdf8;
+  --glass-blur:       18px;      /* frosted-glass intensity */
+  --card-radius:      1.5rem;
+}
+```
+
+4. Swap the plan name, price, and feature list directly in `demo.html`.
+
+## File structure
+
+```
+submissions/examples/glassmorphism-pricing-card/
+├── demo.html    ← open in browser, zero dependencies
+├── style.css    ← all styles + keyframes
+└── README.md    ← this file
+```
+
+## Browser support
+
+`backdrop-filter` is supported in all modern browsers (Chrome 76+, Firefox 103+, Safari 9+, Edge 79+). A graceful fallback (slightly more opaque background) is provided for unsupported environments via the semi-transparent `--glass-bg` variable.

--- a/submissions/examples/glassmorphism-pricing-card/demo.html
+++ b/submissions/examples/glassmorphism-pricing-card/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glassmorphism Pricing Card — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <article class="pricing-card" role="region" aria-label="Pro pricing plan">
+
+    <!-- Ambient orbs (purely decorative) -->
+    <span class="orb orb-1" aria-hidden="true"></span>
+    <span class="orb orb-2" aria-hidden="true"></span>
+
+    <!-- Badge -->
+    <div class="pricing-badge" aria-label="Most popular plan">
+      <span class="dot" aria-hidden="true"></span>
+      Most Popular
+    </div>
+
+    <!-- Plan name -->
+    <p class="pricing-plan">Pro Plan</p>
+
+    <!-- Price -->
+    <div class="pricing-amount" aria-label="Price: 29 dollars per month">
+      <span class="pricing-currency" aria-hidden="true">$</span>
+      <span class="pricing-price" aria-hidden="true">29</span>
+    </div>
+    <p class="pricing-period">per month, billed annually</p>
+
+    <div class="pricing-divider" role="separator"></div>
+
+    <!-- Features -->
+    <ul class="pricing-features" aria-label="Plan features">
+      <li>
+        <span class="icon" aria-hidden="true">✓</span>
+        Unlimited projects
+      </li>
+      <li>
+        <span class="icon" aria-hidden="true">✓</span>
+        50 GB cloud storage
+      </li>
+      <li>
+        <span class="icon" aria-hidden="true">✓</span>
+        Priority support (24 / 7)
+      </li>
+      <li>
+        <span class="icon" aria-hidden="true">✓</span>
+        Advanced analytics dashboard
+      </li>
+      <li>
+        <span class="icon" aria-hidden="true">✓</span>
+        Custom domain + SSL
+      </li>
+    </ul>
+
+    <!-- CTA -->
+    <button class="pricing-cta" type="button">
+      Get started — it's free for 14 days
+    </button>
+
+  </article>
+
+</body>
+</html>

--- a/submissions/examples/glassmorphism-pricing-card/style.css
+++ b/submissions/examples/glassmorphism-pricing-card/style.css
@@ -1,0 +1,310 @@
+/* =========================================================
+   Glassmorphism Pricing Card — EaseMotion CSS Example
+   ========================================================= */
+
+/* CSS Variables */
+:root {
+  --glass-bg: rgba(255, 255, 255, 0.10);
+  --glass-border: rgba(255, 255, 255, 0.22);
+  --glass-blur: 18px;
+  --glass-shadow: 0 8px 40px rgba(0, 0, 0, 0.35);
+
+  --accent-primary: #a78bfa;    /* violet-400 */
+  --accent-secondary: #38bdf8;  /* sky-400 */
+  --accent-glow: rgba(167, 139, 250, 0.45);
+
+  --badge-bg: rgba(167, 139, 250, 0.25);
+  --badge-border: rgba(167, 139, 250, 0.55);
+
+  --text-primary: #f1f5f9;
+  --text-muted: rgba(241, 245, 249, 0.58);
+  --text-price: #ffffff;
+
+  --divider: rgba(255, 255, 255, 0.12);
+  --check-color: #34d399;       /* emerald-400 */
+
+  --card-radius: 1.5rem;
+  --transition-base: 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Reset & Base */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Inter', system-ui, sans-serif;
+  background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
+  padding: 2rem;
+}
+
+/* ── Entrance Animation ─────────────────────────────────── */
+@keyframes ease-card-in {
+  from {
+    opacity: 0;
+    transform: translateY(32px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ── Shimmer Sweep ──────────────────────────────────────── */
+@keyframes ease-shimmer {
+  0%   { transform: translateX(-100%) skewX(-12deg); }
+  100% { transform: translateX(220%)  skewX(-12deg); }
+}
+
+/* ── Badge Pulse ────────────────────────────────────────── */
+@keyframes ease-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 var(--accent-glow); }
+  50%       { box-shadow: 0 0 0 8px transparent; }
+}
+
+/* ── Floating Dots (background ambient) ─────────────────── */
+@keyframes ease-float {
+  0%, 100% { transform: translateY(0px); }
+  50%       { transform: translateY(-14px); }
+}
+
+/* ── Card ───────────────────────────────────────────────── */
+.pricing-card {
+  position: relative;
+  width: min(360px, 100%);
+  padding: 2.25rem 2rem 2rem;
+  border-radius: var(--card-radius);
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  overflow: hidden;
+  animation: ease-card-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+
+  /* Subtle inner highlight at top */
+  background-image: linear-gradient(
+    160deg,
+    rgba(255,255,255,0.07) 0%,
+    transparent 60%
+  );
+}
+
+/* Shimmer overlay — hidden until hover */
+.pricing-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    rgba(255,255,255,0.13) 50%,
+    transparent 70%
+  );
+  transform: translateX(-100%) skewX(-12deg);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.pricing-card:hover::before {
+  animation: ease-shimmer 0.75s ease forwards;
+}
+
+.pricing-card:hover {
+  border-color: rgba(255, 255, 255, 0.34);
+  box-shadow:
+    var(--glass-shadow),
+    0 0 40px var(--accent-glow);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+/* ── Badge ──────────────────────────────────────────────── */
+.pricing-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  background: var(--badge-bg);
+  border: 1px solid var(--badge-border);
+  color: var(--accent-primary);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 1.35rem;
+  animation: ease-pulse 2.2s ease-in-out infinite;
+  position: relative;
+  z-index: 2;
+}
+
+.pricing-badge .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  flex-shrink: 0;
+}
+
+/* ── Plan Name ──────────────────────────────────────────── */
+.pricing-plan {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.35rem;
+  position: relative;
+  z-index: 2;
+}
+
+/* ── Price Block ────────────────────────────────────────── */
+.pricing-amount {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.15rem;
+  margin-bottom: 0.25rem;
+  position: relative;
+  z-index: 2;
+}
+
+.pricing-currency {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-top: 0.55rem;
+  line-height: 1;
+}
+
+.pricing-price {
+  font-size: 3.6rem;
+  font-weight: 800;
+  color: var(--text-price);
+  line-height: 1;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #ffffff 40%, var(--accent-secondary));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.pricing-period {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+  position: relative;
+  z-index: 2;
+}
+
+/* ── Divider ────────────────────────────────────────────── */
+.pricing-divider {
+  height: 1px;
+  background: var(--divider);
+  margin-bottom: 1.5rem;
+  position: relative;
+  z-index: 2;
+}
+
+/* ── Feature List ───────────────────────────────────────── */
+.pricing-features {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  margin-bottom: 2rem;
+  position: relative;
+  z-index: 2;
+}
+
+.pricing-features li {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.88rem;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.pricing-features li .icon {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(52, 211, 153, 0.15);
+  border: 1px solid rgba(52, 211, 153, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--check-color);
+  font-size: 0.6rem;
+}
+
+/* ── CTA Button ─────────────────────────────────────────── */
+.pricing-cta {
+  display: block;
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  border: none;
+  cursor: pointer;
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #0f0c29;
+  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
+  box-shadow: 0 4px 24px rgba(167, 139, 250, 0.38);
+  transition:
+    transform var(--transition-base),
+    box-shadow var(--transition-base),
+    filter var(--transition-base);
+  position: relative;
+  z-index: 2;
+}
+
+.pricing-cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 36px rgba(167, 139, 250, 0.58);
+  filter: brightness(1.07);
+}
+
+.pricing-cta:active {
+  transform: translateY(0);
+}
+
+/* ── Floating ambient orbs ──────────────────────────────── */
+.orb {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+  filter: blur(28px);
+  opacity: 0.28;
+}
+
+.orb-1 {
+  width: 130px;
+  height: 130px;
+  background: var(--accent-primary);
+  top: -40px;
+  right: -30px;
+  animation: ease-float 5.5s ease-in-out infinite;
+}
+
+.orb-2 {
+  width: 80px;
+  height: 80px;
+  background: var(--accent-secondary);
+  bottom: 20px;
+  left: -20px;
+  animation: ease-float 7s ease-in-out infinite reverse;
+}
+
+/* ── Reduced motion ─────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .pricing-card,
+  .pricing-badge,
+  .orb { animation: none; }
+  .pricing-card::before { display: none; }
+}


### PR DESCRIPTION
feat: Add Animated Glassmorphism Pricing Card to examples (#14273)

## Summary
Adds a self-contained glassmorphism pricing card component to `submissions/examples/glassmorphism-pricing-card/` as requested in issue #14273.

## What's included
- `demo.html` — zero-dependency, opens directly in browser
- `style.css` — CSS variables, `backdrop-filter`, and four named keyframes
- `README.md` — covers what it does, why it's useful, and how to use it

## Animations
| Keyframe | Trigger | Effect |
|---|---|---|
| `ease-card-in` | Page load | Fade + slide-up entrance |
| `ease-shimmer` | Hover | Diagonal highlight sweep |
| `ease-pulse` | Continuous | Radiating glow on badge |
| `ease-float` | Continuous | Ambient orb float |

## Checklist
- [x] Files placed only inside `submissions/examples/glassmorphism-pricing-card/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to core library
- [x] `prefers-reduced-motion` respected
- [x] Zero external dependencies

Closes #14273