### PR TITLE
feat: add ease-swipe-delete-reveal animation (#13701)

### DIFF
--- a/submissions/examples/ease-swipe-delete-reveal/README.md
+++ b/submissions/examples/ease-swipe-delete-reveal/README.md
@@ -1,0 +1,24 @@
+﻿# ease-swipe-delete-reveal – Swipe to Delete Reveal
+
+An iOS‑style swipe‑to‑delete interaction. Swiping left on a list item reveals a red delete background and icon. Works with both touch and mouse.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-max-w-md
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400, ease-font-semibold
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-8
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How it works
+- Each item has a red delete <div> absolutely positioned behind the foreground content.
+- JavaScript tracks pointerdown, pointermove, and pointerup to translate the content leftward.
+- If the swipe exceeds half the delete area, the item snaps to the open state (-120px).
+- Tapping the delete area removes the item with a smooth collapse.
+- The item snaps back if the swipe is insufficient.
+- 	ouch-action: pan-y allows vertical scrolling while swiping horizontally.
+- The animation respects prefers-reduced-motion.
+
+## How to use
+1. Copy the HTML, CSS, and JS into your project.
+2. Ensure the path to easemotion.css is correct.
+3. Open demo.html in any modern browser.

--- a/submissions/examples/ease-swipe-delete-reveal/demo.html
+++ b/submissions/examples/ease-swipe-delete-reveal/demo.html
@@ -1,0 +1,123 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-swipe-delete-reveal – Swipe to Delete</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-max-w-md ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">
+      Swipe to Delete
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Swipe left on an item to reveal the delete button. Works with touch & mouse.
+    </p>
+
+    <ul id="list" class="list">
+      <li class="list-item" data-id="1">
+        <div class="delete-bg">🗑️ Delete</div>
+        <div class="item-content">
+          <span class="ease-font-semibold">Meeting at 10 AM</span>
+          <span class="ease-text-sm ease-text-gray-500">Conference room B</span>
+        </div>
+      </li>
+      <li class="list-item" data-id="2">
+        <div class="delete-bg">🗑️ Delete</div>
+        <div class="item-content">
+          <span class="ease-font-semibold">Lunch with team</span>
+          <span class="ease-text-sm ease-text-gray-500">12:30 PM – The Bistro</span>
+        </div>
+      </li>
+      <li class="list-item" data-id="3">
+        <div class="delete-bg">🗑️ Delete</div>
+        <div class="item-content">
+          <span class="ease-font-semibold">Project review</span>
+          <span class="ease-text-sm ease-text-gray-500">2:00 PM – Desk</span>
+        </div>
+      </li>
+    </ul>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      CSS visual layers + JavaScript touch/mouse tracking.
+    </p>
+  </div>
+
+  <script>
+    const list = document.getElementById('list');
+
+    let startX = 0;
+    let currentItem = null;
+    let isDragging = false;
+    let initialTranslateX = 0;
+
+    list.addEventListener('pointerdown', (e) => {
+      const item = e.target.closest('.list-item');
+      if (!item) return;
+
+      // Reset other items
+      document.querySelectorAll('.list-item.open').forEach(el => {
+        if (el !== item) {
+          el.classList.remove('open');
+          el.querySelector('.item-content').style.transform = '';
+        }
+      });
+
+      startX = e.clientX;
+      currentItem = item;
+      isDragging = true;
+      initialTranslateX = 0;
+      const content = item.querySelector('.item-content');
+      if (content.style.transform) {
+        initialTranslateX = parseFloat(content.style.transform.match(/-?[\d.]+/)?.[0] ?? '0');
+      }
+      content.style.transition = 'none';
+    });
+
+    window.addEventListener('pointermove', (e) => {
+      if (!isDragging || !currentItem) return;
+      const dx = e.clientX - startX + initialTranslateX;
+      const content = currentItem.querySelector('.item-content');
+      if (dx <= 0) {
+        content.style.transform = 	ranslateX(px);
+      }
+    });
+
+    window.addEventListener('pointerup', () => {
+      if (!isDragging || !currentItem) return;
+      isDragging = false;
+      const content = currentItem.querySelector('.item-content');
+      content.style.transition = 'transform 0.3s ease';
+      const currentTranslate = parseFloat(content.style.transform.match(/-?[\d.]+/)?.[0] ?? '0');
+      if (currentTranslate < -60) {
+        content.style.transform = 'translateX(-120px)';
+        currentItem.classList.add('open');
+      } else {
+        content.style.transform = '';
+        currentItem.classList.remove('open');
+      }
+      currentItem = null;
+    });
+
+    // Delete button click
+    list.addEventListener('click', (e) => {
+      if (e.target.closest('.delete-bg')) {
+        const item = e.target.closest('.list-item');
+        if (item) {
+          item.style.transition = 'opacity 0.3s ease, max-height 0.3s ease';
+          item.style.maxHeight = item.offsetHeight + 'px';
+          requestAnimationFrame(() => {
+            item.style.maxHeight = '0';
+            item.style.opacity = '0';
+          });
+          item.addEventListener('transitionend', () => item.remove());
+        }
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-swipe-delete-reveal/style.css
+++ b/submissions/examples/ease-swipe-delete-reveal/style.css
@@ -1,0 +1,57 @@
+﻿/* ============================================================
+   ease-swipe-delete-reveal – Swipe to reveal delete
+   CSS visual layers + JS touch/mouse tracking
+   ============================================================ */
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.list-item {
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  margin-bottom: 0.5rem;
+  background: #ffffff;
+  user-select: none;
+}
+
+/* Red delete background */
+.delete-bg {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 120px;
+  height: 100%;
+  background: #ef4444;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.9rem;
+  border-radius: 0 0.75rem 0.75rem 0;
+  cursor: pointer;
+}
+
+/* Foreground content */
+.item-content {
+  position: relative;
+  z-index: 1;
+  background: #ffffff;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s ease;
+  touch-action: pan-y; /* allow vertical scroll */
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .item-content {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #13701

ease-swipe-delete-reveal – iOS‑style swipe‑to‑delete
Swiping left reveals a red delete background and icon. Works with touch & mouse.

Files added
- submissions/examples/ease-swipe-delete-reveal/demo.html
- submissions/examples/ease-swipe-delete-reveal/style.css
- submissions/examples/ease-swipe-delete-reveal/README.md

How it works
- Delete area is absolutely positioned behind the content.
- JS pointer events track horizontal drag to translate the content.
- Snap to open if swiped >60px; snap back otherwise.
- Tapping delete removes the item with a collapse animation.
- CSS handles visual layers; JS handles touch/mouse logic.
- Respects prefers-reduced-motion.

EaseMotion classes used
ease-container, ease-flex, ease-fade-in, ease-delay-*, ease-text-*, ease-bg-gray-50, etc.

Custom CSS (>5 lines) for layering, delete background, and transitions.