### PR TITLE
feat(submission): add badge new glow CSS effect

### DIFF
--- a/submissions/examples/badge-new-glow-ag/README.md
+++ b/submissions/examples/badge-new-glow-ag/README.md
@@ -1,0 +1,13 @@
+# Badge New Glow
+
+## What does this do?
+
+Adds a pulsing glow animation to notification badges, drawing attention to new items, unread counts, or "NEW" labels.
+
+## How is it used?
+
+Apply the `.glow-badge` class to a badge element inside a positioned container. Color variants (`.green`, `.blue`, `.amber`) are available. The `.new-label` class provides a standalone glowing label style.
+
+## Why is this useful?
+
+Provides an attention-grabbing visual cue for new content without JavaScript, aligning with EaseMotion CSS's approach of declarative, accessible CSS utilities.

--- a/submissions/examples/badge-new-glow-ag/demo.html
+++ b/submissions/examples/badge-new-glow-ag/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Badge New Glow</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1>Glowing notification badges</h1>
+    <div class="showcase">
+      <div class="badge-host">&#9993; <span class="glow-badge">3</span></div>
+      <div class="badge-host">
+        &#128276; <span class="glow-badge green">9+</span>
+      </div>
+      <div class="badge-host">
+        &#128722; <span class="glow-badge blue">1</span>
+      </div>
+      <div class="badge-host">
+        &#9879; <span class="glow-badge amber">!</span>
+      </div>
+    </div>
+    <div class="showcase">
+      <span class="glow-badge new-label">NEW</span>
+      <span class="glow-badge new-label green">LIVE</span>
+      <span class="glow-badge new-label blue">UPDATED</span>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/badge-new-glow-ag/style.css
+++ b/submissions/examples/badge-new-glow-ag/style.css
@@ -1,0 +1,107 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f0f0f;
+  color: #fff;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 32px;
+  padding: 20px;
+}
+
+h1 {
+  font-size: 20px;
+  text-align: center;
+  color: #aaa;
+}
+
+.showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+}
+
+.badge-host {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  background: #1a1a1a;
+  border-radius: 16px;
+  border: 1px solid #2a2a2a;
+  font-size: 28px;
+}
+
+.glow-badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 28px;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: badge-glow 2s ease-in-out infinite;
+  box-shadow: 0 0 8px rgba(239, 68, 68, 0.5);
+}
+
+.glow-badge.green {
+  background: #22c55e;
+  box-shadow: 0 0 8px rgba(34, 197, 94, 0.5);
+}
+
+.glow-badge.blue {
+  background: #3b82f6;
+  box-shadow: 0 0 8px rgba(59, 130, 246, 0.5);
+}
+
+.glow-badge.amber {
+  background: #f59e0b;
+  box-shadow: 0 0 8px rgba(245, 158, 11, 0.5);
+}
+
+.glow-badge.new-label {
+  position: static;
+  min-width: 52px;
+  height: 26px;
+  font-size: 13px;
+  letter-spacing: 0.5px;
+}
+
+@keyframes badge-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 4px currentColor;
+    transform: scale(1);
+  }
+  50% {
+    box-shadow:
+      0 0 14px currentColor,
+      0 0 28px currentColor;
+    transform: scale(1.08);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glow-badge {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a glowing badge animation submission to `submissions/examples/badge-new-glow-ag/`. Badges pulse with a soft glow effect to draw attention.

## Demo
Open `demo.html` in a browser to see glowing notification badges and NEW labels in multiple colors.

## Files
- `demo.html` - self-contained demo
- `style.css` - glow animation using @keyframes and box-shadow
- `README.md` - description and usage

Refs: #14697

gssoc26