### PR TITLE
resolve #17142: MacOS Style Floating Dock Navigation Bar

### DIFF
--- a/submissions/examples/new-floating-dock-nav-sn100/README.md
+++ b/submissions/examples/new-floating-dock-nav-sn100/README.md
@@ -1,0 +1,7 @@
+﻿# MacOS Style Floating Dock Navigation Bar
+
+macOS-inspired floating dock navigation selector expanding icons on hover.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-floating-dock-nav-sn100/demo.html
+++ b/submissions/examples/new-floating-dock-nav-sn100/demo.html
@@ -1,0 +1,29 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: MacOS Style Floating Dock Navigation Bar</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-dock">
+  <div class="dock-item"><span>🏠</span></div>
+  <div class="dock-item"><span>✉️</span></div>
+  <div class="dock-item"><span>⚙️</span></div>
+  <div class="dock-item"><span>👤</span></div>
+  <div class="dock-item"><span>📂</span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/new-floating-dock-nav-sn100/style.css
+++ b/submissions/examples/new-floating-dock-nav-sn100/style.css
@@ -1,0 +1,34 @@
+﻿/* ==========================================================================
+   EaseMotion CSS: MacOS Style Floating Dock Navigation Bar
+   ========================================================================== */
+
+@layer components {
+.ease-dock {
+  display: flex;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  padding: 8px 16px;
+  border-radius: 20px;
+  gap: 12px;
+  align-items: flex-end;
+  backdrop-filter: blur(10px);
+}
+.dock-item {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: rgba(255,255,255,0.1);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+.dock-item:hover {
+  width: 55px;
+  height: 55px;
+  margin: 0 4px;
+  background: #7f00ff;
+}
+}


### PR DESCRIPTION
﻿Closes #17142

## What this does
macOS-inspired floating dock navigation selector expanding icons on hover.

## Files
- `submissions/examples/new-floating-dock-nav-sn100/style.css`
- `submissions/examples/new-floating-dock-nav-sn100/demo.html`
- `submissions/examples/new-floating-dock-nav-sn100/README.md`
