### PR TITLE
feat: add full medical clinic landing page (issue #14814)

### DIFF
--- a/submissions/examples/medical-clinic-landing-im/README.md
+++ b/submissions/examples/medical-clinic-landing-im/README.md
@@ -1,0 +1,54 @@
+# Riverside Health Clinic — Full Landing Page
+
+A complete, self-contained, ready-to-copy Healthcare business landing page
+built with EaseMotion CSS entrance and hover animation classes. Opens
+directly in a browser — no build step required.
+
+## Files
+- `demo.html` - Full landing page markup
+- `style.css` - All styles, including EaseMotion animation classes and page layout
+- `README.md` - This file
+
+## Required Sections (per issue checklist)
+- ✅ Hero with appointment CTA
+- ✅ Departments/specialties grid (8 specialties)
+- ✅ Doctor profiles with credentials (3 doctors)
+- ✅ Patient portal CTA
+- ✅ Insurance accepted logos (6 providers)
+- ✅ Patient reviews (3 testimonials with star ratings)
+- ✅ Emergency contact banner
+
+## EaseMotion Classes Showcased
+
+| Class | Used For |
+|---|---|
+| `.ease-fade-in` | Section headers, banner, footer, insurance row entrance |
+| `.ease-slide-up` | Hero heading, subtext, and CTA buttons (staggered via `animation-delay`) |
+| `.ease-hover-lift` | Department cards, doctor cards, review cards |
+| `.ease-hover-grow` | Buttons and insurance logos on hover |
+| `.ease-hover-underline` | Nav links |
+| `.ease-btn`, `.ease-btn-primary`, `.ease-btn-outline` | All call-to-action buttons |
+
+Entrance animations are staggered using inline `animation-delay` on grid
+items (e.g. department cards, doctor cards, review cards) to create a
+cascading reveal effect without extra JS.
+
+## Layout Classes
+Page-specific layout/structure classes are namespaced under `clinic-*`
+(e.g. `.clinic-hero`, `.clinic-grid`, `.clinic-card`) to avoid any
+collision with `core/` class names, while every interactive/animated
+element uses the shared `ease-*` classes.
+
+## Responsive Behavior
+- **Desktop**: 4-column department grid, 3-column doctor/review grids
+- **Tablet (≤900px)**: grids collapse to 2 columns
+- **Mobile (≤640px)**: nav links hide, grids collapse to 1 column, hero
+  buttons stack vertically
+
+## Notes for Customization
+- Swap `Riverside Health Clinic` branding, copy, and contact info for your
+  own business.
+- Doctor avatars use initials in colored circles as lightweight
+  placeholders — swap for real photos as needed.
+- All colors are driven by `--ease-color-primary` and related custom
+  properties at the top of `style.css` for easy theme changes.

--- a/submissions/examples/medical-clinic-landing-im/demo.html
+++ b/submissions/examples/medical-clinic-landing-im/demo.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Riverside Health Clinic — EaseMotion CSS Landing Page</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Emergency Contact Banner -->
+  <div class="ease-fade-in clinic-emergency-banner">
+    <span>🚨 Medical Emergency? Call <strong>(555) 911-0199</strong> — Available 24/7</span>
+  </div>
+
+  <!-- Hero -->
+  <header class="clinic-hero">
+    <nav class="clinic-nav ease-fade-in">
+      <span class="clinic-logo">Riverside Health Clinic</span>
+      <div class="clinic-nav-links">
+        <a href="#departments" class="ease-hover-underline">Departments</a>
+        <a href="#doctors" class="ease-hover-underline">Doctors</a>
+        <a href="#reviews" class="ease-hover-underline">Reviews</a>
+        <a href="#portal" class="ease-hover-underline">Patient Portal</a>
+      </div>
+    </nav>
+
+    <div class="clinic-hero-content">
+      <h1 class="ease-slide-up">Compassionate Care, <span class="clinic-accent">Close to Home</span></h1>
+      <p class="ease-slide-up clinic-hero-sub" style="animation-delay: 0.1s;">
+        Riverside Health Clinic offers same-week appointments, board-certified
+        specialists, and a patient-first approach to every visit.
+      </p>
+      <div class="ease-slide-up clinic-hero-actions" style="animation-delay: 0.2s;">
+        <a href="#portal" class="ease-btn ease-btn-primary ease-hover-grow">Book an Appointment</a>
+        <a href="#departments" class="ease-btn ease-btn-outline ease-hover-grow">Explore Departments</a>
+      </div>
+    </div>
+  </header>
+
+  <!-- Departments -->
+  <section id="departments" class="clinic-section">
+    <div class="clinic-section-header ease-fade-in">
+      <span class="clinic-eyebrow">What We Treat</span>
+      <h2>Departments &amp; Specialties</h2>
+      <p>Comprehensive care across 6 core specialties, all under one roof.</p>
+    </div>
+
+    <div class="clinic-grid clinic-grid--4">
+      <div class="clinic-card ease-fade-in ease-hover-lift" style="animation-delay: 0s;">
+        <div class="clinic-card-icon">🫀</div>
+        <h3>Cardiology</h3>
+        <p>Heart health screening, ECGs, and ongoing cardiac care.</p>
+      </div>
+      <div class="clinic-card ease-fade-in ease-hover-lift" style="animation-delay: 0.1s;">
+        <div class="clinic-card-icon">🦴</div>
+        <h3>Orthopedics</h3>
+        <p>Joint, bone, and sports injury diagnosis and treatment.</p>
+      </div>
+      <div class="clinic-card ease-fade-in ease-hover-lift" style="animation-delay: 0.2s;">
+        <div class="clinic-card-icon">🧒</div>
+        <h3>Pediatrics</h3>
+        <p>Routine checkups and specialized care for children of all ages.</p>
+      </div>
+      <div class="clinic-card ease-fade-in ease-hover-lift" style="animation-delay: 0.3s;">
+        <div class="clinic-card-icon">🧠</div>
+        <h3>Neurology</h3>
+        <p>Diagnosis and management of neurological conditions.</p>
+      </div>
+      <div class="clinic-card ease-fade-in ease-hover-lift" style="animation-delay: 0.4s;">
+        <div class="clinic-card-icon">👁️</div>
+        <h3>Ophthalmology</h3>
+        <p>Eye exams, vision correction, and surgical consultations.</p>
+      </div>
+      <div class="clinic-card ease-fade-in ease-hover-lift" style="animation-delay: 0.5s;">
+        <div class="clinic-card-icon">🩺</div>
+        <h3>Family Medicine</h3>
+        <p>Primary care for every stage of life, from infants to seniors.</p>
+      </div>
+      <div class="clinic-card ease-fade-in ease-hover-lift" style="animation-delay: 0.6s;">
+        <div class="clinic-card-icon">🦷</div>
+        <h3>Dental Care</h3>
+        <p>Preventive, cosmetic, and restorative dentistry services.</p>
+      </div>
+      <div class="clinic-card ease-fade-in ease-hover-lift" style="animation-delay: 0.7s;">
+        <div class="clinic-card-icon">🧴</div>
+        <h3>Dermatology</h3>
+        <p>Skin condition treatment, screenings, and cosmetic dermatology.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Doctor Profiles -->
+  <section id="doctors" class="clinic-section clinic-section--alt">
+    <div class="clinic-section-header ease-fade-in">
+      <span class="clinic-eyebrow">Meet Our Team</span>
+      <h2>Board-Certified Doctors</h2>
+      <p>Experienced specialists dedicated to your long-term health.</p>
+    </div>
+
+    <div class="clinic-grid clinic-grid--3">
+      <div class="clinic-doctor-card ease-fade-in ease-hover-lift" style="animation-delay: 0s;">
+        <div class="clinic-doctor-avatar">DR</div>
+        <h3>Dr. Anita Rao</h3>
+        <p class="clinic-doctor-role">Cardiologist, MD, FACC</p>
+        <p class="clinic-doctor-bio">15 years of experience in interventional cardiology and preventive heart care.</p>
+      </div>
+      <div class="clinic-doctor-card ease-fade-in ease-hover-lift" style="animation-delay: 0.1s;">
+        <div class="clinic-doctor-avatar">MK</div>
+        <h3>Dr. Marcus Klein</h3>
+        <p class="clinic-doctor-role">Orthopedic Surgeon, MD</p>
+        <p class="clinic-doctor-bio">Specializes in sports medicine and minimally invasive joint surgery.</p>
+      </div>
+      <div class="clinic-doctor-card ease-fade-in ease-hover-lift" style="animation-delay: 0.2s;">
+        <div class="clinic-doctor-avatar">SP</div>
+        <h3>Dr. Sara Patel</h3>
+        <p class="clinic-doctor-role">Pediatrician, MD, FAAP</p>
+        <p class="clinic-doctor-bio">12 years caring for newborns through adolescents with a gentle, family-first approach.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Patient Portal CTA -->
+  <section id="portal" class="clinic-portal-cta ease-fade-in">
+    <h2>Manage Your Care Online</h2>
+    <p>Book appointments, view test results, and message your doctor — anytime, anywhere.</p>
+    <a href="#" class="ease-btn ease-btn-primary ease-hover-grow">Access Patient Portal</a>
+  </section>
+
+  <!-- Insurance Accepted -->
+  <section class="clinic-section">
+    <div class="clinic-section-header ease-fade-in">
+      <span class="clinic-eyebrow">Coverage</span>
+      <h2>Insurance We Accept</h2>
+    </div>
+    <div class="clinic-insurance-row ease-fade-in">
+      <span class="clinic-insurance-logo ease-hover-grow">BlueCross</span>
+      <span class="clinic-insurance-logo ease-hover-grow">Aetna</span>
+      <span class="clinic-insurance-logo ease-hover-grow">Cigna</span>
+      <span class="clinic-insurance-logo ease-hover-grow">UnitedHealth</span>
+      <span class="clinic-insurance-logo ease-hover-grow">Medicare</span>
+      <span class="clinic-insurance-logo ease-hover-grow">Humana</span>
+    </div>
+  </section>
+
+  <!-- Patient Reviews -->
+  <section id="reviews" class="clinic-section clinic-section--alt">
+    <div class="clinic-section-header ease-fade-in">
+      <span class="clinic-eyebrow">Testimonials</span>
+      <h2>What Our Patients Say</h2>
+    </div>
+
+    <div class="clinic-grid clinic-grid--3">
+      <div class="clinic-review-card ease-fade-in ease-hover-lift" style="animation-delay: 0s;">
+        <div class="clinic-stars">★★★★★</div>
+        <p>"Dr. Rao took the time to explain everything clearly. Best cardiology care I've received."</p>
+        <span class="clinic-review-author">— Jennifer M.</span>
+      </div>
+      <div class="clinic-review-card ease-fade-in ease-hover-lift" style="animation-delay: 0.1s;">
+        <div class="clinic-stars">★★★★★</div>
+        <p>"The patient portal makes booking and follow-ups incredibly easy. Highly recommend."</p>
+        <span class="clinic-review-author">— David T.</span>
+      </div>
+      <div class="clinic-review-card ease-fade-in ease-hover-lift" style="animation-delay: 0.2s;">
+        <div class="clinic-stars">★★★★★</div>
+        <p>"Dr. Patel is wonderful with kids. My daughter actually looks forward to checkups now!"</p>
+        <span class="clinic-review-author">— Priya S.</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="clinic-footer ease-fade-in">
+    <p>&copy; 2026 Riverside Health Clinic. All rights reserved.</p>
+    <p class="clinic-footer-sub">123 Wellness Ave, Riverside, CA · (555) 200-1010</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/medical-clinic-landing-im/style.css
+++ b/submissions/examples/medical-clinic-landing-im/style.css
@@ -1,0 +1,399 @@
+/* EaseMotion CSS - Medical Clinic Landing Page
+   Built using ease-* core classes (fade-in, slide-up, hover-lift,
+   hover-grow, hover-underline, btn) plus page-specific layout
+   classes prefixed "clinic-" to avoid colliding with core/.
+*/
+
+:root {
+  --ease-color-primary: #0d9488;
+  --ease-color-primary-dark: #0f766e;
+  --ease-color-bg: #f8fafc;
+  --ease-color-surface: #ffffff;
+  --ease-color-border: #e2e8f0;
+  --ease-color-text: #1e293b;
+  --ease-color-text-muted: #64748b;
+  --ease-speed-medium: 0.4s;
+  --ease-ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  margin: 0;
+  line-height: 1.6;
+}
+
+/* =====================
+   CORE EASEMOTION CLASSES
+   (entrance + hover animations used throughout the page)
+   ===================== */
+
+.ease-fade-in {
+  animation: ease-fade-in var(--ease-speed-medium) var(--ease-ease) both;
+}
+
+@keyframes ease-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.ease-slide-up {
+  animation: ease-slide-up 0.6s var(--ease-ease) both;
+}
+
+@keyframes ease-slide-up {
+  from { opacity: 0; transform: translateY(24px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.ease-hover-lift {
+  transition: transform var(--ease-speed-medium) var(--ease-ease),
+              box-shadow var(--ease-speed-medium) var(--ease-ease);
+}
+
+.ease-hover-lift:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.ease-hover-grow {
+  transition: transform 0.25s var(--ease-ease);
+  display: inline-block;
+}
+
+.ease-hover-grow:hover {
+  transform: scale(1.05);
+}
+
+.ease-hover-underline {
+  position: relative;
+  color: var(--ease-color-text);
+  text-decoration: none;
+}
+
+.ease-hover-underline::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 0;
+  height: 2px;
+  background: var(--ease-color-primary);
+  transition: width 0.25s var(--ease-ease);
+}
+
+.ease-hover-underline:hover::after {
+  width: 100%;
+}
+
+.ease-btn {
+  display: inline-block;
+  padding: 0.85rem 1.75rem;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+.ease-btn-primary {
+  background: var(--ease-color-primary);
+  color: #ffffff;
+}
+
+.ease-btn-primary:hover {
+  background: var(--ease-color-primary-dark);
+}
+
+.ease-btn-outline {
+  background: transparent;
+  border-color: var(--ease-color-primary);
+  color: var(--ease-color-primary);
+}
+
+.ease-btn-outline:hover {
+  background: rgba(13, 148, 136, 0.08);
+}
+
+/* =====================
+   PAGE LAYOUT (clinic-* namespace)
+   ===================== */
+
+.clinic-emergency-banner {
+  background: #dc2626;
+  color: #ffffff;
+  text-align: center;
+  padding: 0.6rem 1rem;
+  font-size: 0.85rem;
+}
+
+.clinic-hero {
+  background: linear-gradient(180deg, #ecfdf5 0%, var(--ease-color-bg) 100%);
+  padding-bottom: 4rem;
+}
+
+.clinic-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.clinic-logo {
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: var(--ease-color-primary-dark);
+}
+
+.clinic-nav-links {
+  display: flex;
+  gap: 1.75rem;
+  font-size: 0.9rem;
+}
+
+.clinic-hero-content {
+  max-width: 700px;
+  margin: 3rem auto 0;
+  text-align: center;
+  padding: 0 1.5rem;
+}
+
+.clinic-hero-content h1 {
+  font-size: 2.5rem;
+  margin: 0 0 1rem;
+  color: var(--ease-color-text);
+}
+
+.clinic-accent {
+  color: var(--ease-color-primary);
+}
+
+.clinic-hero-sub {
+  color: var(--ease-color-text-muted);
+  font-size: 1.05rem;
+  margin-bottom: 2rem;
+}
+
+.clinic-hero-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.clinic-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+
+.clinic-section--alt {
+  background: var(--ease-color-surface);
+  max-width: 100%;
+}
+
+.clinic-section--alt > * {
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.clinic-section-header {
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto 2.5rem;
+}
+
+.clinic-eyebrow {
+  display: inline-block;
+  color: var(--ease-color-primary);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.5rem;
+}
+
+.clinic-section-header h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.85rem;
+}
+
+.clinic-section-header p {
+  color: var(--ease-color-text-muted);
+  margin: 0;
+}
+
+.clinic-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.clinic-grid--4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.clinic-grid--3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.clinic-card,
+.clinic-doctor-card,
+.clinic-review-card {
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.clinic-card-icon {
+  font-size: 1.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.clinic-card h3,
+.clinic-doctor-card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.05rem;
+}
+
+.clinic-card p,
+.clinic-doctor-bio,
+.clinic-review-card p {
+  color: var(--ease-color-text-muted);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.clinic-doctor-card {
+  text-align: center;
+}
+
+.clinic-doctor-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--ease-color-primary);
+  color: #ffffff;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1rem;
+  font-size: 1.1rem;
+}
+
+.clinic-doctor-role {
+  color: var(--ease-color-primary-dark);
+  font-weight: 600;
+  font-size: 0.85rem;
+  margin-bottom: 0.6rem;
+}
+
+.clinic-portal-cta {
+  background: var(--ease-color-primary);
+  color: #ffffff;
+  text-align: center;
+  padding: 4rem 1.5rem;
+}
+
+.clinic-portal-cta h2 {
+  margin: 0 0 0.75rem;
+}
+
+.clinic-portal-cta p {
+  opacity: 0.9;
+  margin-bottom: 1.75rem;
+}
+
+.clinic-portal-cta .ease-btn-primary {
+  background: #ffffff;
+  color: var(--ease-color-primary-dark);
+}
+
+.clinic-portal-cta .ease-btn-primary:hover {
+  background: #f1f5f9;
+}
+
+.clinic-insurance-row {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.clinic-insurance-logo {
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: 8px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  color: var(--ease-color-text-muted);
+  font-size: 0.9rem;
+}
+
+.clinic-stars {
+  color: #f59e0b;
+  margin-bottom: 0.6rem;
+}
+
+.clinic-review-author {
+  display: block;
+  margin-top: 0.75rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--ease-color-text);
+}
+
+.clinic-footer {
+  text-align: center;
+  padding: 2rem 1.5rem;
+  color: var(--ease-color-text-muted);
+  font-size: 0.85rem;
+  border-top: 1px solid var(--ease-color-border);
+}
+
+.clinic-footer-sub {
+  margin-top: 0.25rem;
+}
+
+/* =====================
+   RESPONSIVE
+   ===================== */
+
+@media (max-width: 900px) {
+  .clinic-grid--4 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .clinic-grid--3 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .clinic-nav-links {
+    display: none;
+  }
+
+  .clinic-hero-content h1 {
+    font-size: 1.9rem;
+  }
+
+  .clinic-grid--4,
+  .clinic-grid--3 {
+    grid-template-columns: 1fr;
+  }
+
+  .clinic-hero-actions {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Description
Adds a complete, self-contained Healthcare business landing page (Riverside Health Clinic) built entirely with EaseMotion CSS animation and hover classes, covering all 7 required sections.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other

## Submission Checklist
- [x] Created folder `submissions/examples/medical-clinic-landing-im/`
- [x] Included `demo.html`
- [x] Included `style.css`
- [x] Included `README.md`
- [x] One feature/fix per PR
- [x] Folder name follows naming convention

## Feature Description
A fully responsive, ready-to-copy medical clinic landing page including:
- Hero with appointment CTA
- Departments/specialties grid (8 specialties)
- Doctor profiles with credentials (3 doctors)
- Patient portal CTA
- Insurance accepted logos (6 providers)
- Patient reviews with star ratings (3 testimonials)
- Emergency contact banner

Uses `.ease-fade-in` and `.ease-slide-up` for entrance animations (staggered via `animation-delay` on grid items), `.ease-hover-lift` on cards, `.ease-hover-grow` on buttons/logos, `.ease-hover-underline` on nav links, and `.ease-btn`/`.ease-btn-primary`/`.ease-btn-outline` for all CTAs. Page-specific layout classes are namespaced under `clinic-*` to avoid colliding with `core/`. Realistic placeholder copy throughout — no lorem ipsum.

## Demo
- [x] Included a working demo (`demo.html`)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

## Notes for Maintainer
- Single self-contained `demo.html` + one `style.css`, no build step, opens directly in browser.
- Animation/hover class names follow the existing `ease-*` convention seen across prior submissions in this repo; please flag if any core class names differ so I can align them exactly.
- Fully responsive: 4→2→1 column grid collapse at 900px/640px breakpoints, nav links hide on mobile, hero buttons stack vertically on small screens.
- Doctor avatars use initials in colored circles as lightweight placeholders.

Closes #14814