### PR TITLE
feat: add label float bounce with spring overshoot on focus (#13805)

### DIFF
--- a/submissions/examples/label-float-bounce-ij/README.md
+++ b/submissions/examples/label-float-bounce-ij/README.md
@@ -1,0 +1,7 @@
+# Label Float Bounce
+
+1. What does this do? A floating label input where the label has a tiny overshoot bounce when it floats up on focus, using a spring-like cubic-bezier curve for the transition.
+
+2. How is it used? Builds on the floating label pattern. Add a `.float-group` with `.float-input` and `.float-label`. The label floats up on `:focus` and `:not(:placeholder-shown)`. The `cubic-bezier(0.34, 1.56, 0.64, 1)` curve provides the bounce.
+
+3. Why is it useful? It polishes the standard floating label pattern with a subtle bounce that makes the interaction feel more lively and responsive.

--- a/submissions/examples/label-float-bounce-ij/demo.html
+++ b/submissions/examples/label-float-bounce-ij/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Label Float Bounce - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Label Float Bounce</h1>
+    <div class="form">
+      <div class="float-group">
+        <input type="text" class="float-input" id="nameInput" placeholder=" " autocomplete="off">
+        <label class="float-label" for="nameInput">Full Name</label>
+      </div>
+      <div class="float-group">
+        <input type="email" class="float-input" id="emailInput" placeholder=" " autocomplete="off">
+        <label class="float-label" for="emailInput">Email Address</label>
+      </div>
+      <div class="float-group">
+        <input type="password" class="float-input" id="passInput" placeholder=" " autocomplete="off">
+        <label class="float-label" for="passInput">Password</label>
+      </div>
+    </div>
+    <p class="description">Focus on an input to see the label float up with a subtle bounce overshoot.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/label-float-bounce-ij/style.css
+++ b/submissions/examples/label-float-bounce-ij/style.css
@@ -1,0 +1,93 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.demo-wrapper {
+  text-align: center;
+  max-width: 480px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 3rem;
+  color: #94a3b8;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.description {
+  margin-top: 2.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+/* ─── Form ─── */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* ─── Float Group ─── */
+.float-group {
+  position: relative;
+}
+
+.float-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: #f1f5f9;
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.float-input:focus {
+  border-color: #fbbf24;
+}
+
+.float-input:focus::placeholder {
+  color: transparent;
+}
+
+.float-input::placeholder {
+  color: transparent;
+}
+
+/* ─── Float Label ─── */
+.float-label {
+  position: absolute;
+  top: 50%;
+  left: 1rem;
+  transform: translateY(-50%);
+  font-size: 1rem;
+  color: #64748b;
+  pointer-events: none;
+  transition: all 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  background: #1e293b;
+  padding: 0 0.25rem;
+}
+
+.float-input:focus + .float-label,
+.float-input:not(:placeholder-shown) + .float-label {
+  top: 0;
+  transform: translateY(-50%) scale(0.85);
+  color: #fbbf24;
+}


### PR DESCRIPTION
## Component: ease-label-float-bounce — floating label bounces slightly when activated

**Closes #13805**

### What this adds
A floating label input where the label has a tiny overshoot bounce when it floats up on focus, using a spring-like cubic-bezier curve for the transition.

### Acceptance Criteria covered
- Builds on ease-float-label component
- Adds subtle overshoot bounce to the float-up transition
- Smooth cubic-bezier animation

### Files
- `submissions/examples/label-float-bounce-ij/demo.html`
- `submissions/examples/label-float-bounce-ij/style.css`
- `submissions/examples/label-float-bounce-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Click or tab into any input to see the label float up with a subtle bounce overshoot.