### PR TITLE
feat: add cursor help demo

### DIFF
--- a/submissions/examples/10797-cursor-help-kkp/README.md
+++ b/submissions/examples/10797-cursor-help-kkp/README.md
@@ -1,0 +1,14 @@
+# Cursor Help Utility
+
+CSS-only demo for a `cursor-help` utility class. The example uses help chips and tooltip-style hints to show where contextual help is available.
+
+## Files
+
+- `demo.html` - help chip markup
+- `style.css` - cursor utility, chips, and tooltip hint styling
+
+## Usage
+
+Open `demo.html` and hover the help chips.
+
+Closes #10797

--- a/submissions/examples/10797-cursor-help-kkp/demo.html
+++ b/submissions/examples/10797-cursor-help-kkp/demo.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cursor Help Utility</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="panel" aria-label="Cursor help utility demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>cursor-help</h1>
+        <div class="help-row">
+          <button
+            class="help-chip cursor-help"
+            type="button"
+            data-tip="Explains billing terms"
+          >
+            Billing?
+          </button>
+          <button
+            class="help-chip cursor-help"
+            type="button"
+            data-tip="Shows keyboard shortcuts"
+          >
+            Shortcuts?
+          </button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/10797-cursor-help-kkp/style.css
+++ b/submissions/examples/10797-cursor-help-kkp/style.css
@@ -1,0 +1,95 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #fefce8, #f8fafc);
+}
+
+.shell {
+  width: min(92vw, 680px);
+}
+
+.panel {
+  padding: 44px;
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 26px 70px rgba(202, 138, 4, 0.16);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #ca8a04;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 30px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+}
+
+.help-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 18px;
+}
+
+.help-chip {
+  position: relative;
+  border: 0;
+  border-radius: 999px;
+  padding: 14px 22px;
+  color: #713f12;
+  background: #fef3c7;
+  font-size: 1rem;
+  font-weight: 900;
+  box-shadow: inset 0 0 0 1px rgba(202, 138, 4, 0.24);
+}
+
+.help-chip::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 12px);
+  width: max-content;
+  max-width: 220px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  color: #ffffff;
+  background: #1f2937;
+  font-size: 0.82rem;
+  opacity: 0;
+  transform: translate(-50%, 8px);
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+  pointer-events: none;
+}
+
+.help-chip:hover::after,
+.help-chip:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.cursor-help {
+  cursor: help;
+}


### PR DESCRIPTION
## Summary
- add a CSS-only cursor-help utility example
- include help chips and contextual tooltip hints

Closes #10797

## Validation
- npx prettier --check submissions/examples/10797-cursor-help-kkp/README.md submissions/examples/10797-cursor-help-kkp/demo.html submissions/examples/10797-cursor-help-kkp/style.css