### PR TITLE
fix: add missing @keyframes ease-kf-hover-pulse-glow

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1366,6 +1366,17 @@
     filter: blur(0);
   }
 
+@keyframes ease-kf-hover-pulse-glow {
+  0%, 100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 0px rgba(108, 99, 255, 0));
+  }
+  50% {
+    transform: scale(1.06);
+    filter: drop-shadow(0 0 12px rgba(108, 99, 255, 0.45));
+  }
+}
+
 /* ── Issue #10072: .ease-hover-pulse-glow — Combined Pulse + Glow Hover Animation ── */
   .ease-hover-pulse-glow {
     z-index: 1;


### PR DESCRIPTION
## Summary

Fixes #16208. The `.ease-hover-pulse-glow` class referenced a non-existent `@keyframes ease-kf-hover-pulse-glow` animation. Added the missing keyframe definition.

## Changes

- Added `@keyframes ease-kf-hover-pulse-glow` to `core/animations.css` with:
  - 0% / 100%: scale(1), no glow
  - 50%: scale(1.06) + drop-shadow glow

## Evidence

The class at line 1378 references `ease-kf-hover-pulse-glow` but no matching keyframe existed anywhere in the codebase. Verified via grep.

## Testing

- `npm run build` — passes
- `npm test` — all 13 tests pass

@SAPTARSHI-coder Please review.