### PR TITLE
feat: add skeleton image demo

### DIFF
--- a/submissions/examples/13569-skeleton-image-kkp/README.md
+++ b/submissions/examples/13569-skeleton-image-kkp/README.md
@@ -1,0 +1,14 @@
+# Skeleton Image Placeholder
+
+CSS-only skeleton loading placeholder for image cards. The demo uses shimmer motion, fixed aspect ratios, and a loaded preview state.
+
+## Files
+
+- `demo.html` - example card markup
+- `style.css` - skeleton blocks, shimmer animation, and responsive layout
+
+## Usage
+
+Open `demo.html` in a browser to view the placeholder animation.
+
+Closes #13569

--- a/submissions/examples/13569-skeleton-image-kkp/demo.html
+++ b/submissions/examples/13569-skeleton-image-kkp/demo.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skeleton Image Placeholder</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section
+        class="card"
+        aria-label="Skeleton image loading placeholder demo"
+      >
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>Skeleton Image</h1>
+        <div class="grid">
+          <article class="photo loading">
+            <span class="media"></span>
+            <span class="line wide"></span>
+            <span class="line"></span>
+          </article>
+          <article class="photo ready">
+            <span class="media">Loaded</span>
+            <strong>Mountain preview</strong>
+            <span>Final image state after loading.</span>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/13569-skeleton-image-kkp/style.css
+++ b/submissions/examples/13569-skeleton-image-kkp/style.css
@@ -1,0 +1,135 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #132033;
+  background: linear-gradient(135deg, #f8fafc, #dbeafe);
+}
+
+.shell {
+  width: min(94vw, 860px);
+}
+
+.card {
+  padding: 40px;
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 26px 70px rgba(30, 64, 175, 0.18);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 26px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.photo {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid #e2e8f0;
+  border-radius: 22px;
+  background: #f8fafc;
+}
+
+.media {
+  display: grid;
+  place-items: center;
+  min-height: 240px;
+  border-radius: 18px;
+  overflow: hidden;
+}
+
+.loading .media,
+.loading .line {
+  position: relative;
+  background: #e2e8f0;
+}
+
+.loading .media::after,
+.loading .line::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.7),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: skeleton-sweep 1.35s ease-in-out infinite;
+}
+
+.line {
+  height: 16px;
+  border-radius: 999px;
+}
+
+.line.wide {
+  width: 78%;
+}
+
+.line:not(.wide) {
+  width: 52%;
+}
+
+.ready .media {
+  color: #ffffff;
+  font-size: 1.7rem;
+  font-weight: 900;
+  background:
+    radial-gradient(
+      circle at 28% 24%,
+      rgba(255, 255, 255, 0.45),
+      transparent 16%
+    ),
+    linear-gradient(135deg, #0f766e, #3b82f6);
+}
+
+.ready strong {
+  font-size: 1.1rem;
+}
+
+.ready span:not(.media) {
+  color: #64748b;
+}
+
+@keyframes skeleton-sweep {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (max-width: 700px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only skeleton image placeholder example
- include shimmer loading state and loaded preview state

Closes #13569

## Validation
- npx prettier --check submissions/examples/13569-skeleton-image-kkp/README.md submissions/examples/13569-skeleton-image-kkp/demo.html submissions/examples/13569-skeleton-image-kkp/style.css