### PR TITLE
feat: manual implementation of animation-play-state utilities #16468

### DIFF
--- a/submissions/examples/animation-state-unique-16468/README.md
+++ b/submissions/examples/animation-state-unique-16468/README.md
@@ -1,0 +1,2 @@
+# Animation Play State Utilities
+Manual implementation for #16468. Provides utility classes for `animation-play-state` to toggle CSS animations between running and paused states dynamically.

--- a/submissions/examples/animation-state-unique-16468/demo.html
+++ b/submissions/examples/animation-state-unique-16468/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Animation Play State Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="orbit-box anim-paused"></div>
+  <p>Element paused via utility class.</p>
+</body>
+</html>

--- a/submissions/examples/animation-state-unique-16468/style.css
+++ b/submissions/examples/animation-state-unique-16468/style.css
@@ -1,0 +1,15 @@
+/* Animation-play-state utilities for #16468 */
+.anim-running { animation-play-state: running; }
+.anim-paused { animation-play-state: paused; }
+
+.orbit-box {
+  width: 50px;
+  height: 50px;
+  background: #8b5cf6;
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Pull Request Description
This PR submits the implementation for `animation-play-state` utilities (Issue #16468). These utilities provide a declarative way to pause or resume CSS animations, which is highly useful for interactive UI elements like play/pause toggles or motion reduction preferences.

Closes #16468

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/animation-state-unique-16468/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Implementation is manual and original to ensure compliance with integrity standards.
- [x] No modifications to existing `core/` or `components/` files.

---

## Feature Description
- Adds `.anim-running` and `.anim-paused`.
- Simplifies animation state toggling without needing external JavaScript event listeners.

**How to use:**
```html
<div class="anim-paused">Animated element</div>