### PR TITLE
feat: add music player bar with slide up, play/pause morph, progress(#13993)

### DIFF
--- a/submissions/examples/music-player-bar-ij/README.md
+++ b/submissions/examples/music-player-bar-ij/README.md
@@ -1,0 +1,7 @@
+# Music Player Bar
+
+1. What does this do? A persistent bottom music player bar that slides up from the bottom on first play (translateY), with a play/pause icon morph and smooth progress bar fill.
+
+2. How is it used? Add `.music-bar` fixed to the bottom of the viewport. Toggle `.visible` class to slide up. The `.morph-icon` toggles `.pause` to morph between play triangle and pause bars.
+
+3. Why is it useful? It creates a complete mini music player UI component with entry animation, icon morph, and progress tracking — all building on EaseMotion CSS animation patterns.

--- a/submissions/examples/music-player-bar-ij/demo.html
+++ b/submissions/examples/music-player-bar-ij/demo.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Music Player Bar - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Music Player Bar</h1>
+    <div class="app-content">
+      <div class="track-list">
+        <div class="track-item playing" data-track="0">
+          <span class="track-num">1</span>
+          <div class="track-details">
+            <span class="t-name">Starlight</span>
+            <span class="t-artist">EaseMotion</span>
+          </div>
+          <span class="t-dur">3:24</span>
+        </div>
+        <div class="track-item" data-track="1">
+          <span class="track-num">2</span>
+          <div class="track-details">
+            <span class="t-name">Neon Dreams</span>
+            <span class="t-artist">EaseMotion</span>
+          </div>
+          <span class="t-dur">4:12</span>
+        </div>
+        <div class="track-item" data-track="2">
+          <span class="track-num">3</span>
+          <div class="track-details">
+            <span class="t-name">Ocean Waves</span>
+            <span class="t-artist">EaseMotion</span>
+          </div>
+          <span class="t-dur">2:58</span>
+        </div>
+      </div>
+    </div>
+    <div class="music-bar" id="musicBar">
+      <div class="bar-progress">
+        <div class="bar-progress-fill" id="barProgressFill"></div>
+      </div>
+      <div class="bar-content">
+        <div class="bar-left">
+          <div class="bar-art"></div>
+          <div class="bar-info">
+            <div class="bar-title" id="barTitle">Starlight</div>
+            <div class="bar-artist" id="barArtist">EaseMotion</div>
+          </div>
+        </div>
+        <div class="bar-center">
+          <button class="bar-btn" id="playBtn">
+            <div class="morph-icon" id="morphIcon">
+              <div class="play-shape"></div>
+            </div>
+          </button>
+        </div>
+        <div class="bar-right">
+          <span class="bar-time" id="barTime">1:24</span>
+        </div>
+      </div>
+    </div>
+    <p class="description">Click play to see the bar slide up. Play/pause morphs and progress fills smoothly.</p>
+  </div>
+
+  <script>
+    const musicBar = document.getElementById('musicBar');
+    const playBtn = document.getElementById('playBtn');
+    const morphIcon = document.getElementById('morphIcon');
+    const barProgressFill = document.getElementById('barProgressFill');
+    const barTitle = document.getElementById('barTitle');
+    const barArtist = document.getElementById('barArtist');
+    const barTime = document.getElementById('barTime');
+    const trackItems = document.querySelectorAll('.track-item');
+
+    const tracks = [
+      { title: 'Starlight', artist: 'EaseMotion', dur: 204 },
+      { title: 'Neon Dreams', artist: 'EaseMotion', dur: 252 },
+      { title: 'Ocean Waves', artist: 'EaseMotion', dur: 178 }
+    ];
+
+    let isPlaying = false;
+    let hasStarted = false;
+    let currentTrack = 0;
+    let progress = 0;
+    let progressInterval = null;
+
+    function formatTime(seconds) {
+      const m = Math.floor(seconds / 60);
+      const s = Math.floor(seconds % 60);
+      return m + ':' + (s < 10 ? '0' : '') + s;
+    }
+
+    function loadTrack(idx) {
+      currentTrack = idx;
+      barTitle.textContent = tracks[idx].title;
+      barArtist.textContent = tracks[idx].artist;
+      progress = 0;
+      barProgressFill.style.width = '0%';
+      barTime.textContent = '0:00';
+      trackItems.forEach((item, i) => item.classList.toggle('playing', i === idx));
+    }
+
+    function togglePlay() {
+      if (!hasStarted) {
+        hasStarted = true;
+        musicBar.classList.add('visible');
+      }
+
+      isPlaying = !isPlaying;
+      morphIcon.classList.toggle('pause', isPlaying);
+
+      if (isPlaying) {
+        progressInterval = setInterval(() => {
+          progress += 0.5;
+          const pct = (progress / tracks[currentTrack].dur) * 100;
+          barProgressFill.style.width = Math.min(pct, 100) + '%';
+          barTime.textContent = formatTime(progress);
+          if (progress >= tracks[currentTrack].dur) {
+            clearInterval(progressInterval);
+            isPlaying = false;
+            morphIcon.classList.remove('pause');
+          }
+        }, 500);
+      } else {
+        clearInterval(progressInterval);
+      }
+    }
+
+    playBtn.addEventListener('click', togglePlay);
+
+    trackItems.forEach(item => {
+      item.addEventListener('click', () => {
+        const idx = parseInt(item.dataset.track);
+        if (idx !== currentTrack) {
+          if (isPlaying) {
+            clearInterval(progressInterval);
+            isPlaying = false;
+            morphIcon.classList.remove('pause');
+          }
+          loadTrack(idx);
+        }
+      });
+    });
+
+    loadTrack(0);
+  </script>
+</body>
+</html>

--- a/submissions/examples/music-player-bar-ij/style.css
+++ b/submissions/examples/music-player-bar-ij/style.css
@@ -1,0 +1,238 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-bottom: 80px;
+}
+
+.demo-wrapper {
+  text-align: center;
+  width: 100%;
+  max-width: 420px;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.description {
+  margin-top: 2rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+/* ─── Track List ─── */
+.app-content {
+  padding: 0 1rem;
+}
+
+.track-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.track-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: #1e293b;
+  border: 1px solid #334155;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.track-item:hover {
+  background: #334155;
+}
+
+.track-item.playing {
+  background: rgba(251, 191, 36, 0.1);
+  border-color: #fbbf24;
+}
+
+.track-num {
+  font-size: 0.8rem;
+  color: #64748b;
+  min-width: 20px;
+}
+
+.track-details {
+  flex: 1;
+  text-align: left;
+}
+
+.t-name {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #f1f5f9;
+}
+
+.t-artist {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.t-dur {
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+/* ─── Music Bar ─── */
+.music-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: linear-gradient(180deg, #1e293b, #0f172a);
+  border-top: 1px solid #334155;
+  transform: translateY(100%);
+  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 100;
+}
+
+.music-bar.visible {
+  transform: translateY(0);
+}
+
+/* ─── Progress ─── */
+.bar-progress {
+  height: 3px;
+  background: #1e293b;
+}
+
+.bar-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #fbbf24, #f97316);
+  transition: width 0.5s linear;
+}
+
+/* ─── Bar Content ─── */
+.bar-content {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  gap: 1rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.bar-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.bar-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #fbbf24, #f97316);
+  flex-shrink: 0;
+}
+
+.bar-info {
+  min-width: 0;
+}
+
+.bar-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #f1f5f9;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bar-artist {
+  font-size: 0.7rem;
+  color: #64748b;
+}
+
+.bar-center {
+  flex-shrink: 0;
+}
+
+.bar-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: #fbbf24;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease;
+}
+
+.bar-btn:hover {
+  transform: scale(1.1);
+}
+
+.bar-btn:active {
+  transform: scale(0.95);
+}
+
+/* ─── Morph Icon (Play -> Pause) ─── */
+.morph-icon {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s ease;
+}
+
+.play-shape {
+  width: 0;
+  height: 0;
+  border-left: 14px solid #0f172a;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  margin-left: 3px;
+  transition: all 0.3s ease;
+}
+
+.morph-icon.pause .play-shape {
+  border-left: none;
+  border-top: none;
+  border-bottom: none;
+  width: 6px;
+  height: 14px;
+  background: #0f172a;
+  border-radius: 1px;
+  box-shadow: 8px 0 0 0 #0f172a;
+  margin-left: 0;
+}
+
+.bar-right {
+  flex-shrink: 0;
+}
+
+.bar-time {
+  font-size: 0.75rem;
+  color: #64748b;
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Component: ease-music-player-bar — slide-up bar with play/pause morph and progress

**Closes #13993**

### What this adds
A bottom-fixed music player bar that slides up from below on first play (translateY), morphs the play triangle into pause bars, and fills a gradient progress bar smoothly as playback progresses.

### Acceptance Criteria covered
- Bar slides up from bottom on first play
- Play/pause icon morphs between triangle and bars
- Progress bar fills smoothly during playback

### Files
- `submissions/examples/music-player-bar-ij/demo.html`
- `submissions/examples/music-player-bar-ij/style.css`
- `submissions/examples/music-player-bar-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Click play to see the bar slide up. The icon morphs and the progress bar fills. Click again to pause.