### PR TITLE
Add release note category filter pills example

### DIFF
--- a/submissions/examples/release-note-category-filter-pills-ts/README.md
+++ b/submissions/examples/release-note-category-filter-pills-ts/README.md
@@ -1,0 +1,17 @@
+# Release Note Category Filter Pills
+
+## What does this do?
+
+Shows release note category pills with active, security, and breaking-change states.
+
+## How is it used?
+
+```html
+<div class="release-filters">
+  <button class="filter-pill is-active">Features</button>
+</div>
+```
+
+## Why is it useful?
+
+Changelog and release pages benefit from clear category filtering patterns.

--- a/submissions/examples/release-note-category-filter-pills-ts/demo.html
+++ b/submissions/examples/release-note-category-filter-pills-ts/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Release Note Category Filter Pills</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="release-title">
+      <p class="eyebrow">Changelog</p>
+      <h1 id="release-title">Release filters</h1>
+      <div class="release-filters" aria-label="Release note categories">
+        <button class="filter-pill is-active" type="button">Features</button>
+        <button class="filter-pill" type="button">Fixes</button>
+        <button class="filter-pill is-security" type="button">Security</button>
+        <button class="filter-pill is-breaking" type="button">Breaking</button>
+        <button class="filter-pill" type="button">Docs</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/release-note-category-filter-pills-ts/style.css
+++ b/submissions/examples/release-note-category-filter-pills-ts/style.css
@@ -1,0 +1,25 @@
+:root {
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --blue: #2563eb;
+  --red: #dc2626;
+  --amber: #b45309;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--text); background: var(--bg); }
+.demo-shell { min-height: 100vh; display: grid; place-items: center; padding: 28px; }
+.panel { width: min(760px, 100%); padding: 28px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12); }
+.eyebrow { margin: 0 0 6px; color: var(--blue); font-size: 0.78rem; font-weight: 800; text-transform: uppercase; }
+h1 { margin: 0 0 22px; font-size: clamp(1.6rem, 4vw, 2.35rem); }
+.release-filters { display: flex; flex-wrap: wrap; gap: 10px; padding: 10px; border: 1px solid var(--line); border-radius: 8px; background: #f1f5f9; }
+.filter-pill { min-height: 42px; padding: 0 18px; border: 0; border-radius: 999px; background: transparent; color: var(--muted); font: inherit; font-weight: 900; cursor: pointer; transition: transform 180ms ease, background-color 180ms ease, color 180ms ease; }
+.filter-pill:hover, .filter-pill:focus-visible { transform: translateY(-2px); color: var(--text); outline: none; }
+.filter-pill.is-active { color: var(--blue); background: #ffffff; box-shadow: 0 8px 22px rgba(37, 99, 235, 0.14); }
+.filter-pill.is-security { color: var(--red); background: #fee2e2; animation: securityPulse 1400ms ease-in-out infinite; }
+.filter-pill.is-breaking { color: var(--amber); background: #fef3c7; }
+@keyframes securityPulse { 50% { box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.1); } }
+@media (max-width: 480px) { .demo-shell { padding: 18px; } .panel { padding: 20px; } .filter-pill { flex: 1 1 130px; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; } }


### PR DESCRIPTION
## Pull Request Description

Adds a responsive release note category filter pills example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14345

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/release-note-category-filter-pills-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed