### PR TITLE
feat: add css-only parallax scroll timeline showcase page

### DIFF
--- a/submissions/examples/css-parallax/README.md
+++ b/submissions/examples/css-parallax/README.md
@@ -1,0 +1,27 @@
+# CSS-Only Parallax Scroll
+
+A modern, high-performance, CSS-only parallax scrolling animation. The background moves slower than the foreground content on scroll, using native CSS `animation-timeline: scroll()` instead of heavy JS scroll listeners.
+
+## EaseMotion CSS Classes Showcased
+
+This feature submits a self-contained prototype demonstrating native scroll-driven parallax effects.
+
+### Classes:
+- `.ease-parallax-container`: Establishing scrollport parent properties.
+- `.ease-parallax-bg`: Applies a vertical Translate3d offset tied directly to the viewport scroll height.
+- Modern CSS features used:
+  - `animation-timeline: scroll(root block)`
+  - `animation-range: start end`
+
+### Usage in HTML:
+```html
+<div class="ease-parallax-container">
+  <div class="ease-parallax-bg"></div>
+  <div class="parallax-content">
+     <!-- Floating foreground cards -->
+  </div>
+</div>
+```
+
+---
+Created as a contribution to EaseMotion CSS. Open `demo.html` in any browser to view the interactive prototype!

--- a/submissions/examples/css-parallax/demo.html
+++ b/submissions/examples/css-parallax/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Parallax Scroll - EaseMotion CSS</title>
+  
+  <!-- EaseMotion CSS Core -->
+  <link rel="stylesheet" href="../../../core/variables.css">
+  <link rel="stylesheet" href="../../../core/base.css">
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="../../../core/utilities.css">
+  <link rel="stylesheet" href="../../../components/cards.css">
+  
+  <!-- Local Showcase Stylesheet -->
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-card">
+    <h2 style="margin: 0; font-weight: 800;">CSS-Only Parallax Scroll</h2>
+    <p style="color: var(--ease-color-muted); font-size: var(--ease-text-sm); margin: 0;">
+      Scroll inside the container. The background shifts slower than the cards, powered by scroll-timelines.
+    </p>
+
+    <!-- Parallax Scroll viewport container -->
+    <div class="ease-parallax-container">
+      
+      <!-- Slow moving parallax background -->
+      <div class="ease-parallax-bg"></div>
+
+      <!-- Foreground scrolling content -->
+      <div class="parallax-content">
+        <div class="parallax-card" style="align-self: flex-start;">
+          <h4 style="margin: 0 0 var(--ease-space-2) 0; font-weight: 700;">Foreground Layer 1</h4>
+          <p style="margin: 0; color: var(--ease-color-muted); font-size: var(--ease-text-sm);">
+            This card scrolls normally at default viewport scroll velocity.
+          </p>
+        </div>
+
+        <div class="parallax-card" style="align-self: flex-end;">
+          <h4 style="margin: 0 0 var(--ease-space-2) 0; font-weight: 700;">Foreground Layer 2</h4>
+          <p style="margin: 0; color: var(--ease-color-muted); font-size: var(--ease-text-sm);">
+            Notice the abstract background shifting slower underneath.
+          </p>
+        </div>
+
+        <div class="parallax-card" style="align-self: center; margin-bottom: 50px;">
+          <h4 style="margin: 0 0 var(--ease-space-2) 0; font-weight: 700;">Foreground Layer 3</h4>
+          <p style="margin: 0; color: var(--ease-color-muted); font-size: var(--ease-text-sm);">
+            Complete, pure CSS parallax implementation with zero JS lag.
+          </p>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-parallax/style.css
+++ b/submissions/examples/css-parallax/style.css
@@ -1,0 +1,107 @@
+/* ============================================================
+   EaseMotion CSS — CSS-Only Parallax Scroll
+   ============================================================ */
+
+/* ── Keyframe Definitions (Scroll Mapping) ──────────────────── */
+@keyframes ease-kf-parallax-scroll {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(0, 160px, 0);
+  }
+}
+
+/* ── Parallax Layout Classes ────────────────────────────────── */
+.ease-parallax-container {
+  position: relative;
+  width: 100%;
+  height: 500px;
+  overflow: hidden;
+  border-radius: var(--ease-radius-lg, 1rem);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  box-shadow: var(--ease-shadow-lg);
+}
+
+.ease-parallax-bg {
+  position: absolute;
+  top: -80px; /* Offset overflow for translate bounds */
+  left: 0;
+  width: 100%;
+  height: 120%;
+  background: linear-gradient(135deg, var(--ease-color-primary-dark, #4b44cc) 0%, var(--ease-color-secondary-dark, #7c3aed) 100%);
+  z-index: 1;
+  
+  /* Native Scroll-driven animation properties */
+  animation: ease-kf-parallax-scroll linear;
+  animation-timeline: scroll(nearest block);
+  animation-range: entry 0% exit 100%;
+  will-change: transform;
+}
+
+/* Abstract constellation background decoration */
+.ease-parallax-bg::after {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background-image: radial-gradient(white, rgba(255,255,255,.2) 2px, transparent 40px);
+  background-size: 80px 80px;
+  opacity: 0.15;
+}
+
+.parallax-content {
+  position: relative;
+  z-index: 2;
+  height: 100%;
+  overflow-y: auto;
+  padding: var(--ease-space-8);
+  display: flex;
+  flex-direction: column;
+  gap: 150px; /* Force internal scrolling */
+  scroll-behavior: smooth;
+}
+
+.parallax-card {
+  background: var(--ease-color-surface);
+  color: var(--ease-color-text);
+  padding: var(--ease-space-8);
+  border-radius: var(--ease-radius-lg);
+  box-shadow: var(--ease-shadow-md);
+  max-width: 320px;
+  opacity: 0.95;
+}
+
+/* ── Demo page custom helper style structure ──────────────── */
+body {
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: var(--ease-font-sans);
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.demo-card {
+  width: 100%;
+  max-width: 580px;
+  padding: var(--ease-space-8);
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-neutral-200);
+  border-radius: var(--ease-radius-lg);
+  box-shadow: var(--ease-shadow-lg);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ease-space-6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-parallax-bg {
+    animation: none !important;
+    top: 0 !important;
+    height: 100% !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Submits a native CSS-only parallax scroll timeline template (`.ease-parallax-bg`) that maps translation shifts to parent viewport scrolling, eliminating layout lag and heavy JS scroll listeners.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-parallax/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — custom CSS styles containing scroll-driven timeline keyframes, offsets, and relative container setups
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A high-performance CSS-only scroll-driven parallax background shift (`.ease-parallax-bg`) using `animation-timeline: scroll()`.

**How does a developer use it?**

```html
<!-- Wrap scroll target content inside relative positioning boundaries -->
<div class="ease-parallax-container">
  <div class="ease-parallax-bg"></div>
  <div class="parallax-content">Scroll content cards</div>
</div>