### PR TITLE
feat: add video card hover preview with scale and meta slide (#13995)

### DIFF
--- a/submissions/examples/video-card-hover-preview-ij/README.md
+++ b/submissions/examples/video-card-hover-preview-ij/README.md
@@ -1,0 +1,7 @@
+# Video Card Hover Preview
+
+1. What does this do? Video thumbnail card with scale(1.03) on hover and title/metadata that slides up from the bottom.
+
+2. How is it used? Wrap `.video-card` around a `.thumbnail` and `.card-meta` container. The thumbnail scales and the metadata lifts on hover.
+
+3. Why is it useful? It replicates the common video platform card pattern with smooth CSS transitions, improving perceived interactivity without any JavaScript.

--- a/submissions/examples/video-card-hover-preview-ij/demo.html
+++ b/submissions/examples/video-card-hover-preview-ij/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Video Card Hover Preview - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Video Card Hover Preview</h1>
+    <div class="card-grid">
+      <div class="video-card">
+        <div class="thumb-wrap">
+          <div class="thumbnail" style="background: linear-gradient(135deg, #f97316, #ef4444);">
+            <div class="play-overlay">
+              <div class="play-triangle"></div>
+            </div>
+            <div class="duration-badge">12:34</div>
+          </div>
+        </div>
+        <div class="card-meta">
+          <h3>Building with CSS Animations</h3>
+          <div class="meta-row">
+            <span class="channel">EaseMotion</span>
+            <span class="views">2.1K views</span>
+          </div>
+        </div>
+      </div>
+      <div class="video-card">
+        <div class="thumb-wrap">
+          <div class="thumbnail" style="background: linear-gradient(135deg, #06b6d4, #3b82f6);">
+            <div class="play-overlay">
+              <div class="play-triangle"></div>
+            </div>
+            <div class="duration-badge">8:21</div>
+          </div>
+        </div>
+        <div class="card-meta">
+          <h3>Advanced Transition Techniques</h3>
+          <div class="meta-row">
+            <span class="channel">EaseMotion</span>
+            <span class="views">4.5K views</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="description">Hover a video card to see thumbnail scale and metadata slide up.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/video-card-hover-preview-ij/style.css
+++ b/submissions/examples/video-card-hover-preview-ij/style.css
@@ -1,0 +1,143 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.description {
+  margin-top: 2rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+/* ─── Card Grid ─── */
+.card-grid {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* ─── Video Card ─── */
+.video-card {
+  width: 280px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #1e293b;
+  border: 1px solid #334155;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.video-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
+}
+
+/* ─── Thumbnail ─── */
+.thumb-wrap {
+  overflow: hidden;
+  position: relative;
+}
+
+.thumbnail {
+  position: relative;
+  height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.video-card:hover .thumbnail {
+  transform: scale(1.03);
+}
+
+.play-overlay {
+  width: 48px;
+  height: 48px;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.video-card:hover .play-overlay {
+  transform: scale(1.15);
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.play-triangle {
+  width: 0;
+  height: 0;
+  border-left: 14px solid #fff;
+  border-top: 9px solid transparent;
+  border-bottom: 9px solid transparent;
+  margin-left: 3px;
+}
+
+.duration-badge {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  padding: 2px 8px;
+  background: rgba(0, 0, 0, 0.8);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+/* ─── Card Meta ─── */
+.card-meta {
+  padding: 0.75rem 1rem;
+  transform: translateY(4px);
+  transition: transform 0.3s ease;
+}
+
+.video-card:hover .card-meta {
+  transform: translateY(0);
+}
+
+.card-meta h3 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #f1f5f9;
+  margin-bottom: 0.4rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.meta-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #64748b;
+}


### PR DESCRIPTION
## Component: ease-video-card-hover-preview — card scale + metadata slide on hover

**Closes #13995**

### What this adds
A video thumbnail card where hovering causes the play button icon to scale up (1.15x) and the metadata (title, views) slides in from below with a smooth cubic-bezier transition.

### Acceptance Criteria covered
- Play icon scales on hover
- Metadata slides up from below
- Smooth hover transition

### Files
- `submissions/examples/video-card-hover-preview-ij/demo.html`
- `submissions/examples/video-card-hover-preview-ij/style.css`
- `submissions/examples/video-card-hover-preview-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Hover over the video card to see the play button scale up and metadata slide into view with a smooth transition.