### PR TITLE
Add inventory restock alert strip example

### DIFF
--- a/submissions/examples/inventory-restock-alert-strip-ts/README.md
+++ b/submissions/examples/inventory-restock-alert-strip-ts/README.md
@@ -1,0 +1,17 @@
+# Inventory Restock Alert Strip
+
+## What does this do?
+
+Shows inventory restock alerts for critical, low stock, and incoming shipment states.
+
+## How is it used?
+
+```html
+<div class="alert critical">
+  <strong>Critical</strong><span>Thermal labels</span><em>4 left</em>
+</div>
+```
+
+## Why is it useful?
+
+It adds an operational alert pattern for ecommerce and warehouse dashboards.

--- a/submissions/examples/inventory-restock-alert-strip-ts/demo.html
+++ b/submissions/examples/inventory-restock-alert-strip-ts/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inventory Restock Alert Strip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="inventory-panel">
+    <h1>Inventory alerts</h1>
+    <div class="alert critical"><strong>Critical</strong><span>Thermal labels</span><em>4 left</em></div>
+    <div class="alert low"><strong>Low stock</strong><span>Packing tape</span><em>23 left</em></div>
+    <div class="alert incoming"><strong>Incoming</strong><span>Mailer boxes</span><em>arrives Tue</em></div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/inventory-restock-alert-strip-ts/style.css
+++ b/submissions/examples/inventory-restock-alert-strip-ts/style.css
@@ -1,0 +1,74 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f1f5f9;
+  color: #182230;
+  font-family: Arial, sans-serif;
+}
+
+.inventory-panel {
+  width: min(760px, 92vw);
+  padding: 24px;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 40px rgba(24, 34, 48, 0.12);
+}
+
+h1 {
+  margin: 0 0 18px;
+}
+
+.alert {
+  --tone: #2563eb;
+  display: grid;
+  grid-template-columns: 120px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  margin-top: 12px;
+  padding: 15px;
+  border: 1px solid color-mix(in srgb, var(--tone) 25%, white);
+  border-left: 6px solid var(--tone);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--tone) 8%, white);
+}
+
+.alert strong {
+  color: var(--tone);
+}
+
+.alert em {
+  padding: 6px 9px;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #334155;
+  font-style: normal;
+  font-weight: 700;
+}
+
+.critical {
+  --tone: #dc2626;
+}
+
+.low {
+  --tone: #d97706;
+}
+
+.incoming {
+  --tone: #059669;
+}
+
+.alert:hover {
+  outline: 3px solid color-mix(in srgb, var(--tone) 20%, transparent);
+}
+
+@media (max-width: 620px) {
+  .alert {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive inventory restock alert strip example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15299

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/inventory-restock-alert-strip-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed