### PR TITLE
feat: add selection-bg-transparent utility

### DIFF
--- a/submissions/examples/selection-bg-transparent-utility/README.md
+++ b/submissions/examples/selection-bg-transparent-utility/README.md
@@ -1,0 +1,17 @@
+# Selection Background Transparent Utility
+
+Introduces the transparent text selection highlighting modifier token (`.ease-selection-bg-transparent`) under issue #15175.
+
+## Functional Mechanics
+
+- **The Problem:** Dragging a cursor across highly stylized user interfaces, canvas grids, or minimal splash cards triggers the default operating system selection color (typically a heavy blue or amber block). This masks custom text coloring and disrupts visual immersion during copy behaviors.
+- **The Solution:** Suppresses highlight backdrops while keeping data accessible. The `.ease-selection-bg-transparent` class zeroes out the selection pseudo-element background, allowing clear textual copying without imposing heavy solid colored bars on the layout.
+
+## Usage Layout Structure
+```html
+<p class="ease-selection-bg-transparent">
+  Highlighting this sentence extracts content text invisibly...
+</p>
+```
+
+Closes #15175

--- a/submissions/examples/selection-bg-transparent-utility/demo.html
+++ b/submissions/examples/selection-bg-transparent-utility/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Selection Background Transparent Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f8fafc; padding: 50px 20px; margin: 0;">
+
+  <div class="stealth-selection-card">
+    <h5>Stealth Selection Sandbox</h5>
+    
+    <div class="ease-selection-bg-transparent" style="color: #334155; font-size: 1rem; line-height: 1.65;">
+      <p style="margin: 0;">Click and drag your mouse cursor to highlight this paragraph text block. Notice that while the text characters remain fully highlightable and copyable, the traditional high-contrast blue background rectangular fill color is rendered completely transparently.</p>
+    </div>
+    <p style="font-size: 0.8rem; color: #64748b; margin-top: 12px; margin-bottom: 0;">This prevents default browser selection fills from overlapping underlying micro-interactions or precise vector canvas elements.</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/selection-bg-transparent-utility/style.css
+++ b/submissions/examples/selection-bg-transparent-utility/style.css
@@ -1,0 +1,28 @@
+/* ============================================================
+   ease-selection-bg-transparent — Transparent Highlight Token
+   ============================================================ */
+
+.ease-selection-bg-transparent::-moz-selection {
+  background-color: transparent;
+}
+
+.ease-selection-bg-transparent::selection {
+  background-color: transparent;
+}
+
+/* Custom Interactive Typography Lab Styles */
+.stealth-selection-card {
+  max-width: 550px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 12px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.stealth-selection-card h5 {
+  margin-top: 0;
+  color: #0f172a;
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the typography configuration modifier token for highlight backdrop styling under issue #15175. Introduces `.ease-selection-bg-transparent` to afford developers invisible text-selection control over minimal displays, image blocks, and codecards within an isolated path lane without breaking core layouts or deleting code assets.

Closes #15175

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated selection pseudo-element overrides (`.ease-selection-bg-transparent`) map-bound for both standard browser runtimes and legacy Gecko layouts (`::-moz-selection`).
- Clean user-interaction constraints built to strip out high-contrast system block colors without preventing underlying copy-to-clipboard workflows.

**How does a developer use it?**
```html
<p class="ease-selection-bg-transparent">
  </p>