### PR TITLE
feat: add CSS aspect ratio responsive embeds example

### DIFF
--- a/submissions/examples/aspect-ratio-responsive-embeds/README.md
+++ b/submissions/examples/aspect-ratio-responsive-embeds/README.md
@@ -1,0 +1,18 @@
+# CSS Aspect Ratio Responsive Embeds Feature
+
+Submits responsive layout utility tokens and self-contained sizing canvas previews (`.ease-aspect-*`, `.ease-embed-fluid`) under issue #15396.
+
+## Functional Mechanics
+
+- **The Problem:** Scaling embedded iframes, responsive map views, HTML5 streaming video panels, or data cards across fluctuating mobile breakpoints while protecting their sizing locks has traditionally been error-prone. The historic method relied on complex relative padding tricks (`position: relative; padding-top: 56.25%; height: 0;`), which requires absolute sub-element absolute tracking layers and breaks grid alignment behavior.
+- **The Solution:** Native box aspect ratios. The `.ease-aspect-*` utilities employ standard W3C `aspect-ratio` parameters. By directly declaring the mathematical bounding ratio (e.g., `16 / 9`) alongside a single flexible width rule (`width: 100%`), elements automatically scale their height fluidly to fit mobile and desktop viewports with zero layout shifts.
+
+## Usage Layout Structure
+```html
+<div class="grid-card-wrapper">
+  
+  <iframe class="ease-aspect-video ease-embed-fluid" src="https://example.com/stream"></iframe>
+</div>
+```
+
+Closes #15396

--- a/submissions/examples/aspect-ratio-responsive-embeds/demo.html
+++ b/submissions/examples/aspect-ratio-responsive-embeds/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Aspect Ratio Responsive Embeds Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="embed-sandbox-canvas">
+    <div style="border-bottom: 1px solid #e2e8f0; padding-bottom: 1.25rem; margin-bottom: 1.5rem;">
+      <h4 style="margin: 0 0 6px 0; color: #0f172a; font-size: 1.4rem;">Responsive Embed Constraint Matrix</h4>
+      <p style="margin: 0; color: #64748b; font-size: 0.85rem; line-height: 1.5;">
+        Demonstrates modern native fluid media boxes. Scale the browser viewport width to see elements resize on the fly without using old <code>padding-top: 56.25%</code> relative wrapper hacks.
+      </p>
+    </div>
+
+    <div class="embed-preview-grid">
+
+      <div class="embed-card">
+        <div class="embed-frame-holder ease-aspect-video">
+          <img src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?w=600&auto=format&fit=crop" class="placeholder-svg-graphic ease-embed-fluid" alt="16:9 Landscape Screen">
+        </div>
+        <div class="embed-card-meta">
+          <h5 class="embed-card-title">Standard Widescreen Video</h5>
+          <span class="embed-card-code">aspect-ratio: 16 / 9;</span>
+        </div>
+      </div>
+
+      <div class="embed-card">
+        <div class="embed-frame-holder ease-aspect-square">
+          <img src="https://images.unsplash.com/photo-1614850523459-c2f4c699c52e?w=600&auto=format&fit=crop" class="placeholder-svg-graphic ease-embed-fluid" alt="1:1 Balanced Square">
+        </div>
+        <div class="embed-card-meta">
+          <h5 class="embed-card-title">Square Platform Asset</h5>
+          <span class="embed-card-code">aspect-ratio: 1 / 1;</span>
+        </div>
+      </div>
+
+      <div class="embed-card" style="grid-column: 1 / -1;">
+        <div class="embed-frame-holder ease-aspect-cinema">
+          <img src="https://images.unsplash.com/photo-1634017839464-5c339ebe3cb4?w=1200&auto=format&fit=crop" class="placeholder-svg-graphic ease-embed-fluid" alt="21:9 Ultrawide Cinematic Scale">
+        </div>
+        <div class="embed-card-meta">
+          <h5 class="embed-card-title">Cinematic Ultrawide Pipeline</h5>
+          <span class="embed-card-code">aspect-ratio: 21 / 9;</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/aspect-ratio-responsive-embeds/style.css
+++ b/submissions/examples/aspect-ratio-responsive-embeds/style.css
@@ -1,0 +1,82 @@
+/* ============================================================
+   ease-aspect — Modern Structural Aspect Ratio Utility Tokens
+   ============================================================ */
+
+.ease-aspect-video {
+  aspect-ratio: 16 / 9;
+}
+
+.ease-aspect-square {
+  aspect-ratio: 1 / 1;
+}
+
+.ease-aspect-cinema {
+  aspect-ratio: 21 / 9;
+}
+
+/* Base structural fluid containment rules for modern embeds */
+.ease-embed-fluid {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* Custom Interactive Exhibition Stage Layout Rules */
+.embed-sandbox-canvas {
+  max-width: 850px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 2.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.embed-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.embed-card {
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.embed-frame-holder {
+  background-color: #0f172a; /* Dark masking zone for checking boundary box accuracy */
+  position: relative;
+  width: 100%;
+}
+
+.embed-card-meta {
+  padding: 1rem;
+  background-color: #ffffff;
+  border-top: 1px solid #e2e8f0;
+}
+
+.embed-card-title {
+  margin: 0 0 4px 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.embed-card-code {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: #6366f1;
+}
+
+/* Inside simulated document canvas frame to project image assets cleanly */
+.placeholder-svg-graphic {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the fluid layout container structures and core tracking utility tokens for high-performance responsive media rendering under issue #15396. Introduces the `.ease-aspect-*` framework classes to equip external iframes, graphic maps, and rich media blocks with modern, native aspect-ratio preservation mechanisms inside an isolated workspace path without changing core stylesheet rules.

---

## Type of Change
- [x] ✨ New feature/utility submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Three standalone aspect configuration utilities (`.ease-aspect-video`, `.ease-aspect-square`, `.ease-aspect-cinema`) built around modern browser native box-sizing parameters.
- Fluid containment configurations (`.ease-embed-fluid`) engineered to completely remove old `padding-top` multi-wrapper markup requirements across flexible rows.

**How does a developer use it?**
```html
<video class="ease-aspect-video ease-embed-fluid" src="media.mp4"></video>