### PR TITLE
feat(examples): add ease-sidebar-item-active-indicator — sliding sidebar indicator

### DIFF
--- a/submissions/examples/ease-sidebar-item-active-indicator/README.md
+++ b/submissions/examples/ease-sidebar-item-active-indicator/README.md
@@ -1,0 +1,42 @@
+# ease-sidebar-item-active-indicator
+
+## What does it do?
+Sidebar navigation items show a sliding bar indicator for the active item — pure CSS, no JavaScript.
+
+## Features
+- Vertical indicator bar slides to the active item position
+- Uses radio buttons for exclusive selection
+- Smooth `top` transition on the indicator bar
+- Common dashboard sidebar pattern
+
+## Usage
+```html
+<input type="radio" name="nav" id="item1" hidden checked>
+<input type="radio" name="nav" id="item2" hidden>
+<div class="sidebar-items">
+  <label for="item1">Dashboard</label>
+  <label for="item2">Analytics</label>
+  <div class="indicator-bar"></div>
+</div>
+```
+
+```css
+.indicator-bar {
+  position: absolute;
+  top: 4px;
+  transition: top 0.3s ease;
+}
+
+#item2:checked ~ .sidebar-items .indicator-bar {
+  top: 44px;
+}
+```
+
+## Browser Support
+- `:checked` + `transition` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-sidebar-item-active-indicator/demo.html
+++ b/submissions/examples/ease-sidebar-item-active-indicator/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-sidebar-item-active-indicator — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-sidebar-item-active-indicator</h1>
+  <p class="subtitle">Sidebar nav item gets a sliding vertical active indicator — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Sidebar Demo</h2>
+    <p class="sec-desc">Click each item to see the active indicator slide to it</p>
+    <div class="sidebar-wrap">
+      <div class="sidebar">
+        <input type="radio" name="sidebar" id="s1" hidden checked>
+        <input type="radio" name="sidebar" id="s2" hidden>
+        <input type="radio" name="sidebar" id="s3" hidden>
+        <input type="radio" name="sidebar" id="s4" hidden>
+        <div class="sidebar-items">
+          <label class="side-item" for="s1">Dashboard</label>
+          <label class="side-item" for="s2">Analytics</label>
+          <label class="side-item" for="s3">Settings</label>
+          <label class="side-item" for="s4">Profile</label>
+          <div class="indicator-bar"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p style="color:#9ca3af;line-height:1.8;">Radio buttons control which item is active. Each <code>.side-item</code> label toggles its corresponding radio. The <code>.indicator-bar</code> uses <code>:has()</code> or sibling selectors to reposition via <code>top</code> based on which radio is <code>:checked</code>.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-sidebar-item-active-indicator/style.css
+++ b/submissions/examples/ease-sidebar-item-active-indicator/style.css
@@ -1,0 +1,63 @@
+/* ============================================================
+   EaseMotion CSS — ease-sidebar-item-active-indicator
+   Sidebar nav item gets sliding vertical active indicator
+   ============================================================ */
+
+.sidebar-wrap {
+  display: flex;
+  justify-content: center;
+}
+
+.sidebar {
+  width: 220px;
+}
+
+.sidebar-items {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: #2a2a2a;
+  border-radius: 12px;
+  padding: 0.5rem 0;
+  overflow: hidden;
+}
+
+.side-item {
+  position: relative;
+  z-index: 2;
+  padding: 0.75rem 1.25rem;
+  color: #9ca3af;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: color 0.2s;
+  user-select: none;
+}
+
+.side-item:hover {
+  color: #d1d5db;
+}
+
+.indicator-bar {
+  position: absolute;
+  left: 0;
+  top: 4px;
+  width: 3px;
+  height: 36px;
+  background: #a78bfa;
+  border-radius: 0 3px 3px 0;
+  transition: top 0.3s ease;
+  z-index: 1;
+}
+
+#s1:checked ~ .sidebar-items .indicator-bar { top: 4px; }
+#s2:checked ~ .sidebar-items .indicator-bar { top: 44px; }
+#s3:checked ~ .sidebar-items .indicator-bar { top: 84px; }
+#s4:checked ~ .sidebar-items .indicator-bar { top: 124px; }
+
+#s1:checked ~ .sidebar-items label[for="s1"],
+#s2:checked ~ .sidebar-items label[for="s2"],
+#s3:checked ~ .sidebar-items label[for="s3"],
+#s4:checked ~ .sidebar-items label[for="s4"] {
+  color: #a78bfa;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Description

Sidebar navigation items show a sliding vertical bar indicator for the active item using CSS radio buttons — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] Vertical indicator bar slides to active item position
- [x] Similar technique to nav underline indicator but vertical
- [x] Common dashboard sidebar pattern

## Files

| File | Description |
|------|-------------|
| `demo.html` | Sidebar with 4 items and sliding indicator |
| `style.css` | Radio button controlled indicator with top transition |
| `README.md` | Documentation and usage |

## Related Issue
Closes #13810

<!-- re-trigger label sync -->