### PR TITLE
feat(examples): add ease-typewriter-once — typewriter effect that types once and stops

### DIFF
--- a/submissions/examples/ease-typewriter-once/README.md
+++ b/submissions/examples/ease-typewriter-once/README.md
@@ -1,0 +1,50 @@
+# ease-typewriter-once
+
+## What does it do?
+A typewriter effect that reveals text character by character on hover using CSS `steps()` timing. The text stays fully visible after the animation ends and the cursor fades out.
+
+## Features
+- `steps(22, end)` matches the 22 characters of the demo text for per-character reveal
+- `animation-fill-mode: forwards` keeps text visible after animation
+- Cursor blinks during typing then fades out at the end
+- Triggered on hover of the wrapper
+- `prefers-reduced-motion` support reveals text instantly
+
+## Usage
+```css
+.typewriter-text {
+  overflow: hidden;
+  white-space: nowrap;
+  width: 0;
+}
+
+.wrapper:hover .typewriter-text {
+  animation: typewriterReveal 1.5s steps(22, end) forwards;
+}
+
+.wrapper:hover .typewriter-cursor {
+  animation: cursorBlinkThenFade 1.5s steps(22, end) forwards;
+}
+
+@keyframes typewriterReveal {
+  0%   { width: 0; }
+  100% { width: 100%; }
+}
+
+@keyframes cursorBlinkThenFade {
+  0%   { opacity: 1; }
+  50%  { opacity: 0; }
+  75%  { opacity: 1; }
+  90%  { opacity: 0.6; }
+  100% { opacity: 0; }
+}
+```
+
+## Browser Support
+- `@keyframes` + `steps()` + `animation-fill-mode` — Chrome 43+, Firefox 16+, Safari 9+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-typewriter-once/demo.html
+++ b/submissions/examples/ease-typewriter-once/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-typewriter-once — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: 'Courier New', Courier, monospace; max-width: 700px; margin: 0 auto; text-align: center; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-typewriter-once</h1>
+  <p class="subtitle">A typewriter effect that types out text character by character on hover — then stays fully visible.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Hover the text below to trigger the typewriter effect</p>
+    <div class="typewriter-wrapper">
+      <div class="typewriter-line">
+        <span class="typewriter-text">CSS typewriter effect</span>
+        <span class="typewriter-cursor">|</span>
+      </div>
+    </div>
+    <p style="color:#6b7280;font-size:0.8rem;margin-top:1rem;">Types once per hover — cursor fades out at the end.</p>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p style="color:#9ca3af;line-height:1.8;">The text width animates from <code>0</code> to <code>100%</code> using <code>steps(22)</code> (one step per character) with <code>animation-fill-mode: forwards</code>, so the text stays revealed. The cursor blinks during typing via a separate <code>@keyframes</code> and fades out at the end. On hover, both animations trigger simultaneously using <code>:hover</code> on the parent wrapper.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-typewriter-once/style.css
+++ b/submissions/examples/ease-typewriter-once/style.css
@@ -1,0 +1,79 @@
+/* ============================================================
+   EaseMotion CSS — ease-typewriter-once
+   Typewriter effect that types once on hover
+   ============================================================ */
+
+.typewriter-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 1rem 0;
+}
+
+.typewriter-line {
+  display: inline-flex;
+  align-items: center;
+}
+
+.typewriter-text {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  width: 0;
+  font-size: 1.3rem;
+  color: #d1d5db;
+  letter-spacing: 0.05em;
+}
+
+.typewriter-cursor {
+  font-size: 1.3rem;
+  color: #d1d5db;
+  font-weight: bold;
+  opacity: 0;
+  margin-left: 2px;
+}
+
+.typewriter-wrapper:hover .typewriter-text {
+  animation: typewriterReveal 1.5s steps(22, end) forwards;
+}
+
+.typewriter-wrapper:hover .typewriter-cursor {
+  animation: cursorBlinkThenFade 1.5s steps(22, end) forwards;
+}
+
+@keyframes typewriterReveal {
+  0% {
+    width: 0;
+  }
+  100% {
+    width: 100%;
+  }
+}
+
+@keyframes cursorBlinkThenFade {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  75% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 0.6;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typewriter-wrapper:hover .typewriter-text {
+    animation: none;
+    width: 100%;
+  }
+  .typewriter-wrapper:hover .typewriter-cursor {
+    animation: none;
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Description

Text types out character by character once using `steps(N)` timing, stays at final state via `animation-fill-mode: forwards`, with cursor fading out at the end.

## Acceptance Criteria
- [x] steps(N) timing function based on character count
- [x] animation-fill-mode: forwards (stays at final state)
- [x] Cursor fades out at end

## Files
- `demo.html` — typewriter-once demo
- `style.css` — typewriter animation styles
- `README.md` — documentation

## Related Issue
Closes #13673

<!-- re-trigger label sync -->