### PR TITLE
Add API token permission scope chips example

### DIFF
--- a/submissions/examples/api-token-permission-scope-chips-ts/README.md
+++ b/submissions/examples/api-token-permission-scope-chips-ts/README.md
@@ -1,0 +1,15 @@
+# API Token Permission Scope Chips
+
+## What does this do?
+
+Shows read, write, admin, expiring, and revoked API token scope chips.
+
+## How is it used?
+
+```html
+<span class="scope-chip is-write">Write</span>
+```
+
+## Why is it useful?
+
+Token management screens need compact permission summaries that are easy to audit.

--- a/submissions/examples/api-token-permission-scope-chips-ts/demo.html
+++ b/submissions/examples/api-token-permission-scope-chips-ts/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>API Token Permission Scope Chips</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="token-title">
+      <p class="eyebrow">API access</p>
+      <h1 id="token-title">Token scopes</h1>
+      <div class="scope-wrap">
+        <span class="scope-chip is-read">Read</span>
+        <span class="scope-chip is-write">Write</span>
+        <span class="scope-chip is-admin">Admin</span>
+        <span class="scope-chip is-expiring">Expiring soon</span>
+        <span class="scope-chip is-revoked">Revoked</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/api-token-permission-scope-chips-ts/style.css
+++ b/submissions/examples/api-token-permission-scope-chips-ts/style.css
@@ -1,0 +1,29 @@
+:root {
+  --bg: #111827;
+  --panel: #182235;
+  --text: #f8fafc;
+  --muted: #aab4c4;
+  --line: rgba(255,255,255,0.1);
+  --blue: #60a5fa;
+  --green: #34d399;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --violet: #a78bfa;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--text); background: var(--bg); }
+.demo-shell { min-height: 100vh; display: grid; place-items: center; padding: 28px; }
+.panel { width: min(760px, 100%); padding: 28px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.32); }
+.eyebrow { margin: 0 0 6px; color: var(--blue); font-size: 0.78rem; font-weight: 800; text-transform: uppercase; }
+h1 { margin: 0 0 22px; font-size: clamp(1.6rem, 4vw, 2.35rem); }
+.scope-wrap { display: flex; flex-wrap: wrap; gap: 10px; }
+.scope-chip { display: inline-flex; min-height: 42px; align-items: center; padding: 0 16px; border: 1px solid var(--line); border-radius: 999px; background: rgba(255,255,255,0.08); color: var(--muted); font-weight: 900; transition: transform 180ms ease, border-color 180ms ease; }
+.scope-chip:hover { transform: translateY(-2px); border-color: rgba(96, 165, 250, 0.5); }
+.is-read { color: var(--blue); }
+.is-write { color: var(--green); }
+.is-admin { color: var(--violet); }
+.is-expiring { color: var(--amber); animation: expirePulse 1400ms ease-in-out infinite; }
+.is-revoked { color: var(--red); text-decoration: line-through; opacity: 0.7; }
+@keyframes expirePulse { 50% { box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.12); } }
+@media (max-width: 500px) { .demo-shell { padding: 18px; } .panel { padding: 20px; } .scope-chip { flex: 1 1 145px; justify-content: center; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; } }


### PR DESCRIPTION
## Pull Request Description

Adds a responsive API token permission scope chips example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14349

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/api-token-permission-scope-chips-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed