### PR TITLE
Add feature flag rollout meter example

### DIFF
--- a/submissions/examples/feature-flag-rollout-meter-ts/README.md
+++ b/submissions/examples/feature-flag-rollout-meter-ts/README.md
@@ -1,0 +1,17 @@
+# Feature Flag Rollout Meter
+
+## What does this do?
+
+Shows feature rollout percentage, audience segment, and enabled, paused, or draft states.
+
+## How is it used?
+
+```html
+<article class="flag enabled">
+  <div class="bar"><i style="--value: 72%"></i></div>
+</article>
+```
+
+## Why is it useful?
+
+It provides a release management visual for staged feature launches.

--- a/submissions/examples/feature-flag-rollout-meter-ts/demo.html
+++ b/submissions/examples/feature-flag-rollout-meter-ts/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Feature Flag Rollout Meter</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="flag-panel">
+    <article class="flag enabled"><span>Enabled</span><h1>New checkout</h1><div class="bar"><i style="--value: 72%"></i></div><p>72% of beta users</p></article>
+    <article class="flag paused"><span>Paused</span><h2>Team inbox</h2><div class="bar"><i style="--value: 38%"></i></div><p>38% of workspaces</p></article>
+    <article class="flag draft"><span>Draft</span><h2>Smart search</h2><div class="bar"><i style="--value: 12%"></i></div><p>12% internal only</p></article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/feature-flag-rollout-meter-ts/style.css
+++ b/submissions/examples/feature-flag-rollout-meter-ts/style.css
@@ -1,0 +1,72 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #eef2ff;
+  color: #1d2340;
+  font-family: Arial, sans-serif;
+}
+
+.flag-panel {
+  width: min(900px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.flag {
+  --tone: #4f46e5;
+  padding: 22px;
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 16px 34px rgba(29, 35, 64, 0.12);
+}
+
+.flag span {
+  color: var(--tone);
+  font-weight: 800;
+}
+
+h1,
+h2 {
+  margin: 14px 0;
+}
+
+.bar {
+  height: 14px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e0e7ff;
+}
+
+.bar i {
+  display: block;
+  width: var(--value);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--tone), #06b6d4);
+}
+
+.paused {
+  --tone: #d97706;
+}
+
+.draft {
+  --tone: #64748b;
+}
+
+p {
+  color: #626a86;
+}
+
+@media (max-width: 760px) {
+  .flag-panel {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive feature flag rollout meter example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15324

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/feature-flag-rollout-meter-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed