### PR TITLE
feat: Add Sound Mixer Board with Glowing Slide Potentiometers (resolves #15607)

### DIFF
--- a/submissions/examples/sound-mixer-potentiometer-ad/README.md
+++ b/submissions/examples/sound-mixer-potentiometer-ad/README.md
@@ -1,0 +1,56 @@
+# Sound Mixer Board — Glowing Slide Potentiometers
+
+An audio soundboard mixer layout featuring 7 instrument channel strips plus a Master bus. Each channel has a custom-styled vertical range input (potentiometer) with neon glow shadow, LED level indicators, pan knob, and dB readout display.
+
+## Preview
+
+A dark neon-red bordered mixing console with glowing cyan/green/orange/purple vertical slide faders, LED bar-graph level meters, and a BPM + FX rack footer.
+
+## Features
+
+- 🎚️ **7 Channel Strips + Master** — Kick, Snare, Hi-Hat, Bass, Synth, Lead, Vocal
+- 🌟 **Glowing Slide Potentiometers** — CSS-customized vertical `range` inputs with neon thumb glow
+  - `box-shadow` glow on `::-webkit-slider-thumb` in per-channel accent colors
+  - Custom 6px track with subtle `border-radius` and `box-shadow` halo
+- 📊 **LED Level Indicators** — 10-segment per-channel LED bar meters (green → yellow → red)
+  - JS-driven live animation based on slider position + noise
+- 🔢 **dB Readout** — Real-time decibel display (-18 dB to +12 dB) synced to each fader
+- 🎛️ **Pan Knobs** — CSS-only rotary knobs with indicator dot per channel
+- 🔇 **Mute & Solo Buttons** — With active neon state glow
+- 📡 **Dual Master VU Meter** — Stereo left/right LED columns on Master channel
+- 🔊 **FX Rack Footer** — Reverb, Delay, Compressor, Distortion, EQ toggles
+- 🔴 **Neon Red Board Aesthetic** — `border: 2px solid #ff0055` with full glow shadow
+- ♿ **Accessible** — ARIA roles, labels, `aria-valuenow` updates on fader move
+
+## File Structure
+
+```
+sound-mixer-potentiometer-ad/
+├── demo.html   # Full interactive demo
+├── style.css   # All component styles
+└── README.md   # This file
+```
+
+## CSS Techniques
+
+- `::-webkit-slider-thumb` and `::-moz-range-thumb` for custom potentiometer knobs
+- `box-shadow` neon glow on slider thumb per channel color
+- CSS Custom Properties (`--ch-accent`, `--ch-rgb`, `--pan-deg`) for per-channel theming
+- `writing-mode: vertical-lr` + `direction: rtl` for vertical range input
+- CSS Grid for responsive multi-channel layout
+- `radial-gradient` for pan knob depth shading
+- `@keyframes` for title glow and status dot blinking
+
+## JavaScript Techniques
+
+- Live `input` event → dB label conversion formula
+- `setInterval` LED animation with random noise for natural meter movement
+- Toggle classes for Mute/Solo/FX buttons with `aria-pressed` sync
+
+## Browser Support
+
+All modern browsers (Chrome, Firefox, Safari, Edge).
+
+## License
+
+Part of the EaseMotion CSS open-source library.

--- a/submissions/examples/sound-mixer-potentiometer-ad/demo.html
+++ b/submissions/examples/sound-mixer-potentiometer-ad/demo.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sound Mixer Board — Glowing Slide Potentiometers | EaseMotion CSS</title>
+  <meta name="description" content="An audio soundboard mixer with glowing neon vertical slide potentiometers, LED level indicators, and animated dB readouts." />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>⚡ MIXER BOARD PRO</h1>
+    <p>Glowing Slide Potentiometers · LED Level Indicators</p>
+  </header>
+
+  <main class="mixer-board" id="mixerBoard" role="main" aria-label="Audio Mixer Board">
+
+    <!-- Status Bar -->
+    <div class="status-bar">
+      <span class="status-text" id="boardStatus">● SYSTEM ONLINE — RECORDING ARMED</span>
+      <div class="status-indicators" aria-label="System status indicators">
+        <div class="status-dot on-green"  title="Power"></div>
+        <div class="status-dot on-yellow" title="Signal"></div>
+        <div class="status-dot on-red"    title="Clip"></div>
+      </div>
+      <button class="power-btn" id="powerBtn" aria-label="Master power toggle" title="Power">⏻</button>
+    </div>
+
+    <!-- Channel Grid -->
+    <div class="channels-container" id="channelsContainer" role="region" aria-label="Mixer channels">
+
+      <!-- CH_01 KICK -->
+      <div class="mixer-channel" id="ch1"
+           style="--ch-accent:#00f0ff; --ch-rgb:0,240,255;"
+           role="group" aria-label="Channel 1: Kick">
+        <span class="channel-label">CH_01</span>
+        <span class="channel-label" style="font-size:.42rem; opacity:.7;">KICK</span>
+        <div class="db-readout" id="db1">0 dB</div>
+        <div class="level-indicator" id="led1" aria-label="Level meter" role="meter">
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div>
+        </div>
+        <div class="slider-track-vertical">
+          <input type="range" class="mixer-potentiometer" id="pot1"
+                 orient="vertical" min="0" max="100" value="70"
+                 aria-label="Channel 1 volume" aria-valuenow="70" />
+        </div>
+        <div class="pan-knob-wrap">
+          <div class="pan-knob" style="--pan-deg:0deg" title="Pan center" aria-label="Pan knob"></div>
+          <span class="pan-label">PAN</span>
+        </div>
+        <div class="ch-actions">
+          <button class="ch-action-btn mute" aria-pressed="false" aria-label="Mute channel 1">M</button>
+          <button class="ch-action-btn solo" aria-pressed="false" aria-label="Solo channel 1">S</button>
+        </div>
+      </div>
+
+      <!-- CH_02 SNARE -->
+      <div class="mixer-channel" id="ch2"
+           style="--ch-accent:#00ff88; --ch-rgb:0,255,136;"
+           role="group" aria-label="Channel 2: Snare">
+        <span class="channel-label">CH_02</span>
+        <span class="channel-label" style="font-size:.42rem; opacity:.7;">SNARE</span>
+        <div class="db-readout" id="db2">-3 dB</div>
+        <div class="level-indicator" id="led2" aria-label="Level meter" role="meter">
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div>
+        </div>
+        <div class="slider-track-vertical">
+          <input type="range" class="mixer-potentiometer" id="pot2"
+                 orient="vertical" min="0" max="100" value="60"
+                 aria-label="Channel 2 volume" aria-valuenow="60" />
+        </div>
+        <div class="pan-knob-wrap">
+          <div class="pan-knob" style="--pan-deg:-25deg" aria-label="Pan knob"></div>
+          <span class="pan-label">PAN</span>
+        </div>
+        <div class="ch-actions">
+          <button class="ch-action-btn mute" aria-pressed="false" aria-label="Mute channel 2">M</button>
+          <button class="ch-action-btn solo" aria-pressed="false" aria-label="Solo channel 2">S</button>
+        </div>
+      </div>
+
+      <!-- CH_03 HIHAT -->
+      <div class="mixer-channel" id="ch3"
+           style="--ch-accent:#ff6a00; --ch-rgb:255,106,0;"
+           role="group" aria-label="Channel 3: Hi-Hat">
+        <span class="channel-label">CH_03</span>
+        <span class="channel-label" style="font-size:.42rem; opacity:.7;">HIHAT</span>
+        <div class="db-readout" id="db3">+2 dB</div>
+        <div class="level-indicator" id="led3" aria-label="Level meter" role="meter">
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div>
+        </div>
+        <div class="slider-track-vertical">
+          <input type="range" class="mixer-potentiometer" id="pot3"
+                 orient="vertical" min="0" max="100" value="75"
+                 aria-label="Channel 3 volume" aria-valuenow="75" />
+        </div>
+        <div class="pan-knob-wrap">
+          <div class="pan-knob" style="--pan-deg:30deg" aria-label="Pan knob"></div>
+          <span class="pan-label">PAN</span>
+        </div>
+        <div class="ch-actions">
+          <button class="ch-action-btn mute" aria-pressed="false" aria-label="Mute channel 3">M</button>
+          <button class="ch-action-btn solo" aria-pressed="false" aria-label="Solo channel 3">S</button>
+        </div>
+      </div>
+
+      <!-- CH_04 BASS -->
+      <div class="mixer-channel" id="ch4"
+           style="--ch-accent:#b44fff; --ch-rgb:180,79,255;"
+           role="group" aria-label="Channel 4: Bass">
+        <span class="channel-label">CH_04</span>
+        <span class="channel-label" style="font-size:.42rem; opacity:.7;">BASS</span>
+        <div class="db-readout" id="db4">-6 dB</div>
+        <div class="level-indicator" id="led4" aria-label="Level meter" role="meter">
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div>
+        </div>
+        <div class="slider-track-vertical">
+          <input type="range" class="mixer-potentiometer" id="pot4"
+                 orient="vertical" min="0" max="100" value="50"
+                 aria-label="Channel 4 volume" aria-valuenow="50" />
+        </div>
+        <div class="pan-knob-wrap">
+          <div class="pan-knob" style="--pan-deg:-40deg" aria-label="Pan knob"></div>
+          <span class="pan-label">PAN</span>
+        </div>
+        <div class="ch-actions">
+          <button class="ch-action-btn mute" aria-pressed="false" aria-label="Mute channel 4">M</button>
+          <button class="ch-action-btn solo" aria-pressed="false" aria-label="Solo channel 4">S</button>
+        </div>
+      </div>
+
+      <!-- CH_05 SYNTH -->
+      <div class="mixer-channel" id="ch5"
+           style="--ch-accent:#ff0055; --ch-rgb:255,0,85;"
+           role="group" aria-label="Channel 5: Synth">
+        <span class="channel-label">CH_05</span>
+        <span class="channel-label" style="font-size:.42rem; opacity:.7;">SYNTH</span>
+        <div class="db-readout" id="db5">+4 dB</div>
+        <div class="level-indicator" id="led5" aria-label="Level meter" role="meter">
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div>
+        </div>
+        <div class="slider-track-vertical">
+          <input type="range" class="mixer-potentiometer" id="pot5"
+                 orient="vertical" min="0" max="100" value="80"
+                 aria-label="Channel 5 volume" aria-valuenow="80" />
+        </div>
+        <div class="pan-knob-wrap">
+          <div class="pan-knob" style="--pan-deg:50deg" aria-label="Pan knob"></div>
+          <span class="pan-label">PAN</span>
+        </div>
+        <div class="ch-actions">
+          <button class="ch-action-btn mute" aria-pressed="false" aria-label="Mute channel 5">M</button>
+          <button class="ch-action-btn solo" aria-pressed="false" aria-label="Solo channel 5">S</button>
+        </div>
+      </div>
+
+      <!-- CH_06 LEAD -->
+      <div class="mixer-channel" id="ch6"
+           style="--ch-accent:#ffcc00; --ch-rgb:255,204,0;"
+           role="group" aria-label="Channel 6: Lead">
+        <span class="channel-label">CH_06</span>
+        <span class="channel-label" style="font-size:.42rem; opacity:.7;">LEAD</span>
+        <div class="db-readout" id="db6">-1 dB</div>
+        <div class="level-indicator" id="led6" aria-label="Level meter" role="meter">
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div>
+        </div>
+        <div class="slider-track-vertical">
+          <input type="range" class="mixer-potentiometer" id="pot6"
+                 orient="vertical" min="0" max="100" value="68"
+                 aria-label="Channel 6 volume" aria-valuenow="68" />
+        </div>
+        <div class="pan-knob-wrap">
+          <div class="pan-knob" style="--pan-deg:-15deg" aria-label="Pan knob"></div>
+          <span class="pan-label">PAN</span>
+        </div>
+        <div class="ch-actions">
+          <button class="ch-action-btn mute" aria-pressed="false" aria-label="Mute channel 6">M</button>
+          <button class="ch-action-btn solo" aria-pressed="false" aria-label="Solo channel 6">S</button>
+        </div>
+      </div>
+
+      <!-- CH_07 VOCAL -->
+      <div class="mixer-channel" id="ch7"
+           style="--ch-accent:#00f0ff; --ch-rgb:0,240,255;"
+           role="group" aria-label="Channel 7: Vocal">
+        <span class="channel-label">CH_07</span>
+        <span class="channel-label" style="font-size:.42rem; opacity:.7;">VOCAL</span>
+        <div class="db-readout" id="db7">+6 dB</div>
+        <div class="level-indicator" id="led7" aria-label="Level meter" role="meter">
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div><div class="led"></div><div class="led"></div>
+          <div class="led"></div>
+        </div>
+        <div class="slider-track-vertical">
+          <input type="range" class="mixer-potentiometer" id="pot7"
+                 orient="vertical" min="0" max="100" value="85"
+                 aria-label="Channel 7 volume" aria-valuenow="85" />
+        </div>
+        <div class="pan-knob-wrap">
+          <div class="pan-knob" style="--pan-deg:20deg" aria-label="Pan knob"></div>
+          <span class="pan-label">PAN</span>
+        </div>
+        <div class="ch-actions">
+          <button class="ch-action-btn mute" aria-pressed="false" aria-label="Mute channel 7">M</button>
+          <button class="ch-action-btn solo" aria-pressed="false" aria-label="Solo channel 7">S</button>
+        </div>
+      </div>
+
+      <!-- MASTER -->
+      <div class="mixer-channel master" id="chMaster"
+           style="--ch-accent:#ff0055; --ch-rgb:255,0,85;"
+           role="group" aria-label="Master output">
+        <span class="channel-label" style="font-size:.65rem; letter-spacing:.15em;">MASTER</span>
+        <div class="db-readout" id="dbMaster" style="color:#ff0055; text-shadow:0 0 8px #ff0055;">+3 dB</div>
+        <div class="dual-leds" aria-label="Stereo level meters">
+          <div class="level-indicator" id="ledML" aria-label="Left channel" role="meter">
+            <div class="led"></div><div class="led"></div><div class="led"></div>
+            <div class="led"></div><div class="led"></div><div class="led"></div>
+            <div class="led"></div><div class="led"></div><div class="led"></div>
+            <div class="led"></div>
+          </div>
+          <div class="level-indicator" id="ledMR" aria-label="Right channel" role="meter">
+            <div class="led"></div><div class="led"></div><div class="led"></div>
+            <div class="led"></div><div class="led"></div><div class="led"></div>
+            <div class="led"></div><div class="led"></div><div class="led"></div>
+            <div class="led"></div>
+          </div>
+        </div>
+        <div class="slider-track-vertical">
+          <input type="range" class="mixer-potentiometer" id="potMaster"
+                 orient="vertical" min="0" max="100" value="80"
+                 aria-label="Master volume" aria-valuenow="80" />
+        </div>
+        <div class="ch-actions">
+          <button class="ch-action-btn mute" aria-pressed="false" aria-label="Mute master">M</button>
+          <button class="ch-action-btn solo" aria-pressed="false" aria-label="Dim master">DIM</button>
+        </div>
+      </div>
+
+    </div><!-- /channels-container -->
+
+    <!-- Footer Controls -->
+    <div class="board-footer">
+      <div class="footer-section">
+        <div>
+          <span class="bpm-counter" id="bpmDisplay">128<span class="bpm-sub">BPM</span></span>
+        </div>
+      </div>
+      <div class="footer-section" role="group" aria-label="Effects">
+        <span class="footer-label">FX:</span>
+        <button class="fx-btn on"  id="fx1" aria-pressed="true">REVERB</button>
+        <button class="fx-btn"     id="fx2" aria-pressed="false">DELAY</button>
+        <button class="fx-btn on"  id="fx3" aria-pressed="true">COMP</button>
+        <button class="fx-btn"     id="fx4" aria-pressed="false">DIST</button>
+        <button class="fx-btn on"  id="fx5" aria-pressed="true">EQ</button>
+      </div>
+    </div>
+
+  </main>
+
+  <script>
+    // ── dB Conversion ──────────────────────────────────────
+    const LOW = -18, HIGH = 12;
+    function toDb(val) {
+      const db = Math.round(LOW + (val / 100) * (HIGH - LOW));
+      return db === 0 ? '0 dB' : (db > 0 ? `+${db} dB` : `${db} dB`);
+    }
+
+    // ── LED meter update ───────────────────────────────────
+    function updateLED(container, level) {
+      // level: 0..1
+      const leds = container.querySelectorAll('.led');
+      const count = leds.length;
+      const lit = Math.round(level * count);
+      leds.forEach((led, i) => {
+        led.classList.remove('lit-green', 'lit-yellow', 'lit-red');
+        if (i < lit) {
+          // bottom = green, top = red
+          if (i >= count - 2)     led.classList.add('lit-red');
+          else if (i >= count - 4) led.classList.add('lit-yellow');
+          else                     led.classList.add('lit-green');
+        }
+      });
+    }
+
+    // ── Slider → dB + LED ─────────────────────────────────
+    const sliderConfigs = [
+      { pot:'pot1', db:'db1', led:'led1' },
+      { pot:'pot2', db:'db2', led:'led2' },
+      { pot:'pot3', db:'db3', led:'led3' },
+      { pot:'pot4', db:'db4', led:'led4' },
+      { pot:'pot5', db:'db5', led:'led5' },
+      { pot:'pot6', db:'db6', led:'led6' },
+      { pot:'pot7', db:'db7', led:'led7' },
+      { pot:'potMaster', db:'dbMaster', led:null },
+    ];
+
+    sliderConfigs.forEach(cfg => {
+      const pot = document.getElementById(cfg.pot);
+      const dbEl = document.getElementById(cfg.db);
+      const ledEl = cfg.led ? document.getElementById(cfg.led) : null;
+      if (!pot) return;
+
+      function update() {
+        const val = parseInt(pot.value);
+        pot.setAttribute('aria-valuenow', val);
+        if (dbEl) dbEl.textContent = toDb(val);
+        if (ledEl) updateLED(ledEl, val / 100);
+      }
+
+      pot.addEventListener('input', update);
+      update(); // initial state
+    });
+
+    // ── Master dual LED animation ──────────────────────────
+    function updateMasterLEDs() {
+      const masterPot = document.getElementById('potMaster');
+      const base = masterPot ? parseInt(masterPot.value) / 100 : 0.8;
+      ['ledML', 'ledMR'].forEach((id, i) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        const noise = (Math.random() - 0.5) * 0.18;
+        updateLED(el, Math.max(0, Math.min(1, base + noise)));
+      });
+    }
+
+    // ── Background LED animation for non-master channels ──
+    function animateLEDs() {
+      sliderConfigs.forEach(cfg => {
+        if (!cfg.led || cfg.led === 'ledML' || cfg.led === 'ledMR') return;
+        const pot = document.getElementById(cfg.pot);
+        const ledEl = document.getElementById(cfg.led);
+        if (!pot || !ledEl) return;
+        const base = parseInt(pot.value) / 100;
+        const noise = (Math.random() - 0.5) * 0.2;
+        updateLED(ledEl, Math.max(0, Math.min(1, base + noise)));
+      });
+      updateMasterLEDs();
+    }
+
+    setInterval(animateLEDs, 110);
+
+    // ── Mute / Solo Toggle ─────────────────────────────────
+    document.querySelectorAll('.ch-action-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const on = btn.classList.toggle('on');
+        btn.setAttribute('aria-pressed', on);
+      });
+    });
+
+    // ── FX Toggle ──────────────────────────────────────────
+    document.querySelectorAll('.fx-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const on = btn.classList.toggle('on');
+        btn.setAttribute('aria-pressed', on);
+      });
+    });
+
+    // ── BPM counter visual ─────────────────────────────────
+    // The BPM display just shows a static 128, 
+    // but blink the status dot on every beat
+    const statusDotYellow = document.querySelector('.status-dot.on-yellow');
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/sound-mixer-potentiometer-ad/style.css
+++ b/submissions/examples/sound-mixer-potentiometer-ad/style.css
@@ -1,0 +1,538 @@
+/* ============================================================
+   Sound Mixer Board — Glowing Slide Potentiometers
+   Component: sound-mixer-potentiometer-ad
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Share+Tech+Mono&display=swap');
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── CSS Variables ───────────────────────────────────────── */
+:root {
+  --bg-deep:        #07070f;
+  --bg-board:       #0d0d1c;
+  --bg-channel:     #101020;
+  --bg-surface:     #161628;
+  --neon-red:       #ff0055;
+  --neon-cyan:      #00f0ff;
+  --neon-green:     #00ff88;
+  --neon-yellow:    #ffcc00;
+  --neon-orange:    #ff6a00;
+  --neon-purple:    #b44fff;
+  --text-bright:    #e8eaf6;
+  --text-muted:     #5a627a;
+  --text-dim:       #2a3048;
+  --led-off:        #141428;
+  --glow-red:       rgba(255,0,85,.7);
+  --glow-cyan:      rgba(0,240,255,.7);
+  --glow-green:     rgba(0,255,136,.7);
+  --glow-yellow:    rgba(255,204,0,.7);
+}
+
+/* ── Layout ──────────────────────────────────────────────── */
+body {
+  background: var(--bg-deep);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Share Tech Mono', monospace;
+  padding: 2rem 1rem;
+}
+
+/* Grid dot pattern */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(0,240,255,.06) 1px, transparent 1px);
+  background-size: 28px 28px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+.page-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.page-header h1 {
+  font-family: 'Orbitron', monospace;
+  font-size: clamp(1.2rem, 2.5vw, 2rem);
+  font-weight: 900;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--neon-red);
+  text-shadow: 0 0 12px var(--neon-red), 0 0 35px rgba(255,0,85,.5), 0 0 70px rgba(255,0,85,.2);
+  animation: titleGlow 2.5s ease-in-out infinite alternate;
+}
+
+@keyframes titleGlow {
+  from { text-shadow: 0 0 12px var(--neon-red), 0 0 35px rgba(255,0,85,.5); }
+  to   { text-shadow: 0 0 20px var(--neon-red), 0 0 60px rgba(255,0,85,.8), 0 0 100px rgba(255,0,85,.3); }
+}
+
+.page-header p {
+  color: var(--text-muted);
+  font-size: .72rem;
+  letter-spacing: .3em;
+  text-transform: uppercase;
+  margin-top: .4rem;
+}
+
+/* ── Mixer Board Container ───────────────────────────────── */
+.mixer-board {
+  position: relative;
+  z-index: 1;
+  background: var(--bg-board);
+  border: 2px solid var(--neon-red);
+  box-shadow:
+    0 0 20px rgba(255,0,85,.4),
+    0 0 60px rgba(255,0,85,.15),
+    inset 0 0 30px rgba(255,0,85,.04);
+  border-radius: 16px;
+  padding: 2rem 1.5rem 1.5rem;
+  width: 100%;
+  max-width: 900px;
+}
+
+/* Board top LED strip */
+.mixer-board::before {
+  content: '';
+  position: absolute;
+  top: -1px; left: 10%; right: 10%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--neon-red), transparent);
+  filter: blur(1px);
+}
+
+/* ── Top Status Bar ──────────────────────────────────────── */
+.status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255,0,85,.15);
+}
+
+.status-text {
+  font-family: 'Orbitron', monospace;
+  font-size: .65rem;
+  letter-spacing: .2em;
+  color: var(--neon-red);
+  text-shadow: 0 0 8px var(--neon-red);
+}
+
+.status-indicators {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--led-off);
+}
+
+.status-dot.on-green  { background: var(--neon-green);  box-shadow: 0 0 8px var(--glow-green); }
+.status-dot.on-yellow { background: var(--neon-yellow); box-shadow: 0 0 8px var(--glow-yellow); animation: blink 1s steps(1) infinite; }
+.status-dot.on-red    { background: var(--neon-red);    box-shadow: 0 0 8px var(--glow-red);   animation: blink .5s steps(1) infinite; }
+
+@keyframes blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: .2; }
+}
+
+.power-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid var(--neon-green);
+  background: rgba(0,255,136,.1);
+  color: var(--neon-green);
+  font-size: .9rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 10px rgba(0,255,136,.4);
+  transition: all .2s;
+}
+
+.power-btn:hover {
+  background: rgba(0,255,136,.25);
+  box-shadow: 0 0 20px rgba(0,255,136,.7);
+  transform: scale(1.1);
+}
+
+/* ── Channel Grid ────────────────────────────────────────── */
+.channels-container {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 1rem;
+}
+
+/* ── Individual Channel Strip ────────────────────────────── */
+.mixer-channel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .6rem;
+  background: var(--bg-channel);
+  border: 1px solid rgba(255,255,255,.05);
+  border-radius: 10px;
+  padding: .75rem .4rem .75rem;
+  position: relative;
+}
+
+.mixer-channel::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  height: 2px;
+  background: var(--ch-accent, var(--neon-cyan));
+  border-radius: 0 0 10px 10px;
+  opacity: .5;
+}
+
+/* ── Channel Label ───────────────────────────────────────── */
+.channel-label {
+  font-family: 'Orbitron', monospace;
+  font-size: .5rem;
+  font-weight: 700;
+  letter-spacing: .1em;
+  color: var(--ch-accent, var(--neon-cyan));
+  text-shadow: 0 0 8px var(--ch-accent, var(--neon-cyan));
+  text-transform: uppercase;
+}
+
+/* ── dB Readout ──────────────────────────────────────────── */
+.db-readout {
+  font-family: 'Orbitron', monospace;
+  font-size: .55rem;
+  color: var(--ch-accent, var(--neon-cyan));
+  text-shadow: 0 0 6px var(--ch-accent, var(--neon-cyan));
+  background: var(--bg-surface);
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 4px;
+  padding: 2px 6px;
+  min-width: 40px;
+  text-align: center;
+  transition: color .1s;
+}
+
+/* ── LED Level Indicator (Vertical LED column) ───────────── */
+.level-indicator {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 2px;
+  height: 80px;
+  width: 14px;
+}
+
+.led {
+  flex: 1;
+  border-radius: 2px;
+  background: var(--led-off);
+  transition: background .08s, box-shadow .08s;
+}
+
+.led.lit-green  { background: var(--neon-green);  box-shadow: 0 0 6px var(--glow-green); }
+.led.lit-yellow { background: var(--neon-yellow); box-shadow: 0 0 6px var(--glow-yellow); }
+.led.lit-red    { background: var(--neon-red);    box-shadow: 0 0 6px var(--glow-red); }
+
+/* ── Vertical Slider Track ───────────────────────────────── */
+.slider-track-vertical {
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+/* Glow track behind the input */
+.slider-track-vertical::before {
+  content: '';
+  position: absolute;
+  width: 4px;
+  height: 100%;
+  background: linear-gradient(to top, var(--ch-accent, var(--neon-cyan)), transparent);
+  border-radius: 2px;
+  opacity: .25;
+  filter: blur(2px);
+  pointer-events: none;
+}
+
+/* ── Potentiometer Input ─────────────────────────────────── */
+.mixer-potentiometer {
+  -webkit-appearance: slider-vertical;
+  writing-mode: vertical-lr;
+  direction: rtl;
+  width: 28px;
+  height: 140px;
+  background: transparent;
+  outline: none;
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+}
+
+/* Track */
+.mixer-potentiometer::-webkit-slider-runnable-track {
+  width: 6px;
+  background: #090914;
+  border-radius: 3px;
+  border: 1px solid rgba(255,255,255,.08);
+  box-shadow: 0 0 10px rgba(var(--ch-rgb, 0,240,255), .2);
+}
+
+/* Thumb — glowing sliding knob */
+.mixer-potentiometer::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 26px;
+  height: 12px;
+  background: linear-gradient(180deg, #2a2a45 0%, #0e0e20 100%);
+  border: 1px solid var(--ch-accent, var(--neon-cyan));
+  box-shadow:
+    0 0 10px var(--ch-accent, var(--neon-cyan)),
+    0 0 20px rgba(var(--ch-rgb, 0,240,255), .4),
+    inset 0 1px 0 rgba(255,255,255,.15);
+  border-radius: 3px;
+  cursor: grab;
+  transition: box-shadow .15s;
+}
+
+.mixer-potentiometer::-webkit-slider-thumb:active {
+  cursor: grabbing;
+  box-shadow:
+    0 0 18px var(--ch-accent, var(--neon-cyan)),
+    0 0 40px rgba(var(--ch-rgb, 0,240,255), .7),
+    inset 0 1px 0 rgba(255,255,255,.2);
+}
+
+/* Firefox */
+.mixer-potentiometer::-moz-range-track {
+  width: 6px;
+  height: 140px;
+  background: #090914;
+  border-radius: 3px;
+}
+
+.mixer-potentiometer::-moz-range-thumb {
+  width: 26px;
+  height: 12px;
+  background: linear-gradient(180deg, #2a2a45, #0e0e20);
+  border: 1px solid var(--ch-accent, var(--neon-cyan));
+  border-radius: 3px;
+  box-shadow: 0 0 10px var(--ch-accent, var(--neon-cyan));
+  cursor: grab;
+}
+
+/* ── Pan Knob ────────────────────────────────────────────── */
+.pan-knob-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+
+.pan-knob {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #252540, #080812);
+  border: 1px solid rgba(255,255,255,.1);
+  box-shadow: inset 0 2px 4px rgba(255,255,255,.05), 0 2px 6px rgba(0,0,0,.6);
+  position: relative;
+  cursor: pointer;
+  transition: border-color .2s;
+}
+
+.pan-knob::after {
+  content: '';
+  position: absolute;
+  width: 2px;
+  height: 8px;
+  background: var(--ch-accent, var(--neon-cyan));
+  box-shadow: 0 0 5px var(--ch-accent, var(--neon-cyan));
+  border-radius: 1px;
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%) rotate(var(--pan-deg, 0deg));
+  transform-origin: 50% calc(100% + 2px);
+}
+
+.pan-knob:hover {
+  border-color: var(--ch-accent, var(--neon-cyan));
+  box-shadow: inset 0 2px 4px rgba(255,255,255,.05), 0 0 12px rgba(var(--ch-rgb,0,240,255),.4);
+}
+
+.pan-label {
+  font-size: .48rem;
+  color: var(--text-muted);
+  letter-spacing: .1em;
+}
+
+/* ── Mute / Solo ─────────────────────────────────────────── */
+.ch-actions {
+  display: flex;
+  gap: 3px;
+  width: 100%;
+}
+
+.ch-action-btn {
+  flex: 1;
+  padding: 3px 0;
+  border-radius: 4px;
+  border: 1px solid rgba(255,255,255,.08);
+  background: var(--bg-surface);
+  font-family: 'Share Tech Mono', monospace;
+  font-size: .5rem;
+  letter-spacing: .05em;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all .15s;
+  text-transform: uppercase;
+}
+
+.ch-action-btn.mute:hover,
+.ch-action-btn.mute.on {
+  background: rgba(255,0,85,.2);
+  border-color: var(--neon-red);
+  color: var(--neon-red);
+  box-shadow: 0 0 8px rgba(255,0,85,.4);
+}
+
+.ch-action-btn.solo:hover,
+.ch-action-btn.solo.on {
+  background: rgba(255,204,0,.2);
+  border-color: var(--neon-yellow);
+  color: var(--neon-yellow);
+  box-shadow: 0 0 8px rgba(255,204,0,.4);
+}
+
+/* ── Master Channel (last, wider) ────────────────────────── */
+.mixer-channel.master {
+  background: linear-gradient(180deg, #0e0e20, #07070f);
+  border-color: rgba(255,0,85,.2);
+}
+
+.mixer-channel.master .channel-label {
+  font-size: .6rem;
+}
+
+.master .slider-track-vertical {
+  height: 160px;
+}
+
+.master .mixer-potentiometer {
+  height: 160px;
+  width: 34px;
+}
+
+.master .mixer-potentiometer::-webkit-slider-thumb {
+  width: 32px;
+  height: 14px;
+}
+
+/* ── Master dual LED ─────────────────────────────────────── */
+.dual-leds {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3px;
+}
+
+.dual-leds .level-indicator {
+  width: 10px;
+}
+
+/* ── Bottom Controls Row ─────────────────────────────────── */
+.board-footer {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255,0,85,.1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.footer-section {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+}
+
+.footer-label {
+  font-size: .55rem;
+  color: var(--text-muted);
+  letter-spacing: .2em;
+  text-transform: uppercase;
+}
+
+.fx-btn {
+  padding: 5px 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(255,255,255,.1);
+  background: var(--bg-surface);
+  font-family: 'Share Tech Mono', monospace;
+  font-size: .55rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  letter-spacing: .1em;
+  transition: all .2s;
+}
+
+.fx-btn:hover,
+.fx-btn.on {
+  color: var(--neon-purple);
+  border-color: var(--neon-purple);
+  background: rgba(180,79,255,.15);
+  box-shadow: 0 0 10px rgba(180,79,255,.35);
+}
+
+/* BPM counter */
+.bpm-counter {
+  font-family: 'Orbitron', monospace;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--neon-red);
+  text-shadow: 0 0 12px var(--neon-red);
+  letter-spacing: .05em;
+}
+
+.bpm-sub {
+  font-size: .5rem;
+  color: var(--text-muted);
+  letter-spacing: .2em;
+  display: block;
+  margin-top: 1px;
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+@media (max-width: 700px) {
+  .channels-container {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  .mixer-channel.master {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 400px) {
+  .channels-container {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
Implements the Interactive Audio Sound Mixer Board with Glowing Slide Potentiometers, resolves #15607.

A complete 7-channel + Master audio mixing console with neon-glowing CSS-customized vertical range sliders, live LED level meters, and dB readouts.

## What Was Built
- 7 channel strips (Kick, Snare, Hi-Hat, Bass, Synth, Lead, Vocal) + Master
- CSS-customized `::-webkit-slider-thumb` with `box-shadow` neon glow per channel accent color
- 10-segment LED level meters animated by JS (green → yellow → red based on slider level + noise)
- Real-time dB readout labels (-18 dB to +12 dB) synced to each vertical fader
- CSS-only pan knobs with `--pan-deg` CSS custom property rotation
- Mute/Solo toggle buttons with neon active states
- Dual stereo Master VU meter columns
- FX Rack footer (Reverb, Delay, Comp, Dist, EQ toggles)
- Neon red board aesthetic: `border: 2px solid #ff0055` with full `box-shadow` glow

## Files Added
- `submissions/examples/sound-mixer-potentiometer-ad/demo.html`
- `submissions/examples/sound-mixer-potentiometer-ad/style.css`
- `submissions/examples/sound-mixer-potentiometer-ad/README.md`

## Policy Checklist
- [x] New files only — no existing files modified or deleted
- [x] All 3 required files present (demo.html, style.css, README.md)
- [x] Placed in `submissions/examples/sound-mixer-potentiometer-ad/`
- [x] 980+ lines of code (well exceeds 250-line minimum)
- [x] Self-contained, works by opening demo.html directly
