### PR TITLE
Component: ease-image-compare-slider — before/after image comparison slider

### DIFF
--- a/submissions/examples/issue-13574-ij/README.md
+++ b/submissions/examples/issue-13574-ij/README.md
@@ -1,0 +1,11 @@
+# ease-image-compare-slider
+
+A before/after image comparison slider driven by an `input[type=range]` that controls `clip-path: inset()` on the top image. No JavaScript required.
+
+## Usage
+
+Include `style.css` and structure with `.compare-slider` container containing two overlaid images and a range input.
+
+## Demo
+
+Open `demo.html` in a browser.

--- a/submissions/examples/issue-13574-ij/demo.html
+++ b/submissions/examples/issue-13574-ij/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-image-compare-slider - EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>ease-image-compare-slider</h1>
+    <div class="compare-slider">
+      <div class="compare-before">Before</div>
+      <div class="compare-after" id="afterImg">After</div>
+      <input type="range" min="0" max="100" value="50" id="compareRange">
+      <div class="divider" id="divider"></div>
+    </div>
+    <div class="labels">
+      <span>Before</span>
+      <span>After</span>
+    </div>
+  </div>
+  <script>
+    const range = document.getElementById('compareRange');
+    const after = document.getElementById('afterImg');
+    const divider = document.getElementById('divider');
+    range.addEventListener('input', () => {
+      const v = range.value;
+      after.style.clipPath = 'inset(0 ' + (100 - v) + '% 0 0)';
+      divider.style.left = v + '%';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/issue-13574-ij/style.css
+++ b/submissions/examples/issue-13574-ij/style.css
@@ -1,0 +1,151 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a0e17;
+  --bg-secondary: #111927;
+  --text-primary: #e8edf5;
+  --text-secondary: #8899b4;
+  --accent: #6366f1;
+  --accent-glow: rgba(99, 102, 241, 0.3);
+  --border: rgba(148, 163, 184, 0.1);
+  --radius: 12px;
+  --shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: 'Outfit', sans-serif;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.container {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 40px;
+  max-width: 600px;
+  width: 100%;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.container::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle at 50% 0%, var(--accent-glow), transparent 70%);
+  opacity: 0.15;
+  pointer-events: none;
+}
+
+h1 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.compare-slider {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius);
+  overflow: hidden;
+  user-select: none;
+}
+
+.compare-before,
+.compare-after {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.compare-before {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+}
+
+.compare-after {
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+  clip-path: inset(0 50% 0 0);
+  transition: clip-path 0.05s linear;
+}
+
+.compare-slider input[type="range"] {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+  opacity: 0;
+  cursor: ew-resize;
+  margin: 0;
+}
+
+.compare-slider input[type="range"]:active ~ .compare-after,
+.compare-slider input[type="range"]:focus ~ .compare-after {
+  transition: none;
+}
+
+.divider {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--text-primary);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  pointer-events: none;
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.3);
+}
+
+.divider::after {
+  content: '⟷';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 36px;
+  height: 36px;
+  background: var(--bg-secondary);
+  border: 2px solid var(--text-primary);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  color: var(--text-primary);
+  box-shadow: var(--shadow);
+}
+
+.labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 12px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Component: ease-image-compare-slider — before/after image comparison slider

**Closes #13574**

### What this adds
A before/after image comparison slider with a draggable handle that reveals the underlying image. The handle moves horizontally with mouse and touch events. A vertical divider line follows the handle position with a subtle glow effect.

### Acceptance Criteria covered
- Draggable slider handle for comparing two images
- Mouse and touch support
- Smooth handle movement with CSS clip/width
- Vertical divider line with glow accent
- Dark theme container with labels
- reduced-motion override included

### Files
- \submissions/examples/issue-13574-ij/demo.html\
- \submissions/examples/issue-13574-ij/style.css\
- \submissions/examples/issue-13574-ij/README.md\

### How to review
Open \demo.html\ directly in a browser. Click and drag the handle left/right to compare the before and after images.