### PR TITLE
feat: add whitespace-nowrap utility for issue #15135

### DIFF
--- a/submissions/examples/whitespace-nowrap-tm/README.md
+++ b/submissions/examples/whitespace-nowrap-tm/README.md
@@ -1,0 +1,13 @@
+# whitespace-nowrap-tm
+
+## What does this do?
+Adds a `.whitespace-nowrap` utility class to prevent text from wrapping, keeping inline content on a single line.
+
+## How is it used?
+```html
+<span class="whitespace-nowrap">This text will never wrap</span>
+<a class="whitespace-nowrap" href="#">Nav Item</a>
+```
+
+## Why is it useful?
+Keeps labels, tags, nav links, and inline UI elements on a single line. Fills a gap in EaseMotion's text utility suite with a simple, human-readable class name.

--- a/submissions/examples/whitespace-nowrap-tm/demo.html
+++ b/submissions/examples/whitespace-nowrap-tm/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Whitespace Nowrap Utility Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: sans-serif; padding: 40px; background: #f0f0f0; display: flex; flex-direction: column; gap: 32px; }
+    .demo-box { background: #ffffff; border: 1px solid #e0e0e0; border-radius: 8px; padding: 20px; max-width: 400px; }
+    .label { font-size: 12px; color: #4f46e5; font-weight: bold; margin-bottom: 10px; }
+    .content { background: #f9f9f9; padding: 12px; border-radius: 4px; font-size: 14px; color: #1e293b; border: 1px dashed #cbd5e1; overflow: hidden; }
+    .tag { display: inline-block; background: #4f46e5; color: white; padding: 4px 10px; border-radius: 9999px; font-size: 12px; }
+    .nav { display: flex; gap: 12px; }
+    .nav a { color: #4f46e5; text-decoration: none; font-weight: 500; }
+  </style>
+</head>
+<body>
+
+  <div class="demo-box">
+    <div class="label">Without .whitespace-nowrap (wraps)</div>
+    <div class="content">
+      <span class="tag">This is a very long label that will wrap onto the next line</span>
+    </div>
+  </div>
+
+  <div class="demo-box">
+    <div class="label">With .whitespace-nowrap (stays on one line)</div>
+    <div class="content">
+      <span class="tag whitespace-nowrap">This is a very long label that stays on one line</span>
+    </div>
+  </div>
+
+  <div class="demo-box">
+    <div class="label">Nav links — .whitespace-nowrap keeps inline</div>
+    <div class="content">
+      <nav class="nav">
+        <a class="whitespace-nowrap" href="#">Home</a>
+        <a class="whitespace-nowrap" href="#">About Us</a>
+        <a class="whitespace-nowrap" href="#">Contact</a>
+      </nav>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/whitespace-nowrap-tm/style.css
+++ b/submissions/examples/whitespace-nowrap-tm/style.css
@@ -1,0 +1,3 @@
+.whitespace-nowrap {
+  white-space: nowrap !important;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS utility class for preventing text wrapping, keeping inline labels, tags, and nav links on a single line. Closes #15135

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/whitespace-nowrap-tm/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A single `.whitespace-nowrap` utility class that prevents text from wrapping onto the next line, keeping inline content on one line.

**How does a developer use it?**
<span class="whitespace-nowrap">Label that stays on one line</span>
<a class="whitespace-nowrap" href="#">Nav Item</a>

**Why does it fit EaseMotion CSS?**
Essential for labels, tags, badges, and nav links where line breaks break layout. Follows EaseMotion's human-readable, utility-first naming philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
Single focused utility with !important flag consistent with existing utility patterns. Demo shows before/after comparison for clear visual proof. Class naming can be adjusted to ease-* convention during integration.

Closes #15135