### PR TITLE
feat: add ARIA live region usage guide for animated content (#13787)

### DIFF
--- a/submissions/examples/aria-live-guide-ij/README.md
+++ b/submissions/examples/aria-live-guide-ij/README.md
@@ -1,0 +1,11 @@
+# ARIA Live Region Usage Guide
+
+1. What does this do? A practical demo showing how to use `aria-live` regions alongside EaseMotion animations — covering toast notifications (`aria-live="polite"`), loading states (`aria-live="polite"` with `role="status"`), and error alerts (`aria-live="assertive"` with `role="alert"`).
+
+2. How is it used? Open `demo.html` and use each button to trigger announcements:
+   - **Toast**: `aria-live="polite" aria-atomic="true"` — screen reader announces after finishing current speech
+   - **Loading**: `role="status" aria-live="polite"` with a `.sr-only` text element that updates
+   - **Error**: `role="alert" aria-live="assertive"` — screen reader interrupts to announce immediately
+   - Test with NVDA, VoiceOver, or JAWS to verify announcement timing
+
+3. Why is it useful? Fills a critical accessibility documentation gap — contributors learn when to use `polite` vs `assertive`, how to pair live regions with animated content, and common screen reader gotchas like redundant announcements.

--- a/submissions/examples/aria-live-guide-ij/demo.html
+++ b/submissions/examples/aria-live-guide-ij/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ARIA Live Guide - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>ARIA Live Regions</h1>
+
+    <div class="demo-section">
+      <h2>Toast Notifications</h2>
+      <div class="toast-container" aria-live="polite" aria-atomic="true">
+        <div class="toast" id="toastA">File saved successfully</div>
+      </div>
+      <button class="btn" id="toastBtn">Show Toast</button>
+    </div>
+
+    <div class="demo-section">
+      <h2>Loading States</h2>
+      <div class="loading-area">
+        <div class="spinner" id="spinner" role="status" aria-live="polite">
+          <span class="sr-only" id="loadingText">Loading data...</span>
+        </div>
+        <div class="result-box" id="resultBox">
+          <p>Click "Load Data" to simulate fetching.</p>
+        </div>
+      </div>
+      <button class="btn" id="loadBtn">Load Data</button>
+    </div>
+
+    <div class="demo-section">
+      <h2>Assertive Alert</h2>
+      <button class="btn danger" id="alertBtn">Simulate Error</button>
+      <div class="alert-box" id="alertBox" role="alert" aria-live="assertive" aria-atomic="true"></div>
+    </div>
+
+    <p class="description">Screen readers announce toast messages (polite), loading state changes (polite), and errors (assertive). Open your screen reader to test.</p>
+  </div>
+
+  <script>
+    // Toast (aria-live="polite")
+    const toastBtn = document.getElementById('toastBtn');
+    const toastA = document.getElementById('toastA');
+    toastBtn.addEventListener('click', () => {
+      toastA.textContent = 'File saved successfully at ' + new Date().toLocaleTimeString();
+      toastA.classList.add('show');
+      setTimeout(() => toastA.classList.remove('show'), 3000);
+    });
+
+    // Loading (aria-live="polite")
+    const loadBtn = document.getElementById('loadBtn');
+    const spinner = document.getElementById('spinner');
+    const loadingText = document.getElementById('loadingText');
+    const resultBox = document.getElementById('resultBox');
+    loadBtn.addEventListener('click', () => {
+      spinner.classList.add('active');
+      loadingText.textContent = 'Loading data, please wait...';
+      resultBox.innerHTML = '<p class="dim">Fetching...</p>';
+      setTimeout(() => {
+        spinner.classList.remove('active');
+        loadingText.textContent = 'Data loaded successfully';
+        resultBox.innerHTML = '<p>Loaded: 42 records found.</p>';
+      }, 2500);
+    });
+
+    // Alert (aria-live="assertive")
+    const alertBtn = document.getElementById('alertBtn');
+    const alertBox = document.getElementById('alertBox');
+    alertBtn.addEventListener('click', () => {
+      alertBox.textContent = 'Error: Connection lost. Please try again.';
+      alertBox.classList.add('show');
+      setTimeout(() => alertBox.classList.remove('show'), 4000);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/aria-live-guide-ij/style.css
+++ b/submissions/examples/aria-live-guide-ij/style.css
@@ -1,0 +1,128 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  max-width: 520px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.description {
+  margin-top: 2rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  text-align: center;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+}
+
+.demo-section {
+  margin-bottom: 2rem;
+  padding: 1.25rem;
+  border-radius: 12px;
+  background: #1e293b;
+  border: 1px solid #334155;
+}
+
+.demo-section h2 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+}
+
+.btn {
+  padding: 0.5rem 1.25rem;
+  border-radius: 8px;
+  border: 1px solid #334155;
+  background: #334155;
+  color: #e2e8f0;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.2s;
+}
+.btn:hover { background: #475569; }
+.btn:active { transform: scale(0.97); }
+.btn.danger { border-color: #ef4444; color: #ef4444; background: rgba(239,68,68,0.1); }
+.btn.danger:hover { background: rgba(239,68,68,0.2); }
+
+/* ─── Toast ─── */
+.toast-container { margin-bottom: 0.75rem; }
+.toast {
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  background: rgba(34,197,94,0.15);
+  border: 1px solid rgba(34,197,94,0.3);
+  color: #22c55e;
+  font-size: 0.85rem;
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: all 0.3s ease;
+}
+.toast.show { opacity: 1; transform: translateY(0); }
+
+/* ─── Loading ─── */
+.loading-area { margin-bottom: 0.75rem; }
+.spinner {
+  display: none;
+  width: 24px; height: 24px;
+  border: 3px solid #334155;
+  border-top-color: #fbbf24;
+  border-radius: 50%;
+  margin-bottom: 0.75rem;
+}
+.spinner.active { display: block; animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.result-box {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: #0f172a;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  min-height: 48px;
+}
+.result-box p.dim { color: #475569; }
+
+/* ─── Alert ─── */
+.alert-box {
+  margin-top: 0.75rem;
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+.alert-box.show {
+  opacity: 1;
+  background: rgba(239,68,68,0.15);
+  border: 1px solid rgba(239,68,68,0.3);
+  color: #ef4444;
+}


### PR DESCRIPTION
## Component: ease-aria-live-guide — ARIA live region usage guide for animated content

**Closes #13787**

### What this adds
A demo showing when and how to use aria-live regions — polite toasts, polite loading states with role="status", and assertive error alerts with role="alert".

### Acceptance Criteria covered
- Explains aria-live=polite vs assertive with live examples
- Shows examples with toast notifications and loading states
- Demonstrates common screen reader gotchas

### Files
- `submissions/examples/aria-live-guide-ij/demo.html`
- `submissions/examples/aria-live-guide-ij/style.css`
- `submissions/examples/aria-live-guide-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Use a screen reader (NVDA, VoiceOver) to test announcement timing for each live region type.