### PR TITLE
feat: add pointer-events-none utility for issue #15141

### DIFF
--- a/submissions/examples/15141-pointer-events-none-ad/README.md
+++ b/submissions/examples/15141-pointer-events-none-ad/README.md
@@ -1,0 +1,5 @@
+# Pointer Events None
+
+1. What does this do? Makes an element completely unclickable, even though it remains visible.
+2. How is it used? Apply `.no-pointer` to any element you want to disable from receiving clicks/taps.
+3. Why is it useful? It's commonly used for disabled buttons or loading overlays, preventing accidental clicks without removing the element from the layout.

--- a/submissions/examples/15141-pointer-events-none-ad/demo.html
+++ b/submissions/examples/15141-pointer-events-none-ad/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pointer Events None Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <h2>Pointer Events None</h2>
+
+  <p>Normal button (clickable):</p>
+  <button class="demo-btn" onclick="alert('Clicked!')">Click me</button>
+
+  <p>Disabled overlay (NOT clickable, even though it looks like a button):</p>
+  <button class="demo-btn no-pointer" onclick="alert('You should never see this!')">Try clicking me</button>
+</body>
+</html>

--- a/submissions/examples/15141-pointer-events-none-ad/style.css
+++ b/submissions/examples/15141-pointer-events-none-ad/style.css
@@ -1,0 +1,15 @@
+.demo-btn {
+  padding: 0.7rem 1.4rem;
+  border: 0;
+  border-radius: 6px;
+  background: #6c63ff;
+  color: white;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.no-pointer {
+  pointer-events: none;
+  opacity: 0.5;
+  cursor: default;
+}


### PR DESCRIPTION
Resolves #15141

## What this adds
A simple utility class that makes an element completely unclickable while remaining visible — useful for disabled buttons or loading overlays.

## How to review
Open `submissions/examples/15141-pointer-events-none-ad/demo.html` in a browser. The first button is clickable and shows an alert. The second button (faded) should not respond to any clicks.

## Checklist
- [x] demo.html is self-contained, opens directly in browser
- [x] Only local style.css used, no CDN/external imports
- [x] No edits to core/ or components/
- [x] One feature per PR