### PR TITLE
Add release risk assessment cards example

### DIFF
--- a/submissions/examples/release-risk-assessment-cards-ts/README.md
+++ b/submissions/examples/release-risk-assessment-cards-ts/README.md
@@ -1,0 +1,17 @@
+# Release Risk Assessment Cards
+
+## What does this do?
+
+Summarizes release risk with low, medium, and high go/no-go recommendation cards.
+
+## How is it used?
+
+```html
+<article class="risk high">
+  <span>High risk</span><strong>No-go</strong>
+</article>
+```
+
+## Why is it useful?
+
+It adds a release planning pattern for deployment readiness and blocker review.

--- a/submissions/examples/release-risk-assessment-cards-ts/demo.html
+++ b/submissions/examples/release-risk-assessment-cards-ts/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Release Risk Assessment Cards</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="risk-grid">
+    <article class="risk low"><span>Low risk</span><h1>Docs update</h1><p>0 blockers</p><strong>Go</strong></article>
+    <article class="risk medium"><span>Medium risk</span><h2>Billing patch</h2><p>2 blockers</p><strong>Review</strong></article>
+    <article class="risk high"><span>High risk</span><h2>Auth migration</h2><p>5 blockers</p><strong>No-go</strong></article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/release-risk-assessment-cards-ts/style.css
+++ b/submissions/examples/release-risk-assessment-cards-ts/style.css
@@ -1,0 +1,74 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #eef2ff;
+  color: #1d2340;
+  font-family: Arial, sans-serif;
+}
+
+.risk-grid {
+  width: min(900px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.risk {
+  --tone: #16a34a;
+  padding: 22px;
+  border: 1px solid color-mix(in srgb, var(--tone) 30%, white);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 16px 34px rgba(29, 35, 64, 0.12);
+}
+
+.risk span,
+.risk strong {
+  display: inline-block;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tone) 14%, white);
+  color: var(--tone);
+  font-weight: 800;
+}
+
+h1,
+h2 {
+  margin: 18px 0 8px;
+}
+
+p {
+  color: #626a86;
+}
+
+.medium {
+  --tone: #d97706;
+}
+
+.high {
+  --tone: #dc2626;
+}
+
+.risk:hover,
+.risk:focus-within {
+  transform: translateY(-4px);
+}
+
+@media (max-width: 760px) {
+  .risk-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .risk {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive release risk assessment cards example with CSS-only states and responsive layout.

Closes #15357

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/release-risk-assessment-cards-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
