### PR TITLE
Add usage anomaly alert strip example

### DIFF
--- a/submissions/examples/usage-anomaly-alert-strip-ts/README.md
+++ b/submissions/examples/usage-anomaly-alert-strip-ts/README.md
@@ -1,0 +1,17 @@
+# Usage Anomaly Alert Strip
+
+## What does this do?
+
+Shows normal, elevated, spike, and resolved anomaly alert strips.
+
+## How is it used?
+
+```html
+<aside class="anomaly-strip is-spike">
+  <strong>Usage spike detected</strong>
+</aside>
+```
+
+## Why is it useful?
+
+Operational dashboards need lightweight anomaly indicators that stand out without taking over the page.

--- a/submissions/examples/usage-anomaly-alert-strip-ts/demo.html
+++ b/submissions/examples/usage-anomaly-alert-strip-ts/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Usage Anomaly Alert Strip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="anomaly-title">
+      <p class="eyebrow">Usage monitor</p>
+      <h1 id="anomaly-title">Anomaly strips</h1>
+      <div class="strip-list">
+        <aside class="anomaly-strip is-normal"><strong>Normal usage</strong><span>Within expected range</span></aside>
+        <aside class="anomaly-strip is-elevated"><strong>Elevated usage</strong><span>18% above baseline</span></aside>
+        <aside class="anomaly-strip is-spike"><strong>Usage spike detected</strong><span>240% above baseline</span></aside>
+        <aside class="anomaly-strip is-resolved"><strong>Spike resolved</strong><span>Back to normal</span></aside>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/usage-anomaly-alert-strip-ts/style.css
+++ b/submissions/examples/usage-anomaly-alert-strip-ts/style.css
@@ -1,0 +1,101 @@
+:root {
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --green: #14845f;
+  --amber: #b45309;
+  --red: #dc2626;
+  --blue: #2563eb;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.panel {
+  width: min(780px, 100%);
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12);
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 22px;
+  font-size: clamp(1.6rem, 4vw, 2.35rem);
+}
+
+.strip-list {
+  display: grid;
+  gap: 10px;
+}
+
+.anomaly-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 62px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-left: 6px solid var(--tone);
+  border-radius: 8px;
+  background: #fbfcff;
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.anomaly-strip:hover {
+  transform: translateY(-2px);
+}
+
+.anomaly-strip span {
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.is-normal { --tone: var(--green); }
+.is-elevated { --tone: var(--amber); }
+.is-spike { --tone: var(--red); animation: spikePulse 1300ms ease-in-out infinite; }
+.is-resolved { --tone: var(--blue); opacity: 0.75; }
+
+@keyframes spikePulse {
+  50% { box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.1); }
+}
+
+@media (max-width: 560px) {
+  .demo-shell { padding: 18px; }
+  .panel { padding: 20px; }
+  .anomaly-strip { align-items: flex-start; flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a responsive usage anomaly alert strip example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14307

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/usage-anomaly-alert-strip-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
