### PR TITLE
feat: add ease-image-reveal-mask animation (#13688)

### DIFF
--- a/submissions/examples/ease-image-reveal-mask/README.md
+++ b/submissions/examples/ease-image-reveal-mask/README.md
@@ -1,0 +1,25 @@
+﻿# ease-image-reveal-mask – Image Reveal with Clip Mask
+
+A collection of image reveal animations using CSS clip-path animations instead of simple opacity fades. Includes diagonal wipe, circle expand, and diamond reveal.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-grid, ease-grid-cols-1, ease-md-grid-cols-3, ease-gap-6, ease-py-16
+- **Background:** ease-bg-gray-100
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400, ease-font-semibold
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-2, ease-mt-6
+- **Components:** ease-btn, ease-btn-secondary
+- **Hover Effects:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- Each image is wrapped in a container that has an initial clip-path set to a zero‑area shape (e.g., circle(0%) or polygon(0 0, 0 0, 0 0, 0 0)).
+- JavaScript adds the class .animate after a short delay, which transitions the clip-path to a full‑size shape.
+- The 	ransition property on the wrapper animates the reveal smoothly.
+- Three variants are demonstrated: diagonal wipe, circle expand, and diamond.
+- The "Replay Reveals" button removes and re‑applies the animation class.
+- All animations respect prefers-reduced-motion, showing the full image immediately.
+
+## How to use
+1. Copy the HTML, CSS, and JS into your project.
+2. Ensure the path to easemotion.css is correct.
+3. Open demo.html in any modern browser.

--- a/submissions/examples/ease-image-reveal-mask/demo.html
+++ b/submissions/examples/ease-image-reveal-mask/demo.html
@@ -1,0 +1,76 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-image-reveal-mask – Image Reveal with Clip Mask</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-100 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">
+      Image Reveal Mask
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Three clip‑path reveal variants: diagonal, circle expand, diamond.
+    </p>
+
+    <div class="ease-grid ease-grid-cols-1 ease-md-grid-cols-3 ease-gap-6 ease-mb-8">
+      <!-- Diagonal reveal -->
+      <div class="reveal-card">
+        <div class="reveal-image reveal-diagonal">
+          <img src="https://placehold.co/400x300" alt="Diagonal reveal">
+        </div>
+        <p class="ease-text-sm ease-mt-2 ease-font-semibold">Diagonal Wipe</p>
+      </div>
+
+      <!-- Circle expand reveal -->
+      <div class="reveal-card">
+        <div class="reveal-image reveal-circle">
+          <img src="https://placehold.co/400x300" alt="Circle expand">
+        </div>
+        <p class="ease-text-sm ease-mt-2 ease-font-semibold">Circle Expand</p>
+      </div>
+
+      <!-- Diamond reveal -->
+      <div class="reveal-card">
+        <div class="reveal-image reveal-diamond">
+          <img src="https://placehold.co/400x300" alt="Diamond reveal">
+        </div>
+        <p class="ease-text-sm ease-mt-2 ease-font-semibold">Diamond</p>
+      </div>
+    </div>
+
+    <button id="replay-btn" class="ease-btn ease-btn-secondary ease-hover-scale-105 ease-transition">
+      Replay Reveals
+    </button>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-6 ease-fade-in ease-delay-500">
+      Uses <code>clip‑path</code> animation from 0‑area to full.
+    </p>
+  </div>
+
+  <script>
+    const replayBtn = document.getElementById('replay-btn');
+    const revealWrappers = document.querySelectorAll('.reveal-image');
+
+    function replay() {
+      revealWrappers.forEach(w => {
+        w.classList.remove('animate');
+        void w.offsetWidth; // force reflow
+        w.classList.add('animate');
+      });
+    }
+
+    // Auto-play on load
+    window.addEventListener('load', () => {
+      setTimeout(replay, 300);
+    });
+
+    replayBtn.addEventListener('click', replay);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-image-reveal-mask/style.css
+++ b/submissions/examples/ease-image-reveal-mask/style.css
@@ -1,0 +1,63 @@
+﻿/* ============================================================
+   ease-image-reveal-mask – Image reveals using clip-path
+   Multiple mask variants: diagonal, circle, diamond
+   ============================================================ */
+
+/* Card container */
+.reveal-card {
+  background: #ffffff;
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+}
+
+/* Image wrapper – clip-path is applied here */
+.reveal-image {
+  overflow: hidden;
+  border-radius: 0.5rem;
+  clip-path: polygon(0 0, 0 0, 0 0, 0 0); /* hidden by default */
+  transition: clip-path 1s ease-out;
+}
+
+.reveal-image img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* When the .animate class is added, the clip-path animates to full */
+.reveal-image.animate {
+  /* each variant sets its own final clip-path in its selector */
+}
+
+/* ---------- Diagonal wipe (bottom-left to top-right) ---------- */
+.reveal-diagonal {
+  clip-path: polygon(0 100%, 0 100%, 0 100%, 0 100%);
+}
+.reveal-diagonal.animate {
+  clip-path: polygon(0 100%, 100% 0, 100% 100%, 0 100%);
+}
+
+/* ---------- Circle expand ---------- */
+.reveal-circle {
+  clip-path: circle(0% at 50% 50%);
+}
+.reveal-circle.animate {
+  clip-path: circle(50% at 50% 50%);
+}
+
+/* ---------- Diamond reveal ---------- */
+.reveal-diamond {
+  clip-path: polygon(50% 50%, 50% 50%, 50% 50%, 50% 50%);
+}
+.reveal-diamond.animate {
+  clip-path: polygon(0% 50%, 50% 0%, 100% 50%, 50% 100%);
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .reveal-image {
+    transition: none;
+    clip-path: none; /* show full image */
+  }
+}


### PR DESCRIPTION
Closes #13688

ease-image-reveal-mask – Image Reveal with Clip Mask
Three clip-path reveal variants: diagonal wipe, circle expand, diamond reveal.

Files added
- submissions/examples/ease-image-reveal-mask/demo.html
- submissions/examples/ease-image-reveal-mask/style.css
- submissions/examples/ease-image-reveal-mask/README.md

How it works
- Images wrapped in containers with initial zero‑area clip-path.
- .animate class transitions clip-path to full shape.
- Variants: diagonal (polygon), circle, diamond.
- Replay button resets and re‑triggers animation.
- Respects prefers-reduced-motion.

EaseMotion classes used
ease-btn, ease-btn-secondary, ease-hover-scale-105, ease-fade-in, ease-delay-*,
ease-container, ease-grid, ease-flex, ease-text-*, ease-bg-gray-100, etc.

Custom CSS (>5 lines) for clip-path shapes, transitions, and replay logic.