### PR TITLE
fix(submission): fix card accent double border #14083

### DIFF
--- a/submissions/examples/fix-14083-ease-card-accent-double-border-rs/README.md
+++ b/submissions/examples/fix-14083-ease-card-accent-double-border-rs/README.md
@@ -1,0 +1,14 @@
+# Fix for Issue #14083: ease-card-accent double border
+
+## The Bug
+The `.ease-card-accent` variants create a colored vertical stripe on the left side of the card by applying `border-left: 4px solid`. Because the base `.ease-card` has a `border: 1px solid` and a `1rem` `border-radius`, replacing the left border with a 4px thickness causes the browser to render an awkward diagonal seam at the top-left and bottom-left corners. Visually, this creates a clipping artifact often referred to as a "double border" effect, where the thick and thin borders clash awkwardly at the curve.
+
+## The Fix
+This fix removes the `border-left: 4px solid` property, allowing the card to maintain a continuous, smooth `1px` border around all four sides. Instead, the 4px accent stripe is rendered using an absolute `::before` pseudo-element. 
+
+Because the base `.ease-card` already has `position: relative` and `overflow: hidden`, the pseudo-element sits cleanly against the left edge and perfectly conforms to the inner curve of the border-radius without distorting the actual borders.
+
+## How to Verify Locally
+1. Open `demo.html` in your web browser.
+2. Under the **Before (Broken)** section, inspect the left corners of the cards. You will notice the thick 4px border joining the 1px border at a sharp angle.
+3. Under the **After (Fixed)** section, inspect the same corners. The 1px border now perfectly wraps the card, and the accent color sits cleanly inside without creating any visual artifacts.

--- a/submissions/examples/fix-14083-ease-card-accent-double-border-rs/demo.html
+++ b/submissions/examples/fix-14083-ease-card-accent-double-border-rs/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Bug Fix: Card Accent Double Border</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; font-family: sans-serif; background: #f8fafc; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>Fix for #14083: ease-card-accent double border</h1>
+  <p>The original accent card implementation replaced the 1px left border with a 4px left border. Combined with a <code>1rem</code> border-radius, this causes browsers to render an awkward diagonal corner seam that looks like a "double border" or clipping artifact.</p>
+
+  <div class="grid">
+    <div>
+      <h2>Before (Broken)</h2>
+      <div class="ease-card ease-card-accent demo-broken" style="margin-bottom: 1rem;">
+        <h3 class="ease-card-title">Primary Accent</h3>
+        <div class="ease-card-body">
+          <p>Inspect the top-left and bottom-left corners. The 4px border meets the 1px border at an angle, creating a visual rendering artifact (the "double border" effect).</p>
+        </div>
+      </div>
+      <div class="ease-card ease-card-accent-danger demo-broken">
+        <h3 class="ease-card-title">Danger Accent</h3>
+        <div class="ease-card-body">
+          <p>The seam is visible on all accent variants because they all use <code>border-left: 4px solid</code>.</p>
+        </div>
+      </div>
+    </div>
+    
+    <div>
+      <h2>After (Fixed)</h2>
+      <div class="ease-card ease-card-accent demo-fixed" style="margin-bottom: 1rem;">
+        <h3 class="ease-card-title">Primary Accent</h3>
+        <div class="ease-card-body">
+          <p>The card now maintains its perfect 1px border around all 4 sides. The 4px accent line is rendered using an absolute <code>::before</code> pseudo-element, perfectly clipped by the card's overflow.</p>
+        </div>
+      </div>
+      <div class="ease-card ease-card-accent-danger demo-fixed">
+        <h3 class="ease-card-title">Danger Accent</h3>
+        <div class="ease-card-body">
+          <p>No more corner seams or double border rendering artifacts!</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-14083-ease-card-accent-double-border-rs/style.css
+++ b/submissions/examples/fix-14083-ease-card-accent-double-border-rs/style.css
@@ -1,0 +1,69 @@
+/* ========================================================================
+   Fix for Issue #14083
+   Bug: ease-card-accent uses border-left: 4px solid which overrides the 
+        card's 1px border. With border-radius, this causes browsers to 
+        render an ugly diagonal seam/double-border artifact in the corners.
+   Fix: Maintain the 1px border everywhere and use a ::before pseudo-element
+        for the accent line, naturally clipped by the card's overflow.
+   ======================================================================== */
+
+@layer easemotion-components {
+  /* 
+     1. Revert the buggy border-left override so the card regains 
+        its smooth, continuous 1px outer border.
+        (In the actual framework code, simply remove the border-left lines)
+  */
+  .demo-fixed.ease-card-accent,
+  .demo-fixed.ease-card-accent-success,
+  .demo-fixed.ease-card-accent-danger,
+  .demo-fixed.ease-card-accent-warning {
+    border-left: 1px solid var(--ease-color-neutral-200, #e2e8f0) !important;
+  }
+
+  /* 
+     2. Implement the accent using ::before. 
+        Because .ease-card has position: relative and overflow: hidden,
+        the line sits perfectly inside and conforms to the border-radius.
+  */
+  .demo-fixed.ease-card-accent::before,
+  .demo-fixed.ease-card-accent-success::before,
+  .demo-fixed.ease-card-accent-danger::before,
+  .demo-fixed.ease-card-accent-warning::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 4px;
+    z-index: 1; /* Keep it above the card background */
+  }
+
+  /* 3. Assign the correct accent colors */
+  .demo-fixed.ease-card-accent::before {
+    background-color: var(--ease-color-primary, #6c63ff);
+  }
+  .demo-fixed.ease-card-accent-success::before {
+    background-color: var(--ease-color-success, #22c55e);
+  }
+  .demo-fixed.ease-card-accent-danger::before {
+    background-color: var(--ease-color-danger, #ef4444);
+  }
+  .demo-fixed.ease-card-accent-warning::before {
+    background-color: var(--ease-color-warning, #f59e0b);
+  }
+
+  /* 4. Support dark mode */
+  @media (prefers-color-scheme: dark) {
+    .demo-fixed.ease-card-accent::before { background-color: var(--ease-color-primary-light, #a09af8); }
+    .demo-fixed.ease-card-accent-success::before { background-color: var(--ease-color-success-light, #86efac); }
+    .demo-fixed.ease-card-accent-danger::before { background-color: var(--ease-color-danger-light, #fca5a5); }
+    .demo-fixed.ease-card-accent-warning::before { background-color: var(--ease-color-warning-light, #fcd34d); }
+    
+    .demo-fixed.ease-card-accent,
+    .demo-fixed.ease-card-accent-success,
+    .demo-fixed.ease-card-accent-danger,
+    .demo-fixed.ease-card-accent-warning {
+        border-left-color: var(--ease-color-neutral-700, #334155) !important;
+    }
+  }
+}


### PR DESCRIPTION
**fix(submission): fix card accent double border rendering artifact #14083**

## Related Issue  
Closes #14083

---
## Type of Change
- [x] Bug Fix  
- [ ] New Feature  
- [ ] Documentation Update  
- [ ] Refactor  
- [ ] Chore

---
## Description
This PR addresses a rendering bug with `.ease-card-accent` variants. The original implementation used `border-left: 4px solid` to create the left accent line. When applied to `.ease-card` (which has a `1px` border and a `1rem` `border-radius`), browsers interpolate the difference in width at the corners, creating an awkward diagonal clipping artifact that looks like a "double border" or a broken corner.

To fix this, the accent implementation has been updated to maintain the card's continuous `1px` outer border, instead utilizing an absolute `::before` pseudo-element to draw the 4px accent line. Because the base card has `overflow: hidden`, the pseudo-element perfectly conforms to the border radius without distorting the actual borders.

---
## Changes Made
- `submissions/examples/fix-14083-ease-card-accent-double-border-rs/demo.html` — A demonstration page containing multiple accent card variants, showing the buggy rendering side-by-side with the new fix.
- `submissions/examples/fix-14083-ease-card-accent-double-border-rs/style.css` — The CSS code proposing the pseudo-element fix and reverting the buggy `border-left` override.
- `submissions/examples/fix-14083-ease-card-accent-double-border-rs/README.md` — Detailed explanation of why the "double border" artifact occurs and how the `::before` pseudo-element cleanly resolves it.

---
## How to Verify Locally
1. Checkout the branch locally (`fix/14083-ease-card-accent-double-border`).
2. Open `submissions/examples/fix-14083-ease-card-accent-double-border-rs/demo.html` in your web browser.
3. Under the **Before (Broken)** section, inspect the left corners of the cards to see the awkward border joining angle (double border effect).
4. Under the **After (Fixed)** section, verify that the 1px border perfectly wraps the corners and the accent color sits smoothly inside.

---
## Checklist
- [x] My code follows the project's coding style  
- [x] I have tested my changes locally  
- [x] I have updated the documentation if required  
- [x] No existing functionality has been broken  
- [x] All checks and linting pass successfully

---
## GSSoC'26 Contributor Declaration
- [x] I confirm that I am a participant of GSSoC'26  
- [x] I have followed the contribution guidelines of this project  
- [x] This PR is ready for review

---