### PR TITLE
feat: ease-map-pin-drop animation with bounce settle and squash

### DIFF
--- a/submissions/examples/map-pin-drop-im/README.md
+++ b/submissions/examples/map-pin-drop-im/README.md
@@ -1,0 +1,39 @@
+# ease-map-pin-drop
+
+## What does this do?
+A map pin/marker drops from `translateY(-100px)` with a multi-step bounce settle and a slight squash on landing — the standard marker placement animation for map UIs. A companion `.pin-shadow` element grows in sync with the drop to reinforce the landing illusion.
+
+## How to use it
+```html
+<!-- Default pin drop -->
+<div class="ease-map-pin-drop">
+  <svg ...>...</svg>
+  <div class="pin-shadow"></div>
+</div>
+
+<!-- Variants -->
+<div class="ease-map-pin-drop ease-map-pin-drop--slow">...</div>
+<div class="ease-map-pin-drop ease-map-pin-drop--delay">...</div>
+
+<!-- Staggered multi-pin placement -->
+<div class="ease-map-pin-drop" style="animation-delay: 0s">...</div>
+<div class="ease-map-pin-drop" style="animation-delay: 0.15s">...</div>
+<div class="ease-map-pin-drop" style="animation-delay: 0.30s">...</div>
+```
+
+## Animation detail
+The keyframe sequence:
+- **0%** — starts 100px above, slightly compressed, invisible
+- **55%** — lands with a squash (`scaleY(1.08) scaleX(0.94)`) and a small overshoot
+- **70%–91%** — damped oscillation settles the pin
+- **100%** — rests at natural position
+
+The `.pin-shadow` keyframe mirrors the landing — it's tiny and invisible during the fall, expands on impact, then settles to a natural soft shadow.
+
+## Variants
+- `.ease-map-pin-drop` — default, 0.55s
+- `.ease-map-pin-drop--slow` — 0.8s, for more dramatic placements
+- `.ease-map-pin-drop--delay` — 0.4s delay, for staggered multi-pin reveals
+
+## Why it fits EaseMotion CSS
+Map UIs, delivery trackers, location pickers, and store finders are extremely common, and the bounce-drop marker placement animation is the universal feedback pattern for "a location was just placed here." The squash + grow-shadow combination makes the pin feel physically plausible — matching the framework's animation-first philosophy.

--- a/submissions/examples/map-pin-drop-im/demo.html
+++ b/submissions/examples/map-pin-drop-im/demo.html
@@ -1,0 +1,190 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-map-pin-drop — EaseMotion CSS Submission</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <a href="../../docs/index.html" class="demo-logo">EaseMotion CSS</a>
+    <span class="demo-badge">Submission #14015</span>
+  </header>
+
+  <main class="demo-main">
+
+    <div class="demo-hero ease-fade-in">
+      <h1>ease-map-pin-drop</h1>
+      <p>A map pin drops from above with a bounce landing and a slight squash on impact — the standard marker placement animation for map UIs.</p>
+    </div>
+
+    <!-- Variants -->
+    <section class="demo-section">
+      <h2 class="demo-section-title">Variants — Hover to Replay</h2>
+      <div class="pin-showcase">
+
+        <div class="pin-demo-item">
+          <div class="pin-map-tile">
+            <div class="pin-wrap">
+              <div class="ease-map-pin-drop">
+                <svg class="pin-svg" viewBox="0 0 24 36" width="36" height="54">
+                  <path d="M12 0C5.373 0 0 5.373 0 12c0 9 12 24 12 24S24 21 24 12C24 5.373 18.627 0 12 0z" fill="#6c63ff"/>
+                  <circle cx="12" cy="12" r="5" fill="#fff"/>
+                </svg>
+                <div class="pin-shadow"></div>
+              </div>
+            </div>
+          </div>
+          <span class="pin-label">ease-map-pin-drop</span>
+          <span class="pin-sublabel">Default</span>
+        </div>
+
+        <div class="pin-demo-item">
+          <div class="pin-map-tile">
+            <div class="pin-wrap">
+              <div class="ease-map-pin-drop ease-map-pin-drop--slow">
+                <svg class="pin-svg" viewBox="0 0 24 36" width="36" height="54">
+                  <path d="M12 0C5.373 0 0 5.373 0 12c0 9 12 24 12 24S24 21 24 12C24 5.373 18.627 0 12 0z" fill="#ec4899"/>
+                  <circle cx="12" cy="12" r="5" fill="#fff"/>
+                </svg>
+                <div class="pin-shadow"></div>
+              </div>
+            </div>
+          </div>
+          <span class="pin-label">ease-map-pin-drop--slow</span>
+          <span class="pin-sublabel">0.8s duration</span>
+        </div>
+
+        <div class="pin-demo-item">
+          <div class="pin-map-tile">
+            <div class="pin-wrap">
+              <div class="ease-map-pin-drop ease-map-pin-drop--delay">
+                <svg class="pin-svg" viewBox="0 0 24 36" width="36" height="54">
+                  <path d="M12 0C5.373 0 0 5.373 0 12c0 9 12 24 12 24S24 21 24 12C24 5.373 18.627 0 12 0z" fill="#22c55e"/>
+                  <circle cx="12" cy="12" r="5" fill="#fff"/>
+                </svg>
+                <div class="pin-shadow"></div>
+              </div>
+            </div>
+          </div>
+          <span class="pin-label">ease-map-pin-drop--delay</span>
+          <span class="pin-sublabel">0.4s delay</span>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- Multi-pin map UI demo -->
+    <section class="demo-section">
+      <h2 class="demo-section-title">Multi-Pin Stagger — Click Map to Replay</h2>
+      <div class="pin-map-stage" id="mapStage" onclick="replayPins()">
+        <div class="pin-map-grid">
+          <div class="pin-wrap" style="top: 28%; left: 30%;">
+            <div class="ease-map-pin-drop" style="animation-delay: 0s">
+              <svg class="pin-svg" viewBox="0 0 24 36" width="28" height="42">
+                <path d="M12 0C5.373 0 0 5.373 0 12c0 9 12 24 12 24S24 21 24 12C24 5.373 18.627 0 12 0z" fill="#6c63ff"/>
+                <circle cx="12" cy="12" r="5" fill="#fff"/>
+              </svg>
+              <div class="pin-shadow pin-shadow--sm"></div>
+            </div>
+          </div>
+          <div class="pin-wrap" style="top: 50%; left: 55%;">
+            <div class="ease-map-pin-drop" style="animation-delay: 0.15s">
+              <svg class="pin-svg" viewBox="0 0 24 36" width="28" height="42">
+                <path d="M12 0C5.373 0 0 5.373 0 12c0 9 12 24 12 24S24 21 24 12C24 5.373 18.627 0 12 0z" fill="#ec4899"/>
+                <circle cx="12" cy="12" r="5" fill="#fff"/>
+              </svg>
+              <div class="pin-shadow pin-shadow--sm"></div>
+            </div>
+          </div>
+          <div class="pin-wrap" style="top: 35%; left: 68%;">
+            <div class="ease-map-pin-drop" style="animation-delay: 0.3s">
+              <svg class="pin-svg" viewBox="0 0 24 36" width="28" height="42">
+                <path d="M12 0C5.373 0 0 5.373 0 12c0 9 12 24 12 24S24 21 24 12C24 5.373 18.627 0 12 0z" fill="#f59e0b"/>
+                <circle cx="12" cy="12" r="5" fill="#fff"/>
+              </svg>
+              <div class="pin-shadow pin-shadow--sm"></div>
+            </div>
+          </div>
+          <div class="pin-wrap" style="top: 65%; left: 22%;">
+            <div class="ease-map-pin-drop" style="animation-delay: 0.45s">
+              <svg class="pin-svg" viewBox="0 0 24 36" width="28" height="42">
+                <path d="M12 0C5.373 0 0 5.373 0 12c0 9 12 24 12 24S24 21 24 12C24 5.373 18.627 0 12 0z" fill="#22c55e"/>
+                <circle cx="12" cy="12" r="5" fill="#fff"/>
+              </svg>
+              <div class="pin-shadow pin-shadow--sm"></div>
+            </div>
+          </div>
+          <div class="pin-wrap" style="top: 20%; left: 50%;">
+            <div class="ease-map-pin-drop" style="animation-delay: 0.6s">
+              <svg class="pin-svg" viewBox="0 0 24 36" width="28" height="42">
+                <path d="M12 0C5.373 0 0 5.373 0 12c0 9 12 24 12 24S24 21 24 12C24 5.373 18.627 0 12 0z" fill="#38bdf8"/>
+                <circle cx="12" cy="12" r="5" fill="#fff"/>
+              </svg>
+              <div class="pin-shadow pin-shadow--sm"></div>
+            </div>
+          </div>
+        </div>
+        <span class="pin-map-hint">Click to replay</span>
+      </div>
+    </section>
+
+    <!-- Code -->
+    <section class="demo-section">
+      <h2 class="demo-section-title">How to Use</h2>
+      <div class="code-block">
+        <div class="code-lang">html</div>
+        <pre><code>&lt;!-- Default pin drop --&gt;
+&lt;div class="ease-map-pin-drop"&gt;
+  &lt;svg ...&gt;...&lt;/svg&gt;
+  &lt;div class="pin-shadow"&gt;&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- Variants --&gt;
+&lt;div class="ease-map-pin-drop ease-map-pin-drop--slow"&gt;...&lt;/div&gt;
+&lt;div class="ease-map-pin-drop ease-map-pin-drop--delay"&gt;...&lt;/div&gt;
+
+&lt;!-- Staggered multi-pin --&gt;
+&lt;div class="ease-map-pin-drop" style="animation-delay: 0s"&gt;...&lt;/div&gt;
+&lt;div class="ease-map-pin-drop" style="animation-delay: 0.15s"&gt;...&lt;/div&gt;
+&lt;div class="ease-map-pin-drop" style="animation-delay: 0.3s"&gt;...&lt;/div&gt;</code></pre>
+      </div>
+    </section>
+
+  </main>
+
+  <script>
+    // Replay animation on hover (variant cards)
+    document.querySelectorAll('.pin-demo-item').forEach(item => {
+      item.addEventListener('mouseenter', () => {
+        const pin = item.querySelector('.ease-map-pin-drop');
+        const shadow = item.querySelector('.pin-shadow');
+        pin.style.animation = 'none';
+        shadow.style.animation = 'none';
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            pin.style.animation = '';
+            shadow.style.animation = '';
+          });
+        });
+      });
+    });
+
+    // Replay all pins in map stage on click
+    function replayPins() {
+      document.querySelectorAll('#mapStage .ease-map-pin-drop, #mapStage .pin-shadow').forEach(el => {
+        el.style.animation = 'none';
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            el.style.animation = '';
+          });
+        });
+      });
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/map-pin-drop-im/style.css
+++ b/submissions/examples/map-pin-drop-im/style.css
@@ -1,0 +1,294 @@
+/* ============================================================
+   ease-map-pin-drop — style.css
+   Submission for EaseMotion CSS #14015
+
+   A map pin/marker drops from translateY(-100px) with a
+   bounce settle, slight squash on landing, and a growing
+   shadow that fades in to reinforce the drop illusion.
+
+   Three variants:
+   - .ease-map-pin-drop          default (0.55s)
+   - .ease-map-pin-drop--slow    slower (0.8s)
+   - .ease-map-pin-drop--delay   delayed 0.4s start
+   ============================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--ease-font-sans, 'Inter', system-ui, sans-serif);
+  background: var(--ease-color-bg, #0b1121);
+  color: var(--ease-color-text, #e2e8f0);
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+/* ============================================================
+   THE FEATURE — ease-map-pin-drop
+   ============================================================ */
+
+/* Pin drop keyframes:
+   Drops from -100px, overshoots slightly (-8px), settles.
+   The squash is on the pin itself at landing moment. */
+@keyframes ease-kf-map-pin-drop {
+  0%   { transform: translateY(-100px) scaleY(0.8); opacity: 0; }
+  55%  { transform: translateY(6px) scaleY(1.08) scaleX(0.94); opacity: 1; }
+  70%  { transform: translateY(-8px) scaleY(0.96) scaleX(1.02); }
+  82%  { transform: translateY(3px) scaleY(1.04) scaleX(0.98); }
+  91%  { transform: translateY(-3px) scaleY(0.99) scaleX(1.01); }
+  100% { transform: translateY(0) scaleY(1) scaleX(1); opacity: 1; }
+}
+
+/* Shadow grows in as pin lands */
+@keyframes ease-kf-pin-shadow {
+  0%   { transform: scaleX(0.1); opacity: 0; }
+  55%  { transform: scaleX(1.15); opacity: 0.45; }
+  70%  { transform: scaleX(0.85); opacity: 0.3; }
+  100% { transform: scaleX(1); opacity: 0.35; }
+}
+
+.ease-map-pin-drop {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  transform-origin: bottom center;
+  animation: ease-kf-map-pin-drop 0.55s cubic-bezier(0.215, 0.61, 0.355, 1) both;
+}
+
+/* Shadow element — place directly after the SVG inside .ease-map-pin-drop */
+.pin-shadow {
+  width: 14px;
+  height: 5px;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 50%;
+  margin-top: -3px;
+  transform-origin: center;
+  animation: ease-kf-pin-shadow 0.55s cubic-bezier(0.215, 0.61, 0.355, 1) both;
+}
+
+.pin-shadow--sm {
+  width: 10px;
+  height: 4px;
+}
+
+/* Variant: slower */
+.ease-map-pin-drop--slow {
+  animation-duration: 0.8s;
+}
+.ease-map-pin-drop--slow + .pin-shadow {
+  animation-duration: 0.8s;
+}
+
+/* Variant: delayed */
+.ease-map-pin-drop--delay {
+  animation-delay: 0.4s;
+  opacity: 0;
+  animation-fill-mode: both;
+}
+.ease-map-pin-drop--delay + .pin-shadow {
+  animation-delay: 0.4s;
+  opacity: 0;
+  animation-fill-mode: both;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-map-pin-drop,
+  .pin-shadow {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+
+/* ── Demo: pin wrap for positioning ───────────────────────── */
+.pin-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.pin-svg {
+  display: block;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.25));
+}
+
+/* ── Demo: showcase grid ──────────────────────────────────── */
+.pin-showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.pin-demo-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  cursor: pointer;
+}
+
+.pin-map-tile {
+  width: 160px;
+  height: 160px;
+  background: var(--ease-color-surface, #141e33);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: var(--ease-radius-lg, 1rem);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 2rem;
+  overflow: hidden;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px);
+  background-size: 20px 20px;
+  position: relative;
+}
+
+.pin-label {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.75rem;
+  color: var(--ease-color-secondary-light, #a78bfa);
+  font-weight: 600;
+}
+
+.pin-sublabel {
+  font-size: 0.72rem;
+  color: var(--ease-color-muted, #94a3b8);
+  margin-top: -0.5rem;
+}
+
+/* ── Demo: multi-pin map stage ────────────────────────────── */
+.pin-map-stage {
+  position: relative;
+  width: 100%;
+  height: 300px;
+  background: var(--ease-color-surface, #141e33);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: var(--ease-radius-lg, 1rem);
+  overflow: hidden;
+  cursor: pointer;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+.pin-map-grid {
+  position: absolute;
+  inset: 0;
+}
+
+.pin-map-grid .pin-wrap {
+  position: absolute;
+  transform: translate(-50%, -100%);
+}
+
+.pin-map-hint {
+  position: absolute;
+  bottom: 1rem;
+  right: 1.25rem;
+  font-size: 0.72rem;
+  color: var(--ease-color-muted, #94a3b8);
+  pointer-events: none;
+}
+
+/* ── Demo chrome ──────────────────────────────────────────── */
+.demo-header {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  padding: 0 2rem;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+  background: rgba(11,17,33,0.9);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.demo-logo {
+  font-weight: 800;
+  font-size: 1rem;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-decoration: none;
+}
+
+.demo-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(108,99,255,0.15);
+  color: #a78bfa;
+  border: 1px solid rgba(108,99,255,0.2);
+}
+
+.demo-main { max-width: 900px; margin: 0 auto; padding: 3rem 2rem 5rem; }
+
+.demo-hero { text-align: center; margin-bottom: 3.5rem; }
+
+.demo-hero h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #fff 40%, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.75rem;
+}
+
+.demo-hero p {
+  font-size: 1.05rem;
+  color: var(--ease-color-muted, #94a3b8);
+  max-width: 60ch;
+  margin: 0 auto;
+}
+
+.demo-section { margin-bottom: 3rem; }
+
+.demo-section-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #a78bfa;
+  margin-bottom: 1.5rem;
+}
+
+.code-block {
+  position: relative;
+  background: var(--ease-color-surface, #141e33);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 12px;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+.code-lang {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255,255,255,0.2);
+  font-family: var(--ease-font-mono, monospace);
+}
+
+.code-block pre {
+  margin: 0;
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.8rem;
+  line-height: 1.75;
+  color: #e2e8f0;
+}


### PR DESCRIPTION
## Pull Request Description
Closes #14015 — Adds `ease-map-pin-drop`: a map pin drops from `translateY(-100px)` with a multi-step bounce settle, slight squash on landing, and a companion shadow element that grows on impact. Includes slow and delay variants plus a staggered multi-pin demo.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/map-pin-drop-im/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**
`ease-map-pin-drop` keyframe: drops from -100px, squashes on landing (`scaleY(1.08) scaleX(0.94)`), then oscillates to rest via a damped multi-step bounce. A `.pin-shadow` keyframe mirrors the landing — grows on impact, settles to a natural shadow. Variants: `--slow` (0.8s), `--delay` (0.4s start).

**How does a developer use it?**
```html
<div class="ease-map-pin-drop">
  <svg ...>...</svg>
  <div class="pin-shadow"></div>
</div>

<!-- Staggered multi-pin -->
<div class="ease-map-pin-drop" style="animation-delay: 0s">...</div>
<div class="ease-map-pin-drop" style="animation-delay: 0.15s">...</div>
```

**Why does it fit EaseMotion CSS?**
Map marker placement is a universal UI pattern — delivery trackers, store finders, location pickers — and the bounce-drop animation is the standard feedback for "a pin was just placed here." The squash + shadow-grow combination makes the pin feel physically grounded.

---

## Demo
- [x] Demo added — open `submissions/examples/map-pin-drop-im/demo.html`, hover variant cards to replay, click the multi-pin map to replay all 5 staggered pins

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
Implements all 3 acceptance criteria from the issue:
- **translateY(-100px) → bounce settle at 0** — 6-keyframe sequence with overshoot and damped oscillation
- **Slight squash on landing** — `scaleY(1.08) scaleX(0.94)` at 55% of the animation
- **Common map UI marker placement animation** — companion `.pin-shadow` reinforces the physics; hover-to-replay and staggered multi-pin demos show real usage context

Suggested GSSoC labels: `level:intermediate`, `type:feature`, `animation`, `quality:exceptional` — implements all 3 specified criteria with physically-grounded squash/shadow timing, 3 variants, and an interactive staggered multi-pin demo.