### PR TITLE
feat: add appointment reschedule options feature

### DIFF
--- a/submissions/examples/appointment-reschedule-options/README.md
+++ b/submissions/examples/appointment-reschedule-options/README.md
@@ -1,0 +1,18 @@
+# Appointment Reschedule Options Feature
+
+Submits layout utility architecture and interface token sets for localized calendar adjustment matrix channels (`.ease-reschedule-container`, `.ease-slot-pill`) under issue #15304.
+
+## Functional Mechanics
+
+- **The Problem:** Modifying time windows dynamically within reservation flows or booking portals often relies on clumsy, full-page calendar reloads or bloated, non-semantic grid elements that fail to clearly reflect current versus alternate state adjustments.
+- **The Solution:** Fluid layout state isolation. This feature brings specialized `.ease-slot-pill` elements built on custom transitioning vectors. It gives users immediate visual micro-feedback when choosing alternate appointments, maintaining absolute structural integrity inside complex client-side dashboard panels.
+
+## Usage Layout Structure
+```html
+<div class="ease-reschedule-container">
+  <div class="ease-slot-pill selected">
+    </div>
+</div>
+```
+
+Closes #15304

--- a/submissions/examples/appointment-reschedule-options/demo.html
+++ b/submissions/examples/appointment-reschedule-options/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Appointment Reschedule Interface Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="booking-dashboard-card">
+    <div class="badge-indicator">Reschedule Required</div>
+    <h4 style="margin: 0 0 0.25rem 0; color: #0f172a; font-size: 1.25rem;">Modify Appointment Windows</h4>
+    <p style="color: #64748b; font-size: 0.85rem; margin-top: 0; margin-bottom: 1.5rem;">Select an alternate timeline option block below to reconcile your calendar session parameters cleanly.</p>
+
+    <div class="ease-reschedule-container">
+      <div class="ease-slot-pill selected" onclick="toggleActiveSlot(this)">
+        <div>
+          <span style="display: block; font-size: 0.95rem; font-weight: 600; color: #1e293b;">June 25, 2026 (Thursday)</span>
+          <span style="font-size: 0.8rem; color: #64748b;">09:00 AM - 10:00 AM IST</span>
+        </div>
+        <span style="font-size: 0.8rem; font-weight: 500; color: #2563eb;">Selected Option</span>
+      </div>
+
+      <div class="ease-slot-pill" onclick="toggleActiveSlot(this)">
+        <div>
+          <span style="display: block; font-size: 0.95rem; font-weight: 600; color: #1e293b;">June 26, 2026 (Friday)</span>
+          <span style="font-size: 0.8rem; color: #64748b;">02:30 PM - 03:30 PM IST</span>
+        </div>
+        <span style="font-size: 0.8rem; font-weight: 500; color: #94a3b8;">Available</span>
+      </div>
+    </div>
+
+    <div class="action-btn-row">
+      <div class="btn-ui btn-ui-secondary">Discard Changes</div>
+      <div class="btn-ui btn-ui-primary">Confirm New Slate</div>
+    </div>
+  </div>
+
+  <script>
+    function toggleActiveSlot(element) {
+      const pills = document.querySelectorAll('.ease-slot-pill');
+      pills.forEach(pill => {
+        pill.classList.remove('selected');
+        pill.querySelector('span:last-child').textContent = 'Available';
+        pill.querySelector('span:last-child').style.color = '#94a3b8';
+      });
+      element.classList.add('selected');
+      element.querySelector('span:last-child').textContent = 'Selected Option';
+      element.querySelector('span:last-child').style.color = '#2563eb';
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/appointment-reschedule-options/style.css
+++ b/submissions/examples/appointment-reschedule-options/style.css
@@ -1,0 +1,87 @@
+/* ============================================================
+   ease-reschedule-panel — Interactive Appointment Engine Tokens
+   ============================================================ */
+
+.ease-reschedule-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-slot-pill {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-slot-pill:hover {
+  border-color: #3b82f6;
+  background-color: #f0f6ff;
+  transform: translateY(-1px);
+}
+
+.ease-slot-pill.selected {
+  border-color: #2563eb;
+  background-color: #eff6ff;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+/* UI Showcase Shell Custom Layout Styles */
+.booking-dashboard-card {
+  max-width: 440px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05), 0 10px 15px -3px rgba(0,0,0,0.1);
+}
+.badge-indicator {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background-color: #ffedd5;
+  color: #ea580c;
+  margin-bottom: 0.5rem;
+}
+.action-btn-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+.btn-ui {
+  padding: 0.75rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-align: center;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.2s;
+}
+.btn-ui-primary {
+  background-color: #2563eb;
+  color: #ffffff;
+}
+.btn-ui-primary:hover {
+  background-color: #1d4ed8;
+}
+.btn-ui-secondary {
+  background-color: #ffffff;
+  border-color: #cbd5e1;
+  color: #475569;
+}
+.btn-ui-secondary:hover {
+  background-color: #f8fafc;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the dashboard interface presentation components for timeline modifications under issue #15304. Introduces the `.ease-slot-pill` utility structure to provide developers with responsive, accessible micro-interaction controls over appointment shifts and calendar booking adjustments inside an isolated tracking directory without mutating core framework styles or dropping existing code assets.

Closes #15304

---

## Type of Change
- [x] ✨ New feature/utility submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated component containers (`.ease-reschedule-container`) and layout option blocks (`.ease-slot-pill`).
- Smooth visual hover transformations and distinct selection markers to help transition users between updated appointments safely.

**How does a developer use it?**
```html
<div class="ease-reschedule-container">
  <div class="ease-slot-pill">
    </div>
</div>