### PR TITLE
Add role access matrix cards example

### DIFF
--- a/submissions/examples/role-access-matrix-cards-ts/README.md
+++ b/submissions/examples/role-access-matrix-cards-ts/README.md
@@ -1,0 +1,17 @@
+# Role Access Matrix Cards
+
+## What does this do?
+
+Compares admin roles and their permissions with compact responsive cards.
+
+## How is it used?
+
+```html
+<article class="role-card">
+  <div class="chips"><span>Read</span><span class="off">Delete</span></div>
+</article>
+```
+
+## Why is it useful?
+
+It adds a clear permission comparison pattern for dashboards and settings screens in EaseMotion CSS.

--- a/submissions/examples/role-access-matrix-cards-ts/demo.html
+++ b/submissions/examples/role-access-matrix-cards-ts/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Role Access Matrix Cards</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="matrix">
+    <article class="role-card">
+      <h1>Owner</h1>
+      <span class="level full">Full access</span>
+      <p>Billing, security, members, exports</p>
+      <div class="chips"><span>Read</span><span>Write</span><span>Invite</span><span>Delete</span></div>
+    </article>
+    <article class="role-card">
+      <h2>Editor</h2>
+      <span class="level partial">Limited access</span>
+      <p>Projects, content, comments</p>
+      <div class="chips"><span>Read</span><span>Write</span><span class="off">Billing</span><span class="off">Delete</span></div>
+    </article>
+    <article class="role-card">
+      <h2>Viewer</h2>
+      <span class="level view">View only</span>
+      <p>Reports, dashboards, shared files</p>
+      <div class="chips"><span>Read</span><span class="off">Write</span><span class="off">Invite</span><span class="off">Delete</span></div>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/role-access-matrix-cards-ts/style.css
+++ b/submissions/examples/role-access-matrix-cards-ts/style.css
@@ -1,0 +1,100 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #eef4f3;
+  color: #13201e;
+  font-family: Arial, sans-serif;
+}
+
+.matrix {
+  width: min(920px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.role-card {
+  padding: 22px;
+  border: 1px solid #c9dbd7;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 35px rgba(19, 32, 30, 0.1);
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.role-card:hover,
+.role-card:focus-within {
+  border-color: #0f766e;
+  transform: translateY(-4px);
+}
+
+h1,
+h2 {
+  margin: 0 0 10px;
+}
+
+.level {
+  display: inline-block;
+  padding: 5px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.full {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.partial {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.view {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+p {
+  min-height: 42px;
+  line-height: 1.5;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chips span {
+  padding: 7px 10px;
+  border-radius: 6px;
+  background: #e6fffa;
+  color: #115e59;
+  font-size: 0.85rem;
+}
+
+.chips .off {
+  background: #edf2f7;
+  color: #64748b;
+  text-decoration: line-through;
+}
+
+@media (max-width: 760px) {
+  .matrix {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .role-card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive role access matrix cards example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15296

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/role-access-matrix-cards-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed