### PR TITLE
feat: add price strikethrough demo

### DIFF
--- a/submissions/examples/14725-price-strikethrough-kkp/README.md
+++ b/submissions/examples/14725-price-strikethrough-kkp/README.md
@@ -1,0 +1,5 @@
+# Price Strikethrough Animation
+
+1. What does this do? Draws an animated strike line across the original price before revealing the sale price.
+2. How is it used? Apply `.price-strike-card` to the wrapper and `.old-price` to the crossed-out amount.
+3. Why is it useful? It makes discount changes easier to notice while keeping the sale cue CSS-only and focused.

--- a/submissions/examples/14725-price-strikethrough-kkp/demo.html
+++ b/submissions/examples/14725-price-strikethrough-kkp/demo.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Price Strikethrough Animation</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="price-strike-card" aria-labelledby="price-title">
+        <p class="eyebrow">Sale motion</p>
+        <h1 id="price-title">Animated discount</h1>
+        <p class="demo-copy">
+          The original price is crossed out with a fast draw, then the sale
+          price pops forward.
+        </p>
+        <div
+          class="price-row"
+          aria-label="Original price 129 dollars, sale price 89 dollars"
+        >
+          <span class="old-price">$129</span>
+          <span class="new-price">$89</span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/14725-price-strikethrough-kkp/style.css
+++ b/submissions/examples/14725-price-strikethrough-kkp/style.css
@@ -1,0 +1,116 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f7fbf5;
+  color: #1f2937;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.price-strike-card {
+  width: min(100%, 36rem);
+  border: 1px solid #dcfce7;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  box-shadow: 0 1.5rem 3rem rgb(22 101 52 / 0.12);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #16a34a;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 28rem;
+  margin: 0.85rem 0 1.6rem;
+  color: #526070;
+  line-height: 1.65;
+}
+
+.price-row {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  font-weight: 900;
+}
+
+.old-price {
+  position: relative;
+  color: #94a3b8;
+  font-size: clamp(2rem, 8vw, 4rem);
+}
+
+.old-price::after {
+  content: "";
+  position: absolute;
+  left: -0.2rem;
+  right: -0.2rem;
+  top: 52%;
+  height: 0.22rem;
+  border-radius: 999px;
+  background: #ef4444;
+  transform: scaleX(0) rotate(-8deg);
+  transform-origin: left center;
+  animation: strike-draw 1.8s ease-in-out infinite;
+}
+
+.new-price {
+  color: #16a34a;
+  font-size: clamp(2.35rem, 9vw, 4.8rem);
+  animation: sale-pop 1.8s ease-in-out infinite;
+}
+
+@keyframes strike-draw {
+  28%,
+  100% {
+    transform: scaleX(1) rotate(-8deg);
+  }
+}
+
+@keyframes sale-pop {
+  35% {
+    transform: scale(1.12);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .old-price::after,
+  .new-price {
+    animation: none;
+  }
+
+  .old-price::after {
+    transform: scaleX(1) rotate(-8deg);
+  }
+}


### PR DESCRIPTION
## Summary
- adds a pure CSS animated price strikethrough demo
- includes local demo.html, style.css, and README.md under submissions/examples

## Validation
- npx prettier --check submissions/examples/14725-price-strikethrough-kkp/demo.html submissions/examples/14725-price-strikethrough-kkp/style.css submissions/examples/14725-price-strikethrough-kkp/README.md

Closes #14725