### PR TITLE
feat: add shipping cost calculator with carrier rates

### DIFF
--- a/submissions/examples/shipping-cost-calculator/README.md
+++ b/submissions/examples/shipping-cost-calculator/README.md
@@ -1,0 +1,36 @@
+# Shipping Cost Calculator
+
+## What does it do?
+A shipping cost calculator that takes package weight, dimensions,
+and destination zone as inputs, then displays multiple carrier
+rates with estimated delivery times and highlights the cheapest
+and fastest options.
+
+## How is it used?
+```html
+<!-- Include style.css and open demo.html in browser -->
+<div class="shipping-calc">
+  <div class="shipping-form">
+    <!-- inputs for weight, dimensions, zones -->
+    <button class="calc-btn" onclick="calculate()">Calculate</button>
+  </div>
+  <div class="shipping-results" id="results">
+    <div id="carrier-list"></div>
+    <div class="shipping-summary" id="summary"></div>
+  </div>
+</div>
+```
+
+## Features
+- Weight, L×W×H dimensions, origin/destination zone inputs
+- Volumetric weight calculation (DIM factor 5000)
+- 4 carrier rates with animated results display
+- Best Price and Fastest badges
+- Billable weight summary panel
+- Clickable carrier selection
+- Entrance animation on results
+- Respects prefers-reduced-motion
+- Pure HTML + CSS + vanilla JS
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/shipping-cost-calculator/demo.html
+++ b/submissions/examples/shipping-cost-calculator/demo.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shipping Cost Calculator — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0f172a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      padding: 2.5rem 1.5rem;
+    }
+    .page-title {
+      text-align: center;
+      font-size: 1.75rem;
+      font-weight: 800;
+      margin-bottom: 0.5rem;
+    }
+    .page-sub {
+      text-align: center;
+      color: #64748b;
+      font-size: 0.875rem;
+      margin-bottom: 2.5rem;
+    }
+  </style>
+</head>
+<body>
+
+  <p class="page-title">📦 Shipping Calculator</p>
+  <p class="page-sub">Compare carrier rates and estimated delivery times</p>
+
+  <div class="shipping-calc">
+
+    <!-- Form -->
+    <div class="shipping-form">
+      <h2>📋 Package Details</h2>
+      <div class="form-grid">
+        <div class="form-field">
+          <label>Weight (kg)</label>
+          <input type="number" id="weight" value="2" min="0.1" step="0.1" placeholder="e.g. 2.5">
+        </div>
+        <div class="form-field">
+          <label>Length (cm)</label>
+          <input type="number" id="length" value="30" min="1" placeholder="e.g. 30">
+        </div>
+        <div class="form-field">
+          <label>Width (cm)</label>
+          <input type="number" id="width" value="20" min="1" placeholder="e.g. 20">
+        </div>
+        <div class="form-field">
+          <label>Height (cm)</label>
+          <input type="number" id="height" value="15" min="1" placeholder="e.g. 15">
+        </div>
+        <div class="form-field">
+          <label>Origin Zone</label>
+          <select id="origin">
+            <option value="1">Zone 1 — Local</option>
+            <option value="2">Zone 2 — Regional</option>
+            <option value="3">Zone 3 — National</option>
+          </select>
+        </div>
+        <div class="form-field">
+          <label>Destination Zone</label>
+          <select id="destination">
+            <option value="1">Zone 1 — Local</option>
+            <option value="2" selected>Zone 2 — Regional</option>
+            <option value="3">Zone 3 — National</option>
+            <option value="4">Zone 4 — International</option>
+          </select>
+        </div>
+      </div>
+      <button class="calc-btn" onclick="calculate()">Calculate Shipping Rates</button>
+    </div>
+
+    <!-- Results -->
+    <div class="shipping-results" id="results">
+      <p class="results-title">Available Carriers</p>
+      <div id="carrier-list"></div>
+      <div class="shipping-summary" id="summary"></div>
+    </div>
+
+  </div>
+
+  <script>
+    const carriers = [
+      { name: 'FastShip Express', icon: '🚀', service: 'Express Delivery', baseRate: 8,  perKg: 2.5, zoneMult: 1.2, days: [1,2] },
+      { name: 'EcoPost',          icon: '🌿', service: 'Standard Delivery', baseRate: 4,  perKg: 1.2, zoneMult: 0.9, days: [5,7] },
+      { name: 'SecurePack',       icon: '🔒', service: 'Insured Delivery',  baseRate: 10, perKg: 2.0, zoneMult: 1.1, days: [2,3] },
+      { name: 'BudgetFreight',    icon: '💰', service: 'Economy Delivery',  baseRate: 3,  perKg: 0.9, zoneMult: 1.0, days: [7,10] },
+    ];
+
+    function calculate() {
+      const weight = parseFloat(document.getElementById('weight').value) || 1;
+      const l      = parseFloat(document.getElementById('length').value) || 10;
+      const w      = parseFloat(document.getElementById('width').value) || 10;
+      const h      = parseFloat(document.getElementById('height').value) || 10;
+      const origin = parseInt(document.getElementById('origin').value);
+      const dest   = parseInt(document.getElementById('destination').value);
+
+      // Volumetric weight (DIM factor 5000)
+      const volWeight = (l * w * h) / 5000;
+      const billable  = Math.max(weight, volWeight);
+      const zoneDiff  = Math.abs(dest - origin) + 1;
+
+      const rates = carriers.map(c => ({
+        ...c,
+        price: +(c.baseRate + billable * c.perKg * c.zoneMult * zoneDiff).toFixed(2)
+      })).sort((a, b) => a.price - b.price);
+
+      const minPrice = rates[0].price;
+      const minDays  = Math.min(...rates.map(r => r.days[0]));
+
+      const list = document.getElementById('carrier-list');
+      list.innerHTML = rates.map((r, i) => {
+        const isCheapest = r.price === minPrice;
+        const isFastest  = r.days[0] === minDays && !isCheapest;
+        return `
+          <div class="carrier-card ${isCheapest ? 'is-cheapest' : ''} ${isFastest ? 'is-fastest' : ''}"
+               onclick="selectCarrier(this)">
+            <div class="carrier-icon">${r.icon}</div>
+            <div class="carrier-info">
+              <p class="carrier-name">${r.name}</p>
+              <p class="carrier-service">${r.service}</p>
+              <p class="carrier-delivery">🕐 ${r.days[0]}–${r.days[1]} business days</p>
+            </div>
+            <p class="carrier-price ${isCheapest ? 'is-cheap' : ''}">$${r.price}</p>
+          </div>
+        `;
+      }).join('');
+
+      document.getElementById('summary').innerHTML = `
+        <div class="summary-item"><strong>Actual Weight</strong><span>${weight} kg</span></div>
+        <div class="summary-item"><strong>Volumetric Weight</strong><span>${volWeight.toFixed(2)} kg</span></div>
+        <div class="summary-item"><strong>Billable Weight</strong><span>${billable.toFixed(2)} kg</span></div>
+        <div class="summary-item"><strong>Zone Difference</strong><span>${zoneDiff}</span></div>
+        <div class="summary-item"><strong>Dimensions</strong><span>${l}×${w}×${h} cm</span></div>
+      `;
+
+      const results = document.getElementById('results');
+      results.classList.remove('is-visible');
+      void results.offsetWidth;
+      results.classList.add('is-visible');
+    }
+
+    function selectCarrier(card) {
+      document.querySelectorAll('.carrier-card').forEach(c => c.classList.remove('is-selected'));
+      card.classList.add('is-selected');
+    }
+
+    calculate();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/shipping-cost-calculator/style.css
+++ b/submissions/examples/shipping-cost-calculator/style.css
@@ -1,0 +1,221 @@
+/* ============================================================
+   EaseMotion CSS — Shipping Cost Calculator
+   ============================================================ */
+
+.shipping-calc {
+  max-width: 720px;
+  margin: 0 auto;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+/* Form card */
+.shipping-form {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 16px;
+  padding: 1.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.shipping-form h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  margin-bottom: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Grid layout */
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+/* Field */
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.form-field label {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.form-field input,
+.form-field select {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 0.625rem 0.875rem;
+  color: #f1f5f9;
+  font-size: 0.9rem;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  -moz-appearance: textfield;
+}
+
+.form-field input::-webkit-outer-spin-button,
+.form-field input::-webkit-inner-spin-button { -webkit-appearance: none; }
+
+.form-field input:focus,
+.form-field select:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.form-field select option { background: #1e293b; }
+
+/* Calculate button */
+.calc-btn {
+  width: 100%;
+  margin-top: 1.25rem;
+  padding: 0.875rem;
+  background: #6366f1;
+  color: white;
+  border: none;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.calc-btn:hover { background: #4f46e5; transform: translateY(-1px); }
+.calc-btn:active { transform: translateY(0); }
+
+/* Results */
+.shipping-results {
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+  animation: resultsIn 0.4s ease both;
+}
+
+.shipping-results.is-visible { display: flex; }
+
+@keyframes resultsIn {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.results-title {
+  font-size: 0.75rem;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.25rem;
+}
+
+/* Carrier card */
+.carrier-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+  position: relative;
+}
+
+.carrier-card:hover { border-color: #6366f1; }
+
+.carrier-card.is-selected {
+  border-color: #6366f1;
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.carrier-card.is-cheapest::before {
+  content: 'Best Price';
+  position: absolute;
+  top: -10px;
+  right: 12px;
+  background: #10b981;
+  color: white;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.carrier-card.is-fastest::before {
+  content: 'Fastest';
+  background: #f59e0b;
+}
+
+.carrier-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  background: rgba(99, 102, 241, 0.12);
+  flex-shrink: 0;
+}
+
+.carrier-info { flex: 1; }
+
+.carrier-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #f1f5f9;
+}
+
+.carrier-service {
+  font-size: 0.75rem;
+  color: #64748b;
+  margin-top: 2px;
+}
+
+.carrier-delivery {
+  font-size: 0.78rem;
+  color: #94a3b8;
+  margin-top: 4px;
+}
+
+.carrier-price {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #f1f5f9;
+  white-space: nowrap;
+}
+
+.carrier-price.is-cheap { color: #10b981; }
+
+/* Summary */
+.shipping-summary {
+  background: #0f172a;
+  border: 1px solid #1e293b;
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  font-size: 0.8rem;
+  color: #64748b;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.summary-item { display: flex; flex-direction: column; gap: 2px; }
+.summary-item strong { color: #94a3b8; font-size: 0.7rem; text-transform: uppercase; }
+.summary-item span { color: #f1f5f9; font-weight: 600; }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .shipping-results,
+  .carrier-card,
+  .calc-btn { animation: none !important; transition: none !important; }
+}


### PR DESCRIPTION
Closes #11345

## Pull Request Description
Adds a shipping cost calculator with weight, dimensions,
destination zone inputs, multiple carrier rates display,
and estimated delivery time comparison.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] Files inside `submissions/examples/shipping-cost-calculator/`
- [x] `demo.html` works by opening directly in browser
- [x] `style.css` contains all styles
- [x] `README.md` documents usage
- [x] No edits to `core/` or `components/`
- [x] Respects prefers-reduced-motion
- [x] Pure HTML + CSS + vanilla JS