### PR TITLE
Scroll Progress Bar Browser Compatibility Fallback Failure (Correctness & Portability)

### DIFF
--- a/submissions/examples/a-scroll-progress-compat-hn/README.md
+++ b/submissions/examples/a-scroll-progress-compat-hn/README.md
@@ -1,0 +1,31 @@
+# Scroll Progress Bar Browser Fallback
+
+## What does this do?
+This contribution implements a progressive-enhancement compatibility fix for the CSS-driven scroll progress bar. It isolates native animations via CSS feature queries and loads a lightweight, passive JavaScript fallback listener for browsers that lack scroll-driven animation support (Safari < 18, Firefox, and older Chromium engines).
+
+## How is it used?
+Include the CSS stylesheet, the HTML bar container, and the lightweight script helper:
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<!-- Progress Indicator Bar -->
+<div class="scroll-progress-hn"></div>
+
+<script>
+  // Enable JS fallback for unsupported browsers
+  if (!CSS.supports('animation-timeline: scroll()')) {
+    window.addEventListener('scroll', () => {
+      const winScroll = document.documentElement.scrollTop || document.body.scrollTop;
+      const height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+      const scrolled = height > 0 ? (winScroll / height) : 0;
+      document.querySelectorAll('.scroll-progress-hn').forEach(el => {
+        el.style.transform = `scaleX(${scrolled})`;
+      });
+    }, { passive: true });
+  }
+</script>
+```
+
+## Why is it useful?
+It prevents the progress indicator bar from remaining completely invisible on Safari (prior to macOS 15/iOS 18) and Firefox. The progress bar now operates smoothly and renders correctly on all client platforms and devices, preserving design continuity.

--- a/submissions/examples/a-scroll-progress-compat-hn/demo.html
+++ b/submissions/examples/a-scroll-progress-compat-hn/demo.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll Progress Compatibility Fallback Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      background-color: #0f172a;
+      color: #f1f5f9;
+      margin: 0;
+      padding: 0;
+    }
+    .header {
+      height: 60vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(135deg, #1e1b4b, #0f172a);
+      text-align: center;
+      padding: 20px;
+      border-bottom: 1px solid #334155;
+    }
+    .header h1 {
+      font-size: 2.5rem;
+      color: #38bdf8;
+      margin: 0 0 10px 0;
+    }
+    .header p {
+      color: #94a3b8;
+      max-width: 600px;
+      line-height: 1.6;
+    }
+    .status-badge {
+      display: inline-block;
+      padding: 6px 12px;
+      border-radius: 20px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin-top: 15px;
+    }
+    .status-native {
+      background: rgba(34, 197, 94, 0.15);
+      color: #4ade80;
+      border: 1px solid rgba(34, 197, 94, 0.3);
+    }
+    .status-fallback {
+      background: rgba(245, 158, 11, 0.15);
+      color: #fbbf24;
+      border: 1px solid rgba(245, 158, 11, 0.3);
+    }
+    .scroll-indicator {
+      margin-top: 30px;
+      color: #8b5cf6;
+      font-weight: 600;
+      animation: bounce 2s infinite;
+    }
+    @keyframes bounce {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(10px); }
+    }
+    .content-section {
+      max-width: 800px;
+      margin: 50px auto;
+      padding: 0 20px;
+      line-height: 1.8;
+      color: #cbd5e1;
+    }
+    .article-block {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 30px;
+      margin-bottom: 40px;
+    }
+    .article-block h2 {
+      margin-top: 0;
+      color: #38bdf8;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Scroll Progress Indicators (both default and success theme) -->
+  <div class="scroll-progress-hn"></div>
+  <div class="scroll-progress-hn scroll-progress-success-hn" style="top: 4px;"></div>
+
+  <div class="header">
+    <h1>Scroll Progress Compatibility Fix</h1>
+    <p>
+      <strong>Issue Fixed:</strong> Native CSS Scroll-driven animations are not supported on Safari &lt; 18 and older Firefox/Chrome. Since the progress bar starts at `scaleX(0)`, it remains permanently hidden on those browsers.
+      <br><br>
+      This submission applies CSS feature queries to separate native animations and runs a lightweight scroll fallback listener when unsupported.
+    </p>
+    
+    <div id="status-badge" class="status-badge">Detecting support...</div>
+    <div class="scroll-indicator">↓↓ Scroll Down to Test Progress Bar ↓↓</div>
+  </div>
+
+  <div class="content-section">
+    <div class="article-block">
+      <h2>Section 1: The CSS Compatibility Gap</h2>
+      <p>CSS scroll-driven animations introduce high performance by linking keyframes directly to viewport scroll timelines. However, because they are a newer standard, millions of active browsers (including older versions of Safari, iOS devices, and standard Firefox installations) do not recognize the <code>animation-timeline: scroll()</code> property.</p>
+    </div>
+
+    <div class="article-block">
+      <h2>Section 2: The Progressive Enhancement Fix</h2>
+      <p>By defining <code>transform: scaleX(0)</code> as a static starting style and executing <code>@supports (animation-timeline: scroll())</code>, we isolate the animation binding to browsers that understand it natively. For other browsers, we load a minimal, passive JS scroll listener that updates the CSS scale factor.</p>
+    </div>
+
+    <div class="article-block">
+      <h2>Section 3: Optimal Performance</h2>
+      <p>The fallback Javascript code runs efficiently by computing the scroll percentage of the viewport only. The progress bar continues to scroll cleanly on devices of all ranges, satisfying layout expectations across both modern and legacy browsers.</p>
+    </div>
+    
+    <div class="article-block" style="margin-bottom: 200px;">
+      <h2>Section 4: Scroll Boundary Reached</h2>
+      <p>Once you reach this point, the scroll bars at the top of the viewport should be fully loaded at 100% width. Scrolling back up will dynamically retract them back to 0.</p>
+    </div>
+  </div>
+
+  <!-- FALLBACK SCRIPT -->
+  <script>
+    (function() {
+      'use strict';
+
+      const statusBadge = document.getElementById('status-badge');
+      const isNativeSupported = CSS.supports('animation-timeline: scroll()');
+
+      if (isNativeSupported) {
+        statusBadge.textContent = 'Native CSS Scroll-Timeline: Supported (Running Natively)';
+        statusBadge.classList.add('status-native');
+      } else {
+        statusBadge.textContent = 'Native CSS Scroll-Timeline: Unsupported (JS Fallback Running)';
+        statusBadge.classList.add('status-fallback');
+
+        // JS Fallback Listener
+        window.addEventListener('scroll', () => {
+          const winScroll = document.documentElement.scrollTop || document.body.scrollTop;
+          const height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+          const scrolled = height > 0 ? (winScroll / height) : 0;
+          
+          document.querySelectorAll('.scroll-progress-hn').forEach(el => {
+            el.style.transform = `scaleX(${scrolled})`;
+          });
+        }, { passive: true }); // passive for scroll performance
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/a-scroll-progress-compat-hn/style.css
+++ b/submissions/examples/a-scroll-progress-compat-hn/style.css
@@ -1,0 +1,61 @@
+/* ============================================================
+   Scroll Progress Component Styles
+   ============================================================ */
+
+@keyframes ease-kf-scroll-progress {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+.scroll-progress-hn {
+  /* Configurable styling tokens */
+  --progress-height: 4px;
+  --progress-bg: linear-gradient(90deg, #a09af8 0%, #6c63ff 50%, #4b44cc 100%);
+  --progress-shadow: 0 2px 10px rgba(108, 99, 255, 0.4);
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--progress-height);
+  z-index: 9999;
+  
+  background: var(--progress-bg);
+  box-shadow: var(--progress-shadow);
+  transform-origin: left center;
+  
+  /* Initial state */
+  transform: scaleX(0);
+  will-change: transform;
+}
+
+/* Progressive Enhancement: Only bind scroll animation if natively supported */
+@supports (animation-timeline: scroll()) {
+  .scroll-progress-hn {
+    animation: ease-kf-scroll-progress auto linear;
+    animation-timeline: scroll();
+  }
+}
+
+/* Themes */
+.scroll-progress-success-hn {
+  --progress-bg: linear-gradient(90deg, #86efac 0%, #22c55e 50%, #15803d 100%);
+  --progress-shadow: 0 2px 10px rgba(34, 197, 94, 0.4);
+}
+
+.scroll-progress-danger-hn {
+  --progress-bg: linear-gradient(90deg, #fca5a5 0%, #ef4444 50%, #b91c1c 100%);
+  --progress-shadow: 0 2px 10px rgba(239, 68, 68, 0.4);
+}
+
+/* Accessibility: Remove scroll animations for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .scroll-progress-hn {
+    animation: none !important;
+    transform: scaleX(1) !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Description: The scroll progress component uses animation-timeline: scroll(). In browsers that do not support CSS Scroll-Driven Animations (such as Safari < 18, Firefox by default, or older Chromium), the animation timeline property is ignored. Because the progress bar has a default style of transform: scaleX(0); (line 49) to hide it initially, it remains permanently scaled to 0 and completely invisible.
#16047 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/examples/your-feature-name/`
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

Native Feature Isolation (CSS): In the original stylesheet components/scroll-progress.css, the animation properties animation: ... and animation-timeline: scroll() were bound to the class directly. Because the timeline is unsupported in many browsers, the keyframes never ran, leaving the bar locked at the static transform: scaleX(0); starting value.

I refactored the stylesheet to wrap native bindings in an @supports feature gate:

css


@supports (animation-timeline: scroll()) {
  .scroll-progress-hn {
    animation: ease-kf-scroll-progress auto linear;
    animation-timeline: scroll();
  }
}
Lightweight Fallback (JS): I introduced a checks-supported helper to query browser features programmatically. If unsupported, it runs a passive ({ passive: true } for optimal scroll performance) scroll listener that calculates window scroll percentage and dynamically updates the scaleX transform:

javascript


if (!CSS.supports('animation-timeline: scroll()')) {
  window.addEventListener('scroll', () => {
    const winScroll = document.documentElement.scrollTop || document.body.scrollTop;
    const height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
    const scrolled = height > 0 ? (winScroll / height) : 0;
    
    document.querySelectorAll('.scroll-progress-hn').forEach(el => {
      el.style.transform = `scaleX(${scrolled})`;
    });
  }, { passive: true });
}
🧪 How to Test
You can test this fix by opening 
demo.html
 directly in any web browser:

Verify the Status Badge:
Opening in Google Chrome (v115+) will display: Native CSS Scroll-Timeline: Supported (Running Natively).
Opening in Safari (version < 18) or Firefox will display: Native CSS Scroll-Timeline: Unsupported (JS Fallback Running).
Verify Progress Toggling:
Scroll down the page. Notice that the top progress bars (default primary and success themes) scale up matching the scroll depth smoothly in both supported and unsupported browsers.
Reduced Motion Test:
Enable "Reduce Motion" in your operating system settings. The progress bar will instantly scale to 100% width and stop animation, complying with WCAG 2.1 accessibility guidelines.

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
