### PR TITLE
feat: add neumorphic step progress bar component

### DIFF
--- a/submissions/examples/neumorphic-step-progress/README.md
+++ b/submissions/examples/neumorphic-step-progress/README.md
@@ -1,0 +1,16 @@
+# Neumorphic Step Progress Bar
+
+A clean, modern horizontal step progress tracker built using the "Neumorphism" design system. It visually represents a multi-step process (like a checkout flow or a signup wizard), showing completed steps, the current active step, and future steps.
+
+## Features
+- Pure CSS implementation
+- Beautiful neumorphic depth effects using both inset and outset `box-shadow` properties
+- Animated background progress line that fills up to the current step
+- Three distinct CSS states (`.active`, `.current`, and default) for easy JavaScript integration
+
+## Usage
+Add the HTML structure and the accompanying `style.css` to your project. To change the state of a step, simply toggle the CSS classes:
+- Add the `active` class to a `.step` when the user has completed it.
+- Add the `current` class to a `.step` to indicate the user is currently on it.
+- Remove both classes for future, incomplete steps.
+Modify the `calc()` percentage in the `.step-progress::after` CSS rule to dynamically adjust the width of the animated line based on the number of steps completed.

--- a/submissions/examples/neumorphic-step-progress/demo.html
+++ b/submissions/examples/neumorphic-step-progress/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Step Progress Bar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="progress-container">
+        <ul class="step-progress">
+            <li class="step active">
+                <div class="step-icon">1</div>
+                <div class="step-text">Details</div>
+            </li>
+            <li class="step active">
+                <div class="step-icon">2</div>
+                <div class="step-text">Shipping</div>
+            </li>
+            <li class="step current">
+                <div class="step-icon">3</div>
+                <div class="step-text">Payment</div>
+            </li>
+            <li class="step">
+                <div class="step-icon">4</div>
+                <div class="step-text">Confirm</div>
+            </li>
+        </ul>
+    </div>
+</body>
+</html>

--- a/submissions/examples/neumorphic-step-progress/style.css
+++ b/submissions/examples/neumorphic-step-progress/style.css
@@ -1,0 +1,128 @@
+/* Neumorphic Step Progress Bar CSS */
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: #e0e5ec;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.progress-container {
+    padding: 40px;
+    background: #e0e5ec;
+    border-radius: 30px;
+    box-shadow: 15px 15px 30px #a3b1c6, -15px -15px 30px #ffffff;
+}
+
+.step-progress {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    position: relative;
+}
+
+/* The connecting line background */
+.step-progress::before {
+    content: '';
+    position: absolute;
+    top: 25px; 
+    left: 60px; /* Half of first step width */
+    width: calc(100% - 120px);
+    height: 6px;
+    background: #e0e5ec;
+    box-shadow: inset 3px 3px 6px #a3b1c6, inset -3px -3px 6px #ffffff;
+    z-index: 0;
+    transform: translateY(-50%);
+    border-radius: 3px;
+}
+
+/* The filled connecting line */
+.step-progress::after {
+    content: '';
+    position: absolute;
+    top: 25px;
+    left: 60px;
+    /* 3 intervals between 4 steps. 2 steps complete = 2/3 fill */
+    width: calc((100% - 120px) * 0.66); 
+    height: 6px;
+    background: linear-gradient(90deg, #6b8cce, #8ba8df);
+    z-index: 0;
+    transform: translateY(-50%);
+    border-radius: 3px;
+    box-shadow: inset 2px 2px 4px rgba(0,0,0,0.2);
+    animation: fill-progress 1.5s ease-in-out forwards;
+    transform-origin: left;
+}
+
+@keyframes fill-progress {
+    0% { transform: translateY(-50%) scaleX(0); }
+    100% { transform: translateY(-50%) scaleX(1); }
+}
+
+.step {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 120px;
+    cursor: default;
+}
+
+/* The Circle Icons */
+.step-icon {
+    position: relative;
+    z-index: 2;
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background: #e0e5ec;
+    box-shadow: 6px 6px 12px #a3b1c6, -6px -6px 12px #ffffff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 18px;
+    font-weight: 700;
+    color: #8a97a8;
+    transition: 0.4s ease;
+    margin-bottom: 15px;
+}
+
+/* The Text Label */
+.step-text {
+    font-size: 14px;
+    font-weight: 600;
+    color: #8a97a8;
+    transition: 0.4s ease;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+/* Active State (Completed Steps) */
+.step.active .step-icon {
+    color: #6b8cce;
+    box-shadow: inset 6px 6px 12px #a3b1c6, inset -6px -6px 12px #ffffff;
+}
+
+.step.active .step-text {
+    color: #6b8cce;
+}
+
+/* Current State (In-Progress Step) */
+.step.current .step-icon {
+    color: #fff;
+    background: #6b8cce;
+    box-shadow: 6px 6px 12px #a3b1c6, -6px -6px 12px #ffffff, inset 2px 2px 5px rgba(255,255,255,0.3);
+}
+
+.step.current .step-text {
+    color: #4d5b6e;
+}
+
+/* Hover effects for interactivity */
+.step:hover .step-icon {
+    transform: translateY(-2px);
+}


### PR DESCRIPTION
### Description
This PR introduces a brand new component to the library: the **Neumorphic Step Progress Bar**.

The submission is placed entirely within a new folder under `submissions/examples/neumorphic-step-progress/` and contains the required `demo.html`, `style.css`, and `README.md` files.

The design utilizes:
- Multiple layers of light and dark `box-shadow` values to simulate 3D neumorphic depth.
- CSS pseudo-elements (`::before` and `::after`) placed dynamically using `calc()` to draw and animate the connecting progress line behind the steps.
- `inset` shadows to physically recess the completed steps into the background.

### Related Issue
Fixes #15847 

### Changes Made
- Added `submissions/examples/neumorphic-step-progress/demo.html`
- Added `submissions/examples/neumorphic-step-progress/style.css`
- Added `submissions/examples/neumorphic-step-progress/README.md`

### Validation
This PR complies with all repository guidelines:
- No existing core files or other submissions were modified.
- No code was deleted.
- All three required files are present and contain valid structure and original content.

### Labels
Maintainers, please ensure the following labels are added to this PR:
- `gssoc:approved`
- `difficulty`
- `type`
- `quality`
