### PR TITLE
feat: manual implementation of scroll-snap-align utilities #16524

### DIFF
--- a/submissions/examples/snap-align-unique-16524/README.md
+++ b/submissions/examples/snap-align-unique-16524/README.md
@@ -1,0 +1,2 @@
+# Scroll Snap Align Utilities
+Manual implementation for #16524. Defines the snapping alignment of child elements within a scroll container.

--- a/submissions/examples/snap-align-unique-16524/demo.html
+++ b/submissions/examples/snap-align-unique-16524/demo.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="snap-container">
+    <div style="min-width: 300px;" class="snap-align-center">Centered Snap Item</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/snap-align-unique-16524/style.css
+++ b/submissions/examples/snap-align-unique-16524/style.css
@@ -1,0 +1,12 @@
+/* Scroll-snap-align utilities for #16524 */
+.snap-align-none { scroll-snap-align: none; }
+.snap-align-start { scroll-snap-align: start; }
+.snap-align-end { scroll-snap-align: end; }
+.snap-align-center { scroll-snap-align: center; }
+
+.snap-container {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  width: 300px;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `scroll-snap-align` utilities (Issue #16524). These tokens allow developers to specify the alignment of a snap element within a scroll container's snap port, crucial for building precise carousel and scroll-pagination experiences.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/snap-align-unique-16524/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Adds `.snap-align-none`, `.snap-align-start`, `.snap-align-end`, and `.snap-align-center`.
- Standardizes interaction behavior for scrollable content.

Closes #16524