### PR TITLE
fix: register dark text token for glass cards

### DIFF
--- a/components/cards.css
+++ b/components/cards.css
@@ -181,7 +181,7 @@
   .ease-card-glass {
     --ease-glass-bg: color-mix(in srgb, var(--ease-color-surface, #1e293b) 50%, transparent);
 
-    color: var(--ease-color-text-dark, #f8fafc);
+    color: var(--ease-color-text-dark);
   }
 
   .ease-card-neumorphic {

--- a/core/variables.css
+++ b/core/variables.css
@@ -162,14 +162,15 @@
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    color-scheme: dark;
+  @media (prefers-color-scheme: dark) {
+    :root {
+      color-scheme: dark;
 
-    --ease-color-bg:      #0b1121;
-    --ease-color-surface: #141e33;
-    --ease-color-text:    #e2e8f0;
-    --ease-color-muted:   #94a3b8;
+      --ease-color-bg:      #0b1121;
+      --ease-color-surface: #141e33;
+      --ease-color-text:    #e2e8f0;
+      --ease-color-text-dark: #f8fafc;
+      --ease-color-muted:   #94a3b8;
     --ease-shadow-sm:  0 1px 3px rgba(0, 0, 0, 0.30),
                        0 1px 2px rgba(0, 0, 0, 0.20);
     --ease-shadow-md:  0 4px 6px -1px rgba(0, 0, 0, 0.35),
@@ -205,6 +206,7 @@
   --ease-color-bg:      #0b1121;
   --ease-color-surface: #141e33;
   --ease-color-text:    #e2e8f0;
+  --ease-color-text-dark: #f8fafc;
   --ease-color-muted:   #94a3b8;
   --ease-shadow-sm:  0 1px 3px rgba(0, 0, 0, 0.30),
                      0 1px 2px rgba(0, 0, 0, 0.20);
@@ -271,4 +273,3 @@
   }
 }
 }
-


### PR DESCRIPTION
## What changed
- Added `--ease-color-text-dark` to the dark-mode token registry in `core/variables.css`.
- Updated `.ease-card-glass` to read that token directly instead of using a hardcoded fallback color.

## Why
The glass card component was bypassing the framework's token system in dark mode. This keeps the color source centralized and makes the component easier to override consistently.

## Validation
- `git diff --check`
- `rg -n "ease-color-text-dark" core components`
