### PR TITLE
feat: add ease-glitch utility for retro glitch text animation #2583

### DIFF
--- a/submissions/examples/ease-glitch-pre/README.md
+++ b/submissions/examples/ease-glitch-pre/README.md
@@ -1,0 +1,25 @@
+## ease-glitch
+
+**What does this do?**
+A pure CSS glitch effect that creates a retro digital distortion
+animation on text or elements, using keyframes with clip-path
+and transform — no JavaScript, no dependencies.
+
+**How is it used?**
+<!-- Basic glitch on a heading -->
+<h1 class="glitch" data-text="Hello World">Hello World</h1>
+
+<!-- Glitch on a card -->
+<div class="glitch glitch-box" data-text="Hover me">Hover me</div>
+
+<!-- Slow glitch variant -->
+<h2 class="glitch glitch-slow" data-text="EaseMotion">EaseMotion</h2>
+
+<!-- Fast glitch variant -->
+<h2 class="glitch glitch-fast" data-text="EaseMotion">EaseMotion</h2>
+
+**Why is it useful?**
+Glitch effects are widely used in portfolios, gaming UIs, and
+tech landing pages. This single-class utility gives instant
+visual impact with zero JS — consistent with EaseMotion CSS's
+animation-first philosophy.

--- a/submissions/examples/ease-glitch-pre/demo.html
+++ b/submissions/examples/ease-glitch-pre/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Ease Glitch Utility</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="section">
+    <h2>Default Glitch — Heading</h2>
+    <h1 class="glitch glitch-heading" data-text="Hello World">
+      Hello World
+    </h1>
+  </div>
+
+  <div class="section">
+    <h2>Glitch on a Card — Hover me</h2>
+    <div class="glitch glitch-box" data-text="Hover me">
+      Hover me
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Slow Glitch Variant</h2>
+    <h2 class="glitch glitch-slow glitch-sub" data-text="EaseMotion">
+      EaseMotion
+    </h2>
+  </div>
+
+  <div class="section">
+    <h2>Fast Glitch Variant</h2>
+    <h2 class="glitch glitch-fast glitch-sub" data-text="GSSoC 2026">
+      GSSoC 2026
+    </h2>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-glitch-pre/style.css
+++ b/submissions/examples/ease-glitch-pre/style.css
@@ -1,0 +1,102 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: #0d0d0d;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 48px;
+  padding: 40px 20px;
+}
+
+h2 {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: #555;
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.section {
+  text-align: center;
+}
+
+/* === GLITCH ANIMATION === */
+@keyframes glitch-anim {
+  0%, 100% { clip-path: inset(0 0 0 0); transform: translate(0, 0); }
+  20%      { clip-path: inset(30% 0 50% 0); transform: translate(2px, 0); }
+  40%      { clip-path: inset(60% 0 20% 0); transform: translate(-2px, 0); }
+  60%      { clip-path: inset(80% 0 5% 0); transform: translate(2px, 0); }
+  80%      { clip-path: inset(10% 0 70% 0); transform: translate(-2px, 0); }
+}
+
+.glitch {
+  position: relative;
+  color: #f0f0f0;
+  animation: glitch-anim var(--glitch-speed, 3s) infinite steps(1);
+}
+
+.glitch-slow { --glitch-speed: 6s; }
+.glitch-fast { --glitch-speed: 1s; }
+
+/* === RGB SPLIT LAYERS === */
+.glitch::before,
+.glitch::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  background: inherit;
+  white-space: nowrap;
+}
+
+.glitch::before {
+  color: #ff0055;
+  animation: glitch-anim var(--glitch-speed, 3s) infinite steps(1);
+  animation-delay: 0.1s;
+}
+
+.glitch::after {
+  color: #00ffcc;
+  animation: glitch-anim var(--glitch-speed, 3s) infinite steps(1) reverse;
+}
+
+/* === GLITCH HEADING === */
+.glitch-heading {
+  font-size: 48px;
+  font-weight: 900;
+  letter-spacing: 4px;
+  text-transform: uppercase;
+}
+
+/* === GLITCH BOX (card) === */
+.glitch-box {
+  display: inline-block;
+  background: #1a1a2e;
+  border: 1.5px solid #2a2a3e;
+  border-radius: 12px;
+  padding: 24px 40px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.glitch-box:hover {
+  border-color: #6c63ff;
+}
+
+/* === GLITCH SUBHEADING === */
+.glitch-sub {
+  font-size: 28px;
+  font-weight: 800;
+  color: #a78bfa;
+  letter-spacing: 2px;
+}


### PR DESCRIPTION
Closes #2583

Added ease-glitch utility with:
- Base .glitch class with RGB split (red/cyan) using pseudo-elements
- Pure CSS keyframes with clip-path + transform — no JS, no dependencies
- glitch-slow (6s) and glitch-fast (1s) speed variants
- Works on headings, cards, and any text element