### PR TITLE
feat(submission): add heatmap cell #13780

### DIFF
--- a/submissions/examples/heatmap-cell-ij/README.md
+++ b/submissions/examples/heatmap-cell-ij/README.md
@@ -1,0 +1,7 @@
+# Heatmap Cell
+
+1. What does this do? A contribution-style heatmap grid where each cell fades in with a staggered delay. Color intensity is driven by the `--cell-color` CSS variable (using alpha channels). Cells scale up on hover for interactive feedback.
+
+2. How is it used? Add a `.heatmap-grid` container with `.hm-cell` children. Set each cell's color via `--cell-color` (e.g., `style="--cell-color: #22c55e60;"`) and stagger delay via `--cell-delay`. The CSS animation reads both variables to create the cascading entrance.
+
+3. Why is it useful? Heatmaps are widely used for GitHub-style contribution charts, activity tracking, and density visualizations. The staggered fade-in gives a polished entrance effect, and the CSS variable approach makes intensity mapping straightforward.

--- a/submissions/examples/heatmap-cell-ij/demo.html
+++ b/submissions/examples/heatmap-cell-ij/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Heatmap Cell - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Activity Heatmap</h1>
+
+    <div class="heatmap-card">
+      <div class="heatmap-header">
+        <span class="hm-label">Contributions in the last 4 weeks</span>
+        <div class="hm-legend">
+          <span class="legend-item">Less</span>
+          <span class="legend-swatch" style="--cell-color: #1e293b;"></span>
+          <span class="legend-swatch" style="--cell-color: #22c55e30;"></span>
+          <span class="legend-swatch" style="--cell-color: #22c55e60;"></span>
+          <span class="legend-swatch" style="--cell-color: #22c55e90;"></span>
+          <span class="legend-swatch" style="--cell-color: #22c55e;"></span>
+          <span class="legend-item">More</span>
+        </div>
+      </div>
+
+      <div class="heatmap-grid">
+        <div class="hm-cell" style="--cell-color: #22c55e20; --cell-delay: 0ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e60; --cell-delay: 30ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e30; --cell-delay: 60ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e90; --cell-delay: 90ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e; --cell-delay: 120ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e10; --cell-delay: 150ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e40; --cell-delay: 180ms;"></div>
+
+        <div class="hm-cell" style="--cell-color: #22c55e60; --cell-delay: 40ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e80; --cell-delay: 70ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e; --cell-delay: 100ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e20; --cell-delay: 130ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e50; --cell-delay: 160ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e90; --cell-delay: 190ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e30; --cell-delay: 220ms;"></div>
+
+        <div class="hm-cell" style="--cell-color: #22c55e30; --cell-delay: 80ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e; --cell-delay: 110ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e20; --cell-delay: 140ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e70; --cell-delay: 170ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e; --cell-delay: 200ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e50; --cell-delay: 230ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e80; --cell-delay: 260ms;"></div>
+
+        <div class="hm-cell" style="--cell-color: #22c55e90; --cell-delay: 120ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e20; --cell-delay: 150ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e60; --cell-delay: 180ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e; --cell-delay: 210ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e30; --cell-delay: 240ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e70; --cell-delay: 270ms;"></div>
+        <div class="hm-cell" style="--cell-color: #22c55e; --cell-delay: 300ms;"></div>
+      </div>
+    </div>
+
+    <p class="description">Each cell fades in with a staggered delay. Color intensity is controlled by the <code>--cell-color</code> CSS variable.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/heatmap-cell-ij/style.css
+++ b/submissions/examples/heatmap-cell-ij/style.css
@@ -1,0 +1,121 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 400px;
+}
+
+.description code {
+  background: #1e293b;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: #fbbf24;
+}
+
+/* ─── Heatmap Card ─── */
+.heatmap-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 16px;
+  padding: 1.25rem;
+  width: 440px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+/* ─── Header ─── */
+.heatmap-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.hm-label {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+.hm-legend {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.legend-item {
+  font-size: 0.65rem;
+  color: #64748b;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: var(--cell-color, #1e293b);
+  border: 1px solid #334155;
+}
+
+/* ─── Heatmap Grid ─── */
+.heatmap-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+}
+
+/* ─── Cell ─── */
+.hm-cell {
+  aspect-ratio: 1;
+  border-radius: 4px;
+  background: var(--cell-color, #1e293b);
+  border: 1px solid #334155;
+  opacity: 0;
+  animation: cell-fade-in 0.4s ease forwards;
+  animation-delay: var(--cell-delay, 0ms);
+  transition: transform 0.2s ease;
+}
+
+@keyframes cell-fade-in {
+  from { opacity: 0; transform: scale(0.85); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.hm-cell:hover {
+  transform: scale(1.3);
+  border-color: #94a3b8;
+  z-index: 1;
+}
+
+.hm-cell:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Component: ease-heatmap-cell — grid cells fade in with staggered delay, color via CSS var for intensity

**Closes #13780**

### What this adds
A contribution-style heatmap grid (7 columns) where each cell fades in with a `scale(0.85→1)` transition and staggered delay. Color intensity is driven by the `--cell-color` CSS variable (alpha channel). Cells scale up on hover.

### Acceptance Criteria covered
- Grid cells fade in with staggered delay
- Color via CSS variable for intensity
- Hover scale effect

### Files
- `submissions/examples/heatmap-cell-ij/demo.html`
- `submissions/examples/heatmap-cell-ij/style.css`
- `submissions/examples/heatmap-cell-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Cells fade in with cascading delays; hover over cells to see the scale-up effect.
