### PR TITLE
feat(examples): add ease-mention-highlight-pulse — @mention pulse on message

### DIFF
--- a/submissions/examples/ease-mention-highlight-pulse/README.md
+++ b/submissions/examples/ease-mention-highlight-pulse/README.md
@@ -1,0 +1,34 @@
+# ease-mention-highlight-pulse
+
+## What does it do?
+When a user is @mentioned, their username briefly pulses with a highlight color using pure CSS keyframe animation — no JavaScript required.
+
+## Features
+- `background-color` pulse animation, 2–3 cycles then settles
+- Draws attention without being permanently distracting
+- Common chat/social UI pattern
+
+## Usage
+```css
+.mention {
+  animation: mention-pulse 2s ease 1;
+}
+
+@keyframes mention-pulse {
+  0%   { background-color: transparent; }
+  15%  { background-color: rgba(167, 139, 250, 0.25); }
+  30%  { background-color: rgba(167, 139, 250, 0.1); }
+  50%  { background-color: rgba(167, 139, 250, 0.2); }
+  70%  { background-color: rgba(167, 139, 250, 0.05); }
+  100% { background-color: transparent; }
+}
+```
+
+## Browser Support
+- `@keyframes` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-mention-highlight-pulse/demo.html
+++ b/submissions/examples/ease-mention-highlight-pulse/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-mention-highlight-pulse — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-mention-highlight-pulse</h1>
+  <p class="subtitle">@mention highlights with a brief background pulse — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Chat Messages</h2>
+    <p class="sec-desc">Each message contains a @mention that pulses on page load to draw attention</p>
+    <div class="chat">
+      <div class="msg"><span class="avatar" style="background:#6366f1;"></span><div class="msg-body"><strong>Alice</strong> <span class="mention">@bob</span> check the latest design</div></div>
+      <div class="msg"><span class="avatar" style="background:#22c55e;"></span><div class="msg-body"><strong>Bob</strong> <span class="mention">@charlie</span> the PR is ready for review</div></div>
+      <div class="msg"><span class="avatar" style="background:#f59e0b;"></div><div class="msg-body"><strong>Charlie</strong> <span class="mention">@alice</span> looks good to me</div></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p style="color:#9ca3af;line-height:1.8;">The <code>.mention</code> class uses a <code>@keyframes</code> animation that pulses the background color 2–3 cycles then settles at the end state. The animation runs on page load via <code>animation: mention-pulse 2s ease 1</code>.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-mention-highlight-pulse/style.css
+++ b/submissions/examples/ease-mention-highlight-pulse/style.css
@@ -1,0 +1,66 @@
+/* ============================================================
+   EaseMotion CSS — ease-mention-highlight-pulse
+   @mention highlights with brief background pulse
+   ============================================================ */
+
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.msg {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.msg-body {
+  background: #2a2a2a;
+  padding: 0.6rem 1rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #d1d5db;
+}
+
+.msg-body strong {
+  color: #ffffff;
+  margin-right: 0.4rem;
+}
+
+.mention {
+  color: #a78bfa;
+  font-weight: 500;
+  border-radius: 4px;
+  padding: 0.1em 0.3em;
+  animation: mention-pulse 2s ease 1;
+}
+
+@keyframes mention-pulse {
+  0% {
+    background-color: transparent;
+  }
+  15% {
+    background-color: rgba(167, 139, 250, 0.25);
+  }
+  30% {
+    background-color: rgba(167, 139, 250, 0.1);
+  }
+  50% {
+    background-color: rgba(167, 139, 250, 0.2);
+  }
+  70% {
+    background-color: rgba(167, 139, 250, 0.05);
+  }
+  100% {
+    background-color: transparent;
+  }
+}


### PR DESCRIPTION
## Description

When a user is @mentioned, their username briefly pulses with a highlight color using pure CSS keyframe animation — no JavaScript required.

## Acceptance Criteria
- [x] background-color pulse, 2-3 cycles then settles
- [x] Draws attention without being permanently distracting
- [x] Common chat/social UI pattern

## Files

| File | Description |
|------|-------------|
| `demo.html` | Chat message demo with @mention highlights |
| `style.css` | Keyframe animation for mention pulse |
| `README.md` | Documentation and usage |

## Related Issue
Closes #13819

<!-- re-trigger label sync -->