### PR TITLE
Add feedback sentiment breakdown bars example

### DIFF
--- a/submissions/examples/feedback-sentiment-breakdown-bars-ts/README.md
+++ b/submissions/examples/feedback-sentiment-breakdown-bars-ts/README.md
@@ -1,0 +1,18 @@
+# Feedback Sentiment Breakdown Bars
+
+## What does this do?
+
+Shows positive, neutral, negative, and mixed feedback sentiment bars.
+
+## How is it used?
+
+```html
+<div class="sentiment-row is-positive">
+  <span>Positive</span>
+  <b><i></i></b>
+</div>
+```
+
+## Why is it useful?
+
+Product feedback dashboards need a quick way to compare sentiment without a chart library.

--- a/submissions/examples/feedback-sentiment-breakdown-bars-ts/demo.html
+++ b/submissions/examples/feedback-sentiment-breakdown-bars-ts/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Feedback Sentiment Breakdown Bars</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="sentiment-title">
+      <p class="eyebrow">Feedback</p>
+      <h1 id="sentiment-title">Sentiment breakdown</h1>
+      <div class="sentiment-list">
+        <div class="sentiment-row is-positive"><span>Positive</span><b><i></i></b><em>64%</em></div>
+        <div class="sentiment-row is-neutral"><span>Neutral</span><b><i></i></b><em>21%</em></div>
+        <div class="sentiment-row is-negative"><span>Negative</span><b><i></i></b><em>9%</em></div>
+        <div class="sentiment-row is-mixed"><span>Mixed</span><b><i></i></b><em>6%</em></div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/feedback-sentiment-breakdown-bars-ts/style.css
+++ b/submissions/examples/feedback-sentiment-breakdown-bars-ts/style.css
@@ -1,0 +1,30 @@
+:root {
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --green: #14845f;
+  --blue: #2563eb;
+  --red: #dc2626;
+  --amber: #b45309;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--text); background: var(--bg); }
+.demo-shell { min-height: 100vh; display: grid; place-items: center; padding: 28px; }
+.panel { width: min(760px, 100%); padding: 28px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12); }
+.eyebrow { margin: 0 0 6px; color: var(--blue); font-size: 0.78rem; font-weight: 800; text-transform: uppercase; }
+h1 { margin: 0 0 22px; font-size: clamp(1.6rem, 4vw, 2.35rem); }
+.sentiment-list { display: grid; gap: 12px; }
+.sentiment-row { display: grid; grid-template-columns: 90px 1fr 50px; gap: 14px; align-items: center; min-height: 56px; padding: 12px; border: 1px solid var(--line); border-radius: 8px; background: #fbfcff; }
+.sentiment-row span, .sentiment-row em { font-style: normal; font-weight: 900; }
+.sentiment-row em { color: var(--muted); text-align: right; }
+.sentiment-row b { height: 12px; overflow: hidden; border-radius: 999px; background: #e5e7eb; }
+.sentiment-row i { display: block; width: var(--value); height: 100%; border-radius: inherit; background: var(--tone); animation: fillBar 900ms ease both; }
+.is-positive { --value: 64%; --tone: var(--green); }
+.is-neutral { --value: 21%; --tone: var(--blue); }
+.is-negative { --value: 9%; --tone: var(--red); }
+.is-mixed { --value: 6%; --tone: var(--amber); }
+@keyframes fillBar { from { width: 0; } }
+@media (max-width: 520px) { .demo-shell { padding: 18px; } .panel { padding: 20px; } .sentiment-row { grid-template-columns: 1fr; } .sentiment-row em { text-align: left; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; } }


### PR DESCRIPTION
## Pull Request Description

Adds a responsive feedback sentiment breakdown bars example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14352

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/feedback-sentiment-breakdown-bars-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed