### PR TITLE
feat: manual implementation of transform-box utilities #16545

### DIFF
--- a/submissions/examples/transform-box-unique-16545/README.md
+++ b/submissions/examples/transform-box-unique-16545/README.md
@@ -1,0 +1,2 @@
+# Transform-Box Utilities
+Manual implementation for #16545. Provides utilities for `transform-box` to define the layout box to which the `transform` and `transform-origin` properties relate.

--- a/submissions/examples/transform-box-unique-16545/demo.html
+++ b/submissions/examples/transform-box-unique-16545/demo.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Transform-Box Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="box-fill demo-element">
+    Transform origin relative to fill-box
+  </div>
+</body>
+</html>

--- a/submissions/examples/transform-box-unique-16545/style.css
+++ b/submissions/examples/transform-box-unique-16545/style.css
@@ -1,0 +1,12 @@
+/* Transform-box utilities for #16545 */
+.box-content { transform-box: content-box; }
+.box-border { transform-box: border-box; }
+.box-fill { transform-box: fill-box; }
+.box-view { transform-box: view-box; }
+
+.demo-element {
+  width: 100px;
+  height: 100px;
+  background: #3b82f6;
+  transition: transform 0.3s;
+}


### PR DESCRIPTION
## Pull Request Description
This PR submits the implementation for `transform-box` utilities (Issue #16545). These utilities allow developers to specify the layout box that `transform` and `transform-origin` properties use as a reference frame, which is critical for precise SVG and DOM element positioning.

Closes #16545

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/transform-box-unique-16545/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Implementation is manual and original to ensure compliance with integrity standards.
- [x] No modifications to existing `core/` or `components/` files.

---

## Feature Description
- Adds `.box-content`, `.box-border`, `.box-fill`, and `.box-view` to handle transform reference frames.
- Essential for controlling the origin of rotations and scales in non-rectangular elements.

**How to use:**
```html
<div class="box-fill">Transformed element</div>