### PR TITLE
Fix: Prevent inline code tags from wrapping across lines

### DIFF
--- a/submissions/Broken-Code-Tag-Typography/README.md
+++ b/submissions/Broken-Code-Tag-Typography/README.md
@@ -1,0 +1,6 @@
+### Bug Fix: Broken Code Tag Typography (#2)
+
+**Issue:** Code snippet tags within the feature cards were breaking across multiple lines (e.g., rendering `[in]` on a new line), breaking the pill-shaped UI aesthetic.
+
+**Resolution:** - Updated the `.tag` class in the main stylesheet to include `white-space: nowrap` and `display: inline-block`. 
+- This explicitly instructs the browser engine to treat the entire code block as a single, unbreakable visual element.

--- a/submissions/Broken-Code-Tag-Typography/demo.html
+++ b/submissions/Broken-Code-Tag-Typography/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS — Interactive Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main style="padding: 20px;">
+    <article class="ease-card ease-card-shadow">
+      <div class="ease-card-header">
+        <span class="ease-badge ease-badge-success">Stable</span>
+      </div>
+      <h3 class="ease-card-title">Human Readable</h3>
+      <div class="ease-card-body">
+        <p>Class names read like English. <code class="tag">ease-fade-in</code>, <code class="tag">ease-hover-grow</code> — instantly obvious.</p>
+      </div>
+    </article>
+  </main>
+
+</body>
+</html>

--- a/submissions/Broken-Code-Tag-Typography/style.css
+++ b/submissions/Broken-Code-Tag-Typography/style.css
@@ -1,0 +1,12 @@
+/* ISSUE 2 FIX: CSS to prevent tags from breaking across lines */
+.tag {
+  display: inline-block;
+  white-space: nowrap; /* CRITICAL: Prevents line breaks inside the tag */
+  background: rgba(108, 99, 255, 0.15);
+  color: #a78bfa;
+  border: 1px solid rgba(108, 99, 255, 0.3);
+  padding: 0.15em 0.6em;
+  border-radius: 9999px; /* Fully rounded borders */
+  font-family: monospace;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Motivation and Context
Inline `<code>` tags (like the ones used in the "Human Readable" feature card) were wrapping awkwardly at the end of lines, causing the pill-shaped UI elements to break into multiple pieces (e.g., leaving just `[in]` on a new line).

## Changes Made
- Applied `white-space: nowrap` and `display: inline-block` to the `.tag` class in `style.css`.
- Ensured all relevant inline code snippets in `demo.html` use the updated `.tag` class.

## Fixes Issues
Closes #17278 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change