### PR TITLE
feat: add music artist/band landing page showcase

### DIFF
--- a/submissions/examples/music-artist-band/README.md
+++ b/submissions/examples/music-artist-band/README.md
@@ -1,0 +1,37 @@
+# Echo Nebula Music Artist / Band Landing Page
+
+## What does this do?
+
+A premium, highly interactive synthwave music artist and band landing page for the fictional band _ECHO NEBULA_. It showcases the band's latest album release, streaming platforms, upcoming concert tour schedules, discography releases, music video preview cards, limited merch shop previews, and fan club club registrations.
+
+## How is it used?
+
+Simply open [demo.html](file:///d:/GSSOC2/EaseMotion/EaseMotion-css/submissions/examples/music-artist-band/demo.html) directly in any modern browser. It loads stylesheet dependencies from [easemotion.css](file:///d:/GSSOC2/EaseMotion/EaseMotion-css/easemotion.css) in the root directory, a scoped custom [style.css](file:///d:/GSSOC2/EaseMotion/EaseMotion-css/submissions/examples/music-artist-band/style.css) locally, and the scroll reveal engine [reveal.js](file:///d:/GSSOC2/EaseMotion/EaseMotion-css/core/reveal.js) in the core directory.
+
+## Why is it useful?
+
+It demonstrates how EaseMotion's responsive components and layout tools can be tailored to high-concept, highly branded interfaces like band marketing pages. The dark theme leverages magenta and purple glow variables and fluid grids to present audio and merchandise content cleanly while maintaining high visual polish.
+
+## EaseMotion CSS Classes Showcased
+
+- **Scroll Progress Indicator**: `.ease-scroll-progress`, `.ease-scroll-progress-warning`, `.ease-scroll-progress-root` (tracks page scroll through CSS scroll-driven animations).
+- **Announce Bar**: `.ease-announce-bar`, `.ease-announce-bar-dismiss`, `.ease-announce-bar-content`, `.ease-announce-bar-close` (pure CSS dismissible notification banner).
+- **Glassmorphic Navigation**: `.ease-navbar-glass`, `.ease-navbar-glass-sticky`, `.ease-navbar-glass-blur`, `.ease-navbar-brand`, `.ease-navbar-menu`, `.ease-navbar-item` (responsive top bar).
+- **Buttons**: `.ease-btn`, `.ease-btn-primary`, `.ease-btn-outline`, `.ease-btn-sm`.
+- **Viewport Entrance Reveals**: `.ease-reveal` combined with `.ease-reveal-up`, `.ease-reveal-scale`, and delay modifiers `.ease-reveal-delay-1` through `.ease-reveal-delay-4`.
+- **Micro-Animations**: `.ease-hover-grow`, `.ease-hover-lift`, `.ease-hover-pulse-glow`, `.ease-hover-bounce-text` (for subtle active feedback on interactive buttons and streaming icons).
+
+## Tech Stack
+
+- HTML5 (Semantic outline)
+- CSS3 (Vanilla variable overrides, space/dimension properties, and grid layouts)
+- JavaScript (Via [reveal.js](file:///d:/GSSOC2/EaseMotion/EaseMotion-css/core/reveal.js) for entrance transitions)
+
+## Preview
+
+Open [demo.html](file:///d:/GSSOC2/EaseMotion/EaseMotion-css/submissions/examples/music-artist-band/demo.html) directly in your browser to view the page.
+
+## Contribution Notes
+
+- Custom style variables are isolated under the `.mu-` class namespace.
+- Adheres to repository rules by not modifying any files under [core/](file:///d:/GSSOC2/EaseMotion/EaseMotion-css/core) or [components/](file:///d:/GSSOC2/EaseMotion/EaseMotion-css/components).

--- a/submissions/examples/music-artist-band/demo.html
+++ b/submissions/examples/music-artist-band/demo.html
@@ -1,0 +1,977 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Echo Nebula — Official band landing page featuring synthwave albums, tour dates, music video previews, official merchandise, and fan club newsletter."
+    />
+    <title>Echo Nebula — Official Synthwave Artist Landing Page</title>
+
+    <!-- Link to EaseMotion CSS entry point -->
+    <link rel="stylesheet" href="../../../easemotion.css" />
+
+    <!-- Link to page-specific scoped styles -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body class="mu-body">
+    <!-- Pure CSS Scroll-Driven Progress Bar -->
+    <div
+      class="ease-scroll-progress ease-scroll-progress-warning ease-scroll-progress-root"
+    ></div>
+
+    <!-- Ambient lighting glows -->
+    <div class="mu-spotlight-left"></div>
+    <div class="mu-spotlight-right"></div>
+
+    <!-- Dismissible Announcement Bar -->
+    <input
+      type="checkbox"
+      id="announce-dismiss"
+      class="ease-announce-bar-dismiss"
+    />
+    <div class="ease-announce-bar is-danger">
+      <div class="ease-announce-bar-content">
+        ⚡ <strong>Tour Announcement:</strong>
+        <em>Hyperspace Tour 2026</em> tickets are selling out fast.
+        <a href="#tour">Grab yours today!</a>
+      </div>
+      <label
+        for="announce-dismiss"
+        class="ease-announce-bar-close"
+        aria-label="Dismiss"
+        >&times;</label
+      >
+    </div>
+
+    <!-- Sticky Glassmorphic Header Navigation -->
+    <header class="mu-header">
+      <nav
+        class="ease-navbar-glass ease-navbar-glass-sticky ease-navbar-glass-blur"
+      >
+        <a
+          href="#"
+          class="ease-navbar-brand"
+          style="
+            font-family: &quot;Syne&quot;, sans-serif;
+            font-weight: 800;
+            font-size: 1.45rem;
+            text-decoration: none;
+            color: inherit;
+            letter-spacing: 0.05em;
+          "
+          >ECHO NEBULA</a
+        >
+        <div class="ease-navbar-menu">
+          <a href="#tour" class="ease-navbar-item">Tour</a>
+          <a href="#discography" class="ease-navbar-item">Discography</a>
+          <a href="#videos" class="ease-navbar-item">Videos</a>
+          <a href="#merch" class="ease-navbar-item">Merch</a>
+          <a href="#newsletter" class="ease-navbar-item">Fan Club</a>
+          <a
+            href="#tour"
+            class="ease-btn ease-btn-primary ease-btn-sm ease-hover-pulse-glow"
+            style="
+              margin-left: 0.5rem;
+              background: var(--mu-primary);
+              border-color: var(--mu-primary);
+              color: #fff;
+            "
+            >Get Tickets</a
+          >
+        </div>
+      </nav>
+    </header>
+
+    <!-- Main Showcase Content -->
+    <main>
+      <!-- Hero Section -->
+      <section class="fm-section mu-hero ease-reveal ease-reveal-up" id="hero">
+        <div>
+          <span
+            class="mu-section-tag"
+            style="
+              color: var(--mu-accent);
+              border-color: var(--mu-accent);
+              background: rgba(204, 255, 0, 0.05);
+            "
+            >New Release</span
+          >
+          <h1 class="mu-hero-title">Hyperspace <span>Drift</span></h1>
+          <p class="mu-hero-subtitle">
+            The highly anticipated third studio album is out now. Immerse
+            yourself in a retro-futuristic sonic journey across the cosmic grid.
+          </p>
+          <div class="mu-hero-actions">
+            <a
+              href="#discography"
+              class="ease-btn ease-btn-primary ease-hover-grow"
+              style="
+                background: var(--mu-primary);
+                border-color: var(--mu-primary);
+                color: #fff;
+              "
+              >Listen Now</a
+            >
+            <a
+              href="#tour"
+              class="ease-btn ease-btn-outline ease-hover-lift"
+              style="color: var(--mu-primary); border-color: var(--mu-primary)"
+              >View Tour Dates</a
+            >
+          </div>
+          <!-- Streaming platform hooks -->
+          <div class="mu-platform-list">
+            <span
+              style="
+                font-size: var(--ease-text-xs, 0.75rem);
+                text-transform: uppercase;
+                letter-spacing: 0.1em;
+                color: var(--mu-text-muted);
+              "
+              >Stream On:</span
+            >
+            <a
+              href="#spotify"
+              class="mu-platform-btn ease-hover-bounce-text"
+              title="Spotify"
+              >🟢</a
+            >
+            <a
+              href="#apple"
+              class="mu-platform-btn ease-hover-bounce-text"
+              title="Apple Music"
+              >🍎</a
+            >
+            <a
+              href="#bandcamp"
+              class="mu-platform-btn ease-hover-bounce-text"
+              title="Bandcamp"
+              >⛺</a
+            >
+            <a
+              href="#youtube"
+              class="mu-platform-btn ease-hover-bounce-text"
+              title="YouTube"
+              >🔴</a
+            >
+          </div>
+        </div>
+        <div
+          class="mu-album-art-wrapper ease-reveal ease-reveal-scale ease-reveal-delay-2"
+        >
+          <div class="mu-album-art-frame">
+            <div class="mu-album-art-canvas">
+              <!-- Premium Album Art SVG -->
+              <svg
+                width="100%"
+                height="100%"
+                viewBox="0 0 400 400"
+                xmlns="http://www.w3.org/2000/svg"
+                style="position: absolute; top: 0; left: 0"
+              >
+                <defs>
+                  <linearGradient
+                    id="sky-grad"
+                    x1="0%"
+                    y1="0%"
+                    x2="0%"
+                    y2="100%"
+                  >
+                    <stop offset="0%" stop-color="#14062f" />
+                    <stop offset="50%" stop-color="#310a5a" />
+                    <stop offset="100%" stop-color="#ff007f" />
+                  </linearGradient>
+                  <linearGradient
+                    id="sun-grad"
+                    x1="0%"
+                    y1="0%"
+                    x2="0%"
+                    y2="100%"
+                  >
+                    <stop offset="0%" stop-color="#ccff00" />
+                    <stop offset="100%" stop-color="#ff007f" />
+                  </linearGradient>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#sky-grad)" />
+                <!-- Retro Sun -->
+                <circle cx="200" cy="200" r="100" fill="url(#sun-grad)" />
+                <!-- Sun stripes (synthwave look) -->
+                <rect x="90" y="215" width="220" height="4" fill="#14062f" />
+                <rect x="90" y="230" width="220" height="6" fill="#14062f" />
+                <rect x="90" y="248" width="220" height="9" fill="#14062f" />
+                <rect x="90" y="270" width="220" height="13" fill="#14062f" />
+                <rect x="90" y="295" width="220" height="20" fill="#14062f" />
+                <!-- Synth Horizon Grid -->
+                <path d="M 0 320 L 400 320" stroke="#ccff00" stroke-width="2" />
+                <line
+                  x1="200"
+                  y1="320"
+                  x2="200"
+                  y2="400"
+                  stroke="#ccff00"
+                  stroke-width="1.5"
+                />
+                <line
+                  x1="160"
+                  y1="320"
+                  x2="110"
+                  y2="400"
+                  stroke="#ccff00"
+                  stroke-width="1.5"
+                />
+                <line
+                  x1="120"
+                  y1="320"
+                  x2="20"
+                  y2="400"
+                  stroke="#ccff00"
+                  stroke-width="1.5"
+                />
+                <line
+                  x1="240"
+                  y1="320"
+                  x2="290"
+                  y2="400"
+                  stroke="#ccff00"
+                  stroke-width="1.5"
+                />
+                <line
+                  x1="280"
+                  y1="320"
+                  x2="380"
+                  y2="400"
+                  stroke="#ccff00"
+                  stroke-width="1.5"
+                />
+                <!-- Horizontal grid lines -->
+                <line
+                  x1="0"
+                  y1="335"
+                  x2="400"
+                  y2="335"
+                  stroke="#ccff00"
+                  stroke-width="1"
+                  opacity="0.8"
+                />
+                <line
+                  x1="0"
+                  y1="355"
+                  x2="400"
+                  y2="355"
+                  stroke="#ccff00"
+                  stroke-width="1"
+                  opacity="0.6"
+                />
+                <line
+                  x1="0"
+                  y1="380"
+                  x2="400"
+                  y2="380"
+                  stroke="#ccff00"
+                  stroke-width="1"
+                  opacity="0.4"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Tour Schedule Section -->
+      <section id="tour" class="mu-section ease-reveal ease-reveal-up">
+        <div class="mu-section-title-wrapper">
+          <span class="mu-section-tag">On the Road</span>
+          <h2 class="mu-section-title">Hyperspace Tour 2026</h2>
+          <p class="mu-section-subtitle">
+            Catch Echo Nebula live in cities around the world this summer.
+          </p>
+        </div>
+        <div class="mu-tour-container ease-reveal ease-reveal-up">
+          <!-- Tour Row 1 -->
+          <div class="mu-tour-row">
+            <div class="mu-tour-date">JUN 18, 2026</div>
+            <div class="mu-tour-venue">THE ELECTRIC DOME</div>
+            <div class="mu-tour-city">CHICAGO, IL</div>
+            <div>
+              <button
+                class="ease-btn ease-btn-primary ease-btn-sm ease-hover-grow"
+                style="
+                  background: var(--mu-primary);
+                  border-color: var(--mu-primary);
+                  color: #fff;
+                "
+                onclick="alert('Redirecting to ticket portal...')"
+              >
+                TICKETS
+              </button>
+            </div>
+          </div>
+          <!-- Tour Row 2 -->
+          <div class="mu-tour-row">
+            <div class="mu-tour-date">JUN 25, 2026</div>
+            <div class="mu-tour-venue">NEON GRID AMPHITHEATER</div>
+            <div class="mu-tour-city">LOS ANGELES, CA</div>
+            <div>
+              <button
+                class="ease-btn ease-btn-primary ease-btn-sm ease-hover-grow"
+                style="
+                  background: var(--mu-primary);
+                  border-color: var(--mu-primary);
+                  color: #fff;
+                "
+                onclick="alert('Redirecting to ticket portal...')"
+              >
+                TICKETS
+              </button>
+            </div>
+          </div>
+          <!-- Tour Row 3 -->
+          <div class="mu-tour-row">
+            <div class="mu-tour-date">JUL 02, 2026</div>
+            <div class="mu-tour-venue">THE SYNTH PAVILION</div>
+            <div class="mu-tour-city">NEW YORK, NY</div>
+            <div>
+              <button
+                class="ease-btn ease-btn-primary ease-btn-sm ease-hover-grow"
+                style="
+                  background: var(--mu-primary);
+                  border-color: var(--mu-primary);
+                  color: #fff;
+                "
+                onclick="alert('Redirecting to ticket portal...')"
+              >
+                TICKETS
+              </button>
+            </div>
+          </div>
+          <!-- Tour Row 4 -->
+          <div class="mu-tour-row">
+            <div class="mu-tour-date">JUL 15, 2026</div>
+            <div class="mu-tour-venue">COSMIC DUST WAREHOUSE</div>
+            <div class="mu-tour-city">LONDON, UK</div>
+            <div>
+              <button
+                class="ease-btn ease-btn-primary ease-btn-sm ease-hover-grow"
+                style="
+                  background: var(--mu-primary);
+                  border-color: var(--mu-primary);
+                  color: #fff;
+                "
+                onclick="alert('Redirecting to ticket portal...')"
+              >
+                TICKETS
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Discography Section -->
+      <section id="discography" class="mu-section ease-reveal ease-reveal-up">
+        <div class="mu-section-title-wrapper">
+          <span class="mu-section-tag">Releases</span>
+          <h2 class="mu-section-title">Discography</h2>
+          <p class="mu-section-subtitle">
+            Explore the complete collection of official studio releases.
+          </p>
+        </div>
+        <div class="mu-disco-grid">
+          <!-- Album 1 -->
+          <div
+            class="mu-disco-card ease-reveal ease-reveal-up ease-reveal-delay-1"
+          >
+            <div class="mu-disco-art">
+              <div class="mu-disco-canvas">
+                <svg
+                  width="100%"
+                  height="100%"
+                  viewBox="0 0 200 200"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect width="100%" height="100%" fill="#14062f" />
+                  <circle
+                    cx="100"
+                    cy="100"
+                    r="50"
+                    fill="none"
+                    stroke="#ff007f"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M 50 100 Q 100 50 150 100"
+                    fill="none"
+                    stroke="#8b5cf6"
+                    stroke-width="4"
+                  />
+                  <path
+                    d="M 50 100 Q 100 150 150 100"
+                    fill="none"
+                    stroke="#ccff00"
+                    stroke-width="4"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div class="mu-disco-info">
+              <h3 class="mu-disco-title">Hyperspace Drift</h3>
+              <span class="mu-disco-meta">LP | 2026</span>
+            </div>
+          </div>
+          <!-- Album 2 -->
+          <div
+            class="mu-disco-card ease-reveal ease-reveal-up ease-reveal-delay-2"
+          >
+            <div class="mu-disco-art">
+              <div class="mu-disco-canvas">
+                <svg
+                  width="100%"
+                  height="100%"
+                  viewBox="0 0 200 200"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect width="100%" height="100%" fill="#14062f" />
+                  <line
+                    x1="20"
+                    y1="20"
+                    x2="180"
+                    y2="180"
+                    stroke="#ff007f"
+                    stroke-width="3"
+                  />
+                  <line
+                    x1="20"
+                    y1="180"
+                    x2="180"
+                    y2="20"
+                    stroke="#8b5cf6"
+                    stroke-width="3"
+                  />
+                  <circle
+                    cx="100"
+                    cy="100"
+                    r="40"
+                    fill="#ccff00"
+                    opacity="0.3"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div class="mu-disco-info">
+              <h3 class="mu-disco-title">Neon Nights</h3>
+              <span class="mu-disco-meta">LP | 2024</span>
+            </div>
+          </div>
+          <!-- Album 3 -->
+          <div
+            class="mu-disco-card ease-reveal ease-reveal-up ease-reveal-delay-3"
+          >
+            <div class="mu-disco-art">
+              <div class="mu-disco-canvas">
+                <svg
+                  width="100%"
+                  height="100%"
+                  viewBox="0 0 200 200"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect width="100%" height="100%" fill="#14062f" />
+                  <circle
+                    cx="100"
+                    cy="100"
+                    r="60"
+                    fill="none"
+                    stroke="#8b5cf6"
+                    stroke-width="1"
+                    stroke-dasharray="4 4"
+                  />
+                  <circle
+                    cx="100"
+                    cy="100"
+                    r="40"
+                    fill="none"
+                    stroke="#ff007f"
+                    stroke-width="2"
+                  />
+                  <circle cx="100" cy="100" r="15" fill="#ccff00" />
+                </svg>
+              </div>
+            </div>
+            <div class="mu-disco-info">
+              <h3 class="mu-disco-title">Spectral Echo</h3>
+              <span class="mu-disco-meta">EP | 2023</span>
+            </div>
+          </div>
+          <!-- Album 4 -->
+          <div
+            class="mu-disco-card ease-reveal ease-reveal-up ease-reveal-delay-4"
+          >
+            <div class="mu-disco-art">
+              <div class="mu-disco-canvas">
+                <svg
+                  width="100%"
+                  height="100%"
+                  viewBox="0 0 200 200"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect width="100%" height="100%" fill="#14062f" />
+                  <rect
+                    x="50"
+                    y="50"
+                    width="100"
+                    height="100"
+                    fill="none"
+                    stroke="#ccff00"
+                    stroke-width="2"
+                  />
+                  <rect
+                    x="70"
+                    y="70"
+                    width="60"
+                    height="60"
+                    fill="none"
+                    stroke="#ff007f"
+                    stroke-width="1.5"
+                  />
+                  <line
+                    x1="50"
+                    y1="50"
+                    x2="150"
+                    y2="150"
+                    stroke="#8b5cf6"
+                    stroke-width="1"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div class="mu-disco-info">
+              <h3 class="mu-disco-title">Zero Gravity</h3>
+              <span class="mu-disco-meta">LP | 2022</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Music Videos Section -->
+      <section id="videos" class="mu-section ease-reveal ease-reveal-up">
+        <div class="mu-section-title-wrapper">
+          <span class="mu-section-tag">Visuals</span>
+          <h2 class="mu-section-title">Music Videos</h2>
+          <p class="mu-section-subtitle">
+            Watch official video concepts and interactive visualizer sequences.
+          </p>
+        </div>
+        <div class="mu-video-grid">
+          <!-- Video 1 -->
+          <div
+            class="mu-video-item ease-reveal ease-reveal-up ease-reveal-delay-1"
+            onclick="alert('Streaming: Hyperspace Drift Official Video...')"
+          >
+            <div class="mu-video-canvas">
+              <svg
+                width="100%"
+                height="100%"
+                viewBox="0 0 520 292"
+                xmlns="http://www.w3.org/2000/svg"
+                style="position: absolute; top: 0; left: 0"
+              >
+                <rect width="100%" height="100%" fill="#0a0512" />
+                <circle
+                  cx="260"
+                  cy="146"
+                  r="60"
+                  fill="none"
+                  stroke="#ff007f"
+                  stroke-width="2"
+                />
+                <line
+                  x1="200"
+                  y1="146"
+                  x2="320"
+                  y2="146"
+                  stroke="#8b5cf6"
+                  stroke-width="2"
+                />
+                <text
+                  x="20"
+                  y="40"
+                  fill="#ccff00"
+                  font-family="monospace"
+                  font-size="12"
+                >
+                  HYPERSPACE DRIFT // OFFICIAL VIDEO
+                </text>
+              </svg>
+              <div class="mu-play-icon"></div>
+            </div>
+          </div>
+          <!-- Video 2 -->
+          <div
+            class="mu-video-item ease-reveal ease-reveal-up ease-reveal-delay-2"
+            onclick="alert('Streaming: Neon Nights Visualizer...')"
+          >
+            <div class="mu-video-canvas">
+              <svg
+                width="100%"
+                height="100%"
+                viewBox="0 0 520 292"
+                xmlns="http://www.w3.org/2000/svg"
+                style="position: absolute; top: 0; left: 0"
+              >
+                <rect width="100%" height="100%" fill="#0a0512" />
+                <polygon
+                  points="260,86 310,186 210,186"
+                  fill="none"
+                  stroke="#ccff00"
+                  stroke-width="2"
+                />
+                <circle
+                  cx="260"
+                  cy="146"
+                  r="30"
+                  fill="none"
+                  stroke="#8b5cf6"
+                  stroke-width="1.5"
+                />
+                <text
+                  x="20"
+                  y="40"
+                  fill="#ff007f"
+                  font-family="monospace"
+                  font-size="12"
+                >
+                  NEON NIGHTS // INTERACTIVE VISUALIZER
+                </text>
+              </svg>
+              <div class="mu-play-icon"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Merchandise Section -->
+      <section id="merch" class="mu-section ease-reveal ease-reveal-up">
+        <div class="mu-section-title-wrapper">
+          <span class="mu-section-tag">Store</span>
+          <h2 class="mu-section-title">Official Merchandise</h2>
+          <p class="mu-section-subtitle">
+            Grab limited physical formats, clothing designs, and collector
+            posters.
+          </p>
+        </div>
+        <div class="mu-merch-grid">
+          <!-- Merch 1 -->
+          <div
+            class="mu-merch-card ease-reveal ease-reveal-up ease-reveal-delay-1"
+          >
+            <div class="mu-merch-visual">
+              <div class="mu-merch-canvas">
+                <svg
+                  width="100%"
+                  height="100%"
+                  viewBox="0 0 200 200"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect width="100%" height="100%" fill="#0e0a1a" />
+                  <!-- Silhouette of a T-Shirt with printed sun logo -->
+                  <path
+                    d="M 60 40 L 80 20 L 120 20 L 140 40 L 130 70 L 120 65 L 120 180 L 80 180 L 80 65 L 70 70 Z"
+                    fill="#150f26"
+                    stroke="#ff007f"
+                    stroke-width="1.5"
+                  />
+                  <circle
+                    cx="100"
+                    cy="90"
+                    r="18"
+                    fill="#ccff00"
+                    opacity="0.8"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div class="mu-merch-details">
+              <h3 class="mu-merch-title">Nebula Sun Tee</h3>
+              <span class="mu-merch-price">$28</span>
+            </div>
+            <button
+              class="ease-btn ease-btn-outline ease-btn-sm"
+              style="
+                width: 100%;
+                border-color: var(--mu-secondary);
+                color: var(--mu-secondary);
+              "
+              onclick="alert('Added Nebula Sun Tee to cart!')"
+            >
+              Add to Cart
+            </button>
+          </div>
+          <!-- Merch 2 -->
+          <div
+            class="mu-merch-card ease-reveal ease-reveal-up ease-reveal-delay-2"
+          >
+            <div class="mu-merch-visual">
+              <div class="mu-merch-canvas">
+                <svg
+                  width="100%"
+                  height="100%"
+                  viewBox="0 0 200 200"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect width="100%" height="100%" fill="#0e0a1a" />
+                  <!-- Vinyl Record -->
+                  <circle
+                    cx="100"
+                    cy="100"
+                    r="70"
+                    fill="#120c22"
+                    stroke="#ff007f"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="100"
+                    cy="100"
+                    r="60"
+                    fill="none"
+                    stroke="#fff"
+                    stroke-width="0.5"
+                    opacity="0.3"
+                  />
+                  <circle
+                    cx="100"
+                    cy="100"
+                    r="50"
+                    fill="none"
+                    stroke="#fff"
+                    stroke-width="0.5"
+                    opacity="0.3"
+                  />
+                  <circle
+                    cx="100"
+                    cy="100"
+                    r="40"
+                    fill="none"
+                    stroke="#fff"
+                    stroke-width="0.5"
+                    opacity="0.3"
+                  />
+                  <circle cx="100" cy="100" r="25" fill="#ccff00" />
+                  <circle cx="100" cy="100" r="5" fill="#0e0a1a" />
+                </svg>
+              </div>
+            </div>
+            <div class="mu-merch-details">
+              <h3 class="mu-merch-title">Hyperspace Vinyl</h3>
+              <span class="mu-merch-price">$35</span>
+            </div>
+            <button
+              class="ease-btn ease-btn-outline ease-btn-sm"
+              style="
+                width: 100%;
+                border-color: var(--mu-secondary);
+                color: var(--mu-secondary);
+              "
+              onclick="alert('Added Hyperspace Vinyl to cart!')"
+            >
+              Add to Cart
+            </button>
+          </div>
+          <!-- Merch 3 -->
+          <div
+            class="mu-merch-card ease-reveal ease-reveal-up ease-reveal-delay-3"
+          >
+            <div class="mu-merch-visual">
+              <div class="mu-merch-canvas">
+                <svg
+                  width="100%"
+                  height="100%"
+                  viewBox="0 0 200 200"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect width="100%" height="100%" fill="#0e0a1a" />
+                  <!-- Poster design -->
+                  <rect
+                    x="40"
+                    y="20"
+                    width="120"
+                    height="160"
+                    fill="#170d2b"
+                    stroke="#8b5cf6"
+                    stroke-width="2"
+                  />
+                  <circle cx="100" cy="90" r="30" fill="#ff007f" />
+                  <line
+                    x1="50"
+                    y1="140"
+                    x2="150"
+                    y2="140"
+                    stroke="#ccff00"
+                    stroke-width="1.5"
+                  />
+                  <text
+                    x="60"
+                    y="160"
+                    fill="#fff"
+                    font-family="sans-serif"
+                    font-size="8"
+                    letter-spacing="1"
+                  >
+                    ECHO NEBULA
+                  </text>
+                </svg>
+              </div>
+            </div>
+            <div class="mu-merch-details">
+              <h3 class="mu-merch-title">Collector Poster</h3>
+              <span class="mu-merch-price">$15</span>
+            </div>
+            <button
+              class="ease-btn ease-btn-outline ease-btn-sm"
+              style="
+                width: 100%;
+                border-color: var(--mu-secondary);
+                color: var(--mu-secondary);
+              "
+              onclick="alert('Added Collector Poster to cart!')"
+            >
+              Add to Cart
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <!-- Newsletter/Fan Club Section -->
+      <section id="newsletter" class="mu-section ease-reveal ease-reveal-up">
+        <div class="mu-fan-banner">
+          <span
+            class="mu-section-tag"
+            style="
+              color: var(--mu-accent);
+              border-color: var(--mu-accent);
+              background: rgba(204, 255, 0, 0.05);
+            "
+            >Join the Grid</span
+          >
+          <h2
+            style="
+              font-family: &quot;Syne&quot;, sans-serif;
+              font-size: 2.25rem;
+              font-weight: 800;
+              color: #fff;
+              margin-bottom: 0.5rem;
+              text-transform: uppercase;
+            "
+          >
+            Echo Club Newsletter
+          </h2>
+          <p
+            style="
+              color: var(--mu-text-muted);
+              max-width: 500px;
+              margin: 0 auto;
+            "
+          >
+            Get early ticket booking opportunities, members-only discount codes
+            on merchandise, and exclusive demo downloads.
+          </p>
+          <form
+            class="mu-fan-form"
+            onsubmit="
+              event.preventDefault();
+              alert(
+                'Welcome to the Echo Nebula fan club! Check your inbox for updates.'
+              );
+            "
+          >
+            <input
+              type="email"
+              placeholder="Enter your email address"
+              class="mu-fan-input"
+              required
+            />
+            <button
+              type="submit"
+              class="ease-btn ease-btn-primary"
+              style="
+                background: var(--mu-primary);
+                border-color: var(--mu-primary);
+                color: #fff;
+              "
+            >
+              Join Club
+            </button>
+          </form>
+        </div>
+      </section>
+
+      <!-- Social Links Grid Section -->
+      <section class="mu-section ease-reveal ease-reveal-up">
+        <div class="mu-section-title-wrapper">
+          <span class="mu-section-tag">Connect</span>
+          <h2 class="mu-section-title">Follow the Nebula</h2>
+          <p class="mu-section-subtitle">
+            Stay connected with the band across all digital spheres.
+          </p>
+        </div>
+        <div class="mu-social-grid">
+          <!-- Social 1 -->
+          <a
+            href="#instagram"
+            class="mu-social-card ease-reveal ease-reveal-up ease-reveal-delay-1"
+          >
+            <div class="mu-social-icon">📸</div>
+            <span class="mu-social-name">Instagram</span>
+            <span class="mu-social-handle">@echonebula</span>
+          </a>
+          <!-- Social 2 -->
+          <a
+            href="#twitter"
+            class="mu-social-card ease-reveal ease-reveal-up ease-reveal-delay-2"
+          >
+            <div class="mu-social-icon">🐦</div>
+            <span class="mu-social-name">Twitter</span>
+            <span class="mu-social-handle">@echonebula_band</span>
+          </a>
+          <!-- Social 3 -->
+          <a
+            href="#youtube"
+            class="mu-social-card ease-reveal ease-reveal-up ease-reveal-delay-3"
+          >
+            <div class="mu-social-icon">📺</div>
+            <span class="mu-social-name">YouTube</span>
+            <span class="mu-social-handle">Echo Nebula Official</span>
+          </a>
+          <!-- Social 4 -->
+          <a
+            href="#soundcloud"
+            class="mu-social-card ease-reveal ease-reveal-up ease-reveal-delay-4"
+          >
+            <div class="mu-social-icon">☁️</div>
+            <span class="mu-social-name">SoundCloud</span>
+            <span class="mu-social-handle">echonebula</span>
+          </a>
+        </div>
+      </section>
+    </main>
+
+    <!-- Band Footer Section -->
+    <footer class="mu-footer">
+      <div class="mu-footer-bottom">
+        <div class="mu-footer-copyright">
+          &copy; 2026 Echo Nebula Music. All rights reserved.
+        </div>
+        <div class="mu-footer-copyright">
+          Built with
+          <a
+            href="https://github.com/SAPTARSHI-coder/EaseMotion-css"
+            style="color: var(--mu-primary); text-decoration: none"
+            >EaseMotion CSS</a
+          >
+        </div>
+      </div>
+    </footer>
+
+    <!-- Scroll-triggered Entrance Animations JavaScript -->
+    <script src="../../../core/reveal.js"></script>
+  </body>
+</html>

--- a/submissions/examples/music-artist-band/style.css
+++ b/submissions/examples/music-artist-band/style.css
@@ -1,0 +1,617 @@
+/* ==========================================================================
+   Echo Nebula Synthwave Music Artist/Band Landing Page — Custom Scope Styles
+   Prefix: .mu-
+   ========================================================================== */
+
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Syne:wght@500;600;700;800&display=swap");
+
+:root {
+  --mu-bg: #07050d;
+  --mu-surface: #0e0a1a;
+  --mu-surface-card: #150f26;
+  --mu-primary: #ff007f; /* Neon Magenta */
+  --mu-secondary: #8b5cf6; /* Neon Purple */
+  --mu-accent: #ccff00; /* Neon Lime Yellow */
+  --mu-text-light: #f3f4f6;
+  --mu-text-muted: #9ca3af;
+  --mu-border: rgba(255, 255, 255, 0.05);
+  --mu-border-glow: rgba(255, 0, 127, 0.25);
+  --mu-shadow-glow: 0 0 20px rgba(255, 0, 127, 0.15);
+}
+
+.mu-body {
+  background-color: var(--mu-bg) !important;
+  color: var(--mu-text-light) !important;
+  font-family:
+    "Outfit",
+    system-ui,
+    -apple-system,
+    sans-serif !important;
+  overflow-x: hidden;
+  position: relative;
+  line-height: 1.6;
+}
+
+/* Ambient glow backdrops */
+.mu-spotlight-left {
+  position: absolute;
+  top: 15%;
+  left: -15%;
+  width: 700px;
+  height: 700px;
+  z-index: -1;
+  background: radial-gradient(
+    circle,
+    rgba(255, 0, 127, 0.04) 0%,
+    transparent 70%
+  );
+  filter: blur(120px);
+  pointer-events: none;
+}
+
+.mu-spotlight-right {
+  position: absolute;
+  top: 55%;
+  right: -15%;
+  width: 700px;
+  height: 700px;
+  z-index: -1;
+  background: radial-gradient(
+    circle,
+    rgba(139, 92, 246, 0.04) 0%,
+    transparent 70%
+  );
+  filter: blur(120px);
+  pointer-events: none;
+}
+
+.mu-header {
+  max-width: var(--ease-container-max, 1200px);
+  margin: 1.5rem auto;
+  padding: 0 1rem;
+}
+
+.mu-section {
+  max-width: var(--ease-container-max, 1200px);
+  margin: 8rem auto;
+  padding: 0 1.5rem;
+}
+
+.mu-section-title-wrapper {
+  text-align: center;
+  margin-bottom: 4.5rem;
+}
+
+.mu-section-tag {
+  display: inline-block;
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  color: var(--mu-primary);
+  margin-bottom: 0.75rem;
+  background: rgba(255, 0, 127, 0.06);
+  padding: 0.3rem 1rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  border: 1px solid rgba(255, 0, 127, 0.15);
+}
+
+.mu-section-title {
+  font-family: "Syne", sans-serif;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 800;
+  color: var(--mu-text-light);
+  letter-spacing: -0.01em;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+.mu-section-subtitle {
+  font-size: var(--ease-text-lg, 1.125rem);
+  color: var(--mu-text-muted);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* Hero layout - album cover + copy details */
+.mu-hero {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5rem;
+  align-items: center;
+  min-height: 75vh;
+  margin-top: 2rem;
+  margin-bottom: 6rem;
+}
+
+.mu-hero-title {
+  font-family: "Syne", sans-serif;
+  font-size: clamp(3rem, 6vw, 4.75rem);
+  font-weight: 800;
+  line-height: 1.05;
+  color: var(--mu-text-light);
+  margin-bottom: 1.5rem;
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+}
+
+.mu-hero-title span {
+  background: linear-gradient(
+    135deg,
+    var(--mu-primary) 0%,
+    var(--mu-secondary) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.mu-hero-subtitle {
+  font-size: var(--ease-text-lg, 1.125rem);
+  color: var(--mu-text-muted);
+  margin-bottom: 2rem;
+  max-width: 500px;
+}
+
+.mu-hero-actions {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  margin-bottom: 2.5rem;
+}
+
+/* Album Art Mockup */
+.mu-album-art-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.mu-album-art-frame {
+  background: #000;
+  border: 1px solid var(--mu-border);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow:
+    0 30px 60px -15px rgba(0, 0, 0, 0.8),
+    0 0 30px rgba(255, 0, 127, 0.05);
+  width: 100%;
+  max-width: 420px;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  position: relative;
+  transition:
+    border-color var(--ease-speed-medium) var(--ease-ease),
+    box-shadow var(--ease-speed-medium) var(--ease-ease);
+}
+
+.mu-album-art-frame:hover {
+  border-color: var(--mu-primary);
+  box-shadow:
+    0 30px 60px -15px rgba(0, 0, 0, 0.8),
+    0 0 30px rgba(255, 0, 127, 0.25);
+}
+
+.mu-album-art-canvas {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #18092d 0%, #07050d 100%);
+  position: relative;
+}
+
+/* Stream Platform list */
+.mu-platform-list {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.mu-platform-btn {
+  font-size: 1.5rem;
+  color: var(--mu-text-muted);
+  text-decoration: none;
+  transition:
+    color var(--ease-speed-fast) var(--ease-ease),
+    transform var(--ease-speed-fast) var(--ease-ease);
+}
+
+.mu-platform-btn:hover {
+  color: var(--mu-primary);
+  transform: translateY(-2px);
+}
+
+/* Tour Schedule List */
+.mu-tour-container {
+  background: var(--mu-surface-card);
+  border: 1px solid var(--mu-border);
+  border-radius: var(--ease-radius-lg, 1rem);
+  overflow: hidden;
+}
+
+.mu-tour-row {
+  display: grid;
+  grid-template-columns: 1.2fr 2fr 2fr 1fr;
+  padding: 1.75rem 2.5rem;
+  border-bottom: 1px solid var(--mu-border);
+  align-items: center;
+}
+
+.mu-tour-row:last-child {
+  border-bottom: none;
+}
+
+.mu-tour-date {
+  font-family: var(--ease-font-mono, monospace);
+  font-weight: 700;
+  font-size: var(--ease-text-md, 1rem);
+  color: var(--mu-primary);
+}
+
+.mu-tour-venue {
+  font-family: "Syne", sans-serif;
+  font-weight: 700;
+  font-size: var(--ease-text-base, 1rem);
+  color: var(--mu-text-light);
+}
+
+.mu-tour-city {
+  font-size: var(--ease-text-base, 1rem);
+  color: var(--mu-text-muted);
+}
+
+/* Discography Grid */
+.mu-disco-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 2rem;
+}
+
+.mu-disco-card {
+  background: var(--mu-surface-card);
+  border: 1px solid var(--mu-border);
+  border-radius: var(--ease-radius-md, 0.75rem);
+  overflow: hidden;
+  transition: border-color var(--ease-speed-medium) var(--ease-ease);
+}
+
+.mu-disco-card:hover {
+  border-color: var(--mu-primary);
+}
+
+.mu-disco-art {
+  aspect-ratio: 1 / 1;
+  background: #0e0a1a;
+  position: relative;
+  overflow: hidden;
+}
+
+.mu-disco-canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.mu-disco-info {
+  padding: 1.25rem;
+}
+
+.mu-disco-title {
+  font-family: "Syne", sans-serif;
+  font-weight: 700;
+  font-size: var(--ease-text-md, 1rem);
+  color: var(--mu-text-light);
+  margin-bottom: 0.25rem;
+}
+
+.mu-disco-meta {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--mu-text-muted);
+}
+
+/* Video Gallery Section */
+.mu-video-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2.5rem;
+}
+
+.mu-video-item {
+  aspect-ratio: 16 / 9;
+  background: var(--mu-surface-card);
+  border: 1px solid var(--mu-border);
+  border-radius: var(--ease-radius-md, 0.75rem);
+  overflow: hidden;
+  position: relative;
+  cursor: pointer;
+  transition:
+    border-color var(--ease-speed-medium) var(--ease-ease),
+    box-shadow var(--ease-speed-medium) var(--ease-ease);
+}
+
+.mu-video-item:hover {
+  border-color: var(--mu-primary);
+  box-shadow: 0 10px 20px rgba(255, 0, 127, 0.1);
+}
+
+.mu-video-canvas {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mu-play-icon {
+  width: 4rem;
+  height: 4rem;
+  background: rgba(255, 0, 127, 0.15);
+  border: 2px solid var(--mu-primary);
+  color: var(--mu-primary);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  box-shadow: 0 0 20px rgba(255, 0, 127, 0.3);
+  transition:
+    transform var(--ease-speed-fast) var(--ease-ease),
+    background-color var(--ease-speed-fast) var(--ease-ease),
+    color var(--ease-speed-fast) var(--ease-ease);
+}
+
+.mu-play-icon::before {
+  content: "▶";
+  font-size: 1.15rem;
+  margin-left: 0.25rem;
+}
+
+.mu-video-item:hover .mu-play-icon {
+  transform: scale(1.1);
+  background-color: var(--mu-primary);
+  color: #000;
+  box-shadow: 0 0 30px rgba(255, 0, 127, 0.5);
+}
+
+/* Merch Store Grid */
+.mu-merch-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2rem;
+}
+
+.mu-merch-card {
+  background: var(--mu-surface-card);
+  border: 1px solid var(--mu-border);
+  border-radius: var(--ease-radius-md, 0.75rem);
+  padding: 1.5rem;
+  transition:
+    border-color var(--ease-speed-medium) var(--ease-ease),
+    transform var(--ease-speed-medium) var(--ease-ease);
+}
+
+.mu-merch-card:hover {
+  border-color: var(--mu-secondary);
+  transform: translateY(-4px);
+}
+
+.mu-merch-visual {
+  aspect-ratio: 1 / 1;
+  background: #0e0a1a;
+  border-radius: var(--ease-radius-sm, 0.5rem);
+  overflow: hidden;
+  position: relative;
+  margin-bottom: 1.25rem;
+}
+
+.mu-merch-canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.mu-merch-details {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.mu-merch-title {
+  font-family: "Syne", sans-serif;
+  font-weight: 700;
+  font-size: var(--ease-text-md, 1rem);
+  color: var(--mu-text-light);
+}
+
+.mu-merch-price {
+  font-family: var(--ease-font-mono, monospace);
+  font-weight: 700;
+  color: var(--mu-accent);
+}
+
+/* Newsletter/Fan Club Sign-up Banner */
+.mu-fan-banner {
+  background: linear-gradient(135deg, #0e0a1a 0%, #170d2b 100%);
+  border: 1px solid var(--mu-border);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: 4.5rem 3rem;
+  text-align: center;
+  box-shadow: var(--mu-shadow-glow);
+}
+
+.mu-fan-form {
+  display: flex;
+  gap: 0.75rem;
+  max-width: 500px;
+  margin: 2.5rem auto 0 auto;
+}
+
+.mu-fan-input {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid var(--mu-border);
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  padding: 0.85rem 1.25rem;
+  color: #fff;
+  font-family: inherit;
+}
+
+.mu-fan-input:focus {
+  outline: none;
+  border-color: var(--mu-primary);
+  background: rgba(0, 0, 0, 0.6);
+}
+
+/* Social Media Handles Grid */
+.mu-social-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 2rem;
+}
+
+.mu-social-card {
+  background: var(--mu-surface-card);
+  border: 1px solid var(--mu-border);
+  border-radius: var(--ease-radius-md, 0.75rem);
+  padding: 2rem;
+  text-align: center;
+  text-decoration: none;
+  color: var(--mu-text-light);
+  transition:
+    border-color var(--ease-speed-fast) var(--ease-ease),
+    background-color var(--ease-speed-fast) var(--ease-ease);
+}
+
+.mu-social-card:hover {
+  border-color: var(--mu-primary);
+  background: rgba(255, 0, 127, 0.03);
+}
+
+.mu-social-icon {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.mu-social-name {
+  font-family: "Syne", sans-serif;
+  font-weight: 700;
+  font-size: var(--ease-text-base, 1rem);
+}
+
+.mu-social-handle {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--mu-text-muted);
+  display: block;
+  margin-top: 0.25rem;
+}
+
+/* Footer Section */
+.mu-footer {
+  background: #040307;
+  border-top: 1px solid var(--mu-border);
+  padding: 5rem 0 3rem 0;
+}
+
+.mu-footer-bottom {
+  max-width: var(--ease-container-max, 1200px);
+  margin: 4rem auto 0 auto;
+  padding: 2rem 1.5rem 0 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.03);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.mu-footer-copyright {
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--mu-text-muted);
+}
+
+/* Responsive Media Queries */
+@media (max-width: 1024px) {
+  .mu-hero {
+    gap: 3rem;
+  }
+
+  .mu-tour-row {
+    grid-template-columns: 1.2fr 2fr 1.8fr 1.2fr;
+    padding: 1.5rem 2rem;
+  }
+
+  .mu-disco-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .mu-merch-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .mu-hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+    gap: 3.5rem;
+  }
+
+  .mu-hero-subtitle {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .mu-hero-actions {
+    justify-content: center;
+  }
+
+  .mu-platform-list {
+    justify-content: center;
+  }
+
+  .mu-tour-row {
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    padding: 1.5rem;
+    text-align: center;
+  }
+
+  .mu-tour-row > *:last-child {
+    grid-column: span 2;
+    margin-top: 0.5rem;
+  }
+
+  .mu-disco-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .mu-video-grid {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  .mu-social-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem;
+  }
+
+  .mu-fan-banner {
+    padding: 3rem 2rem;
+  }
+
+  .mu-fan-form {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 640px) {
+  .mu-disco-grid,
+  .mu-merch-grid,
+  .mu-social-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mu-footer-bottom {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
### Description
This pull request resolves issue #14885 by adding a complete, highly interactive, and fully responsive **Music Artist / Band Landing Page** ("ECHO NEBULA") showcase under the `submissions/examples/music-artist-band/` directory.

### Key Sections Showcased
- **Announcement Bar**: Styled dismissible banner (`.ease-announce-bar.is-danger`) using CSS toggle states.
- **Scroll Progress Tracker**: Warning-themed scroll bar (`.ease-scroll-progress`) tracking the page root.
- **Glassmorphic Navigation**: Sticky top header (`.ease-navbar-glass`).
- **Hero & Streaming Platform CTAs**: Album showcase displaying a custom vector sun artwork along with hover-animated stream icons.
- **Tour Schedule & Discography**: Structured tour date rows and a card grid displaying album covers.
- **Videos, Merch, & Social Links**: Video mockups, custom vector merchandise graphics (tees, vinyl, poster), and follow grids utilizing `.ease-hover-grow`, `.ease-hover-lift`, and `.ease-hover-pulse-glow` micro-animations.

### Guidelines Followed
- Self-contained inside `submissions/examples/music-artist-band/`.
- Scoped custom styles under the `.mu-` class prefix.
- Did not modify any framework core files or common components.
- Formatted local files and passed all vitest framework smoke tests.