### PR TITLE
feat: add cursor text demo

### DIFF
--- a/submissions/examples/10803-cursor-text-kkp/README.md
+++ b/submissions/examples/10803-cursor-text-kkp/README.md
@@ -1,0 +1,14 @@
+# Cursor Text Utility
+
+CSS-only demo for a `cursor-text` utility class. The example highlights editable-style text regions that use the text cursor.
+
+## Files
+
+- `demo.html` - text region markup
+- `style.css` - cursor utility and editable region styling
+
+## Usage
+
+Open `demo.html` and hover the text regions.
+
+Closes #10803

--- a/submissions/examples/10803-cursor-text-kkp/demo.html
+++ b/submissions/examples/10803-cursor-text-kkp/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cursor Text Utility</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="panel" aria-label="Cursor text utility demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>cursor-text</h1>
+        <div class="text-card cursor-text">
+          <strong>Editable title</strong>
+          <p>Hover this text surface to show the text selection cursor.</p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/10803-cursor-text-kkp/style.css
+++ b/submissions/examples/10803-cursor-text-kkp/style.css
@@ -1,0 +1,78 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc, #eef2ff);
+}
+
+.shell {
+  width: min(92vw, 680px);
+}
+
+.panel {
+  padding: 42px;
+  border-radius: 28px;
+  background: #ffffff;
+  box-shadow: 0 26px 70px rgba(79, 70, 229, 0.16);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #4f46e5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 28px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+}
+
+.text-card {
+  padding: 28px;
+  border: 2px solid #c7d2fe;
+  border-radius: 22px;
+  background: #eef2ff;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.text-card:hover,
+.text-card:focus-within {
+  border-color: #4f46e5;
+  box-shadow: 0 18px 36px rgba(79, 70, 229, 0.18);
+}
+
+.text-card strong {
+  display: block;
+  margin-bottom: 10px;
+  color: #312e81;
+  font-size: 1.25rem;
+}
+
+.text-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.7;
+}
+
+.cursor-text {
+  cursor: text;
+}


### PR DESCRIPTION
## Summary
- add a CSS-only cursor-text utility example
- include editable-style text surface using the text cursor

Closes #10803

## Validation
- npx prettier --check submissions/examples/10803-cursor-text-kkp/README.md submissions/examples/10803-cursor-text-kkp/demo.html submissions/examples/10803-cursor-text-kkp/style.css