### PR TITLE
Fix: Align brand logo within the navigation bar

### DIFF
--- a/submissions/Misaligned-Brand-Logo/README.md
+++ b/submissions/Misaligned-Brand-Logo/README.md
@@ -1,0 +1,6 @@
+### Bug Fix: Misaligned Header Logo (#1)
+
+**Issue:** The EaseMotion brand logo was detached from the main navigation flow, rendering at the absolute top of the viewport instead of aligning inline with the navigation links.
+
+**Resolution:** - Restructured the HTML by placing the `.demo-logo` anchor tag inside a `.nav-brand-group` wrapper.
+- Applied `display: flex` and `align-items: center` to the navbar container in `style.css` to enforce a strictly horizontal, space-between layout.

--- a/submissions/Misaligned-Brand-Logo/demo.html
+++ b/submissions/Misaligned-Brand-Logo/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS — Interactive Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="demo-nav">
+    <div class="ease-container demo-nav-inner">
+      <div class="nav-brand-group">
+        <a href="index.html" class="demo-logo">EaseMotion CSS</a>
+      </div>
+      <ul class="demo-nav-links">
+        <li><a href="#buttons">Buttons</a></li>
+        <li><a href="#cards">Cards</a></li>
+        <li><a href="#animations">Animations</a></li>
+      </ul>
+    </div>
+  </nav>
+
+</body>
+</html>

--- a/submissions/Misaligned-Brand-Logo/style.css
+++ b/submissions/Misaligned-Brand-Logo/style.css
@@ -1,0 +1,19 @@
+/* ISSUE 1 FIX: CSS for proper logo alignment within the navbar */
+.demo-nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 15px 20px;
+}
+
+.nav-brand-group {
+  display: flex;
+  align-items: center;
+  gap: 10px; /* Provides spacing if other elements like toggles are added here */
+}
+
+.demo-logo {
+  text-decoration: none;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Motivation and Context
The "EaseMotion CSS" brand logo was floating at the absolute top of the page, completely detached from the navigation bar. This broke the header layout visually.

## Changes Made
- Wrapped the `.demo-logo` tag inside a `.nav-brand-group` div within `demo.html`.
- Updated `style.css` to apply `display: flex` and `justify-content: space-between` to the `.demo-nav-inner` container, properly aligning the logo to the left and links to the right.

## Fixes Issues
Closes #17276 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
<img width="280" height="554" alt="Screenshot 2026-06-22 at 9 44 09 PM" src="https://github.com/user-attachments/assets/c1ec9657-ce23-4a4f-8504-29a38d0eaa5d" />
