### PR TITLE
fix: make landing page hero full height to prevent section overflow

### DIFF
--- a/submissions/examples/ease-hero-fullheight-nk/README.md
+++ b/submissions/examples/ease-hero-fullheight-nk/README.md
@@ -1,0 +1,18 @@
+### 1. What does this do?
+This submission recreates the main landing page hero section and fixes a layout issue where the hero container did not extend to the full height of the viewport, causing the subsequent "Buttons" section to peek through prematurely at the bottom.
+
+### 2. How is it used?
+By applying `min-height: 100vh` to the `.demo-hero` container and using flexbox (`display: flex; flex-direction: column; justify-content: center;`) to perfectly center the content vertically.
+
+```css
+.demo-hero {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+```
+
+### 3. Why is it useful?
+It provides a much cleaner, more professional landing page flow. It ensures the hero section takes up exactly one full screen before the user scrolls, eliminating awkward clipping or visible breaks with the next section.

--- a/submissions/examples/ease-hero-fullheight-nk/demo.html
+++ b/submissions/examples/ease-hero-fullheight-nk/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hero Full Height Fix Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="demo-nav">
+    <div class="nav-container">
+      <a href="#" class="demo-logo">EaseMotion</a>
+      <ul class="demo-nav-links">
+        <li><a href="#buttons">Buttons</a></li>
+        <li><a href="#cards">Cards</a></li>
+        <li><a href="#animations">Animations</a></li>
+        <li><a href="#layout">Layout</a></li>
+        <li><a href="#">Docs</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Hero Section -->
+  <header class="demo-hero">
+    <div class="hero-container">
+      <div class="demo-section-label">Interactive Demo</div>
+      <h1>Build with EaseMotion</h1>
+      <p>Human-readable class names. Animation-first. No memorization required.</p>
+      <div class="hero-buttons">
+        <a href="#" class="btn btn-primary">Read Docs</a>
+        <a href="#" class="btn btn-outline">GitHub ↗</a>
+      </div>
+    </div>
+  </header>
+
+  <!-- Next Section (To demonstrate it's pushed down properly) -->
+  <section id="buttons" class="demo-section">
+    <div class="container">
+      <div class="demo-section-label">Components</div>
+      <h2>Buttons</h2>
+      <p>Compose buttons by stacking modifier classes. Every style is human-readable.</p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/ease-hero-fullheight-nk/style.css
+++ b/submissions/examples/ease-hero-fullheight-nk/style.css
@@ -1,0 +1,175 @@
+/* Basic reset */
+* {
+  box-sizing: border-box;
+}
+
+body, html {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #0f0e17; /* Dark theme background */
+  color: #fffffe;
+}
+
+/* Navigation */
+.demo-nav {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 1.5rem 0;
+  z-index: 100;
+}
+
+.nav-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 2rem;
+}
+
+.demo-logo {
+  font-weight: 700;
+  font-size: 1.5rem;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-decoration: none;
+}
+
+.demo-nav-links {
+  list-style: none;
+  display: flex;
+  gap: 2rem;
+  margin: 0;
+  padding: 0;
+}
+
+.demo-nav-links a {
+  color: rgba(255, 255, 255, 0.65);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.875rem;
+  transition: color 0.2s ease;
+}
+
+.demo-nav-links a:hover {
+  color: #fff;
+}
+
+/* 
+  =========================================
+  HERO SECTION (THE FIX)
+  =========================================
+*/
+.demo-hero {
+  /* This ensures the hero takes the full viewport height */
+  min-height: 100vh;
+  
+  /* Flexbox centers the content within the 100vh container */
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  
+  text-align: center;
+  background: radial-gradient(ellipse 80% 60% at 50% 0%, rgba(108, 99, 255, 0.18) 0%, transparent 70%);
+  padding: 0 2rem;
+}
+
+.hero-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.demo-section-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #a78bfa;
+  margin-bottom: 1rem;
+}
+
+.demo-hero h1 {
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  font-weight: 800;
+  margin: 0 0 1rem;
+  background: linear-gradient(135deg, #ffffff 0%, #a78bfa 60%, #6c63ff 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.demo-hero p {
+  font-size: 1.125rem;
+  color: rgba(255, 255, 255, 0.65);
+  max-width: 560px;
+  margin: 0 auto 2rem;
+  line-height: 1.6;
+}
+
+.hero-buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 1.35rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  font-size: 1rem;
+}
+
+.btn-primary {
+  background-color: #6c63ff;
+  color: #fff;
+  border: none;
+}
+
+.btn-primary:hover {
+  background-color: #5a52d5;
+}
+
+.btn-outline {
+  background-color: transparent;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.btn-outline:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+/* Next Section (For testing the layout flow) */
+.demo-section {
+  padding: 6rem 2rem;
+  background-color: #16161a;
+  min-height: 100vh;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.demo-section h2 {
+  font-size: 2.5rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.demo-section p {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 1.125rem;
+}


### PR DESCRIPTION
This PR fixes the hero section so it now covers the full height of the page instead of cutting off early.

Edited the CSS in the hero container so the next section no longer peeks through at the bottom.

Tested by resizing the browser and scrolling, the hero now fills the screen properly on different screen sizes.

Kindly merge and close this issue: #17302