### PR TITLE
Tooling: Add pre-commit hook for CSS formatting

### DIFF
--- a/submissions/examples/pre-commit-hook-ij/README.md
+++ b/submissions/examples/pre-commit-hook-ij/README.md
@@ -1,0 +1,20 @@
+# Component: Pre-commit Hook
+
+This submission implements a pre-commit hook guide for EaseMotion CSS formatting for issue **#13656**.
+
+## Description
+
+A guide demonstrating how to set up a Husky pre-commit hook that auto-formats CSS files using lint-staged. Ensures all committed EaseMotion CSS follows consistent formatting rules. Includes the hook script, package.json configuration, and setup instructions.
+
+## Acceptance Criteria
+
+- Step-by-step Husky + lint-staged setup guide
+- Code block showing the pre-commit hook script
+- Code block showing package.json lint-staged configuration
+- Explanation of the workflow
+
+## Files
+
+- `submissions/examples/pre-commit-hook-ij/demo.html`
+- `submissions/examples/pre-commit-hook-ij/style.css`
+- `submissions/examples/pre-commit-hook-ij/README.md`

--- a/submissions/examples/pre-commit-hook-ij/demo.html
+++ b/submissions/examples/pre-commit-hook-ij/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pre-commit Hook — EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <h1>Pre-commit Hook</h1>
+    <p class="subtitle">Auto-format EaseMotion CSS files before every commit using Husky + lint-staged</p>
+
+    <div class="step">
+      <h3>1. Install dependencies</h3>
+      <p>Install Husky and lint-staged as dev dependencies in your project.</p>
+    </div>
+
+    <div class="step">
+      <h3>2. Configure lint-staged</h3>
+      <p>Add the following to your <code>package.json</code> to run the formatter on staged CSS files.</p>
+    </div>
+
+    <pre><code>// package.json
+"lint-staged": {
+  "*.css": [
+    "npx prettier --write",
+    "npx stylelint --fix"
+  ]
+}</code></pre>
+
+    <div class="step">
+      <h3>3. Create the Husky hook</h3>
+      <p>The <code>.husky/pre-commit</code> hook runs lint-staged automatically before each commit.</p>
+    </div>
+
+    <pre><code>#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged</code></pre>
+
+    <div class="step">
+      <h3>4. Initialize Husky</h3>
+      <p>Run <code>npx husky install</code> and <code>npx husky add .husky/pre-commit "npx lint-staged"</code> to set up the hook.</p>
+    </div>
+
+    <div class="step">
+      <h3>How It Works</h3>
+      <p>When you run <code>git commit</code>, Husky triggers the pre-commit hook, which executes lint-staged. Only staged CSS files are formatted with Prettier and linted with Stylelint. If formatting fails, the commit is aborted, ensuring only clean CSS enters the repository.</p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/pre-commit-hook-ij/style.css
+++ b/submissions/examples/pre-commit-hook-ij/style.css
@@ -1,0 +1,118 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a0e17;
+  --bg-surface: rgba(26, 36, 56, 0.6);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --color-primary: #3b82f6;
+  --color-success: #10b981;
+  --color-text: #f3f4f6;
+  --color-text-muted: #9ca3af;
+  --font-sans: 'Outfit', sans-serif;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
+  background-image: radial-gradient(circle at 50% 50%, rgba(59, 130, 246, 0.12) 0%, transparent 60%);
+}
+
+.container {
+  max-width: 700px;
+  width: 100%;
+  backdrop-filter: blur(20px);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  text-align: center;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #60a5fa, #3b82f6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+  color: var(--color-text-muted);
+  margin-bottom: 2.5rem;
+  font-size: 1rem;
+}
+
+button {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-color);
+  color: var(--color-text);
+  padding: 0.75rem 1.5rem;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  font-family: var(--font-sans);
+  transition: all 0.25s;
+  outline: none;
+}
+
+button:hover {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 15px rgba(59, 130, 246, 0.4);
+}
+
+button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}
+
+pre {
+  background: #0d1117;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1.5rem;
+  text-align: left;
+  overflow-x: auto;
+  margin: 1rem 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #e6edf3;
+}
+
+code {
+  font-family: 'Cascadia Code', 'Fira Code', monospace;
+}
+
+.step {
+  text-align: left;
+  margin: 1.5rem 0;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  border-left: 3px solid var(--color-primary);
+}
+
+.step h3 {
+  margin-bottom: 0.5rem;
+  color: var(--color-primary);
+}
+
+.step p {
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Component: Tooling: Add pre-commit hook for CSS formatting

**Closes #13656**

### What this adds
A complete submission under submissions/examples/pre-commit-hook-ij/. Files: demo.html, style.css, README.md.

### Acceptance Criteria covered
- Implementation meets all requirements specified in the issue
- CSS custom properties for configuration
- Dark theme, responsive, accessible
- reduced-motion override included

### Files
- \submissions/examples/pre-commit-hook-ij/demo.html\
- \submissions/examples/pre-commit-hook-ij/style.css\
- \submissions/examples/pre-commit-hook-ij/README.md\

### How to review
Open \demo.html\ directly in a browser.