### PR TITLE
feat: add security audit finding list feature

### DIFF
--- a/submissions/examples/security-audit-finding-list/README.md
+++ b/submissions/examples/security-audit-finding-list/README.md
@@ -1,0 +1,23 @@
+# Security Audit Finding List Feature
+
+Submits layout utility architecture and class configuration structures for vulnerability tracking panels (`.ease-audit-list`, `.ease-finding-row`) under issue #15303.
+
+## Functional Mechanics
+
+- **The Problem:** Displaying system vulnerabilities or compliance audit logs within administrative consoles typically involves un-styled tables or generic list blocks that fail to convey risk hierarchies, leading to alert fatigue or overlooked high-risk exposures.
+- **The Solution:** Highly scannable semantic rows. This feature standardizes visual indicators to separate critical, high, and medium severity findings cleanly. It pairs micro-transition border envelopes with explicit typographic styling to help operators rapidly isolate, sort, and triage risks within monitoring portals.
+
+## Usage Layout Structure
+```html
+<div class="ease-audit-list">
+  <div class="ease-finding-row">
+    <span class="ease-severity-badge ease-severity-critical">Critical</span>
+    <div class="finding-meta">
+      <h5 class="finding-title">Finding Title Here</h5>
+      <p class="finding-desc">Description of vulnerability vector...</p>
+    </div>
+  </div>
+</div>
+```
+
+Closes #15303

--- a/submissions/examples/security-audit-finding-list/demo.html
+++ b/submissions/examples/security-audit-finding-list/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Security Audit Finding List Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #0f172a; padding: 60px 20px; margin: 0;">
+
+  <div class="audit-panel-shell">
+    <div style="margin-bottom: 1.5rem; border-bottom: 1px solid #e2e8f0; padding-bottom: 1rem;">
+      <h4 style="margin: 0 0 0.25rem 0; color: #0f172a; font-size: 1.25rem;">Vulnerability Scan Manifest</h4>
+      <p style="color: #64748b; font-size: 0.85rem; margin: 0;">Review package dependencies and perimeter posture alerts flagged during systems analysis.</p>
+    </div>
+
+    <div class="ease-audit-list">
+      <div class="ease-finding-row">
+        <span class="ease-severity-badge ease-severity-critical">Critical</span>
+        <div class="finding-meta">
+          <h5 class="finding-title">Remote Code Execution (RCE) in Image Processor Module</h5>
+          <p class="finding-desc">Flaw in parsing untrusted payload headers allows unauthenticated actors to execute secondary binary blocks on core clusters.</p>
+        </div>
+      </div>
+
+      <div class="ease-finding-row">
+        <span class="ease-severity-badge ease-severity-high">High</span>
+        <div class="finding-meta">
+          <h5 class="finding-title">Broken Object Level Authorization (BOLA)</h5>
+          <p class="finding-desc">API endpoints fail to adequately validate tenant context tokens when processing direct data record fetch commands.</p>
+        </div>
+      </div>
+
+      <div class="ease-finding-row">
+        <span class="ease-severity-badge ease-severity-medium">Medium</span>
+        <div class="finding-meta">
+          <h5 class="finding-title">Permissive Cross-Origin Resource Sharing (CORS) Policy</h5>
+          <p class="finding-desc">Wildcard configuration rules accept credentials from arbitrary origin paths, exposing browser frames to data reading risks.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/security-audit-finding-list/style.css
+++ b/submissions/examples/security-audit-finding-list/style.css
@@ -1,0 +1,83 @@
+/* ============================================================
+   ease-security-audit — Security Finding Container Tokens
+   ============================================================ */
+
+.ease-audit-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-finding-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.25rem;
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-finding-row:hover {
+  border-color: #cbd5e1;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+/* Severity Indicator Badges */
+.ease-severity-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.ease-severity-critical {
+  background-color: #fef2f2;
+  color: #dc2626;
+  border: 1px solid #fee2e2;
+}
+
+.ease-severity-high {
+  background-color: #fff7ed;
+  color: #ea580c;
+  border: 1px solid #ffedd5;
+}
+
+.ease-severity-medium {
+  background-color: #fefce8;
+  color: #ca8a04;
+  border: 1px solid #fef08a;
+}
+
+/* Layout Custom Presentation Elements */
+.audit-panel-shell {
+  max-width: 650px;
+  margin: 0 auto;
+  background-color: #f8fafc;
+  border-radius: 12px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+}
+.finding-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex-grow: 1;
+}
+.finding-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+  margin: 0;
+}
+.finding-desc {
+  font-size: 0.85rem;
+  color: #475569;
+  margin: 0;
+  line-height: 1.5;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the dashboard interface presentation components for log triaging under issue #15303. Introduces the `.ease-audit-list` and severity mapping metrics to give developers unified, clear, and highly scannable layouts for managing vulnerability listings and compliance logs inside an isolated tracking path without altering core style files or losing repository code assets.

Closes #15303

---

## Type of Change
- [x] ✨ New feature/utility submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated security roster groups (`.ease-audit-list`) and layout container panels (`.ease-finding-row`).
- Semantic high-contrast severity tags (`.ease-severity-*`) engineered to prioritize risk density cleanly.

**How does a developer use it?**
```html
<div class="ease-audit-list">
  <div class="ease-finding-row">
    <span class="ease-severity-badge ease-severity-critical">Critical</span>
    </div>
</div>