### PR TITLE
feat: Add Animated Split Button Collection (issue #15857)

### DIFF
--- a/submissions/examples/split-button-collection/README.md
+++ b/submissions/examples/split-button-collection/README.md
@@ -1,0 +1,73 @@
+# Animated Split Button Collection
+
+**EaseMotion CSS — Issue #15857**
+`submissions/examples/split-button-collection/`
+
+A split button component (primary action + dropdown caret sharing one visual unit) with smooth CSS animations for divider fade, caret rotation, and menu reveal.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `style.css` | All component styles and transitions |
+| `demo.html` | Live demo with all variants |
+| `README.md` | This file |
+
+## Classes
+
+| Class | Element | Behaviour |
+|---|---|---|
+| `ease-split-btn` | `div` | Container joining main button and caret into one unit |
+| `ease-split-btn-main` | `button` | Primary action button |
+| `ease-split-btn-divider` | `span` | Thin separator; fades in on hover |
+| `ease-split-btn-caret` | `button` | Dropdown trigger button |
+| `ease-split-caret-rotate` | `span` | Rotates 180° when menu is open |
+| `ease-split-menu-reveal` | `ul` | Dropdown menu; scales and fades in from caret anchor |
+| `ease-split-menu-divider` | `li` | Thin horizontal rule inside menu |
+| `is-open` | `ease-split-btn` | Toggled by JS to open/close menu |
+
+## Variants
+
+| Class on `ease-split-btn` | Look |
+|---|---|
+| *(none)* | Primary — indigo |
+| `ease-split-btn-danger` | Red destructive style |
+| `ease-split-btn-neutral` | Outline on white |
+| `ease-split-theme-dark` | Dark dropdown menu |
+
+## Usage
+
+```html
+<div class="ease-split-btn" id="my-split">
+  <button class="ease-split-btn-main">Save</button>
+  <span class="ease-split-btn-divider"></span>
+  <button class="ease-split-btn-caret" onclick="toggleSplit('my-split')">
+    <span class="ease-split-caret-rotate">▾</span>
+  </button>
+  <ul class="ease-split-menu-reveal">
+    <li><button>Save as draft</button></li>
+    <li><button>Save and publish</button></li>
+  </ul>
+</div>
+
+<script>
+function toggleSplit(id) {
+  document.getElementById(id).classList.toggle('is-open');
+}
+document.addEventListener('click', function(e) {
+  document.querySelectorAll('.ease-split-btn.is-open').forEach(function(btn) {
+    if (!btn.contains(e.target)) btn.classList.remove('is-open');
+  });
+});
+</script>
+```
+
+## Notes
+
+- All visual states are pure CSS transitions
+- JS is one `classList.toggle` call only
+- `prefers-reduced-motion` respected
+
+## Contributor
+
+**Akanksha Thakur** (`@thakurakanksha288`) — GSSoC 2026

--- a/submissions/examples/split-button-collection/demo.html
+++ b/submissions/examples/split-button-collection/demo.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Split Button Collection — EaseMotion CSS</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      background: #f8f9fc;
+      font-family: "Inter", system-ui, sans-serif;
+      color: #101828;
+      padding: 3rem 1.5rem 5rem;
+    }
+    .page-header { text-align: center; margin-bottom: 3.5rem; }
+    .page-header h1 { font-size: 2rem; font-weight: 800; letter-spacing: -0.02em; margin-bottom: 0.4rem; }
+    .page-header p { color: #667085; font-size: 1rem; }
+    .demo-grid { display: grid; gap: 2.5rem; max-width: 700px; margin: 0 auto; }
+    .demo-card { background: #fff; border: 1px solid #e4e7ec; border-radius: 1rem; padding: 2rem 2.5rem; box-shadow: 0 1px 3px rgba(16,24,40,.06); }
+    .demo-card h2 { font-size: 0.75rem; font-weight: 600; letter-spacing: 0.07em; text-transform: uppercase; color: #98a2b3; margin-bottom: 0.35rem; }
+    .demo-card p { font-size: 0.9rem; color: #475467; margin-bottom: 1.5rem; }
+    .demo-row { display: flex; flex-wrap: wrap; gap: 1.25rem; align-items: center; }
+    .demo-card.dark-card { background: #1e1e2e; border-color: #3b3b52; color: #e2e2f0; }
+    .demo-card.dark-card h2 { color: #6b6b8a; }
+    .demo-card.dark-card p { color: #9898b8; }
+  </style>
+</head>
+<body>
+
+<header class="page-header">
+  <h1>Animated Split Button Collection</h1>
+  <p>EaseMotion CSS — Issue #15857 · submissions/examples/split-button-collection</p>
+</header>
+
+<div class="demo-grid">
+
+  <div class="demo-card">
+    <h2>Primary variant</h2>
+    <p>Hover to see the divider fade in. Click the caret to open the menu with a scale-fade reveal and caret rotation.</p>
+    <div class="demo-row">
+      <div class="ease-split-btn" id="split-primary">
+        <button class="ease-split-btn-main">Save</button>
+        <span class="ease-split-btn-divider"></span>
+        <button class="ease-split-btn-caret ease-split-theme-dark" aria-label="More options" onclick="toggleSplit('split-primary')">
+          <span class="ease-split-caret-rotate">▾</span>
+        </button>
+        <ul class="ease-split-menu-reveal">
+          <li><button>Save as draft</button></li>
+          <li><button>Save and publish</button></li>
+          <li class="ease-split-menu-divider"></li>
+          <li><button>Duplicate</button></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-card">
+    <h2>Danger variant</h2>
+    <p>Add <code>ease-split-btn-danger</code> to the container for a destructive action pattern.</p>
+    <div class="demo-row">
+      <div class="ease-split-btn ease-split-btn-danger" id="split-danger">
+        <button class="ease-split-btn-main">Delete</button>
+        <span class="ease-split-btn-divider"></span>
+        <button class="ease-split-btn-caret" aria-label="More options" onclick="toggleSplit('split-danger')">
+          <span class="ease-split-caret-rotate">▾</span>
+        </button>
+        <ul class="ease-split-menu-reveal">
+          <li><button>Delete selected</button></li>
+          <li><button>Delete all</button></li>
+          <li class="ease-split-menu-divider"></li>
+          <li><button>Archive instead</button></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-card">
+    <h2>Neutral / outline variant</h2>
+    <p>Add <code>ease-split-btn-neutral</code> for a subtle outline style on light backgrounds.</p>
+    <div class="demo-row">
+      <div class="ease-split-btn ease-split-btn-neutral" id="split-neutral">
+        <button class="ease-split-btn-main">Export</button>
+        <span class="ease-split-btn-divider"></span>
+        <button class="ease-split-btn-caret" aria-label="More options" onclick="toggleSplit('split-neutral')">
+          <span class="ease-split-caret-rotate">▾</span>
+        </button>
+        <ul class="ease-split-menu-reveal">
+          <li><button>Export as CSV</button></li>
+          <li><button>Export as PDF</button></li>
+          <li><button>Export as JSON</button></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-card dark-card ease-split-theme-dark">
+    <h2>Dark theme menu</h2>
+    <p>Add <code>ease-split-theme-dark</code> to the container for a dark dropdown menu.</p>
+    <div class="demo-row">
+      <div class="ease-split-btn ease-split-theme-dark" id="split-dark">
+        <button class="ease-split-btn-main">Deploy</button>
+        <span class="ease-split-btn-divider"></span>
+        <button class="ease-split-btn-caret" aria-label="More options" onclick="toggleSplit('split-dark')">
+          <span class="ease-split-caret-rotate">▾</span>
+        </button>
+        <ul class="ease-split-menu-reveal">
+          <li><button>Deploy to staging</button></li>
+          <li><button>Deploy to production</button></li>
+          <li class="ease-split-menu-divider"></li>
+          <li><button>Rollback</button></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<script>
+function toggleSplit(id) {
+  const btn = document.getElementById(id);
+  btn.classList.toggle('is-open');
+}
+
+document.addEventListener('click', function(e) {
+  document.querySelectorAll('.ease-split-btn.is-open').forEach(function(btn) {
+    if (!btn.contains(e.target)) {
+      btn.classList.remove('is-open');
+    }
+  });
+});
+</script>
+
+</body>
+</html>

--- a/submissions/examples/split-button-collection/style.css
+++ b/submissions/examples/split-button-collection/style.css
@@ -1,0 +1,240 @@
+/* =====================================================
+   EaseMotion CSS — Animated Split Button Collection
+   Issue #15857
+   ===================================================== */
+
+:root {
+  --split-font: "Inter", "Segoe UI", system-ui, sans-serif;
+  --split-font-size: 0.9rem;
+  --split-font-weight: 600;
+  --split-radius: 0.5rem;
+  --split-height: 2.5rem;
+
+  /* primary variant */
+  --split-primary-bg: #6366f1;
+  --split-primary-hover: #4f46e5;
+  --split-primary-text: #ffffff;
+  --split-primary-divider: rgba(255, 255, 255, 0.3);
+
+  /* danger variant */
+  --split-danger-bg: #f04438;
+  --split-danger-hover: #d92d20;
+  --split-danger-text: #ffffff;
+  --split-danger-divider: rgba(255, 255, 255, 0.3);
+
+  /* neutral variant */
+  --split-neutral-bg: #ffffff;
+  --split-neutral-hover: #f9fafb;
+  --split-neutral-text: #344054;
+  --split-neutral-border: #d0d5dd;
+  --split-neutral-divider: #d0d5dd;
+
+  /* menu */
+  --split-menu-bg: #ffffff;
+  --split-menu-border: #e4e7ec;
+  --split-menu-shadow: 0 8px 24px rgba(16, 24, 40, 0.12);
+  --split-menu-radius: 0.5rem;
+  --split-menu-item-hover: #f9fafb;
+  --split-menu-text: #344054;
+}
+
+/* ── Container ── */
+.ease-split-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+  font-family: var(--split-font);
+  font-size: var(--split-font-size);
+  font-weight: var(--split-font-weight);
+  height: var(--split-height);
+  border-radius: var(--split-radius);
+  overflow: visible;
+}
+
+/* ── Main action button ── */
+.ease-split-btn-main {
+  padding: 0 1.1rem;
+  border: none;
+  background: var(--split-primary-bg);
+  color: var(--split-primary-text);
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  cursor: pointer;
+  border-radius: var(--split-radius) 0 0 var(--split-radius);
+  transition: background 0.18s ease, transform 0.1s ease;
+  white-space: nowrap;
+}
+
+.ease-split-btn-main:hover {
+  background: var(--split-primary-hover);
+}
+
+.ease-split-btn-main:active {
+  transform: scale(0.97);
+}
+
+/* ── Divider ── */
+.ease-split-btn-divider {
+  width: 1px;
+  background: var(--split-primary-divider);
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+  pointer-events: none;
+}
+
+.ease-split-btn:hover .ease-split-btn-divider {
+  opacity: 1;
+}
+
+/* ── Caret trigger button ── */
+.ease-split-btn-caret {
+  padding: 0 0.7rem;
+  border: none;
+  background: var(--split-primary-bg);
+  color: var(--split-primary-text);
+  font-family: inherit;
+  font-size: 1rem;
+  cursor: pointer;
+  border-radius: 0 var(--split-radius) var(--split-radius) 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.18s ease;
+}
+
+.ease-split-btn-caret:hover {
+  background: var(--split-primary-hover);
+}
+
+/* ── Caret rotate animation (ease-split-caret-rotate) ── */
+.ease-split-caret-rotate {
+  display: inline-block;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-split-btn.is-open .ease-split-caret-rotate {
+  transform: rotate(180deg);
+}
+
+/* ── Dropdown menu reveal (ease-split-menu-reveal) ── */
+.ease-split-menu-reveal {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 160px;
+  background: var(--split-menu-bg);
+  border: 1px solid var(--split-menu-border);
+  border-radius: var(--split-menu-radius);
+  box-shadow: var(--split-menu-shadow);
+  padding: 0.35rem 0;
+  z-index: 100;
+  transform-origin: top right;
+  transform: scale(0.92) translateY(-6px);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.18s ease;
+}
+
+.ease-split-btn.is-open .ease-split-menu-reveal {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ease-split-menu-reveal li {
+  list-style: none;
+}
+
+.ease-split-menu-reveal a,
+.ease-split-menu-reveal button {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  font-family: var(--split-font);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--split-menu-text);
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.14s ease;
+  white-space: nowrap;
+}
+
+.ease-split-menu-reveal a:hover,
+.ease-split-menu-reveal button:hover {
+  background: var(--split-menu-item-hover);
+}
+
+.ease-split-menu-divider {
+  height: 1px;
+  background: var(--split-menu-border);
+  margin: 0.3rem 0;
+}
+
+/* ── Danger variant ── */
+.ease-split-btn-danger .ease-split-btn-main,
+.ease-split-btn-danger .ease-split-btn-caret {
+  background: var(--split-danger-bg);
+  color: var(--split-danger-text);
+}
+
+.ease-split-btn-danger .ease-split-btn-main:hover,
+.ease-split-btn-danger .ease-split-btn-caret:hover {
+  background: var(--split-danger-hover);
+}
+
+.ease-split-btn-danger .ease-split-btn-divider {
+  background: var(--split-danger-divider);
+}
+
+/* ── Neutral / outline variant ── */
+.ease-split-btn-neutral .ease-split-btn-main,
+.ease-split-btn-neutral .ease-split-btn-caret {
+  background: var(--split-neutral-bg);
+  color: var(--split-neutral-text);
+  border: 1px solid var(--split-neutral-border);
+}
+
+.ease-split-btn-neutral .ease-split-btn-main {
+  border-right: none;
+}
+
+.ease-split-btn-neutral .ease-split-btn-caret {
+  border-left: none;
+}
+
+.ease-split-btn-neutral .ease-split-btn-main:hover,
+.ease-split-btn-neutral .ease-split-btn-caret:hover {
+  background: var(--split-neutral-hover);
+}
+
+.ease-split-btn-neutral .ease-split-btn-divider {
+  background: var(--split-neutral-divider);
+}
+
+/* ── Dark theme ── */
+.ease-split-theme-dark {
+  --split-menu-bg: #1e1e2e;
+  --split-menu-border: #3b3b52;
+  --split-menu-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  --split-menu-item-hover: #2a2a42;
+  --split-menu-text: #e2e2f0;
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-split-caret-rotate,
+  .ease-split-menu-reveal,
+  .ease-split-btn-divider,
+  .ease-split-btn-main,
+  .ease-split-btn-caret {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #15857

## Summary
Adds an animated split button collection under `submissions/examples/split-button-collection/`.

## Files Added
- `style.css` — component CSS API with all transitions
- `demo.html` — live demo with primary, danger, neutral, and dark variants
- `README.md` — usage docs and class reference

## Classes Implemented
| Class | Behaviour |
|---|---|
| `ease-split-btn` | Container joining main button and caret into one unit |
| `ease-split-btn-divider` | Thin separator; fades in on hover |
| `ease-split-caret-rotate` | Caret rotates 180° when menu opens |
| `ease-split-menu-reveal` | Dropdown scales and fades in from caret anchor |

## Variants
- Primary (indigo)
- `ease-split-btn-danger` (red)
- `ease-split-btn-neutral` (outline)
- `ease-split-theme-dark` (dark dropdown)

## Notes
- All visual states are pure CSS transitions
- JS is one classList.toggle call only
- `prefers-reduced-motion` respected

---
GSSoC 2026 contribution by @thakurakanksha288