### PR TITLE
feat: add mix-blend-mode showcase example

### DIFF
--- a/submissions/examples/mix-blend-mode-showcase/README.md
+++ b/submissions/examples/mix-blend-mode-showcase/README.md
@@ -1,0 +1,19 @@
+# CSS Mix Blend Mode Showcase Feature
+
+Submits layout utility architectures and layer compositing sandbox panels (`.ease-blend-*`, `.blend-card-specimen`) under issue #15392.
+
+## Functional Mechanics
+
+- **The Problem:** Presenting complex graphical color manipulation theories, hardware blending parameters, or visual layer interactions within raw code files obscures the direct output states. This forces UI engineers to repeatedly build throwaway boilerplate test canvases to inspect how foreground parameters react against dark, light, or multi-colored gradient backgrounds.
+- **The Solution:** A unified interactive blend-mode exhibition matrix. This layout packages core compositing classes (`.ease-blend-multiply`, `.ease-scroll-screen`, etc.) into a scannable grid module. It lets layout designers quickly examine contrast limits, pixel math variables, and accessibility states within an organized, presentation-ready framework dashboard.
+
+## Usage Layout Structure
+```html
+<div class="blend-viewport-frame">
+  <div class="gradient-layer"></div>
+  
+  <h1 class="ease-blend-overlay">Volumetric Text</h1>
+</div>
+```
+
+Closes #15392

--- a/submissions/examples/mix-blend-mode-showcase/demo.html
+++ b/submissions/examples/mix-blend-mode-showcase/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Mix Blend Mode Showcase Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="showcase-stage-canvas">
+    <div style="border-bottom: 1px solid #e2e8f0; padding-bottom: 1.25rem; margin-bottom: 1.5rem;">
+      <h4 style="margin: 0 0 6px 0; color: #0f172a; font-size: 1.4rem;">Layer Compositing Exhibition Matrix</h4>
+      <p style="margin: 0; color: #64748b; font-size: 0.85rem; line-height: 1.5;">
+        Demonstrates advanced interaction rendering modes when foreground graphical objects or solid geometric elements overlap complex, color-shifting background tracks.
+      </p>
+    </div>
+
+    <div class="showcase-grid">
+
+      <div class="blend-card-specimen">
+        <div class="blend-viewport-frame" style="background: #f1f5f9;">
+          <div class="viewport-split-bg">
+            <div class="bg-half-left" style="background-color: #fca5a5;"></div>
+            <div class="bg-half-right" style="background-color: #93c5fd;"></div>
+          </div>
+          <div class="overlay-graphic-circle ease-blend-multiply" style="background-color: #4f46e5;"></div>
+        </div>
+        <div class="blend-card-meta">
+          <h5 class="blend-card-title">Multiply Configuration</h5>
+          <span class="blend-card-code">mix-blend-mode: multiply;</span>
+        </div>
+      </div>
+
+      <div class="blend-card-specimen">
+        <div class="blend-viewport-frame" style="background: #0f172a;">
+          <div class="viewport-split-bg">
+            <div class="bg-half-left" style="background-color: #311042;"></div>
+            <div class="bg-half-right" style="background-color: #111827;"></div>
+          </div>
+          <div class="overlay-graphic-circle ease-blend-screen" style="background-color: #f43f5e;"></div>
+        </div>
+        <div class="blend-card-meta">
+          <h5 class="blend-card-title">Screen Configuration</h5>
+          <span class="blend-card-code">mix-blend-mode: screen;</span>
+        </div>
+      </div>
+
+      <div class="blend-card-specimen">
+        <div class="blend-viewport-frame">
+          <h1 class="overlay-typography-text ease-blend-overlay">Texture</h1>
+        </div>
+        <div class="blend-card-meta">
+          <h5 class="blend-card-title">Overlay Configuration</h5>
+          <span class="blend-card-code">mix-blend-mode: overlay;</span>
+        </div>
+      </div>
+
+      <div class="blend-card-specimen">
+        <div class="blend-viewport-frame" style="background: #ffffff;">
+          <div class="viewport-split-bg">
+            <div class="bg-half-left" style="background-color: #ffffff;"></div>
+            <div class="bg-half-right" style="background-color: #000000;"></div>
+          </div>
+          <h1 class="overlay-typography-text ease-blend-difference" style="color: #ffffff;">Contrast</h1>
+        </div>
+        <div class="blend-card-meta">
+          <h5 class="blend-card-title">Difference Configuration</h5>
+          <span class="blend-card-code">mix-blend-mode: difference;</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/mix-blend-mode-showcase/style.css
+++ b/submissions/examples/mix-blend-mode-showcase/style.css
@@ -1,0 +1,99 @@
+/* ============================================================
+   ease-blend-showcase — Layer Compositing Exhibition Tokens
+   ============================================================ */
+
+.ease-blend-multiply { mix-blend-mode: multiply; }
+.ease-blend-screen { mix-blend-mode: screen; }
+.ease-blend-overlay { mix-blend-mode: overlay; }
+.ease-blend-difference { mix-blend-mode: difference; }
+
+/* Interactive Showcase Exhibition Stage Layout */
+.showcase-stage-canvas {
+  max-width: 900px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 2.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.blend-card-specimen {
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.blend-card-meta {
+  padding: 1rem;
+  background-color: #ffffff;
+  border-top: 1px solid #e2e8f0;
+}
+
+.blend-card-title {
+  margin: 0 0 4px 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.blend-card-code {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: #6366f1;
+}
+
+/* Base Graphic Compositing Windows */
+.blend-viewport-frame {
+  height: 200px;
+  position: relative;
+  background: linear-gradient(45deg, #f43f5e 0%, #3b82f6 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+/* Light/Dark underlying checker option for testing multiplication layers */
+.viewport-split-bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  z-index: 1;
+}
+.bg-half-left { flex: 1; background-color: #e2e8f0; }
+.bg-half-right { flex: 1; background-color: #0f172a; }
+
+.overlay-graphic-circle {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background-color: #10b981;
+  position: relative;
+  z-index: 2;
+}
+
+.overlay-typography-text {
+  font-size: 3.5rem;
+  font-weight: 900;
+  color: #ffffff;
+  margin: 0;
+  position: relative;
+  z-index: 2;
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout presentation and layer compositing showcase components for multi-mode color rendering under issue #15392. Introduces the `.ease-blend-*` configuration suite to equip design toolkits and component reference libraries with clean, easily verifiable contrast grid modules inside an isolated path without changing global core system files or losing codebase assets.

---

## Type of Change
- [x] ✨ New feature/utility submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Four high-performance compositing helper classes (`.ease-blend-multiply`, `.ease-blend-screen`, `.ease-blend-overlay`, `.ease-blend-difference`) mapped to hardware-accelerated CSS properties.
- Structured card containment configurations (`.blend-card-specimen`) explicitly optimized to track layered graphic properties across light/dark grid sections.

**How does a developer use it?**
```html
<div class="blend-viewport-frame">
  <div class="ease-blend-difference">Contrast Anchor Element</div>
</div>