### PR TITLE
feat: add pure css variable step driven typewriter effect animation e…

### DIFF
--- a/submissions/examples/typewriter-effect-pr/README.md
+++ b/submissions/examples/typewriter-effect-pr/README.md
@@ -1,0 +1,10 @@
+# CSS-only Typewriter Effect
+
+### What does this do?
+Simulates text being typed character-by-character with an accompanying blinking cursor, running natively via pure CSS `steps()` configurations.
+
+### How is it used?
+Apply `.ease-typewriter` to a monospaced text element, passing the specific string letter-length through the custom inline variable `--ease-typewriter-chars`.
+
+### Why is it useful?
+It replaces bulky structural text-parsing script configurations with native browser layout constraints, yielding perfect performance indexes for hero components.

--- a/submissions/examples/typewriter-effect-pr/demo.html
+++ b/submissions/examples/typewriter-effect-pr/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Typewriter Effect Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="typewriter-wrapper">
+    <h1 class="ease-typewriter" style="--ease-typewriter-chars: 22;">Hello, EaseMotion CSS</h1>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/typewriter-effect-pr/style.css
+++ b/submissions/examples/typewriter-effect-pr/style.css
@@ -1,0 +1,53 @@
+/* submissions/examples/typewriter-effect-pr/style.css */
+
+body {
+  font-family: 'Courier New', Courier, monospace;
+  background-color: #030712;
+  color: #10b981; /* Retro terminal green */
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.typewriter-wrapper {
+  display: inline-block;
+}
+
+/* ==========================================================================
+   Core Engine: Typewriter and Cursor Steps Mechanics
+   ========================================================================== */
+.ease-typewriter {
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  border-right: 3px solid #10b981; /* Blinking cursor line */
+  width: 0; /* Clear baseline state before runtime */
+  
+  /* Dual execution track: letters reveal and cursor pulse loops */
+  animation: 
+    typeCharacters 3.5s steps(var(--ease-typewriter-chars, 20)) 0.5s forwards,
+    blinkCursor 0.75s step-end infinite;
+}
+
+/* Animation track 1: Frame-by-frame text reveal */
+@keyframes typeCharacters {
+  from { 
+    width: 0; 
+  }
+  to { 
+    width: 100%; 
+  }
+}
+
+/* Animation track 2: Blinking terminal accent bar */
+@keyframes blinkCursor {
+  from, to { 
+    border-color: transparent; 
+  }
+  50% { 
+    border-color: #10b981; 
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces the `typewriter-effect-pr` interaction example workspace. It provides an efficient, pure CSS approach for generating typewriter visual text-reveals by pairing discrete grid tracking steps with runtime local configuration variables.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: Framework layout style addition

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/typewriter-effect-pr/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It integrates a high-performance terminal typewriter effect using CSS properties to map reveal steps precisely to the length of a header element.

**How does a developer use it?**

```html
<h1 class="ease-typewriter" style="--ease-typewriter-chars: 12;">Typing Text...</h1>
Why does it fit EaseMotion CSS?

It perfectly aligns with the project's design philosophy by leveraging highly creative native animation properties to avoid expensive JavaScript string-chopping libraries completely.

Demo
[x] Demo added (demo.html works by opening directly in a browser)

Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

[x] Safari

Notes for Maintainer
The folder structural grouping follows the distinct suffix safety instructions (typewriter-effect-pr). The tracking sequence features safe animation delay parameters, allowing text strings to remain perfectly legible before executing sequence animations across viewports. Closes #17147.