### PR TITLE
Add dataset quality scoreboard example

### DIFF
--- a/submissions/examples/dataset-quality-scoreboard-ts/README.md
+++ b/submissions/examples/dataset-quality-scoreboard-ts/README.md
@@ -1,0 +1,17 @@
+# Dataset Quality Scoreboard
+
+## What does this do?
+
+Displays dataset completeness, freshness, validity, and duplicate-rate quality scores.
+
+## How is it used?
+
+```html
+<article class="score warn">
+  <span>78%</span><h2>Validity</h2>
+</article>
+```
+
+## Why is it useful?
+
+It adds a data operations pattern for analytics quality and monitoring dashboards.

--- a/submissions/examples/dataset-quality-scoreboard-ts/demo.html
+++ b/submissions/examples/dataset-quality-scoreboard-ts/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dataset Quality Scoreboard</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="quality-board">
+    <article class="score good"><span>97%</span><h1>Completeness</h1><p>Healthy</p></article>
+    <article class="score good"><span>91%</span><h2>Freshness</h2><p>Updated hourly</p></article>
+    <article class="score warn"><span>78%</span><h2>Validity</h2><p>Needs review</p></article>
+    <article class="score bad"><span>12%</span><h2>Duplicates</h2><p>Above target</p></article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/dataset-quality-scoreboard-ts/style.css
+++ b/submissions/examples/dataset-quality-scoreboard-ts/style.css
@@ -1,0 +1,66 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f0f9ff;
+  color: #172033;
+  font-family: Arial, sans-serif;
+}
+
+.quality-board {
+  width: min(900px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.score {
+  --tone: #16a34a;
+  padding: 22px;
+  border: 1px solid color-mix(in srgb, var(--tone) 25%, white);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 14px 30px rgba(23, 32, 51, 0.1);
+}
+
+.score span {
+  color: var(--tone);
+  font-size: 2rem;
+  font-weight: 800;
+}
+
+h1,
+h2 {
+  margin: 14px 0 8px;
+  font-size: 1.12rem;
+}
+
+p {
+  margin: 0;
+  color: #64748b;
+}
+
+.warn {
+  --tone: #d97706;
+}
+
+.bad {
+  --tone: #dc2626;
+}
+
+@media (max-width: 820px) {
+  .quality-board {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .quality-board {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive dataset quality scoreboard example with CSS-only states and responsive layout.

Closes #15362

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/dataset-quality-scoreboard-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
