### PR TITLE
feat: add dark mode toggle component #16340

### DIFF
--- a/docs/components/dark-mode-16340/theme.css
+++ b/docs/components/dark-mode-16340/theme.css
@@ -1,0 +1,14 @@
+/* Theme variables for #16340 */
+:root[data-theme='light'] {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+:root[data-theme='dark'] {
+  --bg-color: #1a202c;
+  --text-color: #f7fafc;
+}
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s;
+}

--- a/docs/components/dark-mode-16340/toggle.html
+++ b/docs/components/dark-mode-16340/toggle.html
@@ -1,0 +1,11 @@
+<button id="theme-toggle" aria-label="Toggle Dark Mode">
+  Switch Theme
+</button>
+
+<script>
+const toggle = document.getElementById('theme-toggle');
+toggle.addEventListener('click', () => {
+  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+  document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+});
+</script>


### PR DESCRIPTION
## Pull Request Description
This PR adds a standalone Dark Mode toggle component to the documentation site (Issue #16340). It uses CSS custom properties and a data-attribute switcher to provide a performant, dependency-free theme toggle.

---

## Type of Change
- [x] ✨ Documentation UI enhancement

## Submission Checklist
- [x] All assets contained in `docs/components/dark-mode-16340/`
- [x] No modifications to existing global stylesheets.

## Feature Description
- Implements theme switching via `data-theme` attribute.
- Provides smooth transition states for color variables.

Closes #16340