### PR TITLE
feat: implement custom range slider with animated bubble (#13552)

### DIFF
--- a/submissions/examples/ease-slider-range/README.md
+++ b/submissions/examples/ease-slider-range/README.md
@@ -1,0 +1,20 @@
+# Animated Range Slider (`ease-slider-range`)
+
+A custom-styled `<input type="range">` featuring a smooth, animated value bubble that perfectly tracks the thumb. Built for the EaseMotion-css framework.
+
+## 🚀 Features
+
+- **Perfect Tracking Math**: Native range thumbs don't perfectly align with simple percentage widths. The bubble uses a specialized `calc()` formula that accounts for the thumb's exact 20px dimensions, ensuring the bubble never drifts off-center at the extreme 0% and 100% edges.
+- **Bouncy Pop Animation**: The value bubble smoothly fades and scales into view when the user hovers, focuses, or clicks the slider.
+- **Interactive Thumb**: The thumb utilizes a `cubic-bezier` timing function to slightly enlarge when actively grabbed, providing excellent tactile feedback.
+- **Cross-Browser Compatibility**: Includes both `::-webkit-slider-thumb` and `::-moz-range-thumb` pseudo-selectors for wide support.
+
+## 🛠️ Usage
+
+Wrap the native range input and the value bubble inside a `.ease-slider-wrapper` container. **Important:** The `.ease-slider-bubble` must be placed *after* the input so it can be targeted with CSS sibling selectors.
+
+```html
+<div class="ease-slider-wrapper">
+  <input type="range" class="ease-slider-range" id="my-slider" min="0" max="100" />
+  <div class="ease-slider-bubble" id="my-bubble">50</div>
+</div>

--- a/submissions/examples/ease-slider-range/demo.html
+++ b/submissions/examples/ease-slider-range/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range Slider - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="demo-wrapper">
+    <header class="demo-header">
+      <h1>EaseMotion Range Slider</h1>
+      <p>Custom styled input[type=range] with a bouncy value bubble that perfectly tracks the thumb.</p>
+    </header>
+
+    <main class="demo-grid">
+      <section class="demo-card">
+        <h2>Adjust Volume</h2>
+        
+        <div class="slider-container">
+          
+          <div class="ease-slider-wrapper">
+            <!-- The Native Range Input -->
+            <input type="range" class="ease-slider-range" id="volume-slider" min="0" max="100" value="50" />
+            
+            <!-- The Value Bubble -->
+            <div class="ease-slider-bubble" id="volume-bubble">50</div>
+          </div>
+
+        </div>
+        
+      </section>
+    </main>
+  </div>
+
+  <script>
+    const slider = document.getElementById('volume-slider');
+    const bubble = document.getElementById('volume-bubble');
+    const wrapper = slider.parentElement;
+
+    function updateSlider() {
+      const val = Number(slider.value);
+      const min = Number(slider.min ? slider.min : 0);
+      const max = Number(slider.max ? slider.max : 100);
+      
+      // Calculate a ratio between 0 and 1
+      const ratio = (val - min) / (max - min);
+      
+      // Update text
+      bubble.textContent = val;
+      
+      // Pass the ratio to CSS for precise positioning
+      wrapper.style.setProperty('--slider-ratio', ratio);
+    }
+
+    // Update on load and on drag
+    updateSlider();
+    slider.addEventListener('input', updateSlider);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-slider-range/style.css
+++ b/submissions/examples/ease-slider-range/style.css
@@ -1,0 +1,159 @@
+/* ========================================================================
+   Component: ease-slider-range
+   ======================================================================== */
+
+:root {
+  --ease-slider-track: #cbd5e1;
+  --ease-slider-thumb: #3b82f6;
+  --ease-slider-thumb-size: 20px;
+  --ease-slider-bubble-bg: #1e293b;
+  --ease-slider-bubble-text: #ffffff;
+}
+
+/* --- Wrapper --- */
+.ease-slider-wrapper {
+  position: relative;
+  width: 100%;
+  padding-top: 36px; /* Reserve space above the slider for the bubble */
+  /* Default ratio if JS fails to load */
+  --slider-ratio: 0.5;
+}
+
+/* --- The Native Range Input --- */
+.ease-slider-range {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  background: var(--ease-slider-track);
+  border-radius: 4px;
+  outline: none;
+  margin: 0;
+}
+
+/* --- Custom Thumb (Webkit/Blink) --- */
+.ease-slider-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--ease-slider-thumb-size);
+  height: var(--ease-slider-thumb-size);
+  border-radius: 50%;
+  background: var(--ease-slider-thumb);
+  cursor: pointer;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* --- Custom Thumb (Firefox) --- */
+.ease-slider-range::-moz-range-thumb {
+  width: var(--ease-slider-thumb-size);
+  height: var(--ease-slider-thumb-size);
+  border: none;
+  border-radius: 50%;
+  background: var(--ease-slider-thumb);
+  cursor: pointer;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Enlarge thumb when actively dragging */
+.ease-slider-range:active::-webkit-slider-thumb { transform: scale(1.2); }
+.ease-slider-range:active::-moz-range-thumb { transform: scale(1.2); }
+
+/* --- The Value Bubble --- */
+.ease-slider-bubble {
+  position: absolute;
+  top: 0;
+  
+  /* 
+    The magic formula to perfectly track the thumb center.
+    At 0%, left is half the thumb size (10px).
+    At 100%, left is 100% minus half the thumb size.
+  */
+  left: calc(var(--slider-ratio) * 100% + (10px - var(--slider-ratio) * 20px));
+  
+  background-color: var(--ease-slider-bubble-bg);
+  color: var(--ease-slider-bubble-text);
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  
+  /* Hidden by default, scaled down and pushed slightly up */
+  transform: translateX(-50%) translateY(10px) scale(0);
+  opacity: 0;
+  pointer-events: none; /* Let clicks pass through to the slider track */
+  
+  /* Bouncy pop transition */
+  transition: 
+    transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), 
+    opacity 0.2s ease;
+}
+
+/* The little triangle pointer at the bottom of the bubble */
+.ease-slider-bubble::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 4px 4px 0;
+  border-style: solid;
+  border-color: var(--ease-slider-bubble-bg) transparent transparent transparent;
+}
+
+/* Show the bubble when interacting with the slider */
+.ease-slider-range:hover ~ .ease-slider-bubble,
+.ease-slider-range:focus ~ .ease-slider-bubble,
+.ease-slider-range:active ~ .ease-slider-bubble {
+  transform: translateX(-50%) translateY(0) scale(1);
+  opacity: 1;
+}
+
+/* Keyboard accessibility */
+.ease-slider-range:focus-visible {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+/* ========================================================================
+   Demo Page Styling (Not part of core component)
+   ======================================================================== */
+
+body {
+  margin: 0;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+.demo-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.demo-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 2.5rem;
+  max-width: 450px;
+  margin: 0 auto;
+  width: 100%;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.demo-card h2 {
+  margin-top: 0;
+  margin-bottom: 2rem;
+  font-size: 1.25rem;
+  text-align: center;
+}
+
+.slider-container {
+  display: flex;
+  flex-direction: column;
+  padding: 0 1rem;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #13552 by introducing the `ease-slider-range` component. It provides custom styling for native range inputs alongside an animated value bubble that perfectly tracks the thumb.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-slider-range/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It overrides the ugly default browser styling for `<input type="range">` and adds a bouncy tooltip bubble that appears and tracks the thumb's precise location on interaction.

**How does a developer use it?**

```html
<div class="ease-slider-wrapper">
  <input type="range" class="ease-slider-range" />
  <div class="ease-slider-bubble">50</div>
</div>


**Why does it fit EaseMotion CSS?**

It relies heavily on CSS for state management and animation. The bubble appearing/disappearing is handled entirely by :hover, :focus, and :active CSS pseudo-classes combined with the ~ sibling selector. JS is only required to supply a lightweight --slider-ratio variable to power a highly-accurate CSS calc() positioning
---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Range inputs natively adjust their thumb position so the thumb doesn't overflow the track edges, making it difficult to center a bubble directly over it using standard percentages. To solve this, I wrote a calc() formula in the CSS left property that dynamically offsets the bubble based on the 20px width of the thumb.
