### PR TITLE
feat(examples): add ease-blur-in-up — blur in while rising

### DIFF
--- a/submissions/examples/ease-blur-in-up/README.md
+++ b/submissions/examples/ease-blur-in-up/README.md
@@ -1,0 +1,38 @@
+# ease-blur-in-up
+
+## What does it do?
+Element blurs in while rising — from `translateY(20px) + blur(10px) + opacity(0)` to fully clear — pure CSS, no JavaScript.
+
+## Features
+- Combined translate + blur + opacity transition
+- Staggered animation delay per element
+- Smooth 0.7s entrance animation
+
+## Usage
+```css
+.element {
+  animation: blur-in-up 0.7s ease forwards;
+}
+
+@keyframes blur-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+    filter: blur(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+```
+
+## Browser Support
+- `@keyframes` + `filter` — Chrome 53+, Firefox 49+, Safari 9.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-blur-in-up/demo.html
+++ b/submissions/examples/ease-blur-in-up/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-blur-in-up — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; text-align: center; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-blur-in-up</h1>
+  <p class="subtitle">Element blurs in while rising — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Blur In Up</h2>
+    <p class="sec-desc">Cards animate on load: blur + fade + translate → clear + visible</p>
+    <div class="blur-grid">
+      <div class="blur-card" style="--i:1;">Card 1</div>
+      <div class="blur-card" style="--i:2;">Card 2</div>
+      <div class="blur-card" style="--i:3;">Card 3</div>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-blur-in-up/style.css
+++ b/submissions/examples/ease-blur-in-up/style.css
@@ -1,0 +1,40 @@
+/* ============================================================
+   EaseMotion CSS — ease-blur-in-up
+   Element blurs in while rising
+   ============================================================ */
+
+.blur-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.blur-card {
+  width: 180px;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #6366f1, #a78bfa);
+  border-radius: 12px;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 1rem;
+  opacity: 0;
+  animation: blur-in-up 0.7s ease forwards;
+  animation-delay: calc(var(--i, 1) * 0.15s);
+}
+
+@keyframes blur-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+    filter: blur(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}


### PR DESCRIPTION
## Description

Element blurs in while rising from translateY(20px) + blur(10px) + opacity(0) to fully clear — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] translateY(20px) + blur(10px) + opacity(0) → 0

## Files

| File | Description |
|------|-------------|
| `demo.html` | Three cards with staggered blur-in-up animation |
| `style.css` | Keyframe animation with blur + translate |
| `README.md` | Documentation and usage |

## Related Issue
Closes #11879

<!-- re-trigger label sync -->