### PR TITLE
feat: add sort arrow flip with 180deg rotation transition (#13808)

### DIFF
--- a/submissions/examples/sort-arrow-flip-ij/README.md
+++ b/submissions/examples/sort-arrow-flip-ij/README.md
@@ -1,0 +1,7 @@
+# Sort Arrow Flip
+
+1. What does this do? A data table sort arrow that rotates 180° to indicate ascending/descending sort direction on click.
+
+2. How is it used? Add a `.sort-arrow` element inside a clickable table header. Toggle `.flipped` class to rotate the arrow 180° with a spring-like transition.
+
+3. Why is it useful? This is a core table sorting pattern — the smooth arrow flip makes sort direction changes feel intuitive and responsive.

--- a/submissions/examples/sort-arrow-flip-ij/demo.html
+++ b/submissions/examples/sort-arrow-flip-ij/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sort Arrow Flip - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Sort Arrow Flip</h1>
+    <table class="sort-table">
+      <thead>
+        <tr>
+          <th class="sort-header" data-col="name">
+            <span>Name</span>
+            <span class="sort-arrow" id="arrowName">&#9650;</span>
+          </th>
+          <th class="sort-header" data-col="price">
+            <span>Price</span>
+            <span class="sort-arrow" id="arrowPrice">&#9650;</span>
+          </th>
+          <th class="sort-header" data-col="stock">
+            <span>Stock</span>
+            <span class="sort-arrow" id="arrowStock">&#9650;</span>
+          </th>
+        </tr>
+      </thead>
+      <tbody id="tableBody">
+        <tr><td>Alpha</td><td>$85</td><td>42</td></tr>
+        <tr><td>Beta</td><td>$42</td><td>120</td></tr>
+        <tr><td>Gamma</td><td>$120</td><td>8</td></tr>
+        <tr><td>Delta</td><td>$65</td><td>33</td></tr>
+      </tbody>
+    </table>
+    <p class="description">Click any column header to sort. The arrow flips 180° on each click.</p>
+  </div>
+
+  <script>
+    const headers = document.querySelectorAll('.sort-header');
+    let sortState = {};
+
+    headers.forEach(th => {
+      th.addEventListener('click', () => {
+        const col = th.dataset.col;
+        const arrow = th.querySelector('.sort-arrow');
+        const asc = sortState[col] !== 'asc';
+        sortState = {};
+        sortState[col] = asc ? 'asc' : 'desc';
+        arrow.classList.toggle('flipped', !asc);
+
+        headers.forEach(h => {
+          const a = h.querySelector('.sort-arrow');
+          if (h !== th) a.classList.remove('flipped');
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/sort-arrow-flip-ij/style.css
+++ b/submissions/examples/sort-arrow-flip-ij/style.css
@@ -1,0 +1,91 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.demo-wrapper {
+  text-align: center;
+  max-width: 600px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.description {
+  margin-top: 2rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+/* ─── Table ─── */
+.sort-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #1e293b;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+.sort-table th,
+.sort-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+}
+
+.sort-table thead {
+  background: #334155;
+}
+
+.sort-table tbody tr {
+  border-top: 1px solid #334155;
+  transition: background 0.15s ease;
+}
+
+.sort-table tbody tr:hover {
+  background: #1e293b;
+}
+
+/* ─── Sort Header ─── */
+.sort-header {
+  cursor: pointer;
+  user-select: none;
+  display: table-cell;
+}
+
+.sort-header:hover {
+  color: #fbbf24;
+}
+
+.sort-header span:first-child {
+  margin-right: 0.4rem;
+}
+
+/* ─── Arrow ─── */
+.sort-arrow {
+  display: inline-block;
+  font-size: 0.7rem;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.sort-arrow.flipped {
+  transform: rotate(180deg);
+}


### PR DESCRIPTION
## Component: ease-sort-arrow-flip — 180° rotation on sort direction toggle

**Closes #13808**

### What this adds
A data table where clicking a column header rotates the sort arrow 180° to indicate ascending/descending direction. The flip uses a spring-like cubic-bezier curve for a snappy feel.

### Acceptance Criteria covered
- Arrow rotates 180° on click
- Spring-like transition curve
- Only active column shows flipped state

### Files
- `submissions/examples/sort-arrow-flip-ij/demo.html`
- `submissions/examples/sort-arrow-flip-ij/style.css`
- `submissions/examples/sort-arrow-flip-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Click any column header to see the arrow flip direction. Click again to toggle back.