### PR TITLE
feat: add ease-teleport-fade teleport animation (#13754)

### DIFF
--- a/submissions/examples/ease-teleport-fade/README.md
+++ b/submissions/examples/ease-teleport-fade/README.md
@@ -1,0 +1,25 @@
+﻿# ease-teleport-fade – Teleportation Fade & Reform Effect
+
+A sci‑fi teleportation transition: an element dissolves into particles, pauses, then reforms at a new state with a color change.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen
+- **Background:** ease-bg-gray-900
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-white, ease-text-gray-400, ease-text-sm, ease-text-gray-500
+- **Spacing:** ease-mb-4, ease-mb-6, ease-mt-4, ease-mt-6
+- **Components:** ease-btn, ease-btn-primary
+- **Hover Effects:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- A central orb is displayed.
+- On click, JavaScript hides the orb and generates 30 small colored particles at its location.
+- Particles burst outward with random angles and distances, fading to zero.
+- After a short pause, the orb reappears in a new color and particles implode back into the center.
+- All animations are handled by CSS transitions with custom properties for angle and distance.
+- The effect respects prefers-reduced-motion.
+
+## How to use
+1. Copy demo.html, style.css into your project.
+2. Ensure the path to easemotion.css is correct (usually from core/).
+3. Open demo.html in any modern browser.

--- a/submissions/examples/ease-teleport-fade/demo.html
+++ b/submissions/examples/ease-teleport-fade/demo.html
@@ -1,0 +1,116 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-teleport-fade – Teleportation Effect</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-900 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-text-white ease-mb-4 ease-fade-in">
+      Teleport Fade
+    </h1>
+    <p class="ease-text-gray-400 ease-mb-6 ease-fade-in ease-delay-200">
+      Click the button to teleport the orb.
+    </p>
+
+    <div id="teleport-area" class="teleport-area">
+      <div id="orb" class="orb"></div>
+      <!-- particles are injected here by JS -->
+    </div>
+
+    <button id="teleport-btn" class="ease-btn ease-btn-primary ease-hover-scale-105 ease-transition ease-mt-6">
+      ⚡ Teleport
+    </button>
+
+    <p id="message" class="ease-text-sm ease-text-gray-500 ease-mt-4 ease-fade-in ease-delay-500">
+      Ready.
+    </p>
+  </div>
+
+  <script>
+    const area = document.getElementById('teleport-area');
+    const orb = document.getElementById('orb');
+    const btn = document.getElementById('teleport-btn');
+    const msg = document.getElementById('message');
+    let teleporting = false;
+
+    // Generate particles from the orb
+    function createParticles() {
+      const rect = orb.getBoundingClientRect();
+      const areaRect = area.getBoundingClientRect();
+      const centerX = rect.left + rect.width/2 - areaRect.left;
+      const centerY = rect.top + rect.height/2 - areaRect.top;
+
+      // Create 30 small squares
+      for (let i = 0; i < 30; i++) {
+        const particle = document.createElement('div');
+        particle.className = 'particle';
+        particle.style.left = centerX + 'px';
+        particle.style.top = centerY + 'px';
+        particle.style.backgroundColor = i % 2 === 0 ? '#6366f1' : '#a855f7';
+        particle.style.setProperty('--angle', (i * 12) + 'deg');
+        particle.style.setProperty('--distance', (40 + Math.random() * 60) + 'px');
+        particle.style.setProperty('--delay', (Math.random() * 0.2) + 's');
+        area.appendChild(particle);
+      }
+    }
+
+    function removeParticles() {
+      const particles = area.querySelectorAll('.particle');
+      particles.forEach(p => p.remove());
+    }
+
+    function teleport() {
+      if (teleporting) return;
+      teleporting = true;
+      btn.disabled = true;
+      msg.textContent = 'Teleporting...';
+
+      // Hide orb
+      orb.style.opacity = '0';
+      orb.style.transform = 'scale(0)';
+
+      // Create particles at orb's position
+      createParticles();
+
+      // Trigger particle burst
+      setTimeout(() => {
+        const particles = area.querySelectorAll('.particle');
+        particles.forEach(p => p.classList.add('burst'));
+      }, 50);
+
+      // After burst, wait a bit, then reverse
+      setTimeout(() => {
+        // Change orb color for "new location"
+        orb.style.backgroundColor = '#10b981';
+        orb.style.transform = 'scale(1)';
+        orb.style.opacity = '1';
+
+        // Remove burst and apply implode
+        const particles = area.querySelectorAll('.particle');
+        particles.forEach(p => {
+          p.classList.remove('burst');
+          p.classList.add('implode');
+        });
+
+        // Clean up after implode
+        setTimeout(() => {
+          removeParticles();
+          teleporting = false;
+          btn.disabled = false;
+          msg.textContent = 'Teleported! Orb is now green.';
+          // Reset orb color after a while
+          setTimeout(() => { orb.style.backgroundColor = '#6366f1'; }, 2000);
+        }, 800);
+      }, 1200);
+    }
+
+    btn.addEventListener('click', teleport);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-teleport-fade/style.css
+++ b/submissions/examples/ease-teleport-fade/style.css
@@ -1,0 +1,73 @@
+﻿/* ============================================================
+   ease-teleport-fade – Teleportation fade & reform effect
+   Particles burst out then implode back into the object
+   ============================================================ */
+
+/* Teleport area */
+.teleport-area {
+  position: relative;
+  width: 300px;
+  height: 300px;
+  margin: 0 auto;
+  background: rgba(255,255,255,0.05);
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+/* Central orb */
+.orb {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 60px;
+  height: 60px;
+  margin-left: -30px;
+  margin-top: -30px;
+  background: #6366f1;
+  border-radius: 50%;
+  box-shadow: 0 0 20px rgba(99,102,241,0.5);
+  transition: opacity 0.3s ease, transform 0.3s ease, background-color 0.5s ease;
+  will-change: transform, opacity;
+}
+
+/* Individual particle */
+.particle {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  margin-left: -4px;
+  margin-top: -4px;
+  transition: transform 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.6s ease;
+  opacity: 0.9;
+  will-change: transform, opacity;
+}
+
+/* Burst: particles fly outward */
+.particle.burst {
+  transform: translate(
+    calc(cos(var(--angle)) * var(--distance)),
+    calc(sin(var(--angle)) * var(--distance))
+  ) scale(0.2);
+  opacity: 0;
+  transition-delay: var(--delay);
+}
+
+/* Implode: particles return to center */
+.particle.implode {
+  transform: translate(0, 0) scale(1);
+  opacity: 0.9;
+  transition-delay: var(--delay);
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .orb,
+  .particle {
+    transition: none;
+  }
+  .particle.burst,
+  .particle.implode {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #13754

ease-teleport-fade – Teleportation Fade & Reform
Sci‑fi effect: an orb dissolves into particles, pauses, then reforms in a new color.

Files added
- submissions/examples/ease-teleport-fade/demo.html
- submissions/examples/ease-teleport-fade/style.css
- submissions/examples/ease-teleport-fade/README.md

How it works
- Orb hidden, 30 particles burst outward with CSS transforms.
- After pause, orb reappears with color change, particles implode back.
- Uses CSS custom properties for angles/distances and transitions.
- Respects prefers-reduced-motion.

EaseMotion classes used
ease-btn, ease-btn-primary, ease-hover-scale-105, ease-fade-in, ease-delay-*,
ease-container, ease-flex, ease-text-*, ease-bg-gray-900, etc.

Custom CSS (>5 lines) for orb, particles, burst/implode transitions.