### PR TITLE
feat: add CSS writing mode vertical text example

### DIFF
--- a/submissions/examples/writing-mode-vertical-text/README.md
+++ b/submissions/examples/writing-mode-vertical-text/README.md
@@ -1,0 +1,19 @@
+# CSS Writing Mode Vertical Text Feature
+
+Submits typographical utility architectures and asymmetrical multi-directional editorial layouts (`.ease-write-vertical-rl`, `.ease-write-vertical-lr`) under issue #15400.
+
+## Functional Mechanics
+
+- **The Problem:** Rotating labels for graphical data axes, sidebar tabs, magazine header strips, or internationalized text streams usually relies on hardcoded CSS transform patches (`transform: rotate(-90deg)`). However, rotation offsets completely discard native block dimensions, leaving the browser unable to compute correct width or height allocations. This causes broken container wraps, overlapping texts, and messy alignment code.
+- **The Solution:** Native cross-axis typographical flow. The `.ease-write-vertical-rl` and `.ease-write-vertical-lr` utilities tap straight into browser-native writing systems. This alters the layout engine's behavior so text naturally structures vertically from top to bottom, keeping box model dimensions intact and avoiding collision artifacts.
+
+## Usage Layout Structure
+```html
+<div class="editorial-row-container" style="display: flex;">
+  <h2 class="ease-write-vertical-rl">Vertical Context Header</h2>
+  
+  <p>Standard document paragraph flow elements align smoothly here...</p>
+</div>
+```
+
+Closes #15400

--- a/submissions/examples/writing-mode-vertical-text/demo.html
+++ b/submissions/examples/writing-mode-vertical-text/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Writing Mode Vertical Text Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="typography-sandbox-canvas">
+    <div style="border-bottom: 1px solid #e2e8f0; padding-bottom: 1.25rem; margin-bottom: 1.5rem;">
+      <h4 style="margin: 0 0 6px 0; color: #0f172a; font-size: 1.4rem;">Multi-Directional Typographical Layout</h4>
+      <p style="margin: 0; color: #64748b; font-size: 0.85rem; line-height: 1.5;">
+        Demonstrates native cross-axis structural flow using <code>writing-mode</code> parameters. Perfect for clean editorial grids, specialized chart labels, sidebars, and East Asian typographical systems.
+      </p>
+    </div>
+
+    <div class="editorial-layout-grid">
+      
+      <div class="ease-write-vertical-rl vertical-header-strip">
+        Editorial Feature Title
+      </div>
+
+      <div class="standard-content-column">
+        <h5 style="margin: 0; font-size: 1.1rem; font-weight: 700; color: #0f172a;">Horizontal Flow Axis Baseline</h5>
+        <p class="standard-paragraph">
+          This container block maps standard horizontal typesetting alongside vertical components. Adjusting the text direction properties changes how block-level elements behave, changing default inline sizing rules into vertical length parameters effortlessly.
+        </p>
+        <p class="standard-paragraph">
+          Native vertical text layout systems avoid complex, fragile hacks like <code>transform: rotate(-90deg)</code>, which throw off layout bounds calculations and cause overlap errors inside fluid document flows.
+        </p>
+      </div>
+
+      <div class="ease-write-vertical-lr vertical-aside-text" style="border-right: 1px solid #cbd5e1; padding-right: 0.5rem;">
+        Issue No. 400 • June 2026
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/writing-mode-vertical-text/style.css
+++ b/submissions/examples/writing-mode-vertical-text/style.css
@@ -1,0 +1,69 @@
+/* ============================================================
+   ease-writing-mode — Multi-Directional Typographical Tokens
+   ============================================================ */
+
+.ease-write-vertical-rl {
+  writing-mode: vertical-rl;
+}
+
+.ease-write-vertical-lr {
+  writing-mode: vertical-lr;
+}
+
+/* Custom Interactive Exhibition Stage Layout Rules */
+.typography-sandbox-canvas {
+  max-width: 850px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 2.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.editorial-layout-grid {
+  display: flex;
+  gap: 2.5rem;
+  margin-top: 2rem;
+  min-height: 320px;
+  background-color: #faf8f5;
+  border-radius: 12px;
+  padding: 2rem;
+  border: 1px dashed #e2e8f0;
+}
+
+/* Vertical Text Segment Styling Blocks */
+.vertical-header-strip {
+  font-size: 1.75rem;
+  font-weight: 900;
+  color: #0f172a;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  line-height: 1.2;
+  border-left: 2px solid #6366f1;
+  padding-left: 0.5rem;
+}
+
+.vertical-aside-text {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  line-height: 1.5;
+}
+
+.standard-content-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.standard-paragraph {
+  font-size: 0.95rem;
+  color: #334155;
+  line-height: 1.6;
+  margin: 0;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the typography configuration and layout presentation components for multi-directional text flows under issue #15400. Introduces the `.ease-write-vertical-rl` and `.ease-write-vertical-lr` utility markers to equip design matrices, data visualization axes, and editorial layouts with stable box-model aligned vertical structures inside an isolated path without changing core style properties or altering global framework setups.

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Two high-performance typographical layout utilities (`.ease-write-vertical-rl` and `.ease-write-vertical-lr`) pointing straight to standard W3C `writing-mode` rules.
- Native typographical block realignment designed to handle true vertical inline streams without using layout-breaking 2D rotation modifiers.

**How does a developer use it?**
```html
<div class="ease-write-vertical-rl">Vertical Sidebar Content</div>