### PR TITLE
feat: add accessible like button submission with pure-CSS burst animation

### DIFF
--- a/submissions/examples/accessible-like-button-as/README.md
+++ b/submissions/examples/accessible-like-button-as/README.md
@@ -1,0 +1,27 @@
+# Accessible Like Button (-as)
+
+## What does this do?
+
+A like/favourite toggle, built on a real checkbox, that plays a heart "pop" and an expanding burst when liked - keyboard operable and screen-reader friendly, with no JavaScript.
+
+## How is it used?
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<input type="checkbox" id="ease-like-demo" class="ease-like__input" />
+<label for="ease-like-demo" class="ease-like">
+  <span class="ease-like__burst" aria-hidden="true"></span>
+  <svg class="ease-like__heart" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path d="M12 21s-7.4-4.6-9.4-9C1.1 8.6 2.6 5.6 5.6 5.6c1.9 0 3.2 1.1 4.4 2.6 1.2-1.5 2.5-2.6 4.4-2.6 3 0 4.5 3 3 6.4-2 4.4-9.4 9-9.4 9z" />
+  </svg>
+  <span class="ease-like__text ease-like__text--off">Like</span>
+  <span class="ease-like__text ease-like__text--on">Liked</span>
+</label>
+```
+
+The hidden `<input type="checkbox">` does the work: `Tab` moves focus to it and `Space` toggles it. The `:checked` state drives the colour, the heart pop, the burst rings, and the `Like` to `Liked` text swap via sibling selectors.
+
+## Why is it useful?
+
+Like buttons are one of the most common micro-interactions, but they are usually built from a `<div>` or a hover-only effect, which keyboard and screen-reader users cannot operate. This version is accessible by construction: a native checkbox provides focus and toggling for free, the keyboard focus ring is visible, and the announced state stays correct. The animation is pure CSS and respects `prefers-reduced-motion` (the burst and pop are dropped, leaving just the colour change), which fits EaseMotion's animation-first but accessible and zero-dependency philosophy.

--- a/submissions/examples/accessible-like-button-as/demo.html
+++ b/submissions/examples/accessible-like-button-as/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Accessible Like Button (-as)</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1.5rem;
+      background: #f8fafc;
+      color: #1e293b;
+    }
+    .hint {
+      max-width: 28rem;
+      text-align: center;
+      color: #475569;
+      line-height: 1.5;
+    }
+    kbd {
+      background: #e2e8f0;
+      border-radius: 4px;
+      padding: 0.1rem 0.35rem;
+      font-size: 0.85em;
+    }
+  </style>
+</head>
+<body>
+  <h1>Accessible Like Button</h1>
+  <p class="hint">
+    <kbd>Tab</kbd> to the button and press <kbd>Space</kbd> to like. It is a
+    real checkbox, so keyboard and screen-reader users get the same behaviour
+    as a mouse click.
+  </p>
+
+  <div>
+    <input type="checkbox" id="ease-like-demo" class="ease-like__input" />
+    <label for="ease-like-demo" class="ease-like">
+      <span class="ease-like__burst" aria-hidden="true"></span>
+      <svg class="ease-like__heart" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M12 21s-7.4-4.6-9.4-9C1.1 8.6 2.6 5.6 5.6 5.6c1.9 0 3.2 1.1 4.4 2.6 1.2-1.5 2.5-2.6 4.4-2.6 3 0 4.5 3 3 6.4-2 4.4-9.4 9-9.4 9z" />
+      </svg>
+      <span class="ease-like__text ease-like__text--off">Like</span>
+      <span class="ease-like__text ease-like__text--on">Liked</span>
+    </label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/accessible-like-button-as/style.css
+++ b/submissions/examples/accessible-like-button-as/style.css
@@ -1,0 +1,158 @@
+/*
+ * Accessible Like Button (-as)
+ *
+ * A like/favourite toggle built on a real checkbox, so it is keyboard
+ * operable (Tab to it, Space to toggle) and its state is announced by screen
+ * readers - no JavaScript. Liking plays a heart "pop" plus an expanding burst.
+ * Hover and keyboard focus are both styled, and everything is disabled under
+ * prefers-reduced-motion, leaving only the colour change.
+ */
+
+/* Real checkbox, visually hidden but still focusable and announced. */
+.ease-like__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.ease-like {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #334155;
+  font: 600 0.95rem/1 system-ui, sans-serif;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 200ms ease, color 200ms ease;
+}
+
+.ease-like:hover {
+  background: #e2e8f0;
+}
+
+/* Visible focus ring driven by the hidden checkbox's keyboard focus. */
+.ease-like__input:focus-visible + .ease-like {
+  outline: 3px solid #fca5a5;
+  outline-offset: 2px;
+}
+
+.ease-like__heart {
+  width: 1.4rem;
+  height: 1.4rem;
+  fill: none;
+  stroke: #94a3b8;
+  stroke-width: 2;
+  transition: fill 200ms ease, stroke 200ms ease, transform 200ms ease;
+}
+
+/* Liked state */
+.ease-like__input:checked + .ease-like {
+  color: #e11d48;
+}
+
+.ease-like__input:checked + .ease-like .ease-like__heart {
+  fill: #e11d48;
+  stroke: #e11d48;
+  animation: ease-like-pop 320ms ease;
+}
+
+@keyframes ease-like-pop {
+  0% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(0.8);
+  }
+  70% {
+    transform: scale(1.25);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* Expanding burst rings, centred on the heart. */
+.ease-like__burst {
+  position: absolute;
+  left: 1.25rem;
+  top: 50%;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.ease-like__input:checked + .ease-like .ease-like__burst::before,
+.ease-like__input:checked + .ease-like .ease-like__burst::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  border-radius: 50%;
+  transform: translate(-50%, -50%) scale(0);
+}
+
+.ease-like__input:checked + .ease-like .ease-like__burst::before {
+  width: 2.4rem;
+  height: 2.4rem;
+  border: 3px solid #fb7185;
+  animation: ease-like-ring 520ms ease-out;
+}
+
+.ease-like__input:checked + .ease-like .ease-like__burst::after {
+  width: 1.6rem;
+  height: 1.6rem;
+  border: 2px solid #fda4af;
+  animation: ease-like-ring 520ms 60ms ease-out;
+}
+
+@keyframes ease-like-ring {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.9;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0;
+  }
+}
+
+/* Label text swaps Like -> Liked for sighted users; the checkbox state
+   continues to convey it to assistive tech. */
+.ease-like__text--on {
+  display: none;
+}
+
+.ease-like__input:checked + .ease-like .ease-like__text--off {
+  display: none;
+}
+
+.ease-like__input:checked + .ease-like .ease-like__text--on {
+  display: inline;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-like__heart {
+    transition: fill 1ms linear, stroke 1ms linear;
+  }
+
+  .ease-like__input:checked + .ease-like .ease-like__heart {
+    animation: none;
+  }
+
+  .ease-like__input:checked + .ease-like .ease-like__burst::before,
+  .ease-like__input:checked + .ease-like .ease-like__burst::after {
+    animation: none;
+    content: none;
+  }
+}


### PR DESCRIPTION
## What does this do?

Adds a self-contained submission under `submissions/examples/accessible-like-button-as/` — a like/favourite toggle that plays a heart "pop" and an expanding burst when liked, built on a real checkbox so it is keyboard operable and screen-reader friendly, with **no JavaScript**.

## Why

Like buttons are one of the most common micro-interactions, but they are usually built from a `<div>` or a hover-only effect that keyboard and screen-reader users cannot operate. This one is accessible by construction:

- A visually-hidden native `<input type="checkbox">` provides focus and toggling for free (`Tab` to it, `Space` to like).
- A visible `:focus-visible` ring for keyboard users.
- The liked state is announced by assistive tech (checkbox state) and the label swaps `Like` → `Liked`.
- The burst rings + heart pop are pure CSS and fully disabled under `prefers-reduced-motion`, leaving just the colour change.
- Animations use only `transform`/`opacity`, so they stay on the compositor.

This complements the existing decorative heartbeat animations (which are non-interactive pulses) with an interactive, accessible like control, and fits EaseMotion's animation-first, beginner-friendly, zero-dependency philosophy.

## Files

- `submissions/examples/accessible-like-button-as/demo.html` — opens directly in a browser, no CDN / external dependencies
- `submissions/examples/accessible-like-button-as/style.css`
- `submissions/examples/accessible-like-button-as/README.md`

## Checklist

- [x] All changes are inside `submissions/examples/accessible-like-button-as/`
- [x] No edits to `core/`, `components/`, `docs/`, `examples/`, workflows, or configs
- [x] Includes the three required files (`demo.html`, `style.css`, `README.md`)
- [x] `demo.html` is self-contained (no CDN / external frameworks) and works by opening directly
- [x] Single, focused feature; single commit
- [x] Unique suffix (`-as`) appended to avoid naming conflicts