### PR TITLE
feat: add filter chip add with scale-in bounce entrance and exit (#13809)

### DIFF
--- a/submissions/examples/filter-chip-add-ij/README.md
+++ b/submissions/examples/filter-chip-add-ij/README.md
@@ -1,0 +1,7 @@
+# Filter Chip Add
+
+1. What does this do? When a filter is applied, a chip representing it scales and fades into the filter bar with a gentle bounce, and can be removed with a reverse animation.
+
+2. How is it used? Create a `.chip` element with `scale(0)` / `opacity(0)` and toggle the `.visible` class to trigger the entrance animation. The remove button triggers `.removing` for exit.
+
+3. Why is it useful? It provides a polished filter UI interaction pattern — chips enter with a satisfying spring-like bounce and exit cleanly, improving the feel of dynamic filter bars.

--- a/submissions/examples/filter-chip-add-ij/demo.html
+++ b/submissions/examples/filter-chip-add-ij/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Filter Chip Add - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Filter Chip Add</h1>
+    <div class="filter-bar">
+      <div class="filter-chips" id="filterChips"></div>
+    </div>
+    <div class="filter-options">
+      <button class="filter-btn" data-filter="Category: Design">Design</button>
+      <button class="filter-btn" data-filter="Category: Dev">Dev</button>
+      <button class="filter-btn" data-filter="Tag: CSS">CSS</button>
+      <button class="filter-btn" data-filter="Tag: JS">JS</button>
+      <button class="filter-btn" data-filter="Status: Done">Done</button>
+    </div>
+    <p class="description">Click a filter to add a chip. Each chip animates in with scale and opacity bounce.</p>
+  </div>
+
+  <script>
+    const chipsContainer = document.getElementById('filterChips');
+
+    document.querySelectorAll('.filter-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const label = btn.dataset.filter;
+        const existing = chipsContainer.querySelector('[data-label="' + label + '"]');
+        if (existing) return;
+
+        const chip = document.createElement('div');
+        chip.className = 'chip';
+        chip.dataset.label = label;
+        chip.innerHTML = '<span class="chip-label">' + label.split(': ')[1] + '</span><span class="chip-remove">&times;</span>';
+
+        chip.querySelector('.chip-remove').addEventListener('click', (e) => {
+          e.stopPropagation();
+          chip.classList.add('removing');
+          setTimeout(() => chip.remove(), 300);
+        });
+
+        chipsContainer.appendChild(chip);
+        requestAnimationFrame(() => chip.classList.add('visible'));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/filter-chip-add-ij/style.css
+++ b/submissions/examples/filter-chip-add-ij/style.css
@@ -1,0 +1,128 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.demo-wrapper {
+  text-align: center;
+  max-width: 500px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.description {
+  margin-top: 2rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+/* ─── Filter Bar ─── */
+.filter-bar {
+  min-height: 48px;
+  padding: 0.5rem;
+  border-radius: 12px;
+  background: #1e293b;
+  border: 1px solid #334155;
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.filter-chips {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+/* ─── Chip ─── */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(251, 191, 36, 0.15);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+  transform: scale(0);
+  opacity: 0;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+              opacity 0.3s ease;
+}
+
+.chip.visible {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.chip.removing {
+  transform: scale(0);
+  opacity: 0;
+}
+
+.chip-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #fbbf24;
+}
+
+.chip-remove {
+  font-size: 1rem;
+  color: #fbbf24;
+  cursor: pointer;
+  opacity: 0.6;
+  line-height: 1;
+  transition: opacity 0.2s ease;
+}
+
+.chip-remove:hover {
+  opacity: 1;
+}
+
+/* ─── Filter Buttons ─── */
+.filter-options {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.filter-btn {
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.2s ease;
+}
+
+.filter-btn:hover {
+  background: #334155;
+  color: #fbbf24;
+  border-color: #fbbf24;
+}
+
+.filter-btn:active {
+  transform: scale(0.95);
+}


### PR DESCRIPTION
## Component: ease-filter-chip-add — scale-in bounce entrance for filter chips

**Closes #13809**

### What this adds
A filter bar where clicking a category button adds a chip that scales in from 0 to 1 with a spring-like bounce (cubic-bezier). Chips can be removed with a reverse scale-out animation.

### Acceptance Criteria covered
- Chip scales in with bounce on add
- Chip scales out on remove
- Works alongside existing filter chips

### Files
- `submissions/examples/filter-chip-add-ij/demo.html`
- `submissions/examples/filter-chip-add-ij/style.css`
- `submissions/examples/filter-chip-add-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Click any filter button to add a chip with a bounce entrance. Click the × on a chip to remove it with a reverse animation.