### PR TITLE
feat(examples): add ease-table-row-hover-highlight — table row highlight

### DIFF
--- a/submissions/examples/ease-table-row-hover-highlight/README.md
+++ b/submissions/examples/ease-table-row-hover-highlight/README.md
@@ -1,0 +1,39 @@
+# ease-table-row-hover-highlight
+
+## What does it do?
+Table rows get a smooth background color transition on hover, with an optional subtle scale effect — pure CSS, no JavaScript.
+
+## Features
+- Smooth `background-color` transition on row hover
+- Optional subtle `scale(1.005)` for depth
+- Common data table UX pattern
+
+## Usage
+```css
+tr {
+  transition: background-color 0.25s ease;
+}
+
+tr:hover {
+  background-color: rgba(167, 139, 250, 0.1);
+}
+
+/* With scale */
+tr {
+  transition: background-color 0.25s ease, transform 0.25s ease;
+}
+
+tr:hover {
+  background-color: rgba(167, 139, 250, 0.1);
+  transform: scale(1.005);
+}
+```
+
+## Browser Support
+- `transition` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-table-row-hover-highlight/demo.html
+++ b/submissions/examples/ease-table-row-hover-highlight/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-table-row-hover-highlight — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-table-row-hover-highlight</h1>
+  <p class="subtitle">Table row highlights smoothly on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Data Table</h2>
+    <p class="sec-desc">Hover any row to see the background transition with optional subtle scale</p>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr><th>Name</th><th>Role</th><th>Status</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Alice</td><td>Designer</td><td>Active</td></tr>
+          <tr><td>Bob</td><td>Developer</td><td>Active</td></tr>
+          <tr><td>Charlie</td><td>Manager</td><td>Inactive</td></tr>
+          <tr><td>Diana</td><td>Developer</td><td>Active</td></tr>
+          <tr><td>Eve</td><td>Designer</td><td>Inactive</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>With Scale Option</h2>
+    <p class="sec-desc">Table with optional subtle <code>scale(1.005)</code> for extra depth</p>
+    <div class="table-wrap">
+      <table class="data-table data-table-scale">
+        <thead>
+          <tr><th>Item</th><th>Qty</th><th>Price</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Widget A</td><td>3</td><td>$9.99</td></tr>
+          <tr><td>Widget B</td><td>1</td><td>$14.99</td></tr>
+          <tr><td>Widget C</td><td>5</td><td>$4.99</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-table-row-hover-highlight/style.css
+++ b/submissions/examples/ease-table-row-hover-highlight/style.css
@@ -1,0 +1,47 @@
+/* ============================================================
+   EaseMotion CSS — ease-table-row-hover-highlight
+   Table row highlights smoothly on hover
+   ============================================================ */
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.data-table th {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  color: #9ca3af;
+  font-weight: 600;
+  border-bottom: 1px solid #333;
+}
+
+.data-table td {
+  padding: 0.75rem 1rem;
+  color: #d1d5db;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.data-table tbody tr {
+  transition: background-color 0.25s ease;
+}
+
+.data-table tbody tr:hover {
+  background-color: rgba(167, 139, 250, 0.1);
+}
+
+/* ---- With scale option ---- */
+
+.data-table-scale tbody tr {
+  transition: background-color 0.25s ease, transform 0.25s ease;
+}
+
+.data-table-scale tbody tr:hover {
+  background-color: rgba(167, 139, 250, 0.1);
+  transform: scale(1.005);
+}


### PR DESCRIPTION
## Description

Table rows get a smooth background color transition on hover with optional subtle scale — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] background-color smooth transition on hover
- [x] Optional subtle scale(1.005) for depth
- [x] Common data table UX pattern

## Files

| File | Description |
|------|-------------|
| `demo.html` | Two tables: standard highlight + with scale option |
| `style.css` | Row hover transitions |
| `README.md` | Documentation and usage |

## Related Issue
Closes #13806

<!-- re-trigger label sync -->