### PR TITLE
feat: add counter odometer demo

### DIFF
--- a/submissions/examples/13677-counter-odometer-kkp/README.md
+++ b/submissions/examples/13677-counter-odometer-kkp/README.md
@@ -1,0 +1,14 @@
+# Counter Odometer Animation
+
+CSS-only odometer-style number rolling demo for EaseMotion. The example stacks digits in vertical reels and animates each reel at a different pace.
+
+## Files
+
+- `demo.html` - accessible demo markup
+- `style.css` - odometer reels, timing, and panel styling
+
+## Usage
+
+Open `demo.html` in a browser to view the rolling counter.
+
+Closes #13677

--- a/submissions/examples/13677-counter-odometer-kkp/demo.html
+++ b/submissions/examples/13677-counter-odometer-kkp/demo.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Counter Odometer Animation</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="counter-card" aria-label="Odometer-style rolling counter">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>Rolling Metrics</h1>
+        <div class="odometer" aria-label="Counter value 2486">
+          <span class="digit" style="--target: -2"
+            ><span>0 1 2 3 4 5 6 7 8 9</span></span
+          >
+          <span class="digit" style="--target: -4"
+            ><span>0 1 2 3 4 5 6 7 8 9</span></span
+          >
+          <span class="digit" style="--target: -8"
+            ><span>0 1 2 3 4 5 6 7 8 9</span></span
+          >
+          <span class="digit" style="--target: -6"
+            ><span>0 1 2 3 4 5 6 7 8 9</span></span
+          >
+        </div>
+        <p class="caption">
+          Each column rolls into place with staggered motion.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/13677-counter-odometer-kkp/style.css
+++ b/submissions/examples/13677-counter-odometer-kkp/style.css
@@ -1,0 +1,118 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(
+      circle at 20% 10%,
+      rgba(14, 165, 233, 0.18),
+      transparent 34%
+    ),
+    linear-gradient(135deg, #f8fafc, #dbeafe);
+}
+
+.demo-shell {
+  width: min(92vw, 720px);
+}
+
+.counter-card {
+  padding: 48px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: 26px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 24px 70px rgba(30, 64, 175, 0.22);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2rem, 6vw, 4rem);
+}
+
+.odometer {
+  display: inline-flex;
+  gap: 10px;
+  padding: 18px;
+  border-radius: 22px;
+  background: #0f172a;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.digit {
+  width: clamp(48px, 12vw, 72px);
+  height: clamp(66px, 14vw, 94px);
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(#1e293b, #020617), #0f172a;
+  box-shadow:
+    inset 0 10px 22px rgba(255, 255, 255, 0.08),
+    inset 0 -10px 22px rgba(0, 0, 0, 0.34);
+}
+
+.digit span {
+  display: grid;
+  grid-auto-rows: clamp(66px, 14vw, 94px);
+  color: #e0f2fe;
+  font-size: clamp(2.6rem, 9vw, 4.5rem);
+  font-weight: 900;
+  line-height: clamp(66px, 14vw, 94px);
+  text-shadow: 0 0 20px rgba(56, 189, 248, 0.55);
+  word-spacing: 2rem;
+  animation: odometer-roll 1.8s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.digit:nth-child(2) span {
+  animation-delay: 0.12s;
+}
+
+.digit:nth-child(3) span {
+  animation-delay: 0.24s;
+}
+
+.digit:nth-child(4) span {
+  animation-delay: 0.36s;
+}
+
+.caption {
+  margin: 24px auto 0;
+  max-width: 360px;
+  color: #475569;
+  font-size: 1rem;
+}
+
+@keyframes odometer-roll {
+  0% {
+    transform: translateY(-900%);
+  }
+
+  75% {
+    transform: translateY(calc((var(--target) * 100%) - 8%));
+  }
+
+  100% {
+    transform: translateY(calc(var(--target) * 100%));
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only odometer counter animation example
- include staggered digit reels and responsive demo layout

Closes #13677

## Validation
- npx prettier --check submissions/examples/13677-counter-odometer-kkp/README.md submissions/examples/13677-counter-odometer-kkp/demo.html submissions/examples/13677-counter-odometer-kkp/style.css