### PR TITLE
feat: add team capacity allocation bars feature

### DIFF
--- a/submissions/examples/team-capacity-allocation-bars/README.md
+++ b/submissions/examples/team-capacity-allocation-bars/README.md
@@ -1,0 +1,18 @@
+# Team Capacity Allocation Bars Feature
+
+Submits layout utility architectures and multi-segmented progress bar configurations for agile resourcing dashboards (`.ease-capacity-track`, `.ease-capacity-segment`) under issue #15331.
+
+## Functional Mechanics
+
+- **The Problem:** Tracking team velocity or project workload contributions using separate, traditional progress bars fills dashboards with vertical noise and fails to display relative balance within a fixed pool of resource hours.
+- **The Solution:** Inline composite tracking. This layout utility structures a unified horizontal track capable of accepting adjacent, proportional segment fragments. This allows developers to construct highly readable, multi-colored distribution indicators that preserve spatial boundaries inside project planning management grids.
+
+## Usage Layout Structure
+```html
+<div class="ease-capacity-track">
+  <div class="ease-capacity-segment ease-capacity-engineering" style="width: 60%;"></div>
+  <div class="ease-capacity-segment ease-capacity-design" style="width: 40%;"></div>
+</div>
+```
+
+Closes #15331

--- a/submissions/examples/team-capacity-allocation-bars/demo.html
+++ b/submissions/examples/team-capacity-allocation-bars/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Team Capacity Allocation Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f8fafc; padding: 60px 20px; margin: 0;">
+
+  <div class="capacity-dashboard-card">
+    <h5>Sprint 24 Allocation Profile</h5>
+    <p style="font-size: 0.85rem; color: #64748b; line-height: 1.5; margin-bottom: 1.5rem;">
+      Visualizing cross-functional bandwidth distribution across engineering resources, product design, and strategic project overhead buffers.
+    </p>
+
+    <div class="ease-capacity-track">
+      <div class="ease-capacity-segment ease-capacity-engineering" style="width: 50%;" title="Engineering: 50%"></div>
+      <div class="ease-capacity-segment ease-capacity-design" style="width: 25%;" title="Product Design: 25%"></div>
+      <div class="ease-capacity-segment ease-capacity-management" style="width: 15%;" title="Management: 15%"></div>
+      <div class="ease-capacity-segment ease-capacity-buffer" style="width: 10%;" title="Buffer: 10%"></div>
+    </div>
+
+    <div class="legend-grid">
+      <div class="legend-item">
+        <div class="color-dot ease-capacity-engineering"></div>
+        <span>Engineering (50%)</span>
+      </div>
+      <div class="legend-item">
+        <div class="color-dot ease-capacity-design"></div>
+        <span>Product Design (25%)</span>
+      </div>
+      <div class="legend-item">
+        <div class="color-dot ease-capacity-management"></div>
+        <span>Management (15%)</span>
+      </div>
+      <div class="legend-item">
+        <div class="color-dot ease-capacity-buffer"></div>
+        <span>Risk Buffer (10%)</span>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/team-capacity-allocation-bars/style.css
+++ b/submissions/examples/team-capacity-allocation-bars/style.css
@@ -1,0 +1,69 @@
+/* ============================================================
+   ease-capacity-bar — Team Allocation Tracking Tokens
+   ============================================================ */
+
+.ease-capacity-track {
+  width: 100%;
+  height: 10px;
+  background-color: #e2e8f0;
+  border-radius: 9999px;
+  overflow: hidden;
+  display: flex;
+}
+
+.ease-capacity-segment {
+  height: 100%;
+  transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Allocation Context Colors */
+.ease-capacity-engineering {
+  background-color: #3b82f6; /* Core Blue */
+}
+
+.ease-capacity-design {
+  background-color: #ec4899; /* Magenta Pink */
+}
+
+.ease-capacity-management {
+  background-color: #10b981; /* Emerald Green */
+}
+
+.ease-capacity-buffer {
+  background-color: #f59e0b; /* Amber Amber */
+}
+
+/* Custom Interactive Team Sizing Canvas Rules */
+.capacity-dashboard-card {
+  max-width: 520px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 12px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.capacity-dashboard-card h5 {
+  margin-top: 0;
+  color: #0f172a;
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+.legend-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+.color-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the product dashboard interface presentation components for composite resource tracking under issue #15331. Introduces the `.ease-capacity-track` and segment modifiers to arm management modules with fluid, highly scannable, and multi-segmented bandwidth visualization meters within an isolated submission space without changing core framework style files or losing repository codebase blocks.

---

## Type of Change
- [x] ✨ New feature/utility submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated multi-segment track wrappers (`.ease-capacity-track`) along with fluid breakdown nodes (`.ease-capacity-segment`).
- Contextual color roles built to isolate core departments (engineering, design, management, and buffers) clearly in single-row blocks.

**How does a developer use it?**
```html
<div class="ease-capacity-track">
  <div class="ease-capacity-segment ease-capacity-engineering" style="width: 70%;"></div>
  </div>