### PR TITLE
feat: add browser extension landing page

### DIFF
--- a/submissions/examples/14851-browser-extension-landing-kp/README.md
+++ b/submissions/examples/14851-browser-extension-landing-kp/README.md
@@ -1,0 +1,20 @@
+# Browser Extension Landing Page
+
+## What does this do?
+
+It provides a responsive landing page for a browser extension with a toolbar popup preview, feature cards, and install metrics.
+
+## How is it used?
+
+```html
+<section class="hero">
+  <h1>
+    Organize tabs, save sessions, and block distractions from one tiny toolbar.
+  </h1>
+  <a class="button" href="#install">Add to browser</a>
+</section>
+```
+
+## Why is it useful?
+
+It demonstrates a complete extension marketing page with CSS-only preview motion and clear product positioning.

--- a/submissions/examples/14851-browser-extension-landing-kp/demo.html
+++ b/submissions/examples/14851-browser-extension-landing-kp/demo.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Browser Extension Landing Page</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="nav">
+      <strong>TabPilot</strong>
+      <nav>
+        <a href="#features">Features</a>
+        <a href="#preview">Preview</a>
+        <a href="#install">Install</a>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <div>
+          <p class="eyebrow">Browser extension for focused browsing</p>
+          <h1>
+            Organize tabs, save sessions, and block distractions from one tiny
+            toolbar.
+          </h1>
+          <p>
+            TabPilot is a responsive extension landing page with a product
+            preview, feature cards, and install-focused messaging.
+          </p>
+          <a class="button" href="#install">Add to browser</a>
+        </div>
+        <aside
+          class="extension-card"
+          id="preview"
+          aria-label="Extension popup preview"
+        >
+          <span class="window-bar"></span>
+          <span class="row active">Focus session</span>
+          <span class="row">Saved reading list</span>
+          <span class="row">Blocked distractions</span>
+        </aside>
+      </section>
+      <section id="features" class="cards">
+        <article>
+          <h2>Session restore</h2>
+          <p>Save tab groups and reopen them when the work context returns.</p>
+        </article>
+        <article>
+          <h2>Focus timer</h2>
+          <p>
+            Pair site blocking with timed sessions and calming visual feedback.
+          </p>
+        </article>
+        <article>
+          <h2>Privacy first</h2>
+          <p>Keep browsing data local and explain permissions clearly.</p>
+        </article>
+      </section>
+      <section id="install" class="panel">
+        <p class="eyebrow">Install confidence</p>
+        <div class="stats">
+          <span><strong>4.9</strong> rating</span
+          ><span><strong>20k</strong> users</span
+          ><span><strong>0</strong> trackers</span>
+        </div>
+      </section>
+    </main>
+    <footer>Browser extension landing page demo.</footer>
+  </body>
+</html>

--- a/submissions/examples/14851-browser-extension-landing-kp/style.css
+++ b/submissions/examples/14851-browser-extension-landing-kp/style.css
@@ -1,0 +1,202 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  color: #172033;
+  background: #f7fbff;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 6vw;
+  border-bottom: 1px solid #dceaf8;
+  background: rgba(247, 251, 255, 0.95);
+}
+
+.nav nav {
+  display: flex;
+  gap: 1rem;
+  color: #4c647a;
+}
+
+.hero {
+  min-height: 72vh;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(18rem, 0.9fr);
+  gap: 2rem;
+  align-items: center;
+  padding: 5rem 6vw 3rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.8rem;
+  color: #2563eb;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 52rem;
+  font-size: clamp(2.5rem, 7vw, 5.2rem);
+  line-height: 0.95;
+}
+
+.hero p {
+  max-width: 38rem;
+  color: #4c647a;
+  font-size: 1.1rem;
+  line-height: 1.7;
+}
+
+.button {
+  display: inline-block;
+  padding: 0.9rem 1.2rem;
+  border-radius: 0.6rem;
+  color: #ffffff;
+  background: #2563eb;
+  font-weight: 800;
+  box-shadow: 0 1rem 1.8rem rgba(37, 99, 235, 0.22);
+  transition: transform 180ms ease;
+}
+
+.button:hover,
+.cards article:hover {
+  transform: translateY(-0.35rem);
+}
+
+.extension-card,
+.cards article,
+.panel {
+  border: 1px solid #dceaf8;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(23, 32, 51, 0.08);
+}
+
+.extension-card {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1.5rem;
+  animation: float-card 4s ease-in-out infinite;
+}
+
+.window-bar {
+  height: 2rem;
+  border-radius: 0.8rem;
+  background: #dbeafe;
+}
+
+.row {
+  display: block;
+  padding: 1rem;
+  border-radius: 0.8rem;
+  background: #eff6ff;
+  font-weight: 800;
+  animation: row-in 700ms ease-out both;
+}
+
+.row:nth-child(3) {
+  animation-delay: 120ms;
+}
+.row:nth-child(4) {
+  animation-delay: 240ms;
+}
+.active {
+  background: #bfdbfe;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  padding: 2rem 6vw;
+}
+
+.cards article {
+  padding: 1.4rem;
+  transition: transform 180ms ease;
+}
+
+.panel {
+  margin: 2rem 6vw 4rem;
+  padding: 2rem;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.stats span {
+  padding: 1rem;
+  border-radius: 0.8rem;
+  background: #eff6ff;
+}
+
+.stats strong {
+  display: block;
+  color: #2563eb;
+  font-size: 2.2rem;
+}
+
+footer {
+  padding: 2rem 6vw;
+  color: #4c647a;
+}
+
+@keyframes row-in {
+  from {
+    opacity: 0;
+    transform: translateX(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes float-card {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-0.6rem);
+  }
+}
+
+@media (max-width: 760px) {
+  .hero,
+  .cards,
+  .stats {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .extension-card,
+  .row,
+  .button,
+  .cards article {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a full responsive browser extension landing page submission
- include hero, extension popup preview, feature cards, and install metrics
- document usage in README

Closes #14851

## Validation
- npx prettier --write submissions/examples/14851-browser-extension-landing-kp/**/*.{html,css,md}
- git diff --check