### PR TITLE
feat: add product return reason selector feature

### DIFF
--- a/submissions/examples/product-return-reason-selector/README.md
+++ b/submissions/examples/product-return-reason-selector/README.md
@@ -1,0 +1,19 @@
+# Product Return Reason Selector Feature
+
+Submits layout utility architectures and responsive multi-option grids for order cancellation channels (`.ease-return-grid`, `.ease-return-card`) under issue #15323.
+
+## Functional Mechanics
+
+- **The Problem:** Processing reverse logistics or product returns using basic browser dropdown `<select>` menus or compact radio rows forces buyers through monotonous reading passes. This layout style obscures alternative text paths and raises abandonment rates within post-purchase care segments.
+- **The Solution:** Highly tactile card selection matrices. This utility structures an adaptive grid array featuring elevation transitions and active border state bindings. This setup gives e-commerce operators clear, icon-friendly micro-layouts that streamline consumer input capture during return verification loops.
+
+## Usage Layout Structure
+```html
+<div class="ease-return-grid">
+  <div class="ease-return-card selected">
+    <input type="radio" class="ease-return-radio" checked />
+    </div>
+</div>
+```
+
+Closes #15323

--- a/submissions/examples/product-return-reason-selector/demo.html
+++ b/submissions/examples/product-return-reason-selector/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Product Return Reason Selector Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="returns-desk-wrapper">
+    <div style="margin-bottom: 1.75rem; border-bottom: 1px solid #f1f5f9; padding-bottom: 1rem;">
+      <h4 style="margin: 0 0 4px 0; color: #0f172a; font-size: 1.3rem;">Why are you returning this item?</h4>
+      <p style="margin: 0; color: #64748b; font-size: 0.85rem;">Select the most accurate reconciliation parameter to guarantee swift refund validation routing.</p>
+    </div>
+
+    <div class="ease-return-grid">
+      
+      <div class="ease-return-card selected" onclick="selectReason(this)">
+        <input type="radio" name="return_reason" class="ease-return-radio" checked>
+        <span style="font-size: 1.5rem; margin-bottom: 0.25rem;">📐</span>
+        <h5 class="reason-title">Inaccurate Sizing</h5>
+        <p class="reason-desc">The item dimensions do not match standard metric fitting catalogs.</p>
+      </div>
+
+      <div class="ease-return-card" onclick="selectReason(this)">
+        <input type="radio" name="return_reason" class="ease-return-radio">
+        <span style="font-size: 1.5rem; margin-bottom: 0.25rem;">💥</span>
+        <h5 class="reason-title">Damaged or Defective</h5>
+        <p class="reason-desc">Product arrived with functional fractures or material cosmetic splits.</p>
+      </div>
+
+      <div class="ease-return-card" onclick="selectReason(this)">
+        <input type="radio" name="return_reason" class="ease-return-radio">
+        <span style="font-size: 1.5rem; margin-bottom: 0.25rem;">🔄</span>
+        <h5 class="reason-title">Incorrect Product</h5>
+        <p class="reason-desc">Shipped variant code diverges from the receipt ledger description.</p>
+      </div>
+
+    </div>
+  </div>
+
+  <script>
+    function selectReason(element) {
+      const cards = document.querySelectorAll('.ease-return-card');
+      cards.forEach(card => {
+        card.classList.remove('selected');
+        card.querySelector('.ease-return-radio').checked = false;
+      });
+      element.classList.add('selected');
+      element.querySelector('.ease-return-radio').checked = true;
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/product-return-reason-selector/style.css
+++ b/submissions/examples/product-return-reason-selector/style.css
@@ -1,0 +1,69 @@
+/* ============================================================
+   ease-return-selector — Product Return Option Grid Tokens
+   ============================================================ */
+
+.ease-return-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-return-card {
+  border: 2px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 1.25rem;
+  cursor: pointer;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+}
+
+.ease-return-card:hover {
+  border-color: #cbd5e1;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.ease-return-card.selected {
+  border-color: #2563eb;
+  background-color: #f0f6ff;
+}
+
+/* Radio Input Hidden Override Layer */
+.ease-return-radio {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: #2563eb;
+}
+
+/* Custom Interactive Returns Desk Shell Rules */
+.returns-desk-wrapper {
+  max-width: 680px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+.reason-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+  padding-right: 1.5rem;
+}
+.reason-desc {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin: 0;
+  line-height: 1.4;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the checkout and post-purchase interface presentation components for transaction reconciliation under issue #15323. Introduces the `.ease-return-grid` and card selection mechanics to equip merchant platforms and buyer portals with modern, conversion-friendly return mapping profiles inside an isolated workspace lane without mutating core style sheets or breaking code assets.

---

## Type of Change
- [x] ✨ New feature/utility submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Fluid option layout matrices (`.ease-return-grid`) and high-performance option nodes (`.ease-return-card`).
- Built-in position anchors (`.ease-return-radio`) to perfectly format semantic native form inputs alongside elaborate card content descriptions.

**How does a developer use it?**
```html
<div class="ease-return-grid">
  <div class="ease-return-card">
    </div>
</div>