### PR TITLE
feat: add animated copy-confirmation button collection (morph, pulse,…

### DIFF
--- a/submissions/examples/copy-confirmation-collection-tk/README.md
+++ b/submissions/examples/copy-confirmation-collection-tk/README.md
@@ -1,0 +1,79 @@
+# Animated Copy-Confirmation Button Collection
+
+## What does this do?
+A set of four reusable, CSS-driven confirmation animations for any "copy" button — icon morph, scale-pulse, label crossfade, and a ripple-style ring burst — that work on any copy target (code, email, link, coupon) rather than being tied to code blocks specifically.
+
+## How is it used?
+
+```html
+<button class="ease-copy-btn ease-copy-morph" data-copy-text="hello@example.com">
+  <span class="ease-copy-icon">
+    <span class="ease-check-stroke">
+      <svg viewBox="0 0 14 14"><path d="M2 7.5 L5.5 11 L12 3" /></svg>
+    </span>
+  </span>
+  Copy email
+</button>
+
+<button class="ease-copy-btn ease-copy-pulse" data-copy-text="EASEMOTION25">
+  Copy coupon code
+</button>
+
+<button class="ease-copy-btn ease-copy-label-swap" data-copy-text="https://easemotion.css/docs">
+  <span class="ease-copy-label">
+    <span class="label-default">Copy link</span>
+    <span class="label-copied">Copied!</span>
+  </span>
+</button>
+
+<button class="ease-copy-btn ease-copy-ring" data-copy-text="npm install easemotion-css">
+  Copy install command
+</button>
+```
+
+One shared JS handler drives every variant — it's the only JavaScript in
+this collection, and it's the same ~10 lines regardless of which
+animation class is applied:
+
+```js
+document.querySelectorAll('.ease-copy-btn').forEach((button) => {
+  button.addEventListener('click', () => {
+    navigator.clipboard.writeText(button.dataset.copyText || '');
+    button.classList.remove('is-copied');
+    void button.offsetWidth; // restart animation on rapid repeat clicks
+    button.classList.add('is-copied');
+    setTimeout(() => button.classList.remove('is-copied'), 1500);
+  });
+});
+```
+
+## Why is it useful?
+EaseMotion CSS already has a copy-to-clipboard button tied specifically to
+code blocks, but most real apps need to copy all sorts of things — emails,
+referral links, coupon codes, API keys — and end up rebuilding the same
+confirmation feedback each time. This collection separates the
+*confirmation animation* from the *copy target* entirely: drop
+`ease-copy-btn` plus any one variant class onto any button, toggle a single
+`.is-copied` state, and the rest is pure CSS (clip-path/stroke morph,
+scale-pulse, crossfade, ripple burst). That keeps it dependency-free and
+composable with EaseMotion CSS's animation-first philosophy, and it can sit
+alongside the existing code-block copy button rather than replacing it.
+
+## Tech Stack
+- HTML (with a tiny inline SVG checkmark for the morph variant)
+- CSS only for every confirmation animation (`transition`, `@keyframes`,
+  `stroke-dashoffset` morph, `clip-path`-free checkmark draw-in)
+- ~10 lines of shared JS — the clipboard call and state-class toggle,
+  identical across all four variants, not specific to any one of them
+
+## Preview
+Open `demo.html` directly in your browser — no build step, no server,
+no external dependencies. Click each button to see its confirmation
+animation play.
+
+## Note on naming
+Submitted as `copy-confirmation-collection-tk` (suffixed per the repo's
+naming-collision policy in `CONTRIBUTING.md`) since a code-block-specific
+copy button already exists (`copy-to-clipboard`, `copy-to-clipboard-btn`,
+etc.). This collection is scoped to confirmation *animations* that work on
+any button, so it complements rather than duplicates that prior art.

--- a/submissions/examples/copy-confirmation-collection-tk/demo.html
+++ b/submissions/examples/copy-confirmation-collection-tk/demo.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Copy-Confirmation Button Collection — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header style="max-width:640px;margin:0 auto 3rem;">
+    <h1 style="font-size:1.6rem;margin-bottom:0.3rem;">Animated Copy-Confirmation Button Collection</h1>
+    <p style="color:#9a9aab;font-size:0.95rem;">
+      Four reusable confirmation animations for any copy button — works on
+      code, emails, links, or coupon codes. All animation is CSS; the only
+      JavaScript is the clipboard call itself and toggling
+      <code>.is-copied</code>.
+    </p>
+  </header>
+
+  <!-- 1. copy-morph -->
+  <section class="demo-section">
+    <h2>ease-copy-morph</h2>
+    <p class="demo-desc">Icon morphs from a copy glyph into a checkmark on click.</p>
+    <div class="demo-row">
+      <button
+        class="ease-copy-btn ease-copy-morph"
+        data-copy-text="hello@example.com"
+      >
+        <span class="ease-copy-icon">
+          <span class="ease-check-stroke">
+            <svg viewBox="0 0 14 14">
+              <path d="M2 7.5 L5.5 11 L12 3" />
+            </svg>
+          </span>
+        </span>
+        Copy email
+      </button>
+    </div>
+  </section>
+
+  <!-- 2. copy-pulse -->
+  <section class="demo-section">
+    <h2>ease-copy-pulse</h2>
+    <p class="demo-desc">Button briefly scale-pulses and flashes green on click.</p>
+    <div class="demo-row">
+      <button class="ease-copy-btn ease-copy-pulse" data-copy-text="EASEMOTION25">
+        Copy coupon code
+      </button>
+    </div>
+  </section>
+
+  <!-- 3. copy-label-swap -->
+  <section class="demo-section">
+    <h2>ease-copy-label-swap</h2>
+    <p class="demo-desc">Label crossfades from "Copy" to "Copied!" and back.</p>
+    <div class="demo-row">
+      <button
+        class="ease-copy-btn ease-copy-label-swap"
+        data-copy-text="https://easemotion.css/docs"
+      >
+        <span class="ease-copy-label">
+          <span class="label-default">Copy link</span>
+          <span class="label-copied">Copied!</span>
+        </span>
+      </button>
+    </div>
+  </section>
+
+  <!-- 4. copy-ring -->
+  <section class="demo-section">
+    <h2>ease-copy-ring</h2>
+    <p class="demo-desc">Expanding ripple-style ring burst confirms the click registered.</p>
+    <div class="demo-row">
+      <button
+        class="ease-copy-btn ease-copy-ring"
+        data-copy-text="npm install easemotion-css"
+      >
+        Copy install command
+      </button>
+    </div>
+  </section>
+
+  <script>
+    // The only JavaScript this collection needs: read the data-copy-text
+    // attribute, write it to the clipboard, and toggle .is-copied so the
+    // CSS confirmation animation plays. Works identically for every
+    // variant above regardless of what's being copied.
+    document.querySelectorAll('.ease-copy-btn').forEach((button) => {
+      button.addEventListener('click', () => {
+        const text = button.dataset.copyText || '';
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).catch(() => {
+            /* clipboard permissions can fail silently in some browsers/iframes */
+          });
+        }
+
+        // restart animation reliably even on rapid repeat clicks
+        button.classList.remove('is-copied');
+        void button.offsetWidth;
+        button.classList.add('is-copied');
+
+        setTimeout(() => button.classList.remove('is-copied'), 1500);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/copy-confirmation-collection-tk/style.css
+++ b/submissions/examples/copy-confirmation-collection-tk/style.css
@@ -1,0 +1,277 @@
+/* =====================================================================
+   Animated Copy-Confirmation Button Collection
+   Pure CSS confirmation animations for any "copy" button, independent
+   of what's actually being copied (code, email, link, coupon, etc).
+   All animations are driven by a single .is-copied state class, which
+   is toggled by ~3 lines of JS (the clipboard call itself). Four pieces:
+     1. copy-morph        - icon morphs from copy-icon to checkmark
+     2. copy-pulse         - scale-pulse + green flash
+     3. copy-label-swap     - text label crossfades "Copy" -> "Copied!"
+     4. copy-ring             - expanding ripple-style ring burst on click
+   ===================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0d0d12;
+  color: #f4f4f7;
+  margin: 0;
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.demo-section {
+  max-width: 640px;
+  margin: 0 auto 3.5rem;
+}
+
+.demo-section h2 {
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+  color: #9a9aab;
+  text-transform: uppercase;
+  margin-bottom: 0.4rem;
+}
+
+.demo-section p.demo-desc {
+  color: #6f6f81;
+  font-size: 0.9rem;
+  margin-top: 0;
+  margin-bottom: 1.2rem;
+}
+
+.demo-note {
+  font-size: 0.78rem;
+  color: #6f6f81;
+  margin-top: 0.8rem;
+}
+
+code {
+  background: #1a1a24;
+  border: 1px solid #2c2c3c;
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.85em;
+}
+
+/* ---------------------------------------------------------------------
+   Base button shared by every variant
+   --------------------------------------------------------------------- */
+.ease-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: 10px;
+  border: 1px solid #2c2c3c;
+  background: #1a1a24;
+  color: #e7e7f0;
+  font-size: 0.9rem;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.15s ease;
+}
+
+.ease-copy-btn:hover {
+  border-color: #3a3a4d;
+}
+
+.ease-copy-btn:active {
+  transform: scale(0.97);
+}
+
+/* generic copy icon (css-drawn, no external asset) */
+.ease-copy-icon {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.ease-copy-icon::before,
+.ease-copy-icon::after {
+  content: "";
+  position: absolute;
+  border: 1.5px solid #9a9aab;
+  border-radius: 2px;
+  transition: border-color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
+}
+
+.ease-copy-icon::before {
+  width: 9px;
+  height: 9px;
+  top: 0;
+  left: 4px;
+  background: #1a1a24;
+}
+
+.ease-copy-icon::after {
+  width: 9px;
+  height: 9px;
+  top: 4px;
+  left: 0;
+  background: #1a1a24;
+}
+
+/* ---------------------------------------------------------------------
+   1. copy-morph
+   Icon morphs from the two-square copy glyph into a checkmark when
+   .is-copied is applied. Implemented by cross-fading the copy squares
+   out while drawing a checkmark with two pseudo-element strokes that
+   animate their clip-path / scale in.
+   --------------------------------------------------------------------- */
+.ease-copy-morph .ease-copy-icon::before,
+.ease-copy-morph .ease-copy-icon::after {
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.ease-copy-morph.is-copied .ease-copy-icon::before,
+.ease-copy-morph.is-copied .ease-copy-icon::after {
+  opacity: 0;
+  transform: scale(0.5);
+}
+
+.ease-copy-morph .ease-copy-icon .ease-check-stroke {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: scale(0.6);
+  transition: opacity 0.18s ease 0.1s, transform 0.18s ease 0.1s;
+}
+
+.ease-copy-morph .ease-check-stroke svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.ease-copy-morph .ease-check-stroke path {
+  fill: none;
+  stroke: #4ade80;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 16;
+  stroke-dashoffset: 16;
+  transition: stroke-dashoffset 0.25s ease 0.12s;
+}
+
+.ease-copy-morph.is-copied .ease-check-stroke {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.ease-copy-morph.is-copied .ease-check-stroke path {
+  stroke-dashoffset: 0;
+}
+
+.ease-copy-morph.is-copied {
+  border-color: #4ade80;
+}
+
+/* ---------------------------------------------------------------------
+   2. copy-pulse
+   Button briefly scale-pulses and flashes green on .is-copied.
+   --------------------------------------------------------------------- */
+.ease-copy-pulse.is-copied {
+  animation: copy-pulse 0.4s ease;
+  border-color: #4ade80;
+  background: rgba(74, 222, 128, 0.1);
+}
+
+@keyframes copy-pulse {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.06);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* ---------------------------------------------------------------------
+   3. copy-label-swap
+   Text label crossfades from "Copy" to "Copied!" on .is-copied, then
+   reverts once the class is removed by the consuming app's timeout.
+   --------------------------------------------------------------------- */
+.ease-copy-label-swap .ease-copy-label {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-copy-label-swap .ease-copy-label .label-default,
+.ease-copy-label-swap .ease-copy-label .label-copied {
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.ease-copy-label-swap .ease-copy-label .label-copied {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateY(4px);
+  color: #4ade80;
+  white-space: nowrap;
+}
+
+.ease-copy-label-swap.is-copied .ease-copy-label .label-default {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+.ease-copy-label-swap.is-copied .ease-copy-label .label-copied {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ---------------------------------------------------------------------
+   4. copy-ring
+   Expanding ripple-style ring burst confirming the click registered.
+   Pure CSS keyframe triggered by .is-copied; uses an ::after ring that
+   restarts cleanly each time the class re-applies (JS toggles the class
+   off and back on, see demo.html).
+   --------------------------------------------------------------------- */
+.ease-copy-ring {
+  isolation: isolate;
+}
+
+.ease-copy-ring::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 2px solid #7c5cff;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-copy-ring.is-copied::after {
+  animation: copy-ring-burst 0.5s ease-out;
+}
+
+@keyframes copy-ring-burst {
+  0% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(1.35);
+    opacity: 0;
+  }
+}
+
+.ease-copy-ring.is-copied {
+  border-color: #7c5cff;
+}
+
+/* Demo-only layout helpers */
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}


### PR DESCRIPTION
## Description

Implements the Animated Copy-Confirmation Button Collection requested in #15827 — four reusable, CSS-driven confirmation animations for any "copy" button, bundled under `submissions/examples/copy-confirmation-collection-tk/`.

## Pieces included

| Class | Behavior | Technique |
|---|---|---|
| `ease-copy-btn` | Base button, default idle state | Shared structure across all variants |
| `ease-copy-morph` | Copy icon morphs into a checkmark on `.is-copied` | CSS opacity/scale cross-fade + `stroke-dashoffset` draw-in on an inline SVG check |
| `ease-copy-pulse` | Button briefly scale-pulses + flashes green | CSS `@keyframes` scale pulse |
| `ease-copy-label-swap` | Text label crossfades "Copy" → "Copied!" and back | CSS opacity/translateY cross-fade between two stacked spans |
| `ease-copy-ring` | Expanding ripple-style ring burst on click | CSS `@keyframes` scale + fade on a pseudo-element ring |

## Design decision: confirmation animation only, not copy logic

This submission deliberately owns only the *confirmation feedback*, not the clipboard mechanics. Every variant is triggered by a single `.is-copied` state class, toggled by one shared JS handler (~10 lines: `navigator.clipboard.writeText()` + class toggle + timeout). That handler is identical across all four variants and works for any copy target — code, email, link, coupon — rather than being tied to code blocks like the existing `copy-to-clipboard` submission.

## Files added

- `submissions/examples/copy-confirmation-collection-tk/demo.html`
- `submissions/examples/copy-confirmation-collection-tk/style.css`
- `submissions/examples/copy-confirmation-collection-tk/README.md`

## Checklist

- [x] Added files only inside `submissions/examples/copy-confirmation-collection-tk/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] `demo.html` is self-contained — opens directly in browser, no server, no CDN/external frameworks
- [x] No edits to `core/`, `components/`, `docs/`, or `examples/`
- [x] README answers: what it does, how it's used, why it's useful
- [x] Commits squashed into one logical commit
- [x] Folder suffixed (`-tk`) per naming-collision policy, since a code-block-specific copy button already exists (`copy-to-clipboard`)

Closes #15827