### PR TITLE
feat(submission): add mobile app icon press #13783

### DIFF
--- a/submissions/examples/mobile-app-icon-press-ij/README.md
+++ b/submissions/examples/mobile-app-icon-press-ij/README.md
@@ -1,0 +1,7 @@
+# Mobile App Icon Press
+
+1. What does this do? A grid of app icons that scale down to 0.92 on press (`:active` pseudo-class). The release transition uses a spring-like cubic-bezier for a fast spring-back effect. Each icon has a unique color set via the `--icon-color` CSS variable.
+
+2. How is it used? Add `.app-icon` buttons with an inner `.icon-bg` colored by `--icon-color`. The `:active` state triggers `scale(0.92)` with a near-instant linear transition. The normal state transitions back with `cubic-bezier(0.34, 1.56, 0.64, 1)` for the spring-back feel.
+
+3. Why is it useful? This mimics the native iOS home screen icon press effect. It provides tactile-like feedback for touch interactions, making the UI feel more responsive and polished without any JavaScript.

--- a/submissions/examples/mobile-app-icon-press-ij/demo.html
+++ b/submissions/examples/mobile-app-icon-press-ij/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobile App Icon Press - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <h1>App Icon Press</h1>
+
+    <div class="phone-frame">
+      <div class="phone-screen">
+        <div class="icon-grid">
+          <button class="app-icon" style="--icon-color: #3b82f6;">
+            <span class="icon-bg">
+              <span class="icon-emoji">&#9993;</span>
+            </span>
+            <span class="icon-name">Mail</span>
+          </button>
+          <button class="app-icon" style="--icon-color: #22c55e;">
+            <span class="icon-bg">
+              <span class="icon-emoji">&#128196;</span>
+            </span>
+            <span class="icon-name">Files</span>
+          </button>
+          <button class="app-icon" style="--icon-color: #f59e0b;">
+            <span class="icon-bg">
+              <span class="icon-emoji">&#128247;</span>
+            </span>
+            <span class="icon-name">Photos</span>
+          </button>
+          <button class="app-icon" style="--icon-color: #ef4444;">
+            <span class="icon-bg">
+              <span class="icon-emoji">&#9654;</span>
+            </span>
+            <span class="icon-name">Music</span>
+          </button>
+          <button class="app-icon" style="--icon-color: #8b5cf6;">
+            <span class="icon-bg">
+              <span class="icon-emoji">&#128467;</span>
+            </span>
+            <span class="icon-name">Calendar</span>
+          </button>
+          <button class="app-icon" style="--icon-color: #06b6d4;">
+            <span class="icon-bg">
+              <span class="icon-emoji">&#9881;</span>
+            </span>
+            <span class="icon-name">Settings</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <p class="description">Press and hold any icon to see the scale(0.92) effect. Release to watch it spring back.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/mobile-app-icon-press-ij/style.css
+++ b/submissions/examples/mobile-app-icon-press-ij/style.css
@@ -1,0 +1,115 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-wrapper {
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+}
+
+.description {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  max-width: 300px;
+}
+
+/* ─── Phone Frame ─── */
+.phone-frame {
+  width: 280px;
+  border-radius: 32px;
+  background: #1e293b;
+  border: 2px solid #334155;
+  overflow: hidden;
+  margin: 0 auto;
+}
+
+.phone-screen {
+  padding: 2rem 1.25rem;
+  min-height: 350px;
+}
+
+/* ─── Icon Grid ─── */
+.icon-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem 1rem;
+  justify-items: center;
+}
+
+/* ─── App Icon ─── */
+.app-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.app-icon:active {
+  transform: scale(0.92);
+  transition: transform 0.05s linear;
+}
+
+.app-icon:hover {
+  transform: scale(1.05);
+}
+
+.app-icon:active:hover {
+  transform: scale(0.92);
+}
+
+/* ─── Icon Background ─── */
+.icon-bg {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--icon-color, #3b82f6);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.icon-emoji {
+  font-size: 1.5rem;
+  filter: brightness(1.2);
+}
+
+/* ─── Icon Name ─── */
+.icon-name {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+/* ─── Focus ─── */
+.app-icon:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 4px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Component: ease-mobile-app-icon-press — scale(0.92) on :active, fast spring-back on release

**Closes #13783**

### What this adds
A grid of app icons that scale down to 0.92 on `:active` (press). The release transition uses a spring-like cubic-bezier for fast spring-back. Each icon has a unique color set via `--icon-color`. No JavaScript needed.

### Acceptance Criteria covered
- `scale(0.92)` on `:active`
- Fast spring-back on release
- No JavaScript required

### Files
- `submissions/examples/mobile-app-icon-press-ij/demo.html`
- `submissions/examples/mobile-app-icon-press-ij/style.css`
- `submissions/examples/mobile-app-icon-press-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Press and hold any icon to see the scale-down effect; release to watch it spring back.