### PR TITLE
feat: add cursor grab demo

### DIFF
--- a/submissions/examples/10790-cursor-grab-kkp/README.md
+++ b/submissions/examples/10790-cursor-grab-kkp/README.md
@@ -1,0 +1,14 @@
+# Cursor Grab Utility
+
+CSS-only demo for a `cursor-grab` utility class. The example shows draggable-style cards that communicate they can be picked up.
+
+## Files
+
+- `demo.html` - card markup
+- `style.css` - cursor utility and grab card styling
+
+## Usage
+
+Open `demo.html` and hover the cards.
+
+Closes #10790

--- a/submissions/examples/10790-cursor-grab-kkp/demo.html
+++ b/submissions/examples/10790-cursor-grab-kkp/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cursor Grab Utility</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="panel" aria-label="Cursor grab utility demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>cursor-grab</h1>
+        <div class="board">
+          <article class="grab-card cursor-grab">Backlog</article>
+          <article class="grab-card cursor-grab">In review</article>
+          <article class="grab-card cursor-grab">Done</article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/10790-cursor-grab-kkp/style.css
+++ b/submissions/examples/10790-cursor-grab-kkp/style.css
@@ -1,0 +1,82 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f0fdf4, #eff6ff);
+}
+
+.shell {
+  width: min(92vw, 820px);
+}
+
+.panel {
+  padding: 42px;
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 26px 70px rgba(22, 163, 74, 0.16);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #16a34a;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.grab-card {
+  min-height: 170px;
+  display: grid;
+  place-items: center;
+  border: 2px dashed rgba(22, 163, 74, 0.3);
+  border-radius: 22px;
+  color: #14532d;
+  background: #dcfce7;
+  font-size: 1.1rem;
+  font-weight: 900;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.grab-card:hover,
+.grab-card:focus-visible {
+  transform: translateY(-6px) rotate(-1deg);
+  box-shadow: 0 20px 38px rgba(22, 163, 74, 0.18);
+}
+
+.cursor-grab {
+  cursor: grab;
+}
+
+@media (max-width: 700px) {
+  .board {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only cursor-grab utility example
- include draggable-style cards that use the grab cursor

Closes #10790

## Validation
- npx prettier --check submissions/examples/10790-cursor-grab-kkp/README.md submissions/examples/10790-cursor-grab-kkp/demo.html submissions/examples/10790-cursor-grab-kkp/style.css