### PR TITLE
Add incident response status board example

### DIFF
--- a/submissions/examples/incident-response-status-board-ts/README.md
+++ b/submissions/examples/incident-response-status-board-ts/README.md
@@ -1,0 +1,17 @@
+# Incident Response Status Board
+
+## What does this do?
+
+Shows incident severity, owner, elapsed time, and mitigation status in responsive cards.
+
+## How is it used?
+
+```html
+<section class="incident critical">
+  <span>SEV-1</span><strong>Mitigating · 18 min</strong>
+</section>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS an operations-focused status pattern for incident dashboards.

--- a/submissions/examples/incident-response-status-board-ts/demo.html
+++ b/submissions/examples/incident-response-status-board-ts/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Incident Response Status Board</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="incident-board">
+    <section class="incident critical">
+      <span>SEV-1</span>
+      <h1>Checkout latency</h1>
+      <p>Owner: Platform</p>
+      <strong>Mitigating · 18 min</strong>
+    </section>
+    <section class="incident warning">
+      <span>SEV-2</span>
+      <h2>Email delay</h2>
+      <p>Owner: Messaging</p>
+      <strong>Monitoring · 41 min</strong>
+    </section>
+    <section class="incident stable">
+      <span>SEV-3</span>
+      <h2>Report export</h2>
+      <p>Owner: Data</p>
+      <strong>Resolved · 2 hr</strong>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/incident-response-status-board-ts/style.css
+++ b/submissions/examples/incident-response-status-board-ts/style.css
@@ -1,0 +1,83 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f8fafc;
+  color: #172033;
+  font-family: Arial, sans-serif;
+}
+
+.incident-board {
+  width: min(920px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.incident {
+  --tone: #2563eb;
+  padding: 22px;
+  border: 1px solid color-mix(in srgb, var(--tone) 24%, white);
+  border-top: 5px solid var(--tone);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 16px 36px rgba(23, 32, 51, 0.12);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.incident:hover,
+.incident:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 42px rgba(23, 32, 51, 0.16);
+}
+
+.incident span {
+  display: inline-block;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tone) 13%, white);
+  color: var(--tone);
+  font-weight: 800;
+}
+
+h1,
+h2 {
+  margin: 18px 0 8px;
+}
+
+p {
+  color: #64748b;
+}
+
+strong {
+  color: var(--tone);
+}
+
+.critical {
+  --tone: #dc2626;
+}
+
+.warning {
+  --tone: #d97706;
+}
+
+.stable {
+  --tone: #16a34a;
+}
+
+@media (max-width: 760px) {
+  .incident-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .incident {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive incident response status board example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15322

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/incident-response-status-board-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed