### PR TITLE
feat: add drag-and-drop visual feedback collection (handle, drop-zone, ghost, invalid, success)

### DIFF
--- a/submissions/examples/drag-feedback-collection-tk/README.md
+++ b/submissions/examples/drag-feedback-collection-tk/README.md
@@ -1,0 +1,75 @@
+# Drag-and-Drop Visual Feedback Collection
+
+## What does this do?
+A set of five CSS-only visual states for drag interactions — a grip-handle affordance, a drop-zone highlight, a drag-ghost placeholder, and invalid/success drop flashes — that pair with native HTML5 Drag and Drop or any JS sortable library without this submission owning the drag logic itself.
+
+## How is it used?
+
+```html
+<!-- Drop zone + items with a drag handle -->
+<div class="drop-zone" id="zone">
+  <ul class="drag-list" id="list">
+    <li class="drag-item" draggable="true">
+      <span class="drag-handle">⠿</span> Item one
+    </li>
+    <li class="drag-item" draggable="true">
+      <span class="drag-handle">⠿</span> Item two
+    </li>
+  </ul>
+</div>
+```
+
+State classes your drag logic toggles at the right moments:
+
+```js
+// While the user drags an item over the zone
+zone.classList.add('is-dragover');     // drop-zone highlight
+zone.classList.remove('is-dragover');  // on dragleave / drop
+
+// On the item currently being dragged
+item.classList.add('is-dragging');     // drag-ghost placeholder
+item.classList.remove('is-dragging');  // on dragend
+
+// On drop — pick one, then remove it after ~450ms so it can replay
+item.classList.add('is-invalid');      // shake + red flash, rejected drop
+item.classList.add('is-success');      // pulse + green flash, accepted drop
+```
+
+`demo.html` includes a small native HTML5 Drag and Drop wiring (`dragstart`,
+`dragover`, `drop`, etc.) so the demo is interactive out of the box, plus two
+buttons that manually trigger the invalid/success states for preview. None
+of that wiring is required to use the CSS — any drag implementation that
+toggles the same class names gets the same visual feedback.
+
+## Why is it useful?
+Drag-and-drop is everywhere (reorderable lists, kanban boards, file
+uploaders, sortable galleries), but every implementation reinvents the same
+five visual cues from scratch: "this is draggable," "you can drop here,"
+"this is what's moving," "that didn't work," "that worked." Centralizing
+just the *look* of those states — and deliberately not the drag mechanics —
+keeps this submission framework-agnostic and dependency-free, fitting
+EaseMotion CSS's animation-first philosophy: contributors bring their own
+drag logic (native DnD, SortableJS, dnd-kit, whatever), and these classes
+make the interaction feel polished without adding a single dependency.
+
+## Tech Stack
+- HTML
+- CSS only for every visual state (`transition`, `:hover`/`:active`,
+  `@keyframes` shake/pulse)
+- JS in `demo.html` is demo wiring only (native HTML5 DnD events + two
+  preview buttons) — not part of the CSS API surface
+
+## Preview
+Open `demo.html` directly in your browser — no build step, no server,
+no external dependencies. Try actually dragging an item in the first
+section, and use the buttons in the third section to preview the
+invalid/success flashes.
+
+## Note on naming
+Submitted as `drag-feedback-collection-tk` (suffixed per the repo's
+naming-collision policy in `CONTRIBUTING.md`) in case of overlap with
+existing drag-related submissions (`drag-and-drop-list`, `drag-handle`,
+`elastic-drag-sgr`, etc.). This collection is scoped specifically to
+*feedback states* (zone highlight, ghost, invalid/success) rather than
+full sortable-list mechanics, so it complements rather than duplicates
+that prior art.

--- a/submissions/examples/drag-feedback-collection-tk/demo.html
+++ b/submissions/examples/drag-feedback-collection-tk/demo.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drag-and-Drop Visual Feedback Collection — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header style="max-width:720px;margin:0 auto 3rem;">
+    <h1 style="font-size:1.6rem;margin-bottom:0.3rem;">Drag-and-Drop Visual Feedback Collection</h1>
+    <p style="color:#9a9aab;font-size:0.95rem;">
+      Five CSS-only visual states for drag interactions. This collection only
+      owns the look — drop-zone highlight, drag ghost, invalid/success
+      flashes, and a grip-handle affordance. The actual drag mechanics
+      (native HTML5 Drag and Drop, or any JS sortable library) just need to
+      toggle the state classes shown below.
+    </p>
+  </header>
+
+  <!-- 1 & 2. Drag handle + drop zone, working together with real native DnD -->
+  <section class="demo-section">
+    <h2>ease-drag-handle + ease-drop-zone</h2>
+    <p class="demo-desc">
+      Grip affordance on each item, dashed zone that highlights on dragover.
+      Try actually dragging an item with your mouse — this uses native HTML5
+      Drag and Drop.
+    </p>
+    <div class="drop-zone" id="zone">
+      <ul class="drag-list" id="list">
+        <li class="drag-item" draggable="true">
+          <span class="drag-handle">⠿</span> Item one
+        </li>
+        <li class="drag-item" draggable="true">
+          <span class="drag-handle">⠿</span> Item two
+        </li>
+        <li class="drag-item" draggable="true">
+          <span class="drag-handle">⠿</span> Item three
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- 3. Drag ghost -->
+  <section class="demo-section">
+    <h2>ease-drag-ghost</h2>
+    <p class="demo-desc">Placeholder style for the item currently being dragged.</p>
+    <ul class="drag-list">
+      <li class="drag-item">
+        <span class="drag-handle">⠿</span> Normal item
+      </li>
+      <li class="drag-item is-dragging">
+        <span class="drag-handle">⠿</span> This item is being dragged
+      </li>
+    </ul>
+  </section>
+
+  <!-- 4 & 5. Invalid / success drop feedback (manual trigger for demo) -->
+  <section class="demo-section">
+    <h2>ease-drop-invalid / ease-drop-success</h2>
+    <p class="demo-desc">
+      Shake + red flash for a rejected drop, scale-pulse + green flash for
+      an accepted one. Click the buttons below to preview each animation.
+    </p>
+    <ul class="drag-list">
+      <li class="drag-item" id="feedback-item">
+        <span class="drag-handle">⠿</span> Drop target preview
+      </li>
+    </ul>
+    <div class="demo-controls">
+      <button class="demo-btn" id="btn-invalid">Simulate invalid drop</button>
+      <button class="demo-btn" id="btn-success">Simulate successful drop</button>
+    </div>
+    <p class="demo-note">
+      In real use, your drag logic adds <code>.is-invalid</code> or
+      <code>.is-success</code> on drop, then removes it after the animation
+      ends (~450ms) so it can replay on the next interaction.
+    </p>
+  </section>
+
+  <script>
+    // --- Native HTML5 Drag and Drop wiring for the handle + drop-zone demo ---
+    // This is the consuming app's responsibility in real usage; included
+    // here only so the demo is interactive out of the box.
+    const zone = document.getElementById('zone');
+    const list = document.getElementById('list');
+    let draggedEl = null;
+
+    list.querySelectorAll('.drag-item').forEach((item) => {
+      item.addEventListener('dragstart', () => {
+        draggedEl = item;
+        item.classList.add('is-dragging');
+      });
+      item.addEventListener('dragend', () => {
+        item.classList.remove('is-dragging');
+        zone.classList.remove('is-dragover');
+      });
+    });
+
+    zone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      zone.classList.add('is-dragover');
+    });
+
+    zone.addEventListener('dragleave', () => {
+      zone.classList.remove('is-dragover');
+    });
+
+    zone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      zone.classList.remove('is-dragover');
+      if (draggedEl) {
+        const after = [...list.children].find(
+          (child) => child !== draggedEl && e.clientY < child.getBoundingClientRect().top + child.offsetHeight / 2
+        );
+        list.insertBefore(draggedEl, after || null);
+      }
+    });
+
+    // --- Manual triggers for the invalid / success demo only ---
+    const feedbackItem = document.getElementById('feedback-item');
+
+    function flash(el, className) {
+      el.classList.remove('is-invalid', 'is-success');
+      // restart animation reliably even if clicked rapidly
+      void el.offsetWidth;
+      el.classList.add(className);
+      setTimeout(() => el.classList.remove(className), 500);
+    }
+
+    document.getElementById('btn-invalid').addEventListener('click', () => {
+      flash(feedbackItem, 'is-invalid');
+    });
+
+    document.getElementById('btn-success').addEventListener('click', () => {
+      flash(feedbackItem, 'is-success');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/drag-feedback-collection-tk/style.css
+++ b/submissions/examples/drag-feedback-collection-tk/style.css
@@ -1,0 +1,228 @@
+/* =====================================================================
+   Drag-and-Drop Visual Feedback Collection
+   Pure CSS visual states for drag interactions. This collection only
+   owns the LOOK of drag feedback -- the actual drag mechanics (native
+   HTML5 Drag and Drop, or a JS sortable library) toggle the state
+   classes below. Five pieces:
+     1. drag-handle    - grip affordance signalling "draggable"
+     2. drop-zone       - dashed container, highlights on .is-dragover
+     3. drag-ghost       - placeholder style for the item being dragged
+     4. drop-invalid     - shake + red flash for a rejected drop
+     5. drop-success      - scale-pulse + green flash for an accepted drop
+   ===================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0d0d12;
+  color: #f4f4f7;
+  margin: 0;
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.demo-section {
+  max-width: 720px;
+  margin: 0 auto 3.5rem;
+}
+
+.demo-section h2 {
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+  color: #9a9aab;
+  text-transform: uppercase;
+  margin-bottom: 0.4rem;
+}
+
+.demo-section p.demo-desc {
+  color: #6f6f81;
+  font-size: 0.9rem;
+  margin-top: 0;
+  margin-bottom: 1.2rem;
+}
+
+.demo-note {
+  font-size: 0.78rem;
+  color: #6f6f81;
+  margin-top: 0.8rem;
+}
+
+code {
+  background: #1a1a24;
+  border: 1px solid #2c2c3c;
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.85em;
+}
+
+/* ---------------------------------------------------------------------
+   Shared list/item shell used across the demo
+   --------------------------------------------------------------------- */
+.drag-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.drag-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  background: #1a1a24;
+  border: 1px solid #2c2c3c;
+  border-radius: 10px;
+  color: #e7e7f0;
+  font-size: 0.95rem;
+  cursor: grab;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.drag-item:active {
+  cursor: grabbing;
+}
+
+/* ---------------------------------------------------------------------
+   1. drag-handle
+   Grip-dot affordance. Lifts slightly + brightens on hover/active to
+   signal "this is draggable" before the user even picks it up.
+   --------------------------------------------------------------------- */
+.drag-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  color: #6f6f81;
+  font-size: 1rem;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: color 0.15s ease, transform 0.15s ease, background 0.15s ease;
+}
+
+.drag-item:hover .drag-handle {
+  color: #c9c9da;
+  background: #232330;
+  transform: translateY(-1px);
+}
+
+.drag-item:active .drag-handle {
+  color: #7c5cff;
+  transform: scale(0.92);
+}
+
+/* ---------------------------------------------------------------------
+   2. drop-zone
+   Dashed container that highlights when a draggable item is over it.
+   The highlight itself is driven entirely by CSS transitions; only the
+   .is-dragover class needs to be toggled by JS/native DnD events.
+   --------------------------------------------------------------------- */
+.drop-zone {
+  border: 2px dashed #2c2c3c;
+  border-radius: 14px;
+  padding: 1rem;
+  background: #14141c;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.drop-zone.is-dragover {
+  border-color: #7c5cff;
+  background: rgba(124, 92, 255, 0.08);
+  transform: scale(1.01);
+}
+
+/* ---------------------------------------------------------------------
+   3. drag-ghost
+   Placeholder style applied to the item currently being dragged --
+   reduced opacity, slight rotation and lift, so the source slot reads
+   clearly as "in motion" while the drag is active.
+   --------------------------------------------------------------------- */
+.drag-item.is-dragging {
+  opacity: 0.45;
+  transform: rotate(-2deg) scale(0.98);
+  border-style: dashed;
+  box-shadow: none;
+  cursor: grabbing;
+}
+
+/* ---------------------------------------------------------------------
+   4. drop-invalid
+   Brief shake + red flash for a rejected drop. Add .is-invalid, then
+   remove it after the animation ends (e.g. ~500ms) so it can replay.
+   --------------------------------------------------------------------- */
+.drag-item.is-invalid {
+  animation: drop-shake 0.45s ease;
+  border-color: #f87171;
+  background: rgba(248, 113, 113, 0.08);
+}
+
+@keyframes drop-shake {
+  0%, 100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-6px);
+  }
+  40% {
+    transform: translateX(5px);
+  }
+  60% {
+    transform: translateX(-4px);
+  }
+  80% {
+    transform: translateX(3px);
+  }
+}
+
+/* ---------------------------------------------------------------------
+   5. drop-success
+   Quick scale-pulse + green flash confirming an accepted drop. Add
+   .is-success, then remove it after the animation ends (~500ms).
+   --------------------------------------------------------------------- */
+.drag-item.is-success {
+  animation: drop-pulse 0.4s ease;
+  border-color: #4ade80;
+  background: rgba(74, 222, 128, 0.08);
+}
+
+@keyframes drop-pulse {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.03);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* Demo-only controls (buttons to trigger states without real DnD) */
+.demo-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.demo-btn {
+  padding: 0.45rem 0.9rem;
+  border-radius: 8px;
+  border: 1px solid #2c2c3c;
+  background: #1a1a24;
+  color: #c9c9da;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.demo-btn:hover {
+  border-color: #7c5cff;
+  color: #fff;
+}


### PR DESCRIPTION
## Description

Implements the Drag-and-Drop Visual Feedback Collection requested in #15822 — five CSS-only visual states for drag interactions, bundled as one submission under `submissions/examples/drag-feedback-collection-tk/`.

## Pieces included

| Class | Behavior | Technique |
|---|---|---|
| `ease-drag-handle` | Grip-dot affordance that lifts on hover/active to signal "draggable" | CSS `:hover`/`:active` transitions |
| `ease-drop-zone` | Dashed container that highlights when a draggable item is over it | CSS transition driven by an `.is-dragover` state class |
| `ease-drag-ghost` | Reduced-opacity, rotated placeholder for the item currently being dragged | CSS `transform`/`opacity` via an `.is-dragging` state class |
| `ease-drop-invalid` | Shake + red flash for a rejected drop | CSS `@keyframes` shake via an `.is-invalid` state class |
| `ease-drop-success` | Scale-pulse + green flash for an accepted drop | CSS `@keyframes` pulse via an `.is-success` state class |

## Design decision: feedback states only, not drag mechanics

This submission deliberately owns only the *look* of drag interactions, not the drag logic itself. State classes (`.is-dragover`, `.is-dragging`, `.is-invalid`, `.is-success`) are toggled by whatever the consuming app already uses — native HTML5 Drag and Drop, SortableJS, dnd-kit, or anything else — so the CSS stays framework-agnostic and dependency-free, matching EaseMotion CSS's philosophy.

`demo.html` does include working native HTML5 Drag and Drop wiring so the demo is interactive out of the box (drag an item between/within the zone), plus two buttons to preview the invalid/success flashes — but that wiring is demo convenience only, not part of the CSS API surface.

## Files added

- `submissions/examples/drag-feedback-collection-tk/demo.html`
- `submissions/examples/drag-feedback-collection-tk/style.css`
- `submissions/examples/drag-feedback-collection-tk/README.md`

## Checklist

- [x] Added files only inside `submissions/examples/drag-feedback-collection-tk/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] `demo.html` is self-contained — opens directly in browser, no server, no CDN/external frameworks
- [x] No edits to `core/`, `components/`, `docs/`, or `examples/`
- [x] README answers: what it does, how it's used, why it's useful
- [x] Commits squashed into one logical commit
- [x] Folder suffixed (`-tk`) per naming-collision policy, since