### PR TITLE
feat(submission): add metric comparison bar #13779

### DIFF
--- a/submissions/examples/metric-comparison-bar-ij/README.md
+++ b/submissions/examples/metric-comparison-bar-ij/README.md
@@ -1,0 +1,7 @@
+# Metric Comparison Bar
+
+1. What does this do? A comparison widget showing two horizontal bars per metric — current period vs previous period. Both bars animate from 0 to their target width on load. The difference between values is highlighted with green (improvement) or red (decline).
+
+2. How is it used? Add a `.comparison-card` with `.comparison-group` sections. Each group contains a `.bar-pair` with two `.bar-row` elements (`.current` and `.previous`). Set the bar width via the `--bar-width` CSS variable inline. The `.diff-indicator` with `.up` or `.down` shows the percentage change.
+
+3. Why is it useful? Month-over-month comparison is a standard dashboard pattern. The side-by-side bars make it easy to visually compare performance, and the color-coded diff indicator gives immediate context on whether metrics are trending positively or negatively.

--- a/submissions/examples/metric-comparison-bar-ij/demo.html
+++ b/submissions/examples/metric-comparison-bar-ij/demo.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Metric Comparison Bar - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Metric Comparison</h1>
+
+    <div class="comparison-card">
+      <div class="comparison-group">
+        <div class="metric-header">
+          <span class="metric-name">Revenue</span>
+          <span class="metric-values">
+            <span class="val current">$48.2K</span>
+            <span class="val previous">$42.9K</span>
+          </span>
+        </div>
+        <div class="bar-pair">
+          <div class="bar-row current">
+            <span class="bar-label">This Month</span>
+            <div class="bar-track">
+              <div class="bar-fill" style="--bar-width: 82%;"></div>
+            </div>
+          </div>
+          <div class="bar-row previous">
+            <span class="bar-label">Last Month</span>
+            <div class="bar-track">
+              <div class="bar-fill" style="--bar-width: 65%;"></div>
+            </div>
+          </div>
+        </div>
+        <div class="diff-indicator up">+12.3% vs last month</div>
+      </div>
+
+      <div class="comparison-group">
+        <div class="metric-header">
+          <span class="metric-name">Bounce Rate</span>
+          <span class="metric-values">
+            <span class="val current">24.6%</span>
+            <span class="val previous">27.7%</span>
+          </span>
+        </div>
+        <div class="bar-pair">
+          <div class="bar-row current">
+            <span class="bar-label">This Month</span>
+            <div class="bar-track">
+              <div class="bar-fill" style="--bar-width: 49%;"></div>
+            </div>
+          </div>
+          <div class="bar-row previous">
+            <span class="bar-label">Last Month</span>
+            <div class="bar-track">
+              <div class="bar-fill" style="--bar-width: 55%;"></div>
+            </div>
+          </div>
+        </div>
+        <div class="diff-indicator down">-3.1% vs last month</div>
+      </div>
+
+      <div class="comparison-group">
+        <div class="metric-header">
+          <span class="metric-name">Active Users</span>
+          <span class="metric-values">
+            <span class="val current">12.4K</span>
+            <span class="val previous">11.5K</span>
+          </span>
+        </div>
+        <div class="bar-pair">
+          <div class="bar-row current">
+            <span class="bar-label">This Month</span>
+            <div class="bar-track">
+              <div class="bar-fill" style="--bar-width: 74%;"></div>
+            </div>
+          </div>
+          <div class="bar-row previous">
+            <span class="bar-label">Last Month</span>
+            <div class="bar-track">
+              <div class="bar-fill" style="--bar-width: 60%;"></div>
+            </div>
+          </div>
+        </div>
+        <div class="diff-indicator up">+7.8% vs last month</div>
+      </div>
+    </div>
+
+    <p class="description">Two bars per metric animate to their target lengths. The difference between current and previous is highlighted with green (up) or red (down).</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/metric-comparison-bar-ij/style.css
+++ b/submissions/examples/metric-comparison-bar-ij/style.css
@@ -1,0 +1,174 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 400px;
+}
+
+/* ─── Comparison Card ─── */
+.comparison-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 16px;
+  padding: 1.5rem;
+  width: 440px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.comparison-group {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #1e293b;
+}
+
+.comparison-group:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+/* ─── Metric Header ─── */
+.metric-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.metric-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.metric-values {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.val {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.val.current {
+  color: #f8fafc;
+}
+
+.val.previous {
+  color: #64748b;
+}
+
+/* ─── Bar Pair ─── */
+.bar-pair {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.bar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.bar-label {
+  font-size: 0.7rem;
+  color: #64748b;
+  width: 80px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* ─── Bar Track ─── */
+.bar-track {
+  flex: 1;
+  height: 10px;
+  background: #1e293b;
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.bar-row.current .bar-track {
+  background: #1e293b;
+}
+
+.bar-row.previous .bar-track {
+  background: #0f172a;
+}
+
+/* ─── Bar Fill ─── */
+.bar-fill {
+  height: 100%;
+  width: 0;
+  border-radius: 5px;
+  transition: width 0.8s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.bar-row.current .bar-fill {
+  background: linear-gradient(90deg, #f59e0b, #fbbf24);
+}
+
+.bar-row.previous .bar-fill {
+  background: #475569;
+}
+
+.bar-row .bar-fill {
+  width: var(--bar-width);
+}
+
+/* ─── Difference Indicator ─── */
+.diff-indicator {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.diff-indicator.up {
+  color: #22c55e;
+}
+
+.diff-indicator.down {
+  color: #ef4444;
+}
+
+/* ─── Hover ─── */
+.comparison-group:hover {
+  opacity: 0.9;
+}
+
+/* ─── Focus ─── */
+.comparison-group:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Component: ease-metric-comparison-bar — two side-by-side bars animate to lengths, difference highlighted with color

**Closes #13779**

### What this adds
A comparison widget showing two horizontal bars per metric — current vs previous period. Both bars animate from 0 to target width on load. The difference is highlighted with green (improvement) or red (decline).

### Acceptance Criteria covered
- Two bars side by side animate to target lengths
- Difference highlighted with color
- Multiple metrics shown

### Files
- `submissions/examples/metric-comparison-bar-ij/demo.html`
- `submissions/examples/metric-comparison-bar-ij/style.css`
- `submissions/examples/metric-comparison-bar-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Observe both bars per metric animate in; note the color-coded difference indicator.
