### PR TITLE
feat(examples): add patched modal script fixing tab trap escape

### DIFF
--- a/submissions/examples/modal-tab-trap-fix/README.md
+++ b/submissions/examples/modal-tab-trap-fix/README.md
@@ -1,0 +1,12 @@
+# Modal Tab Trap Escape Fix
+
+This submission resolves Issue #15684 by providing a patched modal logic script that properly prevents the keyboard tab trap from escaping when a user clicks on non-focusable areas.
+
+## What it does
+When an `.ease-modal` is active, clicking on the empty background inside the modal drops the focus to `document.body`. If the user presses `Tab` after that, the default focus handler allows the focus to escape to the underlying page elements. This patched script explicitly checks if the `document.activeElement` is outside the modal, and if so, aggressively wraps focus back to the first element in the modal.
+
+## How to use it
+In this demo, the standard modal logic is extended/patched via `modal-patched.js`. Simply use the standard `.ease-modal` markup, and include this script instead of the default `modal.js` if you need rigorous focus trap compliance.
+
+## Why it fits EaseMotion CSS
+Accessibility and robust keyboard navigation are critical for a professional CSS framework. This submission serves as a proof of concept for an eventual core update while strictly following the contribution guidelines.

--- a/submissions/examples/modal-tab-trap-fix/demo.html
+++ b/submissions/examples/modal-tab-trap-fix/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal Tab Trap Fix Demo</title>
+  <link rel="stylesheet" href="../../../core/ease.css"> <!-- Assumed core css -->
+  <link rel="stylesheet" href="style.css">
+  <script src="modal-patched.js" defer></script>
+</head>
+<body>
+  <div style="padding: 2rem;">
+    <h1>Modal Tab Trap Escape Fix</h1>
+    <p>This demo shows the patched modal logic that prevents keyboard focus from escaping when a user clicks on non-focusable areas.</p>
+    
+    <a href="#">A background link (Should NOT be focusable while modal is open)</a>
+    <br><br>
+    
+    <a href="#demo-modal" class="btn ease-btn">Open Modal</a>
+  </div>
+
+  <div id="demo-modal" class="ease-modal-overlay">
+    <div class="ease-modal" aria-modal="true" role="dialog">
+      <h2>Interactive Modal</h2>
+      <p>Click on the blank space in this modal, then press the <strong>Tab</strong> key.</p>
+      <p><em>Expected behavior:</em> The focus wraps back to the first focusable element inside the modal.</p>
+      <div style="margin-top: 1rem;">
+        <button class="ease-btn">Inside Button 1</button>
+        <button class="ease-btn">Inside Button 2</button>
+      </div>
+      <a href="#" class="ease-modal-close">Close</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/modal-tab-trap-fix/modal-patched.js
+++ b/submissions/examples/modal-tab-trap-fix/modal-patched.js
@@ -1,0 +1,140 @@
+(function () {
+  'use strict';
+
+  let previousFocusedElement = null;
+
+  function checkModal() {
+    const hash = window.location.hash;
+    const body = document.body;
+
+    // Remove active class from all overlays just in case
+    const overlays = document.querySelectorAll('.ease-modal-overlay');
+    overlays.forEach((overlay) => overlay.classList.remove('is-active'));
+
+    if (hash) {
+      // Find overlay by hash (pure CSS `:target` fallback)
+      try {
+        const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
+        const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
+        if (overlay) {
+          body.style.overflow = 'hidden';
+
+          previousFocusedElement = document.activeElement;
+
+          overlay.classList.add('is-active');
+
+          const modal = overlay.querySelector('.ease-modal');
+          if (modal) {
+            if (!overlay.classList.contains('is-active')) {
+              previousFocusedElement = document.activeElement;
+            }
+
+            modal.setAttribute('tabindex', '-1');
+            modal.focus();
+          }
+          return;
+        }
+      } catch (e) {
+        window.location.hash = ''; // Clear invalid hash
+      }
+    }
+
+    // If no active modal is found
+    body.style.overflow = '';
+
+    if (
+      previousFocusedElement &&
+      typeof previousFocusedElement.focus === 'function'
+    ) {
+      previousFocusedElement.focus();
+      previousFocusedElement = null;
+    }
+  }
+
+  // Setup event listeners for hash changes (opening/closing via anchors)
+  window.addEventListener('hashchange', checkModal);
+
+  // Setup backdrop click listener to close modal
+  document.addEventListener('click', function (e) {
+    const hash = window.location.hash;
+    if (!hash) return;
+
+    try {
+      const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
+      const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
+      if (!overlay || !overlay.classList.contains('is-active')) return;
+
+      if (e.target === overlay) {
+        window.location.hash = ''; // Clear hash = close modal properly
+        e.preventDefault();
+      }
+    } catch (e) {
+      // Invalid selector, ignore
+    }
+  }, true); // Capture phase
+
+  // Setup keyboard trap and escape key
+  document.addEventListener('keydown', function (e) {
+    const hash = window.location.hash;
+    if (!hash) return;
+
+    try {
+      const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
+      const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
+      if (!overlay) return;
+
+      // Escape key to close
+      if (e.key === 'Escape') {
+        window.location.hash = ''; // This will trigger hashchange and close the modal
+        return;
+      }
+
+      // Tab trap
+      if (e.key === 'Tab') {
+        const focusableElements = overlay.querySelectorAll(
+          'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
+        );
+        if (focusableElements.length === 0) {
+          e.preventDefault();
+          return;
+        }
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        // --- PATCH START ---
+        // Ensure focus does not escape the modal if the active element is lost to document.body
+        // e.g. when clicking a non-focusable space
+        if (!overlay.contains(document.activeElement)) {
+          e.preventDefault();
+          firstElement.focus();
+          return;
+        }
+        // --- PATCH END ---
+
+        if (e.shiftKey) {
+          // Shift + Tab
+          if (document.activeElement === firstElement || document.activeElement === overlay.querySelector('.ease-modal')) {
+            e.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          // Tab
+          if (document.activeElement === lastElement) {
+            e.preventDefault();
+            firstElement.focus();
+          }
+        }
+      }
+    } catch (e) {
+      // Invalid selector, ignore
+    }
+  });
+
+  // Run on load
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', checkModal);
+  } else {
+    checkModal();
+  }
+})();

--- a/submissions/examples/modal-tab-trap-fix/style.css
+++ b/submissions/examples/modal-tab-trap-fix/style.css
@@ -1,0 +1,8 @@
+/* 
+  No additional CSS needed for this bug fix, 
+  but the template requires style.css to be present. 
+*/
+body {
+  font-family: sans-serif;
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Pull Request Description

This submission resolves a critical accessibility issue (#15684) where the modal's keyboard tab trap could be bypassed. If a user clicked a non-focusable area inside an open modal, `document.activeElement` shifted to the body, allowing subsequent `Tab` keystrokes to escape the modal and interact with the background page. 

This provides a `modal-patched.js` script demonstrating how to aggressively wrap focus back to the first element if it falls outside the modal bounds.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission (or patching core logic)
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A patched `modal-patched.js` script that prevents keyboard focus from escaping the modal if the active element is lost to the document body.

**How does a developer use it?**

```html
<script src="path/to/modal-patched.js" defer></script>
