### PR TITLE
feat: add accessible command palette (Ctrl/Cmd+K) submission — WAI-ARIA combobox, focus-trapped, zero deps

### DIFF
--- a/submissions/examples/accessible-command-palette-as/README.md
+++ b/submissions/examples/accessible-command-palette-as/README.md
@@ -1,0 +1,56 @@
+# Accessible Command Palette (-as)
+
+## What does this do?
+
+A `Ctrl`/`Cmd`+`K` command palette (the "spotlight" pattern from editors and modern apps) that filters as you type, is fully keyboard driven, traps and restores focus, and is built to the WAI-ARIA combobox + listbox specification - with a pure-CSS entrance animation that respects `prefers-reduced-motion`. No frameworks, no dependencies.
+
+## How is it used?
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<button type="button" class="ease-cmdk__trigger" aria-haspopup="dialog">
+  Open command palette <span class="ease-cmdk__kbd">Ctrl K</span>
+</button>
+
+<div class="ease-cmdk" id="ease-cmdk" role="dialog" aria-modal="true" aria-label="Command palette" hidden>
+  <div class="ease-cmdk__panel">
+    <input id="ease-cmdk-input" class="ease-cmdk__input" type="text" role="combobox"
+           aria-expanded="true" aria-controls="ease-cmdk-list" aria-autocomplete="list" autocomplete="off" />
+    <ul id="ease-cmdk-list" class="ease-cmdk__list" role="listbox" aria-label="Commands">
+      <li id="ease-cmd-0" role="option" class="ease-cmdk__option" data-label="New file" aria-selected="false">New file</li>
+      <!-- ...more options... -->
+    </ul>
+    <p class="ease-cmdk__empty" hidden>No commands found</p>
+  </div>
+</div>
+```
+
+The small inline script wires up the behaviour; see `demo.html`.
+
+## Keyboard model
+
+| Key | Action |
+|---|---|
+| `Ctrl`/`Cmd` + `K` | Open / close the palette |
+| Type | Filter commands |
+| `Down` / `Up` | Move the active command (wraps) |
+| `Home` / `End` | First / last command |
+| `Enter` | Run the active command |
+| `Esc` | Close |
+| `Tab` / `Shift`+`Tab` | Cycles focus within the dialog (trapped) |
+
+## Accessibility notes
+
+- Implements the [ARIA combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/): focus stays on the `role="combobox"` input, while the highlighted result is tracked with `aria-activedescendant` pointing at the `role="option"` whose `aria-selected` is `true`. The visual highlight is driven by that same `aria-selected`, so what sighted users see always matches what assistive tech announces.
+- `role="dialog"` + `aria-modal="true"`, focus moved to the input on open, **focus trapped** while open, and focus **restored** to the trigger on close.
+- The active option is kept in view with `scrollIntoView({ block: "nearest" })`.
+- The entrance animation uses only `transform`/`opacity` and is disabled under `prefers-reduced-motion`.
+
+## Why is it useful?
+
+The command palette is a high-value power-user pattern, but it is genuinely hard to get right: most implementations break keyboard navigation, leak focus to the page behind, or never announce the highlighted item. This submission is a correct, dependency-free reference that an app can drop in and trust. It fits EaseMotion's animation-first, beginner-friendly, zero-dependency philosophy while raising the bar on accessibility.
+
+## Browser support
+
+Works in all current browsers. `:focus-visible` and `scrollIntoView` options degrade gracefully on older engines (you still get focus styling and navigation, just without the refinement).

--- a/submissions/examples/accessible-command-palette-as/demo.html
+++ b/submissions/examples/accessible-command-palette-as/demo.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Accessible Command Palette (-as)</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1.25rem;
+      background: #f8fafc;
+      color: #1e293b;
+    }
+    .hint { max-width: 30rem; text-align: center; color: #475569; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <h1>Accessible Command Palette</h1>
+  <p class="hint">
+    Press <strong>Ctrl/Cmd&nbsp;+&nbsp;K</strong> (or the button). Type to filter,
+    use <strong>&uarr; &darr;</strong> / <strong>Home</strong> / <strong>End</strong> to
+    move, <strong>Enter</strong> to run, <strong>Esc</strong> to close.
+  </p>
+
+  <button type="button" class="ease-cmdk__trigger" aria-haspopup="dialog">
+    Open command palette
+    <span class="ease-cmdk__kbd">Ctrl K</span>
+  </button>
+
+  <div class="ease-cmdk" id="ease-cmdk" role="dialog" aria-modal="true" aria-label="Command palette" hidden>
+    <div class="ease-cmdk__panel">
+      <label class="ease-cmdk__sr-only" for="ease-cmdk-input">Search commands</label>
+      <input
+        id="ease-cmdk-input"
+        class="ease-cmdk__input"
+        type="text"
+        role="combobox"
+        aria-expanded="false"
+        aria-controls="ease-cmdk-list"
+        aria-autocomplete="list"
+        autocomplete="off"
+        placeholder="Type a command&hellip;"
+      />
+      <ul id="ease-cmdk-list" class="ease-cmdk__list" role="listbox" aria-label="Commands">
+        <li id="ease-cmd-0" role="option" class="ease-cmdk__option" data-label="New file" aria-selected="false"><span class="ease-cmdk__icon" aria-hidden="true">&#128196;</span> New file <span class="ease-cmdk__hint">Ctrl N</span></li>
+        <li id="ease-cmd-1" role="option" class="ease-cmdk__option" data-label="Open project" aria-selected="false"><span class="ease-cmdk__icon" aria-hidden="true">&#128193;</span> Open project <span class="ease-cmdk__hint">Ctrl O</span></li>
+        <li id="ease-cmd-2" role="option" class="ease-cmdk__option" data-label="Save all" aria-selected="false"><span class="ease-cmdk__icon" aria-hidden="true">&#128190;</span> Save all <span class="ease-cmdk__hint">Ctrl S</span></li>
+        <li id="ease-cmd-3" role="option" class="ease-cmdk__option" data-label="Toggle theme" aria-selected="false"><span class="ease-cmdk__icon" aria-hidden="true">&#127769;</span> Toggle theme</li>
+        <li id="ease-cmd-4" role="option" class="ease-cmdk__option" data-label="Open settings" aria-selected="false"><span class="ease-cmdk__icon" aria-hidden="true">&#9881;</span> Open settings <span class="ease-cmdk__hint">Ctrl ,</span></li>
+        <li id="ease-cmd-5" role="option" class="ease-cmdk__option" data-label="Search docs" aria-selected="false"><span class="ease-cmdk__icon" aria-hidden="true">&#128269;</span> Search docs</li>
+      </ul>
+      <p class="ease-cmdk__empty" hidden>No commands found</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      const trigger = document.querySelector(".ease-cmdk__trigger");
+      const dialog = document.getElementById("ease-cmdk");
+      const input = document.getElementById("ease-cmdk-input");
+      const list = document.getElementById("ease-cmdk-list");
+      const empty = document.querySelector(".ease-cmdk__empty");
+      const options = Array.prototype.slice.call(list.querySelectorAll('[role="option"]'));
+      let activeIndex = -1;
+      let lastFocused = null;
+
+      const visible = () => options.filter((o) => !o.hidden);
+
+      // While the modal is open, make everything behind it inert so assistive
+      // tech and Tab cannot reach the page (complements aria-modal).
+      function setBackgroundInert(on) {
+        Array.prototype.forEach.call(document.body.children, (el) => {
+          if (el === dialog) return;
+          if (on) el.setAttribute("inert", "");
+          else el.removeAttribute("inert");
+        });
+      }
+
+      function setActive(index) {
+        const vis = visible();
+        options.forEach((o) => o.setAttribute("aria-selected", "false"));
+        if (vis.length === 0) {
+          activeIndex = -1;
+          input.removeAttribute("aria-activedescendant");
+          return;
+        }
+        activeIndex = ((index % vis.length) + vis.length) % vis.length;
+        const el = vis[activeIndex];
+        el.setAttribute("aria-selected", "true");
+        input.setAttribute("aria-activedescendant", el.id);
+        el.scrollIntoView({ block: "nearest" });
+      }
+
+      function filter(query) {
+        const q = query.trim().toLowerCase();
+        let any = false;
+        options.forEach((o) => {
+          const match = o.dataset.label.toLowerCase().indexOf(q) !== -1;
+          o.hidden = !match;
+          if (match) any = true;
+        });
+        empty.hidden = any;
+        list.hidden = !any;
+        // Keep aria-expanded accurate: the listbox is only "expanded" when it
+        // actually has results to show.
+        input.setAttribute("aria-expanded", any ? "true" : "false");
+        setActive(0);
+      }
+
+      function open() {
+        if (!dialog.hidden) return;
+        lastFocused = document.activeElement;
+        dialog.hidden = false;
+        setBackgroundInert(true);
+        input.value = "";
+        filter("");
+        input.focus();
+      }
+
+      function close() {
+        if (dialog.hidden) return;
+        dialog.hidden = true;
+        input.removeAttribute("aria-activedescendant");
+        setBackgroundInert(false);
+        if (lastFocused && typeof lastFocused.focus === "function") lastFocused.focus();
+      }
+
+      function run() {
+        const vis = visible();
+        const el = vis[activeIndex];
+        if (!el) return;
+        close();
+        trigger.firstChild.textContent = "Last run: " + el.dataset.label + " ";
+      }
+
+      trigger.addEventListener("click", open);
+      input.addEventListener("input", () => filter(input.value));
+
+      input.addEventListener("keydown", (e) => {
+        const vis = visible();
+        switch (e.key) {
+          case "ArrowDown": e.preventDefault(); setActive(activeIndex + 1); break;
+          case "ArrowUp": e.preventDefault(); setActive(activeIndex - 1); break;
+          case "Home": e.preventDefault(); setActive(0); break;
+          case "End": e.preventDefault(); setActive(vis.length - 1); break;
+          case "Enter": e.preventDefault(); run(); break;
+        }
+      });
+
+      list.addEventListener("click", (e) => {
+        const opt = e.target.closest('[role="option"]');
+        if (!opt) return;
+        activeIndex = visible().indexOf(opt);
+        run();
+      });
+
+      // Backdrop click closes (clicks on the panel do not bubble to here).
+      dialog.addEventListener("mousedown", (e) => {
+        if (e.target === dialog) close();
+      });
+
+      // Dialog-level: Escape closes; Tab is trapped inside the dialog.
+      dialog.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") { e.preventDefault(); close(); return; }
+        if (e.key !== "Tab") return;
+        const focusable = dialog.querySelectorAll(
+          'input, button, [href], [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+        else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+      });
+
+      // Global shortcut: Ctrl/Cmd + K toggles the palette.
+      document.addEventListener("keydown", (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
+          e.preventDefault();
+          dialog.hidden ? open() : close();
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/accessible-command-palette-as/style.css
+++ b/submissions/examples/accessible-command-palette-as/style.css
@@ -1,0 +1,160 @@
+/*
+ * Accessible Command Palette (-as)
+ *
+ * A Ctrl/Cmd+K command palette built to the WAI-ARIA combobox + listbox
+ * pattern: the text input is role="combobox", the results are a role="listbox",
+ * and the active result is tracked with aria-activedescendant (focus stays on
+ * the input). Fully keyboard driven, focus is trapped while open and restored
+ * on close, and the entrance animation is disabled under prefers-reduced-motion.
+ */
+
+.ease-cmdk__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  background: #ffffff;
+  color: #1e293b;
+  font: 600 0.95rem/1 system-ui, sans-serif;
+  cursor: pointer;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.ease-cmdk__trigger:hover {
+  border-color: #94a3b8;
+}
+
+.ease-cmdk__trigger:focus-visible {
+  outline: 3px solid #c7d2fe;
+  outline-offset: 2px;
+}
+
+.ease-cmdk__kbd {
+  display: inline-flex;
+  gap: 0.15rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 6px;
+  background: #f1f5f9;
+  color: #64748b;
+  font-size: 0.8em;
+}
+
+/* Overlay + centering */
+.ease-cmdk {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 12vh 1rem 1rem;
+  background: rgba(2, 6, 23, 0.55);
+}
+
+.ease-cmdk[hidden] {
+  display: none;
+}
+
+.ease-cmdk__panel {
+  width: min(34rem, 100%);
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #ffffff;
+  border-radius: 14px;
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.4);
+  animation: ease-cmdk-in 180ms ease-out;
+}
+
+@keyframes ease-cmdk-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.ease-cmdk__input {
+  padding: 1rem 1.15rem;
+  border: none;
+  border-bottom: 1px solid #e2e8f0;
+  font: 400 1.05rem/1 system-ui, sans-serif;
+  color: #0f172a;
+}
+
+.ease-cmdk__input:focus-visible {
+  outline: none;
+  border-bottom-color: #6366f1;
+}
+
+.ease-cmdk__list {
+  margin: 0;
+  padding: 0.4rem;
+  list-style: none;
+  overflow-y: auto;
+}
+
+.ease-cmdk__option {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 8px;
+  color: #334155;
+  cursor: pointer;
+}
+
+.ease-cmdk__option:hover {
+  background: #f1f5f9;
+}
+
+/* The active descendant (keyboard-highlighted) row. Driven by aria-selected
+   so the visual highlight always matches what assistive tech announces. */
+.ease-cmdk__option[aria-selected="true"] {
+  background: #eef2ff;
+  color: #3730a3;
+  box-shadow: inset 0 0 0 1px #c7d2fe;
+}
+
+.ease-cmdk__icon {
+  flex: none;
+  width: 1.1rem;
+  text-align: center;
+}
+
+.ease-cmdk__hint {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.ease-cmdk__empty {
+  padding: 1.25rem;
+  text-align: center;
+  color: #94a3b8;
+}
+
+.ease-cmdk__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-cmdk__panel {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What does this do?

Adds a self-contained submission under `submissions/examples/accessible-command-palette-as/` — a `Ctrl`/`Cmd`+`K` command palette (the editor "spotlight" pattern) that filters as you type, is fully keyboard driven, traps and restores focus, and is built to the **WAI-ARIA combobox + dialog** specification. Pure CSS animation, vanilla JS, **no frameworks or dependencies**.

## Why this one

Command palettes are a high-value pattern but genuinely hard to get right — most implementations break keyboard navigation, leak focus to the page behind, or never announce the highlighted item. This is a correct, drop-in reference:

- **ARIA combobox pattern:** focus stays on the `role="combobox"` input; the highlighted result is tracked with `aria-activedescendant` → the `role="option"` whose `aria-selected` is `true`. The visual highlight is driven by that same `aria-selected`, so sighted and assistive-tech users always agree. `aria-expanded` reflects whether results are actually shown.
- **Dialog semantics:** `role="dialog"` + `aria-modal`, focus moved to the input on open, **focus trapped** on Tab/Shift+Tab, background content set `inert`, and focus **restored** to the trigger on close.
- **Keyboard model:** `Ctrl/Cmd+K` toggle · type to filter · `↑/↓` (wrapping) · `Home`/`End` · `Enter` to run · `Esc` to close. Active option kept in view via `scrollIntoView`.
- **Motion:** entrance animation uses only `transform`/`opacity` and is fully disabled under `prefers-reduced-motion`.

It fits EaseMotion's animation-first, beginner-friendly, zero-dependency philosophy while raising the accessibility bar.

## Files

- `submissions/examples/accessible-command-palette-as/demo.html` — opens directly in a browser, no CDN / external dependencies (inline vanilla JS)
- `submissions/examples/accessible-command-palette-as/style.css`
- `submissions/examples/accessible-command-palette-as/README.md` — documents the ARIA pattern, keyboard map, and accessibility decisions

## Quality

- JS passes `node --check`; reviewed against the WAI-ARIA Authoring Practices (combobox + modal dialog), including focus trap, focus restore, and `inert` background.

## Checklist

- [x] All changes inside `submissions/examples/accessible-command-palette-as/`
- [x] No edits to `core/`, `components/`, `docs/`, `examples/`, workflows, or configs
- [x] Includes the three required files (`demo.html`, `style.css`, `README.md`)
- [x] `demo.html` is self-contained (no CDN / external frameworks) and works by opening directly
- [x] Single, focused feature; single commit
- [x] Unique suffix (`-as`) appended to avoid naming conflicts