### PR TITLE
feat: add status badge demo

### DIFF
--- a/submissions/examples/13562-status-badge-kkp/README.md
+++ b/submissions/examples/13562-status-badge-kkp/README.md
@@ -1,0 +1,14 @@
+# Animated Status Badge
+
+CSS-only animated status indicator badge demo. The badge combines a live dot, pulse ring, and compact status text.
+
+## Files
+
+- `demo.html` - status badge examples
+- `style.css` - badge states, pulse animation, and layout
+
+## Usage
+
+Open `demo.html` in a browser to view animated status badges.
+
+Closes #13562

--- a/submissions/examples/13562-status-badge-kkp/demo.html
+++ b/submissions/examples/13562-status-badge-kkp/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Animated Status Badge</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="card" aria-label="Animated status badge demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>Status Badges</h1>
+        <div class="stack">
+          <span class="badge online"><i></i> Online</span>
+          <span class="badge warning"><i></i> Syncing</span>
+          <span class="badge offline"><i></i> Offline</span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/13562-status-badge-kkp/style.css
+++ b/submissions/examples/13562-status-badge-kkp/style.css
@@ -1,0 +1,103 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f0fdf4, #eff6ff);
+}
+
+.shell {
+  width: min(92vw, 560px);
+}
+
+.card {
+  padding: 42px;
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 26px 70px rgba(22, 163, 74, 0.16);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #16a34a;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2.1rem, 7vw, 4.2rem);
+}
+
+.stack {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 14px;
+}
+
+.badge {
+  --accent: #22c55e;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
+  border-radius: 999px;
+  color: #172033;
+  background: color-mix(in srgb, var(--accent) 12%, white);
+  font-weight: 900;
+}
+
+.badge i {
+  position: relative;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.badge i::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: inherit;
+  border: 2px solid var(--accent);
+  animation: status-pulse 1.5s ease-out infinite;
+}
+
+.warning {
+  --accent: #f59e0b;
+}
+
+.offline {
+  --accent: #64748b;
+}
+
+.offline i::after {
+  animation: none;
+  opacity: 0.25;
+}
+
+@keyframes status-pulse {
+  100% {
+    transform: scale(1.8);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only animated status badge example
- include live, syncing, and offline states with pulse motion

Closes #13562

## Validation
- npx prettier --check submissions/examples/13562-status-badge-kkp/README.md submissions/examples/13562-status-badge-kkp/demo.html submissions/examples/13562-status-badge-kkp/style.css