### PR TITLE
feat(submission): add isolation-utility CSS demo

### DIFF
--- a/submissions/examples/15907-isolation-utility-tm/README.md
+++ b/submissions/examples/15907-isolation-utility-tm/README.md
@@ -1,0 +1,27 @@
+# Stacking Context Isolation Utility & Demos
+
+Issue: [#15907](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/15907)
+
+## What does this do?
+
+Provides the `.ease-isolate` utility class and demonstrates how the `isolation: isolate` CSS property establishes a new stacking context, preventing child elements with blending modes or z-indexes from bleeding into or interacting with parent backdrops and sibling hierarchies.
+
+## How is it used?
+
+Apply the `ease-isolate` class to a wrapper or parent container to group its children's blending and stacking contexts:
+
+```html
+<!-- Without isolation: the tooltip or blending element interacts with the main page backdrop -->
+<div class="card">
+  <div class="blending-element"></div>
+</div>
+
+<!-- With isolation: the blending element is confined only to the card's backdrop -->
+<div class="card ease-isolate">
+  <div class="blending-element"></div>
+</div>
+```
+
+## Why is it useful?
+
+It enables robust component modularity in modern web design. By isolating stacking contexts, developers can guarantee that components using complex visual features (like `mix-blend-mode` or layered `z-index` overlays) render predictably and do not break when embedded in diverse, dynamic page backgrounds or nested dark/light mode layouts. This aligns with EaseMotion CSS's philosophy of high-performance, modular, and component-first visual styling.

--- a/submissions/examples/15907-isolation-utility-tm/demo.html
+++ b/submissions/examples/15907-isolation-utility-tm/demo.html
@@ -1,0 +1,334 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stacking Context Isolation - EaseMotion CSS Showcase</title>
+
+    <!-- Modern Outfit Font from Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
+
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body class="demo-body">
+    <!-- Glow decorations -->
+    <div class="glow-spot-1"></div>
+    <div class="glow-spot-2"></div>
+
+    <header class="demo-header">
+      <div class="badge-tag">Utility Showcase</div>
+      <h1>isolation-utility</h1>
+      <p>
+        An interactive visual guide to <code>isolation: isolate</code>. Learn
+        how to prevent z-index leaks and mix-blend bleed-through by defining
+        boundaries for CSS stacking contexts.
+      </p>
+    </header>
+
+    <main class="demo-container">
+      <!-- Showcase 1: Mix-Blend Isolation -->
+      <section class="demo-card">
+        <h2 class="card-title">
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            style="color: var(--accent-cyan)"
+          >
+            <circle cx="12" cy="12" r="10"></circle>
+            <path
+              d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
+            ></path>
+          </svg>
+          Mix-Blend Isolation
+        </h2>
+        <p class="card-desc">
+          Without isolation, internal component blending modes mix with the
+          colorful page backdrop. Enabling <code>ease-isolate</code> boundaries
+          confines the blending context strictly inside the component card.
+        </p>
+
+        <div class="blend-mixer-stage">
+          <!-- Component Box that can be isolated using the ease-isolate class -->
+          <div class="component-box" id="blendComponentBox">
+            <div class="component-header">
+              <span class="component-title">Isolated Card Component</span>
+              <span class="component-badge">Active</span>
+            </div>
+            <div class="component-body">
+              <div class="circle-base"></div>
+              <div class="circle-blend" id="blendingCircle"></div>
+            </div>
+            <div class="component-footer">
+              Internal elements blend using 'difference'
+            </div>
+          </div>
+        </div>
+
+        <div class="controls">
+          <div class="controls-row">
+            <div class="control-label">
+              <span>Apply <code>.ease-isolate</code>:</span>
+              <label class="switch">
+                <input type="checkbox" id="isolateBlendToggle" checked />
+                <span class="slider-toggle"></span>
+              </label>
+            </div>
+
+            <div class="control-label">
+              <span>Component Theme:</span>
+              <div class="seg-control" id="themeComponentToggle">
+                <button class="seg-btn" data-theme="light">Light</button>
+                <button class="seg-btn active" data-theme="dark">Dark</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="controls-row">
+            <div
+              class="control-label"
+              style="width: 100%; justify-content: space-between"
+            >
+              <span>Blend Shape Offset:</span>
+              <input
+                type="range"
+                class="demo-range"
+                id="blendOffsetSlider"
+                min="-30"
+                max="30"
+                value="0"
+                style="max-width: 60%; width: 100%"
+              />
+            </div>
+          </div>
+
+          <div class="control-info" id="blendStatusText">
+            Status: Component container is Isolated. Children only blend with
+            the component background.
+          </div>
+        </div>
+      </section>
+
+      <!-- Showcase 2: Stacking Context (Z-Index) Visualizer -->
+      <section class="demo-card">
+        <h2 class="card-title">
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            style="color: var(--accent-purple)"
+          >
+            <polygon points="12 2 2 7 12 12 22 7 12 2"></polygon>
+            <polyline points="2 17 12 22 22 17"></polyline>
+            <polyline points="2 12 12 17 22 12"></polyline>
+          </svg>
+          3D Stacking Context Layering
+        </h2>
+        <p class="card-desc">
+          A stacking context limits z-index hierarchy. When isolated, the purple
+          child (z-index: 10) cannot bleed through and overlap the pink sibling
+          (z-index: 2) which is placed outside the parent.
+        </p>
+
+        <div class="stacking-visualizer-stage">
+          <!-- 3D Stacking Container -->
+          <div class="isometric-container" id="stackingStage">
+            <!-- Parent Container Layer (z-index: 1 relative to sibling) -->
+            <div
+              class="iso-layer layer-backdrop"
+              id="parentLayer"
+              style="z-index: 1"
+            >
+              <span class="layer-label">Parent Container</span>
+              <span class="layer-info" id="parentLayerStatus"
+                >isolation: isolate (z-index: 1)</span
+              >
+
+              <!-- Child Element A (z-index: 10 inside the parent) -->
+              <div class="iso-layer layer-child-a">
+                <span class="layer-label">Child A</span>
+                <span class="layer-info">z-index: 10</span>
+              </div>
+            </div>
+
+            <!-- Sibling Element B (z-index: 2 outside the parent) -->
+            <div class="iso-layer layer-sibling-b">
+              <span class="layer-label">Sibling B</span>
+              <span class="layer-info">z-index: 2 (Outside parent)</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="controls">
+          <div class="controls-row">
+            <div class="control-label">
+              <span>Apply <code>.ease-isolate</code>:</span>
+              <label class="switch">
+                <input type="checkbox" id="isolateZToggle" checked />
+                <span class="slider-toggle"></span>
+              </label>
+            </div>
+
+            <div class="control-label">
+              <span>Stage View:</span>
+              <div class="seg-control" id="viewPerspectiveToggle">
+                <button class="seg-btn active" data-view="isometric">
+                  3D Stack
+                </button>
+                <button class="seg-btn" data-view="flat">2D Layout</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="control-info" id="zStatusText">
+            Status: Parent Container is Isolated. Sibling B (z-index: 2) stacks
+            on top of Parent's internal hierarchy (Child A has z-index: 10 but
+            is trapped inside the parent).
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="demo-footer">
+      <p>
+        EaseMotion CSS - Created for Issue
+        <a
+          href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/15907"
+          target="_blank"
+          >#15907</a
+        >. Standardized classes are managed by the repository maintainer.
+      </p>
+    </footer>
+
+    <!-- Interactive JavaScript Logic -->
+    <script>
+      // -------------------------------------------------------------
+      // Showcase 1: Mix-Blend Isolation Logic
+      // -------------------------------------------------------------
+      const blendComponentBox = document.getElementById("blendComponentBox");
+      const isolateBlendToggle = document.getElementById("isolateBlendToggle");
+      const themeComponentToggle = document.getElementById(
+        "themeComponentToggle"
+      );
+      const blendOffsetSlider = document.getElementById("blendOffsetSlider");
+      const blendingCircle = document.getElementById("blendingCircle");
+      const blendStatusText = document.getElementById("blendStatusText");
+
+      // Toggle Isolation
+      isolateBlendToggle.addEventListener("change", () => {
+        if (isolateBlendToggle.checked) {
+          blendComponentBox.classList.add("ease-isolate");
+          blendStatusText.innerHTML =
+            "Status: Component container is Isolated. Children only blend with the component background.";
+          blendStatusText.style.color = "var(--accent-cyan)";
+        } else {
+          blendComponentBox.classList.remove("ease-isolate");
+          blendStatusText.innerHTML =
+            "Status: Component container is NOT Isolated. Blending circle bleeds and mixes with the outer background gradient.";
+          blendStatusText.style.color = "var(--accent-pink)";
+        }
+      });
+
+      // Initialize state
+      if (isolateBlendToggle.checked) {
+        blendComponentBox.classList.add("ease-isolate");
+      }
+
+      // Toggle Component Dark/Light theme
+      themeComponentToggle.addEventListener("click", (e) => {
+        if (!e.target.classList.contains("seg-btn")) return;
+        themeComponentToggle
+          .querySelectorAll(".seg-btn")
+          .forEach((btn) => btn.classList.remove("active"));
+        e.target.classList.add("active");
+
+        const theme = e.target.dataset.theme;
+        if (theme === "dark") {
+          blendComponentBox.classList.add("dark-mode-component");
+        } else {
+          blendComponentBox.classList.remove("dark-mode-component");
+        }
+      });
+
+      // Set initial dark theme on component
+      blendComponentBox.classList.add("dark-mode-component");
+
+      // Horizontal offset slider
+      blendOffsetSlider.addEventListener("input", () => {
+        const offset = blendOffsetSlider.value;
+        blendingCircle.style.transform = `translate(${offset}px, -50%)`;
+      });
+
+      // -------------------------------------------------------------
+      // Showcase 2: Stacking Context (Z-Index) Visualizer Logic
+      // -------------------------------------------------------------
+      const stackingStage = document.getElementById("stackingStage");
+      const parentLayer = document.getElementById("parentLayer");
+      const parentLayerStatus = document.getElementById("parentLayerStatus");
+      const isolateZToggle = document.getElementById("isolateZToggle");
+      const viewPerspectiveToggle = document.getElementById(
+        "viewPerspectiveToggle"
+      );
+      const zStatusText = document.getElementById("zStatusText");
+
+      // Toggle Stacking Isolation
+      isolateZToggle.addEventListener("change", () => {
+        if (isolateZToggle.checked) {
+          parentLayer.classList.add("ease-isolate");
+          parentLayerStatus.textContent = "isolation: isolate (z-index: 1)";
+          zStatusText.innerHTML =
+            "Status: Parent Container is Isolated. Sibling B (z-index: 2) stacks on top of Parent's internal hierarchy (Child A has z-index: 10 but is trapped inside the parent).";
+          zStatusText.style.color = "var(--accent-purple)";
+
+          // In isolated mode, Sibling B (outside, z-index 2) stacks on top of Parent Container (z-index 1).
+          // Since Parent is isolated, Child A's z-index 10 is contained inside Parent, so Child A cannot go above Sibling B.
+        } else {
+          parentLayer.classList.remove("ease-isolate");
+          parentLayerStatus.textContent = "isolation: auto (z-index: 1)";
+          zStatusText.innerHTML =
+            "Status: Parent Container is NOT Isolated. Child A (z-index: 10) bleeds through and stacks above Sibling B (z-index: 2) because no stacking boundaries exist.";
+          zStatusText.style.color = "var(--accent-orange)";
+
+          // In non-isolated mode, there is no separate stacking context for the parent,
+          // so Child A's z-index: 10 competes globally against Sibling B's z-index: 2 and goes above it.
+        }
+      });
+
+      // Initialize state
+      if (isolateZToggle.checked) {
+        parentLayer.classList.add("ease-isolate");
+      }
+
+      // Toggle 3D vs 2D Perspective view
+      viewPerspectiveToggle.addEventListener("click", (e) => {
+        if (!e.target.classList.contains("seg-btn")) return;
+        viewPerspectiveToggle
+          .querySelectorAll(".seg-btn")
+          .forEach((btn) => btn.classList.remove("active"));
+        e.target.classList.add("active");
+
+        const view = e.target.dataset.view;
+        if (view === "flat") {
+          stackingStage.classList.add("flat-view");
+        } else {
+          stackingStage.classList.remove("flat-view");
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/15907-isolation-utility-tm/style.css
+++ b/submissions/examples/15907-isolation-utility-tm/style.css
@@ -1,0 +1,622 @@
+/* -------------------------------------------------------------
+   EaseMotion CSS - isolation-utility Submission
+   ------------------------------------------------------------- */
+
+/* Core Utility Class */
+.ease-isolate {
+  isolation: isolate !important;
+}
+
+/* -------------------------------------------------------------
+   Dashboard and Demo Showcase Styles
+   ------------------------------------------------------------- */
+
+:root {
+  --font-sans:
+    "Outfit", "Plus Jakarta Sans", system-ui, -apple-system, sans-serif;
+
+  /* Theme colors - Deep Space Obsidian Theme */
+  --bg-primary: #090d16;
+  --bg-secondary: #111827;
+  --bg-tertiary: #1f2937;
+  --accent-cyan: #06b6d4;
+  --accent-purple: #8b5cf6;
+  --accent-pink: #ec4899;
+  --accent-orange: #f97316;
+  --text-main: #f9fafb;
+  --text-muted: #9ca3af;
+  --border-color: #374151;
+  --shadow-lg:
+    0 15px 35px -5px rgba(0, 0, 0, 0.5), 0 10px 15px -6px rgba(0, 0, 0, 0.5);
+  --glass-bg: rgba(17, 24, 39, 0.75);
+  --glass-border: rgba(255, 255, 255, 0.08);
+}
+
+/* Base resets for the demo page */
+.demo-body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-primary);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-x: hidden;
+  line-height: 1.5;
+}
+
+/* Background glowing spots for premium visual appearance */
+.glow-spot-1 {
+  position: absolute;
+  top: 10%;
+  left: 15%;
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(
+    circle,
+    rgba(139, 92, 246, 0.15) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+.glow-spot-2 {
+  position: absolute;
+  top: 40%;
+  right: 10%;
+  width: 500px;
+  height: 500px;
+  background: radial-gradient(
+    circle,
+    rgba(6, 182, 212, 0.12) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+.demo-header {
+  text-align: center;
+  padding: 4rem 1.5rem 2rem;
+  max-width: 800px;
+  position: relative;
+  z-index: 1;
+}
+
+.demo-header h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  margin: 0 0 1rem;
+  background: linear-gradient(
+    135deg,
+    var(--accent-cyan),
+    var(--accent-purple),
+    var(--accent-pink)
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.03em;
+}
+
+.demo-header p {
+  color: var(--text-muted);
+  font-size: 1.2rem;
+  margin: 0 auto;
+  max-width: 650px;
+}
+
+.badge-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(6, 182, 212, 0.12);
+  border: 1px solid rgba(6, 182, 212, 0.3);
+  color: #22d3ee;
+  padding: 0.35rem 0.95rem;
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1.5rem;
+}
+
+/* Dashboard Grid Layout */
+.demo-container {
+  width: 100%;
+  max-width: 1200px;
+  padding: 0 1.5rem 5rem;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+  box-sizing: border-box;
+  position: relative;
+  z-index: 1;
+}
+
+@media (min-width: 960px) {
+  .demo-container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .full-width-card {
+    grid-column: span 2;
+  }
+}
+
+/* Card Styles */
+.demo-card {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 20px;
+  padding: 2.5rem;
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 0.3s cubic-bezier(0.25, 0.8, 0.25, 1),
+    border-color 0.3s ease;
+}
+
+.demo-card:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-4px);
+}
+
+.card-title {
+  font-size: 1.65rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  color: var(--text-main);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.card-desc {
+  font-size: 1rem;
+  color: var(--text-muted);
+  margin: 0 0 2rem;
+}
+
+/* Showcase 1: Mix-Blend Isolation Stage */
+.blend-mixer-stage {
+  width: 100%;
+  height: 340px;
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* Multi-color mesh gradient backdrop acting as the "global page background" */
+  background:
+    radial-gradient(at 0% 0%, #ec4899 0px, transparent 50%),
+    radial-gradient(at 100% 100%, #06b6d4 0px, transparent 50%),
+    radial-gradient(at 100% 0%, #8b5cf6 0px, transparent 50%), #1e1b4b;
+  box-shadow: inset 0 4px 15px rgba(0, 0, 0, 0.3);
+}
+
+/* Simulated Component Container */
+.component-box {
+  width: 280px;
+  height: 220px;
+  background-color: #ffffff; /* White background of our isolated component */
+  border-radius: 12px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1.5rem;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+  transition: background-color 0.3s ease;
+}
+
+.component-box.dark-mode-component {
+  background-color: #1e293b;
+}
+
+.component-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  padding-bottom: 0.5rem;
+}
+
+.component-box.dark-mode-component .component-header {
+  border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+
+.component-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.component-box.dark-mode-component .component-title {
+  color: #f8fafc;
+}
+
+.component-badge {
+  font-size: 0.75rem;
+  background: rgba(139, 92, 246, 0.15);
+  color: #7c3aed;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.component-box.dark-mode-component .component-badge {
+  background: rgba(139, 92, 246, 0.3);
+  color: #a78bfa;
+}
+
+.component-body {
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+/* Graphic elements within the component body */
+.circle-base {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: #f43f5e; /* Rose circle */
+  position: absolute;
+  left: 20%;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+}
+
+.circle-blend {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: #10b981; /* Emerald blending circle */
+  position: absolute;
+  right: 20%;
+  top: 50%;
+  transform: translateY(-50%);
+  mix-blend-mode: difference;
+  z-index: 2;
+  transition: transform 0.4s ease;
+}
+
+.component-footer {
+  font-size: 0.75rem;
+  color: #64748b;
+  text-align: center;
+}
+
+.component-box.dark-mode-component .component-footer {
+  color: #94a3b8;
+}
+
+/* Showcase 2: Stacking Layer Visualizer Stage */
+.stacking-visualizer-stage {
+  width: 100%;
+  height: 380px;
+  background-color: rgba(255, 255, 255, 0.02);
+  border: 1px dashed var(--border-color);
+  border-radius: 14px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  perspective: 1200px; /* Perspective for 3D layout representation */
+}
+
+/* 3D Isometric container */
+.isometric-container {
+  position: relative;
+  width: 320px;
+  height: 240px;
+  transform: rotateX(60deg) rotateZ(-35deg);
+  transform-style: preserve-3d;
+  transition: transform 0.8s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.isometric-container.flat-view {
+  transform: rotateX(0deg) rotateZ(0deg);
+}
+
+/* Stacking context layers */
+.iso-layer {
+  position: absolute;
+  width: 240px;
+  height: 160px;
+  border-radius: 12px;
+  border: 2px solid transparent;
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem;
+  transition:
+    transform 0.8s cubic-bezier(0.25, 0.8, 0.25, 1),
+    background-color 0.4s ease;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  transform-style: preserve-3d;
+}
+
+/* Layer 1: Backdrop/Parent Layer */
+.layer-backdrop {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(255, 255, 255, 0.1);
+  transform: translateZ(0px);
+  z-index: 1;
+}
+
+/* Layer 2: Child Element A (z-index: 10) */
+.layer-child-a {
+  background: rgba(139, 92, 246, 0.9); /* Purple */
+  border-color: rgba(139, 92, 246, 0.4);
+  width: 140px;
+  height: 90px;
+  top: 20px;
+  left: 20px;
+  box-shadow: 0 15px 30px rgba(139, 92, 246, 0.4);
+  transform: translateZ(60px); /* Lifted in 3D */
+  z-index: 10;
+}
+
+/* Layer 3: Sibling Element B (z-index: 2) */
+.layer-sibling-b {
+  background: rgba(236, 72, 153, 0.95); /* Pink */
+  border-color: rgba(236, 72, 153, 0.4);
+  width: 140px;
+  height: 90px;
+  bottom: 20px;
+  right: 20px;
+  box-shadow: 0 15px 30px rgba(236, 72, 153, 0.4);
+  transform: translateZ(120px); /* Lifted higher in 3D */
+  z-index: 2;
+}
+
+/* Hover overlays / lines mapping the stack connections */
+.iso-connector-line {
+  position: absolute;
+  border-left: 2px dashed rgba(255, 255, 255, 0.2);
+  width: 2px;
+  pointer-events: none;
+  transition: opacity 0.5s ease;
+}
+
+.layer-label {
+  font-size: 0.85rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: white;
+}
+
+.layer-info {
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+/* Control Panel & UI Elements */
+.controls {
+  margin-top: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.controls-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.control-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-main);
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.control-info {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+}
+
+.btn-primary-demo {
+  background: linear-gradient(
+    135deg,
+    var(--accent-cyan) 0%,
+    var(--accent-purple) 100%
+  );
+  border: none;
+  color: white;
+  padding: 0.65rem 1.35rem;
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  font-weight: 700;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(6, 182, 212, 0.3);
+  transition: all 0.25s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.btn-primary-demo:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(6, 182, 212, 0.45);
+}
+
+.btn-primary-demo:active {
+  transform: translateY(1px);
+}
+
+/* Style range slider */
+.demo-range {
+  -webkit-appearance: none;
+  width: 100%;
+  max-width: 180px;
+  height: 6px;
+  background: var(--border-color);
+  border-radius: 3px;
+  outline: none;
+}
+
+.demo-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--text-main);
+  cursor: pointer;
+  transition: transform 0.1s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.demo-range::-webkit-slider-thumb:hover {
+  transform: scale(1.25);
+  background: var(--accent-cyan);
+}
+
+/* Segmented Control toggles */
+.seg-control {
+  display: flex;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0.25rem;
+  border-radius: 8px;
+}
+
+.seg-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.45rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.seg-btn.active {
+  background: var(--bg-tertiary);
+  color: var(--text-main);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
+}
+
+/* Toggle Switch Style */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider-toggle {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background-color: var(--border-color);
+  transition: 0.3s;
+  border-radius: 34px;
+}
+
+.slider-toggle:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.3s;
+  border-radius: 50%;
+}
+
+input:checked + .slider-toggle {
+  background-image: linear-gradient(
+    135deg,
+    var(--accent-cyan),
+    var(--accent-purple)
+  );
+}
+
+input:checked + .slider-toggle:before {
+  transform: translateX(24px);
+}
+
+/* Interactive elements in Stacking visualization */
+.stack-sliders {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.stack-slider-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 8px;
+  padding: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.stack-slider-col span {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+/* Footer style */
+.demo-footer {
+  margin-top: auto;
+  padding: 3rem 1.5rem;
+  text-align: center;
+  border-top: 1px solid var(--border-color);
+  width: 100%;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  background: #06090f;
+  position: relative;
+  z-index: 1;
+}
+
+.demo-footer a {
+  color: var(--accent-cyan);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.demo-footer a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Fixes #15907

### Description
This PR adds the `.ease-isolate` utility class demo under `submissions/examples/15907-isolation-utility-tm/`. The demo is a premium, interactive playground showing how `isolation: isolate` establishes a new stacking context. Features:
- Mix-blend isolation showcase (preventing element mix-blend-mode from bleeding into parent gradient backdrop).
- 3D stacking visualizer (interactive 3D layering showing how child z-index is trapped inside isolated parent).

### Checklist
- [x] Make sure no existing issue already covers this idea
- [x] Read the Contribution Guide before opening a PR
- [x] Add files only inside submissions/examples/your-feature-name/
- [x] Include demo.html · style.css · README.md in your folder