### PR TITLE
feat: add polygon clip-path geometric utility layout wrappers

### DIFF
--- a/submissions/examples/clip-path-polygon-pr/README.md
+++ b/submissions/examples/clip-path-polygon-pr/README.md
@@ -1,0 +1,10 @@
+# CSS clip-path Polygon Shape Utilities
+
+### What does this do?
+Introduces structural geometric element masks (Triangle, Diamond, Pentagon, Hexagon) via native CSS `clip-path: polygon()` configurations.
+
+### How is it used?
+Apply the responsive shape modifiers directly onto layouts, imagery wraps, or background cards to clip bounding containers into geometric vectors.
+
+### Why is it useful?
+It creates pixel-perfect mathematical cuts directly inside the browser renderer, replacing the need for external raster image textures or vector SVG tracks.

--- a/submissions/examples/clip-path-polygon-pr/demo.html
+++ b/submissions/examples/clip-path-polygon-pr/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS clip-path Polygon Utilities Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1 style="margin: 0; font-size: 2rem; text-align: center;">Polygon Clip-Path Utilities</h1>
+  <p style="color: #64748b; margin-top: 0.5rem; text-align: center; max-width: 500px;">
+    Native geometric layouts generated using pure CSS vectors without relying on asset files or background SVGs.
+  </p>
+
+  <div class="shapes-grid">
+    <div class="shape-card">
+      <div class="shape-box clip-path-polygon-triangle"></div>
+      <div class="shape-label">.clip-path-polygon-triangle</div>
+    </div>
+
+    <div class="shape-card">
+      <div class="shape-box clip-path-polygon-diamond"></div>
+      <div class="shape-label">.clip-path-polygon-diamond</div>
+    </div>
+
+    <div class="shape-card">
+      <div class="shape-box clip-path-polygon-pentagon"></div>
+      <div class="shape-label">.clip-path-polygon-pentagon</div>
+    </div>
+
+    <div class="shape-card">
+      <div class="shape-box clip-path-polygon-hexagon"></div>
+      <div class="shape-label">.clip-path-polygon-hexagon</div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/clip-path-polygon-pr/style.css
+++ b/submissions/examples/clip-path-polygon-pr/style.css
@@ -1,0 +1,77 @@
+/* submissions/examples/clip-path-polygon-pr/style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #0b0f19;
+  color: #f8fafc;
+  margin: 0;
+  padding: 4rem 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.shapes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 3rem;
+  width: 100%;
+  max-width: 900px;
+  margin-top: 3rem;
+}
+
+.shape-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  background-color: #131c2e;
+  padding: 2rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #1e293b;
+}
+
+/* Base structural canvas for the shape */
+.shape-box {
+  width: 140px;
+  height: 140px;
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  transition: transform 0.3s cubic-bezier(0.25, 1, 0.5, 1), filter 0.3s ease;
+}
+
+.shape-card:hover .shape-box {
+  transform: scale(1.05) rotate(3deg);
+  filter: brightness(1.15);
+}
+
+.shape-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #94a3b8;
+  letter-spacing: 0.05em;
+}
+
+/* ==========================================================================
+   Core Framework Utilities: Polygon Clip Paths
+   ========================================================================== */
+
+/* Triangle: Top-center, Bottom-right, Bottom-left */
+.clip-path-polygon-triangle {
+  clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+}
+
+/* Diamond: Top-center, Right-center, Bottom-center, Left-center */
+.clip-path-polygon-diamond {
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}
+
+/* Pentagon: Top-center, Top-right, Bottom-right, Bottom-left, Top-left */
+.clip-path-polygon-pentagon {
+  clip-path: polygon(50% 0%, 100% 38%, 82% 100%, 18% 100%, 0% 38%);
+}
+
+/* Hexagon: Top-left-center, Top-right-center, Right-center, Bottom-right-center, Bottom-left-center, Left-center */
+.clip-path-polygon-hexagon {
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces the `clip-path-polygon-pr` structural layout utility pack. It delivers a collection of responsive geometric clipping rules to draw triangles, diamonds, pentagons, and hexagons inside modern web apps using pure, lightweight CSS vector masks.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: Core layout utility additions

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/clip-path-polygon-pr/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It integrates highly requested shape vector properties to clip block bounds cleanly down into geometric shapes without image file overhead.

**How does a developer use it?**

```html
<div class="element-box clip-path-polygon-triangle"></div>
<div class="element-box clip-path-polygon-hexagon"></div>