### PR TITLE
fix(cards): add dark-mode override for .ease-card-flat (#14088)

### DIFF
--- a/components/cards.css
+++ b/components/cards.css
@@ -122,6 +122,16 @@
   background-color: var(--ease-color-neutral-100, #f1f5f9);
 }
 
+@media (prefers-color-scheme: dark) {
+  .ease-card-flat {
+    background-color: var(--ease-color-surface, #141e33);
+  }
+}
+
+[data-theme="dark"] .ease-card-flat {
+  background-color: var(--ease-color-surface, #141e33);
+}
+
 /* ── Outlined Card ─────────────────────────────────────────── */
 
 .ease-card-outlined {


### PR DESCRIPTION
**fix(cards): add dark-mode override for .ease-card-flat #14088**

## Related Issue
Closes #14088

---

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Chore

---

## Description
`.ease-card-flat` used `--ease-color-neutral-100` (`#f1f5f9` — a light slate grey) as its background color with no dark-mode counterpart defined anywhere in the codebase. This caused the flat card variant to render as a visually jarring light grey box when the user's system is in dark mode or when `[data-theme="dark"]` is applied, breaking the dark theme's visual consistency.

The fix adds both a `@media (prefers-color-scheme: dark)` block and a `[data-theme="dark"]` attribute selector override, switching the background to `--ease-color-surface` (`#141e33`) — the established dark surface token already used by `.ease-card-neumorphic` and `.ease-card-glass` in the same file.

---

## Changes Made

- `components/cards.css`
  - Added `@media (prefers-color-scheme: dark)` override for `.ease-card-flat` setting `background-color` to `var(--ease-color-surface, #141e33)`
  - Added `[data-theme="dark"] .ease-card-flat` override with the same value to support explicit theme toggling via JS

---

## Screenshots / Recordings
Not applicable. This is a pure CSS dark-mode token fix with no visual regressions in light mode.

---

## How to Verify Locally

1. Open any demo that uses `.ease-card-flat` (or add a card with that class to `examples/demo.html`)
2. Enable dark mode on your system (`Settings → Personalization → Dark`) **or** add `data-theme="dark"` to the `<html>` element in DevTools
3. **Before fix:** card renders as light grey (`#f1f5f9`)
4. **After fix:** card correctly renders as dark surface (`#141e33`)

---

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] I have updated the documentation if required
- [x] No existing functionality has been broken
- [x] All checks and linting pass successfully

---

## GSSoC'26 Contributor Declaration

- [x] I confirm that I am a participant of GSSoC'26
- [x] I have followed the contribution guidelines of this project
- [x] This PR is ready for review

---