### PR TITLE
feat: add skeleton text lines component for issue #13568

### DIFF
--- a/submissions/examples/13568-skeleton-text-ad/README.md
+++ b/submissions/examples/13568-skeleton-text-ad/README.md
@@ -1,0 +1,5 @@
+# Skeleton Text Lines
+
+1. What does this do? Shows animated shimmering placeholder lines that mimic loading paragraph text.
+2. How is it used? Wrap `.skeleton-line` spans inside a `.skeleton-text-block` container; add `.skeleton-line-short` to the last line.
+3. Why is it useful? It improves perceived performance by signaling content is loading, matching EaseMotion CSS's animation-first philosophy.

--- a/submissions/examples/13568-skeleton-text-ad/demo.html
+++ b/submissions/examples/13568-skeleton-text-ad/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Skeleton Text Lines Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <h2>Skeleton Text Lines</h2>
+
+  <div class="skeleton-text-block">
+    <span class="skeleton-line"></span>
+    <span class="skeleton-line"></span>
+    <span class="skeleton-line skeleton-line-short"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/13568-skeleton-text-ad/style.css
+++ b/submissions/examples/13568-skeleton-text-ad/style.css
@@ -1,0 +1,44 @@
+.skeleton-text-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 480px;
+}
+
+.skeleton-line {
+  position: relative;
+  overflow: hidden;
+  display: block;
+  height: 0.9rem;
+  width: 100%;
+  border-radius: 4px;
+  background: #e2e2e2;
+}
+
+.skeleton-line::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0px,
+    #f5f5f5 40px,
+    transparent 80px
+  );
+  translate: -100% 0;
+  animation: skeleton-shimmer-sweep 2s infinite linear forwards;
+}
+
+@keyframes skeleton-shimmer-sweep {
+  to {
+    translate: 100% 0;
+  }
+}
+
+.skeleton-line:nth-child(1) { width: 100%; }
+.skeleton-line:nth-child(2) { width: 92%; }
+.skeleton-line:nth-child(3) { width: 96%; }
+
+.skeleton-line-short {
+  width: 60% !important;
+}


### PR DESCRIPTION
Resolves #13568

## What this adds
Animated shimmering skeleton placeholder lines that mimic loading paragraph text, with the last line shorter to read more naturally.

## How to review
Open `submissions/examples/13568-skeleton-text-ad/demo.html` directly in a browser — no server needed. You should see 3 gray bars with a shimmer sweep, and the last bar shorter than the others.

## Checklist
- [x] demo.html is self-contained, opens directly in browser
- [x] Only local style.css used, no CDN/external imports
- [x] No edits to core/ or components/
- [x] One feature per PR