### PR TITLE
Documentation: Add email-safe CSS subset documentation

### DIFF
--- a/submissions/examples/email-safe-css-ij/README.md
+++ b/submissions/examples/email-safe-css-ij/README.md
@@ -1,0 +1,20 @@
+# Component: Email-Safe CSS Subset
+
+This submission documents email-safe CSS for EaseMotion for issue **#13628**.
+
+## Description
+
+A reference guide showing which CSS features (and EaseMotion utilities) are safe to use in HTML email. Includes a warning banner about email client limitations and a table of safe vs unsafe CSS properties with notes on Gmail, Outlook, and other clients.
+
+## Acceptance Criteria
+
+- Warning banner about email client limitations
+- Table with CSS feature, safety status, and notes
+- Covers animation, keyframes, transforms, inline styles, colors, media queries
+- Notes on Gmail, Outlook, and Apple Mail behavior
+
+## Files
+
+- `submissions/examples/email-safe-css-ij/demo.html`
+- `submissions/examples/email-safe-css-ij/style.css`
+- `submissions/examples/email-safe-css-ij/README.md`

--- a/submissions/examples/email-safe-css-ij/demo.html
+++ b/submissions/examples/email-safe-css-ij/demo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Email-Safe CSS — EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <h1>Email-Safe CSS Subset</h1>
+    <p class="subtitle">Which EaseMotion utilities work inside email clients</p>
+
+    <div class="warning-banner">
+      ⚠️ Email client CSS support varies widely. Gmail strips &lt;style&gt; tags and most animations.
+      Outlook uses Word's rendering engine. Always test emails across clients before sending.
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>CSS Feature</th>
+          <th>Email Safe?</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>animation</code></td>
+          <td class="status-unsafe">✗ Unsafe</td>
+          <td>Removed by Gmail, Outlook</td>
+        </tr>
+        <tr>
+          <td><code>@keyframes</code></td>
+          <td class="status-unsafe">✗ Unsafe</td>
+          <td>Not supported in most clients</td>
+        </tr>
+        <tr>
+          <td><code>transition</code></td>
+          <td class="status-unsafe">✗ Unsafe</td>
+          <td>No hover/interaction in email</td>
+        </tr>
+        <tr>
+          <td><code>transform</code></td>
+          <td class="status-unsafe">✗ Unsafe</td>
+          <td>Stripped by Outlook, Gmail</td>
+        </tr>
+        <tr>
+          <td><code>inline styles</code></td>
+          <td class="status-safe">✓ Safe</td>
+          <td>Use inline for all email CSS</td>
+        </tr>
+        <tr>
+          <td><code>color</code></td>
+          <td class="status-safe">✓ Safe</td>
+          <td>Universally supported</td>
+        </tr>
+        <tr>
+          <td><code>background-color</code></td>
+          <td class="status-safe">✓ Safe</td>
+          <td>Universally supported</td>
+        </tr>
+        <tr>
+          <td><code>font-family</code></td>
+          <td class="status-safe">✓ Safe</td>
+          <td>Use web-safe fallbacks</td>
+        </tr>
+        <tr>
+          <td><code>text-align</code></td>
+          <td class="status-safe">✓ Safe</td>
+          <td>Universally supported</td>
+        </tr>
+        <tr>
+          <td><code>display: none</code></td>
+          <td class="status-safe">✓ Safe</td>
+          <td>Works in most clients</td>
+        </tr>
+        <tr>
+          <td><code>@media queries</code></td>
+          <td class="status-warning">~ Partial</td>
+          <td>Works in Apple Mail, iOS; not Gmail</td>
+        </tr>
+        <tr>
+          <td><code>border-radius</code></td>
+          <td class="status-warning">~ Partial</td>
+          <td>Not supported in Outlook</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/email-safe-css-ij/style.css
+++ b/submissions/examples/email-safe-css-ij/style.css
@@ -1,0 +1,126 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a0e17;
+  --bg-surface: rgba(26, 36, 56, 0.6);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --color-primary: #3b82f6;
+  --color-success: #10b981;
+  --color-text: #f3f4f6;
+  --color-text-muted: #9ca3af;
+  --font-sans: 'Outfit', sans-serif;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
+  background-image: radial-gradient(circle at 50% 50%, rgba(59, 130, 246, 0.12) 0%, transparent 60%);
+}
+
+.container {
+  max-width: 700px;
+  width: 100%;
+  backdrop-filter: blur(20px);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  text-align: center;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #60a5fa, #3b82f6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+  color: var(--color-text-muted);
+  margin-bottom: 2.5rem;
+  font-size: 1rem;
+}
+
+button {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-color);
+  color: var(--color-text);
+  padding: 0.75rem 1.5rem;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  font-family: var(--font-sans);
+  transition: all 0.25s;
+  outline: none;
+}
+
+button:hover {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 15px rgba(59, 130, 246, 0.4);
+}
+
+button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}
+
+.warning-banner {
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  text-align: left;
+  color: #fbbf24;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1.5rem;
+  text-align: left;
+}
+
+th, td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+th {
+  color: var(--color-text-muted);
+  font-weight: 500;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+td {
+  font-size: 0.9rem;
+}
+
+.status-safe {
+  color: var(--color-success);
+}
+
+.status-unsafe {
+  color: #ef4444;
+}


### PR DESCRIPTION
## Component: Documentation: Add email-safe CSS subset documentation

**Closes #13628**

### What this adds
A complete submission under submissions/examples/email-safe-css-ij/. Files: demo.html, style.css, README.md.

### Acceptance Criteria covered
- Implementation meets all requirements specified in the issue
- Dark theme, responsive, accessible
- reduced-motion override included

### Files
- \submissions/examples/email-safe-css-ij/demo.html\
- \submissions/examples/email-safe-css-ij/style.css\
- \submissions/examples/email-safe-css-ij/README.md\

### How to review
Open \demo.html\ directly in a browser.