### PR TITLE
feat: add cursor grabbing demo

### DIFF
--- a/submissions/examples/10792-cursor-grabbing-kkp/README.md
+++ b/submissions/examples/10792-cursor-grabbing-kkp/README.md
@@ -1,0 +1,14 @@
+# Cursor Grabbing Utility
+
+CSS-only demo for a `cursor-grabbing` utility class. The example shows an actively dragged card state with pressed motion.
+
+## Files
+
+- `demo.html` - active drag card markup
+- `style.css` - cursor utility and pressed state styling
+
+## Usage
+
+Open `demo.html` and hover or press the active card.
+
+Closes #10792

--- a/submissions/examples/10792-cursor-grabbing-kkp/demo.html
+++ b/submissions/examples/10792-cursor-grabbing-kkp/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cursor Grabbing Utility</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="panel" aria-label="Cursor grabbing utility demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>cursor-grabbing</h1>
+        <button class="drag-card cursor-grabbing" type="button">
+          Active drag state
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/10792-cursor-grabbing-kkp/style.css
+++ b/submissions/examples/10792-cursor-grabbing-kkp/style.css
@@ -1,0 +1,79 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f5f3ff, #f8fafc);
+}
+
+.shell {
+  width: min(92vw, 620px);
+}
+
+.panel {
+  padding: 44px;
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 26px 70px rgba(124, 58, 237, 0.16);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #7c3aed;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 30px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+}
+
+.drag-card {
+  width: min(100%, 420px);
+  min-height: 190px;
+  border: 0;
+  border-radius: 24px;
+  color: #ffffff;
+  background:
+    radial-gradient(
+      circle at 30% 24%,
+      rgba(255, 255, 255, 0.4),
+      transparent 18%
+    ),
+    linear-gradient(135deg, #7c3aed, #db2777);
+  font-size: 1.25rem;
+  font-weight: 900;
+  box-shadow: 0 24px 46px rgba(124, 58, 237, 0.28);
+  transform: rotate(-2deg) scale(1.02);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.drag-card:hover,
+.drag-card:focus-visible,
+.drag-card:active {
+  transform: rotate(1deg) scale(0.98);
+  box-shadow: 0 14px 30px rgba(124, 58, 237, 0.24);
+}
+
+.cursor-grabbing {
+  cursor: grabbing;
+}


### PR DESCRIPTION
## Summary
- add a CSS-only cursor-grabbing utility example
- include active drag card styling with pressed motion

Closes #10792

## Validation
- npx prettier --check submissions/examples/10792-cursor-grabbing-kkp/README.md submissions/examples/10792-cursor-grabbing-kkp/demo.html submissions/examples/10792-cursor-grabbing-kkp/style.css