### PR TITLE
Add subscription renewal reminder card example

### DIFF
--- a/submissions/examples/subscription-renewal-reminder-card-ts/README.md
+++ b/submissions/examples/subscription-renewal-reminder-card-ts/README.md
@@ -1,0 +1,17 @@
+# Subscription Renewal Reminder Card
+
+## What does this do?
+
+Shows an upcoming subscription renewal card with plan, price, and payment details.
+
+## How is it used?
+
+```html
+<section class="renewal-card is-upcoming">
+  <span class="renewal-date">Renews in 6 days</span>
+</section>
+```
+
+## Why is it useful?
+
+Billing dashboards need visible renewal reminders that stay calm and easy to scan.

--- a/submissions/examples/subscription-renewal-reminder-card-ts/demo.html
+++ b/submissions/examples/subscription-renewal-reminder-card-ts/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Subscription Renewal Reminder Card</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="renewal-card is-upcoming" aria-labelledby="renewal-title">
+      <p class="eyebrow">Billing</p>
+      <h1 id="renewal-title">Pro plan renewal</h1>
+      <div class="renewal-date">Renews in 6 days</div>
+      <dl class="billing-grid">
+        <div><dt>Plan</dt><dd>Team Pro</dd></div>
+        <div><dt>Amount</dt><dd>$49 / month</dd></div>
+        <div><dt>Payment</dt><dd>Visa ending 4242</dd></div>
+      </dl>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/subscription-renewal-reminder-card-ts/style.css
+++ b/submissions/examples/subscription-renewal-reminder-card-ts/style.css
@@ -1,0 +1,111 @@
+:root {
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --blue: #2563eb;
+  --amber: #b45309;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.renewal-card {
+  width: min(780px, 100%);
+  padding: 30px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12);
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 18px;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+}
+
+.renewal-date {
+  display: inline-flex;
+  margin-bottom: 20px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: #fef3c7;
+  color: var(--amber);
+  font-weight: 900;
+  animation: datePulse 1400ms ease-in-out infinite;
+}
+
+.billing-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.billing-grid div {
+  min-height: 92px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcff;
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.billing-grid div:hover {
+  transform: translateY(-2px);
+  border-color: rgba(37, 99, 235, 0.45);
+}
+
+dt {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+dd {
+  margin: 8px 0 0;
+  font-weight: 900;
+}
+
+@keyframes datePulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
+}
+
+@media (max-width: 640px) {
+  .demo-shell { padding: 18px; }
+  .renewal-card { padding: 20px; }
+  .billing-grid { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive subscription renewal reminder card example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14299

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/subscription-renewal-reminder-card-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
