### PR TITLE
feat: add mobile action sheet with slide-up and backdrop fade (#13785)

### DIFF
--- a/submissions/examples/mobile-action-sheet-ij/README.md
+++ b/submissions/examples/mobile-action-sheet-ij/README.md
@@ -1,0 +1,7 @@
+# Mobile Action Sheet
+
+1. What does this do? A mobile-style bottom action sheet that slides up (translateY(100%) → 0) with action items, a draggable handle affordance, backdrop fade, and dismissible by tapping backdrop or Cancel.
+
+2. How is it used? Add `.action-backdrop` with `.action-sheet` inside. Toggle `.open` on both to trigger the slide-up entrance. The spring-like cubic-bezier curve provides a natural iOS-style feel. Dismiss by clicking the backdrop or Cancel button.
+
+3. Why is it useful? Provides a specialized variant of the bottom-sheet pattern for action menus — common in mobile apps for share sheets, file operations, and settings quick-actions, with smooth entrance animation and backdrop context.

--- a/submissions/examples/mobile-action-sheet-ij/demo.html
+++ b/submissions/examples/mobile-action-sheet-ij/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobile Action Sheet - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Action Sheet</h1>
+    <div class="phone-frame">
+      <div class="phone-content">
+        <div class="phone-header">
+          <span>Message</span>
+        </div>
+        <div class="phone-body">
+          <div class="message-bubble received">Hey, want to grab coffee?</div>
+          <div class="message-bubble sent">Sure! When?</div>
+          <div class="message-bubble received">How about 3pm?</div>
+        </div>
+        <div class="phone-footer">
+          <button class="action-trigger" id="actionTrigger">Share</button>
+        </div>
+      </div>
+    </div>
+    <p class="description">Tap "Share" to open the action sheet. It slides up from the bottom with a backdrop fade. Tap backdrop or an action to dismiss.</p>
+  </div>
+
+  <div class="action-backdrop" id="actionBackdrop">
+    <div class="action-sheet" id="actionSheet">
+      <div class="action-sheet-handle"></div>
+      <p class="action-sheet-title">Share to</p>
+      <div class="action-list">
+        <button class="action-item">
+          <span class="action-icon">&#128172;</span>
+          <span>Messages</span>
+        </button>
+        <button class="action-item">
+          <span class="action-icon">&#128231;</span>
+          <span>Mail</span>
+        </button>
+        <button class="action-item">
+          <span class="action-icon">&#128279;</span>
+          <span>Copy Link</span>
+        </button>
+        <button class="action-item">
+          <span class="action-icon">&#128247;</span>
+          <span>Save to Photos</span>
+        </button>
+      </div>
+      <button class="action-cancel">Cancel</button>
+    </div>
+  </div>
+
+  <script>
+    const trigger = document.getElementById('actionTrigger');
+    const backdrop = document.getElementById('actionBackdrop');
+    const sheet = document.getElementById('actionSheet');
+    const cancel = document.querySelector('.action-cancel');
+
+    function open() {
+      backdrop.classList.add('open');
+      sheet.classList.add('open');
+    }
+
+    function close() {
+      backdrop.classList.remove('open');
+      sheet.classList.remove('open');
+    }
+
+    trigger.addEventListener('click', open);
+    cancel.addEventListener('click', close);
+    backdrop.addEventListener('click', (e) => { if (e.target === backdrop) close(); });
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+  </script>
+</body>
+</html>

--- a/submissions/examples/mobile-action-sheet-ij/style.css
+++ b/submissions/examples/mobile-action-sheet-ij/style.css
@@ -1,0 +1,219 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 340px;
+}
+
+/* ─── Phone Frame ─── */
+.phone-frame {
+  width: 320px;
+  height: 520px;
+  border-radius: 32px;
+  background: #1e293b;
+  border: 2px solid #334155;
+  overflow: hidden;
+  position: relative;
+}
+
+.phone-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.phone-header {
+  padding: 0.75rem 1rem;
+  background: #334155;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #f1f5f9;
+  text-align: center;
+}
+
+.phone-body {
+  flex: 1;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.message-bubble {
+  max-width: 75%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 14px;
+  font-size: 0.85rem;
+}
+
+.message-bubble.received {
+  align-self: flex-start;
+  background: #334155;
+  color: #e2e8f0;
+  border-radius: 14px 14px 14px 4px;
+}
+
+.message-bubble.sent {
+  align-self: flex-end;
+  background: rgba(251,191,36,0.15);
+  color: #fbbf24;
+  border-radius: 14px 14px 4px 14px;
+}
+
+.phone-footer {
+  padding: 0.75rem;
+  border-top: 1px solid #334155;
+}
+
+.action-trigger {
+  width: 100%;
+  padding: 0.6rem;
+  border-radius: 10px;
+  border: none;
+  background: #fbbf24;
+  color: #0f172a;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.action-trigger:active {
+  transform: scale(0.97);
+}
+
+/* ─── Backdrop ─── */
+.action-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 100;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.action-backdrop.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ─── Action Sheet ─── */
+.action-sheet {
+  width: 100%;
+  max-width: 400px;
+  background: #1e293b;
+  border-radius: 20px 20px 0 0;
+  padding: 0.75rem 1rem 2rem;
+  transform: translateY(100%);
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.action-sheet.open {
+  transform: translateY(0);
+}
+
+.action-sheet-handle {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: #475569;
+  margin: 0 auto 1rem;
+}
+
+.action-sheet-title {
+  font-size: 0.8rem;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+  text-align: center;
+}
+
+/* ─── Action Items ─── */
+.action-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 0.75rem;
+}
+
+.action-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: none;
+  background: transparent;
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  cursor: pointer;
+  border-radius: 10px;
+  transition: background 0.15s ease;
+}
+
+.action-item:hover {
+  background: #334155;
+}
+
+.action-item:active {
+  background: #1e293b;
+}
+
+.action-icon {
+  font-size: 1.2rem;
+  width: 28px;
+  text-align: center;
+}
+
+.action-cancel {
+  width: 100%;
+  padding: 0.75rem;
+  border: none;
+  border-radius: 12px;
+  background: #334155;
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.action-cancel:hover {
+  background: #475569;
+}
+
+.action-cancel:active {
+  transform: scale(0.98);
+}


### PR DESCRIPTION
## Component: ease-mobile-action-sheet — animated bottom action sheet

**Closes #13785**

### What this adds
A mobile-style action sheet that slides up from the bottom (translateY(100%) → 0) with action items, a handle affordance, backdrop fade, and dismissible by tapping backdrop or Cancel.

### Acceptance Criteria covered
- translateY(100%) → 0 entrance with spring curve
- Backdrop fade overlay
- Builds on ease-bottom-sheet pattern with action-list styling

### Files
- `submissions/examples/mobile-action-sheet-ij/demo.html`
- `submissions/examples/mobile-action-sheet-ij/style.css`
- `submissions/examples/mobile-action-sheet-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Tap "Share" to see the action sheet slide up. Tap the backdrop or Cancel to dismiss.