### PR TITLE
Add delivery window selection cards example

### DIFF
--- a/submissions/examples/delivery-window-selection-cards-ts/README.md
+++ b/submissions/examples/delivery-window-selection-cards-ts/README.md
@@ -1,0 +1,18 @@
+# Delivery Window Selection Cards
+
+## What does this do?
+
+Shows selected, unavailable, fastest, and eco-friendly delivery window states.
+
+## How is it used?
+
+```html
+<label class="delivery-card is-selected">
+  Tomorrow 9-12
+  <input type="radio" checked>
+</label>
+```
+
+## Why is it useful?
+
+Checkout and logistics workflows benefit from clear delivery choice feedback.

--- a/submissions/examples/delivery-window-selection-cards-ts/demo.html
+++ b/submissions/examples/delivery-window-selection-cards-ts/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Delivery Window Selection Cards</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="delivery-title">
+      <p class="eyebrow">Delivery</p>
+      <h1 id="delivery-title">Choose a window</h1>
+      <div class="delivery-grid">
+        <label class="delivery-card is-fastest">Today 4-6<input type="radio" name="delivery"><span>Fastest</span></label>
+        <label class="delivery-card is-selected">Tomorrow 9-12<input type="radio" name="delivery" checked><span>Selected</span></label>
+        <label class="delivery-card is-eco">Friday 12-4<input type="radio" name="delivery"><span>Eco</span></label>
+        <label class="delivery-card is-unavailable">Sunday<input type="radio" name="delivery" disabled><span>Unavailable</span></label>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/delivery-window-selection-cards-ts/style.css
+++ b/submissions/examples/delivery-window-selection-cards-ts/style.css
@@ -1,0 +1,30 @@
+:root {
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --blue: #2563eb;
+  --green: #14845f;
+  --amber: #b45309;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--text); background: var(--bg); }
+.demo-shell { min-height: 100vh; display: grid; place-items: center; padding: 28px; }
+.panel { width: min(880px, 100%); padding: 28px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12); }
+.eyebrow { margin: 0 0 6px; color: var(--blue); font-size: 0.78rem; font-weight: 800; text-transform: uppercase; }
+h1 { margin: 0 0 22px; font-size: clamp(1.6rem, 4vw, 2.35rem); }
+.delivery-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
+.delivery-card { min-height: 152px; display: grid; align-content: start; gap: 10px; padding: 18px; border: 1px solid var(--line); border-radius: 8px; background: #fbfcff; font-weight: 900; cursor: pointer; transition: transform 180ms ease, border-color 180ms ease; }
+.delivery-card:hover { transform: translateY(-3px); border-color: rgba(37, 99, 235, 0.45); }
+.delivery-card input { width: 20px; height: 20px; accent-color: var(--blue); }
+.delivery-card span { width: max-content; padding: 6px 10px; border-radius: 999px; background: #eef2f7; color: var(--muted); font-size: 0.78rem; }
+.is-selected { border-color: rgba(37, 99, 235, 0.6); background: #eff6ff; box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.1); }
+.is-selected span { color: var(--blue); background: #dbeafe; }
+.is-fastest span { color: var(--amber); background: #fef3c7; }
+.is-eco span { color: var(--green); background: #d1fadf; }
+.is-unavailable { opacity: 0.5; cursor: not-allowed; }
+.is-unavailable:hover { transform: none; border-color: var(--line); }
+@media (max-width: 760px) { .delivery-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 480px) { .demo-shell { padding: 18px; } .panel { padding: 20px; } .delivery-grid { grid-template-columns: 1fr; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { transition-duration: 0.01ms !important; } }


### PR DESCRIPTION
## Pull Request Description

Adds a responsive delivery window selection cards example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14351

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/delivery-window-selection-cards-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed