### PR TITLE
feat: add animation speed modifiers and favorite preset demo

### DIFF
--- a/submissions/examples/speed-modifiers-favorites/README.md
+++ b/submissions/examples/speed-modifiers-favorites/README.md
@@ -1,0 +1,36 @@
+# speed-modifiers-favorites
+
+## What it does
+Adds animation speed modifier utility classes (`.ease-fast`, `.ease-normal`,
+`.ease-slow`, `.ease-slower`) that let developers control animation duration
+independently of the animation type. Also includes a demo "Favorite Presets"
+panel showing how an animation + speed combination can be saved and replayed
+for quick reuse — built with localStorage, no backend required.
+
+## Proposed ease-* class names
+- `.ease-fast` — 0.4s duration
+- `.ease-normal` — 0.8s duration (default-like pacing)
+- `.ease-slow` — 1.5s duration
+- `.ease-slower` — 2.5s duration
+
+## Usage
+```html
+<!-- Combine any animation with a speed modifier -->
+<div class="ease-fade-in ease-fast">Fast fade in</div>
+<div class="ease-slide-up ease-slow">Slow slide up</div>
+```
+
+## Why this fits EaseMotion CSS
+Developers frequently want to test the same animation at different speeds
+before settling on one. Currently this requires writing custom
+`animation-duration` overrides. These four utilities make speed a
+first-class, composable modifier — consistent with EaseMotion's
+human-readable, zero-JS-required philosophy for the core animation classes.
+
+The "Favorite Presets" demo panel (JS, demo-only — not a proposed core
+class) shows how this composability could power a future Animation
+Builder feature: pick an animation, pick a speed, save the combo, replay
+it anytime.
+
+## Closes
+Issue #16206

--- a/submissions/examples/speed-modifiers-favorites/demo.html
+++ b/submissions/examples/speed-modifiers-favorites/demo.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Speed Modifiers & Favorite Presets — EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      background: #0f0f0f;
+      color: #fff;
+      padding: 2.5rem 2rem;
+      max-width: 600px;
+      margin: 0 auto;
+    }
+    h1 { font-weight: 300; letter-spacing: 0.04em; margin-bottom: 0.25rem; }
+    .subtitle { color: #888; font-size: 0.9rem; margin-bottom: 2rem; }
+    h2 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.08em; color: #999; margin: 2rem 0 0.75rem; }
+    .preview-row {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.75rem;
+    }
+    .box {
+      width: 50px;
+      height: 50px;
+      background: #6c63ff;
+      border-radius: 10px;
+    }
+    select {
+      background: #1a1a1a;
+      color: #fff;
+      border: 1px solid #333;
+      border-radius: 6px;
+      padding: 0.4rem 0.6rem;
+      font-size: 0.85rem;
+    }
+    button.replay {
+      background: #6c63ff;
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      padding: 0.4rem 0.8rem;
+      font-size: 0.8rem;
+      cursor: pointer;
+    }
+    #presetList { margin-top: 0.5rem; display: flex; flex-direction: column; gap: 0.5rem; }
+    .empty-state { color: #555; font-size: 0.85rem; font-style: italic; }
+  </style>
+</head>
+<body>
+  <h1>Speed Modifiers & Favorite Presets</h1>
+  <p class="subtitle">Pick an animation + speed, preview it, then save it as a favorite for quick reuse.</p>
+
+  <h2>Live Preview</h2>
+  <div class="preview-row">
+    <div class="box" id="previewBox"></div>
+
+    <select id="animationSelect">
+      <option value="ease-fade-in">Fade In</option>
+      <option value="ease-slide-up">Slide Up</option>
+      <option value="ease-bounce">Bounce</option>
+      <option value="ease-rotate">Rotate</option>
+    </select>
+
+    <select id="speedSelect">
+      <option value="ease-fast">Fast</option>
+      <option value="ease-normal" selected>Normal</option>
+      <option value="ease-slow">Slow</option>
+      <option value="ease-slower">Slower</option>
+    </select>
+
+    <button class="replay" id="replayBtn">▶ Preview</button>
+    <button class="star-btn" id="favoriteBtn" title="Save as favorite">☆</button>
+  </div>
+
+  <h2>Saved Favorites</h2>
+  <div id="presetList">
+    <p class="empty-state" id="emptyState">No favorites saved yet — preview a combo above and click ☆ to save it.</p>
+  </div>
+
+  <script>
+    const previewBox = document.getElementById('previewBox');
+    const animationSelect = document.getElementById('animationSelect');
+    const speedSelect = document.getElementById('speedSelect');
+    const replayBtn = document.getElementById('replayBtn');
+    const favoriteBtn = document.getElementById('favoriteBtn');
+    const presetList = document.getElementById('presetList');
+    const emptyState = document.getElementById('emptyState');
+
+    const STORAGE_KEY = 'easemotion-favorite-presets';
+
+    function playPreview() {
+      const animClass = animationSelect.value;
+      const speedClass = speedSelect.value;
+
+      // Reset classes, force reflow, then reapply to restart the animation
+      previewBox.className = 'box';
+      void previewBox.offsetWidth;
+      previewBox.classList.add(animClass, speedClass);
+    }
+
+    function getPresets() {
+      try {
+        return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+      } catch {
+        return [];
+      }
+    }
+
+    function savePresets(presets) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+    }
+
+    function labelFor(animClass, speedClass) {
+      const animLabel = animationSelect.querySelector(`option[value="${animClass}"]`)?.textContent || animClass;
+      const speedLabel = speedSelect.querySelector(`option[value="${speedClass}"]`)?.textContent || speedClass;
+      return `${animLabel} + ${speedLabel}`;
+    }
+
+    function renderPresets() {
+      const presets = getPresets();
+      presetList.innerHTML = '';
+
+      if (presets.length === 0) {
+        presetList.appendChild(emptyState);
+        return;
+      }
+
+      presets.forEach((preset, idx) => {
+        const card = document.createElement('div');
+        card.className = 'preset-card';
+        card.innerHTML = `
+          <span>⭐ ${labelFor(preset.animation, preset.speed)}</span>
+          <div style="display:flex; gap:0.5rem;">
+            <button class="replay" data-idx="${idx}">▶ Play</button>
+            <button class="star-btn active" data-remove="${idx}" title="Remove">✕</button>
+          </div>
+        `;
+        presetList.appendChild(card);
+      });
+    }
+
+    replayBtn.addEventListener('click', playPreview);
+
+    favoriteBtn.addEventListener('click', () => {
+      const presets = getPresets();
+      const newPreset = { animation: animationSelect.value, speed: speedSelect.value };
+
+      const alreadyExists = presets.some(
+        (p) => p.animation === newPreset.animation && p.speed === newPreset.speed
+      );
+      if (!alreadyExists) {
+        presets.push(newPreset);
+        savePresets(presets);
+        renderPresets();
+      }
+    });
+
+    presetList.addEventListener('click', (e) => {
+      if (e.target.dataset.idx !== undefined) {
+        const presets = getPresets();
+        const preset = presets[e.target.dataset.idx];
+        animationSelect.value = preset.animation;
+        speedSelect.value = preset.speed;
+        playPreview();
+      }
+      if (e.target.dataset.remove !== undefined) {
+        const presets = getPresets();
+        presets.splice(e.target.dataset.remove, 1);
+        savePresets(presets);
+        renderPresets();
+      }
+    });
+
+    // Initial render
+    renderPresets();
+  </script>
+</body>
+</html>

--- a/submissions/examples/speed-modifiers-favorites/style.css
+++ b/submissions/examples/speed-modifiers-favorites/style.css
@@ -1,0 +1,43 @@
+/* Animation Speed Utilities */
+.ease-fast {
+  animation-duration: 0.4s;
+}
+
+.ease-normal {
+  animation-duration: 0.8s;
+}
+
+.ease-slow {
+  animation-duration: 1.5s;
+}
+
+.ease-slower {
+  animation-duration: 2.5s;
+}
+
+/* Demo-only styling (not part of the proposed utility classes) */
+.preset-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  color: #eee;
+}
+
+.star-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+  color: #555;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.star-btn.active {
+  color: #facc15;
+  transform: scale(1.15);
+}


### PR DESCRIPTION
## Pull Request Description
Adds four animation speed modifier utility classes (fast, normal, slow, slower) that work alongside any existing EaseMotion animation class, implemented exactly per the CSS snippet in the issue. Also includes a demo "Favorite Presets" panel showing how users could save and replay animation + speed combinations using localStorage, illustrating the second half of the feature request for the Animation Builder UX.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/speed-modifiers-favorites/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
Speed modifier classes `.ease-fast`, `.ease-normal`, `.ease-slow`, `.ease-slower` that set `animation-duration` independently of the animation type, plus a demo of saving/replaying favorite animation+speed combinations via localStorage.

**How does a developer use it?**
```html
<div class="ease-fade-in ease-fast">Fast fade</div>
<div class="ease-bounce ease-slower">Very slow bounce</div>
```

**Why does it fit EaseMotion CSS?**
Speed is one of the first things developers experiment with when trying an animation. Making it a separate composable class (rather than baked into each animation) keeps every animation reusable at any pace without writing custom CSS — true to EaseMotion's human-readable, zero-JS-required philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
The four speed classes are implemented exactly per the issue's CSS snippet. The "Favorite Presets" panel in the demo is JS-only and demo-scoped (uses localStorage) — included to demonstrate how the Animation Builder could use the speed classes for the favorites feature described in the issue, not proposed as a new core CSS class itself. Happy to adjust scope if you'd prefer the demo to focus purely on the speed utilities.

Closes #16206