### PR TITLE
Add device session trust list example

### DIFF
--- a/submissions/examples/device-session-trust-list-ts/README.md
+++ b/submissions/examples/device-session-trust-list-ts/README.md
@@ -1,0 +1,18 @@
+# Device Session Trust List
+
+## What does this do?
+
+Shows current, trusted, expired, and suspicious device session rows.
+
+## How is it used?
+
+```html
+<article class="device-row is-current">
+  <strong>MacBook Pro</strong>
+  <em>Trusted</em>
+</article>
+```
+
+## Why is it useful?
+
+Account security pages need readable session lists with obvious trust and risk states.

--- a/submissions/examples/device-session-trust-list-ts/demo.html
+++ b/submissions/examples/device-session-trust-list-ts/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Device Session Trust List</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="device-title">
+      <p class="eyebrow">Account security</p>
+      <h1 id="device-title">Device sessions</h1>
+      <div class="device-list">
+        <article class="device-row is-current"><strong>MacBook Pro</strong><span>Current session</span><em>Trusted</em></article>
+        <article class="device-row is-trusted"><strong>iPhone 15</strong><span>2 hours ago</span><em>Trusted</em></article>
+        <article class="device-row is-expired"><strong>Windows laptop</strong><span>Expired yesterday</span><em>Expired</em></article>
+        <article class="device-row is-suspicious"><strong>Unknown browser</strong><span>New location</span><em>Review</em></article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/device-session-trust-list-ts/style.css
+++ b/submissions/examples/device-session-trust-list-ts/style.css
@@ -1,0 +1,111 @@
+:root {
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --blue: #2563eb;
+  --green: #14845f;
+  --amber: #b45309;
+  --red: #dc2626;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.panel {
+  width: min(760px, 100%);
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12);
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 22px;
+  font-size: clamp(1.6rem, 4vw, 2.35rem);
+}
+
+.device-list { display: grid; gap: 10px; }
+
+.device-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 14px;
+  min-height: 66px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcff;
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.device-row:hover {
+  transform: translateY(-2px);
+  border-color: rgba(37, 99, 235, 0.45);
+}
+
+.device-row strong,
+.device-row span {
+  display: block;
+}
+
+.device-row span { color: var(--muted); }
+
+.device-row em {
+  padding: 7px 10px;
+  border-radius: 999px;
+  font-style: normal;
+  font-size: 0.78rem;
+  font-weight: 900;
+  background: #eef2f7;
+  color: var(--muted);
+}
+
+.is-current { border-color: rgba(37, 99, 235, 0.45); }
+.is-current em { color: var(--blue); background: #dbeafe; }
+.is-trusted em { color: var(--green); background: #d1fadf; }
+.is-expired { opacity: 0.64; }
+.is-suspicious { border-color: rgba(220, 38, 38, 0.42); animation: reviewPulse 1400ms ease-in-out infinite; }
+.is-suspicious em { color: var(--red); background: #fee2e2; }
+
+@keyframes reviewPulse { 50% { box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.1); } }
+
+@media (max-width: 560px) {
+  .demo-shell { padding: 18px; }
+  .panel { padding: 20px; }
+  .device-row { grid-template-columns: 1fr; }
+  .device-row em { width: max-content; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive device session trust list example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14302

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/device-session-trust-list-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
