### PR TITLE
fix(submission): ease-modal-overlay visibility transition not interru…

### DIFF
--- a/submissions/examples/fix-14087-ease-modal-overlay-rs/README.md
+++ b/submissions/examples/fix-14087-ease-modal-overlay-rs/README.md
@@ -1,0 +1,61 @@
+# Fix: `.ease-modal-overlay` visibility transition is not interruptible in all browsers
+
+**Issue:** [#14087](https://github.com/saptarshi-coder/easemotion-css/issues/14087)
+
+---
+
+## 1. What does this do?
+
+Fixes `.ease-modal-overlay` by removing `visibility` from the `transition` shorthand and replacing it with a delayed snap pattern that is fully interruptible in all browsers (Chrome, Firefox, Safari).
+
+---
+
+## 2. How is it used?
+
+No HTML usage changes — the fix is purely in CSS. The class usage stays the same:
+
+```html
+<div id="my-modal" class="ease-modal-overlay">
+  <div class="ease-modal">...</div>
+</div>
+```
+
+**Proposed fix for `components/modals.css`:**
+
+```css
+/* Hidden state: opacity fades out, visibility snaps AFTER fade completes */
+.ease-modal-overlay {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    visibility 0s linear var(--ease-speed-medium, 300ms);
+}
+
+/* Active state: visibility snaps immediately, THEN opacity fades in */
+.ease-modal-overlay:target,
+.ease-modal-overlay.is-active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    opacity var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    visibility 0s linear 0s;
+}
+```
+
+---
+
+## 3. Why is it useful?
+
+`visibility` is a **discrete CSS property** — it does not interpolate between `hidden` and `visible`. When included in a `transition` shorthand, it snaps at the 50% mark of the duration rather than smoothly transitioning. This causes two problems:
+
+1. **Interrupted transitions flicker** — if the modal is opened/closed rapidly, browsers (especially Safari and Firefox) handle the snap inconsistently, causing the overlay to flicker or get stuck.
+2. **Inconsistent cross-browser behavior** — Chrome, Firefox, and Safari all implement the interrupted `visibility` transition differently.
+
+The fix uses the established pattern for cross-browser overlay transitions:
+- **On hide:** `visibility` delays its snap to `hidden` by the full transition duration, so it only hides after `opacity` has fully faded out.
+- **On show:** `visibility` snaps to `visible` immediately (delay `0s`), so the overlay is accessible before `opacity` fades in.
+
+This pattern is fully interruptible — reversing mid-transition works correctly in all browsers.

--- a/submissions/examples/fix-14087-ease-modal-overlay-rs/demo.html
+++ b/submissions/examples/fix-14087-ease-modal-overlay-rs/demo.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #14087 — .ease-modal-overlay visibility transition interruptibility</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../components/buttons.css" />
+  <link rel="stylesheet" href="../../../components/modals.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background-color: var(--ease-color-bg, #0b1121);
+      color: var(--ease-color-text, #e2e8f0);
+      min-height: 100vh;
+      margin: 0;
+      padding: 2rem;
+      box-sizing: border-box;
+    }
+
+    h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 0.25rem; }
+
+    .issue-badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      background: rgba(239, 68, 68, 0.15);
+      color: #fca5a5;
+      border: 1px solid rgba(239, 68, 68, 0.3);
+      padding: 0.2em 0.75em;
+      border-radius: 9999px;
+      margin-bottom: 2rem;
+    }
+
+    .section-label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #94a3b8;
+      margin-bottom: 0.75rem;
+      margin-top: 2rem;
+    }
+
+    .demo-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+
+    /* ── BUGGY overlay: transitions visibility (broken) ──── */
+    .modal-overlay-buggy {
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(15, 23, 42, 0.7);
+      backdrop-filter: blur(4px);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 1000;
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      /* BUG: visibility is a discrete property — not safely interruptible */
+      transition:
+        opacity 300ms ease,
+        visibility 300ms ease;
+    }
+
+    .modal-overlay-buggy.is-active {
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
+    }
+
+    /* ── FIXED overlay: visibility snaps, opacity fades ──── */
+    .modal-overlay-fixed {
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(15, 23, 42, 0.7);
+      backdrop-filter: blur(4px);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 1000;
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      /* FIX: visibility snaps after opacity fades out (delay = transition duration) */
+      transition:
+        opacity 300ms cubic-bezier(0.4, 0, 0.2, 1),
+        visibility 0s linear 300ms;
+    }
+
+    .modal-overlay-fixed.is-active {
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
+      /* FIX: on open, visibility snaps immediately (delay: 0s) */
+      transition:
+        opacity 300ms cubic-bezier(0.4, 0, 0.2, 1),
+        visibility 0s linear 0s;
+    }
+
+    /* Shared modal box */
+    .demo-modal-box {
+      background: var(--ease-color-surface, #141e33);
+      border-radius: 1rem;
+      padding: 2rem;
+      max-width: 400px;
+      width: 90%;
+      border: 1px solid rgba(255,255,255,0.08);
+      box-shadow: 0 25px 50px -12px rgba(0,0,0,0.5);
+      transform: scale(0.9) translateY(-16px);
+      opacity: 0;
+      transition: transform 300ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 300ms ease;
+    }
+
+    .modal-overlay-buggy.is-active .demo-modal-box,
+    .modal-overlay-fixed.is-active .demo-modal-box {
+      transform: scale(1) translateY(0);
+      opacity: 1;
+    }
+
+    .demo-modal-box h3 {
+      margin: 0 0 0.5rem;
+      font-size: 1.1rem;
+      font-weight: 700;
+    }
+
+    .demo-modal-box p {
+      margin: 0 0 1.25rem;
+      font-size: 0.875rem;
+      color: var(--ease-color-muted, #94a3b8);
+      line-height: 1.6;
+    }
+
+    .close-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1.25rem;
+      background: rgba(255,255,255,0.08);
+      border: 1px solid rgba(255,255,255,0.12);
+      border-radius: 9999px;
+      color: #e2e8f0;
+      font-size: 0.875rem;
+      cursor: pointer;
+      transition: background 150ms ease;
+    }
+
+    .close-btn:hover { background: rgba(255,255,255,0.14); }
+
+    .tag-bug {
+      font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+      padding: 0.15em 0.6em; border-radius: 9999px;
+      background: rgba(239,68,68,0.15); color: #fca5a5;
+      display: inline-block; margin-bottom: 1rem;
+    }
+    .tag-fix {
+      font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+      padding: 0.15em 0.6em; border-radius: 9999px;
+      background: rgba(34,197,94,0.15); color: #86efac;
+      display: inline-block; margin-bottom: 1rem;
+    }
+
+    .hint {
+      font-size: 0.8rem;
+      color: #64748b;
+      margin-top: 0.5rem;
+    }
+
+    .code-block {
+      background: rgba(0,0,0,0.3);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 0.5rem;
+      padding: 1rem 1.25rem;
+      font-family: monospace;
+      font-size: 0.78rem;
+      color: #a09af8;
+      white-space: pre;
+      overflow-x: auto;
+      margin-top: 1rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Fix: <code>.ease-modal-overlay</code> visibility transition</h1>
+  <span class="issue-badge">Bug #14087</span>
+
+  <div class="section-label">Demo — rapidly open/close both modals to see the difference</div>
+
+  <div class="demo-row">
+    <!-- Buggy modal trigger -->
+    <div>
+      <p class="hint" style="margin:0 0 0.5rem;">❌ Buggy (transitions visibility)</p>
+      <button class="ease-btn ease-btn-danger" onclick="document.getElementById('modal-buggy').classList.add('is-active')">
+        Open Buggy Modal
+      </button>
+    </div>
+
+    <!-- Fixed modal trigger -->
+    <div>
+      <p class="hint" style="margin:0 0 0.5rem;">✅ Fixed (opacity + delayed visibility)</p>
+      <button class="ease-btn ease-btn-success" onclick="document.getElementById('modal-fixed').classList.add('is-active')">
+        Open Fixed Modal
+      </button>
+    </div>
+  </div>
+
+  <!-- BUGGY MODAL -->
+  <div id="modal-buggy" class="modal-overlay-buggy" onclick="if(event.target===this) this.classList.remove('is-active')">
+    <div class="demo-modal-box">
+      <span class="tag-bug">❌ Buggy</span>
+      <h3>Buggy Modal</h3>
+      <p>
+        This overlay transitions <code>visibility</code> directly.
+        Rapidly closing and reopening may cause a flicker or the overlay
+        to get stuck in Safari/Firefox.
+      </p>
+      <button class="close-btn" onclick="document.getElementById('modal-buggy').classList.remove('is-active')">
+        Close ✕
+      </button>
+    </div>
+  </div>
+
+  <!-- FIXED MODAL -->
+  <div id="modal-fixed" class="modal-overlay-fixed" onclick="if(event.target===this) this.classList.remove('is-active')">
+    <div class="demo-modal-box">
+      <span class="tag-fix">✅ Fixed</span>
+      <h3>Fixed Modal</h3>
+      <p>
+        This overlay transitions only <code>opacity</code>. Visibility snaps
+        immediately on open and delays (equals transition duration) on close —
+        fully interruptible in all browsers.
+      </p>
+      <button class="close-btn" onclick="document.getElementById('modal-fixed').classList.remove('is-active')">
+        Close ✕
+      </button>
+    </div>
+  </div>
+
+  <!-- Code explanation -->
+  <div class="section-label">Proposed fix</div>
+  <div class="code-block">/* BUGGY: visibility transitions are discrete — not safely interruptible */
+.ease-modal-overlay {
+  transition:
+    opacity 300ms ease,
+    visibility 300ms ease; /* ← problem */
+}
+
+/* FIXED: opacity fades smoothly; visibility snaps after fade completes */
+.ease-modal-overlay {
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 300ms cubic-bezier(0.4, 0, 0.2, 1),
+    visibility 0s linear 300ms; /* delay = transition duration */
+}
+
+/* On open: snap visibility immediately, then fade opacity in */
+.ease-modal-overlay.is-active {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity 300ms cubic-bezier(0.4, 0, 0.2, 1),
+    visibility 0s linear 0s; /* no delay on open */
+}</div>
+
+</body>
+</html>

--- a/submissions/examples/fix-14087-ease-modal-overlay-rs/style.css
+++ b/submissions/examples/fix-14087-ease-modal-overlay-rs/style.css
@@ -1,0 +1,84 @@
+/* ============================================================
+   Fix: .ease-modal-overlay visibility transition is not
+        interruptible in all browsers
+   Issue: #14087
+   Author: rs
+   ============================================================
+
+   BUG:
+   .ease-modal-overlay transitions both `opacity` and `visibility`.
+   The `visibility` property does not transition smoothly — it is a
+   discrete property that snaps between hidden/visible instantly at
+   the transition midpoint. In browsers like Safari and Firefox, if
+   the transition is interrupted mid-way (e.g. rapidly opening and
+   closing the modal), `visibility` snaps to its final value instead
+   of reversing gracefully, causing the overlay to flicker or become
+   permanently hidden/visible.
+
+   CURRENT (BUGGY) CODE:
+   transition:
+     opacity var(--ease-speed-medium, 0.25s) var(--ease-ease, ease),
+     visibility var(--ease-speed-medium, 0.25s) var(--ease-ease, ease);
+
+   ROOT CAUSE:
+   `visibility` is a discrete CSS property. Including it in a
+   `transition` shorthand causes it to jump at the 50% mark of the
+   transition duration rather than interpolating. When interrupted,
+   browsers handle this jump differently — Safari and Firefox snap
+   visibility immediately while Chrome may defer it, leading to
+   inconsistent rendering.
+
+   FIX:
+   Remove `visibility` from the transition entirely and control the
+   hidden state exclusively through `opacity` and `pointer-events`.
+   This is the established cross-browser pattern for overlay show/hide.
+   `pointer-events: none` blocks all interaction when hidden, making
+   `visibility: hidden` redundant.
+
+   For modern browsers (Chrome 117+, Firefox 117+), also add:
+     transition-behavior: allow-discrete;
+   so that `display` can participate in transitions if needed in future.
+   ============================================================ */
+
+/* ── Proposed fix ─────────────────────────────────────────── */
+
+/*
+  STEP 1: Remove `visibility` from the overlay transition.
+  Keep `pointer-events: none` on the hidden state (already present)
+  to prevent interaction while invisible — this replaces the role
+  of `visibility: hidden`.
+*/
+.ease-modal-overlay {
+  transition:
+    opacity var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+/*
+  STEP 2: Since we're no longer transitioning `visibility`, we
+  can still keep `visibility: hidden` on the hidden state for
+  accessibility (screen readers respect visibility:hidden).
+  But remove it from the transition list so it snaps instantly
+  to hidden only AFTER the opacity transition completes.
+
+  We achieve the delay-snap using transition-delay on visibility:
+*/
+.ease-modal-overlay {
+  visibility: hidden;
+  transition:
+    opacity var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    visibility 0s var(--ease-ease, linear) var(--ease-speed-medium, 300ms);
+}
+
+/*
+  STEP 3: On active state, snap visibility to visible IMMEDIATELY
+  (delay: 0s) so the overlay appears before the opacity animates in.
+*/
+.ease-modal-overlay:target,
+.ease-modal-overlay.is-active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    opacity var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    visibility 0s linear 0s;
+}


### PR DESCRIPTION
**fix(submission): `.ease-modal-overlay` visibility transition is not interruptible in all browsers #14087**

## Related Issue
Closes #14087

---

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Chore

---

## Description
`.ease-modal-overlay` currently transitions both `opacity` and `visibility` in its `transition` shorthand. `visibility` is a **discrete CSS property** — it does not interpolate; it snaps at the 50% mark of the duration. When a transition is interrupted mid-way (e.g. rapidly opening and closing the modal), browsers handle this snap inconsistently: Safari and Firefox may snap `visibility` immediately while Chrome defers it, causing overlays to flicker or become permanently stuck.

The fix applies the established cross-browser safe pattern:
- **On close:** `visibility` delays snapping to `hidden` by the full transition duration — it only hides *after* `opacity` fully fades out
- **On open:** `visibility` snaps to `visible` immediately (delay `0s`) — overlay is accessible *before* `opacity` fades in

This makes the transition fully interruptible in all browsers.

---

## Changes Made
- `submissions/examples/fix-14087-ease-modal-overlay-rs/demo.html` — Side-by-side buggy vs fixed modal demo; rapidly open/close both to observe the difference
- `submissions/examples/fix-14087-ease-modal-overlay-rs/style.css` — Proposed transition fix with detailed comments explaining root cause
- `submissions/examples/fix-14087-ease-modal-overlay-rs/README.md` — Root cause analysis, proposed fix, and rationale

---

## How to Verify Locally
1. Open `submissions/examples/fix-14087-ease-modal-overlay-rs/demo.html`
2. Rapidly click **Open → Close → Open** on the **Buggy Modal** — observe flickering/stuck overlay in Firefox/Safari
3. Do the same with the **Fixed Modal** — transitions reverse smoothly every time

---

## Checklist
- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] I have updated the documentation if required
- [x] No existing functionality has been broken
- [x] All checks and linting pass successfully

---

## GSSoC'26 Contributor Declaration
- [x] I confirm that I am a participant of GSSoC'26
- [x] I have followed the contribution guidelines of this project
- [x] This PR is ready for review

---