### PR TITLE
feat: add reader sidenote card demo

### DIFF
--- a/submissions/examples/reader-sidenote-card-kk/README.md
+++ b/submissions/examples/reader-sidenote-card-kk/README.md
@@ -1,0 +1,19 @@
+# Reader Sidenote Card
+
+1. **What does this do?**  
+   It creates an editorial-style article layout with supporting sidenote cards that stay visually attached to the main content.
+
+2. **How is it used?**  
+   Use a two-column layout with an article block and one or more sidenote cards:
+
+   ```html
+   <article class="reader-layout">
+     <section class="article-block">...</section>
+     <aside class="sidenote-column">
+       <section class="sidenote-card">...</section>
+     </aside>
+   </article>
+   ```
+
+3. **Why is it useful?**  
+   It brings a readable, motion-forward content pattern into EaseMotion CSS and works well for documentation, editorial layouts, product explainers, and long-form reading interfaces.

--- a/submissions/examples/reader-sidenote-card-kk/demo.html
+++ b/submissions/examples/reader-sidenote-card-kk/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reader Sidenote Card</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <section class="hero">
+        <p class="eyebrow">Reader Sidenote Card</p>
+        <h1>Context that stays close to the reading flow.</h1>
+        <p class="intro">
+          This demo shows an editorial-style layout where supporting notes live
+          beside the main content instead of interrupting it.
+        </p>
+      </section>
+
+      <article class="reader-layout" aria-labelledby="essay-title">
+        <section class="article-block">
+          <p class="section-label">Article excerpt</p>
+          <h2 id="essay-title">Design systems work better when guidance is visible in the moment.</h2>
+          <p>
+            Readers move faster when supporting details are nearby. Instead of
+            forcing a jump to the bottom of the page, contextual notes can sit
+            beside the content and offer just enough extra meaning.
+          </p>
+          <p>
+            This makes long-form interfaces feel more editorial and more
+            intentional. The main content keeps its rhythm, while references,
+            tips, and commentary stay attached to the exact point where they are
+            most useful.
+          </p>
+
+          <div class="highlight-callout">
+            <span class="highlight-dot" aria-hidden="true"></span>
+            <p>
+              Contextual notes are especially useful for onboarding docs,
+              writing tools, research summaries, and product explainers.
+            </p>
+          </div>
+        </section>
+
+        <aside class="sidenote-column" aria-label="Supporting notes">
+          <div class="connector" aria-hidden="true"></div>
+
+          <section class="sidenote-card sidenote-primary" tabindex="0">
+            <p class="note-label">Note</p>
+            <h3>Keep secondary information lightweight</h3>
+            <p>
+              A sidenote works best when it adds context without overwhelming
+              the main content. Short annotations, citations, and quick product
+              tips are ideal.
+            </p>
+          </section>
+
+          <section class="sidenote-card sidenote-secondary" tabindex="0">
+            <p class="note-label">Reference</p>
+            <p>
+              This layout can collapse into stacked cards on smaller screens so
+              the note remains visible without requiring a separate overlay or
+              drawer.
+            </p>
+          </section>
+        </aside>
+      </article>
+
+      <section class="usage-panel" aria-labelledby="usage-title">
+        <h2 id="usage-title">Suggested usage</h2>
+        <pre><code>&lt;article class="reader-layout"&gt;
+  &lt;section class="article-block"&gt;...&lt;/section&gt;
+  &lt;aside class="sidenote-column"&gt;
+    &lt;section class="sidenote-card"&gt;...&lt;/section&gt;
+  &lt;/aside&gt;
+&lt;/article&gt;</code></pre>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/reader-sidenote-card-kk/style.css
+++ b/submissions/examples/reader-sidenote-card-kk/style.css
@@ -1,0 +1,260 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family:
+    "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue",
+    sans-serif;
+  background:
+    radial-gradient(circle at top left, rgba(108, 99, 255, 0.18), transparent 24%),
+    linear-gradient(180deg, #0d1220 0%, #080c16 100%);
+  color: #edf2ff;
+}
+
+.page-shell {
+  min-height: 100vh;
+  padding: 3rem 1.25rem 4rem;
+}
+
+.hero,
+.reader-layout,
+.usage-panel {
+  width: min(100%, 920px);
+  margin: 0 auto;
+}
+
+.hero {
+  margin-bottom: 2rem;
+}
+
+.eyebrow {
+  display: inline-flex;
+  margin: 0 0 1rem;
+  padding: 0.38rem 0.78rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #c7ceff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero h1,
+.article-block h2,
+.usage-panel h2,
+.sidenote-card h3 {
+  margin: 0;
+  line-height: 1.08;
+}
+
+.hero h1 {
+  max-width: 12ch;
+  font-size: clamp(2.3rem, 5vw, 4.2rem);
+}
+
+.intro {
+  max-width: 56ch;
+  margin: 1rem 0 0;
+  color: #b7c1de;
+  line-height: 1.8;
+  font-size: 1.05rem;
+}
+
+.reader-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(260px, 0.9fr);
+  gap: 1.4rem;
+  align-items: start;
+  margin-bottom: 2rem;
+}
+
+.article-block,
+.sidenote-card,
+.usage-panel {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+}
+
+.article-block {
+  position: relative;
+  padding: 1.7rem;
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent),
+    rgba(17, 22, 37, 0.88);
+  overflow: hidden;
+}
+
+.article-block::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top right, rgba(255, 255, 255, 0.06), transparent 28%),
+    linear-gradient(135deg, rgba(108, 99, 255, 0.14), transparent 36%);
+  pointer-events: none;
+}
+
+.article-block > * {
+  position: relative;
+  z-index: 1;
+}
+
+.section-label,
+.note-label {
+  margin: 0 0 0.8rem;
+  color: #a9b5ff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.article-block h2 {
+  margin-bottom: 1rem;
+  font-size: clamp(1.8rem, 3vw, 2.5rem);
+}
+
+.article-block p,
+.sidenote-card p {
+  margin: 0 0 1rem;
+  color: #c4cbe3;
+  line-height: 1.85;
+}
+
+.highlight-callout {
+  display: flex;
+  gap: 0.9rem;
+  align-items: flex-start;
+  margin-top: 1.3rem;
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.highlight-callout p {
+  margin: 0;
+}
+
+.highlight-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-top: 0.45rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #6c63ff, #8bdaff);
+  box-shadow: 0 0 0 0.32rem rgba(108, 99, 255, 0.14);
+  flex: 0 0 auto;
+}
+
+.sidenote-column {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+  padding-top: 1.1rem;
+}
+
+.connector {
+  position: absolute;
+  top: 2rem;
+  left: -1rem;
+  width: calc(100% + 1rem);
+  height: 2px;
+  background:
+    linear-gradient(90deg, rgba(108, 99, 255, 0.45), rgba(108, 99, 255, 0));
+}
+
+.connector::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: 999px;
+  background: #6c63ff;
+  transform: translateY(-50%);
+  box-shadow: 0 0 0 0.35rem rgba(108, 99, 255, 0.16);
+}
+
+.sidenote-card {
+  position: relative;
+  padding: 1.1rem 1.1rem 1.15rem;
+  border-radius: 22px;
+  outline: none;
+  transition:
+    transform 190ms ease,
+    box-shadow 190ms ease,
+    border-color 190ms ease;
+}
+
+.sidenote-primary {
+  background: rgba(108, 99, 255, 0.12);
+}
+
+.sidenote-secondary {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.sidenote-card:hover,
+.sidenote-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(108, 99, 255, 0.3);
+  box-shadow: 0 28px 56px rgba(0, 0, 0, 0.32);
+}
+
+.sidenote-card h3 {
+  margin-bottom: 0.7rem;
+  font-size: 1.12rem;
+}
+
+.sidenote-card p:last-child {
+  margin-bottom: 0;
+}
+
+.usage-panel {
+  padding: 1.25rem;
+  border-radius: 22px;
+  background: rgba(10, 14, 24, 0.72);
+}
+
+.usage-panel h2 {
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+}
+
+pre {
+  margin: 0;
+  overflow: auto;
+}
+
+code {
+  color: #dce2fd;
+  font-family:
+    "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
+  font-size: 0.93rem;
+  line-height: 1.7;
+}
+
+@media (max-width: 800px) {
+  .reader-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidenote-column {
+    padding-top: 0;
+  }
+
+  .connector {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidenote-card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained reader sidenote card demo inside `submissions/examples/reader-sidenote-card-kk/`. This submission showcases an editorial-style article layout with supporting sidenote cards that stay visually attached to the reading flow.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A reader sidenote card layout for article-style interfaces, with contextual notes placed beside the main content.

**How does a developer use it?**

```html
<article class="reader-layout">
  <section class="article-block">...</section>
  <aside class="sidenote-column">
    <section class="sidenote-card">...</section>
  </aside>
</article>
**Why does it fit EaseMotion CSS?**

It fits EaseMotion CSS by introducing a readable, motion-forward, and composable content pattern that works well for documentation layouts, editorial pages, research content, and product explainers. It expands the library beyond common cards and hover effects with a more contextual reading interface.

---

## Demo

- [✓] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [✓] Chrome
- [✓] Firefox
- [✓] Edge
- [✓] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission is intentionally CSS-only and follows the repository’s standard three-file structure. It is designed as a flexible editorial UI pattern that can later be standardized into EaseMotion-style naming if accepted.

Closes #16568 


---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
