### PR TITLE
Add course module progress map example

### DIFF
--- a/submissions/examples/course-module-progress-map-ts/README.md
+++ b/submissions/examples/course-module-progress-map-ts/README.md
@@ -1,0 +1,15 @@
+# Course Module Progress Map
+
+## What does this do?
+
+Displays completed, current, upcoming, and locked course modules in a responsive path.
+
+## How is it used?
+
+```html
+<li class="current"><span>2</span><strong>Transforms</strong><em>Current</em></li>
+```
+
+## Why is it useful?
+
+It adds a learning-progress component that fits course dashboards and onboarding flows.

--- a/submissions/examples/course-module-progress-map-ts/demo.html
+++ b/submissions/examples/course-module-progress-map-ts/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Course Module Progress Map</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="course-map">
+    <h1>CSS Motion Basics</h1>
+    <ol>
+      <li class="complete"><span>1</span><strong>Timing</strong><em>Complete</em></li>
+      <li class="current"><span>2</span><strong>Transforms</strong><em>Current</em></li>
+      <li><span>3</span><strong>Keyframes</strong><em>Upcoming</em></li>
+      <li class="locked"><span>4</span><strong>Polish</strong><em>Locked</em></li>
+    </ol>
+  </main>
+</body>
+</html>

--- a/submissions/examples/course-module-progress-map-ts/style.css
+++ b/submissions/examples/course-module-progress-map-ts/style.css
@@ -1,0 +1,96 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f6f3ff;
+  color: #201a34;
+  font-family: Arial, sans-serif;
+}
+
+.course-map {
+  width: min(880px, 92vw);
+  padding: 24px;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 40px rgba(32, 26, 52, 0.12);
+}
+
+h1 {
+  margin: 0 0 22px;
+}
+
+ol {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+li {
+  position: relative;
+  padding: 18px;
+  border: 1px solid #ddd6fe;
+  border-radius: 8px;
+  background: #fafaff;
+}
+
+li span {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: 50%;
+  background: #e9d5ff;
+  color: #6d28d9;
+  font-weight: 800;
+}
+
+strong,
+em {
+  display: block;
+  margin-top: 10px;
+}
+
+em {
+  color: #6b647c;
+  font-style: normal;
+}
+
+.complete span {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.current {
+  border-color: #7c3aed;
+  box-shadow: inset 0 0 0 2px #7c3aed;
+}
+
+.locked {
+  opacity: 0.62;
+}
+
+li:hover {
+  transform: translateY(-3px);
+}
+
+@media (max-width: 760px) {
+  ol {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  li {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive course module progress map example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15300

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/course-module-progress-map-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed