### PR TITLE
feat: add CSS box decoration break example

### DIFF
--- a/submissions/examples/box-decoration-break-example/README.md
+++ b/submissions/examples/box-decoration-break-example/README.md
@@ -1,0 +1,19 @@
+# CSS Box Decoration Break Feature
+
+Submits layout utility architectures and multi-line typographic text wraps (`.ease-decoration-clone`, `.ease-decoration-slice`) under issue #15388.
+
+## Functional Mechanics
+
+- **The Problem:** When applying background gradients, borders, box-shadows, or side paddings onto long inline elements (like text emphasis anchors or callout block text strings) that wrap onto multiple screen lines, standard layout engines slice the container open. The end of the first line and the start of the second line lose their border-radius curves, margins, and border styles, producing broken graphical artifacts.
+- **The Solution:** Independent fragment replication. The `.ease-decoration-clone` utility enforces `box-decoration-break: clone`. This instructs browsers to render decoration properties—including border edges, gradients, and padding blocks—independently around every single line string wrap, ensuring neat typographic balance across fluid multi-line screens.
+
+## Usage Layout Structure
+```html
+<p style="max-width: 300px;">
+  <span class="ease-decoration-clone" style="background: indigo; padding: 4px; border-radius: 4px;">
+    Multi-line copy elements reshape themselves elegantly here...
+  </span>
+</p>
+```
+
+Closes #15388

--- a/submissions/examples/box-decoration-break-example/demo.html
+++ b/submissions/examples/box-decoration-break-example/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Box Decoration Break Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="decoration-sandbox-canvas">
+    <div style="border-bottom: 1px solid #e2e8f0; padding-bottom: 1.25rem; margin-bottom: 1.5rem;">
+      <h4 style="margin: 0 0 6px 0; color: #0f172a; font-size: 1.4rem;">Inline Fragment Render Matrix</h4>
+      <p style="margin: 0; color: #64748b; font-size: 0.85rem; line-height: 1.5;">
+        Demonstrates how background gradients, left borders, and inline paddings calculate across multi-line text wraps using <code>box-decoration-break</code> properties.
+      </p>
+    </div>
+
+    <div class="specimen-layout-stack">
+
+      <div class="fragment-container-box">
+        <div class="fragment-label">Default Behavior (box-decoration-break: slice)</div>
+        <p style="margin: 0; line-height: 1.7;">
+          <span class="highlight-text-segment ease-decoration-slice">
+            This paragraph text uses standard slicing rules where background masks stretch open across line fragments seamlessly.
+          </span>
+        </p>
+      </div>
+
+      <div class="fragment-container-box">
+        <div class="fragment-label">Cloned Behavior (box-decoration-break: clone)</div>
+        <p style="margin: 0; line-height: 1.7;">
+          <span class="highlight-text-segment ease-decoration-clone">
+            This paragraph text clones side paddings, rounded corners, and red indicator borders onto every broken inline line segment independently.
+          </span>
+        </p>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/box-decoration-break-example/style.css
+++ b/submissions/examples/box-decoration-break-example/style.css
@@ -1,0 +1,61 @@
+/* ============================================================
+   ease-box-decoration — Multi-Line Inline Rendering Tokens
+   ============================================================ */
+
+.ease-decoration-clone {
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+.ease-decoration-slice {
+  -webkit-box-decoration-break: slice;
+  box-decoration-break: slice;
+}
+
+/* Custom Interactive Exhibition Stage Layout Rules */
+.decoration-sandbox-canvas {
+  max-width: 750px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 2.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.specimen-layout-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  margin-top: 2rem;
+}
+
+.fragment-container-box {
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1.5rem;
+  max-width: 480px; /* Forces text wrap to demonstrate fragmentation */
+}
+
+.fragment-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 1rem 0;
+}
+
+/* Stylized Inline Highlight Text Elements */
+.highlight-text-segment {
+  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+  color: #ffffff;
+  font-size: 1.35rem;
+  font-weight: 800;
+  line-height: 1.7;
+  padding: 6px 14px;
+  border-radius: 6px;
+  border-left: 5px solid #f43f5e;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout presentation and inline content style modifier utilities for multi-line element formatting under issue #15388. Introduces the `.ease-decoration-clone` and `.ease-decoration-slice` layout properties to equip content streams, magazine headings, and highlighted tag wrappers with robust edge containment across nested wrap breaks without modifying global style architectures.

---

## Type of Change
- [x] ✨ New feature/utility submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Two typographical alignment utilities (`.ease-decoration-clone` and `.ease-decoration-slice`) pointing straight to cross-browser `-webkit-box-decoration-break` properties.
- Dedicated inline frame handlers engineered to secure background bounds, outer boxes, and side margin paddings across fluid viewport wraps.

**How does a developer use it?**
```html
<span class="ease-decoration-clone">Wrapped Text Context</span>