### PR TITLE
feat: Add Animated File Diff Highlight Viewer (issue #15855)

### DIFF
--- a/submissions/examples/file-diff-viewer/README.md
+++ b/submissions/examples/file-diff-viewer/README.md
@@ -1,0 +1,70 @@
+# Animated File Diff Highlight Viewer
+
+**EaseMotion CSS — Issue #15855**
+`submissions/examples/file-diff-viewer/`
+
+A line-level diff viewer with smooth CSS animations for added, removed, and modified lines. Useful for changelogs, PR previews, and version-comparison UIs.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `style.css` | All component styles and keyframes |
+| `demo.html` | Live demo with code and changelog variants |
+| `README.md` | This file |
+
+## Classes
+
+| Class | Element | Behaviour |
+|---|---|---|
+| `ease-diff-block` | `div` | Outer container with border and radius |
+| `ease-diff-header` | `div` | File name bar with badge support |
+| `ease-diff-line` | `div` | Base line container; neutral state |
+| `ease-diff-added` | `ease-diff-line` | Green tint; slides in from left on mount |
+| `ease-diff-removed` | `ease-diff-line` | Red tint; strikethrough animates in |
+| `ease-diff-modified` | `ease-diff-line` | Amber tint; highlight pulse animation |
+| `ease-diff-line-number` | `span` | Muted gutter; brightens with line state |
+| `ease-diff-code` | `code` or `span` | Line content area |
+| `ease-diff-badge-added` | `span` | Green badge for added count |
+| `ease-diff-badge-removed` | `span` | Red badge for removed count |
+
+## Themes
+
+| Class on `ease-diff-block` | Look |
+|---|---|
+| *(none)* | Default — light background |
+| `ease-diff-theme-dark` | Dark navy background |
+
+## Usage
+
+```html
+<div class="ease-diff-block">
+  <div class="ease-diff-header">
+    <span>filename.js</span>
+    <span class="ease-diff-badge ease-diff-badge-added">+2</span>
+    <span class="ease-diff-badge ease-diff-removed">-1</span>
+  </div>
+  <div class="ease-diff-line ease-diff-removed">
+    <span class="ease-diff-line-number">1</span>
+    <code class="ease-diff-code">old code here</code>
+  </div>
+  <div class="ease-diff-line ease-diff-added">
+    <span class="ease-diff-line-number">1</span>
+    <code class="ease-diff-code">new code here</code>
+  </div>
+  <div class="ease-diff-line ease-diff-modified">
+    <span class="ease-diff-line-number">2</span>
+    <code class="ease-diff-code">changed line here</code>
+  </div>
+</div>
+```
+
+## Notes
+
+- 100% pure CSS — no JavaScript required
+- Diff computation is the consuming app's job; this only styles pre-classified lines
+- `prefers-reduced-motion` respected
+
+## Contributor
+
+**Akanksha Thakur** (`@thakurakanksha288`) — GSSoC 2026

--- a/submissions/examples/file-diff-viewer/demo.html
+++ b/submissions/examples/file-diff-viewer/demo.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated File Diff Highlight Viewer — EaseMotion CSS</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      background: #f8f9fc;
+      font-family: "Inter", system-ui, sans-serif;
+      color: #101828;
+      padding: 3rem 1.5rem 5rem;
+    }
+    .page-header { text-align: center; margin-bottom: 3.5rem; }
+    .page-header h1 { font-size: 2rem; font-weight: 800; letter-spacing: -0.02em; margin-bottom: 0.4rem; }
+    .page-header p { color: #667085; font-size: 1rem; }
+    .demo-grid { display: grid; gap: 2.5rem; max-width: 800px; margin: 0 auto; }
+    .demo-card { background: #fff; border: 1px solid #e4e7ec; border-radius: 1rem; padding: 2rem 2.5rem; box-shadow: 0 1px 3px rgba(16,24,40,.06); }
+    .demo-card h2 { font-size: 0.75rem; font-weight: 600; letter-spacing: 0.07em; text-transform: uppercase; color: #98a2b3; margin-bottom: 0.35rem; }
+    .demo-card p { font-size: 0.9rem; color: #475467; margin-bottom: 1.5rem; }
+    .demo-card.dark-card { background: #1e1e2e; border-color: #3b3b52; color: #e2e2f0; }
+    .demo-card.dark-card h2 { color: #6b6b8a; }
+    .demo-card.dark-card p { color: #9898b8; }
+  </style>
+</head>
+<body>
+
+<header class="page-header">
+  <h1>Animated File Diff Highlight Viewer</h1>
+  <p>EaseMotion CSS — Issue #15855 · submissions/examples/file-diff-viewer</p>
+</header>
+
+<div class="demo-grid">
+
+  <div class="demo-card">
+    <h2>Default — Added, Removed, Modified, Context</h2>
+    <p>Lines slide in from the left when added, strikethrough animates on removed lines, and modified lines pulse amber.</p>
+    <div class="ease-diff-block">
+      <div class="ease-diff-header">
+        <span>src/utils/formatDate.js</span>
+        <span class="ease-diff-badge ease-diff-badge-added">+3</span>
+        <span class="ease-diff-badge ease-diff-removed">-2</span>
+      </div>
+      <div class="ease-diff-line">
+        <span class="ease-diff-line-number">1</span>
+        <code class="ease-diff-code">import { format } from 'date-fns';</code>
+      </div>
+      <div class="ease-diff-line">
+        <span class="ease-diff-line-number">2</span>
+        <code class="ease-diff-code"> </code>
+      </div>
+      <div class="ease-diff-line ease-diff-removed">
+        <span class="ease-diff-line-number">3</span>
+        <code class="ease-diff-code">export function formatDate(date) {</code>
+      </div>
+      <div class="ease-diff-line ease-diff-removed">
+        <span class="ease-diff-line-number">4</span>
+        <code class="ease-diff-code">  return date.toLocaleDateString();</code>
+      </div>
+      <div class="ease-diff-line ease-diff-added">
+        <span class="ease-diff-line-number">3</span>
+        <code class="ease-diff-code">export function formatDate(date, pattern = 'dd MMM yyyy') {</code>
+      </div>
+      <div class="ease-diff-line ease-diff-added">
+        <span class="ease-diff-line-number">4</span>
+        <code class="ease-diff-code">  if (!date) return '—';</code>
+      </div>
+      <div class="ease-diff-line ease-diff-added">
+        <span class="ease-diff-line-number">5</span>
+        <code class="ease-diff-code">  return format(date, pattern);</code>
+      </div>
+      <div class="ease-diff-line ease-diff-modified">
+        <span class="ease-diff-line-number">6</span>
+        <code class="ease-diff-code">}</code>
+      </div>
+      <div class="ease-diff-line">
+        <span class="ease-diff-line-number">7</span>
+        <code class="ease-diff-code"> </code>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-card">
+    <h2>Changelog diff</h2>
+    <p>Works equally well for text-based changelogs, not just code.</p>
+    <div class="ease-diff-block">
+      <div class="ease-diff-header">
+        <span>CHANGELOG.md</span>
+        <span class="ease-diff-badge ease-diff-badge-added">+4</span>
+        <span class="ease-diff-badge ease-diff-removed">-1</span>
+      </div>
+      <div class="ease-diff-line">
+        <span class="ease-diff-line-number">1</span>
+        <code class="ease-diff-code">## v2.4.0</code>
+      </div>
+      <div class="ease-diff-line ease-diff-removed">
+        <span class="ease-diff-line-number">2</span>
+        <code class="ease-diff-code">- Fixed date formatting bug</code>
+      </div>
+      <div class="ease-diff-line ease-diff-added">
+        <span class="ease-diff-line-number">2</span>
+        <code class="ease-diff-code">- Fixed date formatting bug (#482)</code>
+      </div>
+      <div class="ease-diff-line ease-diff-added">
+        <span class="ease-diff-line-number">3</span>
+        <code class="ease-diff-code">- Added optional date pattern argument</code>
+      </div>
+      <div class="ease-diff-line ease-diff-added">
+        <span class="ease-diff-line-number">4</span>
+        <code class="ease-diff-code">- Improved null date handling</code>
+      </div>
+      <div class="ease-diff-line ease-diff-modified">
+        <span class="ease-diff-line-number">5</span>
+        <code class="ease-diff-code">- Updated date-fns to v3.6.0</code>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-card dark-card">
+    <h2>Dark theme</h2>
+    <p>Add <code>ease-diff-theme-dark</code> to the <code>ease-diff-block</code> element.</p>
+    <div class="ease-diff-block ease-diff-theme-dark">
+      <div class="ease-diff-header">
+        <span>src/components/Button.tsx</span>
+        <span class="ease-diff-badge ease-diff-badge-added">+2</span>
+        <span class="ease-diff-badge ease-diff-removed">-1</span>
+      </div>
+      <div class="ease-diff-line">
+        <span class="ease-diff-line-number">1</span>
+        <code class="ease-diff-code">import React from 'react';</code>
+      </div>
+      <div class="ease-diff-line ease-diff-removed">
+        <span class="ease-diff-line-number">2</span>
+        <code class="ease-diff-code">type Variant = 'primary' | 'ghost';</code>
+      </div>
+      <div class="ease-diff-line ease-diff-added">
+        <span class="ease-diff-line-number">2</span>
+        <code class="ease-diff-code">type Variant = 'primary' | 'ghost' | 'danger';</code>
+      </div>
+      <div class="ease-diff-line ease-diff-modified">
+        <span class="ease-diff-line-number">3</span>
+        <code class="ease-diff-code">interface ButtonProps {</code>
+      </div>
+      <div class="ease-diff-line ease-diff-added">
+        <span class="ease-diff-line-number">4</span>
+        <code class="ease-diff-code">  variant?: Variant;</code>
+      </div>
+      <div class="ease-diff-line">
+        <span class="ease-diff-line-number">5</span>
+        <code class="ease-diff-code">  children: React.ReactNode;</code>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/file-diff-viewer/style.css
+++ b/submissions/examples/file-diff-viewer/style.css
@@ -1,0 +1,247 @@
+/* =====================================================
+   EaseMotion CSS — Animated File Diff Highlight Viewer
+   Issue #15855
+   ===================================================== */
+
+:root {
+  --diff-font: "Fira Code", "Cascadia Code", "Consolas", monospace;
+  --diff-font-size: 0.875rem;
+  --diff-line-height: 1.6;
+  --diff-bg: #ffffff;
+  --diff-border: #e4e7ec;
+  --diff-radius: 0.75rem;
+
+  /* line number gutter */
+  --diff-gutter-bg: #f9fafb;
+  --diff-gutter-color: #98a2b3;
+  --diff-gutter-width: 3rem;
+
+  /* added */
+  --diff-added-bg: #ecfdf5;
+  --diff-added-border: #6ee7b7;
+  --diff-added-gutter-bg: #d1fae5;
+  --diff-added-gutter-color: #059669;
+  --diff-added-text: #065f46;
+
+  /* removed */
+  --diff-removed-bg: #fff1f2;
+  --diff-removed-border: #fca5a5;
+  --diff-removed-gutter-bg: #fee2e2;
+  --diff-removed-gutter-color: #dc2626;
+  --diff-removed-text: #991b1b;
+
+  /* modified */
+  --diff-modified-bg: #fffbeb;
+  --diff-modified-border: #fcd34d;
+  --diff-modified-gutter-bg: #fef3c7;
+  --diff-modified-gutter-color: #d97706;
+  --diff-modified-text: #92400e;
+}
+
+/* ── Block container ── */
+.ease-diff-block {
+  font-family: var(--diff-font);
+  font-size: var(--diff-font-size);
+  line-height: var(--diff-line-height);
+  background: var(--diff-bg);
+  border: 1px solid var(--diff-border);
+  border-radius: var(--diff-radius);
+  overflow: hidden;
+  width: 100%;
+}
+
+/* ── Base line ── */
+.ease-diff-line {
+  display: flex;
+  align-items: stretch;
+  min-height: 2rem;
+  border-left: 3px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.ease-diff-line:hover {
+  filter: brightness(0.97);
+}
+
+/* ── Line number gutter ── */
+.ease-diff-line-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: var(--diff-gutter-width);
+  padding: 0 0.75rem;
+  background: var(--diff-gutter-bg);
+  color: var(--diff-gutter-color);
+  font-size: 0.75rem;
+  user-select: none;
+  border-right: 1px solid var(--diff-border);
+  transition: background 0.2s ease, color 0.2s ease;
+  flex-shrink: 0;
+}
+
+/* line code content */
+.ease-diff-line code,
+.ease-diff-line span.ease-diff-code {
+  padding: 0.2rem 1rem;
+  white-space: pre;
+  flex: 1;
+  color: #344054;
+}
+
+/* ── Added line ── */
+@keyframes ease-diff-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.ease-diff-added {
+  background: var(--diff-added-bg);
+  border-left-color: var(--diff-added-border);
+  animation: ease-diff-slide-in 0.3s ease forwards;
+}
+
+.ease-diff-added .ease-diff-line-number {
+  background: var(--diff-added-gutter-bg);
+  color: var(--diff-added-gutter-color);
+  border-right-color: var(--diff-added-border);
+}
+
+.ease-diff-added code,
+.ease-diff-added .ease-diff-code {
+  color: var(--diff-added-text);
+}
+
+/* ── Removed line ── */
+@keyframes ease-diff-strikethrough {
+  0%   { text-decoration-color: transparent; opacity: 1; }
+  40%  { text-decoration-color: var(--diff-removed-border); opacity: 1; }
+  100% { text-decoration-color: var(--diff-removed-border); opacity: 0.6; }
+}
+
+.ease-diff-removed {
+  background: var(--diff-removed-bg);
+  border-left-color: var(--diff-removed-border);
+}
+
+.ease-diff-removed .ease-diff-line-number {
+  background: var(--diff-removed-gutter-bg);
+  color: var(--diff-removed-gutter-color);
+  border-right-color: var(--diff-removed-border);
+}
+
+.ease-diff-removed code,
+.ease-diff-removed .ease-diff-code {
+  color: var(--diff-removed-text);
+  text-decoration: line-through;
+  text-decoration-color: transparent;
+  animation: ease-diff-strikethrough 0.5s ease 0.1s forwards;
+}
+
+/* ── Modified line ── */
+@keyframes ease-diff-highlight-pulse {
+  0%   { background: var(--diff-modified-bg); }
+  40%  { background: #fef3c7; }
+  70%  { background: var(--diff-modified-border); }
+  100% { background: var(--diff-modified-bg); }
+}
+
+.ease-diff-modified {
+  background: var(--diff-modified-bg);
+  border-left-color: var(--diff-modified-border);
+  animation: ease-diff-highlight-pulse 0.8s ease forwards;
+}
+
+.ease-diff-modified .ease-diff-line-number {
+  background: var(--diff-modified-gutter-bg);
+  color: var(--diff-modified-gutter-color);
+  border-right-color: var(--diff-modified-border);
+}
+
+.ease-diff-modified code,
+.ease-diff-modified .ease-diff-code {
+  color: var(--diff-modified-text);
+}
+
+/* ── Neutral / context line ── */
+.ease-diff-line:not(.ease-diff-added):not(.ease-diff-removed):not(.ease-diff-modified) code,
+.ease-diff-line:not(.ease-diff-added):not(.ease-diff-removed):not(.ease-diff-modified) .ease-diff-code {
+  color: #667085;
+}
+
+/* ── File header bar ── */
+.ease-diff-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  background: #f2f4f7;
+  border-bottom: 1px solid var(--diff-border);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #475467;
+  font-family: var(--diff-font);
+}
+
+.ease-diff-header .ease-diff-badge {
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.ease-diff-badge-added   { background: #d1fae5; color: #059669; }
+.ease-diff-badge-removed { background: #fee2e2; color: #dc2626; }
+
+/* ── Dark theme ── */
+.ease-diff-theme-dark {
+  --diff-bg: #1e1e2e;
+  --diff-border: #3b3b52;
+  --diff-gutter-bg: #16161f;
+  --diff-gutter-color: #6b6b8a;
+  --diff-added-bg: #0d2218;
+  --diff-added-border: #059669;
+  --diff-added-gutter-bg: #0a1f14;
+  --diff-added-gutter-color: #34d399;
+  --diff-added-text: #6ee7b7;
+  --diff-removed-bg: #2d1b1b;
+  --diff-removed-border: #dc2626;
+  --diff-removed-gutter-bg: #261212;
+  --diff-removed-gutter-color: #f87171;
+  --diff-removed-text: #fca5a5;
+  --diff-modified-bg: #2a1f0a;
+  --diff-modified-border: #d97706;
+  --diff-modified-gutter-bg: #221800;
+  --diff-modified-gutter-color: #fbbf24;
+  --diff-modified-text: #fcd34d;
+}
+
+.ease-diff-theme-dark .ease-diff-header {
+  background: #16161f;
+  color: #9898b8;
+}
+
+.ease-diff-theme-dark .ease-diff-line code,
+.ease-diff-theme-dark .ease-diff-line .ease-diff-code {
+  color: #9898b8;
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-diff-added,
+  .ease-diff-removed code,
+  .ease-diff-removed .ease-diff-code,
+  .ease-diff-modified {
+    animation: none;
+  }
+  .ease-diff-removed code,
+  .ease-diff-removed .ease-diff-code {
+    text-decoration-color: var(--diff-removed-border);
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
Closes #15855

## Summary
Adds an animated file diff highlight viewer component under `submissions/examples/file-diff-viewer/`.

## Files Added
- `style.css` — component CSS API with all keyframe animations
- `demo.html` — live demo with code diff, changelog diff, and dark variants
- `README.md` — usage docs and class reference

## Classes Implemented
| Class | Behaviour |
|---|---|
| `ease-diff-line` | Base line container; neutral state |
| `ease-diff-added` | Green tint; slides in from left on mount |
| `ease-diff-removed` | Red tint; strikethrough animates in |
| `ease-diff-modified` | Amber tint; highlight pulse animation |
| `ease-diff-line-number` | Muted gutter; brightens with line state |

## Themes
- Default (light background)
- `ease-diff-theme-dark` (dark navy)

## Notes
- 100% pure CSS — no JavaScript required
- Diff computation is the consuming app's job; this only styles pre-classified lines
- `prefers-reduced-motion` respected

---
GSSoC 2026 contribution by @thakurakanksha288