### PR TITLE
feat: Add Animated PIN/OTP Input Collection (issue #15831)

### DIFF
--- a/submissions/examples/pin-otp-input-collection/README.md
+++ b/submissions/examples/pin-otp-input-collection/README.md
@@ -1,0 +1,51 @@
+# Animated PIN / OTP Input Collection
+
+**EaseMotion CSS — Issue #15831**
+`submissions/examples/pin-otp-input-collection/`
+
+A segmented PIN / OTP entry component with smooth CSS animations.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `style.css` | All component styles and keyframes |
+| `demo.html` | Live demo with all variants |
+| `README.md` | This file |
+
+## Classes
+
+| Class | Element | Behaviour |
+|---|---|---|
+| `ease-otp-row` | `div` | Flex row container |
+| `ease-otp-cell` | `span` | Relative wrapper per digit |
+| `ease-otp-box` | `input` | Single digit cell |
+| `ease-otp-fill-pop` | `input` | Scale pop on digit entry |
+| `ease-otp-caret` | `span` | Blinking caret in empty focused cell |
+| `is-invalid` | `ease-otp-row` | Shake + red flash on wrong code |
+| `is-complete` | `ease-otp-row` | Green glow on correct code |
+
+## Themes
+
+| Class | Look |
+|---|---|
+| *(none)* | Default indigo on white |
+| `ease-otp-theme-dark` | Deep navy, violet accent |
+| `ease-otp-theme-neon` | Black, cyan accent |
+| `ease-otp-theme-soft` | Lavender, pill-shaped cells |
+
+## Usage
+
+```html
+<div class="ease-otp-row">
+  <span class="ease-otp-cell">
+    <input class="ease-otp-box ease-otp-fill-pop"
+           type="text" inputmode="numeric" maxlength="1" />
+    <span class="ease-otp-caret"></span>
+  </span>
+</div>
+```
+
+## Contributor
+
+**Akanksha Thakur** (`@thakurakanksha288`) — GSSoC 2026

--- a/submissions/examples/pin-otp-input-collection/demo.html
+++ b/submissions/examples/pin-otp-input-collection/demo.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated PIN / OTP Input Collection — EaseMotion CSS</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      background: #f8f9fc;
+      font-family: "Inter", system-ui, sans-serif;
+      color: #101828;
+      padding: 3rem 1.5rem 5rem;
+    }
+    .page-header { text-align: center; margin-bottom: 3.5rem; }
+    .page-header h1 { font-size: 2rem; font-weight: 800; letter-spacing: -0.02em; margin-bottom: 0.4rem; }
+    .page-header p { color: #667085; font-size: 1rem; }
+    .demo-grid { display: grid; gap: 2.5rem; max-width: 700px; margin: 0 auto; }
+    .demo-card { background: #fff; border: 1px solid #e4e7ec; border-radius: 1rem; padding: 2rem 2.5rem; box-shadow: 0 1px 3px rgba(16,24,40,.06); }
+    .demo-card h2 { font-size: 0.75rem; font-weight: 600; letter-spacing: 0.07em; text-transform: uppercase; color: #98a2b3; margin-bottom: 0.35rem; }
+    .demo-card p { font-size: 0.9rem; color: #475467; margin-bottom: 1.5rem; }
+    .demo-center { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+    .demo-actions { display: flex; gap: 0.6rem; flex-wrap: wrap; justify-content: center; }
+    button.btn { padding: 0.4rem 1rem; font-family: inherit; font-size: 0.82rem; font-weight: 600; border: none; border-radius: 0.45rem; cursor: pointer; transition: opacity 0.15s; }
+    button.btn:hover { opacity: 0.85; }
+    button.btn-primary { background: #6366f1; color: #fff; }
+    button.btn-danger  { background: #f04438; color: #fff; }
+    button.btn-success { background: #12b76a; color: #fff; }
+    button.btn-ghost   { background: #f2f4f7; color: #344054; }
+    .status-msg { font-size: 0.82rem; font-weight: 500; min-height: 1.2em; text-align: center; }
+    .status-msg.error   { color: #f04438; }
+    .status-msg.success { color: #12b76a; }
+    .demo-card.dark-card { background: #1e1e2e; border-color: #3b3b52; color: #e2e2f0; }
+    .demo-card.dark-card h2 { color: #6b6b8a; }
+    .demo-card.dark-card p  { color: #9898b8; }
+    .demo-card.neon-card { background: #0a0a0f; border-color: #1a1a2e; color: #00f5ff; }
+    .demo-card.neon-card h2 { color: #3a3a5e; }
+    .demo-card.neon-card p  { color: #4a4a7e; }
+    .demo-card.soft-card { background: #faf5ff; border-color: #e9d5ff; }
+    .demo-card.soft-card h2 { color: #c084fc; }
+    .demo-card.soft-card p  { color: #7e22ce; }
+  </style>
+</head>
+<body>
+
+<header class="page-header">
+  <h1>Animated PIN / OTP Input</h1>
+  <p>EaseMotion CSS — Issue #15831 · submissions/examples/pin-otp-input-collection</p>
+</header>
+
+<div class="demo-grid">
+
+  <div class="demo-card">
+    <h2>Default · 4-digit OTP</h2>
+    <p>Core classes: <code>ease-otp-row</code>, <code>ease-otp-cell</code>, <code>ease-otp-box</code>, <code>ease-otp-fill-pop</code>. Type a digit to see the pop animation and blinking caret.</p>
+    <div class="demo-center">
+      <div id="otp-default" class="ease-otp-row" data-length="4"></div>
+      <div class="demo-actions">
+        <button class="btn btn-danger"  onclick="triggerError('otp-default','msg-default')">Wrong code</button>
+        <button class="btn btn-success" onclick="triggerSuccess('otp-default','msg-default')">Correct code</button>
+        <button class="btn btn-ghost"   onclick="resetOtp('otp-default','msg-default')">Reset</button>
+      </div>
+      <span id="msg-default" class="status-msg"></span>
+    </div>
+  </div>
+
+  <div class="demo-card">
+    <h2>6-digit PIN</h2>
+    <p>Set <code>data-length="6"</code> for a longer PIN entry.</p>
+    <div class="demo-center">
+      <div id="otp-6" class="ease-otp-row" data-length="6"></div>
+      <div class="demo-actions">
+        <button class="btn btn-danger"  onclick="triggerError('otp-6','msg-6')">Wrong PIN</button>
+        <button class="btn btn-success" onclick="triggerSuccess('otp-6','msg-6')">Correct PIN</button>
+        <button class="btn btn-ghost"   onclick="resetOtp('otp-6','msg-6')">Reset</button>
+      </div>
+      <span id="msg-6" class="status-msg"></span>
+    </div>
+  </div>
+
+  <div class="demo-card dark-card">
+    <h2>Dark theme</h2>
+    <p>Add <code>ease-otp-theme-dark</code> to the row element.</p>
+    <div class="demo-center">
+      <div id="otp-dark" class="ease-otp-row ease-otp-theme-dark" data-length="4"></div>
+      <div class="demo-actions">
+        <button class="btn btn-danger"  onclick="triggerError('otp-dark','msg-dark')">Wrong</button>
+        <button class="btn btn-success" onclick="triggerSuccess('otp-dark','msg-dark')">Correct</button>
+        <button class="btn btn-ghost"   onclick="resetOtp('otp-dark','msg-dark')">Reset</button>
+      </div>
+      <span id="msg-dark" class="status-msg"></span>
+    </div>
+  </div>
+
+  <div class="demo-card neon-card">
+    <h2>Neon theme</h2>
+    <p>Add <code>ease-otp-theme-neon</code> for a cyberpunk aesthetic.</p>
+    <div class="demo-center">
+      <div id="otp-neon" class="ease-otp-row ease-otp-theme-neon" data-length="4"></div>
+      <div class="demo-actions">
+        <button class="btn btn-danger"  onclick="triggerError('otp-neon','msg-neon')">Wrong</button>
+        <button class="btn btn-success" onclick="triggerSuccess('otp-neon','msg-neon')">Correct</button>
+        <button class="btn btn-ghost"   onclick="resetOtp('otp-neon','msg-neon')">Reset</button>
+      </div>
+      <span id="msg-neon" class="status-msg"></span>
+    </div>
+  </div>
+
+  <div class="demo-card soft-card">
+    <h2>Soft theme</h2>
+    <p>Add <code>ease-otp-theme-soft</code> for pill-shaped pastel cells.</p>
+    <div class="demo-center">
+      <div id="otp-soft" class="ease-otp-row ease-otp-theme-soft" data-length="4"></div>
+      <div class="demo-actions">
+        <button class="btn btn-danger"  onclick="triggerError('otp-soft','msg-soft')">Wrong</button>
+        <button class="btn btn-success" onclick="triggerSuccess('otp-soft','msg-soft')">Correct</button>
+        <button class="btn btn-ghost"   onclick="resetOtp('otp-soft','msg-soft')">Reset</button>
+      </div>
+      <span id="msg-soft" class="status-msg"></span>
+    </div>
+  </div>
+
+</div>
+
+<script>
+function buildOtp(rowId) {
+  const row = document.getElementById(rowId);
+  if (!row) return;
+  const len = parseInt(row.dataset.length || 4, 10);
+  for (let i = 0; i < len; i++) {
+    const cell = document.createElement('span');
+    cell.className = 'ease-otp-cell';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.inputMode = 'numeric';
+    input.pattern = '[0-9]';
+    input.maxLength = 1;
+    input.className = 'ease-otp-box ease-otp-fill-pop';
+    input.setAttribute('aria-label', 'Digit ' + (i + 1) + ' of ' + len);
+    const caret = document.createElement('span');
+    caret.className = 'ease-otp-caret';
+    cell.appendChild(input);
+    cell.appendChild(caret);
+    row.appendChild(cell);
+  }
+  attachListeners(row);
+}
+
+function getInputs(row) {
+  return Array.from(row.querySelectorAll('.ease-otp-box'));
+}
+
+function attachListeners(row) {
+  const inputs = getInputs(row);
+  inputs.forEach(function(input, idx) {
+    input.addEventListener('input', function(e) {
+      const val = e.target.value.replace(/\D/g, '');
+      e.target.value = val;
+      if (val) {
+        input.classList.add('is-filled');
+        input.classList.remove('pop');
+        void input.offsetWidth;
+        input.classList.add('pop');
+        if (idx < inputs.length - 1) inputs[idx + 1].focus();
+      } else {
+        input.classList.remove('is-filled', 'pop');
+      }
+      row.classList.remove('is-invalid', 'is-complete');
+    });
+    input.addEventListener('keydown', function(e) {
+      if (e.key === 'Backspace') {
+        if (input.value === '' && idx > 0) {
+          const prev = inputs[idx - 1];
+          prev.value = '';
+          prev.classList.remove('is-filled', 'pop');
+          prev.focus();
+        } else {
+          input.value = '';
+          input.classList.remove('is-filled', 'pop');
+        }
+        row.classList.remove('is-invalid', 'is-complete');
+        e.preventDefault();
+      }
+      if (e.key === 'ArrowLeft' && idx > 0) inputs[idx - 1].focus();
+      if (e.key === 'ArrowRight' && idx < inputs.length - 1) inputs[idx + 1].focus();
+    });
+    input.addEventListener('paste', function(e) {
+      e.preventDefault();
+      const pasted = (e.clipboardData || window.clipboardData).getData('text').replace(/\D/g, '').slice(0, inputs.length);
+      pasted.split('').forEach(function(ch, ci) {
+        if (inputs[ci]) {
+          inputs[ci].value = ch;
+          inputs[ci].classList.add('is-filled');
+          inputs[ci].classList.remove('pop');
+          void inputs[ci].offsetWidth;
+          inputs[ci].classList.add('pop');
+        }
+      });
+      const nextEmpty = inputs[pasted.length] || inputs[inputs.length - 1];
+      nextEmpty.focus();
+      row.classList.remove('is-invalid', 'is-complete');
+    });
+  });
+}
+
+function triggerError(rowId, msgId) {
+  const row = document.getElementById(rowId);
+  const msg = document.getElementById(msgId);
+  row.classList.remove('is-complete', 'is-invalid');
+  void row.offsetWidth;
+  row.classList.add('is-invalid');
+  if (msg) { msg.textContent = 'Incorrect code. Try again.'; msg.className = 'status-msg error'; }
+  row.addEventListener('animationend', function() { row.classList.remove('is-invalid'); }, { once: true });
+}
+
+function triggerSuccess(rowId, msgId) {
+  const row = document.getElementById(rowId);
+  const msg = document.getElementById(msgId);
+  row.classList.remove('is-invalid');
+  row.classList.add('is-complete');
+  if (msg) { msg.textContent = 'Verified! ✓'; msg.className = 'status-msg success'; }
+}
+
+function resetOtp(rowId, msgId) {
+  const row = document.getElementById(rowId);
+  const msg = document.getElementById(msgId);
+  getInputs(row).forEach(function(inp) {
+    inp.value = '';
+    inp.classList.remove('is-filled', 'pop');
+  });
+  row.classList.remove('is-invalid', 'is-complete');
+  getInputs(row)[0].focus();
+  if (msg) { msg.textContent = ''; msg.className = 'status-msg'; }
+}
+
+['otp-default','otp-6','otp-dark','otp-neon','otp-soft'].forEach(buildOtp);
+</script>
+
+</body>
+</html>

--- a/submissions/examples/pin-otp-input-collection/style.css
+++ b/submissions/examples/pin-otp-input-collection/style.css
@@ -1,0 +1,200 @@
+/* =====================================================
+   EaseMotion CSS — Animated PIN / OTP Input Collection
+   Issue #15831
+   ===================================================== */
+
+:root {
+  --otp-size: 3.2rem;
+  --otp-gap: 0.6rem;
+  --otp-radius: 0.55rem;
+  --otp-font: "Inter", "Segoe UI", system-ui, sans-serif;
+  --otp-font-size: 1.5rem;
+  --otp-font-weight: 700;
+  --otp-border: #d0d5dd;
+  --otp-bg: #ffffff;
+  --otp-text: #101828;
+  --otp-focus-border: #6366f1;
+  --otp-focus-shadow: 0 0 0 4px rgba(99, 102, 241, 0.18);
+  --otp-filled-bg: #f5f3ff;
+  --otp-filled-border: #818cf8;
+  --otp-error-border: #f04438;
+  --otp-error-bg: #fff1f0;
+  --otp-error-shadow: 0 0 0 4px rgba(240, 68, 56, 0.15);
+  --otp-success-border: #12b76a;
+  --otp-success-bg: #ecfdf3;
+  --otp-success-shadow: 0 0 0 6px rgba(18, 183, 106, 0.18);
+  --otp-caret-color: #6366f1;
+  --otp-caret-width: 2px;
+  --otp-caret-height: 1.6rem;
+}
+
+.ease-otp-row {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--otp-gap);
+  font-family: var(--otp-font);
+  position: relative;
+}
+
+.ease-otp-cell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ease-otp-box {
+  width: var(--otp-size);
+  height: var(--otp-size);
+  padding: 0;
+  border: 2px solid var(--otp-border);
+  border-radius: var(--otp-radius);
+  background: var(--otp-bg);
+  color: var(--otp-text);
+  font-family: inherit;
+  font-size: var(--otp-font-size);
+  font-weight: var(--otp-font-weight);
+  text-align: center;
+  line-height: 1;
+  outline: none;
+  cursor: text;
+  caret-color: transparent;
+  transition: border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease, transform 0.12s ease;
+  -webkit-appearance: none;
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+.ease-otp-box::-webkit-outer-spin-button,
+.ease-otp-box::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.ease-otp-box:focus {
+  border-color: var(--otp-focus-border);
+  box-shadow: var(--otp-focus-shadow);
+}
+
+.ease-otp-box.is-filled {
+  background: var(--otp-filled-bg);
+  border-color: var(--otp-filled-border);
+}
+
+@keyframes ease-otp-fill-pop {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.18); }
+  70%  { transform: scale(0.94); }
+  100% { transform: scale(1); }
+}
+
+.ease-otp-fill-pop.pop {
+  animation: ease-otp-fill-pop 0.28s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+@keyframes ease-otp-caret-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+.ease-otp-caret {
+  display: none;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: var(--otp-caret-width);
+  height: var(--otp-caret-height);
+  background: var(--otp-caret-color);
+  border-radius: 1px;
+  pointer-events: none;
+  animation: ease-otp-caret-blink 1s step-end infinite;
+}
+
+.ease-otp-box:focus:not(.is-filled) ~ .ease-otp-caret {
+  display: block;
+}
+
+@keyframes ease-otp-error-shake {
+  0%   { transform: translateX(0); }
+  15%  { transform: translateX(-7px); }
+  30%  { transform: translateX(6px); }
+  45%  { transform: translateX(-5px); }
+  60%  { transform: translateX(4px); }
+  75%  { transform: translateX(-2px); }
+  90%  { transform: translateX(1px); }
+  100% { transform: translateX(0); }
+}
+
+.ease-otp-row.is-invalid {
+  animation: ease-otp-error-shake 0.45s ease forwards;
+}
+
+.ease-otp-row.is-invalid .ease-otp-box {
+  border-color: var(--otp-error-border);
+  background: var(--otp-error-bg);
+  box-shadow: var(--otp-error-shadow);
+  color: var(--otp-error-border);
+}
+
+@keyframes ease-otp-success-glow {
+  0%   { box-shadow: var(--otp-success-shadow); }
+  50%  { box-shadow: 0 0 0 10px rgba(18, 183, 106, 0.08); }
+  100% { box-shadow: var(--otp-success-shadow); }
+}
+
+.ease-otp-row.is-complete .ease-otp-box {
+  border-color: var(--otp-success-border);
+  background: var(--otp-success-bg);
+  color: #027a48;
+  animation: ease-otp-success-glow 0.7s ease forwards;
+}
+
+.ease-otp-theme-dark {
+  --otp-bg: #1e1e2e;
+  --otp-border: #3b3b52;
+  --otp-text: #e2e2f0;
+  --otp-focus-border: #a78bfa;
+  --otp-focus-shadow: 0 0 0 4px rgba(167, 139, 250, 0.2);
+  --otp-filled-bg: #2a2a42;
+  --otp-filled-border: #a78bfa;
+  --otp-caret-color: #a78bfa;
+  --otp-error-bg: #2d1b1b;
+  --otp-success-bg: #0d2218;
+}
+
+.ease-otp-theme-neon {
+  --otp-bg: #0a0a0f;
+  --otp-border: #1a1a2e;
+  --otp-text: #00f5ff;
+  --otp-focus-border: #00f5ff;
+  --otp-focus-shadow: 0 0 0 3px rgba(0, 245, 255, 0.25), 0 0 12px rgba(0, 245, 255, 0.15);
+  --otp-filled-bg: #0d1117;
+  --otp-filled-border: #7c3aed;
+  --otp-caret-color: #00f5ff;
+  --otp-font-weight: 800;
+}
+
+.ease-otp-theme-soft {
+  --otp-bg: #faf5ff;
+  --otp-border: #e9d5ff;
+  --otp-text: #6d28d9;
+  --otp-focus-border: #a855f7;
+  --otp-focus-shadow: 0 0 0 4px rgba(168, 85, 247, 0.15);
+  --otp-filled-bg: #f3e8ff;
+  --otp-filled-border: #a855f7;
+  --otp-caret-color: #a855f7;
+  --otp-radius: 999px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-otp-fill-pop.pop,
+  .ease-otp-row.is-invalid,
+  .ease-otp-row.is-complete .ease-otp-box {
+    animation: none;
+  }
+  .ease-otp-caret {
+    animation: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Closes #15831

## Summary
Adds a fully animated PIN/OTP input component under `submissions/examples/pin-otp-input-collection/`.

## Files Added
- `style.css` — component CSS API with all keyframe animations
- `demo.html` — live demo with 5 variants and interactive controls
- `README.md` — usage docs, class reference, theme table

## Classes Implemented
| Class | Behaviour |
|---|---|
| `ease-otp-box` | Single digit cell; idle, focused, and filled states |
| `ease-otp-fill-pop` | Elastic scale pop when a digit is entered |
| `ease-otp-caret` | Blinking caret in the active empty cell |
| `.is-invalid` on row | Horizontal shake + red flash on wrong code |
| `.is-complete` on row | Green glow on successful entry |

## Themes
- Default (indigo/white)
- `ease-otp-theme-dark`
- `ease-otp-theme-neon`
- `ease-otp-theme-soft` (pill-shaped cells)

## Notes
- All animations are pure CSS `@keyframes` — zero dependencies
- JS in `demo.html` handles focus management only (auto-advance, backspace, paste, arrow keys)
- `prefers-reduced-motion` respected

---
GSSoC 2026 contribution by @thakurakanksha288