### PR TITLE
feat(submission): add dashboard chart bar #13775

### DIFF
--- a/submissions/examples/dashboard-chart-bar-ij/README.md
+++ b/submissions/examples/dashboard-chart-bar-ij/README.md
@@ -1,0 +1,7 @@
+# Dashboard Chart Bar
+
+1. What does this do? A CSS-only bar chart where each bar animates from 0 to its target height using the `--ease-bar-height` CSS custom property. Bars have staggered transition delays (80ms apart) for a cascading entrance effect.
+
+2. How is it used? Add a `.chart-container` with `.bar-group` children. Set the target height via `--ease-bar-height` as an inline style (e.g., `style="--ease-bar-height: 65%;"`). The `.bar-fill` div reads the variable and transitions from 0 to the specified height.
+
+3. Why is it useful? Pure CSS bar charts are lightweight and performant. The staggered animation gives a polished dashboard feel without JavaScript, and the CSS variable approach makes it easy to set arbitrary heights from a CMS or API.

--- a/submissions/examples/dashboard-chart-bar-ij/demo.html
+++ b/submissions/examples/dashboard-chart-bar-ij/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard Chart Bar - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Weekly Revenue</h1>
+
+    <div class="chart-card">
+      <div class="chart-container">
+        <div class="bar-group" style="--ease-bar-height: 65%;">
+          <div class="bar">
+            <div class="bar-fill"></div>
+          </div>
+          <span class="bar-label">Mon</span>
+        </div>
+        <div class="bar-group" style="--ease-bar-height: 45%;">
+          <div class="bar">
+            <div class="bar-fill"></div>
+          </div>
+          <span class="bar-label">Tue</span>
+        </div>
+        <div class="bar-group" style="--ease-bar-height: 80%;">
+          <div class="bar">
+            <div class="bar-fill"></div>
+          </div>
+          <span class="bar-label">Wed</span>
+        </div>
+        <div class="bar-group" style="--ease-bar-height: 55%;">
+          <div class="bar">
+            <div class="bar-fill"></div>
+          </div>
+          <span class="bar-label">Thu</span>
+        </div>
+        <div class="bar-group" style="--ease-bar-height: 90%;">
+          <div class="bar">
+            <div class="bar-fill"></div>
+          </div>
+          <span class="bar-label">Fri</span>
+        </div>
+        <div class="bar-group" style="--ease-bar-height: 70%;">
+          <div class="bar">
+            <div class="bar-fill"></div>
+          </div>
+          <span class="bar-label">Sat</span>
+        </div>
+        <div class="bar-group" style="--ease-bar-height: 50%;">
+          <div class="bar">
+            <div class="bar-fill"></div>
+          </div>
+          <span class="bar-label">Sun</span>
+        </div>
+      </div>
+    </div>
+
+    <p class="description">Bars animate from 0 to target height on load using the <code>--ease-bar-height</code> CSS variable with staggered delays.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dashboard-chart-bar-ij/style.css
+++ b/submissions/examples/dashboard-chart-bar-ij/style.css
@@ -1,0 +1,131 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 400px;
+}
+
+.description code {
+  background: #1e293b;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: #fbbf24;
+}
+
+/* ─── Chart Card ─── */
+.chart-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 16px;
+  padding: 1.5rem;
+  width: 440px;
+  margin: 0 auto;
+}
+
+/* ─── Chart Container ─── */
+.chart-container {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  height: 200px;
+  gap: 0.5rem;
+  padding-top: 1rem;
+}
+
+/* ─── Bar Group ─── */
+.bar-group {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  height: 100%;
+  justify-content: flex-end;
+}
+
+/* ─── Bar ─── */
+.bar {
+  width: 100%;
+  max-width: 40px;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  border-radius: 6px 6px 0 0;
+  overflow: hidden;
+  background: #1e293b;
+}
+
+/* ─── Bar Fill (animated height) ─── */
+.bar-fill {
+  width: 100%;
+  height: 0;
+  background: linear-gradient(to top, #f59e0b, #fbbf24);
+  border-radius: 6px 6px 0 0;
+  transition: height 0.8s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.bar-group:nth-child(1) .bar-fill { transition-delay: 0ms; }
+.bar-group:nth-child(2) .bar-fill { transition-delay: 80ms; }
+.bar-group:nth-child(3) .bar-fill { transition-delay: 160ms; }
+.bar-group:nth-child(4) .bar-fill { transition-delay: 240ms; }
+.bar-group:nth-child(5) .bar-fill { transition-delay: 320ms; }
+.bar-group:nth-child(6) .bar-fill { transition-delay: 400ms; }
+.bar-group:nth-child(7) .bar-fill { transition-delay: 480ms; }
+
+/* ─── Animate on page load ─── */
+.bar-group .bar-fill {
+  height: var(--ease-bar-height);
+}
+
+/* ─── Bar Label ─── */
+.bar-label {
+  font-size: 0.7rem;
+  color: #64748b;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+/* ─── Hover ─── */
+.bar-group:hover .bar-fill {
+  opacity: 0.8;
+}
+
+.bar-group:hover .bar-label {
+  color: #94a3b8;
+}
+
+/* ─── Focus ─── */
+.bar-group:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Component: ease-dashboard-chart-bar — CSS-only bar chart, height 0→target with staggered delays, --ease-bar-height CSS var

**Closes #13775**

### What this adds
A CSS-only bar chart where bars animate from 0 to target height using the `--ease-bar-height` custom property. Bars have staggered transition delays (80ms apart) for a cascading entrance effect. No JavaScript required.

### Acceptance Criteria covered
- CSS-only bar chart
- Height 0→target with staggered delays
- `--ease-bar-height` CSS variable used

### Files
- `submissions/examples/dashboard-chart-bar-ij/demo.html`
- `submissions/examples/dashboard-chart-bar-ij/style.css`
- `submissions/examples/dashboard-chart-bar-ij/README.md`

### How to review
Open `demo.html` directly in a browser. The bars load with staggered animation from bottom to their target heights.
