### PR TITLE
feat: add breadcrumb collapse demo

### DIFF
--- a/submissions/examples/14715-breadcrumb-collapse-kkp/README.md
+++ b/submissions/examples/14715-breadcrumb-collapse-kkp/README.md
@@ -1,0 +1,5 @@
+# Breadcrumb Collapse
+
+1. What does this do? Collapses middle breadcrumb items into a compact animated ellipsis state.
+2. How is it used? Apply `.breadcrumb-collapse` to a breadcrumb list and `.crumb-middle` to items that collapse.
+3. Why is it useful? It keeps long navigation paths readable in tight layouts while preserving a CSS-only reveal.

--- a/submissions/examples/14715-breadcrumb-collapse-kkp/demo.html
+++ b/submissions/examples/14715-breadcrumb-collapse-kkp/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Breadcrumb Collapse</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="breadcrumb-title">
+        <p class="eyebrow">Navigation motion</p>
+        <h1 id="breadcrumb-title">Collapsing breadcrumbs</h1>
+        <p class="demo-copy">
+          Hover or focus the trail to expand the hidden middle items.
+        </p>
+        <nav class="breadcrumb-collapse" aria-label="Breadcrumb">
+          <a href="#">Home</a>
+          <span class="crumb-middle">Catalog</span>
+          <span class="crumb-middle">Shoes</span>
+          <span class="crumb-ellipsis">...</span>
+          <strong>Runner Pro</strong>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/14715-breadcrumb-collapse-kkp/style.css
+++ b/submissions/examples/14715-breadcrumb-collapse-kkp/style.css
@@ -1,0 +1,118 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f8fafc;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 40rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  box-shadow: 0 1.5rem 3rem rgb(15 23 42 / 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #0f766e;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 28rem;
+  margin: 0.85rem 0 1.6rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+.breadcrumb-collapse {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  background: #f0fdfa;
+  padding: 0.8rem 1rem;
+  outline: none;
+}
+
+.breadcrumb-collapse > * {
+  color: #0f766e;
+}
+
+.breadcrumb-collapse > * + *::before {
+  content: "/";
+  margin-right: 0.5rem;
+  color: #94a3b8;
+}
+
+.crumb-middle {
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  transform: translateX(-0.4rem);
+  transition:
+    max-width 260ms ease,
+    opacity 220ms ease,
+    transform 220ms ease;
+}
+
+.breadcrumb-collapse:hover .crumb-middle,
+.breadcrumb-collapse:focus-within .crumb-middle {
+  max-width: 7rem;
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.breadcrumb-collapse:hover .crumb-ellipsis,
+.breadcrumb-collapse:focus-within .crumb-ellipsis {
+  opacity: 0;
+  transform: scale(0.6);
+}
+
+.crumb-ellipsis {
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crumb-middle,
+  .crumb-ellipsis {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- adds a pure CSS breadcrumb collapse demo
- includes local demo.html, style.css, and README.md under submissions/examples

## Validation
- npx prettier --check submissions/examples/14715-breadcrumb-collapse-kkp/demo.html submissions/examples/14715-breadcrumb-collapse-kkp/style.css submissions/examples/14715-breadcrumb-collapse-kkp/README.md

Closes #14715