### PR TITLE
Fix[core]:  Theme-toggle-button-visibility-dark-mode

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -212,43 +212,48 @@ body {
     border-color var(--ease-speed-fast) var(--ease-ease);
 }
 
-.theme-toggle-btn:hover {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: var(--ease-color-primary);
-}
-
-[data-theme="light"] .theme-toggle-btn:hover {
-  background: rgba(15, 23, 42, 0.08);
-}
-
 .theme-toggle-btn svg {
   position: absolute;
   transition:
-    transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
-    opacity 0.3s;
+    transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.3s,
+    fill 0.3s,
+    stroke 0.3s;
 }
 
-/* Sun Icon Default (Dark Mode active) */
+/* Sun Icon (Dark Mode active) */
 .theme-toggle-btn .sun-icon {
   opacity: 1;
   transform: rotate(0deg) scale(1);
+  fill: #facc15;   /* bright yellow */
+  stroke: #facc15;
 }
 
-/* Moon Icon Default (Dark Mode active) */
+/* Moon Icon (Dark Mode active) */
 .theme-toggle-btn .moon-icon {
   opacity: 0;
   transform: rotate(90deg) scale(0);
+  fill: #94a3b8;   /* soft gray-blue moon */
+  stroke: #94a3b8;
+  background: #ffffff;   /* white circle background */
+  border-radius: 100%;    /* ensures circular shape */
+  padding: 4px;          /* spacing so circle is visible */
 }
 
-/* Active State Styles (Light Mode active) */
-[data-theme="light"] .theme-toggle-btn .sun-icon {
-  opacity: 0;
-  transform: rotate(-90deg) scale(0);
-}
-
+/* Light Mode active */
 [data-theme="light"] .theme-toggle-btn .moon-icon {
   opacity: 1;
-  transform: rotate(0deg) scale(1);
+  transform: rotate(360deg) scale(1);
+  fill: #1e293b;   /* dark navy moon */
+  stroke: #1e293b;
+  background: #ffffff;   /* keep white circle background */
+  border-radius: 50%;
+  padding: 4px;
+}
+
+/* Hover effect: brighten icon */
+.theme-toggle-btn:hover svg {
+  filter: brightness(1.2);
 }
 
 /* ── Layout Shell ─────────────────────────────────────── */


### PR DESCRIPTION
## Pull Request Description

Fix a theme toggle improvement with enhanced visibility in Dark Mode. The moon icon now appears inside a white circular background, and the toggle includes a smooth rotation animation when switching between Light and Dark Mode.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---
## Changes
 core theme toggle button` fix: docs/docs.css 215` }to fix `.theme-toggle-btn:hover`

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
closes #15288
