### PR TITLE
feat: add toggle switch demo

### DIFF
--- a/submissions/examples/10455-toggle-switch-kkp/README.md
+++ b/submissions/examples/10455-toggle-switch-kkp/README.md
@@ -1,0 +1,14 @@
+# Animated Toggle Switch
+
+CSS-only animated toggle switch component demo. The switch includes thumb slide motion, track color transition, and a small state label.
+
+## Files
+
+- `demo.html` - toggle switch markup
+- `style.css` - track, thumb, checked state, and motion styling
+
+## Usage
+
+Open `demo.html` and click the switch to toggle the animated state.
+
+Closes #10455

--- a/submissions/examples/10455-toggle-switch-kkp/demo.html
+++ b/submissions/examples/10455-toggle-switch-kkp/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Animated Toggle Switch</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="card" aria-label="Animated toggle switch demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>Toggle Switch</h1>
+        <label class="toggle">
+          <input type="checkbox" checked />
+          <span class="track"><span class="thumb"></span></span>
+          <span class="label-text">Smart mode</span>
+        </label>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/10455-toggle-switch-kkp/style.css
+++ b/submissions/examples/10455-toggle-switch-kkp/style.css
@@ -1,0 +1,105 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #faf5ff, #f8fafc);
+}
+
+.shell {
+  width: min(92vw, 560px);
+}
+
+.card {
+  padding: 44px;
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 26px 70px rgba(124, 58, 237, 0.16);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #7c3aed;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 30px;
+  font-size: clamp(2.2rem, 7vw, 4.4rem);
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+  cursor: pointer;
+}
+
+.toggle input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.track {
+  width: 104px;
+  height: 58px;
+  display: flex;
+  align-items: center;
+  padding: 6px;
+  border-radius: 999px;
+  background: #cbd5e1;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.1);
+  transition:
+    background 240ms ease,
+    box-shadow 240ms ease;
+}
+
+.thumb {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.24);
+  transform: translateX(0);
+  transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.toggle input:checked + .track {
+  background: linear-gradient(135deg, #7c3aed, #06b6d4);
+  box-shadow: 0 0 0 8px rgba(124, 58, 237, 0.12);
+}
+
+.toggle input:checked + .track .thumb {
+  transform: translateX(46px);
+  animation: thumb-pop 280ms ease;
+}
+
+.label-text {
+  font-size: 1.1rem;
+  font-weight: 900;
+}
+
+@keyframes thumb-pop {
+  50% {
+    transform: translateX(46px) scale(1.08);
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only animated toggle switch example
- include sliding thumb, track transition, and checked state motion

Closes #10455

## Validation
- npx prettier --check submissions/examples/10455-toggle-switch-kkp/README.md submissions/examples/10455-toggle-switch-kkp/demo.html submissions/examples/10455-toggle-switch-kkp/style.css