### PR TITLE
feat: add ease-size-selector animated selector (#13771)

### DIFF
--- a/submissions/examples/ease-size-selector/README.md
+++ b/submissions/examples/ease-size-selector/README.md
@@ -1,0 +1,22 @@
+﻿# ease-size-selector – Animated Size/Variant Selector
+
+Product size selector buttons with smooth selected‑state transitions. Uses a CSS‑only radio‑input technique — no JavaScript required.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-2, ease-mb-8, ease-mt-8
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How it works
+- Radio inputs are visually hidden, and their <label> elements are styled as buttons.
+- The :checked pseudo‑class on the hidden radio triggers the selected styling on the adjacent label.
+- Transitions on background, border, color, box-shadow, and transform create a smooth animation.
+- Hover and focus‑visible states are included for accessibility.
+- Respects prefers-reduced-motion.
+
+## How to use
+1. Copy the radio + label markup and the CSS into your project.
+2. Ensure the path to easemotion.css is correct.
+3. Open demo.html in any modern browser.

--- a/submissions/examples/ease-size-selector/demo.html
+++ b/submissions/examples/ease-size-selector/demo.html
@@ -1,0 +1,44 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-size-selector – Animated Size/Variant Selector</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-2 ease-fade-in">
+      Size Selector
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Click a size — the selected button smoothly transitions.
+    </p>
+
+    <!-- Radio-based size selector -->
+    <div class="size-selector" role="radiogroup" aria-label="Select size">
+      <input type="radio" id="size-xs" name="size" value="XS" class="sr-only">
+      <label for="size-xs" class="size-option">XS</label>
+
+      <input type="radio" id="size-sm" name="size" value="S" class="sr-only">
+      <label for="size-sm" class="size-option">S</label>
+
+      <input type="radio" id="size-md" name="size" value="M" class="sr-only" checked>
+      <label for="size-md" class="size-option">M</label>
+
+      <input type="radio" id="size-lg" name="size" value="L" class="sr-only">
+      <label for="size-lg" class="size-option">L</label>
+
+      <input type="radio" id="size-xl" name="size" value="XL" class="sr-only">
+      <label for="size-xl" class="size-option">XL</label>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      CSS‑only — hidden radio inputs + animated labels
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-size-selector/style.css
+++ b/submissions/examples/ease-size-selector/style.css
@@ -1,0 +1,72 @@
+﻿/* ============================================================
+   ease-size-selector – Animated size/variant selector
+   CSS‑only radio‑input technique with smooth transitions
+   ============================================================ */
+
+/* Group of size options */
+.size-selector {
+  display: inline-flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* Hide the actual radio inputs */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Styling the label as a selectable button */
+.size-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3rem;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  font-size: 1rem;
+  color: #374151;
+  background: #ffffff;
+  border: 2px solid #e5e7eb;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease, border-color 0.3s ease,
+              color 0.3s ease, box-shadow 0.3s ease, transform 0.2s ease;
+  user-select: none;
+}
+
+/* Hover state */
+.size-option:hover {
+  border-color: #93c5fd;
+  background: #eff6ff;
+}
+
+/* Focus-visible for keyboard navigation */
+input[type="radio"]:focus-visible + .size-option {
+  outline: 3px solid rgba(59, 130, 246, 0.5);
+  outline-offset: 2px;
+}
+
+/* Selected state – triggers when the hidden radio is checked */
+input[type="radio"]:checked + .size-option {
+  background: #2563eb;
+  color: #ffffff;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.25);
+  transform: scale(1.05);
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .size-option {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #13771

ease-size-selector – Animated Size/Variant Selector
CSS‑only radio‑input technique with smooth transitions for selected buttons.

Files added
- submissions/examples/ease-size-selector/demo.html
- submissions/examples/ease-size-selector/style.css
- submissions/examples/ease-size-selector/README.md

How it works
- Hidden radio inputs control the selected state via :checked.
- Labels are styled as buttons with transitions on background, border, color, box-shadow, and transform.
- Selected button scales up slightly and shows a blue glow ring.
- Hover and focus-visible included.
- Respects prefers-reduced-motion.

EaseMotion classes used
ease-container, ease-flex, ease-fade-in, ease-delay-*, ease-text-*, ease-bg-gray-50, etc.

Custom CSS (>5 lines) for selector group, button states, transitions, and accessibility.