### PR TITLE
feat(submission): add mobile pull refresh spinner #13782

### DIFF
--- a/submissions/examples/mobile-pull-refresh-spinner-ij/README.md
+++ b/submissions/examples/mobile-pull-refresh-spinner-ij/README.md
@@ -1,0 +1,7 @@
+# Mobile Pull Refresh Spinner
+
+1. What does this do? A "pull to refresh" interaction for mobile apps. The circular spinner rotates proportionally to the pull distance via the `--pull-progress` CSS variable. When pulled past the threshold, releasing triggers a full rotation animation. The content translates down with the pull gesture.
+
+2. How is it used? Add a `.pull-container` with a `.pull-spinner` element styled with `--pull-progress`. The JS sets this variable based on drag distance (0 to 1). CSS `transform: rotate(calc(var(--pull-progress) * 360deg))` maps progress to rotation. The `.spinning` class kicks in once refresh is triggered.
+
+3. Why is it useful? Pull-to-refresh is a standard mobile pattern. Using a CSS variable to tie rotation to drag progress keeps the visual logic in CSS while JS handles gesture measurement, making the interaction lightweight and performant.

--- a/submissions/examples/mobile-pull-refresh-spinner-ij/demo.html
+++ b/submissions/examples/mobile-pull-refresh-spinner-ij/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobile Pull Refresh Spinner - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>Pull to Refresh</h1>
+
+    <div class="phone-frame">
+      <div class="phone-screen">
+        <div class="pull-container" id="pullContainer">
+          <div class="spinner-wrapper" id="spinnerWrapper">
+            <div class="pull-spinner" id="pullSpinner" style="--pull-progress: 0;"></div>
+            <span class="pull-text" id="pullText">Pull to refresh</span>
+          </div>
+          <div class="pull-content">
+            <div class="list-item">Message from Sarah</div>
+            <div class="list-item">Meeting reminder: 3:00 PM</div>
+            <div class="list-item">Build #482 passed</div>
+            <div class="list-item">New comment on #342</div>
+            <div class="list-item">Deployment complete</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <p class="description">Click and drag down to see the spinner rotate in proportion to pull distance. CSS handles the visual rotation via <code>--pull-progress</code>.</p>
+  </div>
+
+  <script>
+    const pullContainer = document.getElementById('pullContainer');
+    const spinner = document.getElementById('pullSpinner');
+    const pullText = document.getElementById('pullText');
+    let startY = 0;
+    let isDragging = false;
+    let isRefreshing = false;
+
+    pullContainer.addEventListener('mousedown', (e) => {
+      if (isRefreshing) return;
+      startY = e.clientY;
+      isDragging = true;
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!isDragging || isRefreshing) return;
+      const diff = e.clientY - startY;
+      if (diff <= 0) { pullContainer.style.transform = 'translateY(0)'; return; }
+      const progress = Math.min(diff / 120, 1);
+      const eased = progress * (2 - progress);
+      pullContainer.style.transform = `translateY(${eased * 80}px)`;
+      spinner.style.setProperty('--pull-progress', eased);
+      if (eased >= 1) {
+        pullText.textContent = 'Release to refresh';
+      } else {
+        pullText.textContent = 'Pull to refresh';
+      }
+    });
+
+    document.addEventListener('mouseup', () => {
+      if (!isDragging) return;
+      isDragging = false;
+      const progress = parseFloat(spinner.style.getPropertyValue('--pull-progress')) || 0;
+      if (progress >= 1) {
+        isRefreshing = true;
+        pullText.textContent = 'Refreshing...';
+        pullContainer.style.transform = 'translateY(60px)';
+        spinner.style.setProperty('--pull-progress', '1');
+        spinner.classList.add('spinning');
+        setTimeout(() => {
+          spinner.classList.remove('spinning');
+          pullContainer.style.transform = 'translateY(0)';
+          pullText.textContent = 'Pull to refresh';
+          spinner.style.setProperty('--pull-progress', '0');
+          isRefreshing = false;
+        }, 1500);
+      } else {
+        pullContainer.style.transform = 'translateY(0)';
+        spinner.style.setProperty('--pull-progress', '0');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/mobile-pull-refresh-spinner-ij/style.css
+++ b/submissions/examples/mobile-pull-refresh-spinner-ij/style.css
@@ -1,0 +1,133 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 320px;
+}
+
+.description code {
+  background: #1e293b;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: #fbbf24;
+}
+
+/* ─── Phone Frame ─── */
+.phone-frame {
+  width: 300px;
+  border-radius: 32px;
+  background: #1e293b;
+  border: 2px solid #334155;
+  overflow: hidden;
+  margin: 0 auto;
+}
+
+.phone-screen {
+  overflow: hidden;
+  min-height: 400px;
+}
+
+/* ─── Pull Container ─── */
+.pull-container {
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  cursor: grab;
+  user-select: none;
+}
+
+.pull-container:active {
+  cursor: grabbing;
+}
+
+/* ─── Spinner Wrapper ─── */
+.spinner-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0;
+  height: 60px;
+}
+
+/* ─── Pull Spinner ─── */
+.pull-spinner {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 3px solid #334155;
+  border-top-color: #fbbf24;
+  transform: rotate(calc(var(--pull-progress, 0) * 360deg));
+  transition: transform 0.05s linear;
+  flex-shrink: 0;
+}
+
+.pull-spinner.spinning {
+  animation: spinner-rotate 0.8s linear infinite;
+}
+
+@keyframes spinner-rotate {
+  to { transform: rotate(360deg); }
+}
+
+/* ─── Pull Text ─── */
+.pull-text {
+  font-size: 0.8rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+/* ─── Content ─── */
+.pull-content {
+  padding: 0.5rem 0;
+}
+
+.list-item {
+  padding: 0.85rem 1.25rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  border-bottom: 1px solid #1e293b;
+  transition: background 0.2s ease;
+}
+
+.list-item:last-child {
+  border-bottom: none;
+}
+
+.list-item:hover {
+  background: #0f172a;
+}
+
+/* ─── Focus ─── */
+.pull-container:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Component: ease-mobile-pull-refresh-spinner — circular spinner rotation tied to pull progress, CSS handles visuals

**Closes #13782**

### What this adds
A "pull to refresh" interaction. The circular spinner rotates proportionally to the pull distance via `--pull-progress` CSS variable. Past the threshold, releasing triggers a full rotation animation. Content translates down with the pull gesture.

### Acceptance Criteria covered
- Circular spinner with rotation tied to pull progress
- CSS handles visual rotation via `--pull-progress`
- JS sets progress variable from drag distance

### Files
- `submissions/examples/mobile-pull-refresh-spinner-ij/demo.html`
- `submissions/examples/mobile-pull-refresh-spinner-ij/style.css`
- `submissions/examples/mobile-pull-refresh-spinner-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Click and drag down on the list area; watch the spinner rotate proportionally; release past threshold to trigger refresh animation.
