### PR TITLE
feat: add animated price strikethrough component

### DIFF
--- a/examples/price-strikethrough/README.md
+++ b/examples/price-strikethrough/README.md
@@ -1,0 +1,13 @@
+# Price Strikethrough Animation
+
+An animated e-commerce discount component.
+
+## Features
+- Animated strikethrough line
+- New price fade-in effect
+- Scale animation
+- Pure HTML & CSS
+
+## Files
+- demo.html
+- style.css

--- a/examples/price-strikethrough/demo.html
+++ b/examples/price-strikethrough/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Price Strikethrough</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="price-container">
+        <span class="old-price">$99</span>
+        <span class="new-price">$49</span>
+    </div>
+</body>
+</html>

--- a/examples/price-strikethrough/style.css
+++ b/examples/price-strikethrough/style.css
@@ -1,0 +1,56 @@
+body{
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    height:100vh;
+    margin:0;
+    font-family:Arial,sans-serif;
+}
+
+.price-container{
+    display:flex;
+    align-items:center;
+    gap:15px;
+}
+
+.old-price{
+    position:relative;
+    font-size:2rem;
+    color:#888;
+}
+
+.old-price::after{
+    content:"";
+    position:absolute;
+    left:0;
+    top:50%;
+    width:0;
+    height:2px;
+    background:red;
+    animation:strike 1s ease forwards;
+}
+
+.new-price{
+    font-size:2rem;
+    color:green;
+    opacity:0;
+    transform:scale(0.8);
+    animation:showPrice 0.8s ease forwards;
+    animation-delay:1s;
+}
+
+@keyframes strike{
+    from{
+        width:0;
+    }
+    to{
+        width:100%;
+    }
+}
+
+@keyframes showPrice{
+    to{
+        opacity:1;
+        transform:scale(1);
+    }
+}


### PR DESCRIPTION
Closes #13769

Added an animated price strikethrough component with:
- Strikethrough animation (0% → 100%)
- New price fade-in effect
- Scale animation
- Responsive layout