### PR TITLE
feat: add table row select with background transition on check (#13807)

### DIFF
--- a/submissions/examples/table-row-select-ij/README.md
+++ b/submissions/examples/table-row-select-ij/README.md
@@ -1,0 +1,7 @@
+# Table Row Select
+
+1. What does this do? A table with row-level checkboxes where selected rows get a smooth background transition, building on the table row component of EaseMotion CSS.
+
+2. How is it used? Add `.select-row` to each table row with a `.row-checkbox` input. Toggle the `.selected` class to trigger the background transition on check/uncheck.
+
+3. Why is it useful? This provides a polished selection UX pattern — rows highlight with a smooth background color transition instead of an instant jump, making bulk actions feel more deliberate.

--- a/submissions/examples/table-row-select-ij/demo.html
+++ b/submissions/examples/table-row-select-ij/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Table Row Select - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Table Row Select</h1>
+    <table class="select-table">
+      <thead>
+        <tr>
+          <th class="col-check">
+            <input type="checkbox" id="selectAll">
+          </th>
+          <th>Name</th>
+          <th>Role</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="select-row">
+          <td><input type="checkbox" class="row-checkbox"></td>
+          <td>Alice Chen</td>
+          <td>Designer</td>
+          <td><span class="badge active">Active</span></td>
+        </tr>
+        <tr class="select-row">
+          <td><input type="checkbox" class="row-checkbox"></td>
+          <td>Bob Torres</td>
+          <td>Developer</td>
+          <td><span class="badge away">Away</span></td>
+        </tr>
+        <tr class="select-row">
+          <td><input type="checkbox" class="row-checkbox"></td>
+          <td>Carol Nguyen</td>
+          <td>PM</td>
+          <td><span class="badge active">Active</span></td>
+        </tr>
+        <tr class="select-row">
+          <td><input type="checkbox" class="row-checkbox"></td>
+          <td>David Kim</td>
+          <td>Developer</td>
+          <td><span class="badge offline">Offline</span></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="description">Select rows via checkbox. Background transitions smoothly on check/uncheck.</p>
+  </div>
+
+  <script>
+    const rowCheckboxes = document.querySelectorAll('.row-checkbox');
+    const selectAll = document.getElementById('selectAll');
+
+    rowCheckboxes.forEach(cb => {
+      cb.addEventListener('change', () => {
+        cb.closest('.select-row').classList.toggle('selected', cb.checked);
+        selectAll.checked = document.querySelectorAll('.row-checkbox:checked').length === rowCheckboxes.length;
+      });
+    });
+
+    selectAll.addEventListener('change', () => {
+      rowCheckboxes.forEach(cb => {
+        cb.checked = selectAll.checked;
+        cb.closest('.select-row').classList.toggle('selected', selectAll.checked);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/table-row-select-ij/style.css
+++ b/submissions/examples/table-row-select-ij/style.css
@@ -1,0 +1,117 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.demo-wrapper {
+  text-align: center;
+  max-width: 640px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.description {
+  margin-top: 2rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+/* ─── Table ─── */
+.select-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #1e293b;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #334155;
+}
+
+.select-table th,
+.select-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+}
+
+.select-table thead {
+  background: #334155;
+}
+
+.col-check {
+  width: 48px;
+}
+
+/* ─── Select Row ─── */
+.select-row {
+  border-top: 1px solid #334155;
+  transition: background 0.3s ease;
+}
+
+.select-row.selected {
+  background: rgba(251, 191, 36, 0.1);
+}
+
+.select-row:hover {
+  background: #1e293b;
+}
+
+.select-row.selected:hover {
+  background: rgba(251, 191, 36, 0.15);
+}
+
+/* ─── Checkbox ─── */
+.select-row input[type="checkbox"] {
+  accent-color: #fbbf24;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+#selectAll {
+  accent-color: #fbbf24;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+/* ─── Badge ─── */
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.badge.active {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+}
+
+.badge.away {
+  background: rgba(251, 191, 36, 0.15);
+  color: #fbbf24;
+}
+
+.badge.offline {
+  background: rgba(100, 116, 139, 0.2);
+  color: #64748b;
+}


### PR DESCRIPTION
## Component: ease-table-row-select — background transition on row checkbox toggle

**Closes #13807**

### What this adds
A data table with checkbox-based row selection where the background color transitions smoothly (0.3s ease) from default to a highlighted amber tint when checked. Includes a select-all header checkbox.

### Acceptance Criteria covered
- Row background transitions smoothly on select
- Checkbox toggle drives the selected state
- Select-all checkbox toggles all rows

### Files
- `submissions/examples/table-row-select-ij/demo.html`
- `submissions/examples/table-row-select-ij/style.css`
- `submissions/examples/table-row-select-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Click individual row checkboxes or the header select-all checkbox. Selected rows transition to a highlighted background.