### PR TITLE
feat: add animated online user ripple example

### DIFF
--- a/submissions/examples/u-animated-online-user-ripple-16882/README.md
+++ b/submissions/examples/u-animated-online-user-ripple-16882/README.md
@@ -1,0 +1,43 @@
+# Animated Online User Ripple
+
+## Overview
+
+A reusable online presence indicator with a subtle ripple effect that continuously expands and fades around a status dot.
+
+## Features
+
+- CSS-only ripple animation
+- Online presence indicator
+- User avatar integration
+- Lightweight implementation
+- Responsive layout
+- Accessibility support
+
+## Usage
+
+```html
+<div class="user-status">
+  <span class="online-ripple"></span>
+</div>
+```
+
+## Accessibility
+
+Supports:
+
+```css
+@media(prefers-reduced-motion: reduce)
+```
+
+to disable animations.
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari
+
+## Issue
+
+Created for Issue #16882.

--- a/submissions/examples/u-animated-online-user-ripple-16882/demo.html
+++ b/submissions/examples/u-animated-online-user-ripple-16882/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Online User Ripple</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="container">
+
+    <h1>Animated Online User Ripple</h1>
+
+    <p>
+      A subtle online presence indicator with a continuous ripple animation.
+    </p>
+
+    <div class="users">
+
+      <div class="user-card">
+        <div class="avatar">
+          JD
+          <span class="online-ripple"></span>
+        </div>
+        <h3>John Doe</h3>
+        <span class="status-text">Online</span>
+      </div>
+
+      <div class="user-card">
+        <div class="avatar">
+          AS
+          <span class="online-ripple"></span>
+        </div>
+        <h3>Alice Smith</h3>
+        <span class="status-text">Available</span>
+      </div>
+
+      <div class="user-card">
+        <div class="avatar">
+          MK
+          <span class="online-ripple"></span>
+        </div>
+        <h3>Mike Kent</h3>
+        <span class="status-text">Active Now</span>
+      </div>
+
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/u-animated-online-user-ripple-16882/style.css
+++ b/submissions/examples/u-animated-online-user-ripple-16882/style.css
@@ -1,0 +1,107 @@
+*{
+  margin:0;
+  padding:0;
+  box-sizing:border-box;
+}
+
+body{
+  min-height:100vh;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  padding:20px;
+  font-family:Arial,sans-serif;
+  background:#0f172a;
+  color:#fff;
+}
+
+.container{
+  text-align:center;
+  max-width:900px;
+}
+
+h1{
+  margin-bottom:16px;
+}
+
+p{
+  color:#cbd5e1;
+  margin-bottom:40px;
+}
+
+.users{
+  display:flex;
+  gap:24px;
+  justify-content:center;
+  flex-wrap:wrap;
+}
+
+.user-card{
+  background:#1e293b;
+  padding:24px;
+  border-radius:18px;
+  min-width:180px;
+}
+
+.avatar{
+  position:relative;
+  width:80px;
+  height:80px;
+  margin:0 auto 16px;
+
+  border-radius:50%;
+
+  background:#334155;
+
+  display:flex;
+  align-items:center;
+  justify-content:center;
+
+  font-weight:bold;
+  font-size:1.2rem;
+}
+
+.online-ripple{
+  position:absolute;
+  bottom:4px;
+  right:4px;
+
+  width:16px;
+  height:16px;
+
+  border-radius:50%;
+  background:#22c55e;
+}
+
+.online-ripple::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  background:rgba(34,197,94,.45);
+  animation:ripple 2s infinite;
+}
+
+.status-text{
+  display:block;
+  margin-top:8px;
+  color:#22c55e;
+}
+
+@keyframes ripple{
+  0%{
+    transform:scale(1);
+    opacity:.8;
+  }
+
+  100%{
+    transform:scale(2.8);
+    opacity:0;
+  }
+}
+
+@media(prefers-reduced-motion:reduce){
+  .online-ripple::before{
+    animation:none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new **Animated Online User Ripple** example featuring a subtle ripple effect around an online status indicator. The animation continuously expands and fades to visually communicate active user presence in a lightweight and reusable way.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/u-animated-online-user-ripple-16882/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A reusable online presence indicator with a pulsing ripple animation suitable for avatars, chat applications, collaboration platforms, dashboards, and social interfaces.

### How does a developer use it?

```html id="8p7k3y"
<div class="user-status">
  <span class="online-ripple"></span>
</div>
```

### Why does it fit EaseMotion CSS?

Micro-interactions are a key part of modern UI design. This ripple effect is lightweight, visually clear, easy to customize, and aligns with EaseMotion CSS's animation-first and human-readable approach.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(not tested)*

---

## Notes for Maintainer

* Inspired by WhatsApp, Discord, Slack, and Microsoft Teams.
* Uses a CSS-only ripple animation with no dependencies.
* Includes example avatar cards to demonstrate real-world usage.
* Supports `prefers-reduced-motion` for accessibility.
* Fully contained within `submissions/examples/`.

Closes #16882
