### PR TITLE
Add on-call shift handoff card example

### DIFF
--- a/submissions/examples/on-call-shift-handoff-card-ts/README.md
+++ b/submissions/examples/on-call-shift-handoff-card-ts/README.md
@@ -1,0 +1,17 @@
+# On-call Shift Handoff Card
+
+## What does this do?
+
+Shows outgoing and incoming on-call owners, active alerts, and handoff acknowledgement status.
+
+## How is it used?
+
+```html
+<main class="handoff-card">
+  <span class="status pending">Pending acknowledgement</span>
+</main>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS an operations handoff pattern for support and incident response teams.

--- a/submissions/examples/on-call-shift-handoff-card-ts/demo.html
+++ b/submissions/examples/on-call-shift-handoff-card-ts/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>On-call Shift Handoff Card</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="handoff-card">
+    <span class="status pending">Pending acknowledgement</span>
+    <h1>On-call handoff</h1>
+    <section class="people">
+      <div><strong>Outgoing</strong><p>Maya R.</p></div>
+      <div><strong>Incoming</strong><p>Dev P.</p></div>
+    </section>
+    <ul>
+      <li>3 active alerts</li>
+      <li>Database failover watch</li>
+      <li class="done">Runbook links verified</li>
+    </ul>
+  </main>
+</body>
+</html>

--- a/submissions/examples/on-call-shift-handoff-card-ts/style.css
+++ b/submissions/examples/on-call-shift-handoff-card-ts/style.css
@@ -1,0 +1,79 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #111827;
+  color: #f8fafc;
+  font-family: Arial, sans-serif;
+}
+
+.handoff-card {
+  width: min(620px, 92vw);
+  padding: 24px;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  background: #1f2937;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.25);
+}
+
+.status {
+  display: inline-block;
+  padding: 7px 10px;
+  border-radius: 999px;
+  background: #fef3c7;
+  color: #92400e;
+  font-weight: 800;
+}
+
+h1 {
+  margin: 18px 0;
+}
+
+.people {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.people div,
+li {
+  padding: 14px;
+  border-radius: 7px;
+  background: #111827;
+}
+
+p {
+  margin: 8px 0 0;
+  color: #cbd5e1;
+}
+
+ul {
+  display: grid;
+  gap: 10px;
+  padding: 0;
+  margin: 16px 0 0;
+  list-style: none;
+}
+
+li::before {
+  content: "!";
+  margin-right: 8px;
+  color: #f59e0b;
+  font-weight: 800;
+}
+
+.done::before {
+  content: "OK";
+  color: #22c55e;
+}
+
+@media (max-width: 560px) {
+  .people {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive on-call shift handoff card example with CSS-only states and responsive layout.

Closes #15361

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/on-call-shift-handoff-card-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
