### PR TITLE
feat: add button press ripple demo

### DIFF
--- a/submissions/examples/14695-button-ripple-kkp/README.md
+++ b/submissions/examples/14695-button-ripple-kkp/README.md
@@ -1,0 +1,5 @@
+# Button Press Ripple
+
+1. What does this do? Adds a ripple expansion when a button is pressed or focused.
+2. How is it used? Apply `.press-ripple-button` to a button element.
+3. Why is it useful? It gives click feedback a clear tactile feel using only CSS.

--- a/submissions/examples/14695-button-ripple-kkp/demo.html
+++ b/submissions/examples/14695-button-ripple-kkp/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Button Press Ripple</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="ripple-title">
+        <p class="eyebrow">Button feedback</p>
+        <h1 id="ripple-title">Press ripple</h1>
+        <p class="demo-copy">
+          Press, hover, or focus the button to see the ripple expand from the
+          center.
+        </p>
+        <button class="press-ripple-button" type="button">Save changes</button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/14695-button-ripple-kkp/style.css
+++ b/submissions/examples/14695-button-ripple-kkp/style.css
@@ -1,0 +1,119 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgb(15 23 42 / 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+.press-ripple-button {
+  position: relative;
+  overflow: hidden;
+  border: 0;
+  border-radius: 999px;
+  background: #2563eb;
+  color: #ffffff;
+  padding: 0.95rem 1.35rem;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  box-shadow: 0 1rem 2rem rgb(37 99 235 / 0.24);
+  transition: transform 160ms ease;
+}
+
+.press-ripple-button::after {
+  content: "";
+  position: absolute;
+  inset: 50%;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: rgb(255 255 255 / 0.45);
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0);
+}
+
+.press-ripple-button:hover,
+.press-ripple-button:focus-visible,
+.press-ripple-button:active {
+  transform: translateY(-0.12rem);
+  outline: none;
+}
+
+.press-ripple-button:hover::after,
+.press-ripple-button:focus-visible::after,
+.press-ripple-button:active::after {
+  animation: press-ripple 620ms ease-out;
+}
+
+@keyframes press-ripple {
+  35% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(12);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .press-ripple-button,
+  .press-ripple-button::after {
+    transition: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- adds a pure CSS button press ripple demo
- includes local demo.html, style.css, and README.md under submissions/examples

## Validation
- npx prettier --check submissions/examples/14695-button-ripple-kkp/demo.html submissions/examples/14695-button-ripple-kkp/style.css submissions/examples/14695-button-ripple-kkp/README.md

Closes #14695