### PR TITLE
feat: add screen shake feedback demo

### DIFF
--- a/submissions/examples/14762-screen-shake-kkp/README.md
+++ b/submissions/examples/14762-screen-shake-kkp/README.md
@@ -1,0 +1,5 @@
+# Screen Shake Feedback
+
+1. What does this do? Adds a short horizontal shake animation for impact, error, or attention feedback.
+2. How is it used? Apply `.shake-panel` to the element that should shake when hovered or focused.
+3. Why is it useful? It provides a clear CSS-only feedback cue that can be reused in forms, alerts, and interactive demos.

--- a/submissions/examples/14762-screen-shake-kkp/demo.html
+++ b/submissions/examples/14762-screen-shake-kkp/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Screen Shake Feedback</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="shake-title">
+        <p class="eyebrow">Interaction feedback</p>
+        <h1 id="shake-title">Screen shake cue</h1>
+        <p class="demo-copy">
+          Hover or focus the panel to trigger a compact shake animation for
+          impact or error states.
+        </p>
+
+        <button class="shake-panel" type="button">
+          <span class="shake-icon">!</span>
+          <span>
+            <strong>Action needs attention</strong>
+            <small>Pure CSS shake feedback</small>
+          </span>
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/14762-screen-shake-kkp/style.css
+++ b/submissions/examples/14762-screen-shake-kkp/style.css
@@ -1,0 +1,137 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 38rem);
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  box-shadow: 0 1.5rem 3rem rgb(15 23 42 / 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #dc2626;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.demo-copy {
+  max-width: 28rem;
+  margin: 0.85rem 0 1.5rem;
+  color: #526070;
+  line-height: 1.65;
+}
+
+.shake-panel {
+  width: 100%;
+  border: 1px solid #fecaca;
+  border-radius: 0.75rem;
+  background: #fff7f7;
+  color: #7f1d1d;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.shake-panel:hover,
+.shake-panel:focus-visible {
+  border-color: #f87171;
+  box-shadow: 0 0.9rem 2rem rgb(248 113 113 / 0.18);
+  animation: screen-shake 520ms cubic-bezier(0.36, 0.07, 0.19, 0.97);
+  outline: none;
+}
+
+.shake-icon {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  background: #dc2626;
+  color: #ffffff;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  font-size: 1.5rem;
+  font-weight: 800;
+}
+
+.shake-panel strong,
+.shake-panel small {
+  display: block;
+}
+
+.shake-panel small {
+  margin-top: 0.2rem;
+  color: #991b1b;
+}
+
+@keyframes screen-shake {
+  10%,
+  90% {
+    transform: translateX(-0.08rem);
+  }
+
+  20%,
+  80% {
+    transform: translateX(0.16rem);
+  }
+
+  30%,
+  50%,
+  70% {
+    transform: translateX(-0.26rem);
+  }
+
+  40%,
+  60% {
+    transform: translateX(0.26rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shake-panel:hover,
+  .shake-panel:focus-visible {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- adds a pure CSS screen shake feedback demo
- includes local demo.html, style.css, and README.md under submissions/examples

## Validation
- npx prettier --check submissions/examples/14762-screen-shake-kkp/demo.html submissions/examples/14762-screen-shake-kkp/style.css submissions/examples/14762-screen-shake-kkp/README.md

Closes #14762