### PR TITLE
feat: add interpolate-size accordion example for issue #15432

### DIFF
--- a/submissions/examples/interpolate-size-accordion-tm/README.md
+++ b/submissions/examples/interpolate-size-accordion-tm/README.md
@@ -1,0 +1,15 @@
+# interpolate-size-accordion-tm
+
+## What does this do?
+A self-contained accordion component using CSS interpolate-size for smooth height transitions without JavaScript height calculations.
+
+## How is it used?
+<div class="accordion">
+  <div class="accordion-item open">
+    <button class="accordion-header">Title</button>
+    <div class="accordion-content">Content here</div>
+  </div>
+</div>
+
+## Why is it useful?
+Demonstrates the modern CSS interpolate-size: allow-keywords property for smooth height transitions to and from auto, eliminating the need for JavaScript-based height hacks in accordion components.

--- a/submissions/examples/interpolate-size-accordion-tm/demo.html
+++ b/submissions/examples/interpolate-size-accordion-tm/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>CSS interpolate-size Accordion</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { display: flex; justify-content: center; align-items: flex-start; padding: 60px 20px; background: #f0f0f0; font-family: sans-serif; }
+  </style>
+</head>
+<body>
+  <div class="accordion">
+    <div class="accordion-item">
+      <button class="accordion-header" onclick="toggle(this)">
+        What is EaseMotion CSS? <span class="accordion-arrow">▼</span>
+      </button>
+      <div class="accordion-content">
+        EaseMotion CSS is a curated animation-first CSS framework with human-readable utility classes.
+      </div>
+    </div>
+    <div class="accordion-item">
+      <button class="accordion-header" onclick="toggle(this)">
+        How does interpolate-size work? <span class="accordion-arrow">▼</span>
+      </button>
+      <div class="accordion-content">
+        interpolate-size: allow-keywords enables smooth CSS transitions to and from auto height without JavaScript hacks.
+      </div>
+    </div>
+    <div class="accordion-item">
+      <button class="accordion-header" onclick="toggle(this)">
+        Why use this accordion? <span class="accordion-arrow">▼</span>
+      </button>
+      <div class="accordion-content">
+        Pure CSS accordion with smooth height transitions using the modern interpolate-size property. No JavaScript height calculations needed.
+      </div>
+    </div>
+  </div>
+  <script>
+    function toggle(btn) {
+      const item = btn.parentElement;
+      item.classList.toggle('open');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/interpolate-size-accordion-tm/style.css
+++ b/submissions/examples/interpolate-size-accordion-tm/style.css
@@ -1,0 +1,57 @@
+.accordion {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #e0e0e0;
+}
+
+.accordion-item {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.accordion-item:last-child {
+  border-bottom: none;
+}
+
+.accordion-header {
+  width: 100%;
+  background: #4f46e5;
+  color: white;
+  padding: 16px 20px;
+  font-size: 1rem;
+  font-weight: bold;
+  text-align: left;
+  cursor: pointer;
+  border: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.accordion-header:hover {
+  background: #4338ca;
+}
+
+.accordion-content {
+  interpolate-size: allow-keywords;
+  height: 0;
+  overflow: hidden;
+  transition: height 0.4s ease;
+  background: #f9f9f9;
+  padding: 0 20px;
+}
+
+.accordion-item.open .accordion-content {
+  height: auto;
+  padding: 16px 20px;
+}
+
+.accordion-arrow {
+  transition: transform 0.3s ease;
+}
+
+.accordion-item.open .accordion-arrow {
+  transform: rotate(180deg);
+}


### PR DESCRIPTION
## Pull Request Description
Adds a self-contained accordion component demonstrating CSS interpolate-size for smooth height transitions without JavaScript height calculations. Closes #15432

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/interpolate-size-accordion-tm/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS accordion component using interpolate-size: allow-keywords for smooth height transitions to and from auto height.

**How does a developer use it?**
<div class="accordion">
  <div class="accordion-item open">
    <button class="accordion-header">Title ▼</button>
    <div class="accordion-content">Content here</div>
  </div>
</div>

**Why does it fit EaseMotion CSS?**
Demonstrates a modern CSS-first approach to accordion animations using interpolate-size, eliminating JavaScript height hacks. Fits EaseMotion's animation-first, human-readable philosophy perfectly.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
Uses interpolate-size: allow-keywords which is a modern CSS property. Browser support is growing rapidly. A small JS toggle is used only for the open/close class — all animation is pure CSS. Feel free to adjust class naming during integration.

Closes #15432