### PR TITLE
feat: add object-cover utility

### DIFF
--- a/submissions/examples/object-cover-utility/README.md
+++ b/submissions/examples/object-cover-utility/README.md
@@ -1,0 +1,17 @@
+# Object Cover Utility
+
+Introduces the media aspect-ratio fills parameter utility token (`.ease-object-cover`) under issue #15108.
+
+## Functional Mechanics
+
+- **The Problem:** When building responsive media grids, user profile thumbnails, or article banner placeholders, loaded imagery rarely matches the explicit structural aspect ratios required by the layout grid. Without a containment rule, raw images squash or warp awkwardly to fit their target boxes, degrading UI quality.
+- **The Solution:** Seamless center-cropping. The `.ease-object-cover` utility enforces browser-native scaling logic via `object-fit: cover`. The image scales cleanly to fill the entire layout box, preserving its intrinsic proportions while cleanly clipping overlapping horizontal or vertical margins along a stable center axis.
+
+## Usage Layout Structure
+```html
+<div class="card-hero-slot" style="width: 100%; height: 240px;">
+  <img src="landscape.jpg" class="ease-object-cover" style="width: 100%; height: 100%;" />
+</div>
+```
+
+Closes #15108

--- a/submissions/examples/object-cover-utility/demo.html
+++ b/submissions/examples/object-cover-utility/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Object Cover Utility Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="media-sandbox-canvas">
+    <h4 style="margin: 0 0 0.5rem 0; color: #0f172a; font-size: 1.25rem;">Media Aspect Ratio Cropping Matrix</h4>
+    <p style="font-size: 0.85rem; color: #64748b; line-height: 1.5; margin-top: 0; margin-bottom: 1.5rem;">
+      Compare standard unconstrained stretching against the <code>object-fit: cover</code> utility class using an asymmetrical placeholder asset.
+    </p>
+
+    <div class="comparison-grid">
+      <div class="media-container-frame">
+        <div class="frame-label">Default (Stretched/Distorted)</div>
+        <img src="https://images.unsplash.com/photo-1542831371-29b0f74f9713?w=300&h=400&fit=crop" class="preview-asset" alt="Distorted Specimen">
+      </div>
+
+      <div class="media-container-frame">
+        <div class="frame-label">ease-object-cover (Center-Cropped)</div>
+        <img src="https://images.unsplash.com/photo-1542831371-29b0f74f9713?w=300&h=400&fit=crop" class="preview-asset ease-object-cover" alt="Preserved Specimen">
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/object-cover-utility/style.css
+++ b/submissions/examples/object-cover-utility/style.css
@@ -1,0 +1,50 @@
+/* ============================================================
+   ease-object-cover — Center-Cropped Aspect Ratio Utility Token
+   ============================================================ */
+
+.ease-object-cover {
+  object-fit: cover;
+}
+
+/* Custom Interactive UI Testing Stage Rules */
+.media-sandbox-canvas {
+  max-width: 650px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 14px;
+  padding: 2.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.comparison-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.media-container-frame {
+  background-color: #f1f5f9;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid #cbd5e1;
+  display: flex;
+  flex-direction: column;
+}
+
+.frame-label {
+  background-color: #f8fafc;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.preview-asset {
+  width: 100%;
+  height: 180px;
+  display: block;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the media scaling utility token for proportional image center-cropping under issue #15108. Introduces `.ease-object-cover` to provide developers with stable structural safety when rendering multi-source thumbnails, blog feature headers, and card banners inside rigid bounding frames without warping graphic properties or throwing off aspect alignments.

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated dimensional fill rules (`.ease-object-cover`) leveraging browser-native `object-fit` parameters.
- Clean layout protection designed to eliminate compressed pixels across standard layout structures.

**How does a developer use it?**
```html
<img class="ease-object-cover" src="banner.png" style="width: 100%; height: 100%;" />