### PR TITLE
Add localization coverage progress grid example

### DIFF
--- a/submissions/examples/localization-coverage-progress-grid-ts/README.md
+++ b/submissions/examples/localization-coverage-progress-grid-ts/README.md
@@ -1,0 +1,18 @@
+# Localization Coverage Progress Grid
+
+## What does this do?
+
+Shows translation coverage cards with complete, partial, needs-review, and missing states.
+
+## How is it used?
+
+```html
+<article class="locale-card is-partial">
+  <strong>French</strong>
+  <span class="bar"><i></i></span>
+</article>
+```
+
+## Why is it useful?
+
+Localization dashboards need fast scanning across languages and release readiness.

--- a/submissions/examples/localization-coverage-progress-grid-ts/demo.html
+++ b/submissions/examples/localization-coverage-progress-grid-ts/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Localization Coverage Progress Grid</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="locale-title">
+      <p class="eyebrow">Localization</p>
+      <h1 id="locale-title">Translation coverage</h1>
+      <div class="locale-grid">
+        <article class="locale-card is-complete"><strong>English</strong><span class="bar"><i></i></span><em>100%</em></article>
+        <article class="locale-card is-partial"><strong>French</strong><span class="bar"><i></i></span><em>72%</em></article>
+        <article class="locale-card needs-review"><strong>Spanish</strong><span class="bar"><i></i></span><em>91%</em></article>
+        <article class="locale-card is-missing"><strong>Japanese</strong><span class="bar"><i></i></span><em>18%</em></article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/localization-coverage-progress-grid-ts/style.css
+++ b/submissions/examples/localization-coverage-progress-grid-ts/style.css
@@ -1,0 +1,32 @@
+:root {
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --green: #14845f;
+  --blue: #2563eb;
+  --amber: #b45309;
+  --red: #dc2626;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--text); background: var(--bg); }
+.demo-shell { min-height: 100vh; display: grid; place-items: center; padding: 28px; }
+.panel { width: min(900px, 100%); padding: 28px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12); }
+.eyebrow { margin: 0 0 6px; color: var(--blue); font-size: 0.78rem; font-weight: 800; text-transform: uppercase; }
+h1 { margin: 0 0 22px; font-size: clamp(1.6rem, 4vw, 2.35rem); }
+.locale-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
+.locale-card { display: grid; gap: 12px; min-height: 150px; padding: 18px; border: 1px solid var(--line); border-radius: 8px; background: #fbfcff; transition: transform 180ms ease, border-color 180ms ease; }
+.locale-card:hover { transform: translateY(-3px); border-color: rgba(37, 99, 235, 0.45); }
+.locale-card em { color: var(--muted); font-style: normal; font-weight: 900; }
+.bar { height: 10px; overflow: hidden; border-radius: 999px; background: #e5e7eb; }
+.bar i { display: block; width: var(--coverage); height: 100%; border-radius: inherit; background: var(--tone); animation: fill 900ms ease both; }
+.is-complete { --coverage: 100%; --tone: var(--green); }
+.is-partial { --coverage: 72%; --tone: var(--blue); }
+.needs-review { --coverage: 91%; --tone: var(--amber); animation: reviewPulse 1400ms ease-in-out infinite; }
+.is-missing { --coverage: 18%; --tone: var(--red); }
+@keyframes fill { from { width: 0; } }
+@keyframes reviewPulse { 50% { box-shadow: 0 0 0 4px rgba(180, 83, 9, 0.1); } }
+@media (max-width: 760px) { .locale-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 480px) { .demo-shell { padding: 18px; } .panel { padding: 20px; } .locale-grid { grid-template-columns: 1fr; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; } }


### PR DESCRIPTION
## Pull Request Description

Adds a responsive localization coverage progress grid example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14344

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/localization-coverage-progress-grid-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed