### PR TITLE
feat: add scrollbar-width-thin utility

### DIFF
--- a/submissions/examples/scrollbar-width-thin-utility/README.md
+++ b/submissions/examples/scrollbar-width-thin-utility/README.md
@@ -1,0 +1,16 @@
+# Scrollbar Width Thin Utility
+
+Introduces the minimalist text container layout scrollbar reduction token (`.ease-scrollbar-thin`) under issue #15169.
+
+## Functional Mechanics
+
+- **The Problem:** Default browser scroll tracks are incredibly wide on desktop interfaces, rendering massive gray blocks that often clash with modern, minimal card designs, dropdown menus, or feed components.
+- **The Solution:** Trims layout footprints. The `.ease-scrollbar-thin` utility applies standard cross-browser parameters to compress scrolling tracks down to an unobtrusive `6px` frame, optimizing readable container space without sacrificing user interaction hooks.
+
+## Usage Layout Structure
+```html
+<div class="ease-scrollbar-thin" style="overflow-y: auto; max-height: 200px;">
+  </div>
+```
+
+Closes #15169

--- a/submissions/examples/scrollbar-width-thin-utility/demo.html
+++ b/submissions/examples/scrollbar-width-thin-utility/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scrollbar Width Thin Utility Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div style="max-width: 500px; margin: 0 auto 30px auto; text-align: center; font-family: system-ui;">
+    <h3>Minimalist Scrollbar Track Sandbox</h3>
+    <p style="color: #64748b; font-size: 0.95rem;">Observe the right track boundary. The standard bulky desktop scroll gutter is stripped down to an elegant, low-profile thumb layout.</p>
+  </div>
+
+  <div class="scroll-panel-card ease-scrollbar-thin">
+    <h5>Compact Activity Feed Stream</h5>
+    
+    <div style="color: #475569; font-size: 0.9rem; line-height: 1.6;">
+      <p style="margin-top: 0;">By declaring <code>scrollbar-width: thin</code>, modern Firefox and standard web engines compress the default interactive track width cleanly.</p>
+      <p>We combine this standard property with targeted WebKit pseudo-elements to create a stable, unified layout look across Chrome, Edge, and Safari platforms.</p>
+      <p>This design step is ideal for side navigation structures, embedded data tables, drop-down menus, and multi-pane workspace panels where standard bulky track assemblies steal valuable pixel real estate.</p>
+      <p style="margin-bottom: 0;">End of continuous container layout demonstration parameters.</p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/scrollbar-width-thin-utility/style.css
+++ b/submissions/examples/scrollbar-width-thin-utility/style.css
@@ -1,0 +1,49 @@
+/* ============================================================
+   ease-scrollbar-thin — Standard Narrow Scrollbar Token
+   ============================================================ */
+
+.ease-scrollbar-thin {
+  scrollbar-width: thin;
+}
+
+/* Cross-vendor WebKit overrides to enforce a matching thin viewport profile */
+.ease-scrollbar-thin::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+.ease-scrollbar-thin::-webkit-scrollbar-track {
+  background: #f1f5f9;
+  border-radius: 4px;
+}
+.ease-scrollbar-thin::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 4px;
+}
+.ease-scrollbar-thin::-webkit-scrollbar-thumb:hover {
+  background: #94a3b8;
+}
+
+/* Custom Interactive Feed Panel Showcase Rules */
+.scroll-panel-card {
+  max-width: 420px;
+  height: 280px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  border: 1px solid #e2e8f0;
+  overflow-y: auto;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.scroll-panel-card h5 {
+  margin-top: 0;
+  color: #0f172a;
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+  position: sticky;
+  top: 0;
+  background: #ffffff;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #f1f5f9;
+  z-index: 10;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout interface configuration token for scroll footprint compression under issue #15169. Introduces `.ease-scrollbar-thin` to equip developers with cross-browser low-profile track management inside navigation panels, feed drawers, and dashboard blocks within an isolated path sequence without modifying core framework styles or dropping code assets.

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated width-constraining tokens (`.ease-scrollbar-thin`) supporting standard W3C definitions paired with WebKit pseudo-overrides (`::-webkit-scrollbar`).
- Minimal text track styles built to recover interface real estate within nested dashboard blocks or popovers.

**How does a developer use it?**
```html
<div class="ease-scrollbar-thin" style="overflow: auto;">
  </div>