### PR TITLE
add sidebar close button

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -348,6 +348,35 @@ a.sidebar-group-label:hover {
   box-shadow: inset 20px 0 20px -20px rgba(108, 99, 255, 0.25);
 }
 
+.sidebar-topbar {
+  display: none;
+}
+
+.sidebar-close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--ease-radius-md);
+  background: var(--code-bg);
+  color: var(--page-text);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background var(--ease-speed-fast) var(--ease-ease),
+    border-color var(--ease-speed-fast) var(--ease-ease),
+    color var(--ease-speed-fast) var(--ease-ease);
+}
+
+.sidebar-close-btn:hover {
+  background: var(--nav-link-hover-bg);
+  border-color: var(--ease-color-primary);
+  color: var(--ease-color-primary);
+}
+
 /* ── Mobile Toggle Button ─────────────────────────────── */
 .sidebar-toggle {
   display: none;
@@ -738,6 +767,21 @@ a.sidebar-group-label:hover {
     background: var(--page-bg);
     border-right: 1px solid var(--border-color);
     padding: var(--ease-space-6) var(--ease-space-4);
+  }
+
+  .sidebar-topbar {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: var(--ease-space-4);
+    position: sticky;
+    top: 0;
+    padding-bottom: var(--ease-space-2);
+    background: linear-gradient(
+      to bottom,
+      var(--page-bg) 0%,
+      color-mix(in srgb, var(--page-bg) 84%, transparent) 100%
+    );
+    z-index: 1;
   }
 
   .docs-sidebar.open {

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -117,25 +117,29 @@ if (targetMap.size > 0) {
 // ── Mobile Sidebar Toggle ────────────────────────────────
 document.addEventListener("DOMContentLoaded", function () {
   const sidebarToggle = document.getElementById("sidebarToggle");
+  const sidebarClose = document.getElementById("sidebarClose");
   const sidebar = document.getElementById("docsSidebar");
   const overlay = document.getElementById("sidebarOverlay");
+  const closeSidebar = () => {
+    if (sidebar) sidebar.classList.remove("open");
+    if (overlay) overlay.classList.remove("open");
+  };
   if (sidebarToggle && sidebar) {
     sidebarToggle.addEventListener("click", function (e) {
       e.stopPropagation();
       sidebar.classList.toggle("open");
       if (overlay) overlay.classList.toggle("open");
     });
+    if (sidebarClose) {
+      sidebarClose.addEventListener("click", closeSidebar);
+    }
     if (overlay) {
-      overlay.addEventListener("click", function () {
-        sidebar.classList.remove("open");
-        overlay.classList.remove("open");
-      });
+      overlay.addEventListener("click", closeSidebar);
     }
     sidebar.querySelectorAll("a").forEach((link) => {
       link.addEventListener("click", () => {
         if (window.innerWidth <= 768) {
-          sidebar.classList.remove("open");
-          if (overlay) overlay.classList.remove("open");
+          closeSidebar();
         }
       });
     });

--- a/docs/index.html
+++ b/docs/index.html
@@ -189,6 +189,16 @@
 
       <!-- ── Sidebar ──────────────────────────────────────── -->
       <aside class="docs-sidebar" id="docsSidebar">
+        <div class="sidebar-topbar">
+          <button
+            class="sidebar-close-btn"
+            id="sidebarClose"
+            type="button"
+            aria-label="Close sidebar"
+          >
+            ×
+          </button>
+        </div>
         <div class="sidebar-group">
           <div class="sidebar-group-label">Introduction</div>
           <ul class="sidebar-nav">


### PR DESCRIPTION
Add a close button at the top of the docs sidebar so users can dismiss the panel from inside the sidebar instead of relying on the overlay.

- Issue: #13236
- Added a sidebar top bar with a dedicated close control
- Wired the close button into the existing open/close logic
- Kept the control visible on mobile where the overlay-based flow was least obvious

Validation:
- `node --check docs/docs.js`
- `git diff --check`
