### PR TITLE
fix(submission): ease-stat-value uses 2.5em causing unpredictable sca…

### DIFF
--- a/submissions/examples/fix-14086-ease-card-stat-rs/README.md
+++ b/submissions/examples/fix-14086-ease-card-stat-rs/README.md
@@ -1,0 +1,57 @@
+# Fix: `.ease-card-stat .ease-stat-value` uses `2.5em` — unpredictable scaling when nested
+
+**Issue:** [#14086](https://github.com/saptarshi-coder/easemotion-css/issues/14086)
+
+---
+
+## 1. What does this do?
+
+Fixes `.ease-stat-value` and `.ease-stat-label` by replacing `em` units with `rem`/token-based units so the stat card renders consistently regardless of which parent component it is nested inside.
+
+---
+
+## 2. How is it used?
+
+No HTML changes needed. The fix is purely in CSS:
+
+```html
+<!-- Usage unchanged -->
+<div class="ease-card ease-card-stat">
+  <div class="ease-stat-value">1,240</div>
+  <div class="ease-stat-label">Total Users</div>
+</div>
+```
+
+**Proposed fix for `components/cards.css`:**
+
+```css
+/* BEFORE (buggy) */
+.ease-card-stat .ease-stat-value {
+  font-size: 2.5em;   /* compounds with inherited parent font-size */
+}
+.ease-card-stat .ease-stat-label {
+  font-size: 0.875em; /* same issue */
+}
+
+/* AFTER (fixed) */
+.ease-card-stat .ease-stat-value {
+  font-size: 2.5rem;  /* always root-relative — 40px regardless of nesting */
+}
+.ease-card-stat .ease-stat-label {
+  font-size: var(--ease-text-sm, 0.875rem); /* uses existing rem-based token */
+}
+```
+
+---
+
+## 3. Why is it useful?
+
+The `em` unit is relative to the **current element's inherited font-size**, not the root. When `.ease-card-stat` is nested inside components that set their own `font-size` (modals, sidebars, hero sections, utility classes like `ease-text-sm`), `2.5em` compounds on top of that inherited value — producing stat values wildly different from the intended `40px`.
+
+| Context | Parent font-size | `2.5em` result | Expected |
+|---|---|---|---|
+| Standalone | 16px | 40px ✅ | 40px |
+| Hero section | 22px | 55px ⚠️ | 40px |
+| Sidebar | 13px | 32.5px ⚠️ | 40px |
+
+Switching to `rem` makes `.ease-stat-value` always resolve to `40px` (assuming standard 16px root), regardless of nesting depth or parent font-size — which is the predictable, component-safe behavior.

--- a/submissions/examples/fix-14086-ease-card-stat-rs/demo.html
+++ b/submissions/examples/fix-14086-ease-card-stat-rs/demo.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #14086 — .ease-stat-value 2.5em unpredictable scaling</title>
+
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="../../../core/base.css" />
+  <link rel="stylesheet" href="../../../components/cards.css" />
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background-color: var(--ease-color-bg, #0b1121);
+      color: var(--ease-color-text, #e2e8f0);
+      min-height: 100vh;
+      margin: 0;
+      padding: 2rem;
+      box-sizing: border-box;
+    }
+
+    h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 0.25rem; }
+
+    .issue-badge {
+      display: inline-block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      background: rgba(239, 68, 68, 0.15);
+      color: #fca5a5;
+      border: 1px solid rgba(239, 68, 68, 0.3);
+      padding: 0.2em 0.75em;
+      border-radius: 9999px;
+      margin-bottom: 2rem;
+    }
+
+    .section-label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #94a3b8;
+      margin-bottom: 0.75rem;
+      margin-top: 2rem;
+    }
+
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1.5rem; }
+
+    .scenario-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #94a3b8;
+      margin-bottom: 0.75rem;
+      font-family: monospace;
+    }
+
+    /* Simulate parent components with different font-sizes */
+    .parent-normal  { font-size: 16px; }   /* baseline */
+    .parent-large   { font-size: 22px; }   /* e.g. a hero section */
+    .parent-small   { font-size: 13px; }   /* e.g. a sidebar */
+
+    /* BUGGY: keep em as-is to show the problem */
+    .stat-value-buggy {
+      font-size: 2.5em;  /* compounds with parent */
+      font-weight: 700;
+      color: var(--ease-color-primary, #6c63ff);
+      line-height: 1;
+      margin-bottom: 0.5rem;
+    }
+
+    /* FIXED: use rem — always relative to root */
+    .stat-value-fixed {
+      font-size: 2.5rem; /* always 40px regardless of parent */
+      font-weight: 700;
+      color: var(--ease-color-success, #15803d);
+      line-height: 1;
+      margin-bottom: 0.5rem;
+    }
+
+    .stat-label {
+      font-size: var(--ease-text-sm, 0.875rem);
+      color: var(--ease-color-muted, #94a3b8);
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .tag-bug {
+      font-size: 0.68rem; font-weight: 700; text-transform: uppercase;
+      padding: 0.15em 0.6em; border-radius: 9999px;
+      background: rgba(239,68,68,0.15); color: #fca5a5;
+      display: inline-block; margin-bottom: 0.75rem;
+    }
+    .tag-fix {
+      font-size: 0.68rem; font-weight: 700; text-transform: uppercase;
+      padding: 0.15em 0.6em; border-radius: 9999px;
+      background: rgba(34,197,94,0.15); color: #86efac;
+      display: inline-block; margin-bottom: 0.75rem;
+    }
+
+    .size-annotation {
+      font-size: 0.7rem;
+      color: #64748b;
+      font-family: monospace;
+      margin-top: 0.35rem;
+    }
+
+    .code-block {
+      background: rgba(0,0,0,0.3);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 0.5rem;
+      padding: 1rem 1.25rem;
+      font-family: monospace;
+      font-size: 0.78rem;
+      color: #a09af8;
+      white-space: pre;
+      overflow-x: auto;
+      margin-top: 1rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Fix: <code>.ease-stat-value</code> em scaling</h1>
+  <span class="issue-badge">Bug #14086</span>
+
+  <!-- BUG DEMO -->
+  <div class="section-label">❌ Bug — 2.5em compounds with parent font-size</div>
+  <div class="grid">
+
+    <div class="ease-card parent-normal">
+      <span class="tag-bug">Parent font-size: 16px</span>
+      <div class="ease-card-stat" style="font-size:inherit; padding:1rem 0 0;">
+        <div class="stat-value-buggy">1,240</div>
+        <div class="size-annotation">2.5em × 16px = 40px</div>
+        <div class="stat-label">Total Users</div>
+      </div>
+    </div>
+
+    <div class="ease-card parent-large">
+      <span class="tag-bug">Parent font-size: 22px (hero)</span>
+      <div class="ease-card-stat" style="font-size:inherit; padding:1rem 0 0;">
+        <div class="stat-value-buggy">1,240</div>
+        <div class="size-annotation">2.5em × 22px = 55px ⚠️ Too big</div>
+        <div class="stat-label">Total Users</div>
+      </div>
+    </div>
+
+    <div class="ease-card parent-small">
+      <span class="tag-bug">Parent font-size: 13px (sidebar)</span>
+      <div class="ease-card-stat" style="font-size:inherit; padding:1rem 0 0;">
+        <div class="stat-value-buggy">1,240</div>
+        <div class="size-annotation">2.5em × 13px = 32.5px ⚠️ Too small</div>
+        <div class="stat-label">Total Users</div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- FIX DEMO -->
+  <div class="section-label">✅ Fix — 2.5rem is always root-relative (40px)</div>
+  <div class="grid">
+
+    <div class="ease-card parent-normal">
+      <span class="tag-fix">Parent font-size: 16px</span>
+      <div class="ease-card-stat" style="font-size:inherit; padding:1rem 0 0;">
+        <div class="stat-value-fixed">1,240</div>
+        <div class="size-annotation">2.5rem = 40px ✅</div>
+        <div class="stat-label">Total Users</div>
+      </div>
+    </div>
+
+    <div class="ease-card parent-large">
+      <span class="tag-fix">Parent font-size: 22px (hero)</span>
+      <div class="ease-card-stat" style="font-size:inherit; padding:1rem 0 0;">
+        <div class="stat-value-fixed">1,240</div>
+        <div class="size-annotation">2.5rem = 40px ✅ Consistent</div>
+        <div class="stat-label">Total Users</div>
+      </div>
+    </div>
+
+    <div class="ease-card parent-small">
+      <span class="tag-fix">Parent font-size: 13px (sidebar)</span>
+      <div class="ease-card-stat" style="font-size:inherit; padding:1rem 0 0;">
+        <div class="stat-value-fixed">1,240</div>
+        <div class="size-annotation">2.5rem = 40px ✅ Consistent</div>
+        <div class="stat-label">Total Users</div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- Code explanation -->
+  <div class="section-label">Proposed fix</div>
+  <div class="code-block">/* BUGGY: em compounds with inherited parent font-size */
+.ease-card-stat .ease-stat-value {
+  font-size: 2.5em; /* ← scales unpredictably when nested */
+}
+
+/* FIXED: rem is always relative to root (html) font-size */
+.ease-card-stat .ease-stat-value {
+  font-size: 2.5rem; /* ← always 40px, regardless of parent */
+}
+
+/* Also fix .ease-stat-label: use rem-based token */
+.ease-card-stat .ease-stat-label {
+  font-size: var(--ease-text-sm, 0.875rem); /* ← was 0.875em */
+}</div>
+
+</body>
+</html>

--- a/submissions/examples/fix-14086-ease-card-stat-rs/style.css
+++ b/submissions/examples/fix-14086-ease-card-stat-rs/style.css
@@ -1,0 +1,46 @@
+/* ============================================================
+   Fix: .ease-card-stat .ease-stat-value uses 2.5em which scales
+        relative to the parent component's font-size — causing
+        unpredictable sizing when nested inside other components.
+   Issue: #14086
+   Author: rs
+   ============================================================
+
+   BUG:
+   .ease-card-stat sets `font-size: var(--ease-text-base, 16px)` on
+   the card, and .ease-stat-value uses `font-size: 2.5em`. The `em`
+   unit is relative to the *current* element's font-size which is
+   inherited from the parent. When .ease-card-stat is nested inside
+   a component that sets its own font-size (e.g. a sidebar, modal,
+   or utility class like ease-text-sm), the stat value inherits that
+   font-size and 2.5em compounds on top of it — producing values
+   wildly different from the intended 40px.
+
+   EXAMPLE OF UNPREDICTABLE SCALING:
+   - Standalone card (16px base): 2.5em = 40px ✅ (intended)
+   - Inside .ease-modal (18px base): 2.5em = 45px ⚠️
+   - Inside .ease-text-sm (14px base): 2.5em = 35px ⚠️
+   - Inside another card: compounds further ❌
+
+   FIX:
+   Replace `2.5em` with `2.5rem` (root-relative). `rem` always
+   refers to the root <html> font-size (typically 16px), making
+   the stat value consistently 40px regardless of nesting depth
+   or parent component font-size.
+
+   Also fix `.ease-stat-label` which uses `0.875em` for the same
+   reason — replace with `var(--ease-text-sm, 0.875rem)` which is
+   already a rem-based token.
+   ============================================================ */
+
+/* ── Proposed fix ─────────────────────────────────────────── */
+
+.ease-card-stat .ease-stat-value {
+  /* FIX: rem instead of em — root-relative, not parent-relative */
+  font-size: 2.5rem;
+}
+
+.ease-card-stat .ease-stat-label {
+  /* FIX: use the existing rem-based token instead of em */
+  font-size: var(--ease-text-sm, 0.875rem);
+}


### PR DESCRIPTION
**fix(submission): `.ease-card-stat .ease-stat-value` uses `2.5em` — unpredictable scaling when nested #14086**

## Related Issue
Closes #14086

---

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Chore

---

## Description
`.ease-card-stat .ease-stat-value` uses `font-size: 2.5em` which is relative to the *inherited* parent font-size. When `.ease-card-stat` is nested inside any component that sets its own font-size (modals, sidebars, hero sections, or utility classes like `ease-text-sm`), the value compounds — producing stat numbers wildly different from the intended `40px`.

| Context | Parent font-size | `2.5em` result | Expected |
|---|---|---|---|
| Standalone | 16px | 40px ✅ | 40px |
| Hero section | 22px | 55px ⚠️ | 40px |
| Sidebar | 13px | 32.5px ⚠️ | 40px |

The fix replaces `2.5em` with `2.5rem` (root-relative) so `.ease-stat-value` always resolves to `40px` regardless of nesting depth. Also fixes `.ease-stat-label` (`0.875em` → `var(--ease-text-sm, 0.875rem)`) for the same reason.

---

## Changes Made
- `submissions/examples/fix-14086-ease-card-stat-rs/demo.html` — 6-card grid showing em vs rem across 3 parent font-size contexts (16px / 22px / 13px)
- `submissions/examples/fix-14086-ease-card-stat-rs/style.css` — Proposed rem-based fix with root cause comments
- `submissions/examples/fix-14086-ease-card-stat-rs/README.md` — Before/after comparison table and fix rationale

---

## How to Verify Locally
1. Open `submissions/examples/fix-14086-ease-card-stat-rs/demo.html`
2. Top row (❌ Bug): notice the stat value size changes across the 3 cards
3. Bottom row (✅ Fix): all 3 stat values are the same size regardless of parent

---

## Checklist
- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] I have updated the documentation if required
- [x] No existing functionality has been broken
- [x] All checks and linting pass successfully

---

## GSSoC'26 Contributor Declaration
- [x] I confirm that I am a participant of GSSoC'26
- [x] I have followed the contribution guidelines of this project
- [x] This PR is ready for review

---