### PR TITLE
fix(submission): fix tabs nav border layer cascade #14085

### DIFF
--- a/submissions/examples/fix-14085-ease-tabs-nav-border-layer-cascade-rs/README.md
+++ b/submissions/examples/fix-14085-ease-tabs-nav-border-layer-cascade-rs/README.md
@@ -1,0 +1,19 @@
+# Fix for Issue #14085: Tabs Nav Border Layer Cascade
+
+## The Bug
+The `.ease-tabs-nav` class uses `border-bottom: 2px solid var(--ease-color-neutral-200);` to create the horizontal track line for the tabs. Because EaseMotion CSS properly encapsulates its styles inside cascade layers (e.g., `@layer easemotion-components`), these styles have a lower specificity priority than unlayered styles. 
+
+When users apply a global unlayered CSS reset—such as Tailwind CSS's Preflight, which applies `* { border-width: 0; }`—the unlayered reset overrides the layered `.ease-tabs-nav` border, causing the visual track line to disappear.
+
+## The Fix
+This fix replaces the `border-bottom` property with an equivalent `box-shadow` property:
+`box-shadow: inset 0 -2px 0 0 var(--ease-color-neutral-200);`
+
+Since global CSS resets typically reset `border` properties but leave `box-shadow` alone, this change ensures the tabs navigation track remains visible regardless of whether the user includes unlayered resets like Tailwind's Preflight.
+
+The same fix logic is also applied to the fallback active tab indicator for `ease-tabs-auto`.
+
+## How to Verify
+1. Open `demo.html` in your browser.
+2. The "Before" section demonstrates the bug: an injected global `* { border-width: 0; }` reset removes the border, making the tab track invisible.
+3. The "After" section demonstrates the fix: by using `box-shadow`, the track is restored and the design intent is preserved despite the unlayered reset.

--- a/submissions/examples/fix-14085-ease-tabs-nav-border-layer-cascade-rs/demo.html
+++ b/submissions/examples/fix-14085-ease-tabs-nav-border-layer-cascade-rs/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Bug Fix: Ease Tabs Nav Border Layer Cascade</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    /* Simulated Unlayered Reset (e.g. Tailwind Preflight) */
+    *, ::before, ::after {
+      border-width: 0;
+      border-style: solid;
+    }
+    
+    body {
+      padding: 2rem;
+      font-family: sans-serif;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+  </style>
+</head>
+<body>
+  <h1>Fix for #14085: Tabs Nav Border Layer Cascade</h1>
+  <p>When an unlayered CSS reset (like Tailwind's Preflight) applies <code>* { border-width: 0; }</code>, it overrides the layered <code>border-bottom: 2px</code> on <code>.ease-tabs-nav</code> because unlayered styles have higher priority than layered ones.</p>
+  
+  <h2>Before (Broken by Unlayered Reset)</h2>
+  <div class="ease-tabs demo-broken">
+    <input type="radio" name="tab-group-1" id="tab-1-1" class="ease-tab-input" checked>
+    <input type="radio" name="tab-group-1" id="tab-1-2" class="ease-tab-input">
+    
+    <div class="ease-tabs-nav">
+      <label for="tab-1-1" class="ease-tab-label">Tab 1</label>
+      <label for="tab-1-2" class="ease-tab-label">Tab 2</label>
+      <div class="ease-tab-underline"></div>
+    </div>
+    
+    <div class="ease-tabs-content">
+      <div class="ease-tab-panel">Content for Tab 1</div>
+      <div class="ease-tab-panel">Content for Tab 2</div>
+    </div>
+  </div>
+
+  <h2 style="margin-top: 3rem;">After (Fixed using box-shadow)</h2>
+  <p>By replacing <code>border-bottom</code> with <code>box-shadow: inset 0 -2px 0 0</code>, the visual line is retained because <code>box-shadow</code> is not typically reset globally.</p>
+  <div class="ease-tabs demo-fixed">
+    <input type="radio" name="tab-group-2" id="tab-2-1" class="ease-tab-input" checked>
+    <input type="radio" name="tab-group-2" id="tab-2-2" class="ease-tab-input">
+    
+    <div class="ease-tabs-nav">
+      <label for="tab-2-1" class="ease-tab-label">Tab 1</label>
+      <label for="tab-2-2" class="ease-tab-label">Tab 2</label>
+      <div class="ease-tab-underline"></div>
+    </div>
+    
+    <div class="ease-tabs-content">
+      <div class="ease-tab-panel">Content for Tab 1</div>
+      <div class="ease-tab-panel">Content for Tab 2</div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/fix-14085-ease-tabs-nav-border-layer-cascade-rs/style.css
+++ b/submissions/examples/fix-14085-ease-tabs-nav-border-layer-cascade-rs/style.css
@@ -1,0 +1,40 @@
+/* ========================================================================
+   Fix for Issue #14085
+   Bug: .ease-tabs-nav border-bottom: 2px is outside the layer cascade
+        and is overridden by unlayered user styles (like Tailwind reset).
+   Fix: Replace border-bottom with an inset box-shadow which survives
+        global unlayered border resets.
+   ======================================================================== */
+
+@layer easemotion-components {
+  /* Fix for main tabs-nav border */
+  .demo-fixed .ease-tabs-nav {
+    border-bottom: 0; /* Clear the original if needed */
+    box-shadow: inset 0 -2px 0 0 var(--ease-color-neutral-200);
+  }
+
+  /* Fix for the fallback static active indicator for auto-width tabs */
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(1):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(1),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(2):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(2),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(3):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(3),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(4):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(4),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(5):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(5),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(6):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(6),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(7):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(7),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(8):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(8),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(9):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(9),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(10):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(10),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(11):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(11),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(12):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(12),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(13):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(13),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(14):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(14),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(15):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(15),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(16):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(16),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(17):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(17),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(18):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(18),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(19):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(19),
+  .demo-fixed.ease-tabs-auto .ease-tab-input:nth-of-type(20):checked ~ .ease-tabs-nav .ease-tab-label:nth-of-type(20) {
+    border-bottom: 0; /* Clear the original */
+    box-shadow: inset 0 -2px 0 0 var(--ease-color-primary);
+  }
+}


### PR DESCRIPTION
**fix(submission): fix tabs nav border layer cascade issue #14085**

## Related Issue  
Closes #14085

---
## Type of Change
- [x] Bug Fix  
- [ ] New Feature  
- [ ] Documentation Update  
- [ ] Refactor  
- [ ] Chore

---
## Description
This PR addresses an issue where the horizontal track line for tabs navigation (`border-bottom: 2px`) disappears when a global unlayered CSS reset (like Tailwind's Preflight) is applied. Since unlayered styles take precedence over the framework's layered styles (`@layer easemotion-components`), the `border-width: 0;` reset was overriding the `border-bottom` property. 

To fix this, the `border-bottom` property has been replaced with an equivalent `box-shadow` property (`box-shadow: inset 0 -2px 0 0 ...`). Because global CSS resets typically target `border` properties but leave `box-shadow` alone, this change ensures the tabs track remains visible regardless of user-provided unlayered resets. This logic is also applied to the `ease-tabs-auto` fallback indicator.

---
## Changes Made
- `submissions/examples/fix-14085-ease-tabs-nav-border-layer-cascade-rs/demo.html` — A self-contained HTML page that simulates an unlayered CSS reset, visually demonstrating the bug on original styles and the fix applied side-by-side.
- `submissions/examples/fix-14085-ease-tabs-nav-border-layer-cascade-rs/style.css` — The CSS code containing the proposed `box-shadow` fix to resolve the cascade override issue.
- `submissions/examples/fix-14085-ease-tabs-nav-border-layer-cascade-rs/README.md` — Detailed explanation of why the bug occurs due to layer specificity and how `box-shadow` fixes it.

---
## How to Verify Locally
1. Checkout the branch locally (`fix/14085-ease-tabs-nav-border-layer-cascade`).
2. Open `submissions/examples/fix-14085-ease-tabs-nav-border-layer-cascade-rs/demo.html` in your web browser.
3. Observe the "Before" section where the unlayered CSS reset causes the original tab track line to vanish.
4. Observe the "After" section where the `box-shadow` properly restores the tab line, resolving the override issue while maintaining the visual design.

---
## Checklist
- [x] My code follows the project's coding style  
- [x] I have tested my changes locally  
- [x] I have updated the documentation if required  
- [x] No existing functionality has been broken  
- [x] All checks and linting pass successfully

---
## GSSoC'26 Contributor Declaration
- [x] I confirm that I am a participant of GSSoC'26  
- [x] I have followed the contribution guidelines of this project  
- [x] This PR is ready for review

---