### PR TITLE
feat: add cursor move demo

### DIFF
--- a/submissions/examples/10799-cursor-move-kkp/README.md
+++ b/submissions/examples/10799-cursor-move-kkp/README.md
@@ -1,0 +1,14 @@
+# Cursor Move Utility
+
+CSS-only demo for a `cursor-move` utility class. The example uses repositionable layout tiles that communicate move behavior on hover.
+
+## Files
+
+- `demo.html` - move tile markup
+- `style.css` - cursor utility and tile styling
+
+## Usage
+
+Open `demo.html` and hover the move tiles.
+
+Closes #10799

--- a/submissions/examples/10799-cursor-move-kkp/demo.html
+++ b/submissions/examples/10799-cursor-move-kkp/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cursor Move Utility</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="panel" aria-label="Cursor move utility demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>cursor-move</h1>
+        <div class="canvas">
+          <button class="move-tile cursor-move" type="button">Widget A</button>
+          <button class="move-tile cursor-move" type="button">Widget B</button>
+          <button class="move-tile cursor-move" type="button">Widget C</button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/10799-cursor-move-kkp/style.css
+++ b/submissions/examples/10799-cursor-move-kkp/style.css
@@ -1,0 +1,83 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f0f9ff, #f8fafc);
+}
+
+.shell {
+  width: min(92vw, 820px);
+}
+
+.panel {
+  padding: 42px;
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 26px 70px rgba(37, 99, 235, 0.16);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+}
+
+.canvas {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.move-tile {
+  min-height: 170px;
+  border: 0;
+  border-radius: 22px;
+  color: #ffffff;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.18), transparent),
+    linear-gradient(135deg, #2563eb, #14b8a6);
+  font-size: 1.1rem;
+  font-weight: 900;
+  box-shadow: 0 20px 40px rgba(37, 99, 235, 0.22);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.move-tile:hover,
+.move-tile:focus-visible {
+  transform: translate(4px, -8px);
+  box-shadow: 0 28px 52px rgba(37, 99, 235, 0.28);
+}
+
+.cursor-move {
+  cursor: move;
+}
+
+@media (max-width: 700px) {
+  .canvas {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only cursor-move utility example
- include movable-style tiles that use the move cursor

Closes #10799

## Validation
- npx prettier --check submissions/examples/10799-cursor-move-kkp/README.md submissions/examples/10799-cursor-move-kkp/demo.html submissions/examples/10799-cursor-move-kkp/style.css