### PR TITLE
feat: add outline-offset utilities for controlling focus ring distance

### DIFF
--- a/submissions/examples/outline-offset-utilities-aa/README.md
+++ b/submissions/examples/outline-offset-utilities-aa/README.md
@@ -1,0 +1,14 @@
+# Outline Offset Utilities
+
+1. **What does this do?** Adds utility classes for the CSS `outline-offset` property to control the space between an element's outline and its border.
+
+2. **How is it used?**
+```html
+   <button class="outline-offset-none">No gap</button>
+   <button class="outline-offset-sm">Small gap (2px)</button>
+   <button class="outline-offset-md">Medium gap (4px)</button>
+   <button class="outline-offset-lg">Large gap (8px)</button>
+   <button class="outline-offset-xl">Extra-large gap (12px)</button>
+```
+
+3. **Why is it useful?** Outline-offset utilities allow developers to customize focus ring appearance without writing custom CSS. They complement existing focus-visible utilities and improve accessibility customization options for keyboard navigation styles.

--- a/submissions/examples/outline-offset-utilities-aa/demo.html
+++ b/submissions/examples/outline-offset-utilities-aa/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Outline Offset Utilities Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: sans-serif; padding: 2rem; background: #f5f5f5; }
+    .demo-btn {
+      display: inline-block;
+      margin: 1rem;
+      padding: 0.6rem 1.4rem;
+      background: #4f46e5;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      outline: 3px solid #4f46e5;
+      font-size: 1rem;
+    }
+    h1 { margin-bottom: 1.5rem; }
+    .row { margin-bottom: 1rem; }
+    label { font-size: 0.85rem; color: #555; display: block; margin-bottom: 0.25rem; }
+  </style>
+</head>
+<body>
+  <h1>Outline Offset Utilities</h1>
+  <div class="row">
+    <label>outline-offset-none (0px)</label>
+    <button class="demo-btn outline-offset-none">Button</button>
+  </div>
+  <div class="row">
+    <label>outline-offset-sm (2px)</label>
+    <button class="demo-btn outline-offset-sm">Button</button>
+  </div>
+  <div class="row">
+    <label>outline-offset-md (4px)</label>
+    <button class="demo-btn outline-offset-md">Button</button>
+  </div>
+  <div class="row">
+    <label>outline-offset-lg (8px)</label>
+    <button class="demo-btn outline-offset-lg">Button</button>
+  </div>
+  <div class="row">
+    <label>outline-offset-xl (12px)</label>
+    <button class="demo-btn outline-offset-xl">Button</button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/outline-offset-utilities-aa/style.css
+++ b/submissions/examples/outline-offset-utilities-aa/style.css
@@ -1,0 +1,6 @@
+/* Outline Offset Utilities */
+.outline-offset-none { outline-offset: 0px; }
+.outline-offset-sm { outline-offset: 2px; }
+.outline-offset-md { outline-offset: 4px; }
+.outline-offset-lg { outline-offset: 8px; }
+.outline-offset-xl { outline-offset: 12px; }


### PR DESCRIPTION

Closes #13833
## Pull Request Description
Adds CSS utility classes for the `outline-offset` property to control the space between an element's outline and its border, useful for accessibility focus rings and decorative outlines.

---
## Type of Change
- [x] Other: New utility classes for CSS `outline-offset` property

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
Five utility classes for `outline-offset`: none (0px), sm (2px), md (4px), lg (8px), xl (12px).

**How does a developer use it?**
```html
<button class="outline-offset-sm">Small gap</button>
<button class="outline-offset-md">Medium gap</button>
<button class="outline-offset-lg">Large gap</button>
```

**Why does it fit EaseMotion CSS?**
Complements existing focus-visible utilities and improves accessibility customization for keyboard navigation styles without requiring custom CSS.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---
## Notes for Maintainer
Submission folder: `submissions/examples/outline-offset-utilities-aa/`. Feel free to rename classes to `ease-outline-offset-*` during integration.