### PR TITLE
feat: implement animated removable filter chip (#13560)

### DIFF
--- a/submissions/examples/ease-chip-removable/README.md
+++ b/submissions/examples/ease-chip-removable/README.md
@@ -1,0 +1,20 @@
+# Removable Chip (`ease-chip-removable`)
+
+An interactive tag/chip component featuring a sleek hover-reveal close button and a smooth width-collapsing removal animation. Built for the EaseMotion-css framework.
+
+## 🚀 Features
+
+- **Hover Reveal**: The `&times;` close button is hidden by default and smoothly slides out into view when the chip is hovered.
+- **Collapse Animation**: Instead of instantly disappearing, removed chips smoothly shrink their `max-width`, `padding`, and `margin` to `0` while fading out, preventing abrupt UI jumping.
+- **Overflow Hidden**: Uses `overflow: hidden` and `white-space: nowrap` to ensure text doesn't wrap or spill out during the collapse animation.
+- **Color Variants**: Easy to customize using CSS variables for background and text colors.
+
+## 🛠️ Usage
+
+Use the `.ease-chip` container along with the `.ease-chip-close` button.
+
+```html
+<div class="ease-chip">
+  <span class="ease-chip-text">Frontend</span>
+  <button class="ease-chip-close" aria-label="Remove filter">&times;</button>
+</div>

--- a/submissions/examples/ease-chip-removable/demo.html
+++ b/submissions/examples/ease-chip-removable/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Removable Chip - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="demo-wrapper">
+    <header class="demo-header">
+      <h1>EaseMotion Removable Chip</h1>
+      <p>Filter tags that reveal a close button on hover and collapse smoothly when removed.</p>
+    </header>
+
+    <main class="demo-grid">
+      <section class="demo-card">
+        <h2>Active Filters</h2>
+        
+        <div class="filter-container">
+          
+          <div class="ease-chip">
+            <span class="ease-chip-text">Frontend Development</span>
+            <button class="ease-chip-close" aria-label="Remove filter">&times;</button>
+          </div>
+
+          <div class="ease-chip ease-chip-blue">
+            <span class="ease-chip-text">React.js</span>
+            <button class="ease-chip-close" aria-label="Remove filter">&times;</button>
+          </div>
+
+          <div class="ease-chip ease-chip-green">
+            <span class="ease-chip-text">Open Source</span>
+            <button class="ease-chip-close" aria-label="Remove filter">&times;</button>
+          </div>
+
+          <div class="ease-chip ease-chip-purple">
+            <span class="ease-chip-text">CSS Animations</span>
+            <button class="ease-chip-close" aria-label="Remove filter">&times;</button>
+          </div>
+
+          <button id="reset-btn" class="reset-button">Reset All</button>
+
+        </div>
+        
+      </section>
+    </main>
+  </div>
+
+  <script>
+    // Logic to handle the collapse animation
+    const closeButtons = document.querySelectorAll('.ease-chip-close');
+    const resetBtn = document.getElementById('reset-btn');
+    const chips = document.querySelectorAll('.ease-chip');
+
+    closeButtons.forEach(btn => {
+      btn.addEventListener('click', function() {
+        const chip = this.closest('.ease-chip');
+        // Add the removed class to trigger the CSS transition
+        chip.classList.add('ease-chip-removed');
+        
+        // Optional: Completely remove element from DOM after transition completes
+        setTimeout(() => {
+          chip.style.display = 'none';
+        }, 400); 
+      });
+    });
+
+    // Reset logic for the demo playground
+    resetBtn.addEventListener('click', () => {
+      chips.forEach(chip => {
+        chip.style.display = 'inline-flex';
+        // Small timeout to allow display block to render before removing class
+        setTimeout(() => {
+          chip.classList.remove('ease-chip-removed');
+        }, 10);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-chip-removable/style.css
+++ b/submissions/examples/ease-chip-removable/style.css
@@ -1,0 +1,172 @@
+/* ========================================================================
+   Component: ease-chip-removable
+   ======================================================================== */
+
+:root {
+  --ease-chip-bg: #e2e8f0;
+  --ease-chip-text: #334155;
+  --ease-chip-radius: 9999px;
+  --ease-chip-height: 32px;
+}
+
+/* --- Base Chip Container --- */
+.ease-chip {
+  display: inline-flex;
+  align-items: center;
+  height: var(--ease-chip-height);
+  background-color: var(--ease-chip-bg);
+  color: var(--ease-chip-text);
+  border-radius: var(--ease-chip-radius);
+  padding: 0 12px;
+  margin-right: 8px;
+  margin-bottom: 8px;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+  
+  /* Crucial for the collapse animation */
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 250px; /* Arbitrary large width for transition */
+  opacity: 1;
+  
+  /* Transition max-width, padding, and opacity together */
+  transition: 
+    max-width 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+    padding 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+    margin 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.3s ease,
+    background-color 0.2s ease;
+}
+
+/* Base Hover */
+.ease-chip:hover {
+  background-color: #cbd5e1;
+}
+
+/* --- The Close (×) Button --- */
+.ease-chip-close {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-left: 0;
+  color: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  
+  /* Hidden by default */
+  width: 0;
+  opacity: 0;
+  overflow: hidden;
+  
+  /* Animate sliding in */
+  transition: 
+    width 0.2s cubic-bezier(0.4, 0, 0.2, 1), 
+    opacity 0.2s ease, 
+    margin-left 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Slide in on Chip Hover */
+.ease-chip:hover .ease-chip-close {
+  width: 16px;
+  opacity: 0.6;
+  margin-left: 6px;
+}
+
+/* Highlight button when directly hovered */
+.ease-chip-close:hover {
+  opacity: 1 !important;
+  transform: scale(1.1);
+}
+
+/* --- The Removal State --- */
+/* Applied via JS when the close button is clicked */
+.ease-chip.ease-chip-removed {
+  max-width: 0;
+  padding-left: 0;
+  padding-right: 0;
+  margin-right: 0;
+  opacity: 0;
+  border-width: 0;
+}
+
+/* --- Color Variants (Optional) --- */
+.ease-chip-blue {
+  --ease-chip-bg: #dbeafe;
+  --ease-chip-text: #1e40af;
+}
+.ease-chip-blue:hover { background-color: #bfdbfe; }
+
+.ease-chip-green {
+  --ease-chip-bg: #dcfce3;
+  --ease-chip-text: #166534;
+}
+.ease-chip-green:hover { background-color: #bbf7d0; }
+
+.ease-chip-purple {
+  --ease-chip-bg: #f3e8ff;
+  --ease-chip-text: #6b21a8;
+}
+.ease-chip-purple:hover { background-color: #e9d5ff; }
+
+/* ========================================================================
+   Demo Page Styling (Not part of core component)
+   ======================================================================== */
+
+body {
+  margin: 0;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+.demo-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.demo-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.demo-card h2 {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  font-size: 1.25rem;
+}
+
+.filter-container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  padding: 1rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  min-height: 80px;
+}
+
+.reset-button {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: #3b82f6;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 8px 12px;
+  border-radius: 6px;
+}
+
+.reset-button:hover {
+  background: #eff6ff;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #13560 by introducing the `ease-chip-removable` component. It provides an interactive filter/tag UI element that gracefully animates its removal to prevent abrupt layout shifts.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-chip-removable/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It adds a removable tag/chip component where the close button slides into view on hover, and clicking it triggers a smooth "width collapse to 0" exit animation.

**How does a developer use it?**

```html
<div class="ease-chip">
  <span class="ease-chip-text">React.js</span>
  <button class="ease-chip-close" aria-label="Remove filter">&times;</button>
</div>


**Why does it fit EaseMotion CSS?**

It utilizes a pure CSS transition sequence targeting max-width, margin, padding, and opacity simultaneously to achieve the "collapse to zero" effect. It utilizes overflow: hidden strictly so the inner content never breaks the layout during the animation, adhering to the animation-first UI philosophy.
---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

I implemented the initial width using a large max-width (e.g., 250px) combined with white-space: nowrap. This allows the chip to dynamically fit any text size normally, but still gives the CSS a hard number to transition down to max-width: 0 when the ease-chip-removed class is applied. I've also added a reset button in demo.html so you can test the removal effect multiple times!
