### PR TITLE
feat: manual implementation of text-underline-offset utilities

### DIFF
--- a/submissions/examples/underline-offset-unique-16475/README.md
+++ b/submissions/examples/underline-offset-unique-16475/README.md
@@ -1,0 +1,2 @@
+# Text Underline Offset Utilities
+Manual implementation for #16475. Provides utility classes to adjust the spacing between text and the underline decoration.

--- a/submissions/examples/underline-offset-unique-16475/demo.html
+++ b/submissions/examples/underline-offset-unique-16475/demo.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <a href="#" class="demo-link underline-offset-4">Offset underline link</a>
+</body>
+</html>

--- a/submissions/examples/underline-offset-unique-16475/style.css
+++ b/submissions/examples/underline-offset-unique-16475/style.css
@@ -1,0 +1,12 @@
+/* Text-underline-offset utilities for #16475 */
+.underline-offset-1 { text-underline-offset: 1px; }
+.underline-offset-2 { text-underline-offset: 2px; }
+.underline-offset-4 { text-underline-offset: 4px; }
+.underline-offset-8 { text-underline-offset: 8px; }
+
+.demo-link {
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  font-family: sans-serif;
+  font-size: 1.5rem;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `text-underline-offset` utilities (Issue #16475). These tokens allow developers to adjust the distance between the text baseline and the underline, facilitating better design control and legibility for hyperlinked text.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/underline-offset-unique-16475/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Adds four distinct offset utilities (`1px`, `2px`, `4px`, `8px`).
- Provides clean, predictable typographic control.

Closes #16475