### PR TITLE
feat(demo): add ease-cursor-pointer class to Animation Demo Cards

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -378,6 +378,9 @@
       font-size: 1.5rem;
       color: #fff;
       font-weight: bold;
+    }
+
+    .anim-box.ease-cursor-pointer {
       cursor: pointer;
     }
 
@@ -1038,39 +1041,39 @@
         <div class="demo-chip">// Entrance animations</div>
         <div class="ease-flex ease-flex-wrap ease-gap-6" style="margin-bottom: var(--ease-space-10);">
           <div class="anim-cell">
-            <div class="anim-box ease-fade-in" id="anim-fade" onclick="replay(this,'ease-fade-in')">F</div>
+            <div class="anim-box ease-cursor-pointer ease-fade-in" id="anim-fade" onclick="replay(this,'ease-fade-in')">F</div>
             <span class="tag">ease-fade-in</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-slide-up" id="anim-slide" onclick="replay(this,'ease-slide-up')">↑</div>
+            <div class="anim-box ease-cursor-pointer ease-slide-up" id="anim-slide" onclick="replay(this,'ease-slide-up')">↑</div>
             <span class="tag">ease-slide-up</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-slide-in-left" onclick="replay(this,'ease-slide-in-left')">←</div>
+            <div class="anim-box ease-cursor-pointer ease-slide-in-left" onclick="replay(this,'ease-slide-in-left')">←</div>
             <span class="tag">ease-slide-in-left</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-slide-in-right" onclick="replay(this,'ease-slide-in-right')">→</div>
+            <div class="anim-box ease-cursor-pointer ease-slide-in-right" onclick="replay(this,'ease-slide-in-right')">→</div>
             <span class="tag">ease-slide-in-right</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-slide-in-left" onclick="replay(this,'ease-slide-in-left')">←</div>
+            <div class="anim-box ease-cursor-pointer ease-slide-in-left" onclick="replay(this,'ease-slide-in-left')">←</div>
             <span class="tag">ease-slide-in-left</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-slide-in-right" onclick="replay(this,'ease-slide-in-right')">→</div>
+            <div class="anim-box ease-cursor-pointer ease-slide-in-right" onclick="replay(this,'ease-slide-in-right')">→</div>
             <span class="tag">ease-slide-in-right</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-zoom-in" onclick="replay(this,'ease-zoom-in')">Z</div>
+            <div class="anim-box ease-cursor-pointer ease-zoom-in" onclick="replay(this,'ease-zoom-in')">Z</div>
             <span class="tag">ease-zoom-in</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-flip" onclick="replay(this,'ease-flip')">⟳</div>
+            <div class="anim-box ease-cursor-pointer ease-flip" onclick="replay(this,'ease-flip')">⟳</div>
             <span class="tag">ease-flip</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-contract-image-entrance" onclick="replay(this,'ease-contract-image-entrance')">🖼️
+            <div class="anim-box ease-cursor-pointer ease-contract-image-entrance" onclick="replay(this,'ease-contract-image-entrance')">🖼️
             </div>
             <span class="tag">ease-contract-image-entrance</span>
           </div>
@@ -1137,28 +1140,28 @@
         <div class="demo-chip">// Slide-in from off-canvas (sides & corners)</div>
         <div class="ease-flex ease-flex-wrap ease-gap-6" style="margin-bottom: var(--ease-space-10); overflow: hidden;">
           <div class="anim-cell">
-            <div class="anim-box ease-slide-in-from-top" onclick="replay(this,'ease-slide-in-from-top')">↓</div>
+            <div class="anim-box ease-cursor-pointer ease-slide-in-from-top" onclick="replay(this,'ease-slide-in-from-top')">↓</div>
             <span class="tag">ease-slide-in-from-top</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-slide-in-from-bottom" onclick="replay(this,'ease-slide-in-from-bottom')">↑</div>
+            <div class="anim-box ease-cursor-pointer ease-slide-in-from-bottom" onclick="replay(this,'ease-slide-in-from-bottom')">↑</div>
             <span class="tag">ease-slide-in-from-bottom</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-slide-in-from-left" onclick="replay(this,'ease-slide-in-from-left')">→</div>
+            <div class="anim-box ease-cursor-pointer ease-slide-in-from-left" onclick="replay(this,'ease-slide-in-from-left')">→</div>
             <span class="tag">ease-slide-in-from-left</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-slide-in-from-right" onclick="replay(this,'ease-slide-in-from-right')">←</div>
+            <div class="anim-box ease-cursor-pointer ease-slide-in-from-right" onclick="replay(this,'ease-slide-in-from-right')">←</div>
             <span class="tag">ease-slide-in-from-right</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-slide-in-from-top-left" onclick="replay(this,'ease-slide-in-from-top-left')">↘
+            <div class="anim-box ease-cursor-pointer ease-slide-in-from-top-left" onclick="replay(this,'ease-slide-in-from-top-left')">↘
             </div>
             <span class="tag">ease-slide-in-from-top-left</span>
           </div>
           <div class="anim-cell">
-            <div class="anim-box ease-slide-in-from-top-right" onclick="replay(this,'ease-slide-in-from-top-right')">↙
+            <div class="anim-box ease-cursor-pointer ease-slide-in-from-top-right" onclick="replay(this,'ease-slide-in-from-top-right')">↙
             </div>
             <span class="tag">ease-slide-in-from-top-right</span>
           </div>
@@ -1177,11 +1180,10 @@
         <div class="demo-chip">// Exit animations</div>
         <div class="ease-flex ease-flex-wrap ease-gap-6">
           <div class="anim-cell">
-            <div class="ease-expand-border-exit" onclick="replay(this,'ease-expand-border-exit')" style="width:64px;
+            <div class="ease-cursor-pointer ease-expand-border-exit" onclick="replay(this,'ease-expand-border-exit')" style="width:64px;
           height:64px;
           border:2px solid #a78bfa;
-          border-radius:12px;
-          cursor:pointer;"></div>
+          border-radius:12px;"></div>
             <span class="tag">ease-expand-border-exit</span>
 
           </div>


### PR DESCRIPTION
Replaced inline cursor: pointer styles with ease-cursor-pointer utility class for all clickable animation demo elements. Added .anim-box.ease-cursor-pointer CSS rule and applied the class to all anim-box elements with onclick handlers.

Closes #14771

## Pull Request Description

Added CSS rule for .anim-box.ease-cursor-pointer - This allows applying cursor: pointer only to anim-box elements that need it.

Added ease-cursor-pointer class to all 16 clickable animation demo elements that have onclick="replay(...)" handlers:

ease-fade-in, ease-slide-up, ease-slide-in-left, ease-slide-in-right
ease-zoom-in, ease-flip, ease-contract-image-entrance
ease-slide-in-from-top, ease-slide-in-from-bottom
ease-slide-in-from-left, ease-slide-in-from-right
ease-slide-in-from-top-left, ease-slide-in-from-top-right
ease-slide-in-from-bottom-left, ease-slide-in-from-bottom-right
ease-expand-border-exit
Replaced inline cursor:pointer; styles with the ease-cursor-pointer utility class for cleaner, more maintainable code.