### PR TITLE
feat: add ease-line-clamp-2 utility

### DIFF
--- a/submissions/examples/ease-line-clamp-2/README.md
+++ b/submissions/examples/ease-line-clamp-2/README.md
@@ -1,0 +1,37 @@
+# ease-line-clamp-2
+
+A utility class that truncates text after exactly two lines and displays an ellipsis when content exceeds the available space.
+
+## Usage
+
+```html
+<p class="ease-line-clamp-2">
+  Long text content...
+</p>
+```
+
+## CSS
+
+```css
+.ease-line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+```
+
+## Features
+
+* Two-line text truncation
+* Ellipsis overflow behavior
+* Useful for cards, blog previews, and descriptions
+* Lightweight utility class
+* Cross-browser fallback support
+
+## Example Use Cases
+
+* Card descriptions
+* Product summaries
+* Blog post previews
+* News headlines

--- a/submissions/examples/ease-line-clamp-2/demo.html
+++ b/submissions/examples/ease-line-clamp-2/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ease-line-clamp-2 Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<h1>ease-line-clamp-2 Demo</h1>
+
+<div class="card">
+
+    <h2>Article Card</h2>
+
+    <p class="ease-line-clamp-2">
+        EaseMotion CSS provides human-readable animation and utility classes.
+        This paragraph intentionally contains more text than two lines so that
+        the truncation utility can demonstrate how content is clipped with an
+        ellipsis after the second visible line.
+    </p>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/ease-line-clamp-2/style.css
+++ b/submissions/examples/ease-line-clamp-2/style.css
@@ -1,0 +1,16 @@
+.ease-line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    line-height: 1.5;
+    max-height: 3em;
+}
+
+/* Fallback */
+.line-clamp-fallback {
+    overflow: hidden;
+}


### PR DESCRIPTION
## Pull Request Description

Added the `ease-line-clamp-2` utility class for truncating text to exactly two lines with ellipsis overflow behavior. This utility is useful for card descriptions, article previews, product summaries, and other UI elements where content length must be constrained consistently.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [x] Other (New CSS Utility)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/ease-line-clamp-2/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

Adds a reusable `ease-line-clamp-2` utility that truncates text after two lines and hides overflow content with an ellipsis.

### How does a developer use it?

```html
<p class="ease-line-clamp-2">
    This is a long paragraph that will automatically be truncated
    after exactly two visible lines.
</p>
```

### Why does it fit EaseMotion CSS?

EaseMotion focuses on simple, human-readable utility classes. The `ease-line-clamp-2` class provides a common UI pattern through a clear and descriptive class name, improving readability and reducing repetitive CSS.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

* Implemented `-webkit-line-clamp: 2`.
* Uses `display: -webkit-box` and `-webkit-box-orient: vertical`.
* Includes overflow handling and fallback behavior.
* Added demo showcasing two-line truncation.
* Added documentation and usage examples.
* All files are contained within `submissions/examples/ease-line-clamp-2/`.

Fixes #13604
