### PR TITLE
feat: add accent-color utilities

### DIFF
--- a/submissions/examples/accent-color-utilities/README.md
+++ b/submissions/examples/accent-color-utilities/README.md
@@ -1,0 +1,17 @@
+# Accent Color Utilities
+
+Introduces a suite of native form element control tinting utility tokens under issue #15165.
+
+## Functional Mechanics
+
+- **The Problem:** Custom styling interactive elements like checkboxes, radio buttons, range sliders, and progress tracks traditionally requires writing massive blocks of complex, non-semantic wrapper markup alongside risky browser vendor overrides (`-webkit-appearance: none`). This introduces accessibility regressions and high maintenance overhead.
+- **The Solution:** Preserves semantic fidelity while applying theme values. The `.ease-accent-*` utility series relies entirely on the modern, native `accent-color` property. This lets developers re-tint internal browser interface indicators directly on native structural nodes without stripping out standard keyboard navigation loops or accessibility focus outlines.
+
+## Usage Layout Structure
+```html
+<input type="checkbox" class="ease-accent-primary" checked />
+<input type="radio" class="ease-accent-success" checked />
+<input type="range" class="ease-accent-warning" />
+```
+
+Closes #15165

--- a/submissions/examples/accent-color-utilities/demo.html
+++ b/submissions/examples/accent-color-utilities/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accent-Color Utilities Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f8fafc; padding: 60px 20px; margin: 0;">
+
+  <div class="form-tint-sandbox">
+    <h5>Native Control Tinting Matrix</h5>
+    
+    <div class="control-row" style="background-color: #f0f6ff;">
+      <input type="checkbox" id="chk-p" class="ease-accent-primary" checked>
+      <label for="chk-p">Primary Checkbox Variant (Blue)</label>
+    </div>
+
+    <div class="control-row" style="background-color: #f0fdf4;">
+      <input type="radio" id="rad-s" class="ease-accent-success" checked>
+      <label for="rad-s">Success Radio Variant (Green)</label>
+    </div>
+
+    <div class="control-row" style="background-color: #fef2f2;">
+      <input type="checkbox" id="chk-d" class="ease-accent-danger" checked>
+      <label for="chk-d">Danger Checkbox Variant (Red)</label>
+    </div>
+
+    <div class="control-row" style="background-color: #fffbeb; flex-direction: column; align-items: flex-start; gap: 0.5rem;">
+      <label for="rng-w" style="font-weight: 500;">Warning Range Slider Track (Amber)</label>
+      <input type="range" id="rng-w" class="ease-accent-warning" min="0" max="100" value="75" style="width: 100%;">
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/accent-color-utilities/style.css
+++ b/submissions/examples/accent-color-utilities/style.css
@@ -1,0 +1,60 @@
+/* ============================================================
+   ease-accent-* — Native Form Control Tinting Utility Tokens
+   ============================================================ */
+
+.ease-accent-primary {
+  accent-color: #3b82f6; /* Vivid Blue */
+}
+
+.ease-accent-success {
+  accent-color: #10b981; /* Emerald Green */
+}
+
+.ease-accent-danger {
+  accent-color: #ef4444; /* Crimson Red */
+}
+
+.ease-accent-warning {
+  accent-color: #f59e0b; /* Amber Yellow */
+}
+
+/* Custom Interactive Form Specimen Canvas Rules */
+.form-tint-sandbox {
+  max-width: 500px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 12px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.form-tint-sandbox h5 {
+  margin-top: 0;
+  color: #0f172a;
+  font-size: 1.1rem;
+  margin-bottom: 1.25rem;
+}
+.control-row {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  border-radius: 6px;
+}
+.control-row label {
+  font-size: 0.9rem;
+  color: #334155;
+  cursor: pointer;
+  flex-grow: 1;
+}
+.control-row input[type="checkbox"],
+.control-row input[type="radio"] {
+  width: 1.15rem;
+  height: 1.15rem;
+  cursor: pointer;
+}
+.control-row input[type="range"] {
+  cursor: pointer;
+  flex-grow: 1;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout interaction utility tokens for semantic form control color overrides under issue #15165. Introduces the `.ease-accent-*` framework utility matrix to empower developers with clean, high-performance re-tinting controls over checkboxes, radios, sliders, and progress meters inside an isolated workspace channel without altering global layout sheets or removing repository code.

Closes #15165

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated semantic tinting tokens (`.ease-accent-primary`, `.ease-accent-success`, `.ease-accent-danger`, `.ease-accent-warning`) targeting native browser interactive sub-elements.
- Non-destructive form styles that keep default browser validation structures and assistive engineering vectors fully intact.

**How does a developer use it?**
```html
<input type="checkbox" class="ease-accent-success" checked>