### PR TITLE
feat: add sidebar active indicator demo

### DIFF
--- a/submissions/examples/14717-sidebar-indicator-kkp/README.md
+++ b/submissions/examples/14717-sidebar-indicator-kkp/README.md
@@ -1,0 +1,5 @@
+# Sidebar Active Indicator
+
+1. What does this do? Adds a sliding active indicator for sidebar navigation items.
+2. How is it used? Apply `.sidebar-nav` to the list and `.sidebar-link` to each navigation item.
+3. Why is it useful? It gives app navigation a clear active state with a simple CSS-only motion pattern.

--- a/submissions/examples/14717-sidebar-indicator-kkp/demo.html
+++ b/submissions/examples/14717-sidebar-indicator-kkp/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sidebar Active Indicator</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <nav class="sidebar-nav" aria-label="Demo sidebar">
+        <p class="eyebrow">Navigation cue</p>
+        <a class="sidebar-link" href="#">Overview</a>
+        <a class="sidebar-link active" href="#">Analytics</a>
+        <a class="sidebar-link" href="#">Reports</a>
+        <a class="sidebar-link" href="#">Settings</a>
+      </nav>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/14717-sidebar-indicator-kkp/style.css
+++ b/submissions/examples/14717-sidebar-indicator-kkp/style.css
@@ -1,0 +1,101 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.sidebar-nav {
+  width: min(100%, 20rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 1rem;
+  box-shadow: 0 1.5rem 3rem rgb(15 23 42 / 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.8rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sidebar-link {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  border-radius: 0.55rem;
+  color: #475569;
+  padding: 0.85rem 1rem 0.85rem 1.2rem;
+  text-decoration: none;
+  transition:
+    color 180ms ease,
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.sidebar-link::before {
+  content: "";
+  position: absolute;
+  left: 0.35rem;
+  top: 50%;
+  width: 0.28rem;
+  height: 60%;
+  border-radius: 999px;
+  background: #2563eb;
+  transform: translateY(-50%) scaleY(0);
+  transform-origin: center;
+  transition: transform 220ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.sidebar-link:hover,
+.sidebar-link:focus-visible,
+.sidebar-link.active {
+  background: #eff6ff;
+  color: #1d4ed8;
+  transform: translateX(0.18rem);
+  outline: none;
+}
+
+.sidebar-link:hover::before,
+.sidebar-link:focus-visible::before,
+.sidebar-link.active::before {
+  transform: translateY(-50%) scaleY(1);
+}
+
+.sidebar-link + .sidebar-link {
+  margin-top: 0.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-link,
+  .sidebar-link::before {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- adds a pure CSS sidebar active indicator demo
- includes local demo.html, style.css, and README.md under submissions/examples

## Validation
- npx prettier --check submissions/examples/14717-sidebar-indicator-kkp/demo.html submissions/examples/14717-sidebar-indicator-kkp/style.css submissions/examples/14717-sidebar-indicator-kkp/README.md

Closes #14717