### PR TITLE
feat(examples): add ease-text-highlight-sweep — highlighter marker sweep across text

### DIFF
--- a/submissions/examples/ease-text-highlight-sweep/README.md
+++ b/submissions/examples/ease-text-highlight-sweep/README.md
@@ -1,0 +1,43 @@
+# ease-text-highlight-sweep
+
+## What does it do?
+A highlighter marker sweep effect that glides a yellow highlight across text on hover using only CSS. The highlight stays visible after the animation completes.
+
+## Features
+- `background-size: 0%` → `100%` with `linear-gradient` creates the sweep
+- `animation-fill-mode: forwards` keeps the highlight after the sweep
+- `--ease-highlight-color` CSS variable controls the highlight color (default: `#fde047`)
+- Text color inverts on highlight for readability
+- `prefers-reduced-motion` support shows static highlight instantly
+
+## Usage
+```css
+:root {
+  --ease-highlight-color: #fde047;
+}
+
+.highlight-sweep {
+  background: linear-gradient(to right, var(--ease-highlight-color) 0%, var(--ease-highlight-color) 100%);
+  background-repeat: no-repeat;
+  background-size: 0% 100%;
+  background-position: left center;
+}
+
+.highlight-sweep:hover {
+  animation: highlightSweep 0.6s ease-out forwards;
+}
+
+@keyframes highlightSweep {
+  0%   { background-size: 0% 100%;   color: #d1d5db; }
+  100% { background-size: 100% 100%; color: #1a1a1a; }
+}
+```
+
+## Browser Support
+- `@keyframes` + `background-size` — Chrome 43+, Firefox 16+, Safari 9+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-text-highlight-sweep/demo.html
+++ b/submissions/examples/ease-text-highlight-sweep/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-text-highlight-sweep — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; text-align: center; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-text-highlight-sweep</h1>
+  <p class="subtitle">A highlighter marker sweep effect that glides across text on hover — stays highlighted after the sweep completes.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Hover the text below to see the highlighter sweep across it</p>
+    <p class="highlight-sweep">This text gets highlighted like a marker swept over it!</p>
+    <p style="color:#6b7280;font-size:0.8rem;margin-top:1rem;">The highlight stays after the animation ends.</p>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p style="color:#9ca3af;line-height:1.8;">A <code>linear-gradient</code> background is combined with <code>background-size</code> animated from <code>0% 100%</code> to <code>100% 100%</code>. On hover, the <code>background-size</code> grows to cover the full text width, creating a marker sweep effect. <code>animation-fill-mode: forwards</code> keeps the highlight visible. The highlight color is controlled via the <code>--ease-highlight-color</code> CSS variable.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-text-highlight-sweep/style.css
+++ b/submissions/examples/ease-text-highlight-sweep/style.css
@@ -1,0 +1,49 @@
+/* ============================================================
+   EaseMotion CSS — ease-text-highlight-sweep
+   Highlighter marker sweep across text on hover
+   ============================================================ */
+
+:root {
+  --ease-highlight-color: #fde047;
+}
+
+.highlight-sweep {
+  display: inline-block;
+  font-size: 1.25rem;
+  line-height: 1.8;
+  color: #d1d5db;
+  background: linear-gradient(
+    to right,
+    var(--ease-highlight-color) 0%,
+    var(--ease-highlight-color) 100%
+  );
+  background-repeat: no-repeat;
+  background-size: 0% 100%;
+  background-position: left center;
+  padding: 0 4px;
+  cursor: pointer;
+  transition: none;
+}
+
+.highlight-sweep:hover {
+  animation: highlightSweep 0.6s ease-out forwards;
+}
+
+@keyframes highlightSweep {
+  0% {
+    background-size: 0% 100%;
+    color: #d1d5db;
+  }
+  100% {
+    background-size: 100% 100%;
+    color: #1a1a1a;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .highlight-sweep:hover {
+    animation: none;
+    background-size: 100% 100%;
+    color: #1a1a1a;
+  }
+}


### PR DESCRIPTION
## Description

A yellow highlight color sweeps across text using `background-size: 0% → 100%` with a `linear-gradient`, staying highlighted after completion.

## Acceptance Criteria
- [x] background-size: 0% → 100% with linear-gradient
- [x] Stays highlighted after the sweep completes
- [x] --ease-highlight-color variable

## Files
- `demo.html` — text highlight sweep demo
- `style.css` — highlight animation styles
- `README.md` — documentation

## Related Issue
Closes #13675

<!-- re-trigger label sync -->