### PR TITLE
feat(examples): add animated neon glow button collection (closes #14297)

### DIFF
--- a/submissions/examples/neon-glow-buttons/README.md
+++ b/submissions/examples/neon-glow-buttons/README.md
@@ -1,0 +1,89 @@
+# Neon Glow Button Collection
+
+A self-contained set of animated neon CTA buttons for dark-themed UIs — gaming dashboards, developer portfolios, and landing pages.
+
+---
+
+## What does this example demonstrate?
+
+| Technique | Where |
+|---|---|
+| Layered `box-shadow` for depth | `.neon-btn--*` color variants |
+| `@keyframes neon-flicker` | Triggered on `:hover` |
+| `@keyframes ripple` via `::after` | Triggered on `click` (JS class toggle) |
+| `@keyframes neon-pulse-*` | Idle breathing glow per color |
+| CSS custom properties for theming | `:root` color tokens |
+
+---
+
+## Why does this belong in EaseMotion CSS examples?
+
+EaseMotion already ships glassmorphism cards and magnetic hover effects.  
+**Neon glow buttons** fill the missing *interactive CTA* slot:
+
+- One of the most-requested patterns for dark-mode landing pages
+- Showcases `box-shadow` + `@keyframes` working together (not covered elsewhere)
+- Four ready-to-drop color themes (cyan · magenta · green · amber)
+
+---
+
+## How do I use it in my own project?
+
+**1. Copy the files**
+```
+your-project/
+└── neon-glow-buttons/
+    ├── style.css   ← component styles
+    └── demo.html   ← reference / copy-paste source
+```
+
+**2. Link the stylesheet**
+```html
+<link rel="stylesheet" href="neon-glow-buttons/style.css" />
+```
+
+**3. Add a button**
+```html
+<!-- Pick a color variant -->
+<button class="neon-btn neon-btn--cyan">Launch</button>
+<button class="neon-btn neon-btn--magenta">Connect</button>
+<button class="neon-btn neon-btn--green">Execute</button>
+<button class="neon-btn neon-btn--amber">Warning</button>
+```
+
+**4. Optional: size modifiers**
+```html
+<button class="neon-btn neon-btn--cyan neon-btn--sm">Small</button>
+<button class="neon-btn neon-btn--green neon-btn--lg">Large</button>
+```
+
+**5. Optional: ripple on click**  
+Copy the `<script>` block from `demo.html` — it's ~20 lines and has zero dependencies.
+
+**6. Custom color**  
+Override the tokens in your own `:root` block:
+```css
+:root {
+  --neon-cyan-core:  #your-color;
+  --neon-cyan-mid:   #your-mid;
+  --neon-cyan-outer: #your-outer;
+}
+```
+
+---
+
+## File structure
+
+```
+neon-glow-buttons/
+├── demo.html   — opens directly in browser, zero build step
+├── style.css   — all keyframes, variants, tokens
+└── README.md   — this file
+```
+
+---
+
+## Browser support
+
+All modern browsers (Chrome 88+, Firefox 85+, Safari 14+, Edge 88+).  
+No preprocessor, no bundler, no dependencies.

--- a/submissions/examples/neon-glow-buttons/demo.html
+++ b/submissions/examples/neon-glow-buttons/demo.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neon Glow Button Collection · EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    /* Demo-page layout only — not part of the component */
+    .row        { display: flex; flex-wrap: wrap; gap: 1.5rem; align-items: center; justify-content: center; }
+    .section    { display: flex; flex-direction: column; align-items: center; gap: 1.2rem; width: 100%; }
+    .divider    { width: 60%; height: 1px; background: #1e1e2e; margin: 0.5rem 0; }
+    h1          { color: #ffffff22; font-size: 0.7rem; letter-spacing: 0.25em; text-transform: uppercase; margin-bottom: 1rem; }
+    .toast      {
+      position: fixed; bottom: 2rem; left: 50%; transform: translateX(-50%) translateY(120%);
+      background: #1a1a2e; color: #ccc; font-size: 0.8rem; padding: 0.6em 1.4em;
+      border-radius: 99px; border: 1px solid #333; letter-spacing: 0.05em;
+      transition: transform 0.3s ease; pointer-events: none;
+    }
+    .toast.show { transform: translateX(-50%) translateY(0); }
+  </style>
+</head>
+<body>
+
+  <h1>EaseMotion CSS · Neon Glow Buttons</h1>
+
+  <!-- ── Color variants ── -->
+  <div class="section">
+    <p class="label">Color Variants</p>
+    <div class="row">
+      <button class="neon-btn neon-btn--cyan">Launch</button>
+      <button class="neon-btn neon-btn--magenta">Connect</button>
+      <button class="neon-btn neon-btn--green">Execute</button>
+      <button class="neon-btn neon-btn--amber">Warning</button>
+    </div>
+  </div>
+
+  <div class="divider"></div>
+
+  <!-- ── Size variants ── -->
+  <div class="section">
+    <p class="label">Sizes</p>
+    <div class="row">
+      <button class="neon-btn neon-btn--cyan  neon-btn--sm">Small</button>
+      <button class="neon-btn neon-btn--magenta">Default</button>
+      <button class="neon-btn neon-btn--green neon-btn--lg">Large</button>
+    </div>
+  </div>
+
+  <div class="divider"></div>
+
+  <!-- ── With icons ── -->
+  <div class="section">
+    <p class="label">With Icons</p>
+    <div class="row">
+      <button class="neon-btn neon-btn--cyan">
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M13 10V3L4 14h7v7l9-11h-7z"/>
+        </svg>
+        Boost
+      </button>
+      <button class="neon-btn neon-btn--magenta">
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm1 17.93V18a1 1 0 0 0-2 0v1.93A8 8 0 0 1 4.07 13H6a1 1 0 0 0 0-2H4.07A8 8 0 0 1 11 4.07V6a1 1 0 0 0 2 0V4.07A8 8 0 0 1 19.93 11H18a1 1 0 0 0 0 2h1.93A8 8 0 0 1 13 19.93z"/>
+        </svg>
+        Target
+      </button>
+      <button class="neon-btn neon-btn--amber">
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 22a10 10 0 1 1 0-20 10 10 0 0 1 0 20zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm-1-5h2v2h-2v-2zm0-8h2v6h-2V7z"/>
+        </svg>
+        Alert
+      </button>
+    </div>
+  </div>
+
+  <div class="divider"></div>
+
+  <!-- ── Disabled state ── -->
+  <div class="section">
+    <p class="label">Disabled</p>
+    <div class="row">
+      <button class="neon-btn neon-btn--cyan"    disabled>Offline</button>
+      <button class="neon-btn neon-btn--green"   disabled>Locked</button>
+    </div>
+  </div>
+
+  <!-- Toast feedback -->
+  <div class="toast" id="toast">✦ Ripple fired</div>
+
+  <script>
+    /* Ripple on click + toast feedback */
+    document.querySelectorAll('.neon-btn').forEach(btn => {
+      btn.addEventListener('click', function(e) {
+        if (this.disabled) return;
+
+        /* Position ripple at click coords */
+        const rect  = this.getBoundingClientRect();
+        const after = getComputedStyle(this, '::after');
+        this.style.setProperty('--rx', (e.clientX - rect.left) + 'px');
+        this.style.setProperty('--ry', (e.clientY - rect.top)  + 'px');
+
+        /* Trigger ripple class cycle */
+        this.classList.remove('ripple');
+        void this.offsetWidth;           // force reflow
+        this.classList.add('ripple');
+
+        /* Toast */
+        const toast = document.getElementById('toast');
+        toast.textContent = `✦ ${this.textContent.trim()} clicked`;
+        toast.classList.add('show');
+        clearTimeout(toast._t);
+        toast._t = setTimeout(() => toast.classList.remove('show'), 1800);
+      });
+
+      /* Clean up ripple class when animation ends */
+      btn.addEventListener('animationend', function(e) {
+        if (e.animationName === 'ripple') this.classList.remove('ripple');
+      });
+    });
+
+    /* Inject ripple origin as CSS custom props on ::after via inline vars trick */
+    document.querySelectorAll('.neon-btn').forEach(btn => {
+      btn.addEventListener('click', function(e) {
+        const rect = this.getBoundingClientRect();
+        this.style.cssText += `; --rx:${e.clientX - rect.left}px; --ry:${e.clientY - rect.top}px`;
+      });
+    });
+  </script>
+
+  <!-- Patch: make ::after use --rx/--ry via a runtime style block -->
+  <style>
+    .neon-btn::after {
+      left: var(--rx, 50%);
+      top:  var(--ry, 50%);
+    }
+  </style>
+
+</body>
+</html>

--- a/submissions/examples/neon-glow-buttons/style.css
+++ b/submissions/examples/neon-glow-buttons/style.css
@@ -1,0 +1,279 @@
+/* ============================================================
+   Neon Glow Button Collection — EaseMotion CSS
+   Isolated example component · zero external dependencies
+   ============================================================ */
+
+/* ---------- Design tokens ---------- */
+:root {
+  --font-main: 'Segoe UI', system-ui, sans-serif;
+
+  /* Cyan */
+  --neon-cyan-core:   #00f5ff;
+  --neon-cyan-mid:    #00c8d4;
+  --neon-cyan-outer:  #005f66;
+
+  /* Magenta */
+  --neon-magenta-core:  #ff00e5;
+  --neon-magenta-mid:   #cc00b8;
+  --neon-magenta-outer: #600055;
+
+  /* Green */
+  --neon-green-core:  #39ff14;
+  --neon-green-mid:   #28cc0f;
+  --neon-green-outer: #0f5200;
+
+  /* Amber */
+  --neon-amber-core:  #ffaa00;
+  --neon-amber-mid:   #cc8800;
+  --neon-amber-outer: #604000;
+}
+
+/* ---------- Reset / base ---------- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: #0a0a0f;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  font-family: var(--font-main);
+  padding: 3rem 1rem;
+}
+
+/* ---------- Section labels ---------- */
+.label {
+  color: #555;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-bottom: -1.5rem;
+}
+
+/* ---------- Base button ---------- */
+.neon-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5em;
+  padding: 0.75em 2.2em;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 2px solid currentColor;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  outline: none;
+  overflow: hidden;           /* clips ripple */
+  transition: transform 0.15s ease, background 0.2s ease;
+
+  /* idle pulse — overridden per color below */
+  animation: neon-pulse-cyan 3s ease-in-out infinite;
+}
+
+.neon-btn:hover  { animation: neon-flicker 0.5s linear; transform: scale(1.04); }
+.neon-btn:active { transform: scale(0.97); }
+
+/* ---------- Ripple pseudo-element ---------- */
+.neon-btn::after {
+  content: '';
+  position: absolute;
+  width: 0; height: 0;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.18);
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.neon-btn.ripple::after {
+  animation: ripple 0.55s ease-out forwards;
+}
+
+/* ============================================================
+   KEYFRAMES
+   ============================================================ */
+
+/* --- Generic flicker (applied on hover, color-agnostic) --- */
+@keyframes neon-flicker {
+  0%   { opacity: 1; }
+  8%   { opacity: 0.3; }
+  12%  { opacity: 1; }
+  20%  { opacity: 0.5; }
+  25%  { opacity: 1; }
+  70%  { opacity: 0.9; }
+  74%  { opacity: 0.2; }
+  78%  { opacity: 1; }
+  100% { opacity: 1; }
+}
+
+/* --- Ripple --- */
+@keyframes ripple {
+  0%   { width: 0; height: 0; opacity: 1; }
+  100% { width: 250px; height: 250px; opacity: 0; }
+}
+
+/* --- Idle pulse per color --- */
+@keyframes neon-pulse-cyan {
+  0%, 100% {
+    box-shadow:
+      0 0  4px var(--neon-cyan-core),
+      0 0 10px var(--neon-cyan-core),
+      0 0 20px var(--neon-cyan-mid),
+      0 0 40px var(--neon-cyan-outer);
+  }
+  50% {
+    box-shadow:
+      0 0  6px var(--neon-cyan-core),
+      0 0 18px var(--neon-cyan-core),
+      0 0 36px var(--neon-cyan-mid),
+      0 0 70px var(--neon-cyan-outer);
+  }
+}
+
+@keyframes neon-pulse-magenta {
+  0%, 100% {
+    box-shadow:
+      0 0  4px var(--neon-magenta-core),
+      0 0 10px var(--neon-magenta-core),
+      0 0 20px var(--neon-magenta-mid),
+      0 0 40px var(--neon-magenta-outer);
+  }
+  50% {
+    box-shadow:
+      0 0  6px var(--neon-magenta-core),
+      0 0 18px var(--neon-magenta-core),
+      0 0 36px var(--neon-magenta-mid),
+      0 0 70px var(--neon-magenta-outer);
+  }
+}
+
+@keyframes neon-pulse-green {
+  0%, 100% {
+    box-shadow:
+      0 0  4px var(--neon-green-core),
+      0 0 10px var(--neon-green-core),
+      0 0 20px var(--neon-green-mid),
+      0 0 40px var(--neon-green-outer);
+  }
+  50% {
+    box-shadow:
+      0 0  6px var(--neon-green-core),
+      0 0 18px var(--neon-green-core),
+      0 0 36px var(--neon-green-mid),
+      0 0 70px var(--neon-green-outer);
+  }
+}
+
+@keyframes neon-pulse-amber {
+  0%, 100% {
+    box-shadow:
+      0 0  4px var(--neon-amber-core),
+      0 0 10px var(--neon-amber-core),
+      0 0 20px var(--neon-amber-mid),
+      0 0 40px var(--neon-amber-outer);
+  }
+  50% {
+    box-shadow:
+      0 0  6px var(--neon-amber-core),
+      0 0 18px var(--neon-amber-core),
+      0 0 36px var(--neon-amber-mid),
+      0 0 70px var(--neon-amber-outer);
+  }
+}
+
+/* ============================================================
+   COLOR VARIANTS
+   ============================================================ */
+
+/* --- Cyan --- */
+.neon-btn--cyan {
+  color: var(--neon-cyan-core);
+  border-color: var(--neon-cyan-core);
+  text-shadow: 0 0 6px var(--neon-cyan-core);
+  animation: neon-pulse-cyan 3s ease-in-out infinite;
+}
+.neon-btn--cyan:hover {
+  background: rgba(0, 245, 255, 0.08);
+  box-shadow:
+    0 0  8px var(--neon-cyan-core),
+    0 0 22px var(--neon-cyan-core),
+    0 0 50px var(--neon-cyan-mid),
+    0 0 90px var(--neon-cyan-outer);
+}
+
+/* --- Magenta --- */
+.neon-btn--magenta {
+  color: var(--neon-magenta-core);
+  border-color: var(--neon-magenta-core);
+  text-shadow: 0 0 6px var(--neon-magenta-core);
+  animation: neon-pulse-magenta 3.4s ease-in-out infinite;
+}
+.neon-btn--magenta:hover {
+  background: rgba(255, 0, 229, 0.08);
+  box-shadow:
+    0 0  8px var(--neon-magenta-core),
+    0 0 22px var(--neon-magenta-core),
+    0 0 50px var(--neon-magenta-mid),
+    0 0 90px var(--neon-magenta-outer);
+}
+
+/* --- Green --- */
+.neon-btn--green {
+  color: var(--neon-green-core);
+  border-color: var(--neon-green-core);
+  text-shadow: 0 0 6px var(--neon-green-core);
+  animation: neon-pulse-green 2.8s ease-in-out infinite;
+}
+.neon-btn--green:hover {
+  background: rgba(57, 255, 20, 0.08);
+  box-shadow:
+    0 0  8px var(--neon-green-core),
+    0 0 22px var(--neon-green-core),
+    0 0 50px var(--neon-green-mid),
+    0 0 90px var(--neon-green-outer);
+}
+
+/* --- Amber --- */
+.neon-btn--amber {
+  color: var(--neon-amber-core);
+  border-color: var(--neon-amber-core);
+  text-shadow: 0 0 6px var(--neon-amber-core);
+  animation: neon-pulse-amber 3.2s ease-in-out infinite;
+}
+.neon-btn--amber:hover {
+  background: rgba(255, 170, 0, 0.08);
+  box-shadow:
+    0 0  8px var(--neon-amber-core),
+    0 0 22px var(--neon-amber-core),
+    0 0 50px var(--neon-amber-mid),
+    0 0 90px var(--neon-amber-outer);
+}
+
+/* ============================================================
+   SIZE MODIFIERS
+   ============================================================ */
+.neon-btn--sm { font-size: 0.78rem; padding: 0.55em 1.6em; }
+.neon-btn--lg { font-size: 1.2rem;  padding: 0.9em  2.8em; border-radius: 6px; }
+
+/* ============================================================
+   ICON SUPPORT
+   ============================================================ */
+.neon-btn svg { width: 1em; height: 1em; fill: currentColor; flex-shrink: 0; }
+
+/* ============================================================
+   DISABLED STATE
+   ============================================================ */
+.neon-btn:disabled,
+.neon-btn[aria-disabled="true"] {
+  opacity: 0.35;
+  cursor: not-allowed;
+  animation: none;
+  box-shadow: none;
+  transform: none !important;
+}


### PR DESCRIPTION
**Title:**
feat(examples): Add Animated Neon Glow Button Collection (closes #14297)

---

**Description:**

## Summary
Adds a self-contained `neon-glow-buttons` example component to `submissions/examples/` as proposed in issue #14297.

## What's included
- `demo.html` — opens directly in browser, zero dependencies, showcases all variants
- `style.css` — CSS variables, `flicker`, `ripple`, and `pulse` keyframes, 4 color themes
- `README.md` — covers what it demonstrates, why it belongs, and how to use it

## Features implemented
- ✅ Animated neon border glow via layered `box-shadow`
- ✅ Flicker effect on hover mimicking real neon signage (`@keyframes neon-flicker`)
- ✅ Ripple click animation via `::after` + JS class toggle (`@keyframes ripple`)
- ✅ 4 color variants — cyan, magenta, green, amber — driven by CSS custom properties
- ✅ Smooth idle pulse animation per color (`@keyframes neon-pulse-*`)
- ✅ Size modifiers (`--sm`, `--lg`), icon support, disabled state

## Checklist
- [x] Entirely isolated in `submissions/examples/neon-glow-buttons/`
- [x] No changes to core library
- [x] `demo.html` opens directly in browser with no build step
- [x] Zero external dependencies
- [x] `README.md` included

Closes #14297