### PR TITLE
feat: add icon morph animation demo

### DIFF
--- a/submissions/examples/14769-icon-morph-kkp/README.md
+++ b/submissions/examples/14769-icon-morph-kkp/README.md
@@ -1,0 +1,5 @@
+# Icon Morph Animation
+
+1. What does this do? Creates a pure CSS icon morph interaction that transitions a menu icon into a close icon.
+2. How is it used? Apply `.icon-morph-button` to a button containing three `.icon-morph-line` spans.
+3. Why is it useful? It gives navigation controls a clear state change while keeping the effect small, reusable, and dependency-free.

--- a/submissions/examples/14769-icon-morph-kkp/demo.html
+++ b/submissions/examples/14769-icon-morph-kkp/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Icon Morph Animation</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="icon-morph-title">
+        <p class="eyebrow">Pure CSS interaction</p>
+        <h1 id="icon-morph-title">Menu to close morph</h1>
+        <p class="demo-copy">
+          Hover or focus the button to morph the three-line menu icon into a close icon.
+        </p>
+
+        <button class="icon-morph-button" type="button" aria-label="Open navigation">
+          <span class="icon-morph-line"></span>
+          <span class="icon-morph-line"></span>
+          <span class="icon-morph-line"></span>
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/14769-icon-morph-kkp/demo.html
+++ b/submissions/examples/14769-icon-morph-kkp/demo.html
@@ -12,10 +12,15 @@
         <p class="eyebrow">Pure CSS interaction</p>
         <h1 id="icon-morph-title">Menu to close morph</h1>
         <p class="demo-copy">
-          Hover or focus the button to morph the three-line menu icon into a close icon.
+          Hover or focus the button to morph the three-line menu icon into a
+          close icon.
         </p>
 
-        <button class="icon-morph-button" type="button" aria-label="Open navigation">
+        <button
+          class="icon-morph-button"
+          type="button"
+          aria-label="Open navigation"
+        >
           <span class="icon-morph-line"></span>
           <span class="icon-morph-line"></span>
           <span class="icon-morph-line"></span>

--- a/submissions/examples/14769-icon-morph-kkp/style.css
+++ b/submissions/examples/14769-icon-morph-kkp/style.css
@@ -1,0 +1,114 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 34rem);
+  border: 1px solid #d9e2ef;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  box-shadow: 0 1.25rem 3rem rgb(31 41 55 / 0.12);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #4263eb;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.demo-copy {
+  margin: 0.85rem auto 1.75rem;
+  max-width: 24rem;
+  color: #55627a;
+  line-height: 1.6;
+}
+
+.icon-morph-button {
+  width: 5.5rem;
+  height: 5.5rem;
+  border: 0;
+  border-radius: 50%;
+  background: #172033;
+  display: inline-grid;
+  place-content: center;
+  gap: 0.42rem;
+  cursor: pointer;
+  transition:
+    background 220ms ease,
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.icon-morph-line {
+  display: block;
+  width: 2.35rem;
+  height: 0.25rem;
+  border-radius: 999px;
+  background: #ffffff;
+  transform-origin: center;
+  transition:
+    transform 260ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 180ms ease;
+}
+
+.icon-morph-button:hover,
+.icon-morph-button:focus-visible {
+  background: #4263eb;
+  transform: translateY(-0.12rem);
+  box-shadow: 0 1rem 2rem rgb(66 99 235 / 0.28);
+  outline: none;
+}
+
+.icon-morph-button:hover .icon-morph-line:nth-child(1),
+.icon-morph-button:focus-visible .icon-morph-line:nth-child(1) {
+  transform: translateY(0.67rem) rotate(45deg);
+}
+
+.icon-morph-button:hover .icon-morph-line:nth-child(2),
+.icon-morph-button:focus-visible .icon-morph-line:nth-child(2) {
+  opacity: 0;
+  transform: scaleX(0.3);
+}
+
+.icon-morph-button:hover .icon-morph-line:nth-child(3),
+.icon-morph-button:focus-visible .icon-morph-line:nth-child(3) {
+  transform: translateY(-0.67rem) rotate(-45deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .icon-morph-button,
+  .icon-morph-line {
+    transition: none;
+  }
+}

--- a/submissions/examples/14769-icon-morph-kkp/style.css
+++ b/submissions/examples/14769-icon-morph-kkp/style.css
@@ -1,7 +1,12 @@
 :root {
   color-scheme: light;
   font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
     sans-serif;
   background: #f6f8fb;
   color: #172033;


### PR DESCRIPTION
## Summary
- adds a pure CSS menu-to-close icon morph demo
- includes local demo.html, style.css, and README.md under submissions/examples

## Validation
- npx prettier --check submissions/examples/14769-icon-morph-kkp/demo.html submissions/examples/14769-icon-morph-kkp/style.css submissions/examples/14769-icon-morph-kkp/README.md

Closes #14769