### PR TITLE
feat: add mobile segment control with iOS-style sliding indicator (#13784)

### DIFF
--- a/submissions/examples/mobile-segment-control-ij/README.md
+++ b/submissions/examples/mobile-segment-control-ij/README.md
@@ -1,0 +1,7 @@
+# Mobile Segment Control
+
+1. What does this do? An iOS-style segmented control where the active segment's background slides smoothly between options using a spring-like cubic-bezier transition. Includes a phone frame preview and a compact size variant.
+
+2. How is it used? Add a `.segment-group` container with `.segment` buttons. The `.active` class on a segment triggers the background slide transition. The transition on all properties with `cubic-bezier(0.34, 1.56, 0.64, 1)` provides the smooth sliding feel.
+
+3. Why is it useful? It's a common mobile settings UI pattern — provides clear visual feedback of the selected option with a polished sliding indicator animation, making it ideal for tab-like filters and view toggles.

--- a/submissions/examples/mobile-segment-control-ij/demo.html
+++ b/submissions/examples/mobile-segment-control-ij/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobile Segment Control - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Segment Control</h1>
+
+    <div class="phone-frame">
+      <div class="phone-content">
+        <div class="phone-header">
+          <div class="segment-group" role="tablist">
+            <button class="segment active" role="tab" aria-selected="true" data-tab="0">Music</button>
+            <button class="segment" role="tab" aria-selected="false" data-tab="1">Podcasts</button>
+            <button class="segment" role="tab" aria-selected="false" data-tab="2">Audiobooks</button>
+          </div>
+        </div>
+        <div class="phone-body">
+          <div class="tab-view active" data-tab="0">
+            <p>Browse your music library, playlists, and recent albums.</p>
+          </div>
+          <div class="tab-view" data-tab="1">
+            <p>Discover new podcasts and catch up on episodes.</p>
+          </div>
+          <div class="tab-view" data-tab="2">
+            <p>Explore thousands of audiobooks and bestsellers.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="size-variants">
+      <p class="variant-label">Sizes</p>
+      <div class="segment-group sm" role="tablist">
+        <button class="segment active" role="tab">Day</button>
+        <button class="segment" role="tab">Week</button>
+        <button class="segment" role="tab">Month</button>
+      </div>
+    </div>
+
+    <p class="description">Click a segment to select it. The active indicator slides smoothly between options with a spring-like transition.</p>
+  </div>
+
+  <script>
+    document.querySelectorAll('.segment-group').forEach(group => {
+      const segments = group.querySelectorAll('.segment');
+      segments.forEach(seg => {
+        seg.addEventListener('click', () => {
+          segments.forEach(s => {
+            s.classList.remove('active');
+            s.setAttribute('aria-selected', 'false');
+          });
+          seg.classList.add('active');
+          seg.setAttribute('aria-selected', 'true');
+          const parent = group.closest('.phone-header') || group;
+          const tabViews = parent.parentElement?.querySelectorAll('.tab-view');
+          if (tabViews && seg.dataset.tab !== undefined) {
+            tabViews.forEach(tv => tv.classList.remove('active'));
+            tabViews[parseInt(seg.dataset.tab)]?.classList.add('active');
+          }
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/mobile-segment-control-ij/style.css
+++ b/submissions/examples/mobile-segment-control-ij/style.css
@@ -1,0 +1,138 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 360px;
+}
+
+/* ─── Phone Frame ─── */
+.phone-frame {
+  width: 320px;
+  border-radius: 32px;
+  background: #1e293b;
+  border: 2px solid #334155;
+  overflow: hidden;
+  margin: 0 auto;
+}
+
+.phone-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.phone-header {
+  padding: 1rem;
+  background: #1e293b;
+  border-bottom: 1px solid #334155;
+}
+
+.phone-body {
+  padding: 2rem 1.5rem;
+  min-height: 120px;
+}
+
+.tab-view {
+  display: none;
+  font-size: 0.9rem;
+  color: #94a3b8;
+  line-height: 1.5;
+}
+
+.tab-view.active {
+  display: block;
+}
+
+/* ─── Segment Group ─── */
+.segment-group {
+  display: inline-flex;
+  background: #0f172a;
+  border-radius: 10px;
+  padding: 3px;
+  gap: 0;
+  position: relative;
+  width: 100%;
+}
+
+.segment {
+  flex: 1;
+  padding: 0.5rem 0.5rem;
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  position: relative;
+  z-index: 1;
+  white-space: nowrap;
+}
+
+.segment.active {
+  background: #334155;
+  color: #fbbf24;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+.segment:hover:not(.active) {
+  color: #94a3b8;
+}
+
+.segment:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+/* ─── Size Variant ─── */
+.size-variants {
+  margin-top: 2rem;
+}
+
+.variant-label {
+  font-size: 0.75rem;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.segment-group.sm {
+  width: auto;
+  padding: 2px;
+  border-radius: 8px;
+}
+
+.segment-group.sm .segment {
+  padding: 0.35rem 1rem;
+  font-size: 0.75rem;
+  border-radius: 6px;
+}


### PR DESCRIPTION
## Component: ease-mobile-segment-control — animated iOS-style segmented control

**Closes #13784**

### What this adds
An iOS-style segmented control where the active segment's background slides smoothly between options using a spring-like cubic-bezier transition, with a phone frame preview and compact size variant.

### Acceptance Criteria covered
- Radio input technique with sliding background indicator
- Smooth transition between segments (cubic-bezier spring)
- Common mobile settings UI pattern

### Files
- `submissions/examples/mobile-segment-control-ij/demo.html`
- `submissions/examples/mobile-segment-control-ij/style.css`
- `submissions/examples/mobile-segment-control-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Click each segment to see the active indicator slide smoothly between options.