### PR TITLE
feat: add animated typing cursor blink example

### DIFF
--- a/submissions/examples/u-animated-typing-cursor-blink-16854/README.md
+++ b/submissions/examples/u-animated-typing-cursor-blink-16854/README.md
@@ -1,0 +1,55 @@
+# Animated Typing Cursor Blink
+
+## Overview
+
+A reusable blinking cursor animation inspired by text editors, terminal applications, AI chat interfaces, and developer portfolios.
+
+## Features
+
+- CSS-only implementation
+- Smooth blinking animation
+- Multiple cursor sizes
+- Responsive demo
+- Lightweight and reusable
+- Accessibility support
+
+## Usage
+
+```html
+<h2>
+  Building Amazing Experiences
+  <span class="typing-cursor"></span>
+</h2>
+```
+
+## Customization
+
+```css
+.typing-cursor{
+  width:3px;
+  height:1em;
+}
+```
+
+Adjust size, color, and animation speed as needed.
+
+## Accessibility
+
+Supports:
+
+```css
+@media(prefers-reduced-motion:reduce)
+```
+
+to disable animation.
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari
+
+## Issue
+
+Created for Issue #16854.

--- a/submissions/examples/u-animated-typing-cursor-blink-16854/demo.html
+++ b/submissions/examples/u-animated-typing-cursor-blink-16854/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Typing Cursor Blink</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="container">
+    <div class="card">
+      <span class="tag">EaseMotion CSS</span>
+
+      <h1>
+        Building Amazing Experiences
+        <span class="typing-cursor"></span>
+      </h1>
+
+      <p>
+        A lightweight blinking cursor animation inspired by code editors,
+        terminals, and modern portfolio websites.
+      </p>
+
+      <div class="examples">
+        <div class="example">
+          Developer Mode
+          <span class="typing-cursor small"></span>
+        </div>
+
+        <div class="example">
+          AI Assistant
+          <span class="typing-cursor"></span>
+        </div>
+
+        <div class="example">
+          Terminal
+          <span class="typing-cursor large"></span>
+        </div>
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/u-animated-typing-cursor-blink-16854/style.css
+++ b/submissions/examples/u-animated-typing-cursor-blink-16854/style.css
@@ -1,0 +1,129 @@
+*{
+  margin:0;
+  padding:0;
+  box-sizing:border-box;
+}
+
+body{
+  min-height:100vh;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  padding:20px;
+
+  font-family:Arial,sans-serif;
+
+  background:
+  linear-gradient(
+  135deg,
+  #0f172a,
+  #1e293b
+  );
+
+  color:white;
+}
+
+.container{
+  width:100%;
+  max-width:800px;
+}
+
+.card{
+  text-align:center;
+
+  padding:50px 30px;
+
+  border-radius:24px;
+
+  background:
+  rgba(255,255,255,.05);
+
+  border:
+  1px solid rgba(255,255,255,.08);
+}
+
+.tag{
+  display:inline-block;
+
+  padding:8px 14px;
+
+  border-radius:999px;
+
+  margin-bottom:20px;
+
+  background:
+  rgba(99,102,241,.15);
+
+  color:#c7d2fe;
+}
+
+h1{
+  margin-bottom:20px;
+  line-height:1.4;
+}
+
+p{
+  color:#cbd5e1;
+  margin-bottom:35px;
+}
+
+.examples{
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+}
+
+.example{
+  padding:16px;
+
+  border-radius:12px;
+
+  background:
+  rgba(255,255,255,.04);
+}
+
+.typing-cursor{
+  width:3px;
+  height:1em;
+
+  display:inline-block;
+
+  background:currentColor;
+
+  vertical-align:middle;
+
+  animation:blink 1s infinite;
+}
+
+.small{
+  height:.8em;
+}
+
+.large{
+  height:1.4em;
+  width:4px;
+}
+
+@keyframes blink{
+  0%,50%{
+    opacity:1;
+  }
+
+  51%,100%{
+    opacity:0;
+  }
+}
+
+@media(max-width:600px){
+
+  h1{
+    font-size:1.8rem;
+  }
+}
+
+@media(prefers-reduced-motion:reduce){
+
+  .typing-cursor{
+    animation:none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new **Animated Typing Cursor Blink** example featuring a reusable blinking cursor effect inspired by text editors, terminal applications, AI chat interfaces, and developer portfolio websites.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/u-animated-typing-cursor-blink-16854/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A lightweight blinking typing cursor animation that can be used in hero sections, terminal UIs, AI interfaces, developer portfolios, and text-based animations.

### How does a developer use it?

```html
<h2>
  Building Amazing Experiences
  <span class="typing-cursor"></span>
</h2>
```

### Why does it fit EaseMotion CSS?

Typing and cursor effects are common UI micro-interactions that enhance visual feedback and engagement. This implementation is lightweight, reusable, human-readable, and aligns with EaseMotion CSS's animation-first philosophy.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(not tested)*

---

## Notes for Maintainer

* Inspired by VS Code, terminal applications, and modern AI interfaces.
* Includes multiple cursor size variations in the demo.
* CSS-only implementation with no dependencies.
* Supports `prefers-reduced-motion` for accessibility.
* Fully contained within `submissions/examples/`.

Closes #16854
