### PR TITLE
feat: add css-only parallax depth card component

### DIFF
--- a/submissions/examples/css-only-parallax-depth-card/README.md
+++ b/submissions/examples/css-only-parallax-depth-card/README.md
@@ -1,0 +1,13 @@
+# CSS-Only Parallax Depth Card
+
+A stunning, highly-interactive 3D card component built purely with CSS. When hovered, the card physically tilts on the X and Y axes, revealing multiple distinct layers of depth.
+
+## Features
+- Pure CSS implementation (No JavaScript needed for the parallax effect)
+- Uses `transform-style: preserve-3d` to create true spatial depth between elements
+- Elements are pushed back (`translateZ(-50px)`) and pulled forward (`translateZ(90px)`) to create a dramatic parallax illusion during rotation
+- Includes floating, animated abstract orbs that intersect the card's Z-space
+- Fully responsive and easy to integrate
+
+## Usage
+Simply drop the HTML and CSS into your project. To customize the card, replace the background image URL in the `.card-bg` CSS rule. Remember that `transform-style: preserve-3d` does not work well with `overflow: hidden`, so any background elements that should stay within the card's borders must have their own `border-radius` applied manually.

--- a/submissions/examples/css-only-parallax-depth-card/demo.html
+++ b/submissions/examples/css-only-parallax-depth-card/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS-Only Parallax Depth Card</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="card-container">
+        <div class="card">
+            <div class="card-bg"></div>
+            <div class="card-content">
+                <h2>Explore</h2>
+                <p>Dive deep into pure CSS 3D transformations.</p>
+                <a href="#" class="btn">Discover</a>
+            </div>
+            <div class="card-element floating-1"></div>
+            <div class="card-element floating-2"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-only-parallax-depth-card/style.css
+++ b/submissions/examples/css-only-parallax-depth-card/style.css
@@ -1,0 +1,144 @@
+/* CSS-Only Parallax Depth Card CSS */
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: #1e1e24;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    perspective: 1000px;
+}
+
+.card-container {
+    width: 350px;
+    height: 500px;
+    position: relative;
+    transform-style: preserve-3d;
+    transition: transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.card-container:hover {
+    transform: rotateY(15deg) rotateX(-10deg);
+}
+
+.card {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    transform-style: preserve-3d;
+    box-shadow: 0 30px 50px rgba(0, 0, 0, 0.5);
+}
+
+/* Background image that pushes deep back */
+.card-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 20px;
+    background: url('https://images.unsplash.com/photo-1534447677768-be436bb09401?q=80&w=800&auto=format&fit=crop') center/cover;
+    transform: translateZ(-50px) scale(1.1);
+    filter: brightness(0.6);
+    transition: filter 0.5s;
+}
+
+.card-container:hover .card-bg {
+    filter: brightness(0.4);
+}
+
+/* Floating content layers popping out of the card */
+.card-content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) translateZ(60px);
+    text-align: center;
+    width: 80%;
+    color: #fff;
+    pointer-events: none;
+    transition: transform 0.5s;
+}
+
+.card-container:hover .card-content {
+    transform: translate(-50%, -50%) translateZ(80px);
+}
+
+.card-content h2 {
+    font-size: 40px;
+    margin: 0 0 10px;
+    text-transform: uppercase;
+    letter-spacing: 4px;
+    text-shadow: 0 10px 20px rgba(0, 0, 0, 0.5);
+}
+
+.card-content p {
+    font-size: 16px;
+    color: #ccc;
+    margin-bottom: 30px;
+    text-shadow: 0 5px 10px rgba(0, 0, 0, 0.5);
+}
+
+.btn {
+    display: inline-block;
+    padding: 12px 30px;
+    background: linear-gradient(45deg, #ff2e63, #ea2a5b);
+    color: #fff;
+    text-decoration: none;
+    border-radius: 30px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    pointer-events: auto;
+    transition: 0.3s;
+    box-shadow: 0 10px 20px rgba(255, 46, 99, 0.4);
+}
+
+.btn:hover {
+    background: linear-gradient(45deg, #ea2a5b, #ff2e63);
+    box-shadow: 0 15px 30px rgba(255, 46, 99, 0.6);
+}
+
+/* Floating abstract geometric elements popping out of the card */
+.card-element {
+    position: absolute;
+    border-radius: 50%;
+    backdrop-filter: blur(5px);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+}
+
+.floating-1 {
+    width: 80px;
+    height: 80px;
+    top: 20px;
+    right: -20px;
+    background: linear-gradient(135deg, rgba(8, 217, 214, 0.8), rgba(8, 217, 214, 0.2));
+    transform: translateZ(90px);
+    animation: float1 4s ease-in-out infinite alternate;
+}
+
+.floating-2 {
+    width: 120px;
+    height: 120px;
+    bottom: -30px;
+    left: -30px;
+    background: linear-gradient(135deg, rgba(255, 46, 99, 0.8), rgba(255, 46, 99, 0.2));
+    transform: translateZ(50px);
+    animation: float2 6s ease-in-out infinite alternate-reverse;
+}
+
+@keyframes float1 {
+    0% { transform: translateZ(90px) translateY(0px); }
+    100% { transform: translateZ(90px) translateY(-20px); }
+}
+
+@keyframes float2 {
+    0% { transform: translateZ(50px) translateY(0px); }
+    100% { transform: translateZ(50px) translateY(15px); }
+}


### PR DESCRIPTION
### Description
This PR introduces a brand new component to the library: the **CSS-Only Parallax Depth Card**.

The submission is placed entirely within a new folder under `submissions/examples/css-only-parallax-depth-card/` and contains the required `demo.html`, `style.css`, and `README.md` files.

The design utilizes:
- `transform-style: preserve-3d` to unlock true 3D space rendering in CSS.
- Layered elements separated across the Z-axis (`translateZ(-50px)` for the background, `translateZ(60px)` for the text, `translateZ(90px)` for floating orbs) to naturally create parallax when the parent container is rotated.
- Hover states that subtly tilt the parent container (`rotateX` and `rotateY`) while maintaining the 3D context.

### Related Issue
Fixes #15851 

### Changes Made
- Added `submissions/examples/css-only-parallax-depth-card/demo.html`
- Added `submissions/examples/css-only-parallax-depth-card/style.css`
- Added `submissions/examples/css-only-parallax-depth-card/README.md`

### Validation
This PR complies with all repository guidelines:
- No existing core files or other submissions were modified.
- No code was deleted.
- All three required files are present and contain valid structure and original content.

### Labels
Maintainers, please ensure the following labels are added to this PR:
- `gssoc:approved`
- `difficulty`
- `type`
- `quality`
