### PR TITLE
Add campaign budget pacing meter example

### DIFF
--- a/submissions/examples/campaign-budget-pacing-meter-ts/README.md
+++ b/submissions/examples/campaign-budget-pacing-meter-ts/README.md
@@ -1,0 +1,17 @@
+# Campaign Budget Pacing Meter
+
+## What does this do?
+
+Shows campaign budget pacing with on-pace, underspend, and overspend states.
+
+## How is it used?
+
+```html
+<section class="campaign over">
+  <div><span style="--value: 92%"></span></div>
+</section>
+```
+
+## Why is it useful?
+
+It gives marketing dashboards a compact way to compare spend against budget pace.

--- a/submissions/examples/campaign-budget-pacing-meter-ts/demo.html
+++ b/submissions/examples/campaign-budget-pacing-meter-ts/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Campaign Budget Pacing Meter</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="campaigns">
+    <section class="campaign on"><strong>Search ads</strong><div><span style="--value: 58%"></span></div><em>On pace</em></section>
+    <section class="campaign under"><strong>Newsletter</strong><div><span style="--value: 34%"></span></div><em>Underspend</em></section>
+    <section class="campaign over"><strong>Retargeting</strong><div><span style="--value: 92%"></span></div><em>Overspend</em></section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/campaign-budget-pacing-meter-ts/style.css
+++ b/submissions/examples/campaign-budget-pacing-meter-ts/style.css
@@ -1,0 +1,66 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #fff7ed;
+  color: #27180c;
+  font-family: Arial, sans-serif;
+}
+
+.campaigns {
+  width: min(760px, 92vw);
+  display: grid;
+  gap: 14px;
+  padding: 24px;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 40px rgba(39, 24, 12, 0.12);
+}
+
+.campaign {
+  --tone: #16a34a;
+  display: grid;
+  grid-template-columns: 130px 1fr 110px;
+  gap: 14px;
+  align-items: center;
+}
+
+.campaign div {
+  height: 14px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #fed7aa;
+}
+
+.campaign span {
+  display: block;
+  width: var(--value);
+  height: 100%;
+  border-radius: inherit;
+  background: var(--tone);
+}
+
+.campaign em {
+  color: var(--tone);
+  font-style: normal;
+  font-weight: 800;
+}
+
+.under {
+  --tone: #2563eb;
+}
+
+.over {
+  --tone: #dc2626;
+}
+
+@media (max-width: 620px) {
+  .campaign {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive campaign budget pacing meter example with CSS-only states and responsive layout.

Closes #15363

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/campaign-budget-pacing-meter-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
