### PR TITLE
feat: add gallery zoom effect for issue #13573

### DIFF
--- a/submissions/examples/13573-gallery-zoom-ag/README.md
+++ b/submissions/examples/13573-gallery-zoom-ag/README.md
@@ -1,0 +1,12 @@
+# Gallery Zoom Effect
+
+1. What does this do? Scales up an image smoothly inside a fixed-size container on hover without causing any layout shift.
+2. How is it used? Wrap an `<img>` tag inside a container with the `.gallery-zoom` class:
+
+   ```html
+   <div class="gallery-zoom">
+     <img src="image.jpg" alt="Gallery image" />
+   </div>
+   ```
+
+3. Why is it useful? It is a classic interactive gallery design pattern that adds polish and visual interest to photo grids, portfolio sites, and e-commerce listings while keeping the layout completely stable.

--- a/submissions/examples/13573-gallery-zoom-ag/demo.html
+++ b/submissions/examples/13573-gallery-zoom-ag/demo.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gallery Zoom Effect - EaseMotion CSS</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <header>
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>Gallery Hover Zoom</h1>
+        <p class="description">
+          A sleek, classic gallery zoom effect. Hovering over a fixed-size card
+          zooms the image within container boundaries without causing any layout
+          shift.
+        </p>
+      </header>
+
+      <section class="grid" aria-label="Interactive image zoom gallery">
+        <article class="gallery-zoom" aria-label="Misty Forest">
+          <img
+            src="https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?auto=format&fit=crop&w=600&q=80"
+            alt="Misty evergreen forest under soft sunlight"
+            loading="lazy"
+          />
+          <div class="card-overlay">
+            <h2 class="card-title">Misty Forest</h2>
+            <p class="card-category">Nature</p>
+          </div>
+        </article>
+
+        <article class="gallery-zoom" aria-label="Alpine Peak">
+          <img
+            src="https://images.unsplash.com/photo-1454496522488-7a8e488e8606?auto=format&fit=crop&w=600&q=80"
+            alt="Snow-covered alpine mountain range under clear blue sky"
+            loading="lazy"
+          />
+          <div class="card-overlay">
+            <h2 class="card-title">Alpine Peak</h2>
+            <p class="card-category">Adventure</p>
+          </div>
+        </article>
+
+        <article class="gallery-zoom" aria-label="Sunset Coast">
+          <img
+            src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=600&q=80"
+            alt="Golden sunset reflecting on calm ocean waves and sandy beach"
+            loading="lazy"
+          />
+          <div class="card-overlay">
+            <h2 class="card-title">Sunset Coast</h2>
+            <p class="card-category">Seascape</p>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/13573-gallery-zoom-ag/style.css
+++ b/submissions/examples/13573-gallery-zoom-ag/style.css
@@ -1,0 +1,158 @@
+/* Base reset for demo */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #f8fafc;
+  background: linear-gradient(135deg, #0f172a, #1e1b4b, #020617);
+  padding: 2rem;
+}
+
+.shell {
+  width: min(94vw, 1000px);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #818cf8;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: clamp(2.2rem, 7vw, 4.2rem);
+  background: linear-gradient(to right, #ffffff, #c7d2fe);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.description {
+  color: #94a3b8;
+  max-width: 600px;
+  margin: 0 auto 3rem;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+/* =============================================
+   CORE UTILITY CLASSES
+   ============================================= */
+
+/* Container: overflow hidden, fixed dimensions */
+.gallery-zoom {
+  position: relative;
+  overflow: hidden;
+  width: 300px;
+  height: 200px;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  /* Force hardware acceleration and fix clipping bugs in safari/webkit */
+  transform: translateZ(0);
+  background: #1e293b;
+}
+
+/* img: scale(1.1) on container :hover */
+.gallery-zoom img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  /* Smooth transition */
+  transition: transform 0.4s cubic-bezier(0.25, 1, 0.5, 1);
+  will-change: transform;
+}
+
+.gallery-zoom:hover img {
+  transform: scale(1.1);
+}
+
+/* =============================================
+   DEMO-SPECIFIC LAYOUT
+   ============================================= */
+
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 24px;
+  margin-top: 2rem;
+}
+
+/* Glassmorphism card overlay for extra aesthetic polish */
+.card-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.8) 0%,
+    rgba(0, 0, 0, 0) 60%
+  );
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 16px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.gallery-zoom:hover .card-overlay {
+  opacity: 1;
+}
+
+.card-title {
+  font-weight: 700;
+  font-size: 1rem;
+  color: #ffffff;
+  margin: 0 0 4px 0;
+  transform: translateY(10px);
+  transition: transform 0.4s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.gallery-zoom:hover .card-title {
+  transform: translateY(0);
+}
+
+.card-category {
+  font-size: 0.75rem;
+  color: #a5b4fc;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+  transform: translateY(10px);
+  transition: transform 0.4s cubic-bezier(0.25, 1, 0.5, 1) 0.05s;
+}
+
+.gallery-zoom:hover .card-category {
+  transform: translateY(0);
+}
+
+/* Accessibility: Support prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .gallery-zoom img,
+  .card-overlay,
+  .card-title,
+  .card-category {
+    transition: none !important;
+  }
+  .gallery-zoom:hover img {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
Resolves #13573

### Description
This PR adds the Gallery Zoom Effect component to the self-contained submissions. When hovering over the fixed-size card container, the image smoothly scales up (`scale(1.1)`) without causing any layout shifts.

### Review Instructions
Open `submissions/examples/13573-gallery-zoom-ag/demo.html` directly in a browser. Hover over the cards to observe the smooth image zoom and verify that the layout remains completely stable.