### PR TITLE
resolve #17364: Document Reading Scroll Indicator Bar

### DIFF
--- a/submissions/examples/new-scroll-indicator-bar-sn100/README.md
+++ b/submissions/examples/new-scroll-indicator-bar-sn100/README.md
@@ -1,0 +1,7 @@
+﻿# Document Reading Scroll Indicator Bar
+
+Top-fixed horizontal scroll reader progress indicator bar.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-scroll-indicator-bar-sn100/demo.html
+++ b/submissions/examples/new-scroll-indicator-bar-sn100/demo.html
@@ -1,0 +1,25 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: Document Reading Scroll Indicator Bar</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-scroll-bar-container">
+  <div class="ease-scroll-bar"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/new-scroll-indicator-bar-sn100/style.css
+++ b/submissions/examples/new-scroll-indicator-bar-sn100/style.css
@@ -1,0 +1,22 @@
+﻿/* ==========================================================================
+   EaseMotion CSS: Document Reading Scroll Indicator Bar
+   ========================================================================== */
+
+@layer components {
+.ease-scroll-bar-container {
+  position: fixed;
+  top: 0; left: 0; width: 100%; height: 3px;
+  background: rgba(255,255,255,0.05);
+  z-index: 2000;
+}
+.ease-scroll-bar {
+  height: 100%;
+  background: #00ff7f;
+  width: 0%;
+  animation: easeFillScroll linear;
+  animation-timeline: scroll(root);
+}
+@keyframes easeFillScroll {
+  to { width: 100%; }
+}
+}


### PR DESCRIPTION
﻿Closes #17364

## What this does
Top-fixed horizontal scroll reader progress indicator bar.

## Files
- `submissions/examples/new-scroll-indicator-bar-sn100/style.css`
- `submissions/examples/new-scroll-indicator-bar-sn100/demo.html`
- `submissions/examples/new-scroll-indicator-bar-sn100/README.md`
