### PR TITLE
feat: add full spa and wellness landing page (issue #14818)

### DIFF
--- a/submissions/examples/spa-wellness-landing-im/README.md
+++ b/submissions/examples/spa-wellness-landing-im/README.md
@@ -1,0 +1,63 @@
+# Lumen Spa & Wellness — Full Landing Page
+
+A complete, self-contained, ready-to-copy Spa &amp; Wellness business landing
+page built with EaseMotion CSS entrance and hover animation classes.
+Soft pastel, tranquil aesthetic. Opens directly in a browser — no build
+step required.
+
+## Files
+- `demo.html` - Full landing page markup
+- `style.css` - All styles, including EaseMotion animation classes and page layout
+- `README.md` - This file
+
+## Required Sections (per issue checklist)
+- ✅ Tranquil hero with gentle entrance animations
+- ✅ Treatment menu cards (6 treatments with pricing)
+- ✅ Packages/pricing (3 bundled packages, one featured)
+- ✅ Facility gallery (6 spaces)
+- ✅ Gift card CTA
+- ✅ Booking form (name, email, treatment, date)
+- ✅ Testimonials (3 guest reviews with star ratings)
+
+## EaseMotion Classes Showcased
+
+| Class | Used For |
+|---|---|
+| `.ease-fade-in` | Nav, section headers, gift card CTA, booking form, footer |
+| `.ease-slide-up` | Hero eyebrow, heading, subtext, CTA buttons (staggered via `animation-delay`) |
+| `.ease-hover-lift` | Treatment cards, package cards, review cards |
+| `.ease-hover-grow` | Buttons and gallery items on hover |
+| `.ease-hover-underline` | Nav links |
+| `.ease-btn`, `.ease-btn-primary`, `.ease-btn-outline` | All call-to-action buttons |
+
+Entrance animations are staggered using inline `animation-delay` on grid
+items (treatment cards, package cards, gallery items, reviews) for a
+soft, cascading reveal that matches the calm aesthetic.
+
+## Layout Classes
+Page-specific layout/structure classes are namespaced under `spa-*`
+(e.g. `.spa-hero`, `.spa-grid`, `.spa-card`) to avoid any collision with
+`core/` class names, while every interactive/animated element uses the
+shared `ease-*` classes.
+
+## Design Notes
+- Soft pastel palette: warm blush (`#f6e9e4`), sage (`#e7ece3`), and a
+  muted terracotta accent (`#b08968`) for a luxurious, calming feel.
+- Pill-shaped buttons (`border-radius: 999px`) reinforce the soft,
+  organic aesthetic throughout.
+- The featured package card uses a blush background and a "Most Popular"
+  badge to draw attention without breaking the gentle tone.
+
+## Responsive Behavior
+- **Desktop**: 3-column grids for treatments, packages, gallery, and reviews
+- **Tablet (≤900px)**: grids collapse to 2 columns, booking form fields stack
+- **Mobile (≤640px)**: nav links hide, all grids collapse to 1 column, hero
+  buttons stack vertically
+
+## Notes for Customization
+- Swap `Lumen Spa & Wellness` branding, copy, and contact info for your
+  own business.
+- Gallery items use gradient placeholder tiles with labels — swap for
+  real photography as needed.
+- All colors are driven by `--ease-color-*` custom properties at the top
+  of `style.css` for easy theme changes.

--- a/submissions/examples/spa-wellness-landing-im/demo.html
+++ b/submissions/examples/spa-wellness-landing-im/demo.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lumen Spa & Wellness — EaseMotion CSS Landing Page</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Hero -->
+  <header class="spa-hero">
+    <nav class="spa-nav ease-fade-in">
+      <span class="spa-logo">Lumen Spa &amp; Wellness</span>
+      <div class="spa-nav-links">
+        <a href="#treatments" class="ease-hover-underline">Treatments</a>
+        <a href="#packages" class="ease-hover-underline">Packages</a>
+        <a href="#gallery" class="ease-hover-underline">Gallery</a>
+        <a href="#booking" class="ease-hover-underline">Book Now</a>
+      </div>
+    </nav>
+
+    <div class="spa-hero-content">
+      <span class="ease-fade-in spa-eyebrow">Soothe Body &amp; Mind</span>
+      <h1 class="ease-slide-up">Find Your Calm at <span class="spa-accent">Lumen Spa</span></h1>
+      <p class="ease-slide-up spa-hero-sub" style="animation-delay: 0.1s;">
+        A tranquil escape offering massage, skincare, and wellness rituals
+        designed to restore balance to your everyday life.
+      </p>
+      <div class="ease-slide-up spa-hero-actions" style="animation-delay: 0.2s;">
+        <a href="#booking" class="ease-btn ease-btn-primary ease-hover-grow">Book a Treatment</a>
+        <a href="#packages" class="ease-btn ease-btn-outline ease-hover-grow">View Packages</a>
+      </div>
+    </div>
+  </header>
+
+  <!-- Treatment Menu -->
+  <section id="treatments" class="spa-section">
+    <div class="spa-section-header ease-fade-in">
+      <span class="spa-eyebrow">Our Menu</span>
+      <h2>Treatments</h2>
+      <p>Thoughtfully curated services for relaxation, recovery, and renewal.</p>
+    </div>
+
+    <div class="spa-grid spa-grid--3">
+      <div class="spa-card ease-fade-in ease-hover-lift" style="animation-delay: 0s;">
+        <div class="spa-card-icon">💆‍♀️</div>
+        <h3>Swedish Massage</h3>
+        <p>Gentle, flowing strokes to ease tension and promote deep relaxation.</p>
+        <span class="spa-price">$95 / 60 min</span>
+      </div>
+      <div class="spa-card ease-fade-in ease-hover-lift" style="animation-delay: 0.1s;">
+        <div class="spa-card-icon">🧖‍♀️</div>
+        <h3>Hot Stone Therapy</h3>
+        <p>Warm basalt stones melt away muscle stiffness and calm the senses.</p>
+        <span class="spa-price">$120 / 75 min</span>
+      </div>
+      <div class="spa-card ease-fade-in ease-hover-lift" style="animation-delay: 0.2s;">
+        <div class="spa-card-icon">✨</div>
+        <h3>Glow Facial</h3>
+        <p>A hydrating facial treatment that restores radiance and softness.</p>
+        <span class="spa-price">$80 / 45 min</span>
+      </div>
+      <div class="spa-card ease-fade-in ease-hover-lift" style="animation-delay: 0.3s;">
+        <div class="spa-card-icon">🦶</div>
+        <h3>Reflexology</h3>
+        <p>Pressure-point foot therapy to relieve stress throughout the body.</p>
+        <span class="spa-price">$65 / 40 min</span>
+      </div>
+      <div class="spa-card ease-fade-in ease-hover-lift" style="animation-delay: 0.4s;">
+        <div class="spa-card-icon">🌿</div>
+        <h3>Aromatherapy Wrap</h3>
+        <p>A full-body wrap infused with essential oils to soothe and detoxify.</p>
+        <span class="spa-price">$110 / 60 min</span>
+      </div>
+      <div class="spa-card ease-fade-in ease-hover-lift" style="animation-delay: 0.5s;">
+        <div class="spa-card-icon">🧘‍♀️</div>
+        <h3>Sound Bath Meditation</h3>
+        <p>Guided meditation paired with calming sound healing instruments.</p>
+        <span class="spa-price">$45 / 30 min</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Packages / Pricing -->
+  <section id="packages" class="spa-section spa-section--alt">
+    <div class="spa-section-header ease-fade-in">
+      <span class="spa-eyebrow">Save More</span>
+      <h2>Wellness Packages</h2>
+      <p>Bundle your favorite treatments for a complete day of relaxation.</p>
+    </div>
+
+    <div class="spa-grid spa-grid--3">
+      <div class="spa-package-card ease-fade-in ease-hover-lift" style="animation-delay: 0s;">
+        <h3>Quiet Escape</h3>
+        <div class="spa-package-price">$150</div>
+        <ul class="spa-package-list">
+          <li>Swedish Massage (60 min)</li>
+          <li>Reflexology (40 min)</li>
+          <li>Herbal Tea Service</li>
+        </ul>
+        <a href="#booking" class="ease-btn ease-btn-outline ease-hover-grow">Choose Package</a>
+      </div>
+      <div class="spa-package-card spa-package-card--featured ease-fade-in ease-hover-lift" style="animation-delay: 0.1s;">
+        <span class="spa-package-badge">Most Popular</span>
+        <h3>Lumen Signature</h3>
+        <div class="spa-package-price">$240</div>
+        <ul class="spa-package-list">
+          <li>Hot Stone Therapy (75 min)</li>
+          <li>Glow Facial (45 min)</li>
+          <li>Aromatherapy Wrap (60 min)</li>
+          <li>Herbal Tea Service</li>
+        </ul>
+        <a href="#booking" class="ease-btn ease-btn-primary ease-hover-grow">Choose Package</a>
+      </div>
+      <div class="spa-package-card ease-fade-in ease-hover-lift" style="animation-delay: 0.2s;">
+        <h3>Mind &amp; Body Reset</h3>
+        <div class="spa-package-price">$180</div>
+        <ul class="spa-package-list">
+          <li>Sound Bath Meditation (30 min)</li>
+          <li>Swedish Massage (60 min)</li>
+          <li>Glow Facial (45 min)</li>
+        </ul>
+        <a href="#booking" class="ease-btn ease-btn-outline ease-hover-grow">Choose Package</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Facility Gallery -->
+  <section id="gallery" class="spa-section">
+    <div class="spa-section-header ease-fade-in">
+      <span class="spa-eyebrow">Our Space</span>
+      <h2>Facility Gallery</h2>
+      <p>A peaceful retreat designed for total relaxation.</p>
+    </div>
+
+    <div class="spa-gallery-grid">
+      <div class="spa-gallery-item ease-fade-in ease-hover-grow" style="animation-delay: 0s;">Relaxation Lounge</div>
+      <div class="spa-gallery-item ease-fade-in ease-hover-grow" style="animation-delay: 0.1s;">Treatment Room</div>
+      <div class="spa-gallery-item ease-fade-in ease-hover-grow" style="animation-delay: 0.2s;">Hydrotherapy Pool</div>
+      <div class="spa-gallery-item ease-fade-in ease-hover-grow" style="animation-delay: 0.3s;">Steam Room</div>
+      <div class="spa-gallery-item ease-fade-in ease-hover-grow" style="animation-delay: 0.4s;">Garden Courtyard</div>
+      <div class="spa-gallery-item ease-fade-in ease-hover-grow" style="animation-delay: 0.5s;">Tea Lounge</div>
+    </div>
+  </section>
+
+  <!-- Gift Card CTA -->
+  <section class="spa-giftcard-cta ease-fade-in">
+    <h2>Give the Gift of Relaxation</h2>
+    <p>Lumen Spa gift cards are the perfect way to share calm with someone you love.</p>
+    <a href="#" class="ease-btn ease-btn-primary ease-hover-grow">Purchase a Gift Card</a>
+  </section>
+
+  <!-- Booking Form -->
+  <section id="booking" class="spa-section spa-section--alt">
+    <div class="spa-section-header ease-fade-in">
+      <span class="spa-eyebrow">Reserve Your Visit</span>
+      <h2>Book an Appointment</h2>
+      <p>Choose your treatment and preferred time — we'll confirm within 24 hours.</p>
+    </div>
+
+    <form class="spa-booking-form ease-fade-in" onsubmit="return false;">
+      <div class="spa-form-row">
+        <div class="spa-form-group">
+          <label for="spa-name">Full Name</label>
+          <input type="text" id="spa-name" placeholder="Jane Doe" required>
+        </div>
+        <div class="spa-form-group">
+          <label for="spa-email">Email</label>
+          <input type="email" id="spa-email" placeholder="jane@example.com" required>
+        </div>
+      </div>
+      <div class="spa-form-row">
+        <div class="spa-form-group">
+          <label for="spa-treatment">Treatment</label>
+          <select id="spa-treatment">
+            <option>Swedish Massage</option>
+            <option>Hot Stone Therapy</option>
+            <option>Glow Facial</option>
+            <option>Reflexology</option>
+            <option>Aromatherapy Wrap</option>
+            <option>Sound Bath Meditation</option>
+          </select>
+        </div>
+        <div class="spa-form-group">
+          <label for="spa-date">Preferred Date</label>
+          <input type="date" id="spa-date">
+        </div>
+      </div>
+      <button type="submit" class="ease-btn ease-btn-primary ease-hover-grow spa-form-submit">Request Booking</button>
+    </form>
+  </section>
+
+  <!-- Testimonials -->
+  <section class="spa-section">
+    <div class="spa-section-header ease-fade-in">
+      <span class="spa-eyebrow">Guest Stories</span>
+      <h2>Testimonials</h2>
+    </div>
+
+    <div class="spa-grid spa-grid--3">
+      <div class="spa-review-card ease-fade-in ease-hover-lift" style="animation-delay: 0s;">
+        <div class="spa-stars">★★★★★</div>
+        <p>"The most relaxing afternoon I've had in years. The hot stone massage was incredible."</p>
+        <span class="spa-review-author">— Elena R.</span>
+      </div>
+      <div class="spa-review-card ease-fade-in ease-hover-lift" style="animation-delay: 0.1s;">
+        <div class="spa-stars">★★★★★</div>
+        <p>"Lumen Signature package is worth every penny. I left feeling like a new person."</p>
+        <span class="spa-review-author">— Marcus B.</span>
+      </div>
+      <div class="spa-review-card ease-fade-in ease-hover-lift" style="animation-delay: 0.2s;">
+        <div class="spa-stars">★★★★★</div>
+        <p>"Booked a gift card for my mom and she hasn't stopped talking about her visit."</p>
+        <span class="spa-review-author">— Taylor K.</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="spa-footer ease-fade-in">
+    <p>&copy; 2026 Lumen Spa &amp; Wellness. All rights reserved.</p>
+    <p class="spa-footer-sub">45 Serenity Lane, Willowbrook · (555) 300-2020</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/spa-wellness-landing-im/style.css
+++ b/submissions/examples/spa-wellness-landing-im/style.css
@@ -1,0 +1,494 @@
+/* EaseMotion CSS - Spa & Wellness Landing Page
+   Built using ease-* core classes (fade-in, slide-up, hover-lift,
+   hover-grow, hover-underline, btn) plus page-specific layout
+   classes prefixed "spa-" to avoid colliding with core/.
+   Soft pastel, tranquil aesthetic per issue notes.
+*/
+
+:root {
+  --ease-color-primary: #b08968;
+  --ease-color-primary-dark: #8c6845;
+  --ease-color-bg: #fdf8f4;
+  --ease-color-surface: #ffffff;
+  --ease-color-border: #f1e4d8;
+  --ease-color-text: #3f342b;
+  --ease-color-text-muted: #8a7a6c;
+  --ease-color-blush: #f6e9e4;
+  --ease-color-sage: #e7ece3;
+  --ease-speed-medium: 0.5s;
+  --ease-ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  margin: 0;
+  line-height: 1.65;
+}
+
+/* =====================
+   CORE EASEMOTION CLASSES
+   ===================== */
+
+.ease-fade-in {
+  animation: ease-fade-in var(--ease-speed-medium) var(--ease-ease) both;
+}
+
+@keyframes ease-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.ease-slide-up {
+  animation: ease-slide-up 0.7s var(--ease-ease) both;
+}
+
+@keyframes ease-slide-up {
+  from { opacity: 0; transform: translateY(28px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.ease-hover-lift {
+  transition: transform var(--ease-speed-medium) var(--ease-ease),
+              box-shadow var(--ease-speed-medium) var(--ease-ease);
+}
+
+.ease-hover-lift:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 14px 28px rgba(139, 110, 80, 0.12);
+}
+
+.ease-hover-grow {
+  transition: transform 0.3s var(--ease-ease);
+  display: inline-block;
+}
+
+.ease-hover-grow:hover {
+  transform: scale(1.04);
+}
+
+.ease-hover-underline {
+  position: relative;
+  color: var(--ease-color-text);
+  text-decoration: none;
+}
+
+.ease-hover-underline::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 0;
+  height: 2px;
+  background: var(--ease-color-primary);
+  transition: width 0.3s var(--ease-ease);
+}
+
+.ease-hover-underline:hover::after {
+  width: 100%;
+}
+
+.ease-btn {
+  display: inline-block;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+.ease-btn-primary {
+  background: var(--ease-color-primary);
+  color: #ffffff;
+}
+
+.ease-btn-primary:hover {
+  background: var(--ease-color-primary-dark);
+}
+
+.ease-btn-outline {
+  background: transparent;
+  border-color: var(--ease-color-primary);
+  color: var(--ease-color-primary-dark);
+}
+
+.ease-btn-outline:hover {
+  background: var(--ease-color-blush);
+}
+
+/* =====================
+   PAGE LAYOUT (spa-* namespace)
+   ===================== */
+
+.spa-hero {
+  background: linear-gradient(180deg, var(--ease-color-blush) 0%, var(--ease-color-bg) 100%);
+  padding-bottom: 4.5rem;
+}
+
+.spa-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.spa-logo {
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: var(--ease-color-primary-dark);
+  letter-spacing: 0.02em;
+}
+
+.spa-nav-links {
+  display: flex;
+  gap: 1.75rem;
+  font-size: 0.9rem;
+}
+
+.spa-hero-content {
+  max-width: 680px;
+  margin: 3rem auto 0;
+  text-align: center;
+  padding: 0 1.5rem;
+}
+
+.spa-eyebrow {
+  display: inline-block;
+  color: var(--ease-color-primary-dark);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.75rem;
+}
+
+.spa-hero-content h1 {
+  font-size: 2.5rem;
+  margin: 0 0 1rem;
+  font-weight: 600;
+  color: var(--ease-color-text);
+}
+
+.spa-accent {
+  color: var(--ease-color-primary);
+  font-style: italic;
+}
+
+.spa-hero-sub {
+  color: var(--ease-color-text-muted);
+  font-size: 1.05rem;
+  margin-bottom: 2rem;
+}
+
+.spa-hero-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.spa-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4.5rem 1.5rem;
+}
+
+.spa-section--alt {
+  background: var(--ease-color-sage);
+  max-width: 100%;
+}
+
+.spa-section--alt > * {
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.spa-section-header {
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto 2.75rem;
+}
+
+.spa-section-header h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.9rem;
+  font-weight: 600;
+}
+
+.spa-section-header p {
+  color: var(--ease-color-text-muted);
+  margin: 0;
+}
+
+.spa-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.spa-grid--3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.spa-card,
+.spa-package-card,
+.spa-review-card {
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: 16px;
+  padding: 1.75rem;
+}
+
+.spa-card-icon {
+  font-size: 1.85rem;
+  margin-bottom: 0.75rem;
+}
+
+.spa-card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.05rem;
+}
+
+.spa-card p {
+  color: var(--ease-color-text-muted);
+  font-size: 0.9rem;
+  margin: 0 0 0.9rem;
+}
+
+.spa-price {
+  display: inline-block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ease-color-primary-dark);
+}
+
+/* Packages */
+.spa-package-card {
+  text-align: center;
+  position: relative;
+}
+
+.spa-package-card--featured {
+  border-color: var(--ease-color-primary);
+  background: var(--ease-color-blush);
+}
+
+.spa-package-badge {
+  position: absolute;
+  top: -0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--ease-color-primary);
+  color: #ffffff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.3rem 0.9rem;
+  border-radius: 999px;
+}
+
+.spa-package-card h3 {
+  margin: 0.5rem 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.spa-package-price {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--ease-color-primary-dark);
+  margin-bottom: 1rem;
+}
+
+.spa-package-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem;
+  color: var(--ease-color-text-muted);
+  font-size: 0.9rem;
+}
+
+.spa-package-list li {
+  padding: 0.35rem 0;
+  border-bottom: 1px solid var(--ease-color-border);
+}
+
+.spa-package-list li:last-child {
+  border-bottom: none;
+}
+
+/* Gallery */
+.spa-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+.spa-gallery-item {
+  background: linear-gradient(135deg, var(--ease-color-blush), var(--ease-color-sage));
+  border-radius: 14px;
+  height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ease-color-primary-dark);
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-align: center;
+  padding: 1rem;
+}
+
+/* Gift card CTA */
+.spa-giftcard-cta {
+  background: var(--ease-color-primary);
+  color: #ffffff;
+  text-align: center;
+  padding: 4rem 1.5rem;
+}
+
+.spa-giftcard-cta h2 {
+  margin: 0 0 0.75rem;
+  font-weight: 600;
+}
+
+.spa-giftcard-cta p {
+  opacity: 0.92;
+  margin-bottom: 1.75rem;
+}
+
+.spa-giftcard-cta .ease-btn-primary {
+  background: #ffffff;
+  color: var(--ease-color-primary-dark);
+}
+
+.spa-giftcard-cta .ease-btn-primary:hover {
+  background: var(--ease-color-blush);
+}
+
+/* Booking form */
+.spa-booking-form {
+  max-width: 700px;
+  margin: 0 auto;
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: 16px;
+  padding: 2rem;
+}
+
+.spa-form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.spa-form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.spa-form-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ease-color-text);
+}
+
+.spa-form-group input,
+.spa-form-group select {
+  padding: 0.65rem 0.85rem;
+  border: 1px solid var(--ease-color-border);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+}
+
+.spa-form-group input:focus,
+.spa-form-group select:focus {
+  outline: none;
+  border-color: var(--ease-color-primary);
+}
+
+.spa-form-submit {
+  width: 100%;
+  border: none;
+  text-align: center;
+}
+
+/* Reviews */
+.spa-stars {
+  color: #d99a4e;
+  margin-bottom: 0.6rem;
+}
+
+.spa-review-card p {
+  color: var(--ease-color-text-muted);
+  font-size: 0.92rem;
+  margin: 0;
+}
+
+.spa-review-author {
+  display: block;
+  margin-top: 0.85rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--ease-color-text);
+}
+
+/* Footer */
+.spa-footer {
+  text-align: center;
+  padding: 2.5rem 1.5rem;
+  color: var(--ease-color-text-muted);
+  font-size: 0.85rem;
+  border-top: 1px solid var(--ease-color-border);
+}
+
+.spa-footer-sub {
+  margin-top: 0.25rem;
+}
+
+/* =====================
+   RESPONSIVE
+   ===================== */
+
+@media (max-width: 900px) {
+  .spa-grid--3,
+  .spa-gallery-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .spa-form-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .spa-nav-links {
+    display: none;
+  }
+
+  .spa-hero-content h1 {
+    font-size: 1.9rem;
+  }
+
+  .spa-grid--3,
+  .spa-gallery-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .spa-hero-actions {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Description
Adds a complete, self-contained Spa & Wellness business landing page (Lumen Spa & Wellness) built entirely with EaseMotion CSS animation and hover classes, covering all 7 required sections with a soft pastel, tranquil aesthetic.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other

## Submission Checklist
- [x] Created folder `submissions/examples/spa-wellness-landing-im/`
- [x] Included `demo.html`
- [x] Included `style.css`
- [x] Included `README.md`
- [x] One feature/fix per PR
- [x] Folder name follows naming convention

## Feature Description
A fully responsive, ready-to-copy spa landing page including:
- Tranquil hero with gentle staggered entrance animations
- Treatment menu cards (6 treatments with pricing)
- Packages/pricing (3 bundles, one featured with badge)
- Facility gallery (6 spaces)
- Gift card CTA
- Booking form (name, email, treatment select, date)
- Testimonials with star ratings (3 reviews)

Uses `.ease-fade-in` and `.ease-slide-up` for entrance animations (staggered via `animation-delay`), `.ease-hover-lift` on cards, `.ease-hover-grow` on buttons/gallery items, `.ease-hover-underline` on nav links, and `.ease-btn`/`.ease-btn-primary`/`.ease-btn-outline` for all CTAs. Page-specific layout classes are namespaced under `spa-*` to avoid colliding with `core/`. Soft pastel palette (blush, sage, terracotta) per the issue's "luxurious, calm, tranquil" notes. Realistic placeholder copy throughout.

## Demo
- [x] Included a working demo (`demo.html`)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

## Notes for Maintainer
- Single self-contained `demo.html` + one `style.css`, no build step, opens directly in browser.
- Animation/hover class names follow the existing `ease-*` convention seen across prior submissions in this repo; please flag if any core class names differ so I can align them exactly.
- Fully responsive: 3→2→1 column grid collapse at 900px/640px breakpoints, nav links hide on mobile, hero buttons and booking form fields stack on small screens.
- Gallery uses gradient placeholder tiles with labels in place of real photography.

Closes #14818