### PR TITLE
feat: add cyberpunk neon glow input field

### DIFF
--- a/submissions/examples/cyberpunk-glow-input-ad/README.md
+++ b/submissions/examples/cyberpunk-glow-input-ad/README.md
@@ -1,0 +1,20 @@
+# Cyberpunk Neon-Glow Input Field
+
+## 1. What does this do?
+This submission implements a cyberpunk-styled secure text input field. In its default state, it is framed by a simple neon cyan border. When focused by a user, the border shifts to a glowing neon magenta/pink border and loops an active pulsing glow box-shadow animation.
+
+## 2. How is it used?
+Developers can use this component by placing the `.input-group` markup inside their form elements and wrapping their input text tags in the `.cyber-input` class.
+
+```html
+<div class="input-group">
+  <input type="text" class="cyber-input" placeholder="ENTER KEY...">
+  <label class="input-label">ACCESS_GRID</label>
+</div>
+```
+
+## 3. Why is this useful?
+It serves as an introductory, beginner-level example showing:
+- **Focus Pseudo-Class Styling:** Teaches how to style interactive forms using the `:focus` selector.
+- **Custom Pulse Keyframes:** Highlights simple glowing shadow animations using CSS variables.
+- **Responsive Sibling Selection:** Employs sibling selectors (`~`) to illuminate adjacent labels when input elements are selected.

--- a/submissions/examples/cyberpunk-glow-input-ad/demo.html
+++ b/submissions/examples/cyberpunk-glow-input-ad/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Neon-Glow Input Field</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="access-card">
+    <div class="input-group">
+      <!-- Label placed below input to allow the ~ sibling selector in CSS -->
+      <input type="text" class="cyber-input" placeholder="ENTER ACCESS KEY..." aria-label="Cyberpunk Access Key Input">
+      <label class="input-label">SECURE_CREDENTIAL_</label>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-glow-input-ad/style.css
+++ b/submissions/examples/cyberpunk-glow-input-ad/style.css
@@ -1,0 +1,143 @@
+/* Custom CSS for Cyberpunk Neon-Glow Input Field */
+
+:root {
+  --bg-color: #07070c;
+  --neon-cyan: #00f0ff;
+  --neon-pink: #ff0055;
+  --glow-cyan: rgba(0, 240, 255, 0.4);
+  --glow-pink: rgba(255, 0, 85, 0.45);
+  --text-color: #f3f4f6;
+  --text-dim: #6b7280;
+  --card-bg: #0d0d18;
+}
+
+/* Reset and Layout */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  background-image: 
+    linear-gradient(rgba(18, 18, 25, 0.5) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(18, 18, 25, 0.5) 1px, transparent 1px);
+  background-size: 25px 25px;
+  color: var(--text-color);
+  font-family: 'Courier New', Courier, monospace, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+/* Access Key Card Container */
+.access-card {
+  background: var(--card-bg);
+  border: 2px solid var(--neon-cyan);
+  border-radius: 12px;
+  padding: 2.5rem 2rem;
+  width: 100%;
+  max-width: 400px;
+  box-shadow: 
+    0 0 10px var(--glow-cyan),
+    0 10px 30px rgba(0,0,0,0.6);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Neon Scan Line overlay */
+.access-card::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--neon-cyan);
+  opacity: 0.2;
+  box-shadow: 0 0 8px var(--neon-cyan);
+  animation: card-scan 3s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes card-scan {
+  0% { top: 0%; }
+  100% { top: 100%; }
+}
+
+/* Input Fields Wrapper */
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+}
+
+.input-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  transition: color 0.3s ease;
+}
+
+/* Cyberpunk Text Input Field */
+.cyber-input {
+  background: rgba(10, 10, 20, 0.85);
+  border: 1px solid var(--neon-cyan);
+  border-radius: 6px;
+  color: var(--text-color);
+  font-family: monospace;
+  font-size: 1rem;
+  font-weight: bold;
+  letter-spacing: 0.05em;
+  padding: 0.9rem 1.25rem;
+  outline: none;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.5);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+}
+
+.cyber-input::placeholder {
+  color: var(--text-dim);
+}
+
+/* Focus Action - Shifts to Glowing Pink/Magenta */
+.cyber-input:focus {
+  border-color: var(--neon-pink);
+  color: #fff;
+  box-shadow: 
+    0 0 12px var(--glow-pink),
+    inset 0 0 4px var(--glow-pink);
+  animation: input-glow-pulse 1.5s infinite alternate ease-in-out;
+}
+
+/* Label lights up when input focused */
+.cyber-input:focus ~ .input-label,
+.input-group:focus-within .input-label {
+  color: var(--neon-pink);
+  text-shadow: 0 0 4px var(--glow-pink);
+}
+
+@keyframes input-glow-pulse {
+  0% {
+    box-shadow: 0 0 6px var(--glow-pink), inset 0 0 3px var(--glow-pink);
+  }
+  100% {
+    box-shadow: 0 0 15px var(--glow-pink), inset 0 0 6px var(--glow-pink);
+  }
+}
+
+/* Accessibility - Prefers Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .access-card::after {
+    animation: none;
+    top: 50%;
+  }
+  .cyber-input:focus {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a Cyberpunk Neon-Glow Input Field component inside `submissions/examples/cyberpunk-glow-input-ad/`.

Closes #15581

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A cyberpunk-styled secure text input field that glows neon magenta/pink and wiggles when focused by the user.

**How does a developer use it?**
```html
<div class="input-group">
  <input type="text" class="cyber-input" placeholder="ENTER ACCESS KEY...">
</div>
```

**Why does it fit EaseMotion CSS?**
It provides an entry-level learning module for input focus transitions and active pulsing glow animations.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

None.
