### PR TITLE
feat: add ease-underline-bounce animation (#13686)

### DIFF
--- a/submissions/examples/ease-underline-bounce/README.md
+++ b/submissions/examples/ease-underline-bounce/README.md
@@ -1,0 +1,21 @@
+﻿# ease-underline-bounce – Playful Underline Bounce
+
+A hover animation where the underline bounces with an elastic motion, adding a playful touch to navigation links or interactive text.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400, ease-text-xl, ease-font-semibold (via link styling)
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-8
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How it works
+- Each link has a ::after pseudo‑element that acts as an underline, initially scaled to scaleY(1).
+- On hover, a @keyframes underline-bounce animation plays: the underline stretches upward, compresses, overshoots, and settles back to normal.
+- The animation uses a cubic‑bezier timing function for a bouncy, elastic feel.
+- A static variant is provided for users who prefer reduced motion.
+
+## How to use
+1. Add the class ounce-underline to any <a> or text element.
+2. Copy the CSS into your project.
+3. Ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-underline-bounce/demo.html
+++ b/submissions/examples/ease-underline-bounce/demo.html
@@ -1,0 +1,36 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-underline-bounce – Bouncy Underline on Hover</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">
+      Playful Underline Bounce
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Hover over the links to see the underline bounce.
+    </p>
+
+    <p class="ease-text-xl ease-mb-4">
+      <a href="#" class="bounce-underline">Home</a>
+      &nbsp; • &nbsp;
+      <a href="#" class="bounce-underline">About</a>
+      &nbsp; • &nbsp;
+      <a href="#" class="bounce-underline">Portfolio</a>
+      &nbsp; • &nbsp;
+      <a href="#" class="bounce-underline">Contact</a>
+    </p>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Uses <code>transform: scaleY</code> + keyframe bounce on hover.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-underline-bounce/style.css
+++ b/submissions/examples/ease-underline-bounce/style.css
@@ -1,0 +1,48 @@
+﻿/* ============================================================
+   ease-underline-bounce – Playful underline bounce on hover
+   Uses scaleY keyframe animation on ::after pseudo-element
+   ============================================================ */
+
+/* Base link styling */
+.bounce-underline {
+  position: relative;
+  text-decoration: none;
+  color: #1e40af;
+  font-weight: 600;
+  padding-bottom: 0.15em;
+}
+
+/* Underline element */
+.bounce-underline::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: #3b82f6;
+  transform: scaleY(1);
+  transform-origin: bottom;
+  transition: transform 0.2s ease;
+}
+
+/* Bounce animation on hover */
+.bounce-underline:hover::after {
+  animation: underline-bounce 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+@keyframes underline-bounce {
+  0%   { transform: scaleY(1); }
+  40%  { transform: scaleY(2.5); }
+  60%  { transform: scaleY(0.6); }
+  80%  { transform: scaleY(1.6); }
+  100% { transform: scaleY(1); }
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .bounce-underline:hover::after {
+    animation: none;
+    transform: scaleY(1.5); /* subtle static change */
+  }
+}


### PR DESCRIPTION
Closes #13686

ease-underline-bounce – Playful Underline Bounce
An underline that bounces with elastic motion on hover.

Files added
- submissions/examples/ease-underline-bounce/demo.html
- submissions/examples/ease-underline-bounce/style.css
- submissions/examples/ease-underline-bounce/README.md

How it works
- ::after pseudo‑element serves as an underline.
- On hover, a @keyframes animation scales the underline up and down with a bouncy curve.
- Transforms use scaleY with transform-origin bottom.
- Respects prefers-reduced-motion with a static scale.

EaseMotion classes used
ease-container, ease-flex, ease-fade-in, ease-delay-*, ease-text-*, ease-bg-gray-50, etc.

Custom CSS (>5 lines) for pseudo‑element, keyframes, and hover trigger.