### PR TITLE
feat: add cyberpunk password strength analyzer

### DIFF
--- a/submissions/examples/cyberpunk-password-analyzer-ad/README.md
+++ b/submissions/examples/cyberpunk-password-analyzer-ad/README.md
@@ -1,0 +1,29 @@
+# Cyberpunk Interactive Password Strength Analyzer Field
+
+## 1. What does this do?
+This submission implements a security password input field featuring cyberpunk aesthetics. It contains an interactive text field with status terminal diagnostics and a segmented block strength meter that charges block-by-block with glowing colors (Red/Critical, Yellow/Weak, Cyan/Secure) as the password complexity increases.
+
+## 2. How is it used?
+Developers can use this component by placing the `.cyber-pass-card` chassis block into their form structures:
+
+```html
+<div class="cyber-pass-card">
+  <div class="input-container">
+    <input type="password" class="cyber-pass-input">
+    <div class="status-terminal">SYS_STATUS: WAITING_</div>
+  </div>
+  <div class="strength-indicator">
+    <div class="strength-bar">
+      <div class="bar-block"></div>
+      <div class="bar-block"></div>
+      <div class="bar-block"></div>
+    </div>
+  </div>
+</div>
+```
+
+## 3. Why is this useful?
+It provides an advanced form layout demonstration showing:
+- **Interactive Form Indicators:** Combines dynamic JS logic with pure CSS variables to alter container glows and border colors depending on the complexity score.
+- **Segmented Block Alignment:** Employs transitioning segmented indicator blocks that expand neon glow animations without causing browser layout shifts.
+- **Micro-interactivity:** Integrates focus state transformations on input text blocks and status indicators.

--- a/submissions/examples/cyberpunk-password-analyzer-ad/demo.html
+++ b/submissions/examples/cyberpunk-password-analyzer-ad/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Interactive Password Strength Analyzer Field</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="cyber-pass-card" id="cardContainer">
+    <div class="input-container">
+      <input type="password" class="cyber-pass-input" id="passInput" placeholder="ENTER ACCESS CODE..." aria-label="Access Code Password Input">
+      <div class="status-terminal" id="terminalStatus">SYS_STATUS: WAITING_</div>
+    </div>
+    
+    <div class="strength-indicator">
+      <div class="strength-label">ENCRYPTION_STRENGTH</div>
+      <div class="strength-bar" id="strengthBar">
+        <div class="bar-block"></div>
+        <div class="bar-block"></div>
+        <div class="bar-block"></div>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const passInput = document.getElementById('passInput');
+      const terminalStatus = document.getElementById('terminalStatus');
+      const strengthBar = document.getElementById('strengthBar');
+      const cardContainer = document.getElementById('cardContainer');
+
+      passInput.addEventListener('input', (e) => {
+        const val = e.target.value;
+        const len = val.length;
+
+        // Reset classes
+        strengthBar.className = 'strength-bar';
+        cardContainer.className = 'cyber-pass-card';
+
+        if (len === 0) {
+          terminalStatus.textContent = 'SYS_STATUS: WAITING_';
+          terminalStatus.style.color = '';
+          terminalStatus.style.textShadow = '';
+          return;
+        }
+
+        // Calculate strength
+        let hasUpper = /[A-Z]/.test(val);
+        let hasLower = /[a-z]/.test(val);
+        let hasDigit = /[0-9]/.test(val);
+        let hasSpecial = /[^A-Za-z0-9]/.test(val);
+
+        let score = 0;
+        if (len >= 6) score++;
+        if (len >= 10) score++;
+        if (hasUpper && hasLower) score++;
+        if (hasDigit) score++;
+        if (hasSpecial) score++;
+
+        if (score <= 1) {
+          // WEAK
+          terminalStatus.textContent = 'SYS_STATUS: WEAK_';
+          terminalStatus.style.color = '#ff0055';
+          terminalStatus.style.textShadow = '0 0 4px rgba(255,0,85,0.5)';
+          strengthBar.classList.add('weak');
+          cardContainer.classList.add('state-weak');
+        } else if (score >= 2 && score <= 3) {
+          // MEDIUM
+          terminalStatus.textContent = 'SYS_STATUS: COMPROMISED_';
+          terminalStatus.style.color = '#ffcc00';
+          terminalStatus.style.textShadow = '0 0 4px rgba(255,204,0,0.5)';
+          strengthBar.classList.add('medium');
+          cardContainer.classList.add('state-medium');
+        } else {
+          // SECURE
+          terminalStatus.textContent = 'SYS_STATUS: SECURE_';
+          terminalStatus.style.color = '#00f0ff';
+          terminalStatus.style.textShadow = '0 0 4px rgba(0,240,255,0.5)';
+          strengthBar.classList.add('secure');
+          cardContainer.classList.add('state-secure');
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-password-analyzer-ad/style.css
+++ b/submissions/examples/cyberpunk-password-analyzer-ad/style.css
@@ -1,0 +1,171 @@
+/* Custom CSS for Cyberpunk Interactive Password Strength Analyzer Field */
+
+:root {
+  --bg-color: #06060a;
+  --neon-cyan: #00f0ff;
+  --neon-pink: #ff0055;
+  --neon-yellow: #ffcc00;
+  
+  --glow-cyan: rgba(0, 240, 255, 0.4);
+  --glow-pink: rgba(255, 0, 85, 0.45);
+  --glow-yellow: rgba(255, 204, 0, 0.4);
+  
+  --text-color: #e2e8f0;
+  --text-dim: #475569;
+  --card-bg: #0c0c16;
+}
+
+/* Reset and Layout */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  background-image: 
+    radial-gradient(circle at 50% 50%, #15152a 0%, transparent 85%);
+  color: var(--text-color);
+  font-family: 'Courier New', Courier, monospace, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+/* Card chassis */
+.cyber-pass-card {
+  background: var(--card-bg);
+  border: 2px solid var(--neon-cyan);
+  border-radius: 12px;
+  padding: 2.5rem 2rem;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 
+    0 0 12px var(--glow-cyan),
+    0 10px 40px rgba(0,0,0,0.7);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Diagonal stripe background pattern overlay */
+.cyber-pass-card::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; width: 100%; height: 100%;
+  background-image: linear-gradient(135deg, rgba(255,255,255,0.01) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.01) 50%, rgba(255,255,255,0.01) 75%, transparent 75%, transparent);
+  background-size: 40px 40px;
+  pointer-events: none;
+}
+
+.input-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 2rem;
+  position: relative;
+}
+
+/* Password input */
+.cyber-pass-input {
+  background: rgba(10, 10, 18, 0.85);
+  border: 1px solid var(--neon-cyan);
+  border-radius: 6px;
+  color: var(--text-color);
+  font-family: monospace;
+  font-size: 1rem;
+  font-weight: bold;
+  letter-spacing: 0.1em;
+  padding: 0.9rem 1.25rem;
+  outline: none;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.5);
+  transition: all 0.3s ease;
+}
+
+.cyber-pass-input:focus {
+  border-color: var(--neon-pink);
+  box-shadow: 
+    0 0 12px var(--glow-pink),
+    inset 0 0 4px var(--glow-pink);
+}
+
+/* Diagnostic terminal text indicator */
+.status-terminal {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--neon-cyan);
+  text-shadow: 0 0 4px var(--glow-cyan);
+  text-transform: uppercase;
+  transition: all 0.3s ease;
+}
+
+.cyber-pass-input:focus ~ .status-terminal {
+  color: var(--neon-pink);
+  text-shadow: 0 0 4px var(--glow-pink);
+}
+
+/* Segmented Indicator Bars */
+.strength-indicator {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.strength-label {
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+.strength-bar {
+  display: flex;
+  gap: 8px;
+}
+
+.bar-block {
+  flex: 1;
+  height: 8px;
+  border-radius: 2px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* State 1: WEAK (Glowing Pink/Red Block) */
+.strength-bar.weak .bar-block:nth-child(1) {
+  background: var(--neon-pink);
+  border-color: var(--neon-pink);
+  box-shadow: 0 0 10px var(--glow-pink);
+}
+
+/* State 2: MEDIUM (Glowing Yellow Blocks) */
+.strength-bar.medium .bar-block:nth-child(1),
+.strength-bar.medium .bar-block:nth-child(2) {
+  background: var(--neon-yellow);
+  border-color: var(--neon-yellow);
+  box-shadow: 0 0 10px var(--glow-yellow);
+}
+
+/* State 3: SECURE (Glowing Cyan Blocks) */
+.strength-bar.secure .bar-block {
+  background: var(--neon-cyan);
+  border-color: var(--neon-cyan);
+  box-shadow: 0 0 10px var(--glow-cyan);
+}
+
+/* Dynamic glow changes on chassis card border based on complexity state */
+.cyber-pass-card.state-weak { border-color: var(--neon-pink); box-shadow: 0 0 12px var(--glow-pink); }
+.cyber-pass-card.state-medium { border-color: var(--neon-yellow); box-shadow: 0 0 12px var(--glow-yellow); }
+.cyber-pass-card.state-secure { border-color: var(--neon-cyan); box-shadow: 0 0 12px var(--glow-cyan); }
+
+/* Accessibility - Prefers Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .bar-block {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a Cyberpunk Interactive Password Strength Analyzer Field inside `submissions/examples/cyberpunk-password-analyzer-ad/`.

Closes #15598

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An interactive Cyberpunk Password strength input field that updates diagnostic states and segmented block outlines depending on password complexity score.

**How does a developer use it?**
```html
<div class="cyber-pass-card">
  <input type="password" class="cyber-pass-input">
  <div class="strength-bar">
    <div class="bar-block"></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It showcases interactive container glow alterations and focus state transitions combined with lightweight dynamic logic.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

None.
