### PR TITLE
feat(submission): add mix-blend-mode-multiply CSS demo

### DIFF
--- a/submissions/examples/15906-mix-blend-mode-multiply-tm/README.md
+++ b/submissions/examples/15906-mix-blend-mode-multiply-tm/README.md
@@ -1,0 +1,18 @@
+# Mix Blend Mode Multiply Utility & Demos
+
+Issue: [#15906](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/15906)
+
+## What does this do?
+Provides the `.ease-blend-multiply` utility class and demonstrates how the `mix-blend-mode: multiply` CSS property blends overlapping elements to create rich color mixing, double exposures, and textured overlays.
+
+## How is it used?
+Apply the `ease-blend-multiply` class to any overlapping element to multiply its color values with the element behind it:
+```html
+<div class="parent-container">
+  <img class="background-img" src="background.jpg" alt="Background">
+  <div class="overlay ease-blend-multiply"></div>
+</div>
+```
+
+## Why is it useful?
+It allows developers to create advanced graphic design effects—such as CMYK color mixing, realistic shadow overlays, paper/grunge texture mapping, and double-exposure photo effects—directly in the browser using pure CSS, aligning with EaseMotion CSS's philosophy of lightweight, modern, and high-performance visual utilities.

--- a/submissions/examples/15906-mix-blend-mode-multiply-tm/demo.html
+++ b/submissions/examples/15906-mix-blend-mode-multiply-tm/demo.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mix Blend Mode Multiply - EaseMotion CSS Showcase</title>
+  
+  <!-- Modern Outfit Font from Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+  
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="demo-body">
+
+  <header class="demo-header">
+    <div class="badge-tag">Utility Showcase</div>
+    <h1>mix-blend-mode-multiply</h1>
+    <p>
+      An interactive playground demonstrating subtractive color mixing, double exposures, and halftone poster overlays using the CSS <code>mix-blend-mode: multiply</code> property.
+    </p>
+  </header>
+
+  <main class="demo-container">
+    
+    <!-- Showcase 1: Subtractive CMYK Color Mixer -->
+    <section class="demo-card">
+      <h2 class="card-title">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color: var(--accent-cyan);">
+          <circle cx="12" cy="12" r="10"></circle>
+          <circle cx="12" cy="10" r="3"></circle>
+          <circle cx="10" cy="14" r="3"></circle>
+          <circle cx="14" cy="14" r="3"></circle>
+        </svg>
+        CMY Color Wheel
+      </h2>
+      <p class="card-desc">
+        Cyan, Magenta, and Yellow are the primary colors in subtractive blending. Multiplying them produces Red, Green, Blue, and a rich composite Black.
+      </p>
+      
+      <div class="mixer-stage" id="mixerStage">
+        <div class="mixer-circle-container">
+          <div class="cmy-circle cmy-cyan" id="circleCyan"></div>
+          <div class="cmy-circle cmy-magenta" id="circleMagenta"></div>
+          <div class="cmy-circle cmy-yellow" id="circleYellow"></div>
+        </div>
+      </div>
+      
+      <div class="controls">
+        <div class="controls-row">
+          <button class="btn-primary-demo" id="toggleMixerAnim">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" id="playIcon">
+              <polygon points="5 3 19 12 5 21 5 3"></polygon>
+            </svg>
+            <span id="animBtnText">Animate Orbit</span>
+          </button>
+          
+          <div class="control-label">
+            <span>Blend Mode:</span>
+            <div class="seg-control" id="mixerModeToggle">
+              <button class="seg-btn active" data-mode="multiply">Multiply</button>
+              <button class="seg-btn" data-mode="normal">Normal</button>
+            </div>
+          </div>
+        </div>
+        
+        <div class="circle-sliders">
+          <div class="circle-slider-col">
+            <span>Cyan Y-Offset</span>
+            <input type="range" class="demo-range" id="cyanOffset" min="-40" max="60" value="0">
+          </div>
+          <div class="circle-slider-col">
+            <span>Magenta X-Offset</span>
+            <input type="range" class="demo-range" id="magentaOffset" min="-40" max="60" value="0">
+          </div>
+          <div class="circle-slider-col">
+            <span>Yellow X-Offset</span>
+            <input type="range" class="demo-range" id="yellowOffset" min="-40" max="60" value="0">
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Showcase 2: Typography Poster Overlay -->
+    <section class="demo-card">
+      <h2 class="card-title">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color: var(--accent-pink);">
+          <path d="M4 7V4h16v3M9 20h6M12 4v16"></path>
+        </svg>
+        Poster Halftone Overlay
+      </h2>
+      <p class="card-desc">
+        Multiplying bright typography over textured backgrounds allows the texture detail, grains, and grid patterns to show through the solid text layers.
+      </p>
+      
+      <div class="poster-stage" id="posterStage">
+        <h3 class="poster-text" id="posterText" style="color: #ff007f;">MTPY</h3>
+      </div>
+      
+      <div class="controls">
+        <div class="controls-row">
+          <div class="control-label">
+            <span>Text Input:</span>
+            <input type="text" id="textInput" value="MTPY" style="background: rgba(255,255,255,0.05); border: 1px solid var(--border-color); color: white; padding: 0.5rem; border-radius: 6px; width: 100px; font-family: var(--font-sans); font-weight: 600; text-transform: uppercase;">
+          </div>
+          
+          <div class="control-label">
+            <span>Grid Pattern:</span>
+            <label class="switch">
+              <input type="checkbox" id="patternToggle" checked>
+              <span class="slider-toggle"></span>
+            </label>
+          </div>
+        </div>
+        
+        <div class="controls-row">
+          <div class="control-label">
+            <span>Text Color:</span>
+            <div class="color-swatch-group" id="textColorGroup">
+              <div class="color-swatch active" style="background: #ff007f;" data-color="#ff007f"></div>
+              <div class="color-swatch" style="background: #00e5ff;" data-color="#00e5ff"></div>
+              <div class="color-swatch" style="background: #ffdd00;" data-color="#ffdd00"></div>
+              <div class="color-swatch" style="background: #39ff14;" data-color="#39ff14"></div>
+            </div>
+          </div>
+          
+          <div class="control-label">
+            <span>Background Color:</span>
+            <div class="color-swatch-group" id="bgColorGroup">
+              <div class="color-swatch active" style="background: #e2e8f0;" data-color="#e2e8f0"></div>
+              <div class="color-swatch" style="background: #fbcfe8;" data-color="#fbcfe8"></div>
+              <div class="color-swatch" style="background: #ccfbf1;" data-color="#ccfbf1"></div>
+              <div class="color-swatch" style="background: #fef08a;" data-color="#fef08a"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Showcase 3: Creative Double Exposure / Duotone Blending -->
+    <section class="demo-card full-width-card">
+      <h2 class="card-title">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color: var(--accent-purple);">
+          <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+          <circle cx="8.5" cy="8.5" r="1.5"></circle>
+          <polyline points="21 15 16 10 5 21"></polyline>
+        </svg>
+        Double Exposure Duotone
+      </h2>
+      <p class="card-desc">
+        By multiplying a vivid gradient overlay onto a high-contrast grayscale background image, colors blend dynamically—enhancing dark mountain peaks while highlighting the sky.
+      </p>
+      
+      <div class="double-exposure-stage">
+        <div class="scene-bg" id="duotoneBg"></div>
+        <div class="scene-mountains"></div>
+        <div class="gradient-overlay ease-blend-multiply" id="duotoneOverlay"></div>
+      </div>
+      
+      <div class="controls">
+        <div class="controls-row">
+          <div class="control-label">
+            <span>Blend Mode:</span>
+            <div class="seg-control" id="duotoneBlendToggle">
+              <button class="seg-btn active" data-mode="multiply">Multiply Blend</button>
+              <button class="seg-btn" data-mode="normal">Normal Blend</button>
+            </div>
+          </div>
+          
+          <div class="control-label">
+            <span>Overlay Opacity:</span>
+            <input type="range" class="demo-range" id="opacitySlider" min="0" max="100" value="95">
+            <span id="opacityVal" style="font-size: 0.9rem; font-weight: 700; width: 35px; text-align: right;">95%</span>
+          </div>
+          
+          <div class="control-label">
+            <span>Gradient Theme:</span>
+            <div class="seg-control" id="gradientThemeToggle">
+              <button class="seg-btn active" data-theme="neon">Neon</button>
+              <button class="seg-btn" data-theme="sunset">Sunset</button>
+              <button class="seg-btn" data-theme="forest">Forest</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="demo-footer">
+    <p>
+      EaseMotion CSS - Created for Issue <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/15906" target="_blank">#15906</a>. Standardized classes are managed by the repository maintainer.
+    </p>
+  </footer>
+
+  <!-- Interactive JavaScript Logic -->
+  <script>
+    // 1. CMY Color Mixer logic
+    const mixerStage = document.getElementById('mixerStage');
+    const toggleMixerAnim = document.getElementById('toggleMixerAnim');
+    const animBtnText = document.getElementById('animBtnText');
+    const playIcon = document.getElementById('playIcon');
+    const mixerModeToggle = document.getElementById('mixerModeToggle');
+    
+    const circleCyan = document.getElementById('circleCyan');
+    const circleMagenta = document.getElementById('circleMagenta');
+    const circleYellow = document.getElementById('circleYellow');
+    
+    const cyanOffset = document.getElementById('cyanOffset');
+    const magentaOffset = document.getElementById('magentaOffset');
+    const yellowOffset = document.getElementById('yellowOffset');
+    
+    // Animation trigger
+    toggleMixerAnim.addEventListener('click', () => {
+      const isAnimating = mixerStage.classList.toggle('animating');
+      if (isAnimating) {
+        animBtnText.textContent = "Stop Orbit";
+        playIcon.innerHTML = '<rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect>';
+        // Reset offsets when animating
+        cyanOffset.value = 0;
+        magentaOffset.value = 0;
+        yellowOffset.value = 0;
+        circleCyan.style.transform = 'none';
+        circleMagenta.style.transform = 'none';
+        circleYellow.style.transform = 'none';
+      } else {
+        animBtnText.textContent = "Animate Orbit";
+        playIcon.innerHTML = '<polygon points="5 3 19 12 5 21 5 3"></polygon>';
+      }
+    });
+
+    // Custom offset controls
+    function updateOffsets() {
+      if (mixerStage.classList.contains('animating')) {
+        mixerStage.classList.remove('animating');
+        animBtnText.textContent = "Animate Orbit";
+        playIcon.innerHTML = '<polygon points="5 3 19 12 5 21 5 3"></polygon>';
+      }
+      
+      const cyanY = cyanOffset.value;
+      const magentaX = magentaOffset.value;
+      const yellowX = yellowOffset.value;
+      
+      circleCyan.style.transform = `translateY(${cyanY}px)`;
+      circleMagenta.style.transform = `translateX(${magentaX}px)`;
+      circleYellow.style.transform = `translateX(${yellowX}px)`;
+    }
+
+    cyanOffset.addEventListener('input', updateOffsets);
+    magentaOffset.addEventListener('input', updateOffsets);
+    yellowOffset.addEventListener('input', updateOffsets);
+
+    // Toggle blend mode for CMY
+    mixerModeToggle.addEventListener('click', (e) => {
+      if (!e.target.classList.contains('seg-btn')) return;
+      
+      mixerModeToggle.querySelectorAll('.seg-btn').forEach(btn => btn.classList.remove('active'));
+      e.target.classList.add('active');
+      
+      const mode = e.target.dataset.mode;
+      const circles = [circleCyan, circleMagenta, circleYellow];
+      
+      circles.forEach(circle => {
+        if (mode === 'normal') {
+          circle.style.mixBlendMode = 'normal';
+          circle.style.opacity = '0.7'; // standard opacity for visibility in normal mode
+        } else {
+          circle.style.mixBlendMode = 'multiply';
+          circle.style.opacity = '1.0';
+        }
+      });
+    });
+
+    // 2. Poster Typography logic
+    const textInput = document.getElementById('textInput');
+    const posterText = document.getElementById('posterText');
+    const patternToggle = document.getElementById('patternToggle');
+    const posterStage = document.getElementById('posterStage');
+    const textColorGroup = document.getElementById('textColorGroup');
+    const bgColorGroup = document.getElementById('bgColorGroup');
+
+    textInput.addEventListener('input', () => {
+      posterText.textContent = textInput.value || 'MTPY';
+    });
+
+    patternToggle.addEventListener('change', () => {
+      if (patternToggle.checked) {
+        posterStage.style.backgroundImage = `
+          linear-gradient(45deg, #cbd5e1 25%, transparent 25%), 
+          linear-gradient(-45deg, #cbd5e1 25%, transparent 25%), 
+          linear-gradient(45deg, transparent 75%, #cbd5e1 75%), 
+          linear-gradient(-45deg, transparent 75%, #cbd5e1 75%)`;
+      } else {
+        posterStage.style.backgroundImage = 'none';
+      }
+    });
+
+    // Swatch picking
+    textColorGroup.addEventListener('click', (e) => {
+      if (!e.target.classList.contains('color-swatch')) return;
+      textColorGroup.querySelectorAll('.color-swatch').forEach(sw => sw.classList.remove('active'));
+      e.target.classList.add('active');
+      posterText.style.color = e.target.dataset.color;
+    });
+
+    bgColorGroup.addEventListener('click', (e) => {
+      if (!e.target.classList.contains('color-swatch')) return;
+      bgColorGroup.querySelectorAll('.color-swatch').forEach(sw => sw.classList.remove('active'));
+      e.target.classList.add('active');
+      posterStage.style.backgroundColor = e.target.dataset.color;
+    });
+
+    // 3. Double Exposure logic
+    const duotoneBlendToggle = document.getElementById('duotoneBlendToggle');
+    const opacitySlider = document.getElementById('opacitySlider');
+    const opacityVal = document.getElementById('opacityVal');
+    const duotoneOverlay = document.getElementById('duotoneOverlay');
+    const gradientThemeToggle = document.getElementById('gradientThemeToggle');
+
+    duotoneBlendToggle.addEventListener('click', (e) => {
+      if (!e.target.classList.contains('seg-btn')) return;
+      
+      duotoneBlendToggle.querySelectorAll('.seg-btn').forEach(btn => btn.classList.remove('active'));
+      e.target.classList.add('active');
+      
+      const mode = e.target.dataset.mode;
+      if (mode === 'normal') {
+        duotoneOverlay.style.mixBlendMode = 'normal';
+      } else {
+        duotoneOverlay.style.mixBlendMode = 'multiply';
+      }
+    });
+
+    opacitySlider.addEventListener('input', () => {
+      const opacity = opacitySlider.value;
+      opacityVal.textContent = opacity + '%';
+      duotoneOverlay.style.opacity = opacity / 100;
+    });
+
+    gradientThemeToggle.addEventListener('click', (e) => {
+      if (!e.target.classList.contains('seg-btn')) return;
+      
+      gradientThemeToggle.querySelectorAll('.seg-btn').forEach(btn => btn.classList.remove('active'));
+      e.target.classList.add('active');
+      
+      const theme = e.target.dataset.theme;
+      if (theme === 'sunset') {
+        duotoneOverlay.style.background = 'linear-gradient(135deg, #f59e0b 0%, #ef4444 50%, #8b5cf6 100%)';
+      } else if (theme === 'forest') {
+        duotoneOverlay.style.background = 'linear-gradient(135deg, #10b981 0%, #059669 50%, #06b8ff 100%)';
+      } else { // neon default
+        duotoneOverlay.style.background = 'linear-gradient(135deg, #ec4899 0%, #a855f7 50%, #06b6d4 100%)';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/15906-mix-blend-mode-multiply-tm/style.css
+++ b/submissions/examples/15906-mix-blend-mode-multiply-tm/style.css
@@ -1,0 +1,548 @@
+/* -------------------------------------------------------------
+   EaseMotion CSS - mix-blend-mode-multiply Submission
+   ------------------------------------------------------------- */
+
+/* Utility Class */
+.ease-blend-multiply {
+  mix-blend-mode: multiply !important;
+}
+
+/* -------------------------------------------------------------
+   Dashboard and Demo Showcase Styles
+   ------------------------------------------------------------- */
+
+:root {
+  --font-sans: 'Outfit', 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+  
+  /* Theme colors - Deep Tech Space Theme */
+  --bg-primary: #0b0f19;
+  --bg-secondary: #131c31;
+  --bg-tertiary: #1b2643;
+  --accent-cyan: #06b6d4;
+  --accent-purple: #a855f7;
+  --accent-pink: #ec4899;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --border-color: #2e3d67;
+  --shadow-lg: 0 10px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.4);
+  --glass-bg: rgba(19, 28, 49, 0.7);
+  --glass-border: rgba(255, 255, 255, 0.08);
+}
+
+/* Base resets for the demo page */
+.demo-body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-primary);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-x: hidden;
+  line-height: 1.5;
+}
+
+.demo-header {
+  text-align: center;
+  padding: 3rem 1.5rem 1.5rem;
+  max-width: 800px;
+}
+
+.demo-header h1 {
+  font-size: 2.75rem;
+  font-weight: 800;
+  margin: 0 0 1rem;
+  background: linear-gradient(135deg, #38bdf8, #a855f7, #ec4899);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.025em;
+}
+
+.demo-header p {
+  color: var(--text-muted);
+  font-size: 1.15rem;
+  margin: 0 auto;
+  max-width: 600px;
+}
+
+.badge-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(168, 85, 247, 0.15);
+  border: 1px solid rgba(168, 85, 247, 0.3);
+  color: #c084fc;
+  padding: 0.35rem 0.85rem;
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1.25rem;
+}
+
+/* Dashboard Grid Layout */
+.demo-container {
+  width: 100%;
+  max-width: 1200px;
+  padding: 0 1.5rem 4rem;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  box-sizing: border-box;
+}
+
+@media (min-width: 900px) {
+  .demo-container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .full-width-card {
+    grid-column: span 2;
+  }
+}
+
+/* Card Styles */
+.demo-card {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.demo-card:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+}
+
+.card-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  color: var(--text-main);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.card-desc {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  margin: 0 0 1.5rem;
+}
+
+/* Showcase #1: CMYK Color Mixer (Venn Diagram) */
+.mixer-stage {
+  width: 100%;
+  height: 320px;
+  background: #ffffff; /* White background is essential for CMYK blending */
+  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 2px 8px rgba(0,0,0,0.06);
+}
+
+.mixer-circle-container {
+  position: relative;
+  width: 240px;
+  height: 240px;
+}
+
+.cmy-circle {
+  position: absolute;
+  width: 130px;
+  height: 130px;
+  border-radius: 50%;
+  mix-blend-mode: multiply;
+  transition: transform 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transform-origin: center center;
+}
+
+/* CMY Primary subtractive colors */
+.cmy-cyan {
+  background: #00ffff;
+  top: 15px;
+  left: 55px;
+}
+
+.cmy-magenta {
+  background: #ff00ff;
+  bottom: 20px;
+  left: 15px;
+}
+
+.cmy-yellow {
+  background: #ffff00;
+  bottom: 20px;
+  right: 15px;
+}
+
+/* Orbiting Animation state */
+.mixer-stage.animating .cmy-cyan {
+  animation: orbit-cyan 6s linear infinite;
+}
+
+.mixer-stage.animating .cmy-magenta {
+  animation: orbit-magenta 6s linear infinite;
+}
+
+.mixer-stage.animating .cmy-yellow {
+  animation: orbit-yellow 6s linear infinite;
+}
+
+@keyframes orbit-cyan {
+  0% { transform: translate(0, 0); }
+  33% { transform: translate(-30px, 30px); }
+  66% { transform: translate(30px, 30px); }
+  100% { transform: translate(0, 0); }
+}
+
+@keyframes orbit-magenta {
+  0% { transform: translate(0, 0); }
+  33% { transform: translate(30px, -30px); }
+  66% { transform: translate(0, -50px); }
+  100% { transform: translate(0, 0); }
+}
+
+@keyframes orbit-yellow {
+  0% { transform: translate(0, 0); }
+  33% { transform: translate(0, -50px); }
+  66% { transform: translate(-30px, -30px); }
+  100% { transform: translate(0, 0); }
+}
+
+/* Showcase #2: Poster Typography & Background Texture Blending */
+.poster-stage {
+  width: 100%;
+  height: 320px;
+  background-color: #e2e8f0;
+  /* Premium CSS halftone/checkered texture */
+  background-image: 
+    linear-gradient(45deg, #cbd5e1 25%, transparent 25%), 
+    linear-gradient(-45deg, #cbd5e1 25%, transparent 25%), 
+    linear-gradient(45deg, transparent 75%, #cbd5e1 75%), 
+    linear-gradient(-45deg, transparent 75%, #cbd5e1 75%);
+  background-size: 24px 24px;
+  background-position: 0 0, 0 12px, 12px -12px, -12px 0px;
+  border-radius: 12px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  box-shadow: inset 0 2px 8px rgba(0,0,0,0.1);
+  transition: background-color 0.4s ease;
+}
+
+.poster-stage::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  /* Dynamic noise overlay using svg inline */
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.045'/%3E%3C/svg%3E");
+  pointer-events: none;
+}
+
+.poster-text {
+  font-size: 5.5rem;
+  font-weight: 900;
+  text-align: center;
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+  margin: 0;
+  user-select: none;
+  transition: color 0.3s ease;
+}
+
+/* Showcase #3: Double Exposure & Duotone Blending */
+.double-exposure-stage {
+  width: 100%;
+  height: 380px;
+  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 2px 8px rgba(0,0,0,0.2);
+  /* A high-contrast graphic representation of a mountain forest landscape */
+  background: #111;
+}
+
+/* Base high-contrast black and white image vector layout */
+.scene-bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: 
+    radial-gradient(circle at 75% 30%, #fff 0%, #fff 10%, transparent 10.5%),
+    linear-gradient(to top, #000 0%, #000 20%, transparent 50%),
+    linear-gradient(to right, transparent 50%, #222 100%),
+    #fff;
+  background-size: cover;
+  transition: filter 0.3s ease;
+}
+
+/* Draw vector mountains using CSS gradients and SVG paths */
+.scene-mountains {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 800 400' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M-100 400L250 150L600 400H-100Z' fill='%23111111'/%3E%3Cpath d='M200 400L500 80L850 400H200Z' fill='%23000000'/%3E%3Cpath d='M450 400L650 200L850 400H450Z' fill='%23222222'/%3E%3C/svg%3E");
+  background-position: bottom center;
+  background-repeat: no-repeat;
+  background-size: 100% auto;
+}
+
+/* The colorful multiply overlay */
+.gradient-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #ec4899 0%, #a855f7 50%, #06b6d4 100%);
+  mix-blend-mode: multiply;
+  pointer-events: none;
+  opacity: 0.95;
+  transition: opacity 0.3s ease;
+}
+
+/* Control Panel & UI Elements */
+.controls {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 1.25rem;
+}
+
+.controls-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.control-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-main);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.btn-primary-demo {
+  background: linear-gradient(135deg, var(--accent-purple) 0%, var(--accent-pink) 100%);
+  border: none;
+  color: white;
+  padding: 0.65rem 1.25rem;
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  font-weight: 700;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(168, 85, 247, 0.3);
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.btn-primary-demo:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(168, 85, 247, 0.45);
+}
+
+.btn-primary-demo:active {
+  transform: translateY(1px);
+}
+
+/* Style range slider */
+.demo-range {
+  -webkit-appearance: none;
+  width: 100%;
+  max-width: 180px;
+  height: 6px;
+  background: var(--border-color);
+  border-radius: 3px;
+  outline: none;
+}
+
+.demo-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--text-main);
+  cursor: pointer;
+  transition: transform 0.1s ease;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+}
+
+.demo-range::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+  background: var(--accent-cyan);
+}
+
+/* Color selector group */
+.color-swatch-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.color-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.color-swatch:hover {
+  transform: scale(1.15);
+}
+
+.color-swatch.active {
+  border-color: var(--text-main);
+  transform: scale(1.1);
+}
+
+/* Segmented Control toggles */
+.seg-control {
+  display: flex;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0.25rem;
+  border-radius: 8px;
+}
+
+.seg-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.85rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.seg-btn.active {
+  background: var(--bg-tertiary);
+  color: var(--text-main);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+/* Grid overlay toggle style */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 22px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider-toggle {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background-color: var(--border-color);
+  transition: .3s;
+  border-radius: 34px;
+}
+
+.slider-toggle:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: .3s;
+  border-radius: 50%;
+}
+
+input:checked + .slider-toggle {
+  background-image: linear-gradient(135deg, var(--accent-purple), var(--accent-pink));
+}
+
+input:checked + .slider-toggle:before {
+  transform: translateX(22px);
+}
+
+/* Interactive elements in CMY Venn diagram */
+.circle-sliders {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.circle-slider-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 6px;
+  padding: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.circle-slider-col span {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.circle-slider-col .demo-range {
+  max-width: 80px;
+}
+
+/* Footer style */
+.demo-footer {
+  margin-top: auto;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  border-top: 1px solid var(--border-color);
+  width: 100%;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  background: #090c14;
+}
+
+.demo-footer a {
+  color: var(--accent-cyan);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.demo-footer a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Fixes #15906

### Description
This PR adds the `.ease-blend-multiply` utility class and provides an interactive showcase dashboard demonstrating subtractive color mixing (CMY color mixer), poster halftone typography overlays, and creative double exposure effects.

### Checklist
- [x] Make sure no existing issue already covers this idea
- [x] Read the Contribution Guide before opening a PR
- [x] Add files only inside submissions/examples/your-feature-name/
- [x] Include demo.html · style.css · README.md in your folder