### PR TITLE
feat: add ease-desaturate-out exit animation (#17218)

### DIFF
--- a/submissions/examples/ease-desaturate-out/README.md
+++ b/submissions/examples/ease-desaturate-out/README.md
@@ -1,0 +1,25 @@
+﻿# ease-desaturate-out – Desaturate and Fade Exit
+
+An exit animation where an element transitions to grayscale and fades out over 0.5 seconds. Gives a "sad" or "deactivated" feel, useful for removing items or indicating a disabled state.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen
+- **Background:** ease-bg-gray-100
+- **Components:** ease-card, ease-overflow-hidden
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-6
+- **Buttons:** ease-btn, ease-btn-secondary
+- **Hover:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+- **Interactivity:** ease-cursor-pointer
+
+## How it works
+- The element starts with ilter: saturate(1) and opacity: 1.
+- When the class .exit is added (by clicking the card), it transitions to saturate(0) and opacity: 0 using a 0.5s ease‑in.
+- A "Show Again" button removes the .exit class, bringing the element back to its colorful state.
+- The animation respects prefers-reduced-motion.
+
+## How to use
+1. Add the class desaturate-box to any container you want to animate.
+2. Use JavaScript to toggle the class .exit when you want the element to disappear.
+3. Copy the CSS into your project; ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-desaturate-out/demo.html
+++ b/submissions/examples/ease-desaturate-out/demo.html
@@ -1,0 +1,53 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-desaturate-out – Desaturate and Fade Exit</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-100 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">
+      Desaturate Out
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Click the card to see it fade to grayscale and disappear.
+    </p>
+
+    <div id="desaturate-box" class="desaturate-box ease-card ease-overflow-hidden ease-cursor-pointer">
+      <img src="https://placehold.co/400x300" alt="Desaturate demo" class="ease-w-full">
+    </div>
+
+    <button id="replay-btn" class="ease-btn ease-btn-secondary ease-hover-scale-105 ease-transition ease-mt-6">
+      Show Again
+    </button>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-6 ease-fade-in ease-delay-500">
+      <code>filter: saturate(1)</code> → <code>saturate(0)</code> + <code>opacity(0)</code> in 0.5s ease‑in.
+    </p>
+  </div>
+
+  <script>
+    const box = document.getElementById('desaturate-box');
+    const replayBtn = document.getElementById('replay-btn');
+
+    function hideBox() {
+      box.classList.add('exit');
+    }
+
+    function showBox() {
+      box.classList.remove('exit');
+    }
+
+    // Click the card to trigger exit
+    box.addEventListener('click', hideBox);
+
+    // Button to bring it back
+    replayBtn.addEventListener('click', showBox);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-desaturate-out/style.css
+++ b/submissions/examples/ease-desaturate-out/style.css
@@ -1,0 +1,25 @@
+﻿/* ============================================================
+   ease-desaturate-out – Desaturate and fade exit
+   filter: saturate(1) → saturate(0) + opacity(0)
+   ============================================================ */
+
+.desaturate-box {
+  filter: saturate(1);
+  opacity: 1;
+  transition: filter 0.5s ease-in, opacity 0.5s ease-in;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.desaturate-box.exit {
+  filter: saturate(0);
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .desaturate-box {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #17218

ease-desaturate-out – Desaturate and Fade Exit
Element transitions to grayscale (saturate(0)) and fades out in 0.5s ease‑in.

Files added
- submissions/examples/ease-desaturate-out/demo.html
- submissions/examples/ease-desaturate-out/style.css
- submissions/examples/ease-desaturate-out/README.md

How it works
- CSS transition on filter and opacity.
- Click the card to add .exit class → desaturates + fades.
- Show Again button resets the animation.
- Respects prefers-reduced-motion.

EaseMotion classes used
ease-card, ease-btn, ease-btn-secondary, ease-hover-scale-105, ease-fade-in, ease-delay-*, etc.

Custom CSS (>5 lines) for desaturation exit and reduced motion.