### PR TITLE
feat: add ease-saturate-in entrance animation (#17219)

### DIFF
--- a/submissions/examples/ease-saturate-in/README.md
+++ b/submissions/examples/ease-saturate-in/README.md
@@ -1,0 +1,23 @@
+﻿# ease-saturate-in – Saturate Into Color
+
+An entrance animation where an element begins completely grayscale and transparent, then transitions to full saturation and opacity over 0.6 seconds.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-max-w-sm, ease-mx-auto
+- **Background:** ease-bg-gray-100
+- **Components:** ease-card, ease-overflow-hidden
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-6
+- **Buttons:** ease-btn, ease-btn-secondary
+- **Hover:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- The target element starts with ilter: saturate(0) and opacity: 0.
+- When the class .animate is added (on page load or button click), it transitions to saturate(1) and opacity: 1 using a 0.6s ease-out.
+- The animation respects prefers-reduced-motion by showing the element immediately without motion.
+
+## How to use
+1. Add the saturate-box class to any container you want to animate.
+2. Use JavaScript to toggle the class .animate when you want the effect to play.
+3. Copy the CSS into your project; ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-saturate-in/demo.html
+++ b/submissions/examples/ease-saturate-in/demo.html
@@ -1,0 +1,54 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-saturate-in – Saturate Into Color</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-100 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">
+      Saturate In
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      The image starts grayscale and fades into full color.
+    </p>
+
+    <div class="ease-max-w-sm ease-mx-auto">
+      <div id="saturate-box" class="saturate-box ease-card ease-overflow-hidden">
+        <img src="https://placehold.co/400x300" alt="Saturate demo" class="ease-w-full">
+      </div>
+    </div>
+
+    <button id="replay-btn" class="ease-btn ease-btn-secondary ease-hover-scale-105 ease-transition ease-mt-6">
+      Replay Animation
+    </button>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-6 ease-fade-in ease-delay-500">
+      <code>filter: saturate(0)</code> + <code>opacity(0)</code> → <code>saturate(1)</code> + <code>opacity(1)</code> in 0.6s.
+    </p>
+  </div>
+
+  <script>
+    const box = document.getElementById('saturate-box');
+    const replayBtn = document.getElementById('replay-btn');
+
+    function play() {
+      box.classList.remove('animate');
+      void box.offsetWidth; // force reflow
+      box.classList.add('animate');
+    }
+
+    // Auto-play on load
+    window.addEventListener('load', () => {
+      setTimeout(play, 300);
+    });
+
+    replayBtn.addEventListener('click', play);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-saturate-in/style.css
+++ b/submissions/examples/ease-saturate-in/style.css
@@ -1,0 +1,24 @@
+﻿/* ============================================================
+   ease-saturate-in – Grayscale to full color entrance
+   filter: saturate(0) + opacity(0) → saturate(1) + opacity(1)
+   ============================================================ */
+
+.saturate-box {
+  filter: saturate(0);
+  opacity: 0;
+  transition: filter 0.6s ease-out, opacity 0.6s ease-out;
+}
+
+.saturate-box.animate {
+  filter: saturate(1);
+  opacity: 1;
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .saturate-box {
+    transition: none;
+    filter: saturate(1);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Closes #17219

ease-saturate-in – Grayscale to Color Entrance
Element transitions from saturate(0) + opacity(0) → saturate(1) + opacity(1) in 0.6s.

Files added
- submissions/examples/ease-saturate-in/demo.html
- submissions/examples/ease-saturate-in/style.css
- submissions/examples/ease-saturate-in/README.md

How it works
- CSS transition on filter and opacity.
- JavaScript adds .animate class to trigger.
- Replay button and auto-play on load.
- Respects prefers-reduced-motion.

EaseMotion classes used
ease-card, ease-btn, ease-btn-secondary, ease-hover-scale-105, ease-fade-in, ease-delay-*, etc.

Custom CSS (>5 lines) for saturation transition and reduced motion.