### PR TITLE
feat: add incident response status board feature

### DIFF
--- a/submissions/examples/incident-response-status-board/README.md
+++ b/submissions/examples/incident-response-status-board/README.md
@@ -1,0 +1,23 @@
+# Incident Response Status Board Feature
+
+Submits layout utility architectures and contextual operation panel cards for real-time site reliability dashboards (`.ease-incident-board`, `.ease-incident-card`, `.ease-status-*`) under issue #15322.
+
+## Functional Mechanics
+
+- **The Problem:** Presenting critical infrastructure anomalies or support failures inside monitoring interfaces using standard, generic tables or un-styled alerts hides severity context. This leads to slow mitigation responses and poor cross-team coordination during high-pressure events.
+- **The Solution:** Highly scannable status boards. This feature delivers atomic layout segments that pair clear border indicators with status pills (Investigating, Identified, Monitoring, and Resolved). This setup helps network operators quickly isolate bottlenecks and evaluate system triage logs within dedicated DevOps consoles.
+
+## Usage Layout Structure
+```html
+<div class="ease-incident-board">
+  <div class="ease-incident-card" style="border-left: 4px solid #dc2626;">
+    <div class="ease-incident-meta">
+      <strong>Incident Identifier Heading</strong>
+      <span class="ease-status-dot-pill ease-status-investigating">Investigating</span>
+    </div>
+    <p class="incident-body-text">Event description summaries go here...</p>
+  </div>
+</div>
+```
+
+Closes #15322

--- a/submissions/examples/incident-response-status-board/demo.html
+++ b/submissions/examples/incident-response-status-board/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Incident Response Status Board Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #0f172a; padding: 50px 20px; margin: 0;">
+
+  <div class="ops-center-shell">
+    <div style="margin-bottom: 1.5rem; border-bottom: 1px solid #e2e8f0; padding-bottom: 1rem; display: flex; justify-content: space-between; align-items: flex-end;">
+      <div>
+        <h4 style="margin: 0 0 4px 0; color: #0f172a; font-size: 1.3rem;">Command Center Live Operations</h4>
+        <p style="margin: 0; color: #64748b; font-size: 0.85rem;">Active platform anomalies and status resolution workstreams.</p>
+      </div>
+      <span style="font-size: 0.75rem; font-weight: 700; color: #16a34a; background-color: #dcfce7; padding: 4px 8px; border-radius: 4px;">All Channels Operational</span>
+    </div>
+
+    <div class="ease-incident-board">
+      
+      <div class="ease-incident-card" style="border-left: 4px solid #dc2626;">
+        <div class="ease-incident-meta">
+          <div style="display: flex; align-items: center; gap: 0.5rem;">
+            <strong style="color: #0f172a; font-size: 1rem;">INC-8821: API Gateway Latency Spike</strong>
+          </div>
+          <span class="ease-status-dot-pill ease-status-investigating">
+            <span class="ease-pulse-dot"></span>Investigating
+          </span>
+        </div>
+        <p class="incident-body-text">Edge routing layers are shedding requests irregularly across AP-South clusters. Engineering pipelines are examining cloud egress load-balancer logs.</p>
+        <div class="incident-timestamp">Updated: June 21, 2026 - 13:35 UTC</div>
+      </div>
+
+      <div class="ease-incident-card" style="border-left: 4px solid #ea580c;">
+        <div class="ease-incident-meta">
+          <strong style="color: #0f172a; font-size: 1rem;">INC-8819: Cache Hydration Exhaustion</strong>
+          <span class="ease-status-dot-pill ease-status-identified">
+            <span class="ease-pulse-dot"></span>Identified
+          </span>
+        </div>
+        <p class="incident-body-text">A bad data payload deployment triggered an out-of-memory lock loop on the caching tier. A hotfix release is currently being packed for validation checks.</p>
+        <div class="incident-timestamp">Updated: June 21, 2026 - 12:14 UTC</div>
+      </div>
+
+      <div class="ease-incident-card" style="border-left: 4px solid #16a34a;">
+        <div class="ease-incident-meta">
+          <strong style="color: #0f172a; font-size: 1rem;">INC-8704: Webhook Delivery Backlog</strong>
+          <span class="ease-status-dot-pill ease-status-resolved">
+            Resolved
+          </span>
+        </div>
+        <p class="incident-body-text">Worker node capacity scales have finished draining queued webhook stacks safely. Message processing delays have dropped to nominal baseline limits.</p>
+        <div class="incident-timestamp">Resolved: June 21, 2026 - 09:45 UTC</div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/incident-response-status-board/style.css
+++ b/submissions/examples/incident-response-status-board/style.css
@@ -1,0 +1,98 @@
+/* ============================================================
+   ease-incident-board — DevOps Status Board Component Tokens
+   ============================================================ */
+
+.ease-incident-board {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-incident-card {
+  background-color: #ffffff;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-incident-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+/* Header Grid Alignment */
+.ease-incident-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+/* Status Pill Modifiers */
+.ease-status-dot-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.ease-status-investigating {
+  background-color: #fef2f2;
+  color: #dc2626;
+  border: 1px solid #fee2e2;
+}
+
+.ease-status-identified {
+  background-color: #fff7ed;
+  color: #ea580c;
+  border: 1px solid #ffedd5;
+}
+
+.ease-status-monitoring {
+  background-color: #eff6ff;
+  color: #2563eb;
+  border: 1px solid #dbeafe;
+}
+
+.ease-status-resolved {
+  background-color: #f0fdf4;
+  color: #16a34a;
+  border: 1px solid #bbf7d0;
+}
+
+/* Pulsing Beacon Signal for Live Alerts */
+.ease-pulse-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: currentColor;
+}
+
+/* Dashboard Shell presentation wrappers */
+.ops-center-shell {
+  max-width: 680px;
+  margin: 0 auto;
+  background-color: #f8fafc;
+  border-radius: 12px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+}
+.incident-body-text {
+  font-size: 0.9rem;
+  color: #334155;
+  line-height: 1.5;
+  margin: 0;
+}
+.incident-timestamp {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: #64748b;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the operational dashboard interface presentation components for engineering incident logging under issue #15322. Introduces the `.ease-incident-board` configuration hierarchy to supply SRE teams and status centers with organized, highly visible incident tracking metrics inside an isolated submission path without changing core framework style documents or dropping repository code blocks.

---

## Type of Change
- [x] ✨ New feature/utility submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated incident tracking groups (`.ease-incident-board`) and flexible presentation panels (`.ease-incident-card`).
- Semantic stage markers (`.ease-status-*`) designed to map system health transitions (Investigating, Identified, Monitoring, and Resolved) cleanly.

**How does a developer use it?**
```html
<div class="ease-incident-board">
  <div class="ease-incident-card">
    </div>
</div>