### PR TITLE
feat: add scroll-driven horizontal slideshow with zoom transition

### DIFF
--- a/submissions/examples/scroll-horizontal-zoom-sb/README.md
+++ b/submissions/examples/scroll-horizontal-zoom-sb/README.md
@@ -1,0 +1,32 @@
+# CSS Scroll-Driven Horizontal Slideshow with Zoom Transition
+
+## What does it do?
+A full-screen horizontal slideshow driven entirely by CSS
+`animation-timeline: scroll(root)`. As the user scrolls
+vertically, cards slide horizontally and zoom in/out using
+native CSS scroll-driven animations — no JavaScript animation
+libraries needed.
+
+## How it works
+```css
+/* Track slides horizontally as user scrolls */
+.scroll-track {
+  animation: trackSlide linear both;
+  animation-timeline: scroll(root);
+}
+
+/* Each card zooms at its scroll range */
+.scroll-card-inner {
+  animation: cardZoom linear both;
+  animation-timeline: scroll(root);
+  animation-range: 20% 40%; /* card's active range */
+}
+```
+
+## Viewport Sizing Variables
+```css
+:root {
+  --card-count: 5;           /* number of slides */
+  --card-width: 100vw;       /* each card = full viewport width */
+  --card-height: 100vh;      /* each card = full viewport height */
+  --track-width: calc(var(--card-count) *

--- a/submissions/examples/scroll-horizontal-zoom-sb/demo.html
+++ b/submissions/examples/scroll-horizontal-zoom-sb/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll-Driven Horizontal Zoom Slideshow — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Progress bar -->
+  <div class="scroll-progress"></div>
+
+  <!-- Dot navigation -->
+  <div class="scroll-dots" id="dots">
+    <div class="scroll-dot is-active"></div>
+    <div class="scroll-dot"></div>
+    <div class="scroll-dot"></div>
+    <div class="scroll-dot"></div>
+    <div class="scroll-dot"></div>
+  </div>
+
+  <!-- Scroll indicator -->
+  <div class="scroll-indicator">
+    <span>Scroll</span>
+    <svg width="16" height="24" viewBox="0 0 16 24" fill="none">
+      <path d="M8 4v16M3 15l5 5 5-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </div>
+
+  <!-- Main scroll page -->
+  <div class="scroll-page">
+    <div class="scroll-sticky">
+      <div class="scroll-track">
+
+        <!-- Card 1 -->
+        <div class="scroll-card">
+          <div class="scroll-card-bg-circle" style="width:600px;height:600px;top:-100px;right:-100px;"></div>
+          <div class="scroll-card-inner">
+            <div class="scroll-card-content">
+              <p class="scroll-card-tag">01 — Introducing</p>
+              <h2 class="scroll-card-title">EaseMotion</h2>
+              <p class="scroll-card-sub">The most composable CSS animation library. Zero dependencies, maximum impact.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Card 2 -->
+        <div class="scroll-card">
+          <div class="scroll-card-bg-circle" style="width:500px;height:500px;bottom:-80px;left:-80px;"></div>
+          <div class="scroll-card-inner">
+            <div class="scroll-card-content">
+              <p class="scroll-card-tag">02 — Animate</p>
+              <h2 class="scroll-card-title">Entrance</h2>
+              <p class="scroll-card-sub">Fade, slide, zoom, flip — production-ready entrance animations out of the box.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Card 3 -->
+        <div class="scroll-card">
+          <div class="scroll-card-bg-circle" style="width:700px;height:700px;top:-200px;left:50%;transform:translateX(-50%);"></div>
+          <div class="scroll-card-inner">
+            <div class="scroll-card-content">
+              <p class="scroll-card-tag">03 — Interact</p>
+              <h2 class="scroll-card-title">Hover</h2>
+              <p class="scroll-card-sub">Grow, lift, glow, shimmer — hover animations that delight users.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Card 4 -->

--- a/submissions/examples/scroll-horizontal-zoom-sb/style.css
+++ b/submissions/examples/scroll-horizontal-zoom-sb/style.css
@@ -1,0 +1,215 @@
+/* ============================================================
+   EaseMotion CSS — Scroll-Driven Horizontal Slideshow
+   Zoom & Slide Transition using animation-timeline: scroll()
+   ============================================================ */
+
+/* Variables */
+:root {
+  --card-count: 5;
+  --card-width: 100vw;
+  --card-height: 100vh;
+  --track-width: calc(var(--card-count) * var(--card-width));
+}
+
+/* Page setup — tall enough to scroll through all cards */
+.scroll-page {
+  height: calc(var(--card-count) * 100vh);
+  background: #000;
+}
+
+/* Sticky viewport container */
+.scroll-sticky {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* Horizontal track — slides left as user scrolls */
+.scroll-track {
+  display: flex;
+  width: var(--track-width);
+  height: 100vh;
+  animation: trackSlide linear both;
+  animation-timeline: scroll(root);
+  animation-range: 0% 100%;
+}
+
+@keyframes trackSlide {
+  from { transform: translateX(0); }
+  to   { transform: translateX(calc(-1 * var(--track-width) + 100vw)); }
+}
+
+/* Individual card */
+.scroll-card {
+  width: var(--card-width);
+  height: var(--card-height);
+  flex-shrink: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+/* Card inner — zoom effect */
+.scroll-card-inner {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform-origin: center center;
+  animation: cardZoom linear both;
+  animation-timeline: scroll(root);
+}
+
+/* Each card animates at different scroll ranges */
+.scroll-card:nth-child(1) .scroll-card-inner {
+  animation-range: 0% calc(100% / var(--card-count));
+}
+.scroll-card:nth-child(2) .scroll-card-inner {
+  animation-range: calc(1 * 100% / var(--card-count)) calc(2 * 100% / var(--card-count));
+}
+.scroll-card:nth-child(3) .scroll-card-inner {
+  animation-range: calc(2 * 100% / var(--card-count)) calc(3 * 100% / var(--card-count));
+}
+.scroll-card:nth-child(4) .scroll-card-inner {
+  animation-range: calc(3 * 100% / var(--card-count)) calc(4 * 100% / var(--card-count));
+}
+.scroll-card:nth-child(5) .scroll-card-inner {
+  animation-range: calc(4 * 100% / var(--card-count)) 100%;
+}
+
+@keyframes cardZoom {
+  0%   { transform: scale(1);    opacity: 1; }
+  40%  { transform: scale(1.08); opacity: 1; }
+  70%  { transform: scale(0.88); opacity: 0.5; }
+  100% { transform: scale(0.75); opacity: 0; }
+}
+
+/* Card backgrounds */
+.scroll-card:nth-child(1) { background: linear-gradient(135deg, #1e1b4b, #312e81); }
+.scroll-card:nth-child(2) { background: linear-gradient(135deg, #064e3b, #065f46); }
+.scroll-card:nth-child(3) { background: linear-gradient(135deg, #7c2d12, #92400e); }
+.scroll-card:nth-child(4) { background: linear-gradient(135deg, #1e3a5f, #1e40af); }
+.scroll-card:nth-child(5) { background: linear-gradient(135deg, #4a044e, #701a75); }
+
+/* Card content */
+.scroll-card-content {
+  text-align: center;
+  color: white;
+  padding: 2rem;
+  z-index: 1;
+}
+
+.scroll-card-tag {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: rgba(255,255,255,0.5);
+  margin-bottom: 1rem;
+}
+
+.scroll-card-title {
+  font-size: clamp(2.5rem, 7vw, 6rem);
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  margin-bottom: 1rem;
+}
+
+.scroll-card-sub {
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  color: rgba(255,255,255,0.7);
+  max-width: 480px;
+}
+
+/* Background decoration */
+.scroll-card-bg-circle {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.04);
+  pointer-events: none;
+}
+
+/* Scroll indicator */
+.scroll-indicator {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(255,255,255,0.4);
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  animation: indicatorBounce 1.5s ease-in-out infinite;
+  pointer-events: none;
+  z-index: 100;
+}
+
+@keyframes indicatorBounce {
+  0%, 100% { transform: translateX(-50%) translateY(0); opacity: 0.4; }
+  50%       { transform: translateX(-50%) translateY(6px); opacity: 0.8; }
+}
+
+/* Dot navigation */
+.scroll-dots {
+  position: fixed;
+  right: 2rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 100;
+}
+
+.scroll-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.3);
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.scroll-dot.is-active {
+  background: white;
+  transform: scale(1.4);
+}
+
+/* Progress bar */
+.scroll-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 3px;
+  background: linear-gradient(90deg, #6366f1, #ec4899);
+  z-index: 200;
+  animation: progressGrow linear both;
+  animation-timeline: scroll(root);
+  transform-origin: left;
+}
+
+@keyframes progressGrow {
+  from { width: 0%; }
+  to   { width: 100%; }
+}
+
+/* Reduced motion fallback */
+@media (prefers-reduced-motion: reduce) {
+  .scroll-track,
+  .scroll-card-inner,
+  .scroll-progress {
+    animation: none !important;
+  }
+  .scroll-track { transform: none; }
+  .scroll-sticky { position: relative; height: auto; }
+  .scroll-page   { height: auto; }
+  .scroll-card   { height: 100vh; }
+}


### PR DESCRIPTION
Closes #11762

## Pull Request Description
Adds an Apple-style scroll-driven horizontal slideshow using
native CSS animation-timeline: scroll(root). Cards slide
horizontally and zoom in/out as the user scrolls vertically.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] Files inside `submissions/examples/scroll-horizontal-zoom-sb/`
- [x] `demo.html` — sticky horizontal track with vertical scroll
- [x] `style.css` — scroll-linked keyframes and zoom scales
- [x] `README.md` — viewport variables and horizontal calculations
- [x] No edits to `core/` or `components/`
- [x] Reduced motion fallback included
- [x] Pure CSS scroll-driven animations + minimal JS for dots only