### PR TITLE
feat: add scrollbar-width-none utility

### DIFF
--- a/submissions/examples/scrollbar-width-none-utility/README.md
+++ b/submissions/examples/scrollbar-width-none-utility/README.md
@@ -1,0 +1,16 @@
+# Scrollbar Width None Utility
+
+Introduces the layout stealth overflow control token (`.ease-scrollbar-none`) under issue #15171.
+
+## Functional Mechanics
+
+- **The Problem:** When constructing modern horizontal card swipe decks, image carousels, or minimal sidebar channels, the default browser-native scrollbar box injects visual clutters that disrupt grid alignment and distract from the interface.
+- **The Solution:** Completely hides scroll indicators without disabling functionality. The `.ease-scrollbar-none` utility pairs standard W3C layout parameters with legacy Microsoft properties and WebKit layout rules to hide the track entirely while maintaining full touch swipe and mouse wheel capabilities.
+
+## Usage Layout Structure
+```html
+<div class="ease-scrollbar-none" style="overflow-x: auto; display: flex;">
+  </div>
+```
+
+Closes #15171

--- a/submissions/examples/scrollbar-width-none-utility/demo.html
+++ b/submissions/examples/scrollbar-width-none-utility/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scrollbar Width None Utility Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f8fafc; padding: 60px 20px; margin: 0;">
+
+  <div style="max-width: 500px; margin: 0 auto 30px auto; text-align: center; font-family: system-ui;">
+    <h3>Invisible Scroll Track Carousel</h3>
+    <p style="color: #64748b; font-size: 0.95rem;">Click and swipe/scroll horizontally across the blocks. Interactive fluid navigation works perfectly while the layout track remains fully invisible.</p>
+  </div>
+
+  <div class="stealth-scroll-row ease-scrollbar-none">
+    <div class="scroll-slide-node">Matrix Alpha</div>
+    <div class="scroll-slide-node">Matrix Beta</div>
+    <div class="scroll-slide-node">Matrix Gamma</div>
+    <div class="scroll-slide-node">Matrix Delta</div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/scrollbar-width-none-utility/style.css
+++ b/submissions/examples/scrollbar-width-none-utility/style.css
@@ -1,0 +1,41 @@
+/* ============================================================
+   ease-scrollbar-none — Hidden Scroll Track Control Token
+   ============================================================ */
+
+.ease-scrollbar-none {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+
+/* Cross-vendor WebKit overrides to completely suppress track rendering */
+.ease-scrollbar-none::-webkit-scrollbar {
+  display: none;
+  width: 0 !important;
+  height: 0 !important;
+}
+
+/* Custom Interactive Minimalist Slider Showcase Rules */
+.stealth-scroll-row {
+  display: flex;
+  gap: 1rem;
+  max-width: 500px;
+  margin: 0 auto;
+  overflow-x: auto;
+  padding: 1rem;
+  background-color: #ffffff;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+}
+.scroll-slide-node {
+  flex: 0 0 160px;
+  height: 100px;
+  background: linear-gradient(135deg, #f43f5e, #e11d48);
+  color: #ffffff;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout interface configuration token for scroll footprint hiding under issue #15171. Introduces `.ease-scrollbar-none` to equip developers with cross-browser invisible scroll management inside horizontal sliders, navigation grids, and clean menus within an isolated path sequence without modifying core framework styles or dropping code assets.

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated width-hiding tokens (`.ease-scrollbar-none`) supporting standard W3C definitions paired with WebKit pseudo-overrides (`::-webkit-scrollbar { display: none }`) and legacy MS properties.
- Minimal layout styles built to clear out desktop track lines while preserving native swiping workflows intact.

**How does a developer use it?**
```html
<div class="ease-scrollbar-none" style="overflow: auto;">
  </div>