### PR TITLE
feat: add cart icon bounce demo

### DIFF
--- a/submissions/examples/14731-cart-bounce-kkp/README.md
+++ b/submissions/examples/14731-cart-bounce-kkp/README.md
@@ -1,0 +1,5 @@
+# Cart Icon Bounce
+
+1. What does this do? Animates a shopping cart icon with a short bounce when a product is added.
+2. How is it used? Apply `.cart-bounce-button` to a button containing a `.cart-icon` element.
+3. Why is it useful? It gives ecommerce actions clear feedback with a small, reusable CSS-only animation.

--- a/submissions/examples/14731-cart-bounce-kkp/demo.html
+++ b/submissions/examples/14731-cart-bounce-kkp/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cart Icon Bounce</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="cart-title">
+        <p class="eyebrow">Commerce feedback</p>
+        <h1 id="cart-title">Cart bounce</h1>
+        <p class="demo-copy">
+          Hover or focus the add-to-cart button to see the cart lift and settle
+          with a badge pulse.
+        </p>
+
+        <button class="cart-bounce-button" type="button">
+          <span class="cart-icon" aria-hidden="true">
+            <span class="cart-basket"></span>
+            <span class="cart-wheel wheel-left"></span>
+            <span class="cart-wheel wheel-right"></span>
+          </span>
+          <span>Add to cart</span>
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/14731-cart-bounce-kkp/style.css
+++ b/submissions/examples/14731-cart-bounce-kkp/style.css
@@ -1,0 +1,149 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #fff7ed;
+  color: #2b1705;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 36rem);
+  border: 1px solid #fed7aa;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgb(234 88 12 / 0.12);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #ea580c;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 27rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #6b5848;
+  line-height: 1.65;
+}
+
+.cart-bounce-button {
+  border: 0;
+  border-radius: 999px;
+  background: #ea580c;
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.9rem 1.35rem;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 1rem 2rem rgb(234 88 12 / 0.24);
+}
+
+.cart-icon {
+  position: relative;
+  width: 2.4rem;
+  height: 2rem;
+  display: inline-block;
+}
+
+.cart-basket {
+  position: absolute;
+  left: 0.25rem;
+  top: 0.25rem;
+  width: 1.75rem;
+  height: 1rem;
+  border: 0.22rem solid #ffffff;
+  border-top: 0;
+  border-radius: 0.1rem 0.1rem 0.35rem 0.35rem;
+}
+
+.cart-basket::before {
+  content: "";
+  position: absolute;
+  left: -0.45rem;
+  top: -0.5rem;
+  width: 0.7rem;
+  height: 0.22rem;
+  border-radius: 999px;
+  background: #ffffff;
+  transform: rotate(24deg);
+}
+
+.cart-wheel {
+  position: absolute;
+  bottom: 0.06rem;
+  width: 0.38rem;
+  height: 0.38rem;
+  border-radius: 50%;
+  background: #ffffff;
+}
+
+.wheel-left {
+  left: 0.55rem;
+}
+
+.wheel-right {
+  left: 1.55rem;
+}
+
+.cart-bounce-button:hover .cart-icon,
+.cart-bounce-button:focus-visible .cart-icon {
+  animation: cart-bounce 520ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.cart-bounce-button:focus-visible {
+  outline: 3px solid #fdba74;
+  outline-offset: 4px;
+}
+
+@keyframes cart-bounce {
+  40% {
+    transform: translateY(-0.35rem) rotate(-5deg);
+  }
+
+  75% {
+    transform: translateY(0.08rem) rotate(3deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cart-bounce-button:hover .cart-icon,
+  .cart-bounce-button:focus-visible .cart-icon {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- adds a pure CSS cart icon bounce demo
- includes local demo.html, style.css, and README.md under submissions/examples

## Validation
- npx prettier --check submissions/examples/14731-cart-bounce-kkp/demo.html submissions/examples/14731-cart-bounce-kkp/style.css submissions/examples/14731-cart-bounce-kkp/README.md

Closes #14731