### PR TITLE
docs: add color-blind safe palette recommendations

### DIFF
--- a/submissions/examples/colorblind-palette-guide/README.md
+++ b/submissions/examples/colorblind-palette-guide/README.md
@@ -1,0 +1,74 @@
+# Color-Blind Safe Palette Recommendations
+
+This guide explains how to use EaseMotion status colors in an accessible way.
+
+## Default Status Colors
+
+| Variable       | Purpose          |
+| -------------- | ---------------- |
+| --ease-success | Success messages |
+| --ease-warning | Warning messages |
+| --ease-danger  | Error messages   |
+
+## Accessibility Notes
+
+Color alone should never communicate important information.
+
+Instead, combine colors with:
+
+* Icons
+* Labels
+* Status text
+* Patterns or borders
+
+### Good Example
+
+✔ Success
+
+⚠ Warning
+
+✖ Error
+
+### Avoid
+
+Using only green, yellow, or red without supporting text.
+
+## Common Color-Blindness Types
+
+* Protanopia
+* Deuteranopia
+* Tritanopia
+
+Users may not distinguish red and green effectively.
+
+## Recommended Pattern
+
+```html
+<div class="success">
+  ✔ Success: File uploaded
+</div>
+
+<div class="warning">
+  ⚠ Warning: Check your settings
+</div>
+
+<div class="danger">
+  ✖ Error: Upload failed
+</div>
+```
+
+## Color-Blind Simulator
+
+Use:
+
+https://www.color-blindness.com/coblis-color-blindness-simulator/
+
+to test interfaces under different color-vision conditions.
+
+## Recommendations
+
+* Always include text labels
+* Use icons alongside color
+* Maintain sufficient contrast
+* Test with accessibility tools
+* Avoid relying solely on red vs green distinctions

--- a/submissions/examples/colorblind-palette-guide/demo.html
+++ b/submissions/examples/colorblind-palette-guide/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Color-Blind Safe Palette Guide</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<h1>Color-Blind Safe Palette Recommendations</h1>
+
+<h2>Status Colors</h2>
+
+<div class="success">
+    ✔ Success: File uploaded successfully
+</div>
+
+<div class="warning">
+    ⚠ Warning: Review your settings
+</div>
+
+<div class="danger">
+    ✖ Error: Upload failed
+</div>
+
+<h2>Accessibility Guidelines</h2>
+
+<ul>
+    <li>Never rely on color alone</li>
+    <li>Use icons with status messages</li>
+    <li>Add descriptive text labels</li>
+    <li>Maintain good contrast ratios</li>
+</ul>
+
+<h2>Common Color-Blindness Types</h2>
+
+<table>
+<tr>
+    <th>Type</th>
+    <th>Description</th>
+</tr>
+
+<tr>
+    <td>Protanopia</td>
+    <td>Reduced red perception</td>
+</tr>
+
+<tr>
+    <td>Deuteranopia</td>
+    <td>Reduced green perception</td>
+</tr>
+
+<tr>
+    <td>Tritanopia</td>
+    <td>Reduced blue perception</td>
+</tr>
+
+</table>
+
+<h2>Testing Tool</h2>
+
+<p>
+Use the Coblis Color Blindness Simulator to test accessibility.
+</p>
+
+<p>
+https://www.color-blindness.com/coblis-color-blindness-simulator/
+</p>
+
+</body>
+</html>

--- a/submissions/examples/colorblind-palette-guide/style.css
+++ b/submissions/examples/colorblind-palette-guide/style.css
@@ -1,0 +1,57 @@
+:root {
+    --ease-success: #28a745;
+    --ease-warning: #ffc107;
+    --ease-danger: #dc3545;
+}
+
+body {
+    font-family: Arial, sans-serif;
+    max-width: 1000px;
+    margin: auto;
+    padding: 30px;
+    line-height: 1.6;
+}
+
+h1 {
+    text-align: center;
+}
+
+.success,
+.warning,
+.danger {
+    padding: 15px;
+    margin: 15px 0;
+    border-radius: 6px;
+    font-weight: bold;
+}
+
+.success {
+    background: var(--ease-success);
+    color: white;
+}
+
+.warning {
+    background: var(--ease-warning);
+    color: black;
+}
+
+.danger {
+    background: var(--ease-danger);
+    color: white;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+th,
+td {
+    border: 1px solid #ddd;
+    padding: 10px;
+}
+
+th {
+    background: #f0f0f0;
+}


### PR DESCRIPTION
## Pull Request Description

Added documentation for color-blind safe usage of EaseMotion status colors. The guide explains how to use success, warning, and danger colors accessibly, recommends alternatives beyond color alone, and provides resources for testing interfaces with color-vision deficiencies.

---

## Type of Change

* [x] 📝 Documentation improvement

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/colorblind-palette-guide/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A documentation guide covering color-blind safe usage of EaseMotion status colors and accessibility best practices.

### How does a developer use it?

```html
<div class="success">
  ✔ Success: File uploaded successfully
</div>

<div class="warning">
  ⚠ Warning: Review your settings
</div>

<div class="danger">
  ✖ Error: Upload failed
</div>
```

### Why does it fit EaseMotion CSS?

EaseMotion emphasizes accessibility and developer-friendly design. This guide helps developers use status colors responsibly by combining color with icons, labels, and descriptive text, ensuring interfaces remain understandable for users with color-vision deficiencies.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

* Documented default `--ease-success`, `--ease-warning`, and `--ease-danger` color variables.
* Added guidance on accessibility patterns beyond color alone.
* Included icon-based and text-based status examples.
* Added information about common color-blindness types.
* Linked to the Coblis Color Blindness Simulator for testing.
* Added README.md, demo.html, and style.css.
* All files are contained within `submissions/examples/colorblind-palette-guide/`.

Fixes #13789
