### PR TITLE
Add stretch reveal horizontal animation

### DIFF
--- a/submissions/examples/stretch-reveal-horizontal/README.md
+++ b/submissions/examples/stretch-reveal-horizontal/README.md
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Stretch Reveal Horizontal</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="stretch-bar"></div>
+
+</body>
+</html>

--- a/submissions/examples/stretch-reveal-horizontal/demo.html
+++ b/submissions/examples/stretch-reveal-horizontal/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Stretch Reveal Horizontal</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="stretch-bar"></div>
+
+</body>
+</html>

--- a/submissions/examples/stretch-reveal-horizontal/style.css
+++ b/submissions/examples/stretch-reveal-horizontal/style.css
@@ -1,0 +1,40 @@
+body {
+  margin: 0;
+  height: 100vh;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background: #f4f4f4;
+  font-family: Arial, sans-serif;
+}
+
+.stretch-bar {
+  width: 320px;
+  height: 14px;
+
+  background: #2563eb;
+
+  border-radius: 999px;
+
+  transform-origin: left;
+
+  animation: stretchRevealHorizontal 0.8s ease-out forwards;
+}
+
+/* Stretch Reveal Horizontal */
+
+@keyframes stretchRevealHorizontal {
+
+  0% {
+    transform: scaleX(0);
+    opacity: 0;
+  }
+
+  100% {
+    transform: scaleX(1);
+    opacity: 1;
+  }
+
+}


### PR DESCRIPTION
# Pull Request Description

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/examples/stretch-reveal-horizontal/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to** **`core/`**
* [x] **No changes to** **`components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a horizontal stretch reveal animation where the element scales from a thin line to full width while fading in simultaneously. The animation originates from the left side and works well for dividers, progress bars, and loading indicators.

**How does a developer use it?**

```html
<div class="stretch-bar"></div>
```

**Why does it fit EaseMotion CSS?**

* Human-readable naming
* Animation-first utility
* Lightweight implementation
* Reusable reveal animation
* Pure CSS motion effect
* Consistent with existing directional utilities

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #11873 
