### PR TITLE
Add notification preference toggle grid example

### DIFF
--- a/submissions/examples/notification-preference-toggle-grid-ts/README.md
+++ b/submissions/examples/notification-preference-toggle-grid-ts/README.md
@@ -1,0 +1,17 @@
+# Notification Preference Toggle Grid
+
+## What does this do?
+
+Shows notification preference toggles with enabled, optional, and disabled states.
+
+## How is it used?
+
+```html
+<button class="pref active" type="button">
+  <strong>Email</strong><span>Enabled</span>
+</button>
+```
+
+## Why is it useful?
+
+It adds a settings screen pattern for managing communication preferences.

--- a/submissions/examples/notification-preference-toggle-grid-ts/demo.html
+++ b/submissions/examples/notification-preference-toggle-grid-ts/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Notification Preference Toggle Grid</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="preference-grid">
+    <button class="pref active" type="button"><strong>Email</strong><span>Enabled</span></button>
+    <button class="pref" type="button"><strong>SMS</strong><span>Optional</span></button>
+    <button class="pref active" type="button"><strong>Push</strong><span>Enabled</span></button>
+    <button class="pref disabled" type="button" disabled><strong>Digest</strong><span>Locked</span></button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/notification-preference-toggle-grid-ts/style.css
+++ b/submissions/examples/notification-preference-toggle-grid-ts/style.css
@@ -1,0 +1,62 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f0fdfa;
+  color: #15302d;
+  font-family: Arial, sans-serif;
+}
+
+.preference-grid {
+  width: min(760px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.pref {
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+  border: 1px solid #99f6e4;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #115e59;
+  cursor: pointer;
+  box-shadow: 0 14px 30px rgba(21, 48, 45, 0.1);
+}
+
+.pref:focus-visible,
+.pref:hover,
+.pref.active {
+  border-color: #0f766e;
+  outline: 3px solid #ccfbf1;
+  background: #0f766e;
+  color: #ffffff;
+}
+
+.pref span {
+  font-size: 0.88rem;
+}
+
+.disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+@media (max-width: 760px) {
+  .preference-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .preference-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive notification preference toggle grid example with CSS-only states and responsive layout.

Closes #15359

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/notification-preference-toggle-grid-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
