### PR TITLE
feat: add content-none utility

### DIFF
--- a/submissions/examples/content-none-utility/README.md
+++ b/submissions/examples/content-none-utility/README.md
@@ -1,0 +1,17 @@
+# Content None Utility
+
+Introduces the pseudo-element content suppression utility token (`.ease-content-none`) under issue #15094.
+
+## Functional Mechanics
+
+- **The Problem:** Many design systems use global pseudo-elements (like `::before` or `::after`) for list markers, status icons, or decorative bullets. When specific instances of those components need to appear "naked" or un-decorated, developers are often forced to write verbose CSS overrides to reset the `content` property, creating cascade bloat.
+- **The Solution:** Granular content silencing. The `.ease-content-none` utility applies `content: none;`. It provides a clean, single-class override to strip pseudo-element injection for specific modular variations, ensuring design consistency while keeping code lean.
+
+## Usage Layout Structure
+```html
+<div class="list-item has-marker">Item 1</div>
+
+<div class="list-item has-marker ease-content-none">Item 2 (Unmarked)</div>
+```
+
+Closes #15094

--- a/submissions/examples/content-none-utility/demo.html
+++ b/submissions/examples/content-none-utility/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Content None Utility Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="content-sandbox-canvas">
+    <h4 style="margin: 0 0 0.5rem 0; color: #0f172a; font-size: 1.25rem;">Pseudo-Element Suppression</h4>
+    <p style="font-size: 0.85rem; color: #64748b; line-height: 1.5; margin-bottom: 1.5rem;">
+      Use <code>.ease-content-none</code> to override inherited pseudo-element <code>content</code> values, effectively silencing markers in specific variant states without re-declaring the whole component.
+    </p>
+
+    <div class="pseudo-test-box">
+      <div class="has-marker">Standard Item with Marker</div>
+      <div class="has-marker ease-content-none">Suppressed Marker (using .ease-content-none)</div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/content-none-utility/style.css
+++ b/submissions/examples/content-none-utility/style.css
@@ -1,0 +1,39 @@
+/* ============================================================
+   ease-content-none — Pseudo-Element Content Suppression Token
+   ============================================================ */
+
+.ease-content-none {
+  content: none;
+}
+
+/* Custom Interactive UI Testing Stage Rules */
+.content-sandbox-canvas {
+  max-width: 600px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 14px;
+  padding: 2.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.pseudo-test-box {
+  background-color: #f8fafc;
+  padding: 1.5rem;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  margin-top: 1rem;
+}
+
+/* Standard pseudo-element injection */
+.has-marker::before {
+  content: "★";
+  color: #f59e0b;
+  margin-right: 8px;
+}
+
+/* Suppression target */
+.is-suppressed::before {
+  content: none;
+}


### PR DESCRIPTION
## Pull Request Description
Submits the pseudo-element suppression utility token under issue #15094. Introduces `.ease-content-none` to provide developers with native content-injection override capabilities, ideal for stripping list markers, status indicators, and decorative bullets from specific component variations without rewriting core framework rule-sets.

---

## Type of Change
- [x] ✨ New utility class submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- Dedicated pseudo-element silencer (`.ease-content-none`) leveraging CSS `content: none` rules.
- Concise override logic for markers, icons, and bullets, designed for complex component variant states.

**How does a developer use it?**
```html
<div class="decorated-component ease-content-none">Unmarked State</div>