### PR TITLE
feat: add ease-text-split-reveal animation component

### DIFF
--- a/submissions/examples/ease-text-split-reveal/README.md
+++ b/submissions/examples/ease-text-split-reveal/README.md
@@ -1,0 +1,42 @@
+# ease-text-split-reveal
+
+A dramatic text split reveal animation for EaseMotion CSS.
+
+## Usage
+
+```html
+<div class="ease-text-split-reveal">
+  <div class="ease-split-top">Your Text</div>
+  <div class="ease-split-bottom">Your Text</div>
+  <div class="ease-split-content">
+    Revealed content here
+  </div>
+</div>
+```
+
+## Trigger
+
+Add `ease-split-active` class to trigger the animation:
+
+```javascript
+element.classList.add('ease-split-active');
+```
+
+Or toggle on click:
+```html
+<div class="ease-text-split-reveal"
+  onclick="this.classList.toggle('ease-split-active')">
+```
+
+## How it works
+- Two halves (top/bottom) cover the content using clip-path
+- On trigger, top half slides up, bottom half slides down
+- Hidden content fades in beneath with a slight delay
+
+## Features
+- Dramatic hero section reveal effect
+- Click or JS triggered
+- Smooth cubic-bezier transitions
+- Customizable via --ease-color-primary
+- Respects prefers-reduced-motion
+- Uses EaseMotion CSS design tokens

--- a/submissions/examples/ease-text-split-reveal/demo.html
+++ b/submissions/examples/ease-text-split-reveal/demo.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>ease-text-split-reveal Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: Inter, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3rem;
+      min-height: 100vh;
+      background: #0f172a;
+      padding: 2rem;
+    }
+    h2 { color: #fff; font-size: 1.5rem; }
+    p { color: #94a3b8; font-size: 0.9rem; }
+    .row {
+      display: flex;
+      gap: 2rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    /* Card reveal */
+    .split-card {
+      width: 200px;
+      height: 120px;
+      border-radius: 12px;
+      font-size: 1.25rem;
+      font-weight: 700;
+    }
+
+    .split-card .ease-split-top,
+    .split-card .ease-split-bottom {
+      border-radius: 12px;
+    }
+
+    .split-card .ease-split-content {
+      width: 200px;
+      height: 120px;
+      background: #1e293b;
+      border-radius: 12px;
+      border: 1px solid #334155;
+      color: #fff;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .split-card .ease-split-content h3 {
+      margin: 0;
+      font-size: 1rem;
+      color: #a78bfa;
+    }
+
+    .split-card .ease-split-content p {
+      margin: 0;
+      font-size: 0.78rem;
+      color: #64748b;
+    }
+
+    /* Hero text reveal */
+    .split-hero {
+      width: 360px;
+      height: 80px;
+      border-radius: 8px;
+      font-size: 1.5rem;
+    }
+
+    .split-hero .ease-split-content {
+      width: 360px;
+      height: 80px;
+      background: transparent;
+      color: #fff;
+      font-size: 1.5rem;
+      font-weight: 800;
+      letter-spacing: -0.02em;
+    }
+
+    .reset-btn {
+      margin-top: 0.5rem;
+      padding: 0.5rem 1.25rem;
+      background: transparent;
+      border: 1px solid #334155;
+      color: #94a3b8;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85rem;
+      transition: border-color 0.2s, color 0.2s;
+    }
+    .reset-btn:hover {
+      border-color: #7c3aed;
+      color: #a78bfa;
+    }
+  </style>
+</head>
+<body>
+
+  <h2>ease-text-split-reveal</h2>
+  <p>Click to trigger the split reveal animation</p>
+
+  <div class="row">
+
+    <!-- Card 1 -->
+    <div class="ease-text-split-reveal split-card"
+      onclick="this.classList.toggle('ease-split-active')"
+      style="--ease-color-primary:#7c3aed">
+      <div class="ease-split-top">Design</div>
+      <div class="ease-split-bottom">Design</div>
+      <div class="ease-split-content">
+        <h3>Design System</h3>
+        <p>Reveal on click</p>
+      </div>
+    </div>
+
+    <!-- Card 2 -->
+    <div class="ease-text-split-reveal split-card"
+      onclick="this.classList.toggle('ease-split-active')"
+      style="--ease-color-primary:#06b6d4">
+      <div class="ease-split-top">Motion</div>
+      <div class="ease-split-bottom">Motion</div>
+      <div class="ease-split-content">
+        <h3>Animation First</h3>
+        <p>Pure CSS magic</p>
+      </div>
+    </div>
+
+    <!-- Card 3 -->
+    <div class="ease-text-split-reveal split-card"
+      onclick="this.classList.toggle('ease-split-active')"
+      style="--ease-color-primary:#10b981">
+      <div class="ease-split-top">Build</div>
+      <div class="ease-split-bottom">Build</div>
+      <div class="ease-split-content">
+        <h3>Zero JS</h3>
+        <p>CSS only reveal</p>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- Hero text -->
+  <div class="ease-text-split-reveal split-hero"
+    onclick="this.classList.toggle('ease-split-active')">
+    <div class="ease-split-top">EaseMotion CSS</div>
+    <div class="ease-split-bottom">EaseMotion CSS</div>
+    <div class="ease-split-content">✨ Animation First Framework</div>
+  </div>
+
+  <button class="reset-btn" onclick="
+    document.querySelectorAll('.ease-text-split-reveal')
+      .forEach(el => el.classList.remove('ease-split-active'))
+  ">Reset All</button>
+
+</body>
+</html>

--- a/submissions/examples/ease-text-split-reveal/style.css
+++ b/submissions/examples/ease-text-split-reveal/style.css
@@ -1,0 +1,114 @@
+/* Text Split Reveal - EaseMotion CSS */
+
+@keyframes ease-split-left {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+}
+
+@keyframes ease-split-right {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+}
+
+@keyframes ease-reveal-content {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ease-text-split-reveal {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+/* The two halves */
+.ease-split-top,
+.ease-split-bottom {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ease-color-primary, #7c3aed);
+  color: #fff;
+  font-size: inherit;
+  font-weight: inherit;
+  overflow: hidden;
+  transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1),
+              opacity 0.5s ease;
+  z-index: 2;
+}
+
+.ease-split-top {
+  clip-path: inset(0 0 50% 0);
+}
+
+.ease-split-bottom {
+  clip-path: inset(50% 0 0 0);
+}
+
+/* Hidden content beneath */
+.ease-split-content {
+  position: relative;
+  z-index: 1;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.4s ease 0.3s,
+              transform 0.4s ease 0.3s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem 2rem;
+}
+
+/* Triggered state */
+.ease-text-split-reveal.ease-split-active .ease-split-top {
+  transform: translateY(-100%);
+  opacity: 0;
+}
+
+.ease-text-split-reveal.ease-split-active .ease-split-bottom {
+  transform: translateY(100%);
+  opacity: 0;
+}
+
+.ease-text-split-reveal.ease-split-active .ease-split-content {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-split-top,
+  .ease-split-bottom,
+  .ease-split-content {
+    transition: none;
+  }
+  .ease-text-split-reveal.ease-split-active .ease-split-top,
+  .ease-text-split-reveal.ease-split-active .ease-split-bottom {
+    display: none;
+  }
+  .ease-text-split-reveal.ease-split-active .ease-split-content {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a dramatic text split reveal animation to submissions/examples/

## How it works
- Two halves cover the content using clip-path
- On trigger, top half slides up, bottom slides down
- Hidden content fades in beneath with a delay

## Features
- Dramatic hero section reveal effect
- Click or JS triggered via ease-split-active class
- Smooth cubic-bezier transitions
- Color customizable via --ease-color-primary
- Respects prefers-reduced-motion
- Uses EaseMotion CSS design tokens

## Files Added
- submissions/examples/ease-text-split-reveal/style.css
- submissions/examples/ease-text-split-reveal/demo.html
- submissions/examples/ease-text-split-reveal/README.md

## Related Issue
Closes #13676