### PR TITLE
feat: add notification center demo

### DIFF
--- a/submissions/examples/13570-notification-center-kkp/README.md
+++ b/submissions/examples/13570-notification-center-kkp/README.md
@@ -1,0 +1,14 @@
+# Notification Center
+
+CSS-only notification center dropdown demo for EaseMotion. The example shows a bell trigger, animated dropdown panel, and staggered notification list items.
+
+## Files
+
+- `demo.html` - notification center markup
+- `style.css` - dropdown panel and list motion
+
+## Usage
+
+Open `demo.html` and hover or focus the notification center to reveal the panel.
+
+Closes #13570

--- a/submissions/examples/13570-notification-center-kkp/demo.html
+++ b/submissions/examples/13570-notification-center-kkp/demo.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notification Center</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section
+        class="notification-center"
+        aria-label="Animated notification center"
+      >
+        <button class="bell" type="button" aria-label="Open notifications">
+          <span class="badge">3</span>
+        </button>
+        <div class="panel">
+          <header>
+            <p>EaseMotion CSS</p>
+            <h1>Notifications</h1>
+          </header>
+          <article class="note">
+            <strong>Build finished</strong>
+            <span>Your production deploy is ready.</span>
+          </article>
+          <article class="note">
+            <strong>Review assigned</strong>
+            <span>New feedback is waiting.</span>
+          </article>
+          <article class="note">
+            <strong>Milestone hit</strong>
+            <span>Weekly target reached.</span>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/13570-notification-center-kkp/style.css
+++ b/submissions/examples/13570-notification-center-kkp/style.css
@@ -1,0 +1,190 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #172033;
+  background:
+    radial-gradient(
+      circle at 80% 20%,
+      rgba(251, 191, 36, 0.25),
+      transparent 28%
+    ),
+    linear-gradient(135deg, #f8fafc, #e0f2fe);
+}
+
+.shell {
+  display: grid;
+  place-items: center;
+  width: min(92vw, 560px);
+  min-height: 420px;
+}
+
+.notification-center {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+}
+
+.bell {
+  position: relative;
+  width: 82px;
+  height: 82px;
+  border: 0;
+  border-radius: 50%;
+  background: #0f172a;
+  box-shadow: 0 24px 54px rgba(15, 23, 42, 0.24);
+  cursor: pointer;
+}
+
+.bell::before {
+  content: "";
+  position: absolute;
+  inset: 20px 24px 24px;
+  border-radius: 24px 24px 14px 14px;
+  background: #f8fafc;
+  transform-origin: top center;
+  animation: bell-ring 1.6s ease-in-out infinite;
+}
+
+.bell::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 18px;
+  width: 20px;
+  height: 8px;
+  border-radius: 999px;
+  background: #f8fafc;
+  transform: translateX(-50%);
+}
+
+.badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  color: #ffffff;
+  background: #ef4444;
+  font-size: 0.8rem;
+  font-weight: 900;
+}
+
+.panel {
+  position: absolute;
+  top: 106px;
+  right: 50%;
+  width: min(86vw, 360px);
+  padding: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 28px 70px rgba(15, 23, 42, 0.2);
+  opacity: 0;
+  transform: translate(50%, -14px) scale(0.96);
+  transform-origin: top center;
+  pointer-events: none;
+  transition:
+    opacity 220ms ease,
+    transform 220ms ease;
+}
+
+.notification-center:hover .panel,
+.notification-center:focus-within .panel {
+  opacity: 1;
+  transform: translate(50%, 0) scale(1);
+  pointer-events: auto;
+}
+
+header p {
+  margin: 0 0 4px;
+  color: #2563eb;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+h1 {
+  margin: 0 0 14px;
+  font-size: 1.4rem;
+}
+
+.note {
+  display: grid;
+  gap: 4px;
+  padding: 14px;
+  border-radius: 16px;
+  background: #f8fafc;
+  opacity: 0;
+  transform: translateY(12px);
+}
+
+.notification-center:hover .note,
+.notification-center:focus-within .note {
+  animation: note-in 360ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.note + .note {
+  margin-top: 10px;
+}
+
+.note:nth-of-type(2) {
+  animation-delay: 70ms;
+}
+
+.note:nth-of-type(3) {
+  animation-delay: 140ms;
+}
+
+.note strong {
+  color: #0f172a;
+}
+
+.note span {
+  color: #64748b;
+  font-size: 0.92rem;
+}
+
+@keyframes bell-ring {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+
+  20% {
+    transform: rotate(9deg);
+  }
+
+  40% {
+    transform: rotate(-7deg);
+  }
+
+  60% {
+    transform: rotate(4deg);
+  }
+}
+
+@keyframes note-in {
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only animated notification center example
- include bell trigger, dropdown panel, and staggered notification list motion

Closes #13570

## Validation
- npx prettier --check submissions/examples/13570-notification-center-kkp/README.md submissions/examples/13570-notification-center-kkp/demo.html submissions/examples/13570-notification-center-kkp/style.css