### PR TITLE
feat(submission): add dashboard stat card #13774

### DIFF
--- a/submissions/examples/dashboard-stat-card-ij/README.md
+++ b/submissions/examples/dashboard-stat-card-ij/README.md
@@ -1,0 +1,7 @@
+# Dashboard Stat Card
+
+1. What does this do? A dashboard stat card with a count-up number animation on load. The trend arrow shows direction (up/down) with color coding (green for positive, red for negative) and a subtle bounce animation on the arrow.
+
+2. How is it used? Add a `.stat-card` with `.stat-value` containing a `data-target` attribute for the end value. The JS animates from 0 to the target using a cubic ease-out. The `.trend` class with `.up` or `.down` controls arrow direction and color.
+
+3. Why is it useful? Stat cards are a fundamental dashboard UI element. The count-up animation draws attention to the metric value, while the trend arrow with bounce gives immediate directional context for performance indicators.

--- a/submissions/examples/dashboard-stat-card-ij/demo.html
+++ b/submissions/examples/dashboard-stat-card-ij/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard Stat Card - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Stat Cards</h1>
+
+    <div class="card-grid">
+      <div class="stat-card">
+        <div class="stat-header">
+          <span class="stat-label">Total Revenue</span>
+          <span class="trend up">
+            <span class="arrow">&#9650;</span> 12.5%
+          </span>
+        </div>
+        <div class="stat-value" data-target="48250">$0</div>
+        <div class="stat-footer">vs $42,890 last month</div>
+      </div>
+
+      <div class="stat-card">
+        <div class="stat-header">
+          <span class="stat-label">Active Users</span>
+          <span class="trend up">
+            <span class="arrow">&#9650;</span> 8.2%
+          </span>
+        </div>
+        <div class="stat-value" data-target="12480">0</div>
+        <div class="stat-footer">vs 11,530 last month</div>
+      </div>
+
+      <div class="stat-card">
+        <div class="stat-header">
+          <span class="stat-label">Bounce Rate</span>
+          <span class="trend down">
+            <span class="arrow">&#9660;</span> 3.1%
+          </span>
+        </div>
+        <div class="stat-value" data-target="24.6">0%</div>
+        <div class="stat-footer">vs 27.7% last month</div>
+      </div>
+
+      <div class="stat-card">
+        <div class="stat-header">
+          <span class="stat-label">Avg. Session</span>
+          <span class="trend up">
+            <span class="arrow">&#9650;</span> 5.7%
+          </span>
+        </div>
+        <div class="stat-value" data-target="4.8">0m</div>
+        <div class="stat-footer">vs 4.5m last month</div>
+      </div>
+    </div>
+
+    <p class="description">Numbers count up on load. The trend arrow shows direction with a subtle bounce animation.</p>
+  </div>
+
+  <script>
+    function animateValue(el, start, end, suffix, duration) {
+      const startTime = performance.now();
+      function tick(now) {
+        const elapsed = now - startTime;
+        const progress = Math.min(elapsed / duration, 1);
+        const eased = 1 - Math.pow(1 - progress, 3);
+        const current = start + (end - start) * eased;
+        el.textContent = end >= 1000 ? '$' + Math.round(current).toLocaleString() : current.toFixed(1) + suffix;
+        if (progress < 1) requestAnimationFrame(tick);
+      }
+      requestAnimationFrame(tick);
+    }
+
+    document.querySelectorAll('.stat-value').forEach(el => {
+      const target = parseFloat(el.dataset.target);
+      const isMoney = el.dataset.target >= 1000;
+      animateValue(el, 0, target, isMoney ? '' : '', 1200);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/dashboard-stat-card-ij/style.css
+++ b/submissions/examples/dashboard-stat-card-ij/style.css
@@ -1,0 +1,139 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 480px;
+}
+
+/* ─── Card Grid ─── */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+/* ─── Stat Card ─── */
+.stat-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1.25rem;
+  text-align: left;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-2px);
+  border-color: #475569;
+}
+
+/* ─── Header ─── */
+.stat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+/* ─── Trend ─── */
+.trend {
+  font-size: 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.trend.up {
+  color: #22c55e;
+}
+
+.trend.down {
+  color: #ef4444;
+}
+
+.arrow {
+  display: inline-block;
+  animation: bounce-arrow 0.5s ease;
+}
+
+@keyframes bounce-arrow {
+  0% { transform: translateY(0); }
+  30% { transform: translateY(-3px); }
+  60% { transform: translateY(0); }
+  80% { transform: translateY(-1px); }
+  100% { transform: translateY(0); }
+}
+
+.trend.down .arrow {
+  animation-name: bounce-arrow-down;
+}
+
+@keyframes bounce-arrow-down {
+  0% { transform: translateY(0); }
+  30% { transform: translateY(3px); }
+  60% { transform: translateY(0); }
+  80% { transform: translateY(1px); }
+  100% { transform: translateY(0); }
+}
+
+/* ─── Value ─── */
+.stat-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #f8fafc;
+  margin-bottom: 0.3rem;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Footer ─── */
+.stat-footer {
+  font-size: 0.72rem;
+  color: #475569;
+}
+
+.stat-card:hover .stat-footer {
+  color: #64748b;
+}
+
+/* ─── Focus ─── */
+.stat-card:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Component: ease-dashboard-stat-card — number count-up animation, trend arrow with color and bounce

**Closes #13774**

### What this adds
A dashboard stat card with a count-up number animation on load (JS-driven with cubic ease-out). The trend arrow shows direction with green (up) / red (down) coloring and a subtle bounce animation. 2×2 grid layout.

### Acceptance Criteria covered
- Number uses count-up animation on load
- Trend arrow with color coded direction
- Subtle bounce on the arrow

### Files
- `submissions/examples/dashboard-stat-card-ij/demo.html`
- `submissions/examples/dashboard-stat-card-ij/style.css`
- `submissions/examples/dashboard-stat-card-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the numbers animate from 0 to target values; observe the arrow bounce animation.
