### PR TITLE
Add invoice payment status strip example

### DIFF
--- a/submissions/examples/invoice-payment-status-strip-ts/README.md
+++ b/submissions/examples/invoice-payment-status-strip-ts/README.md
@@ -1,0 +1,17 @@
+# Invoice Payment Status Strip
+
+## What does this do?
+
+Displays invoice rows with paid, pending, overdue, and failed payment states.
+
+## How is it used?
+
+```html
+<div class="invoice overdue">
+  <strong>INV-2050</strong><em>Overdue</em>
+</div>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a compact billing status pattern for invoice dashboards.

--- a/submissions/examples/invoice-payment-status-strip-ts/demo.html
+++ b/submissions/examples/invoice-payment-status-strip-ts/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Invoice Payment Status Strip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="invoice-list">
+    <div class="invoice paid"><strong>INV-2048</strong><span>$240</span><em>Paid</em></div>
+    <div class="invoice pending"><strong>INV-2049</strong><span>$680 · Jun 27</span><em>Pending</em></div>
+    <div class="invoice overdue"><strong>INV-2050</strong><span>$430 · Jun 12</span><em>Overdue</em></div>
+    <div class="invoice failed"><strong>INV-2051</strong><span>$120 · Retry</span><em>Failed</em></div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/invoice-payment-status-strip-ts/style.css
+++ b/submissions/examples/invoice-payment-status-strip-ts/style.css
@@ -1,0 +1,63 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f1f5f9;
+  color: #172033;
+  font-family: Arial, sans-serif;
+}
+
+.invoice-list {
+  width: min(780px, 92vw);
+  display: grid;
+  gap: 12px;
+}
+
+.invoice {
+  --tone: #64748b;
+  display: grid;
+  grid-template-columns: 140px 1fr auto;
+  gap: 14px;
+  align-items: center;
+  padding: 16px;
+  border-left: 6px solid var(--tone);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 14px 30px rgba(23, 32, 51, 0.1);
+}
+
+.invoice em {
+  padding: 7px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tone) 13%, white);
+  color: var(--tone);
+  font-style: normal;
+  font-weight: 800;
+}
+
+.paid {
+  --tone: #16a34a;
+}
+
+.pending {
+  --tone: #2563eb;
+}
+
+.overdue {
+  --tone: #d97706;
+}
+
+.failed {
+  --tone: #dc2626;
+}
+
+@media (max-width: 620px) {
+  .invoice {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive invoice payment status strip example with CSS-only states and responsive layout.

Closes #15358

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/invoice-payment-status-strip-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
