### PR TITLE
feat: add badge new glow demo

### DIFF
--- a/submissions/examples/14697-badge-new-glow-kkp/README.md
+++ b/submissions/examples/14697-badge-new-glow-kkp/README.md
@@ -1,0 +1,5 @@
+# New Badge Glow
+
+1. What does this do? Adds a glowing pulse to a "New" badge.
+2. How is it used? Apply `.new-badge-glow` to a badge or label element.
+3. Why is it useful? It highlights fresh content, releases, or new features with a compact CSS-only effect.

--- a/submissions/examples/14697-badge-new-glow-kkp/demo.html
+++ b/submissions/examples/14697-badge-new-glow-kkp/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>New Badge Glow</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="badge-title">
+        <p class="eyebrow">Release cue</p>
+        <h1 id="badge-title">Badge glow</h1>
+        <p class="demo-copy">
+          Use this small glow treatment to make a new feature badge stand out in
+          a toolbar or card.
+        </p>
+        <span class="new-badge-glow">New</span>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/14697-badge-new-glow-kkp/style.css
+++ b/submissions/examples/14697-badge-new-glow-kkp/style.css
@@ -1,0 +1,104 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #111827;
+  color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid rgb(148 163 184 / 0.22);
+  border-radius: 0.75rem;
+  background: #1f2937;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgb(0 0 0 / 0.24);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #a78bfa;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #cbd5e1;
+  line-height: 1.65;
+}
+
+.new-badge-glow {
+  position: relative;
+  display: inline-flex;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #8b5cf6, #ec4899);
+  color: #ffffff;
+  padding: 0.65rem 1rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  box-shadow: 0 0 1rem rgb(236 72 153 / 0.38);
+  animation: badge-glow 1.8s ease-in-out infinite;
+}
+
+.new-badge-glow::after {
+  content: "";
+  position: absolute;
+  inset: -0.25rem;
+  border: 0.12rem solid rgb(236 72 153 / 0.62);
+  border-radius: inherit;
+  animation: badge-ring 1.8s ease-out infinite;
+}
+
+@keyframes badge-glow {
+  50% {
+    box-shadow: 0 0 1.8rem rgb(236 72 153 / 0.68);
+  }
+}
+
+@keyframes badge-ring {
+  80%,
+  100% {
+    opacity: 0;
+    transform: scale(1.16);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .new-badge-glow,
+  .new-badge-glow::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- adds a pure CSS new badge glow demo
- includes local demo.html, style.css, and README.md under submissions/examples

## Validation
- npx prettier --check submissions/examples/14697-badge-new-glow-kkp/demo.html submissions/examples/14697-badge-new-glow-kkp/style.css submissions/examples/14697-badge-new-glow-kkp/README.md

Closes #14697