### PR TITLE
feat: add ease-icon-morph play/pause animation (#13979)

### DIFF
--- a/submissions/examples/ease-icon-morph/README.md
+++ b/submissions/examples/ease-icon-morph/README.md
@@ -1,0 +1,23 @@
+﻿# ease-icon-morph – Play/Pause Icon Morph
+
+A CSS clip‑path icon morph between play (triangle) and pause (two vertical bars), triggered by a class toggle. Common media player UI pattern.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen
+- **Background:** ease-bg-gray-100
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-8
+- **Hover Effects:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- Two absolutely positioned white shapes sit inside a circular blue button.
+- The play icon uses clip-path: polygon(0 0, 100% 50%, 0 100%) for a triangle.
+- The pause icon uses a compound polygon for two vertical bars.
+- Clicking toggles .is-paused on the button, which swaps opacity and animates clip‑path.
+- Transitions are smooth via cubic-bezier easing and respect prefers-reduced-motion.
+
+## How to use
+1. Copy the HTML, CSS, and JS from demo.html into your project.
+2. Ensure the path to easemotion.css is correct.
+3. Open demo.html in any modern browser.

--- a/submissions/examples/ease-icon-morph/demo.html
+++ b/submissions/examples/ease-icon-morph/demo.html
@@ -1,0 +1,38 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-icon-morph – Play/Pause Icon Morph</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-100 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">
+      Icon Morph: Play ⇄ Pause
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Click the button to toggle between play and pause states.
+    </p>
+
+    <button id="morph-btn" class="morph-button ease-hover-scale-105 ease-transition" aria-label="Toggle play/pause">
+      <span class="icon icon-play"></span>
+      <span class="icon icon-pause"></span>
+    </button>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      CSS clip‑path morph + class toggle.
+    </p>
+  </div>
+
+  <script>
+    const btn = document.getElementById('morph-btn');
+    btn.addEventListener('click', () => {
+      btn.classList.toggle('is-paused');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-icon-morph/style.css
+++ b/submissions/examples/ease-icon-morph/style.css
@@ -1,0 +1,58 @@
+﻿/* ============================================================
+   ease-icon-morph – Play/Pause icon morph
+   Uses CSS clip-path transitions between two shapes
+   ============================================================ */
+
+.morph-button {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  border: none;
+  background: #2563eb;
+  border-radius: 50%;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(37,99,235,0.3);
+}
+
+/* Both icons absolutely positioned in the same spot */
+.icon {
+  position: absolute;
+  width: 30px;
+  height: 36px;
+  background: white;
+  transition: clip-path 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Play triangle */
+.icon-play {
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  opacity: 1;
+  transition: opacity 0.3s ease, clip-path 0.4s ease;
+}
+
+/* Pause bars — hidden by default */
+.icon-pause {
+  clip-path: polygon(0 0, 40% 0, 40% 100%, 0 100%, 60% 0, 100% 0, 100% 100%, 60% 100%);
+  opacity: 0;
+  transition: opacity 0.3s ease, clip-path 0.4s ease;
+}
+
+/* Paused state — show pause, hide play */
+.morph-button.is-paused .icon-play {
+  opacity: 0;
+  clip-path: polygon(50% 50%, 50% 50%, 50% 50%);
+}
+
+.morph-button.is-paused .icon-pause {
+  opacity: 1;
+  clip-path: polygon(0 0, 40% 0, 40% 100%, 0 100%, 60% 0, 100% 0, 100% 100%, 60% 100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .icon {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #13979

ease-icon-morph – Play/Pause Icon Morph
CSS clip‑path morph between play triangle and pause bars, triggered by class toggle.

Files added
- submissions/examples/ease-icon-morph/demo.html
- submissions/examples/ease-icon-morph/style.css
- submissions/examples/ease-icon-morph/README.md

How it works
- Two white shapes in a blue circle button.
- Play: triangle polygon. Pause: two-bar polygon.
- .is-paused class toggles opacity and animates clip‑path.
- Respects prefers-reduced-motion.

EaseMotion classes used
ease-hover-scale-105, ease-fade-in, ease-delay-*, ease-container, ease-flex,
ease-text-*, ease-bg-gray-100, etc.

Custom CSS (>5 lines) for button, icon positioning, clip‑path, and transitions.