### PR TITLE
fix(typography): inject global eyebrow em-dash via pseudo-elements

### DIFF
--- a/submissions/Missing-Dash/README.md
+++ b/submissions/Missing-Dash/README.md
@@ -1,0 +1,15 @@
+# Bug 3: Missing Eyebrow Em-Dash (Advanced Fix)
+
+## Overview
+Adds the missing em-dash (`—`) before eyebrow headings across the documentation site. 
+
+## Advanced Implementation Details
+Instead of hardcoding the `&mdash;` HTML entity into the `index.html` file, this fix utilizes a scalable CSS architecture. 
+
+1. **CSS `::before` Pseudo-element**: The em-dash is injected globally to any element with the `.docs-eyebrow` class via the `content` property. 
+2. **Semantic HTML**: This keeps the HTML structure clean and strictly semantic. Screen readers and content scrapers will read "Introduction" rather than "Dash Introduction".
+3. **`user-select: none`**: The injected dash cannot be highlighted by the cursor, ensuring that if a user double-clicks to copy the section title, they only copy the actual text.
+4. **CSS Custom Properties**: The dash string and its spacing are stored in `:root` variables, allowing for instantaneous global updates if the brand design changes in the future.
+
+## Testing
+Open `demo.html`. You will see the em-dashes rendered perfectly before both section headers, despite not existing in the DOM tree's text nodes.

--- a/submissions/Missing-Dash/demo.html
+++ b/submissions/Missing-Dash/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bug 3: Advanced Typographical Fix</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="docs-content">
+    <section class="docs-section">
+      <div class="docs-eyebrow" data-prefix="intro">Introduction</div>
+      <h1 class="docs-h1">EaseMotion CSS</h1>
+      <p>Content goes here...</p>
+    </section>
+
+    <section class="docs-section">
+      <div class="docs-eyebrow">Core Concepts</div>
+      <h2 class="docs-h2">Animations First</h2>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/Missing-Dash/style.css
+++ b/submissions/Missing-Dash/style.css
@@ -1,0 +1,31 @@
+/* --- Boilerplate & Resets --- */
+body { background: #0f172a; color: #f8fafc; font-family: sans-serif; padding: 4rem; margin: 0; }
+.docs-h1, .docs-h2 { margin: 0.5rem 0 1rem 0; font-weight: 800; }
+.docs-section { margin-bottom: 3rem; }
+
+/* --- THE ADVANCED FIX --- */
+/* Global typographical scaling variables */
+:root {
+  --eyebrow-color: #a78bfa;
+  --eyebrow-spacing: 0.5rem;
+  --eyebrow-prefix: "— "; /* The Em-Dash with a trailing space */
+}
+
+/* Base style for the semantic container */
+.docs-eyebrow {
+  color: var(--eyebrow-color);
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  display: flex;
+  align-items: center;
+}
+
+/* Pseudo-element injection */
+.docs-eyebrow::before {
+  content: var(--eyebrow-prefix);
+  margin-right: var(--eyebrow-spacing);
+  opacity: 0.8; /* Subtle visual hierarchy */
+  user-select: none; /* Prevents users from accidentally highlighting the dash when copying text */
+}


### PR DESCRIPTION
Overview
This PR adds the missing typographical em-dash (—) to all section eyebrow headings to ensure the live site strictly matches the original design specifications.
Advanced Implementation Details
Rather than manually hardcoding HTML entities (&mdash;) into individual text nodes—which is tedious and error-prone—this fix establishes a global, automated typographical system:
Pseudo-element Injection: The em-dash is now injected globally into any .docs-eyebrow class via CSS ::before.
Semantic Integrity: The HTML remains strictly semantic. Screen readers will read the content cleanly without being forced to read "Dash" before every section.
Copy/Paste Protection: Added user-select: none to the injected dash so that if a user highlights the section text, they don't accidentally copy the styling character.
Root Configuration: Spacing and the prefix character are stored in :root variables for instant global theming updates.
Testing Instructions
Pull down this branch and open demo.html.
Verify the em-dash appears before the text.
Try to highlight the word "Introduction" with your mouse; notice that the dash itself cannot be highlighted, validating the user-select fix.
closes #16952 