### PR TITLE
feat: add break-inside-avoid utility

### DIFF
--- a/submissions/examples/break-inside-avoid-utility/README.md
+++ b/submissions/examples/break-inside-avoid-utility/README.md
@@ -1,0 +1,16 @@
+# Break Inside Avoid Utility
+
+Introduces the layout fragmentation containment utility token (`.ease-break-inside-avoid`) under issue #15181.
+
+## Functional Mechanics
+
+- **The Problem:** When building masonry dashboards, multi-column reading frames, or print layout documentation sheets, long individual components often snap or split right in half at column boundaries or page break indices. This divides headlines from matching bodies and breaks visual order.
+- **The Solution:** Locks layout components together. The `.ease-break-inside-avoid` class forces the parsing layout shaper to keep the targeted element block fully unified, pushing the entire card onto the next column panel or print row if room runs out.
+
+## Usage Layout Structure
+```html
+<div class="ease-break-inside-avoid">
+  </div>
+```
+
+Closes #15181

--- a/submissions/examples/break-inside-avoid-utility/demo.html
+++ b/submissions/examples/break-inside-avoid-utility/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Break-Inside Avoid Utility Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f8fafc; padding: 40px 20px; margin: 0;">
+
+  <div style="max-width: 600px; margin: 0 auto 30px auto; text-align: center; font-family: system-ui;">
+    <h3>Multi-Column Fragmentation Guard</h3>
+    <p style="color: #64748b; font-size: 0.95rem;">Resize the viewport window or adjust heights. Protected cards will never shear or crack in half across column gutters.</p>
+  </div>
+
+  <div class="masonry-column-canvas">
+    <div class="masonry-content-card ease-break-inside-avoid">
+      <h6>Unsplittable Content Block A</h6>
+      <p style="margin: 0; font-size: 0.85rem; color: #475569; line-height: 1.5;">This modular container element stays fully unified. Natively, CSS columns might snap a container right in half, rendering the headline in column 1 and the body rows in column 2.</p>
+    </div>
+
+    <div class="masonry-content-card ease-break-inside-avoid" style="background-color: #f0fdf4; border-color: #bbf7d0;">
+      <small style="color: #16a34a; font-weight: bold;">[SECURE DATA CARD]</small>
+      <h6 style="margin-top: 4px;">Unified Data Package B</h6>
+      <p style="margin: 0; font-size: 0.85rem; color: #1e293b; line-height: 1.5;">Enforcing the <code>.ease-break-inside-avoid</code> token prevents structural fracture loops during print rendering setups or dynamic multi-column flows.</p>
+    </div>
+
+    <div class="masonry-content-card ease-break-inside-avoid">
+      <h6>Continuous Block C</h6>
+      <p style="margin: 0; font-size: 0.85rem; color: #475569; line-height: 1.5;">Maintains reading alignment across responsive editorial cards and masonry grid feeds seamlessly.</p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/break-inside-avoid-utility/style.css
+++ b/submissions/examples/break-inside-avoid-utility/style.css
@@ -1,0 +1,33 @@
+/* ============================================================
+   ease-break-inside-avoid — Element Fragmentation Guard Token
+   ============================================================ */
+
+.ease-break-inside-avoid {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+/* Custom Interactive Column/Masonry Lab Styles */
+.masonry-column-canvas {
+  column-count: 3;
+  column-gap: 1.5rem;
+  max-width: 900px;
+  margin: 0 auto;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.masonry-content-card {
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 1.25rem;
+  margin-bottom: 1.5rem;
+  display: inline-block;
+  width: 100%;
+  box-sizing: border-box;
+}
+.masonry-content-card h6 {
+  margin-top: 0;
+  color: #0f172a;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the system layout configuration token for layout fragmentation mitigation under issue #15181. Introduces `.ease-break-inside-avoid` to ensure developers can build un-splittable component envelopes inside masonry columns, print decks, and text lists inside an isolated path lane without touching core styles or deleting code assets.

Closes #15181

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated fragmentation containment markers (`.ease-break-inside-avoid`) to prevent card clipping.
- Balanced layout constraints optimized for masonry dashboards, card groups, and print stylesheet frameworks.

**How does a developer use it?**
```html
<div class="ease-break-inside-avoid">
  </div>