### PR TITLE
feat: add OTP code input boxes for verification screens

### DIFF
--- a/submissions/examples/otp-input-boxes/README.md
+++ b/submissions/examples/otp-input-boxes/README.md
@@ -1,0 +1,51 @@
+# OTP Code Input Boxes
+
+## What does it do?
+Individual single-character input boxes for OTP/verification screens.
+Auto-advances to next box on input, supports backspace navigation,
+paste, error/success states, and size variants.
+
+## How is it used?
+```html
+<div class="ease-otp-group">
+  <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+  <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+  <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+  <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+  <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+  <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+</div>
+```
+
+## States
+```html
+<div class="ease-otp-group is-error">...</div>
+<div class="ease-otp-group is-success">...</div>
+```
+
+## Size Variants
+```html
+<div class="ease-otp-group ease-otp-sm">...</div>
+<div class="ease-otp-group ease-otp-lg">...</div>
+```
+
+## Classes
+- `.ease-otp-group` — flex wrapper
+- `.ease-otp-input` — individual character box
+- `.ease-otp-sep` — visual separator
+- `.is-filled` — filled state (auto-applied by JS)
+- `.is-error` — red error state with shake animation
+- `.is-success` — green success state
+- `.ease-otp-sm` — small size variant
+- `.ease-otp-lg` — large size variant
+
+## Features
+- Auto-advance to next input on entry
+- Backspace returns to previous input
+- Paste support — fills all boxes at once
+- Pop animation when digit entered
+- Shake animation on error
+- Respects prefers-reduced-motion
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/otp-input-boxes/demo.html
+++ b/submissions/examples/otp-input-boxes/demo.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OTP Input Boxes — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0f172a;
+      color: #e2e8f0;
+      font-family: 'Segoe UI', sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3rem;
+      padding: 2rem;
+    }
+    .demo-section { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+    .demo-label { font-size: 0.75rem; color: #475569; text-transform: uppercase; letter-spacing: 0.08em; }
+    .btn-row { display: flex; gap: 0.75rem; margin-top: 0.5rem; }
+    .btn {
+      padding: 8px 20px;
+      border-radius: 8px;
+      border: none;
+      font-size: 0.8rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .btn-primary { background: #6366f1; color: white; }
+    .btn-error   { background: #ef4444; color: white; }
+    .btn-reset   { background: #334155; color: #94a3b8; }
+    .status {
+      font-size: 0.85rem;
+      min-height: 1.25rem;
+      color: #64748b;
+    }
+    h1 { font-size: 1.5rem; text-align: center; }
+  </style>
+</head>
+<body>
+
+  <h1>OTP Input Boxes</h1>
+
+  <!-- Default 6-digit -->
+  <div class="demo-section">
+    <p class="demo-label">Default — 6 digit OTP</p>
+    <div class="ease-otp-group" id="otp1">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric" pattern="[0-9]">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric" pattern="[0-9]">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric" pattern="[0-9]">
+      <span class="ease-otp-sep">—</span>
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric" pattern="[0-9]">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric" pattern="[0-9]">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric" pattern="[0-9]">
+    </div>
+    <p class="status" id="status1">Enter your 6-digit code</p>
+    <div class="btn-row">
+      <button class="btn btn-primary" onclick="verifyOTP('otp1','status1')">Verify</button>
+      <button class="btn btn-error"   onclick="errorOTP('otp1','status1')">Simulate Error</button>
+      <button class="btn btn-reset"   onclick="resetOTP('otp1','status1')">Reset</button>
+    </div>
+  </div>
+
+  <!-- Small variant -->
+  <div class="demo-section">
+    <p class="demo-label">Small variant — 4 digit PIN</p>
+    <div class="ease-otp-group ease-otp-sm" id="otp2">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+    </div>
+  </div>
+
+  <!-- Large variant -->
+  <div class="demo-section">
+    <p class="demo-label">Large variant — 4 digit</p>
+    <div class="ease-otp-group ease-otp-lg" id="otp3">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+      <input class="ease-otp-input" maxlength="1" type="text" inputmode="numeric">
+    </div>
+  </div>
+
+  <script>
+    // Auto-advance + backspace
+    document.querySelectorAll('.ease-otp-group').forEach(group => {
+      const inputs = [...group.querySelectorAll('.ease-otp-input')];
+
+      inputs.forEach((input, i) => {
+        input.addEventListener('input', e => {
+          const val = e.target.value.replace(/[^0-9]/g, '');
+          e.target.value = val.slice(-1);
+
+          if (val) {
+            input.classList.add('is-filled');
+            if (i < inputs.length - 1) inputs[i + 1].focus();
+          } else {
+            input.classList.remove('is-filled');
+          }
+        });
+
+        input.addEventListener('keydown', e => {
+          if (e.key === 'Backspace' && !input.value && i > 0) {
+            inputs[i - 1].focus();
+            inputs[i - 1].value = '';
+            inputs[i - 1].classList.remove('is-filled');
+          }
+        });
+
+        input.addEventListener('paste', e => {
+          e.preventDefault();
+          const paste = e.clipboardData.getData('text').replace(/\D/g, '');
+          inputs.forEach((inp, j) => {
+            inp.value = paste[j] || '';
+            inp.classList.toggle('is-filled', !!inp.value);
+          });
+        });
+      });
+    });
+
+    function getOTPValue(groupId) {
+      return [...document.getElementById(groupId)
+        .querySelectorAll('.ease-otp-input')]
+        .map(i => i.value).join('');
+    }
+
+    function verifyOTP(groupId, statusId) {
+      const group  = document.getElementById(groupId);
+      const status = document.getElementById(statusId);
+      const val    = getOTPValue(groupId);
+      if (val.length < 6) { status.textContent = 'Please enter all 6 digits'; status.style.color = '#f59e0b'; return; }
+      group.classList.remove('is-error');
+      group.classList.add('is-success');
+      status.textContent = '✓ Code verified successfully!';
+      status.style.color = '#10b981';
+    }
+
+    function errorOTP(groupId, statusId) {
+      const group  = document.getElementById(groupId);
+      const status = document.getElementById(statusId);
+      group.classList.remove('is-success');
+      group.classList.add('is-error');
+      status.textContent = '✗ Invalid code. Please try again.';
+      status.style.color = '#ef4444';
+      setTimeout(() => group.classList.remove('is-error'), 500);
+    }
+
+    function resetOTP(groupId, statusId) {
+      const group  = document.getElementById(groupId);
+      const status = document.getElementById(statusId);
+      group.classList.remove('is-error', 'is-success');
+      group.querySelectorAll('.ease-otp-input').forEach(i => {
+        i.value = '';
+        i.classList.remove('is-filled');
+      });
+      status.textContent = 'Enter your 6-digit code';
+      status.style.color = '#64748b';
+      group.querySelector('.ease-otp-input').focus();
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/otp-input-boxes/style.css
+++ b/submissions/examples/otp-input-boxes/style.css
@@ -1,0 +1,110 @@
+/* ============================================================
+   EaseMotion CSS — OTP Code Input Boxes
+   ============================================================ */
+
+/* Group wrapper */
+.ease-otp-group {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Individual input box */
+.ease-otp-input {
+  width: 52px;
+  height: 60px;
+  text-align: center;
+  font-size: 1.5rem;
+  font-weight: 700;
+  border-radius: 12px;
+  border: 2px solid var(--ease-otp-border, #334155);
+  background: var(--ease-otp-bg, #1e293b);
+  color: var(--ease-otp-color, #f1f5f9);
+  outline: none;
+  caret-color: transparent;
+  transition: border-color 0.2s ease,
+              box-shadow 0.2s ease,
+              transform 0.15s ease;
+  -moz-appearance: textfield;
+}
+
+.ease-otp-input::-webkit-outer-spin-button,
+.ease-otp-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+/* Focus state */
+.ease-otp-input:focus {
+  border-color: var(--ease-otp-focus, #6366f1);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+  transform: translateY(-2px);
+}
+
+/* Filled state */
+.ease-otp-input.is-filled {
+  border-color: var(--ease-otp-filled, #6366f1);
+  background: rgba(99, 102, 241, 0.08);
+  animation: otpPop 0.2s ease both;
+}
+
+@keyframes otpPop {
+  0%   { transform: scale(0.9); }
+  60%  { transform: scale(1.08); }
+  100% { transform: scale(1); }
+}
+
+/* Error state */
+.ease-otp-group.is-error .ease-otp-input {
+  border-color: #ef4444;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+  animation: otpShake 0.4s ease both;
+}
+
+@keyframes otpShake {
+  0%, 100% { transform: translateX(0); }
+  20%       { transform: translateX(-6px); }
+  40%       { transform: translateX(6px); }
+  60%       { transform: translateX(-4px); }
+  80%       { transform: translateX(4px); }
+}
+
+/* Success state */
+.ease-otp-group.is-success .ease-otp-input {
+  border-color: #10b981;
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.2);
+  background: rgba(16, 185, 129, 0.08);
+}
+
+/* Size variants */
+.ease-otp-sm .ease-otp-input {
+  width: 40px;
+  height: 48px;
+  font-size: 1.125rem;
+  border-radius: 8px;
+}
+
+.ease-otp-lg .ease-otp-input {
+  width: 64px;
+  height: 72px;
+  font-size: 1.75rem;
+  border-radius: 14px;
+}
+
+/* Separator dot */
+.ease-otp-sep {
+  color: #475569;
+  font-size: 1.25rem;
+  font-weight: 700;
+  padding: 0 0.25rem;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-otp-input,
+  .ease-otp-input.is-filled,
+  .ease-otp-group.is-error .ease-otp-input {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #5332

## Pull Request Description
Adds OTP/verification code input boxes with auto-advance,
backspace navigation, paste support, and error/success states.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] Files inside `submissions/examples/otp-input-boxes/`
- [x] `demo.html` works by opening directly in browser
- [x] `style.css` contains all styles
- [x] `README.md` documents usage
- [x] No edits to `core/` or `components/`
- [x] Respects prefers-reduced-motion