### PR TITLE
feat: add powerup glow highlights for issue #13738

### DIFF
--- a/submissions/examples/13738-powerup-glow-ag/README.md
+++ b/submissions/examples/13738-powerup-glow-ag/README.md
@@ -1,0 +1,12 @@
+# Power-up Glow Effect
+
+1. What does this do? Combines a pulsing box-shadow glow with a slow, continuous rotation of a gradient border to highlight special or power-up items.
+2. How is it used? Wrap an icon/item inside a container with the `.powerup-glow` class:
+
+   ```html
+   <div class="powerup-glow">
+     <!-- Your item icon here -->
+   </div>
+   ```
+
+3. Why is it useful? It is a highly engaging micro-interaction ideal for game shop UIs, e-commerce listings, loot box reveals, or feature highlights, drawing user attention without layout shifts.

--- a/submissions/examples/13738-powerup-glow-ag/demo.html
+++ b/submissions/examples/13738-powerup-glow-ag/demo.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Power-up Glow Effect - EaseMotion CSS</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <header>
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>Power-up Highlight</h1>
+        <p class="description">
+          A combination of box-shadow glow pulsing and slow gradient outline
+          rotation indicating special or power-up items in a game shop
+          interface.
+        </p>
+      </header>
+
+      <section class="shop-grid" aria-label="Game item shop">
+        <!-- Card 1: Sword -->
+        <article class="item-card">
+          <div class="item-preview">
+            <div class="powerup-glow" aria-hidden="true">
+              <span class="item-icon">⚔️</span>
+            </div>
+          </div>
+          <h2 class="item-title">Starfall Sword</h2>
+          <p class="item-rarity rarity-legendary">Legendary</p>
+          <div class="item-cost">1,200 Gold</div>
+        </article>
+
+        <!-- Card 2: Potion -->
+        <article class="item-card">
+          <div class="item-preview">
+            <div class="powerup-glow potion-glow" aria-hidden="true">
+              <span class="item-icon">🧪</span>
+            </div>
+          </div>
+          <h2 class="item-title">Elixir of Life</h2>
+          <p class="item-rarity rarity-epic">Epic</p>
+          <div class="item-cost">450 Gold</div>
+        </article>
+
+        <!-- Card 3: Shield -->
+        <article class="item-card">
+          <div class="item-preview">
+            <div class="powerup-glow shield-glow" aria-hidden="true">
+              <span class="item-icon">🛡️</span>
+            </div>
+          </div>
+          <h2 class="item-title">Vanguard Shield</h2>
+          <p class="item-rarity rarity-epic">Epic</p>
+          <div class="item-cost">600 Gold</div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/13738-powerup-glow-ag/style.css
+++ b/submissions/examples/13738-powerup-glow-ag/style.css
@@ -1,0 +1,245 @@
+/* Base reset for demo */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #f8fafc;
+  background: linear-gradient(135deg, #09090b, #0f172a, #020617);
+  padding: 2rem;
+}
+
+.shell {
+  width: min(94vw, 1000px);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #ec4899;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: clamp(2.2rem, 7vw, 4.2rem);
+  background: linear-gradient(to right, #ffffff, #f472b6, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.description {
+  color: #94a3b8;
+  max-width: 600px;
+  margin: 0 auto 3rem;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+/* =============================================
+   CORE UTILITY CLASSES
+   ============================================= */
+
+:root {
+  --ease-glow-color-1: #ec4899;
+  --ease-glow-color-2: #8b5cf6;
+  --ease-glow-speed: 3s;
+  --ease-rotate-speed: 8s;
+}
+
+.powerup-glow {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border-radius: 24px;
+  display: grid;
+  place-items: center;
+  background: #18181b;
+  border: 2px solid var(--ease-glow-color-1);
+  /* Pulsing glow animation */
+  animation: powerup-pulse var(--ease-glow-speed) ease-in-out infinite;
+}
+
+/* Pseudo-element for the slowly rotating gradient outline */
+.powerup-glow::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 28px;
+  padding: 3px;
+  background: linear-gradient(
+    135deg,
+    var(--ease-glow-color-1),
+    var(--ease-glow-color-2),
+    #3b82f6,
+    var(--ease-glow-color-1)
+  );
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  /* Rotation animation */
+  animation: powerup-spin var(--ease-rotate-speed) linear infinite;
+}
+
+@keyframes powerup-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes powerup-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 15px 2px rgba(236, 72, 153, 0.4),
+      0 0 30px 4px rgba(139, 92, 246, 0.2);
+    border-color: var(--ease-glow-color-1);
+  }
+  50% {
+    box-shadow:
+      0 0 25px 6px rgba(236, 72, 153, 0.7),
+      0 0 50px 12px rgba(139, 92, 246, 0.5);
+    border-color: var(--ease-glow-color-2);
+  }
+}
+
+/* =============================================
+   DEMO LAYOUT & DECORATIONS
+   ============================================= */
+
+.shop-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 32px;
+  margin-top: 2rem;
+}
+
+.item-card {
+  background: #18181b;
+  border: 1px solid #27272a;
+  border-radius: 28px;
+  padding: 24px;
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+  transition:
+    transform 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.item-card:hover {
+  transform: translateY(-8px);
+  border-color: #3f3f46;
+}
+
+.item-preview {
+  margin-bottom: 20px;
+  display: grid;
+  place-items: center;
+  width: 140px;
+  height: 140px;
+}
+
+/* Large emojis or stylized elements for shop items */
+.item-icon {
+  font-size: 3rem;
+  line-height: 1;
+  filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.3));
+  transition: transform 0.3s ease;
+}
+
+.item-card:hover .item-icon {
+  transform: scale(1.1) rotate(5deg);
+}
+
+.item-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0 0 6px 0;
+  color: #ffffff;
+}
+
+.item-rarity {
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin: 0 0 16px 0;
+}
+
+.rarity-legendary {
+  color: #fbbf24;
+}
+
+.rarity-epic {
+  color: #a78bfa;
+}
+
+.rarity-common {
+  color: #94a3b8;
+}
+
+.item-cost {
+  background: #27272a;
+  padding: 6px 16px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: #e4e4e7;
+}
+
+/* Custom speed / color variations using variables */
+.potion-glow {
+  --ease-glow-color-1: #a78bfa;
+  --ease-glow-color-2: #8b5cf6;
+  --ease-glow-speed: 2.2s;
+  --ease-rotate-speed: 6s;
+}
+
+.shield-glow {
+  --ease-glow-color-1: #60a5fa;
+  --ease-glow-color-2: #3b82f6;
+  --ease-glow-speed: 4s;
+  --ease-rotate-speed: 12s;
+}
+
+/* Accessibility: Support prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .powerup-glow {
+    animation: none !important;
+  }
+  .powerup-glow::before {
+    animation: none !important;
+  }
+  .item-card:hover {
+    transform: none !important;
+  }
+  .item-card:hover .item-icon {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
Resolves #13738

### Description
This PR implements the Power-up Glow Highlight component inside the self-contained submissions folder. It combines a pulsing box-shadow glow effect with a slowly rotating gradient outline on the pseudo-elements.

### Review Instructions
Open `submissions/examples/13738-powerup-glow-ag/demo.html` directly in any web browser to preview the fantasy shop dashboard showcasing Starfall Sword, Elixir of Life, and Vanguard Shield with the interactive power-up animations.