### PR TITLE
feat(submission): add button press ripple CSS effect

### DIFF
--- a/submissions/examples/button-press-ripple-ag/README.md
+++ b/submissions/examples/button-press-ripple-ag/README.md
@@ -1,0 +1,13 @@
+# Button Press Ripple Effect
+
+## What does this do?
+
+Adds a circular ripple animation on button press that expands outward and fades, giving tactile visual feedback for click/tap interactions.
+
+## How is it used?
+
+Apply the `.ripple-btn` class to any `<button>` element. Variants like `.green`, `.red`, `.amber`, and `.ghost` demonstrate the effect across different color schemes.
+
+## Why is this useful?
+
+Provides immediate visual feedback on press without requiring JavaScript, improving perceived performance and user confidence in interactions. Fits EaseMotion CSS's philosophy of declarative, performant CSS utilities.

--- a/submissions/examples/button-press-ripple-ag/demo.html
+++ b/submissions/examples/button-press-ripple-ag/demo.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Button Press Ripple</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1 class="page-title">Press any button</h1>
+    <div class="variants">
+      <button class="ripple-btn">Default</button>
+      <button class="ripple-btn green">Success</button>
+      <button class="ripple-btn red">Danger</button>
+      <button class="ripple-btn amber">Warning</button>
+      <button class="ripple-btn ghost">Outline</button>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/button-press-ripple-ag/style.css
+++ b/submissions/examples/button-press-ripple-ag/style.css
@@ -1,0 +1,107 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f0f0f;
+  color: #fff;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+}
+
+.page-title {
+  font-size: 22px;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.ripple-btn {
+  position: relative;
+  overflow: hidden;
+  padding: 14px 36px;
+  font-size: 16px;
+  font-weight: 600;
+  border: none;
+  border-radius: 10px;
+  background: #6366f1;
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.12s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.ripple-btn:active {
+  transform: scale(0.94);
+}
+
+.ripple-btn::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: inherit;
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ripple-btn:active::before {
+  animation: ripple-burst 0.5s ease-out forwards;
+}
+
+@keyframes ripple-burst {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.5;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(2.5);
+    opacity: 0;
+  }
+}
+
+.variants {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.ripple-btn.green {
+  background: #22c55e;
+}
+
+.ripple-btn.red {
+  background: #ef4444;
+}
+
+.ripple-btn.amber {
+  background: #f59e0b;
+}
+
+.ripple-btn.ghost {
+  background: transparent;
+  border: 2px solid #6366f1;
+  color: #6366f1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ripple-btn::before {
+    display: none;
+  }
+  .ripple-btn:active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
### Description
Adds a CSS-only button press ripple effect submission to `submissions/examples/button-press-ripple-ag/`. The effect creates a circular ripple on `:active` that expands and fades, giving tactile feedback on click/tap.

### Demo
Open `demo.html` in a browser and press any button.

### Files
- `demo.html` - self-contained demo
- `style.css` - ripple animation using `::before` pseudo-element
- `README.md` - description, usage, and rationale

Refs: #14695

gsso26