### PR TITLE
feat: add ease-pinch-zoom-hint animation (#13702)

### DIFF
--- a/submissions/examples/ease-pinch-zoom-hint/README.md
+++ b/submissions/examples/ease-pinch-zoom-hint/README.md
@@ -1,0 +1,22 @@
+﻿# ease-pinch-zoom-hint – Subtle Pinch‑to‑Zoom Hint
+
+A one‑time, subtle scale pulse (1 → 1.02 → 1) on an image to indicate that it supports pinch‑to‑zoom. Useful for image galleries or product photos on touch devices.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen
+- **Background:** ease-bg-gray-100
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-6, ease-mb-8, ease-mt-6
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How it works
+- The image starts with 	ransform: scale(1).
+- When the load event fires, JavaScript adds the class .pinch-hint-play.
+- This triggers the pinch-pulse animation, which scales to 1.02 and back over 0.6 seconds.
+- The animation plays **only once** (nimation-iteration-count: 1).
+- Respects prefers-reduced-motion by suppressing the animation.
+
+## How to use
+1. Copy demo.html and style.css into your project.
+2. Ensure the path to easemotion.css is correct (usually from core/).
+3. Open demo.html in any modern browser.

--- a/submissions/examples/ease-pinch-zoom-hint/demo.html
+++ b/submissions/examples/ease-pinch-zoom-hint/demo.html
@@ -1,0 +1,38 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-pinch-zoom-hint – Pinch‑to‑zoom hint</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-100 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-6 ease-fade-in">
+      Pinch‑to‑Zoom Hint
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      The image briefly pulses to indicate it supports pinch‑zoom.
+    </p>
+
+    <!-- Image with hint animation -->
+    <div class="image-wrapper">
+      <img
+        id="pinch-image"
+        src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=800&h=600&fit=crop"
+        alt="Scenic landscape"
+        class="pinch-hint-image"
+        loading="lazy"
+        onload="this.classList.add('pinch-hint-play')"
+      >
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-6 ease-fade-in ease-delay-500">
+      Try pinching on a touchscreen to zoom 👆
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-pinch-zoom-hint/style.css
+++ b/submissions/examples/ease-pinch-zoom-hint/style.css
@@ -1,0 +1,50 @@
+﻿/* ============================================================
+   ease-pinch-zoom-hint – Subtle one‑time scale pulse
+   Hints that an image supports pinch‑to‑zoom
+   ============================================================ */
+
+/* Wrapper to center and size the image */
+.image-wrapper {
+  max-width: 600px;
+  width: 100%;
+  margin: 0 auto;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+}
+
+/* Base image styling */
+.pinch-hint-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  transform: scale(1);
+  transition: transform 0.3s ease-out;
+}
+
+/* Plays the pulse animation exactly once */
+.pinch-hint-image.pinch-hint-play {
+  animation: pinch-pulse 0.6s ease-in-out 1;
+}
+
+@keyframes pinch-pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.02);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .pinch-hint-image.pinch-hint-play {
+    animation: none;
+    transform: scale(1);
+  }
+}
+
+/* Optional: disable animation on touch devices? No, the hint is *for* touch, so keep it. */


### PR DESCRIPTION
Closes #13702

ease-pinch-zoom-hint – Pinch‑to‑Zoom Hint Pulse
A one‑time subtle scale pulse (1 → 1.02 → 1) on image load to hint at pinch‑zoom support.

Files added
- submissions/examples/ease-pinch-zoom-hint/demo.html
- submissions/examples/ease-pinch-zoom-hint/style.css
- submissions/examples/ease-pinch-zoom-hint/README.md

How it works
- Image initially scale(1). On load, JS adds .pinch-hint-play.
- Animation pinch-pulse scales to 1.02 and back in 0.6s.
- Plays exactly once; respects prefers-reduced-motion.

EaseMotion classes used
ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen,
ease-bg-gray-100, ease-text-*, ease-fade-in, ease-delay-200, ease-delay-500

Custom CSS (>5 lines) for pulse keyframes and animation control.