### PR TITLE
feat: add accessible tabs submission — WAI-ARIA, roving tabindex, transform-based indicator

### DIFF
--- a/submissions/examples/accessible-tabs-as/README.md
+++ b/submissions/examples/accessible-tabs-as/README.md
@@ -1,0 +1,49 @@
+# Accessible Tabs (-as)
+
+## What does this do?
+
+A tabs component built to the WAI-ARIA Tabs pattern: full keyboard navigation with roving tabindex, an active-tab indicator that slides using only `transform` (so it stays on the compositor), and a `prefers-reduced-motion` fallback. No dependencies.
+
+## How is it used?
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="ease-tabs">
+  <div class="ease-tabs__list" role="tablist" aria-label="Account settings">
+    <button class="ease-tabs__tab" role="tab" id="ease-tab-profile"
+            aria-controls="ease-panel-profile" aria-selected="true" tabindex="0">Profile</button>
+    <button class="ease-tabs__tab" role="tab" id="ease-tab-billing"
+            aria-controls="ease-panel-billing" aria-selected="false" tabindex="-1">Billing</button>
+    <span class="ease-tabs__indicator" aria-hidden="true"></span>
+  </div>
+
+  <div class="ease-tabs__panel" role="tabpanel" id="ease-panel-profile" aria-labelledby="ease-tab-profile" tabindex="0">…</div>
+  <div class="ease-tabs__panel" role="tabpanel" id="ease-panel-billing" aria-labelledby="ease-tab-billing" tabindex="0" hidden>…</div>
+</div>
+```
+
+The small inline script wires up selection, the roving tabindex, and the indicator; see `demo.html`.
+
+## Keyboard model
+
+| Key | Action |
+|---|---|
+| `Tab` | Enter the tablist (lands on the selected tab only) / move to the panel |
+| `Left` / `Right` | Previous / next tab (wraps), activates it |
+| `Home` / `End` | First / last tab |
+
+## Accessibility notes
+
+- Implements the [ARIA Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/): `role="tablist"` / `role="tab"` (`aria-selected`, `aria-controls`) / `role="tabpanel"` (`aria-labelledby`).
+- **Roving tabindex:** only the selected tab is in the tab order (`tabindex="0"`); the rest are `-1`, so `Tab` reaches the tablist once and arrow keys move within it — the expected behaviour for a tab widget.
+- Each panel is focusable (`tabindex="0"`) so keyboard users can move from the tab straight into its content.
+- Visible `:focus-visible` styles on tabs and panels.
+
+## Performance
+
+The indicator is a 1px-wide bar stretched and positioned with `transform: translateX() scaleX()` and `transform-origin: left`, so both the move and the resize are GPU-friendly transforms rather than animating `left`/`width` (which trigger layout). It re-measures on resize, and the transition is removed under `prefers-reduced-motion`.
+
+## Why is it useful?
+
+Tabs are everywhere, but most implementations break the keyboard contract — every tab in the tab order, no arrow-key navigation, or a sliding indicator that animates `width` and janks. This is a correct, dependency-free reference that fits EaseMotion's animation-first, beginner-friendly, zero-dependency philosophy while getting the accessibility and the animation performance right.

--- a/submissions/examples/accessible-tabs-as/demo.html
+++ b/submissions/examples/accessible-tabs-as/demo.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Accessible Tabs (-as)</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1.25rem;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 1rem;
+    }
+    .hint { max-width: 32rem; text-align: center; color: #475569; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <h1>Accessible Tabs</h1>
+  <p class="hint">
+    <strong>Tab</strong> into the tablist, then use <strong>&larr; &rarr;</strong>
+    (or <strong>Home</strong> / <strong>End</strong>) to switch tabs. The selected
+    tab is the only one in the tab order (roving tabindex).
+  </p>
+
+  <div class="ease-tabs">
+    <div class="ease-tabs__list" role="tablist" aria-label="Account settings">
+      <button class="ease-tabs__tab" role="tab" id="ease-tab-profile" aria-controls="ease-panel-profile" aria-selected="true" tabindex="0">Profile</button>
+      <button class="ease-tabs__tab" role="tab" id="ease-tab-billing" aria-controls="ease-panel-billing" aria-selected="false" tabindex="-1">Billing</button>
+      <button class="ease-tabs__tab" role="tab" id="ease-tab-notifications" aria-controls="ease-panel-notifications" aria-selected="false" tabindex="-1">Notifications</button>
+      <span class="ease-tabs__indicator" aria-hidden="true"></span>
+    </div>
+
+    <div class="ease-tabs__panel" role="tabpanel" id="ease-panel-profile" aria-labelledby="ease-tab-profile" tabindex="0">
+      Manage your name, photo, and public profile details.
+    </div>
+    <div class="ease-tabs__panel" role="tabpanel" id="ease-panel-billing" aria-labelledby="ease-tab-billing" tabindex="0" hidden>
+      Review invoices, update your payment method, and manage your plan.
+    </div>
+    <div class="ease-tabs__panel" role="tabpanel" id="ease-panel-notifications" aria-labelledby="ease-tab-notifications" tabindex="0" hidden>
+      Choose which email and push notifications you want to receive.
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      const root = document.querySelector(".ease-tabs");
+      const tabs = Array.prototype.slice.call(root.querySelectorAll('[role="tab"]'));
+      const indicator = root.querySelector(".ease-tabs__indicator");
+
+      function moveIndicator(tab) {
+        // Pure-transform slide: translate to the tab's offset and stretch the
+        // 1px base to the tab's width via scaleX (no layout-triggering props).
+        indicator.style.transform =
+          "translateX(" + tab.offsetLeft + "px) scaleX(" + tab.offsetWidth + ")";
+      }
+
+      function selectTab(tab, setFocus) {
+        tabs.forEach((t) => {
+          const selected = t === tab;
+          t.setAttribute("aria-selected", selected ? "true" : "false");
+          t.tabIndex = selected ? 0 : -1; // roving tabindex
+          document.getElementById(t.getAttribute("aria-controls")).hidden = !selected;
+        });
+        moveIndicator(tab);
+        if (setFocus) tab.focus();
+      }
+
+      root.addEventListener("click", (e) => {
+        const tab = e.target.closest('[role="tab"]');
+        if (tab) selectTab(tab, true);
+      });
+
+      root.addEventListener("keydown", (e) => {
+        const current = tabs.indexOf(document.activeElement);
+        if (current === -1) return;
+        let next = null;
+        switch (e.key) {
+          case "ArrowRight": next = (current + 1) % tabs.length; break;
+          case "ArrowLeft": next = (current - 1 + tabs.length) % tabs.length; break;
+          case "Home": next = 0; break;
+          case "End": next = tabs.length - 1; break;
+          default: return;
+        }
+        e.preventDefault();
+        selectTab(tabs[next], true);
+      });
+
+      // Position the indicator under the initially-selected tab. Re-measure on
+      // resize since tab offsets/widths can change with the layout.
+      const initial = tabs.find((t) => t.getAttribute("aria-selected") === "true") || tabs[0];
+      moveIndicator(initial);
+      window.addEventListener("resize", () => {
+        const selected = tabs.find((t) => t.getAttribute("aria-selected") === "true");
+        if (selected) moveIndicator(selected);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/accessible-tabs-as/style.css
+++ b/submissions/examples/accessible-tabs-as/style.css
@@ -1,0 +1,99 @@
+/*
+ * Accessible Tabs (-as)
+ *
+ * Tabs built to the WAI-ARIA Tabs pattern: a role="tablist" of role="tab"
+ * buttons controlling role="tabpanel" panels, with roving tabindex and full
+ * arrow-key navigation (Left/Right/Home/End, with wrap). The active-tab
+ * indicator slides using only `transform` (translateX + scaleX), so the
+ * animation stays on the compositor, and it is disabled under
+ * prefers-reduced-motion. No dependencies.
+ */
+
+.ease-tabs {
+  max-width: 32rem;
+  font-family: system-ui, sans-serif;
+  color: #1e293b;
+}
+
+.ease-tabs__list {
+  position: relative;
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.ease-tabs__tab {
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0.7rem 1rem;
+  font: 600 0.95rem/1 system-ui, sans-serif;
+  color: #64748b;
+  cursor: pointer;
+  transition: color 160ms ease;
+}
+
+.ease-tabs__tab:hover {
+  color: #334155;
+}
+
+.ease-tabs__tab[aria-selected="true"] {
+  color: #4f46e5;
+}
+
+.ease-tabs__tab:focus-visible {
+  outline: 3px solid #c7d2fe;
+  outline-offset: -3px;
+  border-radius: 6px;
+}
+
+/* Sliding indicator. Base width is 1px and it is stretched with scaleX, so
+   both the move and the resize are pure transforms (no layout animation). */
+.ease-tabs__indicator {
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 1px;
+  height: 3px;
+  background: #4f46e5;
+  transform-origin: left;
+  transform: translateX(0) scaleX(0);
+  transition: transform 250ms ease;
+}
+
+.ease-tabs__panel {
+  padding: 1rem 0.25rem;
+  line-height: 1.6;
+  color: #334155;
+  animation: ease-tabs-fade 220ms ease;
+}
+
+.ease-tabs__panel:focus-visible {
+  outline: 3px solid #c7d2fe;
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.ease-tabs__panel[hidden] {
+  display: none;
+}
+
+@keyframes ease-tabs-fade {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs__indicator {
+    transition: none;
+  }
+  .ease-tabs__panel {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What does this do?

Adds a self-contained submission under `submissions/examples/accessible-tabs-as/` — a tabs component built to the **WAI-ARIA Tabs pattern** with full keyboard navigation (roving tabindex) and an active-tab indicator that slides using only `transform`, so the animation stays on the compositor. Vanilla JS, **no dependencies**.

## Why this one

Tabs are everywhere, but most implementations break the keyboard contract or jank the indicator. This is a correct reference:

- **ARIA Tabs pattern:** `role="tablist"` / `role="tab"` (`aria-selected`, `aria-controls`) / `role="tabpanel"` (`aria-labelledby`).
- **Roving tabindex:** only the selected tab is in the tab order; `←/→` (wrapping) + `Home`/`End` move between tabs — the expected widget behaviour, not Tab-through-every-tab.
- **Focusable panels** (`tabindex="0"`) and visible `:focus-visible` styles on tabs and panels.
- **Compositor-safe indicator:** a 1px bar positioned/stretched with `transform: translateX() scaleX()` (origin `left`) instead of animating `left`/`width` (which trigger layout). It re-measures on resize.
- **Motion-safe:** indicator transition and panel fade are removed under `prefers-reduced-motion`.

It fits EaseMotion's animation-first, beginner-friendly, zero-dependency philosophy while getting both accessibility and animation performance right.

## Files

- `submissions/examples/accessible-tabs-as/demo.html` — opens directly in a browser, no CDN / external deps (inline vanilla JS)
- `submissions/examples/accessible-tabs-as/style.css`
- `submissions/examples/accessible-tabs-as/README.md` — documents the ARIA pattern, keyboard map, and the transform-indicator rationale

## Quality

- JS passes `node --check`; built to the WAI-ARIA Authoring Practices (Tabs).

## Checklist

- [x] All changes inside `submissions/examples/accessible-tabs-as/`
- [x] No edits to `core/`, `components/`, `docs/`, `examples/`, workflows, or configs
- [x] Includes the three required files (`demo.html`, `style.css`, `README.md`)
- [x] `demo.html` is self-contained (no CDN / external frameworks) and works by opening directly
- [x] Single, focused feature; single commit
- [x] Unique suffix (`-as`) appended to avoid naming conflicts