### PR TITLE
feat: manual implementation of justify-items utilities #16437

### DIFF
--- a/submissions/examples/justify-items-unique-16437/README.md
+++ b/submissions/examples/justify-items-unique-16437/README.md
@@ -1,0 +1,2 @@
+# Justify Items Utilities
+Manual implementation for #16437. Provides utility classes for aligning grid items along the inline axis.

--- a/submissions/examples/justify-items-unique-16437/demo.html
+++ b/submissions/examples/justify-items-unique-16437/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="grid-container justify-items-center">
+    <div>Item 1</div>
+    <div>Item 2</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/justify-items-unique-16437/style.css
+++ b/submissions/examples/justify-items-unique-16437/style.css
@@ -1,0 +1,12 @@
+/* Justify-items utilities for #16437 */
+.justify-items-start { justify-items: start; }
+.justify-items-end { justify-items: end; }
+.justify-items-center { justify-items: center; }
+.justify-items-stretch { justify-items: stretch; }
+
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  border: 1px solid #cbd5e1;
+  padding: 0.5rem;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `justify-items` utilities (Issue #16437). These tokens allow developers to define how items are aligned within their grid cells on the inline axis.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/justify-items-unique-16437/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Adds `.justify-items-start`, `.justify-items-end`, `.justify-items-center`, and `.justify-items-stretch`.
- Provides critical control over grid item alignment.

Closes #16437