### PR TITLE
Add team capacity allocation bars example

### DIFF
--- a/submissions/examples/team-capacity-allocation-bars-ts/README.md
+++ b/submissions/examples/team-capacity-allocation-bars-ts/README.md
@@ -1,0 +1,17 @@
+# Team Capacity Allocation Bars
+
+## What does this do?
+
+Shows planned, available, overbooked, and blocked team capacity with CSS-only bars.
+
+## How is it used?
+
+```html
+<section class="capacity overbooked">
+  <div><span style="--value: 96%"></span></div>
+</section>
+```
+
+## Why is it useful?
+
+It adds a planning dashboard pattern for capacity, staffing, and workload allocation.

--- a/submissions/examples/team-capacity-allocation-bars-ts/demo.html
+++ b/submissions/examples/team-capacity-allocation-bars-ts/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Team Capacity Allocation Bars</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="capacity-board">
+    <section class="capacity planned"><strong>Design</strong><div><span style="--value: 68%"></span></div><em>68% planned</em></section>
+    <section class="capacity available"><strong>Frontend</strong><div><span style="--value: 44%"></span></div><em>44% available</em></section>
+    <section class="capacity overbooked"><strong>Backend</strong><div><span style="--value: 96%"></span></div><em>96% overbooked</em></section>
+    <section class="capacity blocked"><strong>QA</strong><div><span style="--value: 28%"></span></div><em>Blocked</em></section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/team-capacity-allocation-bars-ts/style.css
+++ b/submissions/examples/team-capacity-allocation-bars-ts/style.css
@@ -1,0 +1,74 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #eff6ff;
+  color: #172033;
+  font-family: Arial, sans-serif;
+}
+
+.capacity-board {
+  width: min(760px, 92vw);
+  display: grid;
+  gap: 14px;
+  padding: 24px;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 40px rgba(23, 32, 51, 0.12);
+}
+
+.capacity {
+  --tone: #2563eb;
+  display: grid;
+  grid-template-columns: 110px 1fr 130px;
+  gap: 14px;
+  align-items: center;
+}
+
+.capacity div {
+  height: 14px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #dbeafe;
+}
+
+.capacity span {
+  display: block;
+  width: var(--value);
+  height: 100%;
+  border-radius: inherit;
+  background: var(--tone);
+}
+
+.capacity em {
+  color: var(--tone);
+  font-style: normal;
+  font-weight: 800;
+}
+
+.planned {
+  --tone: #2563eb;
+}
+
+.available {
+  --tone: #16a34a;
+}
+
+.overbooked {
+  --tone: #dc2626;
+}
+
+.blocked {
+  --tone: #7c3aed;
+}
+
+@media (max-width: 620px) {
+  .capacity {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive team capacity allocation bars example with CSS-only states, responsive layout, and reduced-motion support where motion is used.

Closes #15331

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/team-capacity-allocation-bars-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed