### PR TITLE
feat(examples): add ease-rotate-in-down-left — rotate in from upper right

### DIFF
--- a/submissions/examples/ease-rotate-in-down-left/README.md
+++ b/submissions/examples/ease-rotate-in-down-left/README.md
@@ -1,0 +1,39 @@
+# ease-rotate-in-down-left
+
+## What does it do?
+Element rotates into view from the upper-right corner using `transform-origin: left bottom` — pure CSS, no JavaScript.
+
+## Features
+- `rotate(-45deg)` with `transform-origin: left bottom`
+- Opacity 0 → 1 transition
+- Staggered animation for multiple elements
+- 0.6s entrance animation
+
+## Usage
+```css
+.element {
+  animation: rotate-in-down-left 0.6s ease forwards;
+}
+
+@keyframes rotate-in-down-left {
+  from {
+    opacity: 0;
+    transform: rotate(-45deg);
+    transform-origin: left bottom;
+  }
+  to {
+    opacity: 1;
+    transform: rotate(0deg);
+    transform-origin: left bottom;
+  }
+}
+```
+
+## Browser Support
+- `@keyframes` + `transform-origin` — Chrome 26+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-rotate-in-down-left/demo.html
+++ b/submissions/examples/ease-rotate-in-down-left/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-rotate-in-down-left — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; text-align: center; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-rotate-in-down-left</h1>
+  <p class="subtitle">Element rotates into view from upper-right corner — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Rotate In Demo</h2>
+    <p class="sec-desc">Cards animate from upper-right with rotation and fade</p>
+    <div class="rot-grid">
+      <div class="rot-card" style="--i:1;">Card 1</div>
+      <div class="rot-card" style="--i:2;">Card 2</div>
+      <div class="rot-card" style="--i:3;">Card 3</div>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-rotate-in-down-left/style.css
+++ b/submissions/examples/ease-rotate-in-down-left/style.css
@@ -1,0 +1,40 @@
+/* ============================================================
+   EaseMotion CSS — ease-rotate-in-down-left
+   Rotates into view from upper-right corner
+   ============================================================ */
+
+.rot-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.rot-card {
+  width: 180px;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #6366f1, #a78bfa);
+  border-radius: 12px;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 1rem;
+  opacity: 0;
+  animation: rotate-in-down-left 0.6s ease forwards;
+  animation-delay: calc(var(--i, 1) * 0.15s);
+}
+
+@keyframes rotate-in-down-left {
+  from {
+    opacity: 0;
+    transform: rotate(-45deg);
+    transform-origin: left bottom;
+  }
+  to {
+    opacity: 1;
+    transform: rotate(0deg);
+    transform-origin: left bottom;
+  }
+}


### PR DESCRIPTION
## Description

Element rotates into view from the upper-right corner using `transform-origin: left bottom` — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] `rotate(-45deg)` + `transform-origin: left bottom`
- [x] Opacity 0 → 1

## Files

| File | Description |
|------|-------------|
| `demo.html` | Three cards with staggered rotate-in animation |
| `style.css` | Keyframe with transform-origin |
| `README.md` | Documentation and usage |

## Related Issue
Closes #11882

<!-- re-trigger label sync -->