### PR TITLE
feat(examples): add ease-breadcrumb-collapse — long breadcrumb collapses

### DIFF
--- a/submissions/examples/ease-breadcrumb-collapse/README.md
+++ b/submissions/examples/ease-breadcrumb-collapse/README.md
@@ -1,0 +1,40 @@
+# ease-breadcrumb-collapse
+
+## What does it do?
+When a breadcrumb path is too long, middle items collapse into an animated ellipsis that expands on click — pure CSS, no JavaScript.
+
+## Features
+- Collapsed state shows `...` as a clickable label
+- Click expands to show full path with smooth slide-down
+- Uses checkbox hack (`:checked`) for toggle interaction
+- Common deep-navigation UI pattern
+
+## Usage
+```html
+<input type="checkbox" id="bc-toggle" hidden>
+<label for="bc-toggle">...</label>
+<div class="collapsed-items">
+  <!-- hidden breadcrumb items -->
+</div>
+```
+
+```css
+.collapsed-items {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.4s ease;
+}
+
+#bc-toggle:checked ~ .collapsed-items {
+  max-height: 200px;
+}
+```
+
+## Browser Support
+- `:checked` + `transition` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-breadcrumb-collapse/demo.html
+++ b/submissions/examples/ease-breadcrumb-collapse/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-breadcrumb-collapse — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-breadcrumb-collapse</h1>
+  <p class="subtitle">Long breadcrumb collapses into animated ellipsis, expands on click — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Breadcrumb Demo</h2>
+    <p class="sec-desc">Click the <code>...</code> to expand/collapse the full path</p>
+    <div class="breadcrumb-wrap">
+      <nav class="breadcrumb">
+        <a href="#">Home</a>
+        <span class="sep">/</span>
+        <a href="#">Products</a>
+        <span class="sep">/</span>
+        <a href="#">Category</a>
+        <span class="sep">/</span>
+        <a href="#">Subcategory</a>
+        <span class="sep">/</span>
+        <label class="toggle" for="bc-toggle">...</label>
+        <input type="checkbox" id="bc-toggle" hidden>
+        <span class="collapsed-items">
+          <a href="#">Deep</a>
+          <span class="sep">/</span>
+          <a href="#">Nested</a>
+          <span class="sep">/</span>
+          <a href="#">Very Deep</a>
+          <span class="sep">/</span>
+          <a href="#">Detail</a>
+          <span class="sep">/</span>
+          <a href="#">Settings</a>
+        </span>
+        <span class="sep">/</span>
+        <span class="current">Current Page</span>
+      </nav>
+    </div>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p style="color:#9ca3af;line-height:1.8;">A hidden checkbox (<code>#bc-toggle</code>) controls the collapsed/expanded state. The <code>.collapsed-items</code> container starts with <code>max-height: 0</code> and transitions to <code>max-height: 200px</code> when <code>:checked</code>, creating a smooth slide-down reveal. The <code>...</code> label toggles visibility.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-breadcrumb-collapse/style.css
+++ b/submissions/examples/ease-breadcrumb-collapse/style.css
@@ -1,0 +1,68 @@
+/* ============================================================
+   EaseMotion CSS — ease-breadcrumb-collapse
+   Long breadcrumb collapses with ellipsis animation
+   ============================================================ */
+
+.breadcrumb-wrap {
+  background: #2a2a2a;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.breadcrumb a {
+  color: #a78bfa;
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.sep {
+  color: #6b7280;
+  margin: 0 0.15rem;
+}
+
+.current {
+  color: #9ca3af;
+}
+
+.toggle {
+  cursor: pointer;
+  color: #a78bfa;
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: 2px;
+  padding: 0 0.25rem;
+  user-select: none;
+}
+
+.toggle:hover {
+  color: #c4b5fd;
+}
+
+.collapsed-items {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.4s ease;
+}
+
+#bc-toggle:checked ~ .collapsed-items {
+  max-height: 200px;
+}
+
+#bc-toggle:checked ~ .toggle {
+  display: none;
+}


### PR DESCRIPTION
## Description

Long breadcrumb collapses into an animated ellipsis and expands on click using the CSS checkbox hack — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] Collapsed state shows '...'
- [x] Click expands to show full path with slide-down transition
- [x] Common deep-navigation UI pattern

## Files

| File | Description |
|------|-------------|
| `demo.html` | Breadcrumb with toggle between collapsed/expanded |
| `style.css` | max-height transition with :checked selector |
| `README.md` | Documentation and usage |

## Related Issue
Closes #13811

<!-- re-trigger label sync -->