### PR TITLE
feat: add CSS calc-size() height animation example

### DIFF
--- a/submissions/examples/calc-size-height-animation/README.md
+++ b/submissions/examples/calc-size-height-animation/README.md
@@ -1,0 +1,19 @@
+# CSS calc-size() Height Animation Feature
+
+Submits intrinsic height animation utility architectures (`.ease-calc-height-auto`) under issue #15433.
+
+## Functional Mechanics
+
+- **The Problem:** Animating an element from `height: 0` to `height: auto` has historically been impossible in CSS without triggering reflows, measuring content via JavaScript `scrollHeight`, or using messy CSS grid hacks. This causes jank, layout shifts, and massive overhead in dynamic UI components like accordions.
+- **The Solution:** Native interpolation via `calc-size()`. The `.ease-calc-height-auto` utility leverages `calc-size(auto, size)` to tell the browser engine to transition specifically between the `0` state and the computed intrinsic layout size, enabling buttery-smooth transitions for accordion panels, dropdown menus, and collapsing widgets.
+
+
+
+## Usage Layout Structure
+```html
+<div class="ease-calc-height-auto" style="height: 0;">
+  <div>Content to expand into...</div>
+</div>
+```
+
+Closes #15433

--- a/submissions/examples/calc-size-height-animation/demo.html
+++ b/submissions/examples/calc-size-height-animation/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS calc-size() Height Sandbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="background-color: #f1f5f9; padding: 60px 20px; margin: 0;">
+
+  <div class="calc-sandbox-canvas">
+    <div style="border-bottom: 1px solid #e2e8f0; padding-bottom: 1.25rem; margin-bottom: 1.5rem;">
+      <h4 style="margin: 0 0 6px 0; color: #0f172a; font-size: 1.4rem;">Intrinsic Height Interpolation</h4>
+      <p style="margin: 0; color: #64748b; font-size: 0.85rem; line-height: 1.5;">
+        Animates height from <code>0</code> to <code>auto</code> natively using <code>calc-size()</code>. No JavaScript height calculation required.
+      </p>
+    </div>
+
+    <button type="button" id="toggle-btn" style="padding: 8px 16px; cursor: pointer;">Toggle Height</button>
+
+    <div class="expansion-controller-box">
+      <div id="content-panel" class="ease-calc-height-auto is-collapsed">
+        <div class="dynamic-content-panel">
+          This panel smoothly expands to fit its content height automatically using the modern <code>calc-size()</code> function, providing a native CSS solution to the long-standing "animate-to-auto" problem.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('toggle-btn');
+    const panel = document.getElementById('content-panel');
+    btn.addEventListener('click', () => {
+      panel.classList.toggle('is-collapsed');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/calc-size-height-animation/style.css
+++ b/submissions/examples/calc-size-height-animation/style.css
@@ -1,0 +1,42 @@
+/* ============================================================
+   ease-calc-size — Dynamic Intrinsic Height Orchestration
+   ============================================================ */
+
+/* Utility for smooth expansion to intrinsic content height */
+.ease-calc-height-auto {
+  height: calc-size(auto, size);
+  transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+}
+
+/* Interactive Animation Showcase Stage */
+.calc-sandbox-canvas {
+  max-width: 600px;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 2.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.expansion-controller-box {
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.dynamic-content-panel {
+  background-color: #f5f3ff;
+  border: 1px solid #ddd6fe;
+  border-radius: 8px;
+  padding: 1rem;
+  color: #5b21b6;
+  font-size: 0.9rem;
+}
+
+/* State toggle implementation */
+.is-collapsed { height: 0; }


### PR DESCRIPTION
## Pull Request Description
Submits the layout presentation and animation containment components for intrinsic height transitions under issue #15433. Introduces the `.ease-calc-height-auto` utility to equip accordion menus, dropdown panels, and collapsible content widgets with fluid, natively interpolated height-to-auto animations inside an isolated path without changing core stylesheet rules.

---

## Type of Change
- [x] ✨ New feature/utility submission

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this utility add?**
- A high-performance intrinsic sizing modifier (`.ease-calc-height-auto`) mapping directly to `calc-size(auto, size)`.
- Smooth transition hooks engineered to facilitate standard "animate-to-auto" layout patterns natively without the need for manual height computation hooks.

**How does a developer use it?**
```html
<div class="ease-calc-height-auto">Panel Content</div>