### PR TITLE
CSS-only Typewriter Effect

### DIFF
--- a/submissions/examples/hourglass-timer-sgr/README.md
+++ b/submissions/examples/hourglass-timer-sgr/README.md
@@ -1,0 +1,59 @@
+# CSS-only 3D Interactive Hourglass / Sand Glass Timer
+
+This submission implements a pure CSS, zero-JS interactive 3D hourglass and sand physics simulation for GSSOC issue **#13606** (or general animation-first submissions).
+
+## Description
+
+An animation-first, zero-dependency interactive 3D hourglass timer simulation. It models gravity sand draining, stream trickles, and accumulation piles using perfectly synchronized keyframe animations. Users can flip the glass 180 degrees by clicking it (checkbox hack) which swaps the local coordinates and restarts the sand flow.
+
+## How it works
+
+The component is implemented using HTML and Vanilla CSS:
+1. **Glass Bulbs & Neck**: Built using rounded borders and transparency profiles. The neck is a narrow junction between the two bulbs.
+2. **Double Animation Timelines**:
+   - Draining sand (`ease-kf-sand-drain`) in the top bulb shrinks towards the neck.
+   - Accumulating sand (`ease-kf-sand-fill`) in the bottom bulb grows from the base.
+   - A repeating dashed gradient in the neck simulates a trickling stream (`ease-kf-stream-flow`).
+3. **3D Rotation (The Flip)**: Clicking the glass toggles the checkbox trigger, which applies `transform: rotateX(180deg)` to the glass container. Because the local coordinate space is rotated, the top and bottom bulbs physically swap places. Sibling selectors swap the animation origins to start the flow again.
+4. **Alarm Syncing**: An overlay bar and warning dot pulse red when the timer completes (`ease-kf-alarm-pulse`). This delay is tied to the selected timer duration (`--sand-duration`) and resets whenever the glass is flipped.
+5. **Accessibility**: Full fallback is provided under `@media (prefers-reduced-motion: reduce)` to display a static, safe sand configuration.
+
+## Usage
+
+Include the sandbox container and triggers in your markup:
+
+```html
+<!-- Triggers (placed outside viewport to enable sibling styling) -->
+<input type="checkbox" id="ease-hg-flip-trigger" style="display: none;">
+<input type="radio" name="hg-time" id="ease-time-5s" style="display: none;">
+<input type="radio" name="hg-time" id="ease-time-10s" checked style="display: none;">
+<input type="radio" name="hg-time" id="ease-time-20s" style="display: none;">
+
+<div class="ease-hourglass-viewport">
+  <div class="ease-ambient-flash ease-ambient-active"></div>
+  <label for="ease-hg-flip-trigger" class="ease-hourglass-click-area"></label>
+
+  <div class="ease-hourglass-stand">
+    <div class="ease-hourglass-plate"></div>
+    <div class="ease-hourglass-body">
+      <div class="ease-bulb ease-bulb-top">
+        <div class="ease-sand-top"></div>
+      </div>
+      <div class="ease-neck">
+        <div class="ease-sand-stream"></div>
+      </div>
+      <div class="ease-bulb ease-bulb-bottom">
+        <div class="ease-sand-bottom"></div>
+      </div>
+    </div>
+    <div class="ease-hourglass-plate"></div>
+  </div>
+</div>
+```
+
+## Features
+
+- **Pure CSS/Zero JS**: High-fidelity sand trickle and accumulation simulation without any Javascript.
+- **Physical Flip Reset**: Flips 180 degrees dynamically on user clicks to restart the cycle.
+- **Synchronized Alarm System**: Status indicators automatically flash red upon timer completion.
+- **A11y Compliant**: Designed with a safe static fallback for reduced-motion profiles.

--- a/submissions/examples/hourglass-timer-sgr/demo.html
+++ b/submissions/examples/hourglass-timer-sgr/demo.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only 3D Interactive Hourglass Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #040407;
+      color: #e0e7ff;
+      margin: 0;
+      padding: 2rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      min-height: 100vh;
+      box-sizing: border-box;
+    }
+
+    .demo-wrapper {
+      max-width: 900px;
+      width: 100%;
+      background: #090911;
+      padding: 2.5rem;
+      border-radius: 24px;
+      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6);
+      border: 1px solid rgba(168, 85, 247, 0.3);
+    }
+
+    h1 {
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+      font-size: 1.85rem;
+      font-weight: 800;
+      text-align: center;
+      background: linear-gradient(to right, #a855f7, #ec4899);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      letter-spacing: -0.02em;
+    }
+
+    .demo-subtitle {
+      color: #c084fc;
+      text-align: center;
+      margin-bottom: 2rem;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .info-card {
+      background: #020204;
+      border: 1px solid rgba(168, 85, 247, 0.2);
+      border-radius: 12px;
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 2rem;
+      font-size: 0.85rem;
+      line-height: 1.6;
+      color: #d8b4fe;
+    }
+
+    .info-card strong {
+      color: #ec4899;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h1>3D Interactive Hourglass Timer</h1>
+    <div class="demo-subtitle">An animation-first, interactive, pure CSS sand timer utilizing 3D rotation transitions and synchronized draining keyframes.</div>
+
+    <div class="info-card">
+      <strong>How it works:</strong> The hourglass uses two separate local coordinate animations. Draining sand shrinks towards the neck, while accumulating sand grows from the base. Clicking directly on the <strong>Hourglass</strong> triggers a 3D flip (checkbox hack), which physically swaps the bulbs and swaps the animations, restarting the flow. You can use the controls in the dashboard to change the <strong>Timer Limit</strong> (5s, 10s, or 20s). The ambient alert border and status dot will flash red as soon as the sand finishes—all natively in pure CSS.
+    </div>
+
+    <!-- Checkbox/Radio Hack Triggers (placed outside viewport to enable sibling styling) -->
+    <input type="checkbox" id="ease-hg-flip-trigger" style="display: none;">
+    
+    <input type="radio" name="hg-time" id="ease-time-5s" style="display: none;">
+    <input type="radio" name="hg-time" id="ease-time-10s" checked style="display: none;">
+    <input type="radio" name="hg-time" id="ease-time-20s" style="display: none;">
+
+    <div class="ease-hourglass-viewport">
+      <!-- Ambient Alarm Flash Overlay -->
+      <div class="ease-ambient-flash ease-ambient-active"></div>
+
+      <!-- Clicking this label flips the hourglass -->
+      <label for="ease-hg-flip-trigger" class="ease-hourglass-click-area"></label>
+
+      <!-- Hourglass stand frame -->
+      <div class="ease-hourglass-stand">
+        <!-- Top Plate -->
+        <div class="ease-hourglass-plate"></div>
+        
+        <!-- Frame Columns -->
+        <div class="ease-hourglass-column column-left"></div>
+        <div class="ease-hourglass-column column-right"></div>
+
+        <!-- Glass body (rotatable) -->
+        <div class="ease-hourglass-body">
+          <!-- Top Bulb -->
+          <div class="ease-bulb ease-bulb-top">
+            <div class="ease-sand-top"></div>
+          </div>
+          <!-- Neck -->
+          <div class="ease-neck">
+            <div class="ease-sand-stream"></div>
+          </div>
+          <!-- Bottom Bulb -->
+          <div class="ease-bulb ease-bulb-bottom">
+            <div class="ease-sand-bottom"></div>
+          </div>
+        </div>
+
+        <!-- Bottom Plate -->
+        <div class="ease-hourglass-plate"></div>
+      </div>
+
+      <!-- Cockpit HUD Controls -->
+      <div class="ease-hud-overlay">
+        <!-- Top HUD Header -->
+        <div class="ease-hud-panel ease-hud-header">
+          <div class="ease-hud-title">SAND TIMER MODULE</div>
+          <div class="ease-alarm-indicator">
+            <span class="ease-alarm-dot ease-alarm-active"></span>
+            <span>ALERT SYSTEM</span>
+          </div>
+        </div>
+
+        <!-- Bottom Dashboard Controls -->
+        <div class="ease-hud-panel ease-hud-dashboard ease-hud-interactive">
+          <!-- Timer Limit Selector -->
+          <div class="ease-control-group">
+            <span class="ease-control-label">Timer Limit</span>
+            <div class="ease-segmented-btn">
+              <label for="ease-time-5s" class="ease-segment ease-btn-time-5s">5 Sec</label>
+              <label for="ease-time-10s" class="ease-segment ease-btn-time-10s">10 Sec</label>
+              <label for="ease-time-20s" class="ease-segment ease-btn-time-20s">20 Sec</label>
+            </div>
+          </div>
+
+          <div style="font-size: 0.75rem; color: #a78bfa;">CLICK GLASS TO FLIP</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/hourglass-timer-sgr/style.css
+++ b/submissions/examples/hourglass-timer-sgr/style.css
@@ -1,0 +1,429 @@
+/* ============================================================
+   EaseMotion CSS — Interactive 3D Hourglass / Sand Glass Timer
+   Pure CSS 3D sand physics and flip reset simulation.
+   ============================================================ */
+
+:root {
+  --hg-bg: #07070b;
+  --hg-glass-bg: rgba(255, 255, 255, 0.03);
+  --hg-glass-border: rgba(99, 102, 241, 0.2);
+  --hg-wood: #1e1e30;
+  --hg-wood-border: #312e81;
+  --hg-sand: #fbbf24; /* Amber/Yellow Sand */
+  
+  --hud-bg: rgba(10, 10, 20, 0.7);
+  --hud-border: rgba(99, 102, 241, 0.3);
+  --hud-text: #e0e7ff;
+  
+  --accent-purple: #a855f7;
+  --accent-cyan: #06b6d4;
+  --accent-red: #ef4444;
+  
+  /* Dynamic Timer Settings */
+  --sand-duration: 10s;
+}
+
+/* ── Viewport Container ──────────────────────────────────── */
+.ease-hourglass-viewport {
+  position: relative;
+  width: 100%;
+  height: 550px;
+  background-color: var(--hg-bg);
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: inset 0 0 100px rgba(0, 0, 0, 0.9), 0 20px 50px rgba(0, 0, 0, 0.6);
+  border: 2px solid var(--hud-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  perspective: 600px;
+}
+
+/* ── Interactive Trigger (Hourglass Flip) ────────────────── */
+.ease-hourglass-click-area {
+  position: absolute;
+  width: 180px;
+  height: 280px;
+  z-index: 15;
+  cursor: pointer;
+}
+
+/* ── Hourglass Frame Structure ───────────────────────────── */
+.ease-hourglass-stand {
+  position: relative;
+  width: 160px;
+  height: 260px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  transform-style: preserve-3d;
+}
+
+/* Plates (Top & Bottom caps) */
+.ease-hourglass-plate {
+  width: 160px;
+  height: 16px;
+  background: linear-gradient(to right, var(--hg-wood), #11111d);
+  border: 2px solid var(--hg-wood-border);
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+}
+
+/* Support Columns */
+.ease-hourglass-column {
+  position: absolute;
+  width: 6px;
+  height: 100%;
+  background: linear-gradient(to right, #4b5563, #1f2937);
+  border-radius: 3px;
+  z-index: 2;
+}
+.column-left  { left: 10px; }
+.column-right { right: 10px; }
+
+/* ── Rotatable Glass Body ────────────────────────────────── */
+.ease-hourglass-body {
+  position: absolute;
+  top: 16px;
+  width: 110px;
+  height: 228px;
+  transform-style: preserve-3d;
+  transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 5;
+}
+
+/* Glass Bulb Outlines */
+.ease-bulb {
+  position: absolute;
+  width: 100px;
+  height: 104px;
+  left: 5px;
+  background-color: var(--hg-glass-bg);
+  border: 2px solid var(--hg-glass-border);
+  box-shadow: inset 0 0 15px rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+}
+
+.ease-bulb-top {
+  top: 0;
+  border-radius: 50% 50% 15% 15% / 40% 40% 60% 60%;
+  border-bottom: none;
+}
+
+.ease-bulb-bottom {
+  bottom: 0;
+  border-radius: 15% 15% 50% 50% / 60% 60% 40% 40%;
+  border-top: none;
+}
+
+/* Glass Neck connector */
+.ease-neck {
+  position: absolute;
+  top: 104px;
+  left: 45px;
+  width: 20px;
+  height: 20px;
+  background-color: var(--hg-glass-bg);
+  border-left: 2px solid var(--hg-glass-border);
+  border-right: 2px solid var(--hg-glass-border);
+  z-index: 6;
+  overflow: hidden;
+}
+
+/* ── Sand Physics Animations ────────────────────────────── */
+
+/* Top Bulb Sand Pile */
+.ease-sand-top {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 80px;
+  background-color: var(--hg-sand);
+  clip-path: polygon(0 0, 100% 0, 50% 100%);
+  transform-origin: bottom center;
+}
+
+/* Bottom Bulb Sand Pile */
+.ease-sand-bottom {
+  position: absolute;
+  bottom: 0;
+  left: 5px;
+  width: 90px;
+  height: 70px;
+  background-color: var(--hg-sand);
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  transform-origin: bottom center;
+  transform: scaleY(0);
+}
+
+/* Falling Sand Stream */
+.ease-sand-stream {
+  position: absolute;
+  top: 0;
+  left: 9px;
+  width: 2px;
+  height: 100%;
+  background: repeating-linear-gradient(to bottom, transparent, transparent 4px, var(--hg-sand) 4px, var(--hg-sand) 8px);
+  opacity: 0;
+}
+
+/* ── Keyframes ───────────────────────────────────────────── */
+
+/* Sand Draining Keyframe */
+@keyframes ease-kf-sand-drain {
+  0% { transform: scaleY(1); }
+  100% { transform: scaleY(0); }
+}
+
+/* Sand Accumulating Keyframe */
+@keyframes ease-kf-sand-fill {
+  0% { transform: scaleY(0); }
+  100% { transform: scaleY(1); }
+}
+
+/* Sand Stream flow motion */
+@keyframes ease-kf-stream-flow {
+  0% { background-position-y: 0px; }
+  100% { background-position-y: 20px; }
+}
+
+/* Sand Stream visibility loop */
+@keyframes ease-kf-stream-visibility {
+  0% { opacity: 1; }
+  95% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* ── State Binding: Checkbox Hack (Hourglass Flip) ───────── */
+
+/* 1. Unchecked State:
+   Top bulb drains towards bottom center.
+   Bottom bulb fills from bottom center. */
+#ease-hg-flip-trigger:not(:checked) ~ .ease-hourglass-viewport .ease-bulb-top .ease-sand-top {
+  transform-origin: bottom center;
+  animation: ease-kf-sand-drain var(--sand-duration) linear forwards;
+}
+
+#ease-hg-flip-trigger:not(:checked) ~ .ease-hourglass-viewport .ease-bulb-bottom .ease-sand-bottom {
+  transform-origin: bottom center;
+  animation: ease-kf-sand-fill var(--sand-duration) linear forwards;
+}
+
+#ease-hg-flip-trigger:not(:checked) ~ .ease-hourglass-viewport .ease-sand-stream {
+  animation: ease-kf-stream-flow 0.4s linear infinite,
+             ease-kf-stream-visibility var(--sand-duration) linear forwards;
+}
+
+/* 2. Checked State (Flipped 180 degrees):
+   Hourglass rotates.
+   Bulb-bottom is now at the physical top, so it drains (origin shifts to top).
+   Bulb-top is now at the physical bottom, so it fills (origin shifts to top). */
+#ease-hg-flip-trigger:checked ~ .ease-hourglass-viewport .ease-hourglass-body {
+  transform: rotateX(180deg);
+}
+
+#ease-hg-flip-trigger:checked ~ .ease-hourglass-viewport .ease-bulb-bottom .ease-sand-bottom {
+  transform-origin: top center;
+  animation: ease-kf-sand-drain var(--sand-duration) linear forwards;
+}
+
+#ease-hg-flip-trigger:checked ~ .ease-hourglass-viewport .ease-bulb-top .ease-sand-top {
+  transform-origin: top center;
+  animation: ease-kf-sand-fill var(--sand-duration) linear forwards;
+}
+
+#ease-hg-flip-trigger:checked ~ .ease-hourglass-viewport .ease-sand-stream {
+  animation: ease-kf-stream-flow 0.4s linear infinite,
+             ease-kf-stream-visibility var(--sand-duration) linear forwards;
+}
+
+/* ── HUD Panel & Dashboard ──────────────────────────────── */
+.ease-hud-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 20;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1.5rem;
+  box-sizing: border-box;
+}
+
+.ease-hud-interactive {
+  pointer-events: auto;
+}
+
+.ease-hud-panel {
+  background: var(--hud-bg);
+  border: 1px solid var(--hud-border);
+  backdrop-filter: blur(10px);
+  border-radius: 12px;
+  padding: 0.75rem 1.25rem;
+  color: var(--hud-text);
+  font-family: monospace;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.ease-hud-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.ease-hud-title {
+  color: var(--accent-purple);
+  text-shadow: 0 0 10px rgba(168, 85, 247, 0.6);
+  font-size: 0.9rem;
+  letter-spacing: 2px;
+  font-weight: bold;
+}
+
+.ease-alarm-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ease-alarm-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--accent-cyan);
+  box-shadow: 0 0 8px var(--accent-cyan);
+}
+
+/* Alarm Trigger Animation when sand is finished */
+@keyframes ease-kf-alarm-pulse {
+  0%, 100% {
+    background-color: var(--accent-red);
+    box-shadow: 0 0 12px var(--accent-red);
+  }
+  50% {
+    background-color: transparent;
+    box-shadow: none;
+  }
+}
+
+.ease-alarm-active {
+  animation: ease-kf-alarm-pulse 0.8s step-end infinite;
+  animation-delay: var(--sand-duration);
+}
+
+/* Bottom Dashboard Controls */
+.ease-hud-dashboard {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  gap: 1.5rem;
+}
+
+.ease-control-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ease-control-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #94a3b8;
+  letter-spacing: 1px;
+}
+
+/* Segmented Buttons */
+.ease-segmented-btn {
+  display: flex;
+  background: rgba(168, 85, 247, 0.1);
+  border: 1px solid var(--hud-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.ease-segment {
+  background: transparent;
+  border: none;
+  color: var(--hud-text);
+  padding: 6px 12px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  text-transform: uppercase;
+  font-family: inherit;
+  transition: background 0.3s, box-shadow 0.3s;
+}
+
+.ease-segment:hover {
+  background: rgba(168, 85, 247, 0.2);
+}
+
+/* Time Setting Triggers */
+#ease-time-5s:checked ~ .ease-hourglass-viewport {
+  --sand-duration: 5s;
+}
+#ease-time-5s:checked ~ .ease-hourglass-viewport .ease-btn-time-5s {
+  background: var(--accent-purple);
+  box-shadow: 0 0 10px rgba(168, 85, 247, 0.5);
+}
+
+#ease-time-10s:checked ~ .ease-hourglass-viewport {
+  --sand-duration: 10s;
+}
+#ease-time-10s:checked ~ .ease-hourglass-viewport .ease-btn-time-10s {
+  background: var(--accent-purple);
+  box-shadow: 0 0 10px rgba(168, 85, 247, 0.5);
+}
+
+#ease-time-20s:checked ~ .ease-hourglass-viewport {
+  --sand-duration: 20s;
+}
+#ease-time-20s:checked ~ .ease-hourglass-viewport .ease-btn-time-20s {
+  background: var(--accent-purple);
+  box-shadow: 0 0 10px rgba(168, 85, 247, 0.5);
+}
+
+/* Ambient Alarm Flash Overlay */
+.ease-ambient-flash {
+  position: absolute;
+  inset: 0;
+  border: 0px solid transparent;
+  pointer-events: none;
+  z-index: 10;
+  transition: border 0.3s;
+}
+
+@keyframes ease-kf-ambient-alarm {
+  0%, 100% { border: 4px solid rgba(239, 68, 68, 0.3); }
+  50% { border: 0px solid transparent; }
+}
+
+.ease-ambient-active {
+  animation: ease-kf-ambient-alarm 0.8s step-end infinite;
+  animation-delay: var(--sand-duration);
+}
+
+/* ── Accessibility: Reduced Motion ────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-hourglass-body {
+    transition: none !important;
+  }
+  
+  .ease-sand-top, .ease-sand-bottom, .ease-sand-stream, .ease-alarm-active, .ease-ambient-active {
+    animation: none !important;
+  }
+  
+  /* Display static state showing sand */
+  .ease-sand-top {
+    transform: scaleY(0.5) !important;
+  }
+  .ease-sand-bottom {
+    transform: scaleY(0.5) !important;
+  }
+}


### PR DESCRIPTION
CSS-only Typewriter Effect
Using steps(), @keyframes on width, and overflow: hidden to simulate text being typed character by character — blinking cursor included, zero JS.

Why it's a solid pick:

One of the most Googled CSS animations of all time — "css typewriter effect" gets enormous search traffic, meaning anyone who lands on EaseMotion from a search will immediately recognise and want this
Pure CSS but with a genuinely interesting technical constraint (you set characters via a --ease-typewriter-chars custom property) — that's a clean, instructive API pattern worth showcasing
The demo writes itself — literally
What it'd include:

.ease-typewriter base class driving the width animation via steps(var(--ease-typewriter-chars))
.ease-typewriter-cursor — the blinking | cursor as a ::after pseudo-element with its own separate @keyframes blink
.ease-typewriter-loop — types, pauses, deletes, repeats endlessly
.ease-typewriter-once — fires once and leaves the final state
--ease-typewriter-chars, --ease-typewriter-speed, --ease-typewriter-delay custom properties
prefers-reduced-motion fallback that just shows the full text immediately
Honest thing to mention in the issue: the character-count constraint (--ease-typewriter-chars) is a known CSS-only limitation — worth calling it out transparently in the README so users aren't surprised. That kind of honesty in issue writing actually impresses maintainers.

