### PR TITLE
Fix: Subheadings are now visible in Light Mode

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -1040,7 +1040,8 @@ body > .docs-shell {
   font-size: 1.1rem;
   letter-spacing: -0.01em;
   margin-bottom: 0.75rem;
-  color: rgba(255, 255, 255, 0.85);
+  /* Swapped hardcoded white for the dynamic subheading variable */
+  color: var(--heading-sub-color); 
 }
 
 .docs-p {


### PR DESCRIPTION
### Pull Request Description

### Type of Change
[ ] ✨ New animation / hover effect

[ ] 🧩 New component

[ ] 📝 Documentation improvement

[x] 🐛 Bug fix in an existing submission

[x] Other (describe below): Core documentation layout fix

### Submission Checklist
⚠️ Note for Maintainer: Since this is a fix for the main documentation site and not a new component submission, the standard submissions/ folder rules do not apply. Only docs/docs.css was modified.

[x] One feature per PR (no bundled unrelated changes)

### Feature Description
### What does this add/fix?
This fixes a major visibility bug on the live documentation site. Previously, the <h3> subheadings (.docs-h3) were hardcoded to an rgba(255, 255, 255, 0.85) white color. When a user toggled the site to Light Mode, these headings became completely invisible against the white background.

I updated .docs-h3 to use the dynamic var(--heading-sub-color) CSS variable defined in the root theme settings.

**How does a developer use it?**
No usage changes. The documentation subheadings now seamlessly switch to #1e293b (dark gray) when the Light Mode theme is toggled.

**Why does it fit EaseMotion CSS?**
It restores accessibility and readability to the framework's primary documentation portal.

### **Demo**
[x] Demo added (Tested locally via browser theme toggle)

### Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

[ ] Safari (optional but appreciated)

Notes for Maintainer
Fixes #14682