### PR TITLE
feat: add split reveal transition showcase page

### DIFF
--- a/submissions/examples/split-reveal/README.md
+++ b/submissions/examples/split-reveal/README.md
@@ -1,0 +1,26 @@
+# Split Reveal Transition
+
+A dramatic hero content reveal animation where a foreground cover splits horizontally into two halves (left and right) to reveal the content underneath. Ideal for landing pages, portfolio gates, or hero visual reveals.
+
+## EaseMotion CSS Classes Showcased
+
+This feature submits a self-contained prototype demonstrating horizontal split reveals utilizing relative positioning, clip paths, and opposing translate coordinates.
+
+### Classes:
+- `.ease-split-reveal-container`: Parent wrapper holding both the background content to reveal and the splitting foreground layers.
+- `.ease-split-reveal-left`: Applies a leftward transition (`translateX(-100%)` and opacity fading) when triggered.
+- `.ease-split-reveal-right`: Applies a rightward transition (`translateX(100%)` and opacity fading) when triggered.
+
+### Usage in HTML:
+```html
+<div class="ease-split-reveal-container">
+  <!-- Revealed content underneath -->
+  <div class="reveal-content">...</div>
+  <!-- Splitting foreground layers -->
+  <div class="ease-split-reveal-left">Left Cover</div>
+  <div class="ease-split-reveal-right">Right Cover</div>
+</div>
+```
+
+---
+Created as a contribution to EaseMotion CSS. Open `demo.html` in any browser to view the interactive prototype!

--- a/submissions/examples/split-reveal/demo.html
+++ b/submissions/examples/split-reveal/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Split Reveal Transition - EaseMotion CSS</title>
+  
+  <!-- EaseMotion CSS Core -->
+  <link rel="stylesheet" href="../../../core/variables.css">
+  <link rel="stylesheet" href="../../../core/base.css">
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="../../../core/utilities.css">
+  <link rel="stylesheet" href="../../../components/cards.css">
+  <link rel="stylesheet" href="../../../components/buttons.css">
+  
+  <!-- Local Showcase Stylesheet -->
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-card">
+    <h2 style="margin: 0; font-weight: 800;">Split Reveal Transition</h2>
+    <p style="color: var(--ease-color-muted); font-size: var(--ease-text-sm); margin: 0;">
+      A foreground cover splits horizontally in opposite directions to reveal the content underneath.
+    </p>
+
+    <!-- Split Reveal Module -->
+    <div id="reveal-container" class="ease-split-reveal-container">
+      
+      <!-- Revealed content underneath -->
+      <div class="reveal-content">
+        <h3 style="margin: 0 0 var(--ease-space-2) 0; font-weight: 800;">Welcome Explorer</h3>
+        <p style="color: var(--ease-color-muted); font-size: var(--ease-text-sm); max-width: 280px; margin: 0;">
+          The hidden gates have opened. Explore the universe of animations.
+        </p>
+      </div>
+
+      <!-- Forefront Splitting Layers -->
+      <div class="ease-split-reveal-left">ROAM</div>
+      <div class="ease-split-reveal-right">WILD</div>
+
+    </div>
+
+    <!-- Controls -->
+    <div class="ease-flex ease-gap-4">
+      <button id="toggle-btn" class="ease-btn ease-btn-primary ease-btn-sm ease-btn-pill ease-btn-hover" style="color:white;">
+        🔑 Trigger Split
+      </button>
+    </div>
+  </div>
+
+  <script>
+    const container = document.getElementById('reveal-container');
+    const toggle = document.getElementById('toggle-btn');
+
+    toggle.addEventListener('click', () => {
+      container.classList.toggle('revealed');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/split-reveal/style.css
+++ b/submissions/examples/split-reveal/style.css
@@ -1,0 +1,102 @@
+/* ============================================================
+   EaseMotion CSS — Split Reveal Transition
+   ============================================================ */
+
+/* ── Split Reveal Layout Styles ────────────────────────────── */
+.ease-split-reveal-container {
+  position: relative;
+  width: 100%;
+  height: 380px;
+  overflow: hidden;
+  border-radius: var(--ease-radius-lg, 1rem);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background-color: var(--ease-color-surface, #ffffff);
+  box-shadow: var(--ease-shadow-lg, 0 10px 15px -3px rgba(0,0,0,0.1));
+}
+
+.reveal-content {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--ease-color-bg, #f8fafc);
+  z-index: 1;
+}
+
+.ease-split-reveal-left,
+.ease-split-reveal-right {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 50%;
+  background: linear-gradient(135deg, var(--ease-color-primary) 0%, var(--ease-color-secondary) 100%);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: 800;
+  z-index: 2;
+  transition: transform var(--ease-speed-slow, 600ms) cubic-bezier(0.77, 0, 0.175, 1),
+              opacity var(--ease-speed-slow, 600ms) ease;
+  will-change: transform, opacity;
+}
+
+.ease-split-reveal-left {
+  left: 0;
+  transform-origin: right center;
+  clip-path: inset(0 0 0 0);
+}
+
+.ease-split-reveal-right {
+  right: 0;
+  transform-origin: left center;
+  clip-path: inset(0 0 0 0);
+}
+
+/* Trigger states */
+.ease-split-reveal-container.revealed .ease-split-reveal-left {
+  transform: translate3d(-100%, 0, 0);
+  opacity: 0;
+}
+
+.ease-split-reveal-container.revealed .ease-split-reveal-right {
+  transform: translate3d(100%, 0, 0);
+  opacity: 0;
+}
+
+/* ── Demo page custom helper style structure ──────────────── */
+body {
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: var(--ease-font-sans);
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.demo-card {
+  width: 100%;
+  max-width: 540px;
+  padding: var(--ease-space-8);
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-neutral-200);
+  border-radius: var(--ease-radius-lg);
+  box-shadow: var(--ease-shadow-lg);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ease-space-6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-split-reveal-left,
+  .ease-split-reveal-right {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Submits a custom split reveal transition (`.ease-split-reveal-left` and `.ease-split-reveal-right`) that slides two foreground halves horizontally to reveal background contents underneath.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/split-reveal/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — custom CSS styles containing splitting transitions, clip-paths, and relative layouts
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A horizontal splitting reveal transition (`.ease-split-reveal-left`, `.ease-split-reveal-right`) triggered by toggling a wrapper class.

**How does a developer use it?**

```html
<!-- Wrap background elements under dual splitting covers -->
<div class="ease-split-reveal-container">
  <div class="reveal-content">Revealed Content</div>
  <div class="ease-split-reveal-left">Left Cover</div>
  <div class="ease-split-reveal-right">Right Cover</div>
</div>