### PR TITLE
feat: add animated status indicator pulse example

### DIFF
--- a/submissions/examples/u-animated-status-indicator-pulse-16842/README.md
+++ b/submissions/examples/u-animated-status-indicator-pulse-16842/README.md
@@ -1,0 +1,45 @@
+# Animated Status Indicator Pulse
+
+## Overview
+
+A lightweight animated status indicator component featuring Online, Away, Busy, and Offline states.
+
+## Features
+
+- Online pulse animation
+- Away pulse animation
+- Busy pulse animation
+- Offline static state
+- Responsive layout
+- Accessibility support
+- Lightweight CSS-only implementation
+
+## Usage
+
+```html
+<div class="status online"></div>
+<div class="status away"></div>
+<div class="status busy"></div>
+<div class="status offline"></div>
+```
+
+## Accessibility
+
+Supports:
+
+```css
+@media (prefers-reduced-motion: reduce)
+```
+
+to disable animations.
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari
+
+## Issue
+
+Created for Issue #16842.

--- a/submissions/examples/u-animated-status-indicator-pulse-16842/demo.html
+++ b/submissions/examples/u-animated-status-indicator-pulse-16842/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Status Indicator Pulse</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <h1>Animated Status Indicator Pulse</h1>
+    <p>Status indicators inspired by modern collaboration platforms.</p>
+
+    <div class="status-grid">
+
+      <div class="status-card">
+        <div class="status online"></div>
+        <span>Online</span>
+      </div>
+
+      <div class="status-card">
+        <div class="status away"></div>
+        <span>Away</span>
+      </div>
+
+      <div class="status-card">
+        <div class="status busy"></div>
+        <span>Busy</span>
+      </div>
+
+      <div class="status-card">
+        <div class="status offline"></div>
+        <span>Offline</span>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/u-animated-status-indicator-pulse-16842/style.css
+++ b/submissions/examples/u-animated-status-indicator-pulse-16842/style.css
@@ -1,0 +1,113 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #0f172a;
+  color: #fff;
+  font-family: Arial, sans-serif;
+}
+
+.container {
+  text-align: center;
+}
+
+h1 {
+  margin-bottom: 12px;
+}
+
+p {
+  color: #cbd5e1;
+  margin-bottom: 40px;
+}
+
+.status-grid {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.status-card {
+  background: #1e293b;
+  padding: 20px;
+  border-radius: 16px;
+  min-width: 120px;
+}
+
+.status-card span {
+  display: block;
+  margin-top: 14px;
+}
+
+.status {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  margin: auto;
+  position: relative;
+}
+
+.status::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  animation: pulse 1.8s infinite;
+}
+
+.online {
+  background: #22c55e;
+}
+
+.online::after {
+  background: rgba(34, 197, 94, 0.4);
+}
+
+.away {
+  background: #f59e0b;
+}
+
+.away::after {
+  background: rgba(245, 158, 11, 0.4);
+}
+
+.busy {
+  background: #ef4444;
+}
+
+.busy::after {
+  background: rgba(239, 68, 68, 0.4);
+}
+
+.offline {
+  background: #64748b;
+}
+
+.offline::after {
+  animation: none;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    opacity: .8;
+  }
+
+  100% {
+    transform: scale(2.2);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new **Animated Status Indicator Pulse** example featuring Online, Away, Busy, and Offline status states with subtle pulsing animations inspired by Discord, Slack, and Microsoft Teams.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/u-animated-status-indicator-pulse-16842/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A lightweight animated status indicator system displaying Online, Away, Busy, and Offline states with pulsing effects for active statuses.

### How does a developer use it?

```html id="dl8c48"
<div class="status online"></div>
<div class="status away"></div>
<div class="status busy"></div>
<div class="status offline"></div>
```

### Why does it fit EaseMotion CSS?

This feature demonstrates a practical micro-interaction commonly used across modern applications. It is lightweight, reusable, easy to understand, and aligns with EaseMotion CSS's animation-first philosophy.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(not tested)*

---

## Notes for Maintainer

* Inspired by Discord, Slack, and Microsoft Teams.
* Includes Online, Away, Busy, and Offline variations.
* Uses CSS-only pulse animations.
* Supports `prefers-reduced-motion` for accessibility.
* Fully contained within `submissions/examples/`.

Closes #16842
