### PR TITLE
feat(nav): add touch-friendly horizontal scrolling with fade mask

### DIFF
--- a/submissions/Header-Content-Overflow/README.md
+++ b/submissions/Header-Content-Overflow/README.md
@@ -1,0 +1,14 @@
+# Bug 2: Header Content Overflow (Advanced Fix)
+
+## Overview
+Resolves the issue where navigation links are cut off on narrow screens by implementing a modern, touch-friendly horizontal scrolling track.
+
+## Advanced Implementation Details
+This solution goes beyond simple `overflow-x: auto`:
+1. **CSS `mask-image`**: Applies a linear gradient mask to the scroll container, creating a subtle fade-out effect on the right side. This serves as a visual cue to the user that more content exists off-screen.
+2. **Scroll Snapping (`scroll-snap-type`)**: Forces the scrolling to elegantly snap to the beginning of each link item, providing a premium, app-like feel on mobile devices.
+3. **`overscroll-behavior-inline`**: Prevents accidental history navigation (swiping back) when the user reaches the end of the horizontal scroll track on trackpads and touch screens.
+4. **Invisible Scrollbars**: Fully hides scrollbars across all rendering engines (Gecko/Webkit) while maintaining keyboard and touch accessibility.
+
+## Testing
+Open `demo.html` in a browser. Try swiping horizontally on the navigation links or using `Shift + ScrollWheel`. Notice the smooth fade on the right side.

--- a/submissions/Header-Content-Overflow/demo.html
+++ b/submissions/Header-Content-Overflow/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bug 2: Advanced Overflow Handling</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="mobile-viewport-simulator">
+    <header class="docs-header">
+      <a href="#" class="docs-logo">EaseMotion</a>
+      <div class="scroll-mask-container">
+        <ul class="docs-header-links scroll-snap-track">
+          <li><a href="#getting-started">Getting Started</a></li>
+          <li><a href="#utilities">Utilities</a></li>
+          <li><a href="#animations">Animations</a></li>
+          <li><a href="#components">Components</a></li>
+          <li><a href="#demo" class="btn-primary">Live Demo →</a></li>
+        </ul>
+      </div>
+    </header>
+  </div>
+</body>
+</html>

--- a/submissions/Header-Content-Overflow/style.css
+++ b/submissions/Header-Content-Overflow/style.css
@@ -1,0 +1,30 @@
+/* --- Boilerplate & Resets --- */
+body { background: #0f172a; margin: 0; padding: 2rem; font-family: sans-serif; }
+.mobile-viewport-simulator { width: 375px; border: 2px solid #334155; margin: 0 auto; border-radius: 12px; overflow: hidden; }
+.docs-header { display: flex; align-items: center; padding: 1rem; background: #1e293b; gap: 1rem; }
+.docs-logo { color: #a78bfa; font-weight: bold; text-decoration: none; flex-shrink: 0; }
+.docs-header-links { list-style: none; padding: 0; margin: 0; display: flex; gap: 1rem; align-items: center; }
+.docs-header-links a { color: #f8fafc; text-decoration: none; white-space: nowrap; }
+.btn-primary { background: #6c63ff; padding: 6px 12px; border-radius: 20px; }
+
+/* --- THE ADVANCED FIX --- */
+/* 1. Mask container: Creates a visual fade-out effect on the right edge */
+.scroll-mask-container {
+  flex-grow: 1;
+  mask-image: linear-gradient(to right, black 85%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, black 85%, transparent 100%);
+}
+
+/* 2. Scroll Track: Native horizontal scrolling with snap points */
+.scroll-snap-track {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain; /* Prevents pull-to-refresh on mobile swipe */
+  scroll-snap-type: x mandatory;       /* Snaps to links for a native feel */
+  scrollbar-width: none;               /* Standard standard scrollbar hiding */
+  padding-right: 2rem;                 /* Breathing room for the mask fade */
+}
+
+.scroll-snap-track::-webkit-scrollbar { display: none; /* Safari/Chrome hide */ }
+.scroll-snap-track li { scroll-snap-align: start; }


### PR DESCRIPTION
Overview
Resolves the accessibility and layout bug where navigation items are clipped off the right side of the screen on narrow viewports, trapping the user without access to core links.
Advanced Implementation Details
This solution bypasses standard, clunky scrollbars in favor of a modern mobile-first experience:
Visual Fade Cue: Applied a CSS mask-image linear gradient to the container. This creates a subtle visual fade-out on the right edge, intuitively signaling to users that more content exists off-screen.
Scroll Snapping: Implemented scroll-snap-type: x mandatory to ensure the scrolling elegantly locks to the start of each link, providing a native app feel.
Overscroll Protection: Added overscroll-behavior-inline: contain to prevent accidental history swiping (going back a page) when users reach the end of the menu track.
Hidden Scrollbars: Standardized invisible scrollbars across Webkit and Firefox.
Testing Instructions
Pull down this branch and open demo.html.
Use mobile emulation in Chrome DevTools (or shrink the window).
Swipe horizontally on the navigation track. Observe the snapping behavior and the right-side fade mask.
closes #16947 
