### PR TITLE
feat: add field-sizing content auto growing form inputs example

### DIFF
--- a/submissions/examples/field-sizing-input-pr/README.md
+++ b/submissions/examples/field-sizing-input-pr/README.md
@@ -1,0 +1,10 @@
+# CSS field-sizing Auto-Growing Inputs
+
+### What does this do?
+Demonstrates fluid input fields (`<input>` and `<textarea>`) that shrink or expand natively to wrap around their exact runtime text layout using pure CSS.
+
+### How is it used?
+Apply the structural property `field-sizing: content` directly to form input targets while configuring layout parameters like `min-width` or `max-height`.
+
+### Why is it useful?
+It replaces complex JavaScript text calculation scripts or invisible shadow mirroring wrappers, optimizing rendering metrics and simplifying micro-form setups.

--- a/submissions/examples/field-sizing-input-pr/demo.html
+++ b/submissions/examples/field-sizing-input-pr/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS field-sizing Auto-Growing Input Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="form-container">
+    <div style="text-align: center; margin-bottom: 0.5rem;">
+      <h2 style="margin: 0; font-size: 1.5rem;">Auto-Sizing Form Fields</h2>
+      <p style="color: #64748b; font-size: 0.9rem; margin-top: 0.25rem;">Type into the fields below to see them resize fluidly to fit your text.</p>
+    </div>
+
+    <div class="input-group">
+      <label for="tags">Dynamic Tag Input (Width-wise)</label>
+      <input type="text" id="tags" class="auto-grow-input" placeholder="Type tag..." value="CSS">
+    </div>
+
+    <div class="input-group">
+      <label for="bio">Dynamic Description (Height-wise)</label>
+      <textarea id="bio" class="auto-grow-textarea" placeholder="Start typing your story here... watch it scale downwards gracefully."></textarea>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/field-sizing-input-pr/style.css
+++ b/submissions/examples/field-sizing-input-pr/style.css
@@ -1,0 +1,77 @@
+/* submissions/examples/field-sizing-input-pr/style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #060814;
+  color: #f8fafc;
+  margin: 0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.form-container {
+  background-color: #0f172a;
+  border: 1px solid #1e293b;
+  border-radius: 16px;
+  padding: 2.5rem;
+  width: 90%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3);
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #94a3b8;
+}
+
+/* Core Auto-Growing Input Fields */
+.auto-grow-input,
+.auto-grow-textarea {
+  background-color: #1e293b;
+  color: #ffffff;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  /* The Magical CSS Feature */
+  field-sizing: content;
+}
+
+/* Setting logical size limits so the field feels natural */
+.auto-grow-input {
+  min-width: 120px;
+  max-width: 100%;
+}
+
+.auto-grow-textarea {
+  min-height: 45px;
+  max-height: 300px;
+  resize: none; /* Disables standard manual drag handle */
+}
+
+.auto-grow-input:focus,
+.auto-grow-textarea:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces the `field-sizing-input-pr` form interface sample. It demonstrates a pure, zero-dependency layout approach where text fields adapt their width or height instantly to accommodate text lengths using the native CSS `field-sizing` property API.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: Native CSS form layout expansion

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/field-sizing-input-pr/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It integrates highly performant text layout blocks that grow dynamically to envelope typed variables inside standard form panels.

**How does a developer use it?**

```html
<input type="text" class="auto-grow-input">
<textarea class="auto-grow-textarea"></textarea>