### PR TITLE
feat: manual implementation of break-inside utilities #16472

### DIFF
--- a/submissions/examples/break-inside-unique-16472/README.md
+++ b/submissions/examples/break-inside-unique-16472/README.md
@@ -1,0 +1,2 @@
+# Break-Inside Utilities
+Manual implementation for #16472. Provides utility classes for `break-inside` to control how elements break across columns or pages.

--- a/submissions/examples/break-inside-unique-16472/demo.html
+++ b/submissions/examples/break-inside-unique-16472/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Break-Inside Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="column-layout">
+    <div class="box-item break-inside-avoid">Avoids breaking column</div>
+    <div class="box-item">Standard box</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/break-inside-unique-16472/style.css
+++ b/submissions/examples/break-inside-unique-16472/style.css
@@ -1,0 +1,15 @@
+/* Break-inside utilities for #16472 */
+.break-inside-auto { break-inside: auto; }
+.break-inside-avoid { break-inside: avoid; }
+.break-inside-avoid-page { break-inside: avoid-page; }
+.break-inside-avoid-column { break-inside: avoid-column; }
+
+.column-layout {
+  column-count: 3;
+  width: 500px;
+}
+.box-item {
+  height: 100px;
+  background: #f59e0b;
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
## Pull Request Description
This PR submits the implementation for `break-inside` utilities (Issue #16472). These utilities provide a way to control the fragmentation behavior of block-level elements within multi-column or paged layouts, preventing orphaned content.

Closes #16472

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/break-inside-unique-16472/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Implementation is manual and original to ensure compliance with integrity standards.
- [x] No modifications to existing `core/` or `components/` files.

---

## Feature Description
- Adds `.break-inside-auto`, `.break-inside-avoid`, `.break-inside-avoid-page`, and `.break-inside-avoid-column`.
- Essential for maintaining layout integrity in printed media and multi-column designs.

**How to use:**
```html
<div class="break-inside-avoid">Fragment-protected content</div>