### PR TITLE
Add product return reason selector example

### DIFF
--- a/submissions/examples/product-return-reason-selector-ts/README.md
+++ b/submissions/examples/product-return-reason-selector-ts/README.md
@@ -1,0 +1,17 @@
+# Product Return Reason Selector
+
+## What does this do?
+
+Presents selectable product return reasons with selected, normal, and unavailable states.
+
+## How is it used?
+
+```html
+<button class="reason selected" type="button">
+  <strong>Wrong size</strong><span>Exchange available</span>
+</button>
+```
+
+## Why is it useful?
+
+It adds a clear ecommerce support pattern for return and exchange flows.

--- a/submissions/examples/product-return-reason-selector-ts/demo.html
+++ b/submissions/examples/product-return-reason-selector-ts/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Product Return Reason Selector</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="return-selector">
+    <button class="reason selected" type="button"><strong>Wrong size</strong><span>Exchange available</span></button>
+    <button class="reason" type="button"><strong>Damaged item</strong><span>Photo required</span></button>
+    <button class="reason" type="button"><strong>Late delivery</strong><span>Refund review</span></button>
+    <button class="reason disabled" type="button" disabled><strong>Final sale</strong><span>Unavailable</span></button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/product-return-reason-selector-ts/style.css
+++ b/submissions/examples/product-return-reason-selector-ts/style.css
@@ -1,0 +1,67 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #fff7ed;
+  color: #27180c;
+  font-family: Arial, sans-serif;
+}
+
+.return-selector {
+  width: min(760px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.reason {
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+  border: 1px solid #fed7aa;
+  border-radius: 8px;
+  background: #ffffff;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  box-shadow: 0 14px 30px rgba(39, 24, 12, 0.1);
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.reason:hover,
+.reason:focus-visible {
+  border-color: #ea580c;
+  outline: 3px solid #fed7aa;
+  transform: translateY(-3px);
+}
+
+.reason span {
+  color: #7c5b45;
+}
+
+.selected {
+  border-color: #ea580c;
+  box-shadow: inset 0 0 0 2px #ea580c, 0 14px 30px rgba(39, 24, 12, 0.1);
+}
+
+.disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+@media (max-width: 620px) {
+  .return-selector {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reason {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive product return reason selector example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15323

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/product-return-reason-selector-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed