### PR TITLE
feat: manual implementation of transform-box utilities

### DIFF
--- a/submissions/examples/transform-box-unique-16479/README.md
+++ b/submissions/examples/transform-box-unique-16479/README.md
@@ -1,0 +1,2 @@
+# Transform Box Utilities
+Manual implementation for #16479. Provides utility classes to control the layout box used by CSS transforms.

--- a/submissions/examples/transform-box-unique-16479/demo.html
+++ b/submissions/examples/transform-box-unique-16479/demo.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-element box-fill"></div>
+</body>
+</html>

--- a/submissions/examples/transform-box-unique-16479/style.css
+++ b/submissions/examples/transform-box-unique-16479/style.css
@@ -1,0 +1,11 @@
+/* Transform-box utilities for #16479 */
+.box-border { transform-box: border-box; }
+.box-fill { transform-box: fill-box; }
+.box-view { transform-box: view-box; }
+
+.demo-element {
+  width: 100px;
+  height: 100px;
+  background: #8b5cf6;
+  transition: transform 0.3s;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `transform-box` utilities (Issue #16479). These tokens allow developers to specify which layout box (border-box, fill-box, or view-box) should be used as the reference box for transform operations, significantly improving control over CSS animations.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/transform-box-unique-16479/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Adds `.box-border`, `.box-fill`, and `.box-view`.
- Enhances precision for SVG and complex element transformations.

Closes #16479