### PR TITLE
fix: remove impossible condition in modal.js focus-save code

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -25,10 +25,6 @@
 
           const modal = overlay.querySelector('.ease-modal');
           if (modal) {
-            if (!overlay.classList.contains('is-active')) {
-              previousFocusedElement = document.activeElement;
-            }
-
             modal.setAttribute('tabindex', '-1');
             modal.focus();
           }


### PR DESCRIPTION
## Summary

Fixes #16209. The `checkModal()` function added the `.is-active` class at line 24, then immediately checked `if (!overlay.classList.contains('is-active'))` at line 28 — which was **always false**. The inner focus-saving code never executed.

## Changes

- Removed the impossible condition block (lines 28-30) in `core/modal.js`
- The `previousFocusedElement` is already correctly saved at line 22 before the class is added

## Evidence

The condition `!overlay.classList.contains('is-active')` can never be true because `.is-active` was just added 4 lines above. This was confirmed by reading the source — no runtime test needed, it is a static unreachable code path.

## Testing

- `npm run build` — passes
- `npm test` — all 13 tests pass

@SAPTARSHI-coder Please review.