### PR TITLE
feat: add cursor zoom out demo

### DIFF
--- a/submissions/examples/10788-cursor-zoom-out-kkp/README.md
+++ b/submissions/examples/10788-cursor-zoom-out-kkp/README.md
@@ -1,0 +1,14 @@
+# Cursor Zoom Out Utility
+
+CSS-only demo for a `cursor-zoom-out` utility class. The example uses expanded preview cards that signal a zoom-out interaction on hover.
+
+## Files
+
+- `demo.html` - preview markup
+- `style.css` - cursor utility and zoom-out card styling
+
+## Usage
+
+Open `demo.html` and hover the preview cards.
+
+Closes #10788

--- a/submissions/examples/10788-cursor-zoom-out-kkp/demo.html
+++ b/submissions/examples/10788-cursor-zoom-out-kkp/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cursor Zoom Out Utility</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="panel" aria-label="Cursor zoom out utility demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>cursor-zoom-out</h1>
+        <div class="preview-grid">
+          <button class="preview cursor-zoom-out" type="button">
+            Expanded photo
+          </button>
+          <button class="preview cursor-zoom-out" type="button">
+            Detail overlay
+          </button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/10788-cursor-zoom-out-kkp/style.css
+++ b/submissions/examples/10788-cursor-zoom-out-kkp/style.css
@@ -1,0 +1,87 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #fef3c7, #f8fafc);
+}
+
+.shell {
+  width: min(92vw, 760px);
+}
+
+.panel {
+  padding: 42px;
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 26px 70px rgba(217, 119, 6, 0.16);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #d97706;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+}
+
+.preview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.preview {
+  min-height: 210px;
+  border: 0;
+  border-radius: 22px;
+  color: #ffffff;
+  background:
+    repeating-linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.14) 0 12px,
+      transparent 12px 24px
+    ),
+    linear-gradient(135deg, #b45309, #ef4444);
+  font-size: 1.25rem;
+  font-weight: 900;
+  transform: scale(1.02);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.preview:hover,
+.preview:focus-visible {
+  transform: scale(0.96);
+  box-shadow: 0 20px 42px rgba(180, 83, 9, 0.28);
+}
+
+.cursor-zoom-out {
+  cursor: zoom-out;
+}
+
+@media (max-width: 640px) {
+  .preview-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only cursor-zoom-out utility example
- include hoverable preview cards that use the zoom-out cursor

Closes #10788

## Validation
- npx prettier --check submissions/examples/10788-cursor-zoom-out-kkp/README.md submissions/examples/10788-cursor-zoom-out-kkp/demo.html submissions/examples/10788-cursor-zoom-out-kkp/style.css