### PR TITLE
feat: add ease-sharpen-in cinematic blur-to-focus entrance animation …

### DIFF
--- a/submissions/examples/ease-sharpen-in-pr/README.md
+++ b/submissions/examples/ease-sharpen-in-pr/README.md
@@ -1,0 +1,10 @@
+# Animation: ease-sharpen-in
+
+### What does this do?
+Animate design elements from complete transparency blurred at `12px` to full structural sharpness and visibility across a `0.5s` ease timeline.
+
+### How is it used?
+Incorporate the utility runtime modifier class `.ease-sharpen-in` onto target components or layout cards to govern their initial insertion phase sequence.
+
+### Why is it useful?
+It creates a sophisticated lens-focus transition effect that elevates basic content fade-ins using lightweight, native browser optimization parameters.

--- a/submissions/examples/ease-sharpen-in-pr/demo.html
+++ b/submissions/examples/ease-sharpen-in-pr/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animation: ease-sharpen-in Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-card ease-sharpen-in">
+    <h1>Cinematic Focus</h1>
+    <p>This container smoothly transitions from a baseline status of complete opacity obscurity and blurred vector paths into sharp high-fidelity view metrics.</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-sharpen-in-pr/style.css
+++ b/submissions/examples/ease-sharpen-in-pr/style.css
@@ -1,0 +1,65 @@
+/* submissions/examples/ease-sharpen-in-pr/style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #030712;
+  color: #f8fafc;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+/* ==========================================================================
+   Core Engine: Sharpen-In Entrance Utility
+   ========================================================================== */
+.ease-sharpen-in {
+  /* Establish base entrance rule constraints per criteria */
+  animation: sharpenIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes sharpenIn {
+  0% {
+    opacity: 0;
+    filter: blur(12px);
+    transform: scale(0.97); /* Subtle scaling creates depth during focus entry */
+  }
+  100% {
+    opacity: 1;
+    filter: blur(0);
+    transform: scale(1);
+  }
+}
+
+/* ==========================================================================
+   Showcase Demo Visual Layouts
+   ========================================================================== */
+.demo-card {
+  background-color: #0f172a;
+  border: 1px solid #1e293b;
+  border-radius: 16px;
+  padding: 2.5rem;
+  max-width: 400px;
+  text-align: center;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+.demo-card h1 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1.75rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  background: linear-gradient(to right, #3b82f6, #60a5fa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.demo-card p {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces the `ease-sharpen-in-pr` animation presentation package. It implements a clean cinematic lens-focus transition asset that moves containers seamlessly from absolute blurred opacity values to crisp resolution profiles, fulfilling the request details on #17217.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-sharpen-in-pr/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It supplies the `.ease-sharpen-in` entrance utility modifier, leveraging continuous keyframe transformation layers to transition content blocks cleanly into view.

**How does a developer use it?**

```html
<div class="card ease-sharpen-in">
  <h2>Header Context</h2>
</div>
Why does it fit EaseMotion CSS?

It complements the library's animation-first architectural mission by giving designers access to elegant, performance-tuned focal entry options that don't depend on bulky scripting engines.

Demo
[x] Demo added (demo.html works by opening directly in a browser)

Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

[x] Safari

Notes for Maintainer
The asset structure is fully constrained inside its isolated subdirectory (ease-sharpen-in-pr). The parameters handle hardware composite handoffs cleanly, tracking filter steps accurately across desktop and mobile layout matrices. Closes #17217.