### PR TITLE
feat: add product quick view demo

### DIFF
--- a/submissions/examples/14727-product-quick-view-kkp/README.md
+++ b/submissions/examples/14727-product-quick-view-kkp/README.md
@@ -1,0 +1,5 @@
+# Product Quick View Modal
+
+1. What does this do? Creates a CSS-only product quick-view panel that scales in when the trigger is hovered or focused.
+2. How is it used? Apply `.quick-view-demo` to the wrapper and `.quick-view-panel` to the revealed product panel.
+3. Why is it useful? It demonstrates an ecommerce preview interaction that feels responsive without JavaScript or external assets.

--- a/submissions/examples/14727-product-quick-view-kkp/demo.html
+++ b/submissions/examples/14727-product-quick-view-kkp/demo.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Product Quick View Modal</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="quick-view-title">
+        <p class="eyebrow">Commerce preview</p>
+        <h1 id="quick-view-title">Quick view reveal</h1>
+        <p class="demo-copy">
+          Hover or focus the product tile to reveal a compact quick-view panel
+          with a smooth scale transition.
+        </p>
+
+        <div class="quick-view-demo" tabindex="0">
+          <div class="product-tile">
+            <span class="product-thumb"></span>
+            <strong>Motion Runner</strong>
+            <small>Hover for details</small>
+          </div>
+          <div class="quick-view-panel">
+            <span class="panel-label">Quick view</span>
+            <strong>Lightweight running shoe</strong>
+            <p>Breathable mesh, cushioned sole, and a flexible everyday fit.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/14727-product-quick-view-kkp/style.css
+++ b/submissions/examples/14727-product-quick-view-kkp/style.css
@@ -1,0 +1,140 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f8fafc;
+  color: #1f2937;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 40rem);
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  box-shadow: 0 1.5rem 3rem rgb(15 23 42 / 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #7c3aed;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 30rem;
+  margin: 0.85rem 0 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+.quick-view-demo {
+  position: relative;
+  width: min(100%, 22rem);
+  outline: none;
+}
+
+.product-tile {
+  border: 1px solid #ddd6fe;
+  border-radius: 0.75rem;
+  background: #f5f3ff;
+  padding: 1rem;
+  display: grid;
+  gap: 0.55rem;
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.product-thumb {
+  height: 9rem;
+  border-radius: 0.55rem;
+  background:
+    radial-gradient(circle at 35% 35%, #c4b5fd 0 20%, transparent 21%),
+    linear-gradient(135deg, #ede9fe, #c4b5fd);
+}
+
+.product-tile small {
+  color: #6d5c86;
+}
+
+.quick-view-panel {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  border-radius: 0.65rem;
+  background: rgb(255 255 255 / 0.96);
+  padding: 1rem;
+  box-shadow: 0 1rem 2rem rgb(76 29 149 / 0.18);
+  opacity: 0;
+  transform: translateY(0.75rem) scale(0.96);
+  transform-origin: bottom center;
+  transition:
+    opacity 220ms ease,
+    transform 260ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.panel-label {
+  display: inline-block;
+  margin-bottom: 0.35rem;
+  color: #7c3aed;
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.quick-view-panel p {
+  margin: 0.35rem 0 0;
+  color: #536173;
+  line-height: 1.5;
+}
+
+.quick-view-demo:hover .product-tile,
+.quick-view-demo:focus-visible .product-tile {
+  transform: translateY(-0.25rem);
+  box-shadow: 0 1rem 2rem rgb(124 58 237 / 0.16);
+}
+
+.quick-view-demo:hover .quick-view-panel,
+.quick-view-demo:focus-visible .quick-view-panel {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .product-tile,
+  .quick-view-panel {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- adds a pure CSS product quick-view reveal demo
- includes local demo.html, style.css, and README.md under submissions/examples

## Validation
- npx prettier --check submissions/examples/14727-product-quick-view-kkp/demo.html submissions/examples/14727-product-quick-view-kkp/style.css submissions/examples/14727-product-quick-view-kkp/README.md

Closes #14727