### PR TITLE
fix: add missing rel=noopener noreferrer to external links for security

### DIFF
--- a/submissions/examples/profile-card-combo-tv/demo.html
+++ b/submissions/examples/profile-card-combo-tv/demo.html
@@ -67,13 +67,14 @@
       </div>
 
       <div class="alm-socials">
-        <a href="https://github.com" target="_blank">GitHub</a>
-        <a href="https://linkedin.com" target="_blank">LinkedIn</a>
+        <a href="https://github.com" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://linkedin.com" target="_blank" rel="noopener noreferrer">LinkedIn</a>
       </div>
 
       <a
         href="https://github.com"
         target="_blank"
+        rel="noopener noreferrer"
         class="alm-profile-action-btn">
         View Profile
       </a>


### PR DESCRIPTION
### Description
This PR resolves a basic but important HTML security issue in the `submissions/examples/profile-card-combo-tv` component. 

The `demo.html` file contained several external links using `target="_blank"` to open in new tabs, but they were missing the standard `rel="noopener noreferrer"` attributes. I have added these attributes to all `target="_blank"` links in the file to prevent reverse tabnabbing vulnerabilities and improve performance by ensuring the new tabs do not run on the same thread as the originating page.

### Related Issue
Fixes #15804 

### Changes Made
- Added `rel="noopener noreferrer"` to external `target="_blank"` links in `submissions/examples/profile-card-combo-tv/demo.html`.

### Labels
Maintainers, please ensure the following labels are added to this PR:
- `gssoc:approved`
- `difficulty`
- `type`
- `quality`
