### PR TITLE
feat: add ease-strikethru animation (#17208)

### DIFF
--- a/submissions/examples/ease-strikethru/README.md
+++ b/submissions/examples/ease-strikethru/README.md
@@ -1,0 +1,24 @@
+﻿# ease-strikethru – Strikethrough Draw
+
+A strikethrough line that draws across the element from left to right when triggered. Uses a CSS custom property for the line color.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-2xl, ease-font-semibold, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-6, ease-mb-8, ease-mt-4, ease-mt-8
+- **Components:** ease-btn, ease-btn-primary
+- **Hover Effects:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- The text element has an ::after pseudo‑element that acts as the strikethrough line, initially with width: 0.
+- The line color is controlled by --ease-strikethru-color (default red).
+- When the class strike is added (via button click), the pseudo‑element's width transitions to 100%, drawing the line across the text.
+- The class can be removed and re‑added to replay the animation.
+- The effect respects prefers-reduced-motion.
+
+## How to use
+1. Add the class strikethru-text to any text element and set --ease-strikethru-color for a custom line color.
+2. Trigger the animation by toggling the strike class via JavaScript.
+3. Copy style.css into your project and ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-strikethru/demo.html
+++ b/submissions/examples/ease-strikethru/demo.html
@@ -1,0 +1,45 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-strikethru – Strikethrough Draw</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">
+      Strikethrough Draw
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Click the button to draw a line across the text.
+    </p>
+
+    <div class="ease-text-2xl ease-font-semibold ease-mb-6">
+      <span id="strike-text" class="strikethru-text">Completed Task</span>
+    </div>
+
+    <button id="strike-btn" class="ease-btn ease-btn-primary ease-hover-scale-105 ease-transition ease-mt-4">
+      Strike Through
+    </button>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Uses <code>::after</code> with animated <code>width</code> and <code>--ease-strikethru-color</code>.
+    </p>
+  </div>
+
+  <script>
+    const text = document.getElementById('strike-text');
+    const btn = document.getElementById('strike-btn');
+
+    btn.addEventListener('click', () => {
+      text.classList.remove('strike');
+      void text.offsetWidth;          // force reflow to restart animation
+      text.classList.add('strike');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-strikethru/style.css
+++ b/submissions/examples/ease-strikethru/style.css
@@ -1,0 +1,38 @@
+﻿/* ============================================================
+   ease-strikethru – Strikethrough line draws across element
+   ::after pseudo-element animates width from 0 to 100%
+   ============================================================ */
+
+.strikethru-text {
+  position: relative;
+  display: inline-block;
+  color: #1e293b;
+}
+
+/* The strikethrough line */
+.strikethru-text::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 0;
+  height: 3px;
+  background: var(--ease-strikethru-color, #ef4444);
+  transform: translateY(-50%);
+  transition: width 0.5s ease;
+}
+
+/* When the .strike class is added, the line expands */
+.strikethru-text.strike::after {
+  width: 100%;
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .strikethru-text::after {
+    transition: none;
+  }
+  .strikethru-text.strike::after {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Closes #17208

ease-strikethru – Strikethrough Draw
A line draws across the element from left to right using an animated ::after pseudo‑element.

Files added
- submissions/examples/ease-strikethru/demo.html
- submissions/examples/ease-strikethru/style.css
- submissions/examples/ease-strikethru/README.md

How it works
- ::after element with initial width 0 expands to 100% on trigger.
- Color controlled by --ease-strikethru-color (default red).
- Button click adds .strike class; animation can be replayed.
- Respects prefers-reduced-motion.