### PR TITLE
feat: add typewriter-once effect for issue #13673

### DIFF
--- a/submissions/examples/13673-typewriter-once-ad/README.md
+++ b/submissions/examples/13673-typewriter-once-ad/README.md
@@ -1,0 +1,5 @@
+# Typewriter Once
+
+1. What does this do? Reveals text one character at a time, like it's being typed, then stops permanently (no looping).
+2. How is it used? Add `.typewriter-text` to an element with a `data-text` attribute holding the full string; the included script types it out automatically on page load.
+3. Why is it useful? Draws attention to important text (headlines, intros) with a polished entrance animation, fitting EaseMotion CSS's animation-first philosophy.

--- a/submissions/examples/13673-typewriter-once-ad/demo.html
+++ b/submissions/examples/13673-typewriter-once-ad/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Typewriter Once Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <h2>Typewriter Effect (Once)</h2>
+
+  <p class="typewriter-text" data-text="Welcome to EaseMotion CSS."></p>
+
+  <script>
+    const el = document.querySelector('.typewriter-text');
+    const fullText = el.getAttribute('data-text');
+    let index = 0;
+
+    function typeNextChar() {
+      if (index < fullText.length) {
+        el.textContent += fullText.charAt(index);
+        index++;
+        setTimeout(typeNextChar, 60);
+      } else {
+        el.classList.add('typewriter-done');
+      }
+    }
+
+    typeNextChar();
+  </script>
+</body>
+</html>

--- a/submissions/examples/13673-typewriter-once-ad/style.css
+++ b/submissions/examples/13673-typewriter-once-ad/style.css
@@ -1,0 +1,11 @@
+.typewriter-text {
+  font-family: monospace;
+  font-size: 1.3rem;
+  border-right: 2px solid #333;
+  white-space: pre;
+  display: inline-block;
+}
+
+.typewriter-done {
+  border-right: none;
+}


### PR DESCRIPTION
Resolves #13673

## What this adds
A typewriter-style text reveal that types one character at a time, then stops permanently — no looping or retyping.

## How to review
Open `submissions/examples/13673-typewriter-once-ad/demo.html` in a browser. The text should appear character-by-character automatically on load, and the blinking cursor line should disappear once typing finishes.

## Checklist
- [x] demo.html is self-contained, opens directly in browser
- [x] Only local style.css used, no CDN/external imports
- [x] No edits to core/ or components/
- [x] One feature per PR