### PR TITLE
Add content moderation decision queue example

### DIFF
--- a/submissions/examples/content-moderation-decision-queue-ts/README.md
+++ b/submissions/examples/content-moderation-decision-queue-ts/README.md
@@ -1,0 +1,18 @@
+# Content Moderation Decision Queue
+
+## What does this do?
+
+Shows pending, approved, flagged, escalated, and removed moderation queue states.
+
+## How is it used?
+
+```html
+<article class="moderation-item is-flagged">
+  <strong>Comment reported</strong>
+  <span>Flagged</span>
+</article>
+```
+
+## Why is it useful?
+
+Moderation tools need clear decision states and queue scanning for repeated review work.

--- a/submissions/examples/content-moderation-decision-queue-ts/demo.html
+++ b/submissions/examples/content-moderation-decision-queue-ts/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Content Moderation Decision Queue</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="moderation-title">
+      <p class="eyebrow">Moderation</p>
+      <h1 id="moderation-title">Decision queue</h1>
+      <div class="moderation-list">
+        <article class="moderation-item is-pending"><strong>New review</strong><span>Pending</span></article>
+        <article class="moderation-item is-approved"><strong>Profile update</strong><span>Approved</span></article>
+        <article class="moderation-item is-flagged"><strong>Comment reported</strong><span>Flagged</span></article>
+        <article class="moderation-item is-escalated"><strong>Policy appeal</strong><span>Escalated</span></article>
+        <article class="moderation-item is-removed"><strong>Spam post</strong><span>Removed</span></article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/content-moderation-decision-queue-ts/style.css
+++ b/submissions/examples/content-moderation-decision-queue-ts/style.css
@@ -1,0 +1,32 @@
+:root {
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --blue: #2563eb;
+  --green: #14845f;
+  --amber: #b45309;
+  --red: #dc2626;
+  --violet: #7c3aed;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--text); background: var(--bg); }
+.demo-shell { min-height: 100vh; display: grid; place-items: center; padding: 28px; }
+.panel { width: min(760px, 100%); padding: 28px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12); }
+.eyebrow { margin: 0 0 6px; color: var(--blue); font-size: 0.78rem; font-weight: 800; text-transform: uppercase; }
+h1 { margin: 0 0 22px; font-size: clamp(1.6rem, 4vw, 2.35rem); }
+.moderation-list { display: grid; gap: 10px; }
+.moderation-item { display: flex; align-items: center; justify-content: space-between; gap: 14px; min-height: 62px; padding: 14px 16px; border: 1px solid var(--line); border-radius: 8px; background: #fbfcff; transition: transform 180ms ease, border-color 180ms ease; }
+.moderation-item:hover { transform: translateY(-2px); border-color: rgba(37, 99, 235, 0.45); }
+.moderation-item span { padding: 7px 10px; border-radius: 999px; background: #eef2f7; color: var(--muted); font-size: 0.78rem; font-weight: 900; }
+.is-pending span { color: var(--blue); background: #dbeafe; }
+.is-approved span { color: var(--green); background: #d1fadf; }
+.is-flagged span { color: var(--amber); background: #fef3c7; }
+.is-escalated { border-color: rgba(124, 58, 237, 0.4); animation: escalatedPulse 1400ms ease-in-out infinite; }
+.is-escalated span { color: var(--violet); background: #ede9fe; }
+.is-removed { opacity: 0.65; }
+.is-removed span { color: var(--red); background: #fee2e2; }
+@keyframes escalatedPulse { 50% { box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.1); } }
+@media (max-width: 540px) { .demo-shell { padding: 18px; } .panel { padding: 20px; } .moderation-item { align-items: flex-start; flex-direction: column; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; } }


### PR DESCRIPTION
## Pull Request Description

Adds a responsive content moderation decision queue example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14350

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/content-moderation-decision-queue-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed