### PR TITLE
Add appointment reschedule options example

### DIFF
--- a/submissions/examples/appointment-reschedule-options-ts/README.md
+++ b/submissions/examples/appointment-reschedule-options-ts/README.md
@@ -1,0 +1,17 @@
+# Appointment Reschedule Options
+
+## What does this do?
+
+Compares appointment reschedule slots with selected, open, and limited availability states.
+
+## How is it used?
+
+```html
+<article class="slot selected">
+  <span>Recommended</span><h2>Tue, 9:30 AM</h2>
+</article>
+```
+
+## Why is it useful?
+
+It adds a scheduling UI pattern for healthcare, booking, and service appointment flows.

--- a/submissions/examples/appointment-reschedule-options-ts/demo.html
+++ b/submissions/examples/appointment-reschedule-options-ts/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Appointment Reschedule Options</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="schedule-options">
+    <article class="slot selected"><span>Recommended</span><h1>Tue, 9:30 AM</h1><p>Downtown clinic</p></article>
+    <article class="slot"><span>Open</span><h2>Wed, 2:00 PM</h2><p>Video visit</p></article>
+    <article class="slot limited"><span>Limited</span><h2>Fri, 4:15 PM</h2><p>North office</p></article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/appointment-reschedule-options-ts/style.css
+++ b/submissions/examples/appointment-reschedule-options-ts/style.css
@@ -1,0 +1,75 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #ecfeff;
+  color: #123033;
+  font-family: Arial, sans-serif;
+}
+
+.schedule-options {
+  width: min(900px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.slot {
+  padding: 22px;
+  border: 1px solid #a5f3fc;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 16px 34px rgba(18, 48, 51, 0.1);
+}
+
+.slot span {
+  display: inline-block;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: #cffafe;
+  color: #0e7490;
+  font-weight: 800;
+}
+
+.selected {
+  border-color: #0891b2;
+  box-shadow: inset 0 0 0 2px #0891b2, 0 18px 38px rgba(18, 48, 51, 0.13);
+}
+
+.limited span {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+h1,
+h2 {
+  margin: 16px 0 8px;
+}
+
+p {
+  margin: 0;
+  color: #526467;
+}
+
+.slot:hover,
+.slot:focus-within {
+  transform: translateY(-4px);
+}
+
+@media (max-width: 760px) {
+  .schedule-options {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slot {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive appointment reschedule options example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15304

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/appointment-reschedule-options-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed