### PR TITLE
Fix: Add missing mobile hamburger navigation toggle

### DIFF
--- a/submissions/Missing-Mobile-Navigation-Toggle/README.md
+++ b/submissions/Missing-Mobile-Navigation-Toggle/README.md
@@ -1,0 +1,6 @@
+### Bug Fix: Missing Mobile Navigation Toggle (#3)
+
+**Issue:** While the CSS contained logic for a mobile sidebar menu, the HTML was entirely missing the trigger button. This rendered the documentation unnavigable on viewport sizes under 768px.
+
+**Resolution:** - Injected a `<button class="sidebar-toggle">` element immediately preceding the logo.
+- Adjusted CSS media queries to ensure the button is hidden on desktop viewports (`> 768px`) and visible on mobile, while simultaneously collapsing the standard `demo-nav-links` list.

--- a/submissions/Missing-Mobile-Navigation-Toggle/demo.html
+++ b/submissions/Missing-Mobile-Navigation-Toggle/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS — Interactive Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="demo-nav">
+    <div class="ease-container demo-nav-inner">
+      <div class="nav-brand-group">
+        <button class="sidebar-toggle" aria-label="Toggle mobile menu">☰</button>
+        <a href="index.html" class="demo-logo">EaseMotion CSS</a>
+      </div>
+      
+      <ul class="demo-nav-links">
+        <li><a href="#buttons">Buttons</a></li>
+        <li><a href="#cards">Cards</a></li>
+      </ul>
+    </div>
+  </nav>
+
+</body>
+</html>

--- a/submissions/Missing-Mobile-Navigation-Toggle/style.css
+++ b/submissions/Missing-Mobile-Navigation-Toggle/style.css
@@ -1,0 +1,23 @@
+/* ISSUE 3 FIX: CSS for the mobile hamburger toggle */
+
+/* Hidden on desktop by default */
+.sidebar-toggle {
+  display: none; 
+  background: none;
+  border: none;
+  color: #fffffe;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+/* Display rules for mobile devices */
+@media (max-width: 768px) {
+  .sidebar-toggle { 
+    display: block; /* Show the hamburger icon */
+  }
+  
+  .demo-nav-links { 
+    display: none; /* Hide the standard nav links */
+  }
+}


### PR DESCRIPTION
## Motivation and Context
The documentation site was inaccessible on viewports under `768px` because the HTML template was missing the trigger button required to open the mobile sidebar menu, despite the CSS logic already being in place.

## Changes Made
- Injected `<button class="sidebar-toggle">☰</button>` into the HTML navigation bar.
- Updated `style.css` to hide this button on desktop by default and only display it when the viewport drops below `768px`.
- Ensured standard navigation links are hidden on mobile to prevent overlapping.

## Fixes Issues
Closes #17279 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change