### PR TITLE
feat: add resize-none utility

### DIFF
--- a/submissions/examples/resize-none-utility/README.md
+++ b/submissions/examples/resize-none-utility/README.md
@@ -1,0 +1,17 @@
+# Resize None Utility
+
+Introduces the rigid layout constraint configuration token (`.ease-resize-none`) under issue #15114.
+
+## Functional Mechanics
+
+- **The Problem:** By default, multi-line `<textarea>` elements display an interactive dragging handle on the bottom-right corner. When an end-user expands fields freely, it pushes surrounding grids aside, breaks delicate absolute alignments, and shatters card layouts.
+- **The Solution:** Locks presentation layouts. The `.ease-resize-none` utility deactivates the user-agent resizing handle completely. This guarantees that your forms, commentary boxes, and review blocks adhere strictly to your intended responsive width and height dimensions.
+
+## Usage Layout Structure
+```html
+<textarea class="ease-resize-none">
+  This container locks down dimensions securely...
+</textarea>
+```
+
+Closes #15114

--- a/submissions/examples/resize-none-utility/demo.html
+++ b/submissions/examples/resize-none-utility/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Resize None Utility Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f8fafc; padding: 60px 20px; margin: 0;">
+
+  <div class="form-canvas-card">
+    <h5>Locked Textarea Form Entry</h5>
+    <p style="font-size: 0.85rem; color: #64748b; line-height: 1.5; margin-bottom: 1.5rem;">
+      Look at the bottom right corner of the input fields below. The second input strips out the standard dragging grid hook completely, maintaining grid structure layout continuity.
+    </p>
+
+    <div class="input-stack-group">
+      <label>Standard Textarea Box (Resizable Matrix Baseline)</label>
+      <textarea placeholder="Users can pull this corner handle out, potentially disrupting surrounding flex grids or landing block containers..."></textarea>
+    </div>
+
+    <div class="input-stack-group">
+      <label>Enforced Textarea Control (.ease-resize-none)</label>
+      <textarea class="ease-resize-none" placeholder="The drag-resize widget is fully deactivated. This element configuration honors fixed design parameters cleanly."></textarea>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/resize-none-utility/style.css
+++ b/submissions/examples/resize-none-utility/style.css
@@ -1,0 +1,51 @@
+/* ============================================================
+   ease-resize-none — Rigid Component Dimensions Control Token
+   ============================================================ */
+
+.ease-resize-none {
+  resize: none;
+}
+
+/* Custom Interactive Form Showcase Rules */
+.form-canvas-card {
+  max-width: 460px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 12px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.form-canvas-card h5 {
+  margin-top: 0;
+  color: #0f172a;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+.input-stack-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+.input-stack-group label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #475569;
+}
+.input-stack-group textarea {
+  width: 100%;
+  height: 110px;
+  padding: 0.75rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5e1;
+  font-family: inherit;
+  font-size: 0.95rem;
+  color: #1e293b;
+  box-sizing: border-box;
+}
+.input-stack-group textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout control configuration token for dimension anchoring under issue #15114. Introduces `.ease-resize-none` to equip developers with cross-browser input handle suppression inside forms, comment areas, and interactive cards within an isolated tracking branch without modifying core framework styles or removing repository code.

Closes #15114

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated sizing control tokens (`.ease-resize-none`) wrapping native CSS layout parameters.
- Structural layout constraints designed to block input expansion from disrupting responsive card containers or flex grids.

**How does a developer use it?**
```html
<textarea class="ease-resize-none"></textarea>