### PR TITLE
Fix/14088 ease card flat dark mode override

### DIFF
--- a/components/cards.css
+++ b/components/cards.css
@@ -122,6 +122,16 @@
   background-color: var(--ease-color-neutral-100, #f1f5f9);
 }
 
+@media (prefers-color-scheme: dark) {
+  .ease-card-flat {
+    background-color: var(--ease-color-surface, #141e33);
+  }
+}
+
+[data-theme="dark"] .ease-card-flat {
+  background-color: var(--ease-color-surface, #141e33);
+}
+
 /* ── Outlined Card ─────────────────────────────────────────── */
 
 .ease-card-outlined {

--- a/components/cards.css
+++ b/components/cards.css
@@ -122,16 +122,6 @@
   background-color: var(--ease-color-neutral-100, #f1f5f9);
 }
 
-@media (prefers-color-scheme: dark) {
-  .ease-card-flat {
-    background-color: var(--ease-color-surface, #141e33);
-  }
-}
-
-[data-theme="dark"] .ease-card-flat {
-  background-color: var(--ease-color-surface, #141e33);
-}
-
 /* ── Outlined Card ─────────────────────────────────────────── */
 
 .ease-card-outlined {

--- a/submissions/examples/fix-14088-ease-card-flat-rs/README.md
+++ b/submissions/examples/fix-14088-ease-card-flat-rs/README.md
@@ -1,0 +1,43 @@
+# Fix: `.ease-card-flat` has no dark-mode background override
+
+**Issue:** [#14088](https://github.com/saptarshi-coder/easemotion-css/issues/14088)
+
+---
+
+## 1. What does this do?
+
+Fixes `.ease-card-flat` rendering as light grey (`#f1f5f9`) in dark mode by adding dark-mode background overrides that switch it to `--ease-color-surface` (`#141e33`).
+
+---
+
+## 2. How is it used?
+
+```html
+<!-- No change to usage — the fix is purely in CSS -->
+<div class="ease-card ease-card-flat">
+  <h3 class="ease-card-title">Card Title</h3>
+  <p>Content here.</p>
+</div>
+```
+
+The proposed fix to add into `components/cards.css`:
+
+```css
+@media (prefers-color-scheme: dark) {
+  .ease-card-flat {
+    background-color: var(--ease-color-surface, #141e33);
+  }
+}
+
+[data-theme="dark"] .ease-card-flat {
+  background-color: var(--ease-color-surface, #141e33);
+}
+```
+
+---
+
+## 3. Why is it useful?
+
+`.ease-card-flat` is meant to be a borderless, low-contrast card variant. In dark mode its hardcoded `--ease-color-neutral-100` background (`#f1f5f9` — light slate grey) clashes violently with dark page backgrounds, breaking visual consistency.
+
+This fix mirrors the exact pattern already used by `.ease-card-neumorphic` and `.ease-card-glass` in `cards.css` — both of which have proper `prefers-color-scheme: dark` and `[data-theme="dark"]` overrides using `--ease-color-surface`. Applying the same treatment to `.ease-card-flat` makes all card variants consistent.

--- a/submissions/examples/fix-14088-ease-card-flat-rs/demo.html
+++ b/submissions/examples/fix-14088-ease-card-flat-rs/demo.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #14088 — .ease-card-flat Dark Mode Override</title>
+
+  <!-- EaseMotion Core -->
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../components/cards.css" />
+
+  <!-- This submission's fix -->
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background-color: var(--ease-color-bg, #0b1121);
+      color: var(--ease-color-text, #e2e8f0);
+      min-height: 100vh;
+      margin: 0;
+      padding: 2rem;
+      box-sizing: border-box;
+    }
+
+    h1 {
+      font-size: 1.75rem;
+      font-weight: 700;
+      margin-bottom: 0.25rem;
+    }
+
+    .issue-badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      background: rgba(239, 68, 68, 0.15);
+      color: #fca5a5;
+      border: 1px solid rgba(239, 68, 68, 0.3);
+      padding: 0.2em 0.75em;
+      border-radius: 9999px;
+      margin-bottom: 2rem;
+    }
+
+    .section-label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #94a3b8;
+      margin-bottom: 0.75rem;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1.5rem;
+      margin-bottom: 3rem;
+    }
+
+    .toggle-row {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 2.5rem;
+    }
+
+    .theme-btn {
+      padding: 0.5rem 1.25rem;
+      border-radius: 9999px;
+      border: 1px solid rgba(255,255,255,0.15);
+      background: rgba(255,255,255,0.06);
+      color: #e2e8f0;
+      font-size: 0.875rem;
+      cursor: pointer;
+      transition: background 200ms ease;
+    }
+
+    .theme-btn:hover {
+      background: rgba(255,255,255,0.12);
+    }
+
+    .theme-btn.active {
+      background: #6c63ff;
+      border-color: #6c63ff;
+      color: #fff;
+    }
+
+    /* ── Bug demonstration: simulate the bug by NOT applying the fix ── */
+    .card-buggy {
+      border-color: transparent;
+      background-color: #f1f5f9; /* hardcoded light grey — the bug */
+    }
+
+    /* Label overlays */
+    .card-label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      padding: 0.2em 0.6em;
+      border-radius: 9999px;
+      display: inline-block;
+      margin-bottom: 0.75rem;
+    }
+
+    .label-bug {
+      background: rgba(239,68,68,0.15);
+      color: #fca5a5;
+    }
+
+    .label-fix {
+      background: rgba(34,197,94,0.15);
+      color: #86efac;
+    }
+
+    .card-desc {
+      font-size: 0.875rem;
+      color: var(--ease-color-muted, #94a3b8);
+      line-height: 1.6;
+      margin-top: 0.5rem;
+    }
+
+    .code-block {
+      background: rgba(0,0,0,0.3);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 0.5rem;
+      padding: 1rem 1.25rem;
+      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-size: 0.8rem;
+      color: #a09af8;
+      margin-top: 2rem;
+      white-space: pre;
+      overflow-x: auto;
+    }
+
+    [data-theme="light"] body,
+    [data-theme="light"] {
+      background-color: #f8fafc;
+      color: #0f172a;
+    }
+
+    [data-theme="light"] .theme-btn {
+      border-color: rgba(0,0,0,0.15);
+      background: rgba(0,0,0,0.04);
+      color: #0f172a;
+    }
+
+    [data-theme="light"] .code-block {
+      background: rgba(0,0,0,0.05);
+      border-color: rgba(0,0,0,0.1);
+      color: #4b44cc;
+    }
+  </style>
+</head>
+<body id="root">
+
+  <h1>Fix: <code>.ease-card-flat</code> Dark Mode</h1>
+  <span class="issue-badge">Bug #14088</span>
+
+  <!-- Theme toggle -->
+  <div class="toggle-row">
+    <span style="font-size:0.875rem; color:#94a3b8;">Toggle theme to see the difference:</span>
+    <button class="theme-btn active" id="btn-dark" onclick="setTheme('dark')">🌙 Dark</button>
+    <button class="theme-btn" id="btn-light" onclick="setTheme('light')">☀️ Light</button>
+  </div>
+
+  <!-- Bug vs Fix side by side -->
+  <div class="section-label">Side-by-side comparison</div>
+  <div class="grid">
+
+    <!-- BUGGY card -->
+    <article class="ease-card card-buggy">
+      <span class="card-label label-bug">❌ Before (Bug)</span>
+      <h3 class="ease-card-title" style="color:#0f172a;">Card Title</h3>
+      <p class="card-desc" style="color:#475569;">
+        This card uses the original <code>.ease-card-flat</code> rule with no
+        dark-mode override. The background is hardcoded to
+        <code>--ease-color-neutral-100</code> (#f1f5f9 — light grey), which
+        makes it visually broken in dark mode.
+      </p>
+    </article>
+
+    <!-- FIXED card -->
+    <article class="ease-card ease-card-flat">
+      <span class="card-label label-fix">✅ After (Fix)</span>
+      <h3 class="ease-card-title">Card Title</h3>
+      <p class="card-desc">
+        This card uses <code>.ease-card-flat</code> with the proposed fix applied.
+        The background now switches to <code>--ease-color-surface</code> (#141e33)
+        in dark mode, consistent with other dark-mode card variants.
+      </p>
+    </article>
+
+  </div>
+
+  <!-- Code block showing the fix -->
+  <div class="section-label">Proposed fix (style.css)</div>
+  <div class="code-block">@media (prefers-color-scheme: dark) {
+  .ease-card-flat {
+    background-color: var(--ease-color-surface, #141e33);
+  }
+}
+
+[data-theme="dark"] .ease-card-flat {
+  background-color: var(--ease-color-surface, #141e33);
+}</div>
+
+  <script>
+    function setTheme(theme) {
+      document.getElementById('root').setAttribute('data-theme', theme);
+      document.getElementById('btn-dark').classList.toggle('active', theme === 'dark');
+      document.getElementById('btn-light').classList.toggle('active', theme === 'light');
+    }
+
+    // Auto-detect system preference on load
+    if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+      setTheme('light');
+    } else {
+      setTheme('dark');
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/fix-14088-ease-card-flat-rs/style.css
+++ b/submissions/examples/fix-14088-ease-card-flat-rs/style.css
@@ -1,0 +1,37 @@
+/* ============================================================
+   Fix: .ease-card-flat dark-mode background override
+   Issue: #14088
+   Author: rs
+   ============================================================
+
+   BUG:
+   .ease-card-flat uses --ease-color-neutral-100 (#f1f5f9) as its
+   background with no dark-mode counterpart. In dark mode it renders
+   as a light grey card — clashing with dark backgrounds.
+
+   FIX:
+   Add @media (prefers-color-scheme: dark) and [data-theme="dark"]
+   overrides that switch the background to --ease-color-surface
+   (#141e33), consistent with how .ease-card-neumorphic and
+   .ease-card-glass handle dark mode in cards.css.
+   ============================================================ */
+
+/* ── Existing rule (unchanged, for reference) ─────────────── */
+/*
+.ease-card-flat {
+  border-color: transparent;
+  background-color: var(--ease-color-neutral-100, #f1f5f9);
+}
+*/
+
+/* ── Proposed fix ─────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .ease-card-flat {
+    background-color: var(--ease-color-surface, #141e33);
+  }
+}
+
+[data-theme="dark"] .ease-card-flat {
+  background-color: var(--ease-color-surface, #141e33);
+}


### PR DESCRIPTION
**fix(submission): `.ease-card-flat` has no dark-mode background override #14088**

## Related Issue
Closes #14088

---

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Chore

---

## Description
`.ease-card-flat` uses `--ease-color-neutral-100` (`#f1f5f9` — light slate grey) as its background with no dark-mode counterpart defined anywhere in the codebase. In dark mode it renders as a jarring light grey card against a dark background, breaking visual consistency across the card system.

The proposed fix adds `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]` overrides that switch the background to `--ease-color-surface` (`#141e33`) — the established dark surface token already used by `.ease-card-neumorphic` and `.ease-card-glass` in `cards.css`.

---

## Changes Made
- `submissions/examples/fix-14088-ease-card-flat-rs/demo.html` — Self-contained side-by-side comparison (bug vs fix) with a live theme toggle
- `submissions/examples/fix-14088-ease-card-flat-rs/style.css` — Proposed CSS overrides for dark mode
- `submissions/examples/fix-14088-ease-card-flat-rs/README.md` — Bug description, proposed fix, and rationale

---

## How to Verify Locally
1. Open `submissions/examples/fix-14088-ease-card-flat-rs/demo.html` in a browser
2. Toggle between Dark and Light using the buttons — or set your system to dark mode
3. **Before fix (left card):** renders as light grey in dark mode
4. **After fix (right card):** renders correctly with dark surface background

---

## Checklist
- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] I have updated the documentation if required
- [x] No existing functionality has been broken
- [x] All checks and linting pass successfully

---

## GSSoC'26 Contributor Declaration
- [x] I confirm that I am a participant of GSSoC'26
- [x] I have followed the contribution guidelines of this project
- [x] This PR is ready for review

---