### PR TITLE
feat: add animated gradient card collection to examples (issue #14318)

### DIFF
--- a/submissions/examples/animated-gradient-cards/README.md
+++ b/submissions/examples/animated-gradient-cards/README.md
@@ -1,0 +1,73 @@
+# Animated Gradient Card Collection
+
+A set of modern, self-contained UI cards for EaseMotion CSS examples.
+
+## What does this example demonstrate?
+
+Three animation techniques working together:
+
+1. **`conic-gradient` + `@keyframes gradient-spin`** — an animated rotating conic gradient used as a 2 px border by layering the card inner surface on top.
+2. **`background-position` shimmer sweep** — on hover, a translucent highlight band travels across the card surface via `@keyframes shimmer`.
+3. **CSS `perspective` 3D tilt** — a tiny vanilla JS listener reads `mousemove` and writes `--tilt-x` / `--tilt-y` CSS custom properties; the card transforms via `rotateX` / `rotateY` with no layout reflow.
+
+## How do I use it?
+
+```html
+<!-- 1. Link the stylesheet -->
+<link rel="stylesheet" href="style.css" />
+
+<!-- 2. Pick a theme class and add data-tilt -->
+<div class="card theme-aurora" data-tilt>
+  <div class="card__inner">
+    <div class="card__icon">⚡</div>
+    <h2 class="card__title">Your title</h2>
+    <p class="card__body">Your description.</p>
+  </div>
+</div>
+
+<!-- 3. Drop in the tilt script (bottom of body) -->
+<script>
+  document.querySelectorAll('[data-tilt]').forEach(card => {
+    card.addEventListener('mousemove', e => {
+      const { left, top, width, height } = card.getBoundingClientRect();
+      const x = (e.clientX - left) / width  - 0.5;
+      const y = (e.clientY - top)  / height - 0.5;
+      card.style.setProperty('--tilt-x', `${(-y * 12).toFixed(2)}deg`);
+      card.style.setProperty('--tilt-y', `${ (x * 12).toFixed(2)}deg`);
+    });
+    card.addEventListener('mouseleave', () => {
+      card.style.setProperty('--tilt-x', '0deg');
+      card.style.setProperty('--tilt-y', '0deg');
+    });
+  });
+</script>
+```
+
+**Available themes:** `theme-aurora` · `theme-sunset` · `theme-ocean` · `theme-ember`
+
+**Card variants:** base feature card · `.card--stat` · `.card--profile`
+
+## Why was this added?
+
+EaseMotion CSS already has neon buttons and glassmorphism panels. Animated gradient cards are one of the most common patterns in SaaS dashboards and portfolio sites, and the `conic-gradient` + `background-position` combination is distinct from anything currently in `submissions/examples/`. This addition closes that gap with a ready-to-drop component that covers three real card layouts across four colour themes, with zero runtime dependencies.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Open directly in a browser — zero build step |
+| `style.css` | All keyframes, theme tokens, card styles |
+| `README.md` | This file |
+
+## Accessibility
+
+All animations are wrapped in:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .card, .card::before, .card__inner::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+```

--- a/submissions/examples/animated-gradient-cards/demo.html
+++ b/submissions/examples/animated-gradient-cards/demo.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Gradient Card Collection — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Animated Gradient Cards</h1>
+    <p>EaseMotion CSS · 4 themes · feature · stat · profile · hover to interact</p>
+  </header>
+
+  <!-- ── FEATURE CARDS ──────────────────────────────────── -->
+  <p class="section-label">Feature Cards</p>
+  <div class="cards-grid">
+
+    <div class="card theme-aurora" data-tilt>
+      <div class="card__inner">
+        <span class="card__badge">Aurora</span>
+        <div class="card__icon">⚡</div>
+        <h2 class="card__title">Lightning Fast</h2>
+        <p class="card__body">GPU-accelerated animations keep every transition at 60 fps — even on mid-range hardware.</p>
+      </div>
+    </div>
+
+    <div class="card theme-sunset" data-tilt>
+      <div class="card__inner">
+        <span class="card__badge">Sunset</span>
+        <div class="card__icon">🎨</div>
+        <h2 class="card__title">Design Tokens</h2>
+        <p class="card__body">Every color is a CSS variable. Swap a theme in one line — no rebundling required.</p>
+      </div>
+    </div>
+
+    <div class="card theme-ocean" data-tilt>
+      <div class="card__inner">
+        <span class="card__badge">Ocean</span>
+        <div class="card__icon">🌊</div>
+        <h2 class="card__title">Zero Dependencies</h2>
+        <p class="card__body">Pure CSS + a tiny vanilla JS tilt listener. Drop one &lt;link&gt; and you're done.</p>
+      </div>
+    </div>
+
+    <div class="card theme-ember" data-tilt>
+      <div class="card__inner">
+        <span class="card__badge">Ember</span>
+        <div class="card__icon">🔥</div>
+        <h2 class="card__title">Accessible</h2>
+        <p class="card__body">Respects <code>prefers-reduced-motion</code>. All animations pause for users who need it.</p>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── STAT CARDS ─────────────────────────────────────── -->
+  <p class="section-label">Stat Cards</p>
+  <div class="cards-grid">
+
+    <div class="card card--stat theme-aurora" data-tilt>
+      <div class="card__inner">
+        <span class="card__badge">Aurora</span>
+        <div class="stat-number">98%</div>
+        <div class="stat-label">Lighthouse Score</div>
+      </div>
+    </div>
+
+    <div class="card card--stat theme-sunset" data-tilt>
+      <div class="card__inner">
+        <span class="card__badge">Sunset</span>
+        <div class="stat-number">4ms</div>
+        <div class="stat-label">Avg. Frame Time</div>
+      </div>
+    </div>
+
+    <div class="card card--stat theme-ocean" data-tilt>
+      <div class="card__inner">
+        <span class="card__badge">Ocean</span>
+        <div class="stat-number">12k</div>
+        <div class="stat-label">GitHub Stars</div>
+      </div>
+    </div>
+
+    <div class="card card--stat theme-ember" data-tilt>
+      <div class="card__inner">
+        <span class="card__badge">Ember</span>
+        <div class="stat-number">∞</div>
+        <div class="stat-label">Customisability</div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── PROFILE CARDS ──────────────────────────────────── -->
+  <p class="section-label">Profile Cards</p>
+  <div class="cards-grid">
+
+    <div class="card card--profile theme-aurora" data-tilt>
+      <div class="card__inner">
+        <div class="avatar">🦄</div>
+        <div class="profile-name">Aria Voss</div>
+        <div class="profile-role">Frontend Lead · Aurora</div>
+        <p class="profile-bio">Writes CSS that makes designers weep with joy and engineers weep with envy.</p>
+      </div>
+    </div>
+
+    <div class="card card--profile theme-sunset" data-tilt>
+      <div class="card__inner">
+        <div class="avatar">🌅</div>
+        <div class="profile-name">Kai Oduya</div>
+        <div class="profile-role">Design Systems · Sunset</div>
+        <p class="profile-bio">Believes every shadow is a promise the light makes to the surface below it.</p>
+      </div>
+    </div>
+
+    <div class="card card--profile theme-ocean" data-tilt>
+      <div class="card__inner">
+        <div class="avatar">🐋</div>
+        <div class="profile-name">Mira Chen</div>
+        <div class="profile-role">Performance Eng · Ocean</div>
+        <p class="profile-bio">Profiler open at all times. Sleep is just blocking the main thread.</p>
+      </div>
+    </div>
+
+    <div class="card card--profile theme-ember" data-tilt>
+      <div class="card__inner">
+        <div class="avatar">🔥</div>
+        <div class="profile-name">Zane Patel</div>
+        <div class="profile-role">OSS Advocate · Ember</div>
+        <p class="profile-bio">If it doesn't ship, it doesn't count. Open-source everything, always.</p>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── 3D TILT SCRIPT ─────────────────────────────────── -->
+  <script>
+    const TILT_MAX = 12; // degrees
+
+    document.querySelectorAll('[data-tilt]').forEach(card => {
+      card.addEventListener('mousemove', e => {
+        const { left, top, width, height } = card.getBoundingClientRect();
+        const x = (e.clientX - left) / width  - 0.5;   // -0.5 → 0.5
+        const y = (e.clientY - top)  / height - 0.5;
+
+        card.style.setProperty('--tilt-x', `${(-y * TILT_MAX).toFixed(2)}deg`);
+        card.style.setProperty('--tilt-y', `${ (x * TILT_MAX).toFixed(2)}deg`);
+      });
+
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--tilt-x', '0deg');
+        card.style.setProperty('--tilt-y', '0deg');
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/animated-gradient-cards/style.css
+++ b/submissions/examples/animated-gradient-cards/style.css
@@ -1,0 +1,290 @@
+/* ============================================================
+   Animated Gradient Card Collection — EaseMotion CSS Example
+   Themes: aurora | sunset | ocean | ember
+   ============================================================ */
+
+/* ── Reset & base ─────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0a0a0f;
+  color: #e8e8f0;
+  min-height: 100vh;
+  padding: 3rem 1.5rem;
+}
+
+/* ── Keyframes ────────────────────────────────────────────── */
+
+/* Idle gradient rotation (conic) */
+@keyframes gradient-spin {
+  0%   { --grad-angle: 0deg; }
+  100% { --grad-angle: 360deg; }
+}
+
+/* Background-position shimmer sweep */
+@keyframes shimmer {
+  0%   { background-position: -200% center; }
+  100% { background-position:  200% center; }
+}
+
+/* Idle pulse (opacity glow) */
+@keyframes idle-pulse {
+  0%, 100% { opacity: 0.75; }
+  50%       { opacity: 1;    }
+}
+
+/* Border glow ring */
+@keyframes border-glow {
+  0%, 100% { box-shadow: 0 0 0px 0px var(--glow); }
+  50%       { box-shadow: 0 0 18px 4px var(--glow); }
+}
+
+/* ── CSS custom-property "registers" (updated by JS for tilt) */
+@property --grad-angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+/* ── Theme tokens ─────────────────────────────────────────── */
+
+.theme-aurora {
+  --c1: #7b2fff;
+  --c2: #00e5ff;
+  --c3: #39ff6e;
+  --glow: rgba(123, 47, 255, 0.55);
+  --text-accent: #c4aaff;
+  --badge-bg: rgba(123, 47, 255, 0.25);
+}
+
+.theme-sunset {
+  --c1: #ff4e50;
+  --c2: #fc913a;
+  --c3: #f9ca24;
+  --glow: rgba(252, 145, 58, 0.55);
+  --text-accent: #ffc37a;
+  --badge-bg: rgba(252, 145, 58, 0.2);
+}
+
+.theme-ocean {
+  --c1: #0072ff;
+  --c2: #00c6ff;
+  --c3: #00ffe0;
+  --glow: rgba(0, 198, 255, 0.5);
+  --text-accent: #80e4ff;
+  --badge-bg: rgba(0, 198, 255, 0.18);
+}
+
+.theme-ember {
+  --c1: #ff0080;
+  --c2: #ff6b00;
+  --c3: #ffcc00;
+  --glow: rgba(255, 107, 0, 0.5);
+  --text-accent: #ffb06b;
+  --badge-bg: rgba(255, 107, 0, 0.2);
+}
+
+/* ── Card shell ───────────────────────────────────────────── */
+
+.card {
+  --tilt-x: 0deg;
+  --tilt-y: 0deg;
+
+  position: relative;
+  border-radius: 1.25rem;
+  padding: 2px;                         /* border space */
+  cursor: default;
+  transform-style: preserve-3d;
+  transform: perspective(800px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y));
+  transition: transform 0.12s ease-out, box-shadow 0.3s ease;
+  animation: border-glow 3s ease-in-out infinite, idle-pulse 4s ease-in-out infinite;
+  will-change: transform;
+}
+
+/* Conic-gradient animated border */
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: conic-gradient(
+    from var(--grad-angle),
+    var(--c1), var(--c2), var(--c3), var(--c1)
+  );
+  animation: gradient-spin 4s linear infinite;
+  z-index: 0;
+}
+
+/* Dark inner surface */
+.card__inner {
+  position: relative;
+  z-index: 1;
+  border-radius: calc(1.25rem - 2px);
+  background: #10101c;
+  padding: 1.75rem;
+  overflow: hidden;
+}
+
+/* Shimmer overlay — activates on hover */
+.card__inner::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    105deg,
+    transparent 40%,
+    rgba(255,255,255,0.12) 50%,
+    transparent 60%
+  );
+  background-size: 200% 100%;
+  background-position: -200% center;
+  border-radius: inherit;
+  pointer-events: none;
+  transition: none;
+}
+
+.card:hover .card__inner::after {
+  animation: shimmer 0.65s ease forwards;
+}
+
+/* ── Card content helpers ─────────────────────────────────── */
+
+.card__icon {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  display: inline-block;
+  filter: drop-shadow(0 0 8px var(--c2));
+}
+
+.card__title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-bottom: 0.5rem;
+  color: #fff;
+}
+
+.card__body {
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: rgba(232, 232, 240, 0.7);
+}
+
+/* Badge */
+.card__badge {
+  display: inline-block;
+  margin-bottom: 1rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--badge-bg);
+  color: var(--text-accent);
+  border: 1px solid var(--c2);
+}
+
+/* Stat card specifics */
+.card--stat .stat-number {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  background: linear-gradient(135deg, var(--c1), var(--c2));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  line-height: 1;
+  margin-bottom: 0.4rem;
+}
+
+.card--stat .stat-label {
+  font-size: 0.82rem;
+  color: rgba(232,232,240,0.55);
+  letter-spacing: 0.04em;
+}
+
+/* Profile card specifics */
+.card--profile .avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--c1), var(--c3));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 0 14px var(--glow);
+}
+
+.card--profile .profile-name {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #fff;
+  margin-bottom: 0.2rem;
+}
+
+.card--profile .profile-role {
+  font-size: 0.8rem;
+  color: var(--text-accent);
+  margin-bottom: 0.9rem;
+}
+
+.card--profile .profile-bio {
+  font-size: 0.83rem;
+  line-height: 1.55;
+  color: rgba(232,232,240,0.65);
+}
+
+/* ── Layout grid ──────────────────────────────────────────── */
+
+.section-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(232,232,240,0.4);
+  margin: 2.5rem 0 1rem;
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+/* ── Page header ──────────────────────────────────────────── */
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page-header h1 {
+  font-size: clamp(1.6rem, 4vw, 2.6rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #7b2fff, #00e5ff, #39ff6e);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  font-size: 0.9rem;
+  color: rgba(232,232,240,0.45);
+}
+
+/* ── Reduced motion ───────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .card::before,
+  .card__inner::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #14318

Adds a self-contained `animated-gradient-cards` component to `submissions/examples/` covering a missing animation pattern in the EaseMotion CSS example library.

## What's added

```
submissions/examples/animated-gradient-cards/
├── demo.html   — opens directly in browser, zero dependencies
├── style.css   — all keyframes, theme tokens, card variants
└── README.md   — answers all 3 required questions
```

## Techniques demonstrated

- **Conic gradient border** — `conic-gradient()` + `@keyframes gradient-spin` animates a rotating colour ring used as a 2px border
- **Shimmer sweep** — `@keyframes shimmer` moves a `background-position` highlight across the card surface on hover
- **3D tilt** — vanilla JS writes `--tilt-x` / `--tilt-y` CSS custom properties; card transforms via `perspective` + `rotateX/Y` with no layout reflow
- **Idle pulse + border glow** — ambient attention-drawing animations for dark backgrounds

## Themes & variants

| Theme | Accent colours |
|-------|---------------|
| `theme-aurora` | purple → cyan → green |
| `theme-sunset` | red → orange → yellow |
| `theme-ocean` | blue → cyan → teal |
| `theme-ember` | pink → orange → gold |

Each theme is applied across 3 card variants: **feature**, **stat**, and **profile** (12 cards total in the demo).

## Accessibility

All animations are disabled under `prefers-reduced-motion: reduce`.

## Testing

- [x] `demo.html` opens directly in browser with no build step
- [x] All 4 themes render correctly
- [x] Tilt and shimmer work on hover
- [x] Animations pause under `prefers-reduced-motion`
- [x] No changes to core library files