### PR TITLE
feat: add CSS filter effects gallery example

### DIFF
--- a/submissions/examples/css-filter-effects-gallery/README.md
+++ b/submissions/examples/css-filter-effects-gallery/README.md
@@ -1,0 +1,18 @@
+# CSS Filter Effects Gallery Feature
+
+Submits layout utility architectures and visual-processing sandbox panels (`.ease-filter-*`, `.filter-viewport-frame`) under issue #15391.
+
+## Functional Mechanics
+
+- **The Problem:** Designing high-impact visual UI states—like hover-activated blur overlays, grayscale inactive states, or dynamically color-shifted theme icons—previously required massive external image asset suites. Maintaining multiple versions of every single image asset consumes bandwidth, hurts delivery speed, and creates massive storage bloat.
+- **The Solution:** GPU-orchestrated image manipulation. The `.ease-filter-*` utility suite leverages standard browser `filter` properties. This permits developers to apply complex graphical transformations—like saturation shifts, blur radius intensity, or high-contrast adjustments—straight to live DOM images or background media assets with near-zero latency or memory overhead.
+
+## Usage Layout Structure
+```html
+<div class="header-banner">
+  <img src="asset.jpg" class="ease-filter-blur" />
+  <img src="asset.jpg" class="ease-filter-grayscale" />
+</div>
+```
+
+Closes #15391

--- a/submissions/examples/css-filter-effects-gallery/demo.html
+++ b/submissions/examples/css-filter-effects-gallery/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Filter Effects Gallery Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="filter-sandbox-canvas">
+    <div style="border-bottom: 1px solid #e2e8f0; padding-bottom: 1.25rem; margin-bottom: 1.5rem;">
+      <h4 style="margin: 0 0 6px 0; color: #0f172a; font-size: 1.4rem;">Visual Processing Exhibition Matrix</h4>
+      <p style="margin: 0; color: #64748b; font-size: 0.85rem; line-height: 1.5;">
+        Demonstrates real-time browser-native graphical manipulation. CSS filters provide GPU-accelerated effects, removing the need for heavy server-side image processing or client-side Canvas overhead.
+      </p>
+    </div>
+
+    <div class="filter-grid">
+
+      <div class="filter-card-specimen">
+        <div class="filter-viewport-frame ease-filter-grayscale"></div>
+        <div class="filter-card-meta">
+          <h5 class="filter-card-title">Grayscale</h5>
+          <span class="filter-card-code">filter: grayscale(100%);</span>
+        </div>
+      </div>
+
+      <div class="filter-card-specimen">
+        <div class="filter-viewport-frame ease-filter-blur"></div>
+        <div class="filter-card-meta">
+          <h5 class="filter-card-title">Blur</h5>
+          <span class="filter-card-code">filter: blur(4px);</span>
+        </div>
+      </div>
+
+      <div class="filter-card-specimen">
+        <div class="filter-viewport-frame ease-filter-sepia"></div>
+        <div class="filter-card-meta">
+          <h5 class="filter-card-title">Sepia</h5>
+          <span class="filter-card-code">filter: sepia(100%);</span>
+        </div>
+      </div>
+
+      <div class="filter-card-specimen">
+        <div class="filter-viewport-frame ease-filter-hue"></div>
+        <div class="filter-card-meta">
+          <h5 class="filter-card-title">Hue Rotation</h5>
+          <span class="filter-card-code">filter: hue-rotate(90deg);</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-filter-effects-gallery/style.css
+++ b/submissions/examples/css-filter-effects-gallery/style.css
@@ -1,0 +1,65 @@
+/* ============================================================
+   ease-filter — Hardware-Accelerated Visual Transformation Tokens
+   ============================================================ */
+
+.ease-filter-grayscale { filter: grayscale(100%); }
+.ease-filter-sepia { filter: sepia(100%); }
+.ease-filter-blur { filter: blur(4px); }
+.ease-filter-hue { filter: hue-rotate(90deg); }
+.ease-filter-contrast { filter: contrast(200%); }
+
+/* Interactive Visual Processing Showcase Stage */
+.filter-sandbox-canvas {
+  max-width: 900px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 2.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.filter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.filter-card-specimen {
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.filter-viewport-frame {
+  height: 180px;
+  width: 100%;
+  background-image: url('https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=600&auto=format&fit=crop');
+  background-size: cover;
+  background-position: center;
+  transition: filter 0.4s ease;
+}
+
+.filter-card-meta {
+  padding: 1rem;
+  background-color: #ffffff;
+  border-top: 1px solid #e2e8f0;
+}
+
+.filter-card-title {
+  margin: 0 0 4px 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.filter-card-code {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: #6366f1;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the layout presentation and graphical processing components for real-time visual styling under issue #15391. Introduces the `.ease-filter-*` configuration suite to equip design toolkits, media galleries, and interactive branding modules with high-performance CSS manipulation hooks inside an isolated path without changing global core stylesheet frameworks.

---

## Type of Change
- [x] ✨ New feature/utility submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Five core visual-processing utility classes (`.ease-filter-grayscale`, `.ease-filter-sepia`, `.ease-filter-blur`, `.ease-filter-hue`, `.ease-filter-contrast`) mapped to GPU-backed browser rendering engines.
- Structured card containment configurations (`.filter-card-specimen`) optimized to showcase visual transformation states live across varying media substrates.

**How does a developer use it?**
```html
<img src="graphic.jpg" class="ease-filter-blur" />