### PR TITLE
feat: add input focus ring pulse with one-shot box-shadow expand animation (#13804)

### DIFF
--- a/submissions/examples/input-focus-ring-pulse-ij/README.md
+++ b/submissions/examples/input-focus-ring-pulse-ij/README.md
@@ -1,0 +1,7 @@
+# Input Focus Ring Pulse
+
+1. What does this do? An input focus ring that does a single pulse — the box-shadow expands outward then settles back to a normal ring size — drawing attention on focus.
+
+2. How is it used? Add a `.pulse-input` element. On `:focus`, the `focus-pulse` keyframe animation runs once (0.4s ease-out): the box-shadow expands to 6px then settles to 3px.
+
+3. Why is it useful? It provides enhanced focus feedback compared to a static ring — the subtle one-shot pulse draws the user's eye to the focused input without being distracting or continuous.

--- a/submissions/examples/input-focus-ring-pulse-ij/demo.html
+++ b/submissions/examples/input-focus-ring-pulse-ij/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Input Focus Ring Pulse - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Focus Ring Pulse</h1>
+    <div class="form">
+      <div class="pulse-group">
+        <input type="text" class="pulse-input" id="searchInput" placeholder="Search..." autocomplete="off">
+      </div>
+      <div class="pulse-group">
+        <input type="text" class="pulse-input" id="userInput" placeholder="Username" autocomplete="off">
+      </div>
+      <div class="pulse-group">
+        <input type="text" class="pulse-input" id="bioInput" placeholder="Short bio" autocomplete="off">
+      </div>
+    </div>
+    <p class="description">Focus an input to see the focus ring pulse — it expands slightly then settles back in one shot.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/input-focus-ring-pulse-ij/style.css
+++ b/submissions/examples/input-focus-ring-pulse-ij/style.css
@@ -1,0 +1,77 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.demo-wrapper {
+  text-align: center;
+  max-width: 480px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 3rem;
+  color: #94a3b8;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.description {
+  margin-top: 2.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+/* ─── Form ─── */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ─── Pulse Group ─── */
+.pulse-group {
+  position: relative;
+}
+
+.pulse-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: #f1f5f9;
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.pulse-input:focus {
+  border-color: #fbbf24;
+  animation: focus-pulse 0.4s ease-out;
+}
+
+@keyframes focus-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(251, 191, 36, 0.2);
+  }
+  100% {
+    box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.15);
+  }
+}


### PR DESCRIPTION
## Component: ease-input-focus-ring-pulse — focus ring pulses once on focus

**Closes #13804**

### What this adds
An input focus ring that does a single pulse animation — the box-shadow expands outward then settles back to a normal ring size — drawn attention on focus without being continuous.

### Acceptance Criteria covered
- box-shadow expands then settles to normal focus ring size
- One-shot, not continuous
- Builds on ease-focus-ring utility

### Files
- `submissions/examples/input-focus-ring-pulse-ij/demo.html`
- `submissions/examples/input-focus-ring-pulse-ij/style.css`
- `submissions/examples/input-focus-ring-pulse-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Focus any input to see the amber focus ring pulse outward and settle back in a single shot.