### PR TITLE
Add billing cycle renewal meter example

### DIFF
--- a/submissions/examples/billing-cycle-renewal-meter-ts/README.md
+++ b/submissions/examples/billing-cycle-renewal-meter-ts/README.md
@@ -1,0 +1,17 @@
+# Billing Cycle Renewal Meter
+
+## What does this do?
+
+Shows subscription renewal progress with active, trial, and overdue billing states.
+
+## How is it used?
+
+```html
+<section class="renewal-card active">
+  <div class="meter"><span style="--value: 72%"></span></div>
+</section>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a practical dashboard pattern for billing timelines, renewal urgency, and subscription status.

--- a/submissions/examples/billing-cycle-renewal-meter-ts/demo.html
+++ b/submissions/examples/billing-cycle-renewal-meter-ts/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Billing Cycle Renewal Meter</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="billing-wrap">
+    <section class="renewal-card active">
+      <span class="status">Active plan</span>
+      <h1>Pro workspace</h1>
+      <div class="meter" aria-label="Billing cycle 72 percent complete"><span style="--value: 72%"></span></div>
+      <p><strong>18 days</strong> until renewal on July 9</p>
+    </section>
+    <section class="renewal-card trial">
+      <span class="status">Trial</span>
+      <h2>Starter trial</h2>
+      <div class="meter" aria-label="Trial 42 percent complete"><span style="--value: 42%"></span></div>
+      <p><strong>7 days</strong> left to choose a plan</p>
+    </section>
+    <section class="renewal-card overdue">
+      <span class="status">Overdue</span>
+      <h2>Team billing</h2>
+      <div class="meter" aria-label="Billing cycle overdue"><span style="--value: 100%"></span></div>
+      <p><strong>Payment needed</strong> to keep seats active</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/billing-cycle-renewal-meter-ts/style.css
+++ b/submissions/examples/billing-cycle-renewal-meter-ts/style.css
@@ -1,0 +1,94 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f5f7fb;
+  color: #152033;
+  font-family: Arial, sans-serif;
+}
+
+.billing-wrap {
+  width: min(960px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.renewal-card {
+  --accent: #2563eb;
+  padding: 22px;
+  border: 1px solid #d9e2f0;
+  border-top: 5px solid var(--accent);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 16px 38px rgba(21, 32, 51, 0.1);
+}
+
+.renewal-card.trial {
+  --accent: #7c3aed;
+}
+
+.renewal-card.overdue {
+  --accent: #dc2626;
+}
+
+.status {
+  display: inline-block;
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 12%, white);
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+h1,
+h2 {
+  margin: 16px 0;
+  font-size: clamp(1.25rem, 3vw, 1.8rem);
+}
+
+.meter {
+  height: 13px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e7edf6;
+}
+
+.meter span {
+  display: block;
+  width: var(--value);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), #14b8a6);
+  transition: width 350ms ease;
+}
+
+p {
+  margin: 14px 0 0;
+  line-height: 1.5;
+}
+
+.renewal-card:focus-within,
+.renewal-card:hover {
+  transform: translateY(-3px);
+}
+
+@media (max-width: 760px) {
+  .billing-wrap {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .meter span,
+  .renewal-card {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive billing cycle renewal meter example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15295

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/billing-cycle-renewal-meter-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed