### PR TITLE
Add asset warranty status cards example

### DIFF
--- a/submissions/examples/asset-warranty-status-cards-ts/README.md
+++ b/submissions/examples/asset-warranty-status-cards-ts/README.md
@@ -1,0 +1,17 @@
+# Asset Warranty Status Cards
+
+## What does this do?
+
+Shows active, expiring, expired, and replacement-needed warranty states for assets.
+
+## How is it used?
+
+```html
+<article class="asset expiring">
+  <span>Expiring</span><h2>Router R08</h2>
+</article>
+```
+
+## Why is it useful?
+
+It gives inventory dashboards a quick pattern for warranty tracking and replacement planning.

--- a/submissions/examples/asset-warranty-status-cards-ts/demo.html
+++ b/submissions/examples/asset-warranty-status-cards-ts/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Asset Warranty Status Cards</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="warranty-grid">
+    <article class="asset active"><span>Active</span><h1>Laptop A14</h1><p>Until Nov 2027</p></article>
+    <article class="asset expiring"><span>Expiring</span><h2>Router R08</h2><p>32 days left</p></article>
+    <article class="asset expired"><span>Expired</span><h2>Monitor M21</h2><p>Ended May 2026</p></article>
+    <article class="asset replace"><span>Replace</span><h2>Scanner S02</h2><p>Warranty denied</p></article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/asset-warranty-status-cards-ts/style.css
+++ b/submissions/examples/asset-warranty-status-cards-ts/style.css
@@ -1,0 +1,74 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #eff6ff;
+  color: #172033;
+  font-family: Arial, sans-serif;
+}
+
+.warranty-grid {
+  width: min(900px, 92vw);
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.asset {
+  --tone: #2563eb;
+  padding: 20px;
+  border: 1px solid color-mix(in srgb, var(--tone) 28%, white);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 14px 30px rgba(23, 32, 51, 0.1);
+}
+
+.asset span {
+  display: inline-block;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tone) 13%, white);
+  color: var(--tone);
+  font-weight: 800;
+}
+
+h1,
+h2 {
+  margin: 16px 0 8px;
+  font-size: 1.15rem;
+}
+
+p {
+  margin: 0;
+  color: #64748b;
+}
+
+.active {
+  --tone: #16a34a;
+}
+
+.expiring {
+  --tone: #d97706;
+}
+
+.expired,
+.replace {
+  --tone: #dc2626;
+}
+
+@media (max-width: 840px) {
+  .warranty-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .warranty-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a responsive asset warranty status cards example with CSS-only states and responsive layout.

Closes #15366

## Type of Change

- [x] New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/asset-warranty-status-cards-ts/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Browser Testing

- [x] Static demo and stylesheet validation completed
