### PR TITLE
Add subscription plan comparison toggle example

### DIFF
--- a/submissions/examples/subscription-plan-comparison-toggle-ts/README.md
+++ b/submissions/examples/subscription-plan-comparison-toggle-ts/README.md
@@ -1,0 +1,16 @@
+# Subscription Plan Comparison Toggle
+
+## What does this do?
+
+Presents subscription plans with a CSS-only monthly and annual billing toggle treatment.
+
+## How is it used?
+
+```html
+<div class="toggle"><span>Monthly</span><strong>Annual</strong></div>
+<section class="plan featured">...</section>
+```
+
+## Why is it useful?
+
+It adds a common pricing comparison layout for SaaS and product interfaces.

--- a/submissions/examples/subscription-plan-comparison-toggle-ts/demo.html
+++ b/submissions/examples/subscription-plan-comparison-toggle-ts/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Subscription Plan Comparison Toggle</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="pricing">
+    <div class="toggle" aria-label="Billing period"><span>Monthly</span><strong>Annual</strong></div>
+    <section class="plan"><h1>Starter</h1><p><strong>$12</strong> per seat</p><span>Basic reports</span></section>
+    <section class="plan featured"><h2>Growth</h2><p><strong>$24</strong> per seat</p><span>Automation included</span></section>
+    <section class="plan"><h2>Scale</h2><p><strong>$48</strong> per seat</p><span>Priority support</span></section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/subscription-plan-comparison-toggle-ts/style.css
+++ b/submissions/examples/subscription-plan-comparison-toggle-ts/style.css
@@ -1,0 +1,87 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f0fdf4;
+  color: #142017;
+  font-family: Arial, sans-serif;
+}
+
+.pricing {
+  width: min(900px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.toggle {
+  grid-column: 1 / -1;
+  justify-self: center;
+  display: flex;
+  gap: 6px;
+  padding: 6px;
+  border: 1px solid #bbf7d0;
+  border-radius: 999px;
+  background: #ffffff;
+}
+
+.toggle span,
+.toggle strong {
+  padding: 9px 15px;
+  border-radius: 999px;
+}
+
+.toggle strong {
+  background: #16a34a;
+  color: #ffffff;
+}
+
+.plan {
+  padding: 22px;
+  border: 1px solid #bbf7d0;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 16px 34px rgba(20, 32, 23, 0.1);
+}
+
+.featured {
+  border-color: #16a34a;
+  box-shadow: inset 0 0 0 2px #16a34a, 0 18px 38px rgba(20, 32, 23, 0.13);
+}
+
+h1,
+h2 {
+  margin: 0;
+}
+
+p strong {
+  font-size: 2rem;
+}
+
+.plan span {
+  display: block;
+  padding-top: 12px;
+  border-top: 1px solid #dcfce7;
+}
+
+.plan:hover {
+  transform: translateY(-4px);
+}
+
+@media (max-width: 760px) {
+  .pricing {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plan {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive subscription plan comparison toggle example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15302

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/subscription-plan-comparison-toggle-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed