### PR TITLE
fix: promote scaled hover elements to composite layers #5694

### DIFF
--- a/submissions/examples/fix-hover-blur/README.md
+++ b/submissions/examples/fix-hover-blur/README.md
@@ -1,0 +1,13 @@
+# Hover Elevation Blur Fix
+
+## Problem
+When applying `transform: scale()` on hover to cards with text or icons, Chromium browsers often trigger sub-pixel anti-aliasing artifacts, causing text to appear blurry or jagged during the animation.
+
+## Solution
+This implementation forces the browser to treat the element as a standalone composite layer:
+- **`will-change: transform`**: Hints the browser to optimize for this specific transformation.
+- **`backface-visibility: hidden`**: Forces a hardware-accelerated layer.
+- **Font Smoothing**: Ensures the browser engine renders typography with consistent weight during transitions.
+
+## Usage
+Simply apply the `blur-target-card` class to any container that uses hover-based scaling.

--- a/submissions/examples/fix-hover-blur/demo.html
+++ b/submissions/examples/fix-hover-blur/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Blur Fix Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="card-container">
+        <div class="blur-target-card">
+            <h4>Subpixel Text Legibility Test</h4>
+            <p>If fixed, this text will remain sharp even while scaling!</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/fix-hover-blur/style.css
+++ b/submissions/examples/fix-hover-blur/style.css
@@ -1,0 +1,21 @@
+/* Fix text blur during transform scale */
+.blur-target-card {
+  width: 250px;
+  padding: 20px;
+  background: #1e293b;
+  color: #ffffff;
+  font-size: 14px;
+  
+  /* Critical fixes for rendering artifacts */
+  will-change: transform;
+  backface-visibility: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  
+  /* Animation setup */
+  transition: transform 0.3s ease;
+}
+
+.blur-target-card:hover {
+  transform: scale(1.05);
+}


### PR DESCRIPTION
Pull Request Description
This PR resolves the issue #5694 where transform: scale() hover effects caused text blur and rendering artifacts due to improper sub-pixel rasterization in Chromium browsers.

Type of Change
[x] 🐛 Bug fix in an existing submission

Submission Checklist
[x] All changes are inside submissions/examples/fix-hover-blur/

[x] Includes demo.html

[x] Includes style.css

[x] Includes README.md

[x] No changes to core/

[x] No changes to components/

[x] One feature per PR

Feature Description
What does this add?
A robust CSS fix that promotes elements to independent composite layers using will-change and hardware acceleration to prevent font blurring during scale transitions.

How does a developer use it?

HTML
<div class="blur-target-card">
  </div>
Why does it fit EaseMotion CSS?
It upholds the animation-first philosophy by ensuring that motion does not degrade visual quality, maintaining the "human-readable" and "smooth-motion" standards of the framework.

Demo
[x] Demo added (demo.html works by opening directly in a browser)

Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

[x] Safari

Notes for Maintainer
The fix utilizes will-change: transform and backface-visibility to force GPU hardware acceleration. This approach is standard for eliminating sub-pixel rendering artifacts in modern browser engines without impacting performance.