### PR TITLE
Add maintenance window countdown banner example

### DIFF
--- a/submissions/examples/maintenance-window-countdown-banner-ts/README.md
+++ b/submissions/examples/maintenance-window-countdown-banner-ts/README.md
@@ -1,0 +1,17 @@
+# Maintenance Window Countdown Banner
+
+## What does this do?
+
+Shows scheduled, starting-soon, in-progress, and complete maintenance banner states.
+
+## How is it used?
+
+```html
+<aside class="maintenance-banner is-soon">
+  <strong>Starts in 30 minutes</strong>
+</aside>
+```
+
+## Why is it useful?
+
+Status pages and admin consoles need visible but non-disruptive maintenance notices.

--- a/submissions/examples/maintenance-window-countdown-banner-ts/demo.html
+++ b/submissions/examples/maintenance-window-countdown-banner-ts/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Maintenance Window Countdown Banner</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="panel" aria-labelledby="maintenance-title">
+      <p class="eyebrow">Status</p>
+      <h1 id="maintenance-title">Maintenance notices</h1>
+      <div class="banner-list">
+        <aside class="maintenance-banner is-scheduled"><strong>Scheduled</strong><span>Tonight at 23:00 UTC</span></aside>
+        <aside class="maintenance-banner is-soon"><strong>Starts in 30 minutes</strong><span>Save your work</span></aside>
+        <aside class="maintenance-banner is-progress"><strong>Maintenance in progress</strong><span>Read-only mode</span></aside>
+        <aside class="maintenance-banner is-complete"><strong>Complete</strong><span>All systems restored</span></aside>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/maintenance-window-countdown-banner-ts/style.css
+++ b/submissions/examples/maintenance-window-countdown-banner-ts/style.css
@@ -1,0 +1,28 @@
+:root {
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dce3ee;
+  --blue: #2563eb;
+  --green: #14845f;
+  --amber: #b45309;
+  --red: #dc2626;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--text); background: var(--bg); }
+.demo-shell { min-height: 100vh; display: grid; place-items: center; padding: 28px; }
+.panel { width: min(820px, 100%); padding: 28px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); box-shadow: 0 22px 58px rgba(16, 24, 40, 0.12); }
+.eyebrow { margin: 0 0 6px; color: var(--blue); font-size: 0.78rem; font-weight: 800; text-transform: uppercase; }
+h1 { margin: 0 0 22px; font-size: clamp(1.6rem, 4vw, 2.35rem); }
+.banner-list { display: grid; gap: 10px; }
+.maintenance-banner { display: flex; align-items: center; justify-content: space-between; gap: 14px; min-height: 62px; padding: 14px 16px; border: 1px solid var(--line); border-left: 6px solid var(--tone); border-radius: 8px; background: #fbfcff; transition: transform 180ms ease, border-color 180ms ease; }
+.maintenance-banner:hover { transform: translateY(-2px); }
+.maintenance-banner span { color: var(--muted); font-weight: 700; }
+.is-scheduled { --tone: var(--blue); }
+.is-soon { --tone: var(--amber); animation: soonPulse 1400ms ease-in-out infinite; }
+.is-progress { --tone: var(--red); }
+.is-complete { --tone: var(--green); opacity: 0.78; }
+@keyframes soonPulse { 50% { box-shadow: 0 0 0 4px rgba(180, 83, 9, 0.12); } }
+@media (max-width: 560px) { .demo-shell { padding: 18px; } .panel { padding: 20px; } .maintenance-banner { align-items: flex-start; flex-direction: column; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; } }


### PR DESCRIPTION
## Pull Request Description

Adds a responsive maintenance window countdown banner example with CSS-only states, responsive layout, and reduced-motion support.

Closes #14353

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/maintenance-window-countdown-banner-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed