### PR TITLE
fix(submission): fix input focus box shadow conflict #14084

### DIFF
--- a/submissions/examples/fix-14084-ease-input-focus-box-shadow-conflict-rs/README.md
+++ b/submissions/examples/fix-14084-ease-input-focus-box-shadow-conflict-rs/README.md
@@ -1,0 +1,14 @@
+# Fix for Issue #14084: ease-input focus box-shadow conflict
+
+## The Bug
+In `forms.css`, a broad `.ease-input:focus` selector was accidentally introduced to resolve an issue with file inputs (#10869). Because this rule uses the `:focus` pseudo-class (which triggers on both mouse and keyboard focus) instead of `:focus-visible` (which triggers only on keyboard navigation), it broke the framework's design intent for all standard inputs.
+
+Additionally, this new rule defined a `box-shadow` opacity of `0.1`. Since it appeared lower in the file than the intended `:focus-visible` rule, it overrode the stronger `0.18` opacity shadow intended for keyboard navigation, creating a visual conflict.
+
+## The Fix
+This fix reverts the erroneous global mouse-click focus styling by applying `box-shadow: none` and restoring the default `border-color` when `:focus:not(:focus-visible)` is active. It also explicitly restores the correct `0.18` opacity box-shadow for `:focus-visible`, ensuring that keyboard navigation works exactly as originally designed.
+
+## How to Verify
+1. Open `demo.html` in your browser.
+2. Under "Before (Broken)", click the text input. Notice that a focus ring appears (which it shouldn't on mouse click), and if you navigate to it via the `Tab` key, the shadow is noticeably weak (0.1 opacity).
+3. Under "After (Fixed)", click the text input. Notice that no focus ring appears, respecting the framework's design intent. When you `Tab` to it, the correct, stronger focus ring (0.18 opacity) is displayed.

--- a/submissions/examples/fix-14084-ease-input-focus-box-shadow-conflict-rs/demo.html
+++ b/submissions/examples/fix-14084-ease-input-focus-box-shadow-conflict-rs/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Bug Fix: Input Focus Box Shadow Conflict</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      padding: 2rem;
+      font-family: sans-serif;
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 3rem;
+      margin-top: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>Fix for #14084: ease-input focus box-shadow conflict</h1>
+  <p>
+    The bug was caused by a broad <code>.ease-input:focus</code> selector added under the file input section in <code>forms.css</code>. 
+    This accidentally targeted all inputs, causing them to show focus rings on mouse click (breaking the <code>:focus-visible</code> design intent) 
+    and conflicting with the proper focus-visible shadow opacity.
+  </p>
+
+  <div class="grid">
+    <div>
+      <h2>Before (Broken)</h2>
+      <p>Clicking the text input shows a focus ring (it shouldn't). Keyboard tabbing shows a weaker 0.1 opacity shadow instead of the intended 0.18.</p>
+      <div class="ease-field demo-broken">
+        <label class="ease-field-label">Text Input</label>
+        <input type="text" class="ease-input" placeholder="Click me (mouse)">
+      </div>
+      <div class="ease-field demo-broken">
+        <label class="ease-field-label">File Input</label>
+        <input type="file" class="ease-input">
+      </div>
+    </div>
+
+    <div>
+      <h2>After (Fixed)</h2>
+      <p>Clicking the text input shows NO focus ring (correct behavior). Keyboard tabbing shows the correct stronger 0.18 opacity shadow.</p>
+      <div class="ease-field demo-fixed">
+        <label class="ease-field-label">Text Input</label>
+        <input type="text" class="ease-input" placeholder="Click me (mouse)">
+      </div>
+      <div class="ease-field demo-fixed">
+        <label class="ease-field-label">File Input</label>
+        <input type="file" class="ease-input">
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-14084-ease-input-focus-box-shadow-conflict-rs/style.css
+++ b/submissions/examples/fix-14084-ease-input-focus-box-shadow-conflict-rs/style.css
@@ -1,0 +1,37 @@
+/* ========================================================================
+   Fix for Issue #14084
+   Bug: A global .ease-input:focus rule added for file inputs overrides
+        the intended :focus-visible behavior for all inputs.
+   Fix: Scope the file input fix properly and revert mouse-click focus 
+        styles for standard inputs.
+   ======================================================================== */
+
+@layer easemotion-components {
+  /* 
+     1. Revert the erroneous global :focus style for mouse clicks.
+        This restores the original design intent where only keyboard
+        navigation triggers the focus ring.
+  */
+  .demo-fixed .ease-input:focus:not(:focus-visible) {
+    border-color: var(--ease-color-neutral-300, #cbd5e1);
+    box-shadow: none;
+  }
+
+  /* 
+     2. Restore the proper :focus-visible box-shadow opacity (0.18) 
+        which was being overridden by the rogue 0.1 rule.
+  */
+  .demo-fixed .ease-input:focus-visible {
+    border-color: var(--ease-color-primary, #6c63ff);
+    box-shadow: 0 0 0 3px var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.18));
+  }
+
+  /* 
+     3. Apply the intended fix for file inputs specifically (if they 
+        need the 0.1 shadow, or just use the standard 0.18).
+  */
+  .demo-fixed .ease-input[type="file"]:focus-visible {
+    border-color: #6c63ff;
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.18);
+  }
+}


### PR DESCRIPTION
**fix(submission): fix input focus box shadow conflict #14084**

## Related Issue  
Closes #14084

---
## Type of Change
- [x] Bug Fix  
- [ ] New Feature  
- [ ] Documentation Update  
- [ ] Refactor  
- [ ] Chore

---
## Description
This PR addresses an issue in `forms.css` where a broad `.ease-input:focus` selector (introduced to resolve a file input bug) accidentally targeted all standard inputs. Because it used `:focus` instead of `:focus-visible`, it caused standard inputs to display a focus ring on mouse click—breaking the framework's design intent. Additionally, the rogue rule applied a `0.1` opacity shadow, overriding the intended, stronger `0.18` opacity shadow for keyboard navigation.

The fix resolves this by resetting the mouse-click focus styling back to its default state (`box-shadow: none`) and explicitly ensuring that the proper `0.18` opacity shadow is restored for the `:focus-visible` state.

---
## Changes Made
- `submissions/examples/fix-14084-ease-input-focus-box-shadow-conflict-rs/demo.html` — A self-contained HTML page demonstrating the original issue (mouse click triggering focus ring and overwritten weaker shadow) alongside the fixed behavior.
- `submissions/examples/fix-14084-ease-input-focus-box-shadow-conflict-rs/style.css` — The CSS code proposing the scoped fix to properly revert the rogue styles and restore the correct `:focus-visible` ring.
- `submissions/examples/fix-14084-ease-input-focus-box-shadow-conflict-rs/README.md` — Detailed explanation of the specificity conflict and how scoping `:focus-visible` resolves it.

---
## How to Verify Locally
1. Checkout the branch locally (`fix/14084-ease-input-focus-box-shadow-conflict`).
2. Open `submissions/examples/fix-14084-ease-input-focus-box-shadow-conflict-rs/demo.html` in your web browser.
3. Under the **Before** section, click the text input to observe the erroneous focus ring appearing on mouse click. Press the `Tab` key to observe the incorrect, weaker `0.1` opacity shadow.
4. Under the **After** section, verify that clicking the input no longer shows the focus ring (correct behavior). Press `Tab` to verify that the strong, expected `0.18` opacity shadow appears.

---
## Checklist
- [x] My code follows the project's coding style  
- [x] I have tested my changes locally  
- [x] I have updated the documentation if required  
- [x] No existing functionality has been broken  
- [x] All checks and linting pass successfully

---
## GSSoC'26 Contributor Declaration
- [x] I confirm that I am a participant of GSSoC'26  
- [x] I have followed the contribution guidelines of this project  
- [x] This PR is ready for review

---