### PR TITLE
Add approval request decision bar example

### DIFF
--- a/submissions/examples/approval-request-decision-bar-ts/README.md
+++ b/submissions/examples/approval-request-decision-bar-ts/README.md
@@ -1,0 +1,17 @@
+# Approval Request Decision Bar
+
+## What does this do?
+
+Shows approve, reject, and request-changes controls in a focused decision bar.
+
+## How is it used?
+
+```html
+<div class="decision-bar">
+  <button class="decision approve">Approve</button>
+</div>
+```
+
+## Why is it useful?
+
+Review workflows need prominent but restrained decision controls for repeated approval tasks.

--- a/submissions/examples/approval-request-decision-bar-ts/demo.html
+++ b/submissions/examples/approval-request-decision-bar-ts/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Approval Request Decision Bar</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="approval-card" aria-labelledby="approval-title">
+      <p class="eyebrow">Review request</p>
+      <h1 id="approval-title">Vendor access change</h1>
+      <p class="summary">Approve, reject, or send the request back with changes.</p>
+      <div class="decision-bar">
+        <button class="decision reject" type="button">Reject</button>
+        <button class="decision changes" type="button">Request changes</button>
+        <button class="decision approve" type="button">Approve</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/approval-request-decision-bar-ts/style.css
+++ b/submissions/examples/approval-request-decision-bar-ts/style.css
@@ -1,0 +1,105 @@
+:root {
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --blue: #2563eb;
+  --green: #14845f;
+  --amber: #b45309;
+  --red: #dc2626;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.approval-card {
+  width: min(760px, 100%);
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12);
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.35rem);
+}
+
+.summary {
+  margin: 10px 0 22px;
+  color: var(--muted);
+}
+
+.decision-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #f1f5f9;
+}
+
+.decision {
+  min-height: 44px;
+  flex: 1 1 150px;
+  border: 0;
+  border-radius: 6px;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  transition: transform 180ms ease, filter 180ms ease;
+}
+
+.decision:hover,
+.decision:focus-visible {
+  transform: translateY(-2px);
+  filter: brightness(1.05);
+  outline: none;
+}
+
+.reject { background: var(--red); }
+.changes { background: var(--amber); }
+.approve { background: var(--green); animation: approvePulse 1500ms ease-in-out infinite; }
+
+@keyframes approvePulse {
+  50% { box-shadow: 0 0 0 4px rgba(20, 132, 95, 0.14); }
+}
+
+@media (max-width: 520px) {
+  .demo-shell { padding: 18px; }
+  .approval-card { padding: 20px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive approval request decision bar example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14306

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/approval-request-decision-bar-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
