### PR TITLE
feat: add user-select-none utility

### DIFF
--- a/submissions/examples/user-select-none-utility/README.md
+++ b/submissions/examples/user-select-none-utility/README.md
@@ -1,0 +1,16 @@
+# User-Select None Utility
+
+Introduces the text selection suppression utility token (`.ease-user-select-none`) under issue #15145.
+
+## Functional Mechanics
+
+- **The Problem:** Rapidly clicking custom UI elements, tabs, accordions, or slider buttons can cause the browser to trigger text-highlight blocks across the element contents. This breaks visual immersion and mimics clunky legacy web designs.
+- **The Solution:** Locks text selection layers without disabling component event listeners. The `.ease-user-select-none` class utilizes vendor-prefixed configurations to fully suppress text-dragging targets over graphical layouts, providing crisp, app-like micro-interactions.
+
+## Usage Layout Structure
+```html
+<div class="ease-user-select-none">
+  </div>
+```
+
+Closes #15145

--- a/submissions/examples/user-select-none-utility/demo.html
+++ b/submissions/examples/user-select-none-utility/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>User-Select None Utility Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f8fafc; padding: 60px 20px; margin: 0;">
+
+  <div class="ui-interaction-card">
+    <h5>Interactive Dashboard Controls</h5>
+    <p style="font-size: 0.85rem; color: #64748b; line-height: 1.5; margin-bottom: 1.5rem;">
+      Double-click or drag your cursor rapidly across the buttons below. The first row stays cleanly isolated without accidental text selection highlights, matching native app behaviors.
+    </p>
+
+    <div class="interactive-action-row ease-user-select-none">
+      <div class="action-pill">Protected Button A</div>
+      <div class="action-pill">Protected Button B</div>
+    </div>
+
+    <div class="interactive-action-row">
+      <div class="action-pill">Standard Box A</div>
+      <div class="action-pill">Standard Box B</div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/user-select-none-utility/style.css
+++ b/submissions/examples/user-select-none-utility/style.css
@@ -1,0 +1,48 @@
+/* ============================================================
+   ease-user-select-none — Drag Highlight Suppression Token
+   ============================================================ */
+
+.ease-user-select-none {
+  -webkit-user-select: none; /* Safari */
+  -moz-user-select: none;    /* Firefox */
+  -ms-user-select: none;     /* IE10+/Edge */
+  user-select: none;         /* Standard */
+}
+
+/* Custom Interactive UI Deck Showcase Rules */
+.ui-interaction-card {
+  max-width: 450px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 12px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.ui-interaction-card h5 {
+  margin-top: 0;
+  color: #0f172a;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+.interactive-action-row {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+.action-pill {
+  flex: 1;
+  background-color: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  padding: 0.75rem;
+  text-align: center;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #334155;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+.action-pill:active {
+  background-color: #e2e8f0;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the typography system utility token for layout interaction protection under issue #15145. Introduces `.ease-user-select-none` to afford developers absolute control over dragging highlight suppression across buttons, badges, controls, and sliders within an isolated path sequence without modifying core framework styles or dropping code assets.

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated selection suppression tokens (`.ease-user-select-none`) configured safely with target multi-browser engine fallbacks (`-webkit-`, `-moz-`, `-ms-`).
- Interaction boundaries built to safeguard buttons and navigation menus from showing jarring text blocks during rapid double-clicks.

**How does a developer use it?**
```html
<button class="ease-user-select-none">Interactive Layer</button>