### PR TITLE
feat: add hyphens-manual utility

### DIFF
--- a/submissions/examples/hyphens-manual-utility/README.md
+++ b/submissions/examples/hyphens-manual-utility/README.md
@@ -1,0 +1,17 @@
+# Hyphens Manual Utility
+
+Introduces the custom typography line-wrapping constraint token (`.ease-hyphens-manual`) under issue #15193.
+
+## Functional Mechanics
+
+- **The Problem:** Aggressive automated browser word-breaking engines wrap text strings at unpredictable layout nodes, which can ruin reading symmetry and design consistency inside narrow text cards.
+- **The Solution:** Restricts line-breaking targets. The `.ease-hyphens-manual` configuration instructs the text layout painter to clip words only where intentional soft hyphen components (`&shy;`) are placed in the HTML markup.
+
+## Usage Layout Structure
+```html
+<p class="ease-hyphens-manual">
+  This is an ultra&shy;long word block.
+</p>
+```
+
+Closes #15193

--- a/submissions/examples/hyphens-manual-utility/demo.html
+++ b/submissions/examples/hyphens-manual-utility/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Manual Hyphenation Rule Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 40px; margin: 0;">
+
+  <div class="hyphen-layout-box">
+    <h4>Controlled Hyphenation</h4>
+    
+    <div class="ease-hyphens-manual" style="color: #334155; font-size: 1rem; line-height: 1.6;">
+      <p style="margin: 0;">The rendering engine will only fragment ultra&shy;long words if a specific soft hyphen character indicator token is embedded inside the string sequence directly.</p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/hyphens-manual-utility/style.css
+++ b/submissions/examples/hyphens-manual-utility/style.css
@@ -1,0 +1,24 @@
+/* ============================================================
+   ease-hyphens-manual — Custom Word Breaks Layout Token
+   ============================================================ */
+
+.ease-hyphens-manual {
+  hyphens: manual;
+  word-break: normal;
+}
+
+/* Custom Interactive Lab Styles */
+.hyphen-layout-box {
+  max-width: 280px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.hyphen-layout-box h4 {
+  margin-top: 0;
+  color: #0f172a;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the typography system utility token for line wrapping constraints under issue #15193. Introduces `.ease-hyphens-manual` to allow developers native, predictable word-breaking control inside narrow container footprints without altering core files or deleting repository code.

Closes #15193

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Targeted layout rules (`.ease-hyphens-manual`) to disable automated browser hyphenation paths.
- Clean layout control options that restrict text line breaks strictly to explicit HTML soft hyphens (`&shy;`).

**How does a developer use it?**
```html
<p class="ease-hyphens-manual">
  An ultra&shy;long word container block.
</p>