### PR TITLE
fix(content): add missing em-dash to introduction eyebrow

### DIFF
--- a/submissions/Missing Eyebrow Em-Dash/README.md
+++ b/submissions/Missing Eyebrow Em-Dash/README.md
@@ -1,0 +1,7 @@
+# Fix Missing Eyebrow Em-Dash
+
+## Overview
+Adds the missing typographical em-dash to the "Introduction" eyebrow text to accurately match the visual design specifications.
+
+## Changes
+- Updated `index.html` to include the `&mdash;` HTML entity before the text inside the `.docs-eyebrow` container.

--- a/submissions/Missing Eyebrow Em-Dash/demo.html
+++ b/submissions/Missing Eyebrow Em-Dash/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bug 3 Fix - Missing Eyebrow Em-Dash</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <style>
+    /* Basic demo styling to make the section visible */
+    body { background-color: #0f172a; color: #f8fafc; margin: 0; padding: 4rem; font-family: sans-serif; }
+    .docs-eyebrow { color: #a78bfa; font-size: 0.85rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.12em; margin-bottom: 0.5rem; }
+    .docs-h1 { font-size: 3rem; font-weight: 800; margin: 0 0 1rem 0; }
+    .docs-p { color: #94a3b8; line-height: 1.6; max-width: 600px; }
+  </style>
+</head>
+<body>
+
+  <main class="docs-content">
+    <section id="getting-started" class="docs-section ease-fade-in">
+      <div class="docs-eyebrow">&mdash; Introduction</div>
+      <h1 class="docs-h1">EaseMotion CSS</h1>
+      <p class="docs-p">
+        EaseMotion CSS is a human-readable, animation-first CSS library. Write UI with simple,
+        English-like class names — no memorizing utilities, no complex configuration.
+      </p>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/Missing Eyebrow Em-Dash/style.css
+++ b/submissions/Missing Eyebrow Em-Dash/style.css
@@ -1,0 +1,1 @@
+/* No CSS changes required for this issue. */


### PR DESCRIPTION
closes #16952 
This PR corrects a minor content discrepancy where the "Introduction" section eyebrow was missing its preceding em-dash. The index.html file has been updated to include the standard &mdash; entity.
<img width="1280" height="608" alt="Screenshot 2026-06-22 at 6 19 11 PM" src="https://github.com/user-attachments/assets/773a4aa9-9c2b-44af-9ea5-02302e343397" />
