### PR TITLE
Add warehouse picking route list example

### DIFF
--- a/submissions/examples/warehouse-picking-route-list-ts/README.md
+++ b/submissions/examples/warehouse-picking-route-list-ts/README.md
@@ -1,0 +1,17 @@
+# Warehouse Picking Route List
+
+## What does this do?
+
+Shows warehouse picking tasks with aisle, bin, quantity, and route status.
+
+## How is it used?
+
+```html
+<div class="pick current">
+  <strong>Aisle 6 · Bin 02</strong><em>Current</em>
+</div>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a fulfillment workflow pattern for warehouse and logistics screens.

--- a/submissions/examples/warehouse-picking-route-list-ts/demo.html
+++ b/submissions/examples/warehouse-picking-route-list-ts/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Warehouse Picking Route List</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="route-list">
+    <h1>Picking route</h1>
+    <div class="pick done"><strong>Aisle 4 · Bin 12</strong><span>3 units</span><em>Done</em></div>
+    <div class="pick current"><strong>Aisle 6 · Bin 02</strong><span>8 units</span><em>Current</em></div>
+    <div class="pick priority"><strong>Aisle 8 · Bin 31</strong><span>1 unit</span><em>Priority</em></div>
+    <div class="pick blocked"><strong>Aisle 9 · Bin 07</strong><span>5 units</span><em>Blocked</em></div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/warehouse-picking-route-list-ts/style.css
+++ b/submissions/examples/warehouse-picking-route-list-ts/style.css
@@ -1,0 +1,70 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f8fafc;
+  color: #182230;
+  font-family: Arial, sans-serif;
+}
+
+.route-list {
+  width: min(760px, 92vw);
+  display: grid;
+  gap: 12px;
+  padding: 24px;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 40px rgba(24, 34, 48, 0.12);
+}
+
+h1 {
+  margin: 0 0 8px;
+}
+
+.pick {
+  --tone: #64748b;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 15px;
+  border-left: 6px solid var(--tone);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--tone) 8%, white);
+}
+
+.pick em {
+  padding: 6px 9px;
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--tone);
+  font-style: normal;
+  font-weight: 800;
+}
+
+.done {
+  --tone: #16a34a;
+}
+
+.current {
+  --tone: #2563eb;
+}
+
+.priority {
+  --tone: #d97706;
+}
+
+.blocked {
+  --tone: #dc2626;
+}
+
+@media (max-width: 620px) {
+  .pick {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive warehouse picking route list example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15327

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/warehouse-picking-route-list-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed