### PR TITLE
feat: add interactive 3d periodic table component

### DIFF
--- a/submissions/examples/interactive-periodic-table-ad/README.md
+++ b/submissions/examples/interactive-periodic-table-ad/README.md
@@ -1,0 +1,32 @@
+# Interactive 3D Periodic Table of Elements
+
+## 1. What does this do?
+This submission displays a clean, glassmorphic Periodic Table of Elements (covering Periods 1-4) where element cards rotate in 3D perspective to reveal core atomic configurations on hover or focus, accompanied by dynamic category highlighting controls.
+
+## 2. How is it used?
+Developers can use this modular component by organizing their cards within an 18-column CSS Grid layout using `data-category` and grid coordinate placement modifiers, then applying the `.periodic-card` 3D animation structure.
+
+```html
+<section class="periodic-table-grid">
+  <div class="periodic-card" data-category="transition" data-row="4" data-col="4" tabindex="0">
+    <div class="periodic-card-inner">
+      <div class="card-front">
+        <span class="number">22</span>
+        <span class="symbol">Ti</span>
+        <span class="name">Titanium</span>
+      </div>
+      <div class="card-back">
+        <span class="weight">47.867</span>
+        <span class="category-label">Transition</span>
+        <span class="config">[Ar] 3d² 4s²</span>
+      </div>
+    </div>
+  </div>
+</section>
+```
+
+## 3. Why is this useful?
+It demonstrates advanced modern CSS layout and animation practices:
+- **3D Transitions & Hardware Acceleration:** Demonstrates `perspective`, `transform-style: preserve-3d`, and `backface-visibility` without performance impact.
+- **Accessible Interactions:** Employs `tabindex` and `:focus-within` to enable keyboard accessibility for 3D state transforms.
+- **Unified Color Systems:** Leverages semantic HSL design tokens for layout categorization, encouraging highly maintainable custom property architectures.

--- a/submissions/examples/interactive-periodic-table-ad/demo.html
+++ b/submissions/examples/interactive-periodic-table-ad/demo.html
@@ -1,0 +1,602 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Interactive 3D Periodic Table of Elements</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="dashboard">
+    <header>
+      <h1>Interactive 3D Periodic Table</h1>
+      <p>Hover or focus cards to rotate in 3D. Click filters to isolate categories.</p>
+    </header>
+
+    <section class="filter-controls">
+      <button class="filter-btn" data-category="all">All Elements</button>
+      <button class="filter-btn" data-category="alkali">Alkali Metals</button>
+      <button class="filter-btn" data-category="alkaline">Alkaline Earth</button>
+      <button class="filter-btn" data-category="transition">Transition Metals</button>
+      <button class="filter-btn" data-category="post-transition">Post-Transition</button>
+      <button class="filter-btn" data-category="metalloid">Metalloids</button>
+      <button class="filter-btn" data-category="nonmetal">Reactive Nonmetals</button>
+      <button class="filter-btn" data-category="noble">Noble Gases</button>
+    </section>
+
+    <section class="periodic-table-grid" id="periodicTable">
+      <!-- Period 1 -->
+      <div class="periodic-card" data-category="nonmetal" data-row="1" data-col="1" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">1</span>
+            <span class="symbol">H</span>
+            <span class="name">Hydrogen</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">1.008</span>
+            <span class="category-label">Nonmetal</span>
+            <span class="config">1s¹</span>
+          </div>
+        </div>
+      </div>
+      
+      <div class="periodic-card" data-category="noble" data-row="1" data-col="18" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">2</span>
+            <span class="symbol">He</span>
+            <span class="name">Helium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">4.0026</span>
+            <span class="category-label">Noble Gas</span>
+            <span class="config">1s²</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Period 2 -->
+      <div class="periodic-card" data-category="alkali" data-row="2" data-col="1" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">3</span>
+            <span class="symbol">Li</span>
+            <span class="name">Lithium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">6.94</span>
+            <span class="category-label">Alkali Metal</span>
+            <span class="config">[He] 2s¹</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="alkaline" data-row="2" data-col="2" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">4</span>
+            <span class="symbol">Be</span>
+            <span class="name">Beryllium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">9.0122</span>
+            <span class="category-label">Alkaline Earth</span>
+            <span class="config">[He] 2s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="metalloid" data-row="2" data-col="13" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">5</span>
+            <span class="symbol">B</span>
+            <span class="name">Boron</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">10.81</span>
+            <span class="category-label">Metalloid</span>
+            <span class="config">[He] 2s² 2p¹</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="nonmetal" data-row="2" data-col="14" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">6</span>
+            <span class="symbol">C</span>
+            <span class="name">Carbon</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">12.011</span>
+            <span class="category-label">Nonmetal</span>
+            <span class="config">[He] 2s² 2p²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="nonmetal" data-row="2" data-col="15" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">7</span>
+            <span class="symbol">N</span>
+            <span class="name">Nitrogen</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">14.007</span>
+            <span class="category-label">Nonmetal</span>
+            <span class="config">[He] 2s² 2p³</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="nonmetal" data-row="2" data-col="16" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">8</span>
+            <span class="symbol">O</span>
+            <span class="name">Oxygen</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">15.999</span>
+            <span class="category-label">Nonmetal</span>
+            <span class="config">[He] 2s² 2p⁴</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="nonmetal" data-row="2" data-col="17" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">9</span>
+            <span class="symbol">F</span>
+            <span class="name">Fluorine</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">18.998</span>
+            <span class="category-label">Nonmetal</span>
+            <span class="config">[He] 2s² 2p⁵</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="noble" data-row="2" data-col="18" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">10</span>
+            <span class="symbol">Ne</span>
+            <span class="name">Neon</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">20.180</span>
+            <span class="category-label">Noble Gas</span>
+            <span class="config">[He] 2s² 2p⁶</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Period 3 -->
+      <div class="periodic-card" data-category="alkali" data-row="3" data-col="1" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">11</span>
+            <span class="symbol">Na</span>
+            <span class="name">Sodium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">22.990</span>
+            <span class="category-label">Alkali Metal</span>
+            <span class="config">[Ne] 3s¹</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="alkaline" data-row="3" data-col="2" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">12</span>
+            <span class="symbol">Mg</span>
+            <span class="name">Magnesium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">24.305</span>
+            <span class="category-label">Alkaline Earth</span>
+            <span class="config">[Ne] 3s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="post-transition" data-row="3" data-col="13" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">13</span>
+            <span class="symbol">Al</span>
+            <span class="name">Aluminum</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">26.982</span>
+            <span class="category-label">Post-Trans.</span>
+            <span class="config">[Ne] 3s² 3p¹</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="metalloid" data-row="3" data-col="14" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">14</span>
+            <span class="symbol">Si</span>
+            <span class="name">Silicon</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">28.085</span>
+            <span class="category-label">Metalloid</span>
+            <span class="config">[Ne] 3s² 3p²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="nonmetal" data-row="3" data-col="15" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">15</span>
+            <span class="symbol">P</span>
+            <span class="name">Phosphorus</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">30.974</span>
+            <span class="category-label">Nonmetal</span>
+            <span class="config">[Ne] 3s² 3p³</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="nonmetal" data-row="3" data-col="16" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">16</span>
+            <span class="symbol">S</span>
+            <span class="name">Sulfur</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">32.06</span>
+            <span class="category-label">Nonmetal</span>
+            <span class="config">[Ne] 3s² 3p⁴</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="nonmetal" data-row="3" data-col="17" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">17</span>
+            <span class="symbol">Cl</span>
+            <span class="name">Chlorine</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">35.45</span>
+            <span class="category-label">Nonmetal</span>
+            <span class="config">[Ne] 3s² 3p⁵</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="noble" data-row="3" data-col="18" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">18</span>
+            <span class="symbol">Ar</span>
+            <span class="name">Argon</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">39.948</span>
+            <span class="category-label">Noble Gas</span>
+            <span class="config">[Ne] 3s² 3p⁶</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Period 4 -->
+      <div class="periodic-card" data-category="alkali" data-row="4" data-col="1" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">19</span>
+            <span class="symbol">K</span>
+            <span class="name">Potassium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">39.098</span>
+            <span class="category-label">Alkali Metal</span>
+            <span class="config">[Ar] 4s¹</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="alkaline" data-row="4" data-col="2" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">20</span>
+            <span class="symbol">Ca</span>
+            <span class="name">Calcium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">40.078</span>
+            <span class="category-label">Alkaline Earth</span>
+            <span class="config">[Ar] 4s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="transition" data-row="4" data-col="3" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">21</span>
+            <span class="symbol">Sc</span>
+            <span class="name">Scandium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">44.956</span>
+            <span class="category-label">Transition</span>
+            <span class="config">[Ar] 3d¹ 4s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="transition" data-row="4" data-col="4" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">22</span>
+            <span class="symbol">Ti</span>
+            <span class="name">Titanium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">47.867</span>
+            <span class="category-label">Transition</span>
+            <span class="config">[Ar] 3d² 4s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="transition" data-row="4" data-col="5" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">23</span>
+            <span class="symbol">V</span>
+            <span class="name">Vanadium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">50.942</span>
+            <span class="category-label">Transition</span>
+            <span class="config">[Ar] 3d³ 4s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="transition" data-row="4" data-col="6" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">24</span>
+            <span class="symbol">Cr</span>
+            <span class="name">Chromium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">51.996</span>
+            <span class="category-label">Transition</span>
+            <span class="config">[Ar] 3d⁵ 4s¹</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="transition" data-row="4" data-col="7" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">25</span>
+            <span class="symbol">Mn</span>
+            <span class="name">Manganese</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">54.938</span>
+            <span class="category-label">Transition</span>
+            <span class="config">[Ar] 3d⁵ 4s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="transition" data-row="4" data-col="8" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">26</span>
+            <span class="symbol">Fe</span>
+            <span class="name">Iron</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">55.845</span>
+            <span class="category-label">Transition</span>
+            <span class="config">[Ar] 3d⁶ 4s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="transition" data-row="4" data-col="9" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">27</span>
+            <span class="symbol">Co</span>
+            <span class="name">Cobalt</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">58.933</span>
+            <span class="category-label">Transition</span>
+            <span class="config">[Ar] 3d⁷ 4s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="transition" data-row="4" data-col="10" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">28</span>
+            <span class="symbol">Ni</span>
+            <span class="name">Nickel</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">58.693</span>
+            <span class="category-label">Transition</span>
+            <span class="config">[Ar] 3d⁸ 4s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="transition" data-row="4" data-col="11" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">29</span>
+            <span class="symbol">Cu</span>
+            <span class="name">Copper</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">63.546</span>
+            <span class="category-label">Transition</span>
+            <span class="config">[Ar] 3d¹⁰ 4s¹</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="transition" data-row="4" data-col="12" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">30</span>
+            <span class="symbol">Zn</span>
+            <span class="name">Zinc</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">65.38</span>
+            <span class="category-label">Transition</span>
+            <span class="config">[Ar] 3d¹⁰ 4s²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="post-transition" data-row="4" data-col="13" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">31</span>
+            <span class="symbol">Ga</span>
+            <span class="name">Gallium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">69.723</span>
+            <span class="category-label">Post-Trans.</span>
+            <span class="config">[Ar] 3d¹⁰ 4s² 4p¹</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="metalloid" data-row="4" data-col="14" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">32</span>
+            <span class="symbol">Ge</span>
+            <span class="name">Germanium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">72.630</span>
+            <span class="category-label">Metalloid</span>
+            <span class="config">[Ar] 3d¹⁰ 4s² 4p²</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="metalloid" data-row="4" data-col="15" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">33</span>
+            <span class="symbol">As</span>
+            <span class="name">Arsenic</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">74.922</span>
+            <span class="category-label">Metalloid</span>
+            <span class="config">[Ar] 3d¹⁰ 4s² 4p³</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="nonmetal" data-row="4" data-col="16" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">34</span>
+            <span class="symbol">Se</span>
+            <span class="name">Selenium</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">78.971</span>
+            <span class="category-label">Nonmetal</span>
+            <span class="config">[Ar] 3d¹⁰ 4s² 4p⁴</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="nonmetal" data-row="4" data-col="17" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">35</span>
+            <span class="symbol">Br</span>
+            <span class="name">Bromine</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">79.904</span>
+            <span class="category-label">Nonmetal</span>
+            <span class="config">[Ar] 3d¹⁰ 4s² 4p⁵</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="periodic-card" data-category="noble" data-row="4" data-col="18" tabindex="0">
+        <div class="periodic-card-inner">
+          <div class="card-front">
+            <span class="number">36</span>
+            <span class="symbol">Kr</span>
+            <span class="name">Krypton</span>
+          </div>
+          <div class="card-back">
+            <span class="weight">83.798</span>
+            <span class="category-label">Noble Gas</span>
+            <span class="config">[Ar] 3d¹⁰ 4s² 4p⁶</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const filterButtons = document.querySelectorAll('.filter-btn');
+      const table = document.getElementById('periodicTable');
+
+      filterButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const category = btn.getAttribute('data-category');
+
+          // Update active class on buttons
+          filterButtons.forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+
+          // Reset all highlight classes on table grid
+          table.className = 'periodic-table-grid';
+
+          // Apply specific category highlight
+          if (category !== 'all') {
+            table.classList.add(`highlight-${category}`);
+          }
+        });
+      });
+      
+      // Default to Active "All" button
+      document.querySelector('.filter-btn[data-category="all"]').classList.add('active');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/interactive-periodic-table-ad/style.css
+++ b/submissions/examples/interactive-periodic-table-ad/style.css
@@ -1,0 +1,348 @@
+/* Custom CSS for Interactive 3D Periodic Table of Elements */
+
+:root {
+  --bg-color: #0b0f19;
+  --panel-bg: rgba(20, 30, 55, 0.4);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --text-primary: #f3f4f6;
+  --text-secondary: #9ca3af;
+  
+  /* HSL Color Palette for Element Categories */
+  --color-alkali: 30, 90%, 55%;         /* Orange */
+  --color-alkaline: 14, 85%, 58%;       /* Coral */
+  --color-transition: 260, 85%, 65%;     /* Purple */
+  --color-post-transition: 210, 85%, 60%; /* Blue */
+  --color-metalloid: 175, 80%, 45%;     /* Teal */
+  --color-nonmetal: 135, 70%, 50%;      /* Green */
+  --color-noble: 320, 95%, 60%;         /* Pink */
+  
+  --card-width: 90px;
+  --card-height: 110px;
+}
+
+/* Reset and Core Styles */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  background-image: 
+    radial-gradient(circle at 10% 20%, rgba(30, 40, 80, 0.15) 0%, transparent 40%),
+    radial-gradient(circle at 90% 80%, rgba(70, 30, 90, 0.1) 0%, transparent 40%);
+  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  overflow-x: hidden;
+}
+
+.dashboard {
+  width: 100%;
+  max-width: 1280px;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  backdrop-filter: blur(20px);
+  padding: 2.5rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+}
+
+/* Header Styles */
+header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  background: linear-gradient(135deg, #fff 0%, #a5b4fc 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+header p {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+}
+
+/* Filter Controls */
+.filter-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-bottom: 3rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.filter-btn {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1.1rem;
+  border-radius: 9999px;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.filter-btn:hover {
+  color: var(--text-primary);
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.filter-btn.active {
+  color: #fff;
+  border-color: transparent;
+}
+
+.filter-btn[data-category="alkali"].active { background: hsl(var(--color-alkali)); box-shadow: 0 0 15px hsla(var(--color-alkali), 0.4); }
+.filter-btn[data-category="alkaline"].active { background: hsl(var(--color-alkaline)); box-shadow: 0 0 15px hsla(var(--color-alkaline), 0.4); }
+.filter-btn[data-category="transition"].active { background: hsl(var(--color-transition)); box-shadow: 0 0 15px hsla(var(--color-transition), 0.4); }
+.filter-btn[data-category="post-transition"].active { background: hsl(var(--color-post-transition)); box-shadow: 0 0 15px hsla(var(--color-post-transition), 0.4); }
+.filter-btn[data-category="metalloid"].active { background: hsl(var(--color-metalloid)); box-shadow: 0 0 15px hsla(var(--color-metalloid), 0.4); }
+.filter-btn[data-category="nonmetal"].active { background: hsl(var(--color-nonmetal)); box-shadow: 0 0 15px hsla(var(--color-nonmetal), 0.4); }
+.filter-btn[data-category="noble"].active { background: hsl(var(--color-noble)); box-shadow: 0 0 15px hsla(var(--color-noble), 0.4); }
+
+/* Periodic Table Grid */
+.periodic-table-grid {
+  display: grid;
+  grid-template-columns: repeat(18, minmax(var(--card-width), 1fr));
+  grid-gap: 8px;
+  justify-content: center;
+  overflow-x: auto;
+  padding: 10px;
+}
+
+/* Base Card Styles */
+.periodic-card {
+  width: 100%;
+  height: var(--card-height);
+  perspective: 1000px;
+  cursor: pointer;
+  transition: opacity 0.4s ease, filter 0.4s ease;
+}
+
+.periodic-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+  transform-style: preserve-3d;
+}
+
+/* Card Flipping on Hover/Focus */
+.periodic-card:hover .periodic-card-inner,
+.periodic-card:focus-within .periodic-card-inner {
+  transform: rotateY(180deg) scale(1.06);
+  z-index: 10;
+}
+
+.card-front, .card-back {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  border-radius: 12px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card-front {
+  background: rgba(13, 17, 30, 0.7);
+}
+
+.card-back {
+  background: #0f1524;
+  transform: rotateY(180deg);
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  gap: 4px;
+}
+
+/* Category Coloring & Theme Glows */
+.periodic-card[data-category="alkali"] .card-front { border-left: 3px solid hsl(var(--color-alkali)); }
+.periodic-card[data-category="alkali"] .card-back { border: 1px solid hsl(var(--color-alkali)); box-shadow: inset 0 0 10px hsla(var(--color-alkali), 0.2); }
+.periodic-card[data-category="alkali"]:hover .card-front { border-color: hsl(var(--color-alkali)); box-shadow: 0 0 15px hsla(var(--color-alkali), 0.3); }
+
+.periodic-card[data-category="alkaline"] .card-front { border-left: 3px solid hsl(var(--color-alkaline)); }
+.periodic-card[data-category="alkaline"] .card-back { border: 1px solid hsl(var(--color-alkaline)); box-shadow: inset 0 0 10px hsla(var(--color-alkaline), 0.2); }
+.periodic-card[data-category="alkaline"]:hover .card-front { border-color: hsl(var(--color-alkaline)); box-shadow: 0 0 15px hsla(var(--color-alkaline), 0.3); }
+
+.periodic-card[data-category="transition"] .card-front { border-left: 3px solid hsl(var(--color-transition)); }
+.periodic-card[data-category="transition"] .card-back { border: 1px solid hsl(var(--color-transition)); box-shadow: inset 0 0 10px hsla(var(--color-transition), 0.2); }
+.periodic-card[data-category="transition"]:hover .card-front { border-color: hsl(var(--color-transition)); box-shadow: 0 0 15px hsla(var(--color-transition), 0.3); }
+
+.periodic-card[data-category="post-transition"] .card-front { border-left: 3px solid hsl(var(--color-post-transition)); }
+.periodic-card[data-category="post-transition"] .card-back { border: 1px solid hsl(var(--color-post-transition)); box-shadow: inset 0 0 10px hsla(var(--color-post-transition), 0.2); }
+.periodic-card[data-category="post-transition"]:hover .card-front { border-color: hsl(var(--color-post-transition)); box-shadow: 0 0 15px hsla(var(--color-post-transition), 0.3); }
+
+.periodic-card[data-category="metalloid"] .card-front { border-left: 3px solid hsl(var(--color-metalloid)); }
+.periodic-card[data-category="metalloid"] .card-back { border: 1px solid hsl(var(--color-metalloid)); box-shadow: inset 0 0 10px hsla(var(--color-metalloid), 0.2); }
+.periodic-card[data-category="metalloid"]:hover .card-front { border-color: hsl(var(--color-metalloid)); box-shadow: 0 0 15px hsla(var(--color-metalloid), 0.3); }
+
+.periodic-card[data-category="nonmetal"] .card-front { border-left: 3px solid hsl(var(--color-nonmetal)); }
+.periodic-card[data-category="nonmetal"] .card-back { border: 1px solid hsl(var(--color-nonmetal)); box-shadow: inset 0 0 10px hsla(var(--color-nonmetal), 0.2); }
+.periodic-card[data-category="nonmetal"]:hover .card-front { border-color: hsl(var(--color-nonmetal)); box-shadow: 0 0 15px hsla(var(--color-nonmetal), 0.3); }
+
+.periodic-card[data-category="noble"] .card-front { border-left: 3px solid hsl(var(--color-noble)); }
+.periodic-card[data-category="noble"] .card-back { border: 1px solid hsl(var(--color-noble)); box-shadow: inset 0 0 10px hsla(var(--color-noble), 0.2); }
+.periodic-card[data-category="noble"]:hover .card-front { border-color: hsl(var(--color-noble)); box-shadow: 0 0 15px hsla(var(--color-noble), 0.3); }
+
+/* Front details */
+.card-front .number {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.card-front .symbol {
+  font-size: 1.6rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.card-front .name {
+  font-size: 0.65rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Back details */
+.card-back .weight {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.card-back .category-label {
+  font-size: 0.55rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;
+  border-radius: 9999px;
+}
+
+.periodic-card[data-category="alkali"] .category-label { color: hsl(var(--color-alkali)); background: hsla(var(--color-alkali), 0.15); }
+.periodic-card[data-category="alkaline"] .category-label { color: hsl(var(--color-alkaline)); background: hsla(var(--color-alkaline), 0.15); }
+.periodic-card[data-category="transition"] .category-label { color: hsl(var(--color-transition)); background: hsla(var(--color-transition), 0.15); }
+.periodic-card[data-category="post-transition"] .category-label { color: hsl(var(--color-post-transition)); background: hsla(var(--color-post-transition), 0.15); }
+.periodic-card[data-category="metalloid"] .category-label { color: hsl(var(--color-metalloid)); background: hsla(var(--color-metalloid), 0.15); }
+.periodic-card[data-category="nonmetal"] .category-label { color: hsl(var(--color-nonmetal)); background: hsla(var(--color-nonmetal), 0.15); }
+.periodic-card[data-category="noble"] .category-label { color: hsl(var(--color-noble)); background: hsla(var(--color-noble), 0.15); }
+
+.card-back .config {
+  font-size: 0.55rem;
+  font-family: monospace;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+/* Grid Spacings (Standard Periodic Table Layout) */
+/* Period 1 */
+.periodic-card[data-row="1"][data-col="1"] { grid-column: 1; }
+.periodic-card[data-row="1"][data-col="18"] { grid-column: 18; }
+
+/* Period 2 */
+.periodic-card[data-row="2"][data-col="1"] { grid-column: 1; }
+.periodic-card[data-row="2"][data-col="2"] { grid-column: 2; }
+.periodic-card[data-row="2"][data-col="13"] { grid-column: 13; }
+.periodic-card[data-row="2"][data-col="14"] { grid-column: 14; }
+.periodic-card[data-row="2"][data-col="15"] { grid-column: 15; }
+.periodic-card[data-row="2"][data-col="16"] { grid-column: 16; }
+.periodic-card[data-row="2"][data-col="17"] { grid-column: 17; }
+.periodic-card[data-row="2"][data-col="18"] { grid-column: 18; }
+
+/* Period 3 */
+.periodic-card[data-row="3"][data-col="1"] { grid-column: 1; }
+.periodic-card[data-row="3"][data-col="2"] { grid-column: 2; }
+.periodic-card[data-row="3"][data-col="13"] { grid-column: 13; }
+.periodic-card[data-row="3"][data-col="14"] { grid-column: 14; }
+.periodic-card[data-row="3"][data-col="15"] { grid-column: 15; }
+.periodic-card[data-row="3"][data-col="16"] { grid-column: 16; }
+.periodic-card[data-row="3"][data-col="17"] { grid-column: 17; }
+.periodic-card[data-row="3"][data-col="18"] { grid-column: 18; }
+
+/* Dynamic Filter Highlighting States */
+.periodic-table-grid.highlight-alkali .periodic-card:not([data-category="alkali"]),
+.periodic-table-grid.highlight-alkaline .periodic-card:not([data-category="alkaline"]),
+.periodic-table-grid.highlight-transition .periodic-card:not([data-category="transition"]),
+.periodic-table-grid.highlight-post-transition .periodic-card:not([data-category="post-transition"]),
+.periodic-table-grid.highlight-metalloid .periodic-card:not([data-category="metalloid"]),
+.periodic-table-grid.highlight-nonmetal .periodic-card:not([data-category="nonmetal"]),
+.periodic-table-grid.highlight-noble .periodic-card:not([data-category="noble"]) {
+  opacity: 0.15;
+  filter: blur(1.5px);
+  pointer-events: none;
+}
+
+/* Pulse Glow Keyframes for Filter Highlighting */
+@keyframes neon-pulse {
+  0%, 100% { transform: scale(1.05); }
+  50% { transform: scale(1.09); }
+}
+
+.periodic-table-grid.highlight-alkali .periodic-card[data-category="alkali"] .card-front,
+.periodic-table-grid.highlight-alkaline .periodic-card[data-category="alkaline"] .card-front,
+.periodic-table-grid.highlight-transition .periodic-card[data-category="transition"] .card-front,
+.periodic-table-grid.highlight-post-transition .periodic-card[data-category="post-transition"] .card-front,
+.periodic-table-grid.highlight-metalloid .periodic-card[data-category="metalloid"] .card-front,
+.periodic-table-grid.highlight-nonmetal .periodic-card[data-category="nonmetal"] .card-front,
+.periodic-table-grid.highlight-noble .periodic-card[data-category="noble"] .card-front {
+  border-color: currentColor;
+  box-shadow: 0 0 20px currentColor;
+  animation: neon-pulse 2s infinite ease-in-out;
+}
+
+/* Accessibility - Prefers Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .periodic-card-inner {
+    transition: none;
+  }
+  .periodic-card:hover .periodic-card-inner {
+    transform: none;
+  }
+  .card-front, .card-back {
+    transition: none;
+  }
+  .periodic-card:hover .card-front {
+    display: none;
+  }
+  .periodic-card:hover .card-back {
+    transform: none;
+  }
+  .periodic-table-grid.highlight-alkali .periodic-card[data-category="alkali"] .card-front,
+  .periodic-table-grid.highlight-alkaline .periodic-card[data-category="alkaline"] .card-front,
+  .periodic-table-grid.highlight-transition .periodic-card[data-category="transition"] .card-front,
+  .periodic-table-grid.highlight-post-transition .periodic-card[data-category="post-transition"] .card-front,
+  .periodic-table-grid.highlight-metalloid .periodic-card[data-category="metalloid"] .card-front,
+  .periodic-table-grid.highlight-nonmetal .periodic-card[data-category="nonmetal"] .card-front,
+  .periodic-table-grid.highlight-noble .periodic-card[data-category="noble"] .card-front {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an Interactive 3D Periodic Table of Elements component inside `submissions/examples/interactive-periodic-table-ad/`.

Closes #15556

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An interactive 3D Periodic Table of Elements with 3D flip card animations on hover/focus and category-based glowing highlights.

**How does a developer use it?**
```html
<div class="periodic-card" data-category="alkali" data-row="2" data-col="1" tabindex="0">
  <div class="periodic-card-inner">
    <div class="card-front">Li</div>
    <div class="card-back">Lithium</div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It showcases advanced CSS 3D transforms (`preserve-3d`, `perspective`) and custom HSL color property styling, which fits the animation-first philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

None.
