### PR TITLE
feat: add CSS all property reset demo example

### DIFF
--- a/submissions/examples/all-property-reset-demo/README.md
+++ b/submissions/examples/all-property-reset-demo/README.md
@@ -1,0 +1,20 @@
+# CSS All Property Reset Demo Feature
+
+Submits layout utility architectures and style isolation boundary test grids (`.ease-reset-all`) under issue #15401.
+
+## Functional Mechanics
+
+- **The Problem:** When loading modular widgets, third-party plugin modules, or shared UI extensions inside deeply nested legacy template engines, parent container parameters leak into the custom elements. Font choices, text alignments, line heights, and button background colors spill into child blocks, breaking visual consistency and forcing engineers to write messy override sheets.
+- **The Solution:** Total style containment. The `.ease-reset-all` utility establishes a strict baseline reset using `all: unset`. This wipes out both element default behaviors and inherited parameters instantly, yielding a blank-slate block context. Developers can then style web elements reliably without fighting cascade issues.
+
+## Usage Layout Structure
+```html
+<div class="legacy-polluted-wrapper">
+  
+  <button type="button" class="ease-reset-all clean-framework-button">
+    Isolated Action Element
+  </button>
+</div>
+```
+
+Closes #15401

--- a/submissions/examples/all-property-reset-demo/demo.html
+++ b/submissions/examples/all-property-reset-demo/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS All Property Reset Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="reset-sandbox-canvas">
+    <div style="border-bottom: 1px solid #e2e8f0; padding-bottom: 1.25rem; margin-bottom: 1.5rem;">
+      <h4 style="margin: 0 0 6px 0; color: #0f172a; font-size: 1.4rem;">Component Boundary Isolation Matrix</h4>
+      <p style="margin: 0; color: #64748b; font-size: 0.85rem; line-height: 1.5;">
+        Demonstrates how the <code>all: unset</code> utility completely severs inherited styles from polluted parent scopes, making it perfect for clean, embeddable widget micro-frontends.
+      </p>
+    </div>
+
+    <div class="inherited-theme-scope">
+      <p style="margin-top: 0; margin-bottom: 1.5rem; font-size: 1rem;">[Parent Scope: Monospace / Rose Theme Active]</p>
+
+      <div class="comparison-split">
+        
+        <div class="specimen-column">
+          <h5 class="column-heading">Standard Inheritance</h5>
+          <button type="button" style="cursor: pointer; padding: 8px 16px;">
+            Polluted Button Element
+          </button>
+          <span style="font-size: 0.75rem; color: #b91c1c; font-weight: 500;">
+            Inherits background tint, fonts, borders, and colors blindly.
+          </span>
+        </div>
+
+        <div class="specimen-column">
+          <h5 class="column-heading">Isolated Boundary</h5>
+          <div>
+            <button type="button" class="ease-reset-all explicit-rebuilt-button">
+              Isolated Rebuilt Button
+            </button>
+          </div>
+          <span style="font-size: 0.75rem; color: #475569; font-weight: 500;">
+            Uses <code>.ease-reset-all</code> to clear inherited pollution completely before applying clean UI styles.
+          </span>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/all-property-reset-demo/style.css
+++ b/submissions/examples/all-property-reset-demo/style.css
@@ -1,0 +1,70 @@
+/* ============================================================
+   ease-reset-all — CSS All-Property Component Isolation Token
+   ============================================================ */
+
+.ease-reset-all {
+  all: unset;
+}
+
+/* Base Styles Applied Globally to Inherit from Parent Elements */
+.inherited-theme-scope {
+  font-family: "Courier New", Courier, monospace;
+  color: #e11d48;
+  font-size: 1.25rem;
+  font-weight: 700;
+  text-align: center;
+  background-color: #ffe4e6;
+  border: 2px dashed #f43f5e;
+  padding: 2rem;
+  border-radius: 12px;
+  margin-top: 1.5rem;
+}
+
+/* Custom Interactive Stage Layout Rules */
+.reset-sandbox-canvas {
+  max-width: 800px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 2.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.comparison-split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.specimen-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.column-heading {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+/* Explicit Re-assignment Rules following the heavy "all: unset" baseline */
+.explicit-rebuilt-button {
+  display: inline-block;
+  background-color: #0f172a;
+  color: #ffffff;
+  padding: 10px 20px;
+  border-radius: 6px;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout presentation and component level containment utility for micro-frontend style safety under issue #15401. Introduces `.ease-reset-all` to provide developers with a native method for wiping out parent style pollution and template leaks inside embeddable cards, third-party integrations, and standalone widget trees without altering core structural setups.

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- A robust style containment utility (`.ease-reset-all`) that maps directly to the CSS `all: unset` shorthand parameter.
- Clean layout isolation boundaries designed to reset both user-agent styles and ancestral cascade inheritance in one single hook.

**How does a developer use it?**
```html
<div class="ease-reset-all custom-rebuilt-card">Isolated Component Tree</div>