### PR TITLE
fix(marquee): pause ease-marquee animation when tab is inactive (#13801)

### DIFF
--- a/submissions/examples/ease-marquee-visibility/README.md
+++ b/submissions/examples/ease-marquee-visibility/README.md
@@ -1,0 +1,25 @@
+# ease-marquee - Tab Visibility Pause Fix
+
+Fixes #13801 - infinite marquee animations now pause when the browser tab
+is backgrounded, saving CPU and battery.
+
+## How It Works
+
+| API | Role |
+|-----|------|
+| Page Visibility API | Detects tab hidden/visible state |
+| visibilitychange event | Fires on every tab switch |
+| .paused CSS class | Sets animation-play-state: paused |
+
+## Files
+- demo.html - live demo with status badge
+- style.css  - marquee styles + .paused class
+- README.md  - this file
+
+## Behavior
+- Tab visible  - animation runs normally
+- Tab hidden   - animation pauses (zero CPU cost)
+- Respects prefers-reduced-motion
+
+## Browser Support
+Page Visibility API supported in all modern browsers.

--- a/submissions/examples/ease-marquee-visibility/demo.html
+++ b/submissions/examples/ease-marquee-visibility/demo.html
@@ -1,0 +1,55 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-marquee - Tab Visibility Pause</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <h1>ease-marquee - Tab Visibility Fix</h1>
+  <p style="color:#94a3b8;font-size:0.9rem;">
+    Switch to another tab - the animation pauses automatically.
+  </p>
+
+  <div class="marquee-wrapper">
+    <div class="marquee-track" id="marqueeTrack">
+      <div class="marquee-item"><span>&#9889;</span> EaseMotion</div>
+      <div class="marquee-item"><span>&#127912;</span> CSS Animations</div>
+      <div class="marquee-item"><span>&#128640;</span> Performance First</div>
+      <div class="marquee-item"><span>&#127769;</span> Dark Mode Ready</div>
+      <div class="marquee-item"><span>&#9855;</span> Accessible</div>
+      <div class="marquee-item"><span>&#128267;</span> Battery Friendly</div>
+      <div class="marquee-item"><span>&#9889;</span> EaseMotion</div>
+      <div class="marquee-item"><span>&#127912;</span> CSS Animations</div>
+      <div class="marquee-item"><span>&#128640;</span> Performance First</div>
+      <div class="marquee-item"><span>&#127769;</span> Dark Mode Ready</div>
+      <div class="marquee-item"><span>&#9855;</span> Accessible</div>
+      <div class="marquee-item"><span>&#128267;</span> Battery Friendly</div>
+    </div>
+  </div>
+
+  <div class="status-badge running" id="statusBadge">&#9654; Animation Running</div>
+
+  <script>
+    const track = document.getElementById('marqueeTrack');
+    const badge = document.getElementById('statusBadge');
+
+    function handleVisibilityChange() {
+      if (document.hidden) {
+        track.classList.add('paused');
+        badge.textContent = 'Animation Paused (tab hidden)';
+        badge.className   = 'status-badge paused';
+      } else {
+        track.classList.remove('paused');
+        badge.textContent = 'Animation Running';
+        badge.className   = 'status-badge running';
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-marquee-visibility/style.css
+++ b/submissions/examples/ease-marquee-visibility/style.css
@@ -1,0 +1,87 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f0f0f;
+  color: #f0f0f0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 2rem;
+}
+
+h1 { font-size: 1.5rem; color: #a78bfa; }
+
+.marquee-wrapper {
+  width: 100%;
+  max-width: 700px;
+  overflow: hidden;
+  border: 1px solid #2d2d2d;
+  border-radius: 12px;
+  padding: 1rem 0;
+  background: #1a1a1a;
+  position: relative;
+}
+
+.marquee-wrapper::before,
+.marquee-wrapper::after {
+  content: "";
+  position: absolute;
+  top: 0; bottom: 0;
+  width: 60px;
+  z-index: 2;
+  pointer-events: none;
+}
+.marquee-wrapper::before {
+  left: 0;
+  background: linear-gradient(to right, #1a1a1a, transparent);
+}
+.marquee-wrapper::after {
+  right: 0;
+  background: linear-gradient(to left, #1a1a1a, transparent);
+}
+
+.marquee-track {
+  display: flex;
+  width: max-content;
+  animation: ease-marquee 18s linear infinite;
+}
+
+.marquee-track.paused {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .marquee-track { animation: none; }
+}
+
+@keyframes ease-marquee {
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+.marquee-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 1.5rem;
+  font-size: 1rem;
+  white-space: nowrap;
+  color: #e2e8f0;
+}
+
+.marquee-item span { font-size: 1.3rem; }
+
+.status-badge {
+  margin-top: 1rem;
+  padding: 0.4rem 1.2rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: background 0.3s, color 0.3s;
+}
+.status-badge.running { background: #14532d; color: #4ade80; }
+.status-badge.paused  { background: #7c2d12; color: #fb923c; }


### PR DESCRIPTION
Closes #13801
## problem?
Infinite marquee animations kept running even when the browser tab
was backgrounded, wasting CPU and battery.

## Fix
Used the Page Visibility API to detect tab state and pause the
animation via animation-play-state: paused.

## Changes
- demo.html – live demo with running/paused status badge
- style.css  – .paused class handles animation-play-state
- README.md  – documents the fix

## Tested
- Switch tab → animation pauses
- Return to tab → animation resumes
- prefers-reduced-motion → animation fully disabled