### PR TITLE
feat: add podcast card with hover play reveal and lift (#13994)

### DIFF
--- a/submissions/examples/podcast-card-ij/README.md
+++ b/submissions/examples/podcast-card-ij/README.md
@@ -1,0 +1,7 @@
+# Podcast Card
+
+1. What does this do? A podcast episode card where the play button fades and scales in on hover with a card lift effect and a duration/progress indicator.
+
+2. How is it used? Wrap `.podcast-card` around `.podcast-art` (with `.play-btn`) and `.podcast-info`. Hover triggers button reveal and card lift.
+
+3. Why is it useful? It provides a polished podcast browsing experience with smooth hover interactions, ideal for podcast app UIs and episode listing pages.

--- a/submissions/examples/podcast-card-ij/demo.html
+++ b/submissions/examples/podcast-card-ij/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Podcast Card - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Podcast Card</h1>
+    <div class="card-grid">
+      <div class="podcast-card">
+        <div class="podcast-art">
+          <div class="art-gradient" style="background: linear-gradient(135deg, #f97316, #ec4899);"></div>
+          <div class="play-btn">
+            <div class="play-icon"></div>
+          </div>
+        </div>
+        <div class="podcast-info">
+          <h3>CSS Deep Dive</h3>
+          <p class="episode">Episode 42 &middot; 45 min</p>
+          <div class="progress-row">
+            <div class="progress-track"><div class="progress-fill" style="width: 65%"></div></div>
+            <span class="prog-label">65%</span>
+          </div>
+        </div>
+      </div>
+      <div class="podcast-card">
+        <div class="podcast-art">
+          <div class="art-gradient" style="background: linear-gradient(135deg, #06b6d4, #3b82f6);"></div>
+          <div class="play-btn">
+            <div class="play-icon"></div>
+          </div>
+        </div>
+        <div class="podcast-info">
+          <h3>Animation Lab</h3>
+          <p class="episode">Episode 28 &middot; 32 min</p>
+          <div class="progress-row">
+            <div class="progress-track"><div class="progress-fill" style="width: 30%"></div></div>
+            <span class="prog-label">30%</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="description">Hover a podcast card to reveal the play button and see the card lift effect.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/podcast-card-ij/style.css
+++ b/submissions/examples/podcast-card-ij/style.css
@@ -1,0 +1,149 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.description {
+  margin-top: 2rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+/* ─── Card Grid ─── */
+.card-grid {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* ─── Podcast Card ─── */
+.podcast-card {
+  width: 260px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: #1e293b;
+  border: 1px solid #334155;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.podcast-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.4);
+}
+
+/* ─── Podcast Art ─── */
+.podcast-art {
+  position: relative;
+  height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.art-gradient {
+  position: absolute;
+  inset: 0;
+}
+
+/* ─── Play Button ─── */
+.play-btn {
+  width: 56px;
+  height: 56px;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: opacity 0.3s ease, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 2;
+}
+
+.podcast-card:hover .play-btn {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.play-icon {
+  width: 0;
+  height: 0;
+  border-left: 16px solid #0f172a;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  margin-left: 4px;
+}
+
+/* ─── Info ─── */
+.podcast-info {
+  padding: 1rem;
+  text-align: left;
+}
+
+.podcast-info h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #f1f5f9;
+  margin-bottom: 0.25rem;
+}
+
+.episode {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin-bottom: 0.75rem;
+}
+
+/* ─── Progress ─── */
+.progress-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.progress-track {
+  flex: 1;
+  height: 6px;
+  background: #0f172a;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #f97316, #ec4899);
+  border-radius: 999px;
+  transition: width 0.4s ease;
+}
+
+.prog-label {
+  font-size: 0.75rem;
+  color: #64748b;
+  min-width: 32px;
+  text-align: right;
+}


### PR DESCRIPTION
## Component: ease-podcast-card — play button reveal + card lift on hover

**Closes #13994**

### What this adds
A podcast episode card where the play button fades and scales in on hover, while the entire card lifts upward (translateY -4px) with a shadow depth change.

### Acceptance Criteria covered
- Play button fades + scales on hover
- Card lifts with translateY
- Shadow depth change on lift

### Files
- `submissions/examples/podcast-card-ij/demo.html`
- `submissions/examples/podcast-card-ij/style.css`
- `submissions/examples/podcast-card-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Hover over the podcast card to see the play button appear and the card lift with an enhanced shadow.