### PR TITLE
feat: add word-break-utilities CSS demo

### DIFF
--- a/submissions/examples/word-break-utilities/README.md
+++ b/submissions/examples/word-break-utilities/README.md
@@ -1,19 +1,35 @@
-# Word Break Utilities
+# word-break-utilities
 
-Control how long words and text wrap within containers using simple utility classes.
-
-## Included Utilities
-
-- `ease-break-word`
-- `ease-break-all`
-- `ease-break-keep`
+Word break and whitespace utility classes for EaseMotion CSS.
 
 ## Usage
 
 ```html
-<div class="ease-break-word">LongText...</div>
+<p class="ease-break-words">Very long unbreakable text...</p>
+<p class="ease-truncate">Text that gets cut off with ellipsis...</p>
 ```
 
-## Demo
+## Classes
 
-Showcases different word-breaking and text-wrapping behaviors for long content.
+| Class | CSS Property |
+|---|---|
+| `ease-break-normal` | word-break: normal |
+| `ease-break-words` | overflow-wrap: break-word |
+| `ease-break-all` | word-break: break-all |
+| `ease-break-keep` | word-break: keep-all |
+| `ease-truncate` | overflow: hidden + ellipsis |
+| `ease-whitespace-normal` | white-space: normal |
+| `ease-whitespace-nowrap` | white-space: nowrap |
+| `ease-whitespace-pre` | white-space: pre |
+| `ease-whitespace-pre-line` | white-space: pre-line |
+| `ease-whitespace-pre-wrap` | white-space: pre-wrap |
+| `ease-hyphens-none` | hyphens: none |
+| `ease-hyphens-auto` | hyphens: auto |
+| `ease-hyphens-manual` | hyphens: manual |
+
+## Features
+- Full word break control
+- Whitespace handling utilities
+- Hyphenation control
+- Truncate with ellipsis
+- Follows ease- naming convention

--- a/submissions/examples/word-break-utilities/demo.html
+++ b/submissions/examples/word-break-utilities/demo.html
@@ -1,39 +1,109 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Word Break Utilities Demo</title>
-    <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Word Break Utilities Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: Inter, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+      min-height: 100vh;
+      background: #f8fafc;
+      padding: 2rem;
+    }
+    h2 { color: #7c3aed; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 1rem;
+      width: 100%;
+      max-width: 640px;
+    }
+    .box {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1rem;
+      width: 100%;
+    }
+    .box label {
+      display: block;
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #94a3b8;
+      margin-bottom: 0.5rem;
+    }
+    .box p {
+      margin: 0;
+      font-size: 0.9rem;
+      color: #334155;
+      border: 1px dashed #e2e8f0;
+      padding: 0.5rem;
+      border-radius: 4px;
+    }
+    .long-word {
+      color: #64748b;
+    }
+  </style>
 </head>
 <body>
 
-    <h1>Word Break Utilities Demo</h1>
+  <h2>Word Break Utilities</h2>
 
-    <div class="container">
+  <div class="grid">
 
-        <div class="card">
-            <p>.ease-break-word</p>
-            <div class="text-box ease-break-word">
-                ThisIsAnExtremelyLongWordWithoutAnySpacesThatNeedsToWrapCorrectlyInsideTheContainerToPreventOverflow.
-            </div>
-        </div>
-
-        <div class="card">
-            <p>.ease-break-all</p>
-            <div class="text-box ease-break-all">
-                ThisIsAnExtremelyLongWordWithoutAnySpacesThatNeedsToWrapCorrectlyInsideTheContainerToPreventOverflow.
-            </div>
-        </div>
-
-        <div class="card">
-            <p>.ease-break-keep</p>
-            <div class="text-box ease-break-keep">
-                ThisIsAnExtremelyLongWordWithoutAnySpacesThatNeedsToWrapCorrectlyInsideTheContainerToPreventOverflow.
-            </div>
-        </div>
-
+    <div class="box">
+      <label>ease-break-normal</label>
+      <p class="ease-break-normal long-word">
+        Thisisaverylongwordthatwillnotbreakbydefault pneumonoultramicroscopicsilicovolcanoconiosis
+      </p>
     </div>
+
+    <div class="box">
+      <label>ease-break-words</label>
+      <p class="ease-break-words long-word">
+        Thisisaverylongwordthatwillnotbreakbydefault pneumonoultramicroscopicsilicovolcanoconiosis
+      </p>
+    </div>
+
+    <div class="box">
+      <label>ease-break-all</label>
+      <p class="ease-break-all long-word">
+        Thisisaverylongwordthatwillbreakeverywhere pneumonoultramicroscopicsilicovolcanoconiosis
+      </p>
+    </div>
+
+    <div class="box">
+      <label>ease-truncate</label>
+      <p class="ease-truncate long-word">
+        This text is very long and will be truncated with an ellipsis at the end of the line
+      </p>
+    </div>
+
+    <div class="box">
+      <label>ease-whitespace-nowrap</label>
+      <p class="ease-whitespace-nowrap" style="overflow:hidden">
+        This text will not wrap no matter how long it gets on a single line
+      </p>
+    </div>
+
+    <div class="box">
+      <label>ease-hyphens-auto</label>
+      <p class="ease-hyphens-auto ease-break-words" lang="en">
+        Pneumonoultramicroscopicsilicovolcanoconiosis is a very long word that benefits from automatic hyphenation.
+      </p>
+    </div>
+
+  </div>
 
 </body>
 </html>

--- a/submissions/examples/word-break-utilities/style.css
+++ b/submissions/examples/word-break-utilities/style.css
@@ -1,48 +1,35 @@
-body {
-    font-family: Arial, sans-serif;
-    background: #f5f5f5;
-    padding: 40px;
+/* Word Break Utilities - EaseMotion CSS */
+
+.ease-break-normal {
+  word-break: normal;
+  overflow-wrap: normal;
 }
 
-h1 {
-    text-align: center;
-    margin-bottom: 40px;
-}
-
-.container {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 25px;
-}
-
-.card {
-    background: white;
-    padding: 20px;
-    border-radius: 12px;
-    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
-}
-
-.text-box {
-    width: 220px;
-    border: 2px solid #ddd;
-    padding: 12px;
-    margin: 0 auto;
-    background: #fafafa;
-}
-
-.ease-break-word {
-    overflow-wrap: break-word;
+.ease-break-words {
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .ease-break-all {
-    word-break: break-all;
+  word-break: break-all;
 }
 
 .ease-break-keep {
-    word-break: keep-all;
+  word-break: keep-all;
 }
 
-p {
-    font-weight: 600;
-    text-align: center;
+.ease-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
+
+.ease-whitespace-normal   { white-space: normal; }
+.ease-whitespace-nowrap   { white-space: nowrap; }
+.ease-whitespace-pre      { white-space: pre; }
+.ease-whitespace-pre-line { white-space: pre-line; }
+.ease-whitespace-pre-wrap { white-space: pre-wrap; }
+
+.ease-hyphens-none  { hyphens: none; }
+.ease-hyphens-auto  { hyphens: auto; }
+.ease-hyphens-manual { hyphens: manual; }


### PR DESCRIPTION
## Summary
Adds word break and whitespace utility classes to submissions/examples/

## Classes Added
- ease-break-normal / ease-break-words / ease-break-all / ease-break-keep
- ease-truncate — overflow ellipsis
- ease-whitespace-* — 5 whitespace variants
- ease-hyphens-* — hyphenation control

## Files Added
- submissions/examples/word-break-utilities/style.css
- submissions/examples/word-break-utilities/demo.html
- submissions/examples/word-break-utilities/README.md

## Related Issue
Closes #15925