### PR TITLE
feat: add animated download arrow bounce example

### DIFF
--- a/submissions/examples/u-animated-download-arrow-bounce-16895/README.md
+++ b/submissions/examples/u-animated-download-arrow-bounce-16895/README.md
@@ -1,0 +1,44 @@
+# Animated Download Arrow Bounce
+
+## Overview
+
+A reusable download indicator animation featuring a gently bouncing arrow designed to draw attention toward downloadable content.
+
+## Features
+
+- CSS-only animation
+- Lightweight implementation
+- Download-focused micro interaction
+- Responsive design
+- Easy customization
+- Accessibility support
+
+## Usage
+
+```html
+<button class="download-button">
+  Download
+  <span class="download-arrow">↓</span>
+</button>
+```
+
+## Accessibility
+
+Supports:
+
+```css
+@media(prefers-reduced-motion: reduce)
+```
+
+to disable animations.
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari
+
+## Issue
+
+Created for Issue #16895.

--- a/submissions/examples/u-animated-download-arrow-bounce-16895/demo.html
+++ b/submissions/examples/u-animated-download-arrow-bounce-16895/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Download Arrow Bounce</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="container">
+
+    <div class="card">
+
+      <span class="badge">EaseMotion CSS</span>
+
+      <h1>Animated Download Arrow Bounce</h1>
+
+      <p>
+        A lightweight download indicator animation that gently
+        attracts attention toward downloadable resources.
+      </p>
+
+      <button class="download-button">
+        Download Now
+        <span class="download-arrow">↓</span>
+      </button>
+
+      <div class="examples">
+
+        <button class="secondary-btn">
+          PDF Guide
+          <span class="download-arrow">↓</span>
+        </button>
+
+        <button class="secondary-btn">
+          Source Code
+          <span class="download-arrow">↓</span>
+        </button>
+
+      </div>
+
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/u-animated-download-arrow-bounce-16895/style.css
+++ b/submissions/examples/u-animated-download-arrow-bounce-16895/style.css
@@ -1,0 +1,129 @@
+*{
+  margin:0;
+  padding:0;
+  box-sizing:border-box;
+}
+
+body{
+  min-height:100vh;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  padding:20px;
+
+  background:
+  linear-gradient(
+  135deg,
+  #0f172a,
+  #1e293b
+  );
+
+  font-family:Arial,sans-serif;
+  color:white;
+}
+
+.container{
+  width:100%;
+  max-width:800px;
+}
+
+.card{
+  text-align:center;
+
+  padding:50px 30px;
+
+  border-radius:24px;
+
+  background:
+  rgba(255,255,255,.05);
+
+  border:
+  1px solid rgba(255,255,255,.08);
+}
+
+.badge{
+  display:inline-block;
+
+  padding:8px 14px;
+
+  border-radius:999px;
+
+  margin-bottom:18px;
+
+  background:
+  rgba(59,130,246,.15);
+
+  color:#93c5fd;
+}
+
+h1{
+  margin-bottom:16px;
+}
+
+p{
+  color:#cbd5e1;
+  margin-bottom:35px;
+}
+
+.download-button,
+.secondary-btn{
+
+  border:none;
+
+  cursor:pointer;
+
+  color:white;
+
+  font-weight:600;
+
+  border-radius:14px;
+
+  padding:14px 24px;
+
+  margin:10px;
+}
+
+.download-button{
+  background:
+  linear-gradient(
+  135deg,
+  #3b82f6,
+  #6366f1
+  );
+}
+
+.secondary-btn{
+  background:#334155;
+}
+
+.download-arrow{
+  display:inline-block;
+
+  margin-left:8px;
+
+  animation:
+  arrowBounce 1.5s infinite;
+}
+
+.examples{
+  margin-top:30px;
+}
+
+@keyframes arrowBounce{
+
+  0%,
+  100%{
+    transform:translateY(0);
+  }
+
+  50%{
+    transform:translateY(5px);
+  }
+}
+
+@media(prefers-reduced-motion:reduce){
+
+  .download-arrow{
+    animation:none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new **Animated Download Arrow Bounce** example featuring a subtle bouncing arrow animation that helps draw attention to downloadable resources, files, and documentation links.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/u-animated-download-arrow-bounce-16895/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A reusable download arrow animation that gently bounces downward to indicate downloadable content and improve visual guidance.

### How does a developer use it?

```html id="js5qhh"
<button class="download-button">
  Download
  <span class="download-arrow">↓</span>
</button>
```

### Why does it fit EaseMotion CSS?

This effect demonstrates a practical micro-interaction that enhances usability while remaining lightweight, reusable, and easy to understand. It aligns with EaseMotion CSS's animation-first philosophy and focuses on common UI patterns.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(not tested)*

---

## Notes for Maintainer

* Inspired by download buttons found on documentation sites, GitHub releases pages, and software distribution platforms.
* CSS-only implementation with no dependencies.
* Includes multiple button examples demonstrating reuse.
* Supports `prefers-reduced-motion` for accessibility.
* Fully contained within `submissions/examples/`.

Closes #16895
