### PR TITLE
Add data retention policy selector example

### DIFF
--- a/submissions/examples/data-retention-policy-selector-ts/README.md
+++ b/submissions/examples/data-retention-policy-selector-ts/README.md
@@ -1,0 +1,18 @@
+# Data Retention Policy Selector
+
+## What does this do?
+
+Shows retention policy options with selected, recommended, and custom states.
+
+## How is it used?
+
+```html
+<label class="retention-option is-selected">
+  <input type="radio" checked>
+  <strong>90 days</strong>
+</label>
+```
+
+## Why is it useful?
+
+Privacy and compliance settings need clear choices with durable visual feedback.

--- a/submissions/examples/data-retention-policy-selector-ts/demo.html
+++ b/submissions/examples/data-retention-policy-selector-ts/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Data Retention Policy Selector</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="retention-title">
+      <p class="eyebrow">Compliance</p>
+      <h1 id="retention-title">Retention policy</h1>
+      <div class="retention-grid">
+        <label class="retention-option"><input type="radio" name="retention"><strong>30 days</strong><span>Short term logs</span></label>
+        <label class="retention-option is-selected"><input type="radio" name="retention" checked><strong>90 days</strong><span>Recommended</span></label>
+        <label class="retention-option"><input type="radio" name="retention"><strong>1 year</strong><span>Compliance archive</span></label>
+        <label class="retention-option is-custom"><input type="radio" name="retention"><strong>Custom</strong><span>Manual schedule</span></label>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/data-retention-policy-selector-ts/style.css
+++ b/submissions/examples/data-retention-policy-selector-ts/style.css
@@ -1,0 +1,111 @@
+:root {
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --blue: #2563eb;
+  --green: #14845f;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.panel {
+  width: min(840px, 100%);
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12);
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 22px;
+  font-size: clamp(1.6rem, 4vw, 2.35rem);
+}
+
+.retention-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.retention-option {
+  min-height: 160px;
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcff;
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background-color 180ms ease;
+}
+
+.retention-option:hover {
+  transform: translateY(-3px);
+  border-color: rgba(37, 99, 235, 0.45);
+}
+
+.retention-option input {
+  width: 20px;
+  height: 20px;
+  accent-color: var(--blue);
+}
+
+.retention-option strong {
+  font-size: 1.15rem;
+}
+
+.retention-option span {
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.is-selected {
+  border-color: rgba(37, 99, 235, 0.6);
+  background: #eff6ff;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.1);
+}
+
+.is-selected span { color: var(--green); font-weight: 900; }
+
+.is-custom { border-style: dashed; }
+
+@media (max-width: 760px) {
+  .retention-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 480px) {
+  .demo-shell { padding: 18px; }
+  .panel { padding: 20px; }
+  .retention-grid { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { transition-duration: 0.01ms !important; }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive data retention policy selector example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14304

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/data-retention-policy-selector-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
