### PR TITLE
feat: add shockwave rings demo

### DIFF
--- a/submissions/examples/14764-shockwave-rings-kkp/README.md
+++ b/submissions/examples/14764-shockwave-rings-kkp/README.md
@@ -1,0 +1,5 @@
+# Explosion Shockwave Rings
+
+1. What does this do? Creates expanding concentric rings that simulate a shockwave from a central impact point.
+2. How is it used? Apply `.shockwave-stage` around `.shockwave-core` and three `.shockwave-ring` elements.
+3. Why is it useful? It provides an expressive CSS-only impact cue for alerts, game UI, or high-energy interaction feedback.

--- a/submissions/examples/14764-shockwave-rings-kkp/demo.html
+++ b/submissions/examples/14764-shockwave-rings-kkp/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Explosion Shockwave Rings</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="shockwave-title">
+        <div class="shockwave-stage" aria-hidden="true">
+          <span class="shockwave-ring ring-one"></span>
+          <span class="shockwave-ring ring-two"></span>
+          <span class="shockwave-ring ring-three"></span>
+          <span class="shockwave-core"></span>
+        </div>
+        <p class="eyebrow">Impact feedback</p>
+        <h1 id="shockwave-title">Expanding shockwave</h1>
+        <p class="demo-copy">
+          Layered rings radiate from the center with staggered timing to create
+          a clean explosion effect.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/14764-shockwave-rings-kkp/style.css
+++ b/submissions/examples/14764-shockwave-rings-kkp/style.css
@@ -1,0 +1,133 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #111827;
+  color: #f9fafb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 50% 35%,
+      rgb(248 113 113 / 0.16),
+      transparent 28rem
+    ),
+    #111827;
+}
+
+.demo-card {
+  width: min(100%, 38rem);
+  border: 1px solid rgb(255 255 255 / 0.14);
+  border-radius: 0.75rem;
+  background: rgb(17 24 39 / 0.82);
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 0.35);
+}
+
+.shockwave-stage {
+  position: relative;
+  width: 15rem;
+  height: 15rem;
+  margin: 0 auto 1.5rem;
+  display: grid;
+  place-items: center;
+}
+
+.shockwave-core {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff7ed 0 18%, #fb923c 45%, #dc2626 100%);
+  box-shadow:
+    0 0 2rem rgb(251 146 60 / 0.8),
+    0 0 4rem rgb(220 38 38 / 0.45);
+  animation: core-pop 1.8s ease-in-out infinite;
+  z-index: 2;
+}
+
+.shockwave-ring {
+  position: absolute;
+  width: 3.5rem;
+  height: 3.5rem;
+  border: 0.22rem solid #fb923c;
+  border-radius: 50%;
+  opacity: 0;
+  animation: shockwave-expand 1.8s cubic-bezier(0.2, 0.75, 0.32, 1) infinite;
+}
+
+.ring-two {
+  animation-delay: 0.28s;
+  border-color: #f97316;
+}
+
+.ring-three {
+  animation-delay: 0.56s;
+  border-color: #ef4444;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #fdba74;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 27rem;
+  margin: 0.85rem auto 0;
+  color: #cbd5e1;
+  line-height: 1.65;
+}
+
+@keyframes shockwave-expand {
+  0% {
+    opacity: 0.9;
+    transform: scale(0.5);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(4);
+  }
+}
+
+@keyframes core-pop {
+  50% {
+    transform: scale(1.12);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shockwave-core,
+  .shockwave-ring {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- adds a pure CSS expanding shockwave ring demo
- includes local demo.html, style.css, and README.md under submissions/examples

## Validation
- npx prettier --check submissions/examples/14764-shockwave-rings-kkp/demo.html submissions/examples/14764-shockwave-rings-kkp/style.css submissions/examples/14764-shockwave-rings-kkp/README.md

Closes #14764