### PR TITLE
feat: add break-inside utilities for controlling how elements split across columns or pages

### DIFF
--- a/submissions/examples/break-inside-utilities-aa/README.md
+++ b/submissions/examples/break-inside-utilities-aa/README.md
@@ -1,0 +1,13 @@
+# Break Inside Utilities
+
+1. **What does this do?** Adds utility classes for the CSS `break-inside` and `page-break-inside` properties to control whether elements may be broken across columns or pages.
+
+2. **How is it used?**
+```html
+   <div class="break-auto">May break across columns</div>
+   <div class="break-avoid">Stays together in one column</div>
+   <div class="break-avoid-page">No page break inside (print)</div>
+   <div class="break-avoid-column">No column break inside</div>
+```
+
+3. **Why is it useful?** When building multi-column article layouts, masonry grids, or printable document styles, `break-avoid` prevents cards and sections from being awkwardly split across columns or pages — filling a practical gap in the layout utility set.

--- a/submissions/examples/break-inside-utilities-aa/demo.html
+++ b/submissions/examples/break-inside-utilities-aa/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Break Inside Utilities Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: sans-serif; padding: 2rem; background: #f5f5f5; }
+    h1 { margin-bottom: 1.5rem; }
+    .columns { column-count: 2; column-gap: 2rem; margin-bottom: 2rem; }
+    .card {
+      background: white;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    label { font-size: 0.8rem; color: #888; display: block; margin-bottom: 0.4rem; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>Break Inside Utilities</h1>
+  <p>Resize the window to see column break behavior.</p>
+
+  <div class="columns">
+    <div class="card break-auto">
+      <label>break-auto</label>
+      <p>Allows page/column break automatically. This card may split across columns.</p>
+    </div>
+    <div class="card break-avoid">
+      <label>break-avoid</label>
+      <p>Avoids any break inside this element. The card stays together in one column.</p>
+    </div>
+    <div class="card break-avoid-page">
+      <label>break-avoid-page</label>
+      <p>Avoids a page break inside this element. Useful for print styles.</p>
+    </div>
+    <div class="card break-avoid-column">
+      <label>break-avoid-column</label>
+      <p>Avoids a column break inside this element in multi-column layouts.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/break-inside-utilities-aa/style.css
+++ b/submissions/examples/break-inside-utilities-aa/style.css
@@ -1,0 +1,5 @@
+/* Break Inside Utilities */
+.break-auto { break-inside: auto; page-break-inside: auto; }
+.break-avoid { break-inside: avoid; page-break-inside: avoid; }
+.break-avoid-page { break-inside: avoid-page; page-break-inside: avoid; }
+.break-avoid-column { break-inside: avoid-column; }


### PR DESCRIPTION
Closes #13835
## Pull Request Description
Adds CSS utility classes for the `break-inside` and `page-break-inside` properties to control whether elements may be broken across columns or pages in multi-column and print layouts.

---
## Type of Change
- [x] Other: New utility classes for CSS `break-inside` property

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
Four utility classes: `break-auto`, `break-avoid`, `break-avoid-page`, `break-avoid-column`.

**How does a developer use it?**
```html
<div class="break-avoid">Card stays together in one column</div>
<div class="break-avoid-column">No column break inside</div>
<div class="break-avoid-page">No page break inside (print)</div>
```

**Why does it fit EaseMotion CSS?**
Prevents cards and sections from being awkwardly split across columns or pages in multi-column layouts and print styles — fills a practical gap in the layout utility set.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---
## Notes for Maintainer
Submission folder: `submissions/examples/break-inside-utilities-aa/`. Feel free to rename to `ease-break-*` during integration.