### PR TITLE
feat: add CSS scroll-driven animation utilities (#16395)

### DIFF
--- a/components/scroll-driven.css
+++ b/components/scroll-driven.css
@@ -1,0 +1,107 @@
+/* ============================================================
+   EaseMotion CSS — scroll-driven.css
+   Scroll-Driven and View-Driven Animation Utilities
+   ============================================================ */
+
+@layer easemotion-components {
+  /* Scroll-Driven Animations - Enabled only when supported */
+  @supports (animation-timeline: view()) {
+    .ease-scroll-reveal {
+      animation: ease-kf-scroll-reveal linear both;
+      animation-timeline: view();
+      animation-range: var(--ease-scroll-reveal-range, entry 0% cover 50%);
+    }
+
+    .ease-scroll-parallax {
+      animation: ease-kf-scroll-parallax linear both;
+      animation-timeline: view();
+      animation-range: var(--ease-scroll-parallax-range, cover 0% cover 100%);
+    }
+
+    .ease-scroll-zoom {
+      animation: ease-kf-scroll-zoom linear both;
+      animation-timeline: view();
+      animation-range: var(--ease-scroll-zoom-range, entry 0% cover 50%);
+    }
+
+    .ease-scroll-blur {
+      animation: ease-kf-scroll-blur linear both;
+      animation-timeline: view();
+      animation-range: var(--ease-scroll-blur-range, entry 0% cover 50%);
+    }
+
+    .ease-view-reveal {
+      animation: ease-kf-view-reveal linear both;
+      animation-timeline: view();
+      animation-range: var(--ease-view-reveal-range, entry 0% entry 100%);
+    }
+
+    .ease-view-slide-in {
+      animation: ease-kf-view-slide-in linear both;
+      animation-timeline: view();
+      animation-range: var(--ease-view-slide-in-range, entry 0% cover 50%);
+    }
+  }
+
+  @supports (animation-timeline: scroll()) {
+    .ease-scroll-progress-bar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: var(--ease-scroll-progress-height, 4px);
+      background: var(--ease-scroll-progress-bg, var(--ease-primary, var(--ease-color-primary, #6c63ff)));
+      animation: ease-kf-scroll-grow linear both;
+      animation-timeline: scroll(root);
+      transform-origin: left;
+      z-index: var(--ease-scroll-progress-z-index, var(--ease-z-toast, 9999));
+    }
+  }
+
+  /* Fallback for browsers without animation-timeline support */
+  @supports not (animation-timeline: scroll()) {
+    .ease-scroll-reveal.ease-scroll-fallback {
+      animation: ease-kf-scroll-reveal var(--ease-scroll-fallback-duration, 0.8s) var(--ease-ease, ease-out) forwards;
+    }
+
+    .ease-scroll-zoom.ease-scroll-fallback {
+      animation: ease-kf-scroll-zoom var(--ease-scroll-fallback-duration, 0.8s) var(--ease-ease, ease-out) forwards;
+    }
+
+    .ease-scroll-blur.ease-scroll-fallback {
+      animation: ease-kf-scroll-blur var(--ease-scroll-fallback-duration, 0.8s) var(--ease-ease, ease-out) forwards;
+    }
+
+    .ease-view-reveal.ease-scroll-fallback {
+      animation: ease-kf-view-reveal var(--ease-scroll-fallback-duration, 0.8s) var(--ease-ease, ease-out) forwards;
+    }
+
+    .ease-view-slide-in.ease-scroll-fallback {
+      animation: ease-kf-view-slide-in var(--ease-scroll-fallback-duration, 0.8s) var(--ease-ease, ease-out) forwards;
+    }
+
+    .ease-scroll-progress-bar.ease-scroll-fallback {
+      width: 100%;
+      transform: scaleX(1);
+    }
+  }
+
+  /* Reduced Motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-scroll-reveal,
+    .ease-scroll-parallax,
+    .ease-scroll-zoom,
+    .ease-scroll-blur,
+    .ease-view-reveal,
+    .ease-view-slide-in {
+      animation: none !important;
+      opacity: 1 !important;
+      transform: none !important;
+      filter: none !important;
+    }
+    .ease-scroll-progress-bar {
+      animation: none !important;
+      transform: scaleX(1) !important;
+    }
+  }
+}

--- a/core/animations.css
+++ b/core/animations.css
@@ -671,6 +671,78 @@
   to { clip-path: circle(75% at center); }
 }
 
+/* ── Scroll-Driven Animation Keyframes ───────────────────────── */
+@keyframes ease-kf-scroll-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes ease-kf-scroll-parallax {
+  from {
+    transform: translateY(var(--ease-scroll-parallax-y-start, 80px));
+  }
+  to {
+    transform: translateY(var(--ease-scroll-parallax-y-end, -80px));
+  }
+}
+
+@keyframes ease-kf-scroll-zoom {
+  from {
+    transform: scale(var(--ease-scroll-zoom-start, 0.8));
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes ease-kf-scroll-grow {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes ease-kf-scroll-blur {
+  from {
+    filter: blur(var(--ease-scroll-blur-amount, 12px));
+    opacity: 0;
+  }
+  to {
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
+@keyframes ease-kf-view-reveal {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes ease-kf-view-slide-in {
+  from {
+    transform: translateX(var(--ease-view-slide-in-x, -100px));
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
 /* ── Animation Utility Classes ─────────────────────────────── */
 .ease-bounce-in {
   animation: ease-kf-bounce-in var(--ease-speed-medium) var(--ease-ease-bounce) both;

--- a/easemotion.css
+++ b/easemotion.css
@@ -37,6 +37,7 @@
 @import "./components/footer.css";
 @import "./components/sidebar.css";
 @import "./components/scroll-progress.css";
+@import "./components/scroll-driven.css";
 @import "./components/tabs.css";
 @import "./components/badges.css";
 @import "./components/loaders.css";


### PR DESCRIPTION

This Pull Request resolves #16395

 by introducing utility classes for the modern CSS Scroll-Driven Animations API (using `animation-timeline: scroll()`, `view-timeline: --name`, `view()`, etc.). This native CSS API allows high-performance animations to be driven dynamically by scroll position or scroll viewport entry without any JavaScript.

A comprehensive fallback mechanism (`.ease-scroll-fallback`) is provided to support browsers that do not yet implement CSS scroll timelines, reverting to standard time-based CSS animations.
