### PR TITLE
feat: add readonly input state styling demo (#13257)

### DIFF
--- a/submissions/examples/ease-readonly-input/README.md
+++ b/submissions/examples/ease-readonly-input/README.md
@@ -1,0 +1,22 @@
+﻿# ease-readonly-input – Readonly Input Styling
+
+A CSS snippet that gives [readonly] inputs a distinct, muted style – lighter than disabled, with cursor: text to indicate the field is still readable and selectable, just not editable.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-block, ease-mx-auto, ease-max-w-sm, ease-w-full
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400, ease-font-semibold
+- **Spacing:** ease-mb-1, ease-mb-4, ease-mb-6, ease-mb-8, ease-mt-8
+- **Components:** ease-input
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How it works
+- Apply the class ease-input--readonly to any <input readonly> element.
+- Sets a very light background (#f9fafb) and normal text color, so the field looks active but not editable.
+- Keeps cursor: text to distinguish from disabled fields (which use cursor: not-allowed).
+- A subtle blue focus ring ensures accessibility.
+
+## How to use
+1. Add class="ease-input ease-input--readonly" to your readonly inputs.
+2. Copy the CSS snippet into your project.
+3. Ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-readonly-input/demo.html
+++ b/submissions/examples/ease-readonly-input/demo.html
@@ -1,0 +1,41 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-readonly-input – Readonly Input Styling</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">
+      Readonly Input Styling
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Readonly fields are visually distinct – muted background, <code>cursor: text</code>, not greyed out like disabled.
+    </p>
+
+    <div class="ease-max-w-sm ease-mx-auto">
+      <div class="ease-mb-6 ease-text-left">
+        <label class="ease-text-sm ease-font-semibold ease-mb-1 ease-block">Normal input</label>
+        <input type="text" value="Editable" class="ease-input ease-w-full">
+      </div>
+      <div class="ease-mb-6 ease-text-left">
+        <label class="ease-text-sm ease-font-semibold ease-mb-1 ease-block">Readonly input</label>
+        <input type="text" value="Readonly" readonly class="ease-input ease-input--readonly ease-w-full">
+      </div>
+      <div class="ease-mb-6 ease-text-left">
+        <label class="ease-text-sm ease-font-semibold ease-mb-1 ease-block">Disabled input</label>
+        <input type="text" value="Disabled" disabled class="ease-input ease-w-full">
+      </div>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Readonly: lighter muted background, <code>cursor: text</code>, no full grey‑out.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-readonly-input/style.css
+++ b/submissions/examples/ease-readonly-input/style.css
@@ -1,0 +1,23 @@
+﻿/* ============================================================
+   ease-input--readonly – Readonly input state
+   Muted background, cursor:text, distinct from disabled
+   ============================================================ */
+
+.ease-input--readonly {
+  background-color: #f9fafb;      /* very light grey */
+  border-color: #d1d5db;
+  color: #374151;
+  cursor: text;                    /* not not-allowed */
+}
+
+.ease-input--readonly:focus {
+  outline: 2px solid #93c5fd;
+  outline-offset: -1px;
+}
+
+/* Respect reduced motion – no animations to disable, but good practice */
+@media (prefers-reduced-motion: reduce) {
+  .ease-input--readonly {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #13257

Readonly Input Styling
A demo and CSS snippet for distinguishing readonly inputs from editable and disabled ones.

Files added
- submissions/examples/ease-readonly-input/demo.html
- submissions/examples/ease-readonly-input/style.css
- submissions/examples/ease-readonly-input/README.md

How it works
- Uses .ease-input--readonly class with light background, cursor:text.
- Distinct from disabled styling.
- Focus ring preserved for accessibility.
- Respects prefers-reduced-motion.

EaseMotion classes used
ease-input, ease-container, ease-flex, ease-fade-in, ease-delay-*, etc.

Custom CSS (>5 lines) for readonly state, focus, and accessibility.