### PR TITLE
feat(examples): add ease-drag-handle-hint — subtle animation hinting an element is draggable

### DIFF
--- a/submissions/examples/ease-drag-handle-hint/README.md
+++ b/submissions/examples/ease-drag-handle-hint/README.md
@@ -1,0 +1,37 @@
+# ease-drag-handle-hint
+
+## What does it do?
+Subtle opacity pulse and micro-bounce on a drag handle (≡ icon) when the user hovers over a draggable container, providing a visual affordance that the element is draggable.
+
+## Features
+- Opacity pulse from 0.5 → 1 combined with horizontal micro-bounce
+- Hover triggers a `0.5s ease-out` keyframe animation on the handle
+- Border and background color shift on the card for extra feedback
+- `prefers-reduced-motion` support disables animation
+
+## Usage
+```css
+.drag-handle {
+  display: inline-block;
+}
+
+.drag-card:hover .drag-handle {
+  animation: dragHandleHint 0.5s ease-out forwards;
+}
+
+@keyframes dragHandleHint {
+  0%   { opacity: 0.5; transform: translateX(0) scale(1); }
+  40%  { opacity: 1;   transform: translateX(4px) scale(1.15); }
+  70%  {                transform: translateX(2px) scale(1); }
+  100% { opacity: 1;   transform: translateX(0) scale(1); }
+}
+```
+
+## Browser Support
+- `@keyframes` + `animation` — Chrome 43+, Firefox 16+, Safari 9+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-drag-handle-hint/demo.html
+++ b/submissions/examples/ease-drag-handle-hint/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-handle-hint — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; text-align: center; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-drag-handle-hint</h1>
+  <p class="subtitle">A subtle animation hinting that an element is draggable — the handle pulses gently on hover.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Hover the draggable item below to see the handle animate</p>
+    <div class="drag-card">
+      <span class="drag-handle">≡</span>
+      <span class="drag-text">Drag me</span>
+    </div>
+    <p style="color:#6b7280;font-size:0.8rem;margin-top:1rem;">The ≡ handle pulses and shifts right on hover.</p>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p style="color:#9ca3af;line-height:1.8;">On <code>:hover</code> of the <code>.drag-card</code>, the <code>.drag-handle</code> (≡ icon) gets a subtle opacity pulse and horizontal micro-bounce using a <code>@keyframes</code> animation. The effect signals to the user that the element can be dragged. The animation plays once on each hover entry using <code>animation-fill-mode: forwards</code>.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-drag-handle-hint/style.css
+++ b/submissions/examples/ease-drag-handle-hint/style.css
@@ -1,0 +1,66 @@
+/* ============================================================
+   EaseMotion CSS — ease-drag-handle-hint
+   Subtle drag handle animation on hover
+   ============================================================ */
+
+.drag-card {
+  width: 280px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #1a1a1a;
+  border: 1px solid #3a3a3a;
+  border-radius: 10px;
+  padding: 14px 18px;
+  cursor: grab;
+  user-select: none;
+  transition: border-color 0.25s, background 0.25s;
+}
+
+.drag-card:hover {
+  border-color: #6366f1;
+  background: #222222;
+}
+
+.drag-handle {
+  font-size: 1.6rem;
+  line-height: 1;
+  color: #6b7280;
+  display: inline-block;
+  transition: color 0.25s;
+}
+
+.drag-card:hover .drag-handle {
+  animation: dragHandleHint 0.5s ease-out forwards;
+  color: #a5b4fc;
+}
+
+.drag-text {
+  font-size: 0.95rem;
+  color: #d1d5db;
+}
+
+@keyframes dragHandleHint {
+  0% {
+    opacity: 0.5;
+    transform: translateX(0) scale(1);
+  }
+  40% {
+    opacity: 1;
+    transform: translateX(4px) scale(1.15);
+  }
+  70% {
+    transform: translateX(2px) scale(1);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drag-card:hover .drag-handle {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

A drag handle icon (≡) gently pulses on hover of a draggable container, providing a subtle UX affordance that the element can be reordered.

## Acceptance Criteria
- [x] Subtle opacity pulse on the handle icon
- [x] Appears on hover of the draggable container
- [x] UX affordance hint

## Files
- `demo.html` — draggable card with pulsing handle
- `style.css` — drag handle animation styles
- `README.md` — documentation

## Related Issue
Closes #13696

<!-- re-trigger label sync -->