### PR TITLE
feat: add user-select-text utility

### DIFF
--- a/submissions/examples/user-select-text-utility/README.md
+++ b/submissions/examples/user-select-text-utility/README.md
@@ -1,0 +1,17 @@
+# User Select Text Utility
+
+Introduces the explicit target pointer text selection token (`.ease-select-text`) under issue #15147.
+
+## Functional Mechanics
+
+- **The Problem:** When applying application-wide selection bans (`user-select: none`) across dynamic UI wrappers or interactive card layouts, nested text components like tracking codes, error messages, or terminal payloads unintentionally become uncopyable.
+- **The Solution:** Resets interaction parameters explicitly. The `.ease-select-text` class overrides inherited structural restrictions, allowing standard mouse and cursor highlight operations to cleanly copy textual blocks.
+
+## Usage Layout Structure
+```html
+<div class="ease-select-text">
+  Only this copyable string code segment can be selected...
+</div>
+```
+
+Closes #15147

--- a/submissions/examples/user-select-text-utility/demo.html
+++ b/submissions/examples/user-select-text-utility/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>User-Select Text Utility Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f8fafc; padding: 40px; margin: 0;">
+
+  <div class="code-snippet-card">
+    <h5>Interactive Documentation Block</h5>
+    
+    <div class="ease-select-text" style="color: #475569; font-size: 0.95rem; line-height: 1.6; background-color: #f1f5f9; padding: 12px; border-radius: 6px;">
+      <code>git commit -m "feat: add user-select-text utility"</code>
+    </div>
+    <p style="font-size: 0.8rem; color: #64748b; margin-top: 8px; margin-bottom: 0;">The block above explicitly forces text highlighters to capture individual characters cleanly, overriding any inherit-none parameters from parental nodes.</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/user-select-text-utility/style.css
+++ b/submissions/examples/user-select-text-utility/style.css
@@ -1,0 +1,27 @@
+/* ============================================================
+   ease-select-text — Explicit Text Selection Layout Token
+   ============================================================ */
+
+.ease-select-text {
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+
+/* Custom Interactive Snippet Lab Styles */
+.code-snippet-card {
+  max-width: 500px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 10px;
+  padding: 1.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.code-snippet-card h5 {
+  margin-top: 0;
+  color: #0f172a;
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the system interface configuration token for user selection constraints under issue #15147. Introduces `.ease-select-text` to enable granular text selection recovery inside application views, tables, or documentation nodes without mutating base styles or deleting code.

Closes #15147
---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated selection restoration wrappers (`.ease-select-text`) with standard vendor prefixes (`-webkit-`, `-moz-`, `-ms-`).
- Granular capability override layers that make code blocks or tracking links selectable within click-protected parental elements.

**How does a developer use it?**
```html
<div class="ease-select-text">
  </div>