### PR TITLE
feat(examples): add ease-hover-border-draw — border draws on hover

### DIFF
--- a/submissions/examples/ease-hover-border-draw/README.md
+++ b/submissions/examples/ease-hover-border-draw/README.md
@@ -1,28 +1,48 @@
-# Ease Hover Border Draw 
+# ease-hover-border-draw
 
-A pure CSS interaction where a solid border progressively draws itself around an element's perimeter when hovered.
+## What does it do?
+Border draws itself around an element on hover — top, right, bottom, left in sequence — using `::before` and `::after` pseudo-elements — pure CSS, no JavaScript.
 
-## What it does
-The `ease-hover-border-draw` utility creates a sequential, animated border effect. Using `::before` and `::after` pseudo-elements, it traces the perimeter of the container (Top → Right → Bottom → Left). When the user's cursor leaves the element, the animation smoothly reverses, erasing the border in the opposite direction without any visual glitches.
+## Features
+- `::before` draws top and right borders
+- `::after` draws bottom and left borders
+- Sequential animation via transition delays
+- Custom properties for color and speed
 
-## How to use it
-Apply the class to any block or inline-block element (like a button or a card). 
-
-```html
-<button class="ease-hover-border-draw">
-    Hover Me
-</button>
-```
-
-You can customize the color and the total animation duration using CSS variables:
+## Usage
 ```css
-:root {
-    --ease-border-color: #6c63ff; /* Default color */
-    --ease-border-speed: 0.4s;    /* Total time for 2 sides (0.8s for full perimeter) */
+.element::before {
+  /* top + right borders */
+  transition:
+    width 0.3s ease,
+    height 0.3s ease 0.3s;
+}
+
+.element::after {
+  /* bottom + left borders */
+  transition:
+    width 0.3s ease 0.6s,
+    height 0.3s ease 0.3s;
+}
+
+.element:hover::before,
+.element:hover::after {
+  width: 100%;
+  height: 100%;
 }
 ```
 
-## Why it fits EaseMotion CSS
-* **Zero Dependencies:** Fully CSS driven using intelligent `transition-delay` sequencing, requiring no JavaScript event listeners.
-* **Responsive:** It relies on percentage-based widths and heights (`100%`), meaning it perfectly traces the element regardless of its dimensions or responsive resizing.
-* **Polished Interaction:** The careful calculation of the "rewind" state (when the mouse leaves) ensures the interaction feels premium and unbroken, tracing its exact steps backward rather than resetting harshly.
+## Customisation
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-border-draw-color` | `#a78bfa` | Border color |
+| `--ease-border-draw-speed` | `0.3s` | Duration per edge |
+
+## Browser Support
+- `::before`/`::after` + `transition` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-border-draw/demo.html
+++ b/submissions/examples/ease-hover-border-draw/demo.html
@@ -1,21 +1,42 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ease Border Draw Demo</title>
-    <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-border-draw — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
 </head>
 <body>
-    <div class="container">
-        <button class="ease-hover-border-draw demo-button">
-            Hover Me
-        </button>
-        
-        <div class="ease-hover-border-draw demo-card">
-            <h3>Demonstration</h3>
-            <p>This demonstrates the ease-hover-border-draw effect.</p>
-        </div>
+  <h1>ease-hover-border-draw</h1>
+  <p class="subtitle">Border draws itself around element on hover — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Border Draw Demo</h2>
+    <p class="sec-desc">Hover the card to see the border draw in sequence: top → right → bottom → left</p>
+    <div class="draw-wrap">
+      <div class="draw-card">
+        <span>Hover Me</span>
+      </div>
     </div>
+  </section>
+
+  <section>
+    <h2>Custom Color</h2>
+    <p class="sec-desc">Using <code>--ease-border-draw-color</code> to customize</p>
+    <div class="draw-wrap">
+      <div class="draw-card draw-alt" style="--ease-border-draw-color: #22c55e;">
+        <span>Green</span>
+      </div>
+    </div>
+  </section>
 </body>
 </html>

--- a/submissions/examples/ease-hover-border-draw/style.css
+++ b/submissions/examples/ease-hover-border-draw/style.css
@@ -1,108 +1,81 @@
-:root {
-    --ease-border-color: #6c63ff;
-    --ease-border-speed: 0.4s;
-}
-
-body {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 100vh;
-    background-color: #0f172a;
-    color: #f8fafc;
-    margin: 0;
-    font-family: system-ui, -apple-system, sans-serif;
-}
-
-.container {
-    display: flex;
-    flex-direction: column;
-    gap: 3rem;
-    align-items: center;
-}
-
-.demo-button {
-    background: transparent;
-    color: #f8fafc;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    padding: 1rem 2rem;
-    font-size: 1.1rem;
-    cursor: pointer;
-}
-
-.demo-card {
-    background: rgba(255, 255, 255, 0.05);
-    padding: 2rem;
-    width: 300px;
-    text-align: center;
-}
-
 /* ============================================================
-   Component: ease-hover-border-draw
+   EaseMotion CSS — ease-hover-border-draw
+   Border draws itself around element on hover
+   ::before = top + right, ::after = bottom + left
    ============================================================ */
 
-.ease-hover-border-draw {
-    position: relative;
-    box-sizing: border-box; 
+.draw-wrap {
+  display: flex;
+  justify-content: center;
 }
 
-.ease-hover-border-draw::before,
-.ease-hover-border-draw::after {
-    content: '';
-    position: absolute;
-    width: 0;
-    height: 0;
-    border: 2px solid transparent; 
-    box-sizing: border-box;
+.draw-card {
+  position: relative;
+  width: 240px;
+  height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2a2a2a;
+  border-radius: 4px;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 1.1rem;
+  cursor: pointer;
+  overflow: hidden;
 }
 
-/* ::before handles Top and Right borders */
-.ease-hover-border-draw::before {
-    top: 0;
-    left: 0;
+.draw-card span {
+  position: relative;
+  z-index: 2;
 }
 
-/* ::after handles Bottom and Left borders */
-.ease-hover-border-draw::after {
-    bottom: 0;
-    right: 0;
+/* ::before → top (width) + right (height) */
+.draw-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  background: transparent;
+  border-top: 2px solid var(--ease-border-draw-color, #a78bfa);
+  border-right: 2px solid var(--ease-border-draw-color, #a78bfa);
+  transition:
+    width var(--ease-border-draw-speed, 0.3s) ease,
+    height var(--ease-border-draw-speed, 0.3s) ease var(--ease-border-draw-speed, 0.3s);
+  pointer-events: none;
 }
 
-.ease-hover-border-draw:hover::before,
-.ease-hover-border-draw:hover::after {
-    width: 100%;
-    height: 100%;
+/* ::after → bottom + left */
+.draw-card::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  background: transparent;
+  border-bottom: 2px solid var(--ease-border-draw-color, #a78bfa);
+  border-left: 2px solid var(--ease-border-draw-color, #a78bfa);
+  transition:
+    width var(--ease-border-draw-speed, 0.3s) ease calc(var(--ease-border-draw-speed, 0.3s) * 2),
+    height var(--ease-border-draw-speed, 0.3s) ease calc(var(--ease-border-draw-speed, 0.3s) * 1);
+  pointer-events: none;
 }
 
-/* --- The Hover State (Draw) --- */
-
-.ease-hover-border-draw:hover::before {
-    border-top-color: var(--ease-border-color);
-    border-right-color: var(--ease-border-color);
-    transition: 
-        width calc(var(--ease-border-speed) / 2) ease-out 0s, 
-        height calc(var(--ease-border-speed) / 2) ease-out calc(var(--ease-border-speed) / 2);
+.draw-card:hover::before {
+  width: 100%;
+  height: 100%;
 }
 
-.ease-hover-border-draw:hover::after {
-    border-bottom-color: var(--ease-border-color);
-    border-left-color: var(--ease-border-color);
-    transition: 
-        border-color 0s ease-out var(--ease-border-speed), 
-        width calc(var(--ease-border-speed) / 2) ease-out var(--ease-border-speed), 
-        height calc(var(--ease-border-speed) / 2) ease-out calc(var(--ease-border-speed) * 1.5);
+.draw-card:hover::after {
+  width: 100%;
+  height: 100%;
 }
 
-.ease-hover-border-draw::before {
-    transition: 
-        border-color 0s ease-out calc(var(--ease-border-speed) * 2), 
-        height calc(var(--ease-border-speed) / 2) ease-out var(--ease-border-speed), 
-        width calc(var(--ease-border-speed) / 2) ease-out calc(var(--ease-border-speed) * 1.5);
-}
+/* ---- Alt color ---- */
 
-.ease-hover-border-draw::after {
-    transition: 
-        border-color 0s ease-out var(--ease-border-speed), 
-        height calc(var(--ease-border-speed) / 2) ease-out 0s, 
-        width calc(var(--ease-border-speed) / 2) ease-out calc(var(--ease-border-speed) / 2);
+.draw-alt {
+  --ease-border-draw-color: #22c55e;
 }


### PR DESCRIPTION
## Description

Border draws itself around an element on hover — top, right, bottom, left in sequence — using ::before and ::after pseudo-elements — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] ::before and ::after pseudo-elements draw 2 sides each
- [x] Width/height animate in sequence via transition delays
- [x] --ease-border-draw-color and --ease-border-draw-speed custom properties

## Files

| File | Description |
|------|-------------|
| `demo.html` | Two cards with default and custom color |
| `style.css` | Sequential border drawing via pseudo-elements |
| `README.md` | Documentation and usage |

## Related Issue
Closes #12528

<!-- re-trigger label sync -->