### PR TITLE
feat : added chip-outline-tm submission for issue #14848

### DIFF
--- a/submissions/examples/chip-outline-tm/README.md
+++ b/submissions/examples/chip-outline-tm/README.md
@@ -1,0 +1,25 @@
+# Component: ease-chip-outline
+
+Demonstrates the `.ease-chip-outline` variant for the chip component — a secondary/ghost style chip with transparent background and colored border.
+
+## Features
+
+- Pure HTML & CSS
+- Follows the same pattern as `.ease-btn-outline` in buttons.css
+- Three sizes: sm, md, lg
+- Hover interaction with subtle background fill
+- Dark mode compatible
+- Reduced motion support
+- No JavaScript required
+
+## Usage
+
+```html
+<span class="ease-chip ease-chip-outline ease-chip-sm">Outline</span>
+<span class="ease-chip ease-chip-outline ease-chip-md">Medium</span>
+<span class="ease-chip ease-chip-outline ease-chip-lg">Large</span>
+```
+
+## Why is it useful?
+
+Outline chips are the standard secondary style for chips — used when you want a less prominent chip alongside filled chips, or for filter states where selected chips are filled and available options are outlined.

--- a/submissions/examples/chip-outline-tm/demo.html
+++ b/submissions/examples/chip-outline-tm/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-chip-outline</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+
+    <h1>.ease-chip-outline Variants</h1>
+    <p class="subtitle">Secondary chip style with transparent background and colored border</p>
+
+    <section>
+        <h2>Primary</h2>
+        <div class="chip-row">
+            <span class="ease-chip ease-chip-outline ease-chip-sm">Small</span>
+            <span class="ease-chip ease-chip-outline">Medium</span>
+            <span class="ease-chip ease-chip-outline ease-chip-lg">Large</span>
+        </div>
+    </section>
+
+    <section>
+        <h2>Success</h2>
+        <div class="chip-row">
+            <span class="ease-chip ease-chip-outline ease-chip-success ease-chip-sm">Approved</span>
+            <span class="ease-chip ease-chip-outline ease-chip-success">Confirmed</span>
+            <span class="ease-chip ease-chip-outline ease-chip-success ease-chip-lg">Verified</span>
+        </div>
+    </section>
+
+    <section>
+        <h2>Danger</h2>
+        <div class="chip-row">
+            <span class="ease-chip ease-chip-outline ease-chip-danger ease-chip-sm">Error</span>
+            <span class="ease-chip ease-chip-outline ease-chip-danger">Failed</span>
+            <span class="ease-chip ease-chip-outline ease-chip-danger ease-chip-lg">Blocked</span>
+        </div>
+    </section>
+
+    <section>
+        <h2>Filter Group</h2>
+        <div class="chip-row">
+            <span class="ease-chip ease-chip-outline ease-chip-sm active">All</span>
+            <span class="ease-chip ease-chip-outline ease-chip-sm">Active</span>
+            <span class="ease-chip ease-chip-outline ease-chip-sm">Pending</span>
+            <span class="ease-chip ease-chip-outline ease-chip-sm">Archived</span>
+        </div>
+    </section>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/chip-outline-tm/style.css
+++ b/submissions/examples/chip-outline-tm/style.css
@@ -1,0 +1,141 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    background: #f8fafc;
+    color: #1e293b;
+    font-family: Inter, system-ui, sans-serif;
+}
+
+.container {
+    width: 100%;
+    max-width: 800px;
+}
+
+h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #0f172a;
+    margin-bottom: 6px;
+}
+
+.subtitle {
+    color: #64748b;
+    margin-bottom: 36px;
+    font-size: 0.9rem;
+}
+
+section {
+    margin-bottom: 28px;
+}
+
+h2 {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #94a3b8;
+    margin-bottom: 10px;
+}
+
+.chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+/* Base chip styles */
+.ease-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    border: 1.5px solid transparent;
+    cursor: default;
+    transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease;
+}
+
+/* Size variants */
+.ease-chip-sm {
+    padding: 4px 10px;
+    font-size: 0.75rem;
+}
+
+.ease-chip {
+    padding: 6px 14px;
+    font-size: 0.875rem;
+}
+
+.ease-chip-lg {
+    padding: 8px 18px;
+    font-size: 1rem;
+}
+
+/* Primary outline */
+.ease-chip-outline {
+    background-color: transparent;
+    color: #6c63ff;
+    border-color: #6c63ff;
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .ease-chip-outline:hover {
+        background-color: rgba(108, 99, 255, 0.1);
+    }
+}
+
+/* Success outline */
+.ease-chip-outline.ease-chip-success {
+    color: #15803d;
+    border-color: #15803d;
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .ease-chip-outline.ease-chip-success:hover {
+        background-color: rgba(21, 128, 61, 0.1);
+    }
+}
+
+/* Danger outline */
+.ease-chip-outline.ease-chip-danger {
+    color: #b91c1c;
+    border-color: #b91c1c;
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .ease-chip-outline.ease-chip-danger:hover {
+        background-color: rgba(185, 28, 28, 0.1);
+    }
+}
+
+/* Active filter state */
+.ease-chip-outline.active {
+    background-color: #6c63ff;
+    color: #ffffff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-chip { transition: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background: #0f172a;
+        color: #e2e8f0;
+    }
+    h1 { color: #f8fafc; }
+    .subtitle { color: #64748b; }
+    section h2 { color: #475569; }
+}


### PR DESCRIPTION
Closes #14948.

Summary of What Has Been Done:
Added the chip-outline-tm submission demonstrating the .ease-chip-outline variant for the chip component — a secondary/ghost style chip with transparent background and colored border.

Changes Made:
Added submissions/examples/chip-outline-tm/ with README.md, demo.html, and style.css showcasing primary, success, and danger outline chips in sm/md/lg sizes, plus a filter group example.

Impact it Made:
Completes the chip component API by adding the outline variant that was missing. Follows the same pattern as .ease-btn-outline in buttons.css for consistency across the component library.