### PR TITLE
feat: add ease-overline-slide-right animation

### DIFF
--- a/submissions/examples/ease-overline-slide-right/README.md
+++ b/submissions/examples/ease-overline-slide-right/README.md
@@ -1,0 +1,33 @@
+# ease-overline-slide-right
+
+## What does this do?
+
+Animates a custom overline above an element, sliding it in smoothly from the left to the right on hover.
+
+## How is it used?
+
+Add the class to any inline or block-level element that supports pseudo-elements (like a link or heading):
+
+```html
+<a href="#" class="ease-overline-slide-right">Hover Over Me</a>
+```
+
+You can customize the color, height, gap, and duration of the overline by overriding the custom CSS variables:
+
+```css
+.custom-element {
+  --ease-overline-color: #ef4444; /* Custom Red Color */
+  --ease-overline-height: 4px; /* Custom Thickness */
+  --ease-overline-gap: 12px; /* Breathing room between element and overline */
+  --ease-overline-duration: 0.4s; /* Transition speed */
+}
+```
+
+## Why is it useful?
+
+Overline slide animations are a modern, high-end alternative to standard underlines for navigation menus, titles, and headers. They draw focus to the interactive element with an elegant, polished motion that respects accessibility (including focus support and a `prefers-reduced-motion` override).
+
+## Tech Stack
+
+- HTML
+- CSS (no frameworks, no JavaScript)

--- a/submissions/examples/ease-overline-slide-right/demo.html
+++ b/submissions/examples/ease-overline-slide-right/demo.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Animation: ease-overline-slide-right</title>
+    <meta
+      name="description"
+      content="A demonstration of the ease-overline-slide-right hover animation showing an overline sliding in from left to right."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1 id="main-title">ease-overline-slide-right</h1>
+        <p class="subtitle" id="main-desc">
+          Hover over the text elements below to see the overline slide in from
+          the left to the right.
+        </p>
+      </header>
+
+      <div class="display-area">
+        <!-- Demo Nav Menu -->
+        <nav class="demo-nav">
+          <a href="#" class="ease-overline-slide-right">Dashboard</a>
+          <a href="#" class="ease-overline-slide-right">Analytics</a>
+          <a href="#" class="ease-overline-slide-right">Settings</a>
+        </nav>
+
+        <!-- Large Interactive Heading -->
+        <span class="demo-heading ease-overline-slide-right"
+          >Interactive Title</span
+        >
+
+        <!-- Overridden Color Example -->
+        <a href="#" class="ease-overline-slide-right custom-overline"
+          >Custom Overline (Green & Thicker)</a
+        >
+      </div>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-overline-slide-right/style.css
+++ b/submissions/examples/ease-overline-slide-right/style.css
@@ -1,0 +1,154 @@
+@import "https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap";
+
+:root {
+  --bg-primary: #0b0f19;
+  --bg-surface: rgba(22, 28, 45, 0.6);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --color-primary: #3b82f6;
+  --color-text: #f3f4f6;
+  --color-text-muted: #9ca3af;
+  --font-sans: "Outfit", sans-serif;
+
+  /* Custom variables for this animation */
+  --ease-overline-color: #3b82f6;
+  --ease-overline-height: 3px;
+  --ease-overline-gap: 8px; /* space between text and overline */
+  --ease-overline-duration: 0.3s;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background-image: radial-gradient(
+    circle at 50% 50%,
+    rgba(59, 130, 246, 0.12) 0%,
+    transparent 60%
+  );
+}
+
+.container {
+  max-width: 600px;
+  width: 100%;
+  backdrop-filter: blur(20px);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  text-align: center;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #60a5fa, #3b82f6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+  color: var(--color-text-muted);
+  margin-bottom: 2.5rem;
+  font-size: 1rem;
+}
+
+.display-area {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  margin-bottom: 1.5rem;
+  padding: 2.5rem;
+  border-radius: 16px;
+  border: 1px dashed var(--border-color);
+  background: rgba(0, 0, 0, 0.2);
+}
+
+/* =============================================
+   EASE-OVERLINE-SLIDE-RIGHT ANIMATION CLASS
+   ============================================= */
+.ease-overline-slide-right {
+  position: relative;
+  display: inline-block;
+  text-decoration: none;
+  color: var(--color-text);
+  font-weight: 600;
+  transition: color var(--ease-overline-duration) ease;
+  cursor: pointer;
+}
+
+.ease-overline-slide-right::before {
+  content: "";
+  position: absolute;
+  top: calc(-1 * var(--ease-overline-gap));
+  left: 0;
+  width: 0;
+  height: var(--ease-overline-height);
+  background-color: var(--ease-overline-color);
+  border-radius: var(--ease-overline-height);
+  transition: width var(--ease-overline-duration)
+    cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.ease-overline-slide-right:hover::before,
+.ease-overline-slide-right:focus-visible::before {
+  width: 100%;
+}
+
+.ease-overline-slide-right:hover {
+  color: #ffffff;
+}
+
+/* Accessible focus outline */
+.ease-overline-slide-right:focus-visible {
+  outline: none;
+  border-radius: 4px;
+}
+
+/* Demo Nav styling */
+.demo-nav {
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border-color);
+  padding: 1rem 2rem;
+  border-radius: 50px;
+}
+
+/* Big Heading Target style */
+.demo-heading {
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+}
+
+/* Color Customizer Target */
+.custom-overline {
+  --ease-overline-color: #10b981; /* Custom Green Overline color */
+  --ease-overline-height: 4px;
+  --ease-overline-gap: 12px;
+}
+
+/* Reduced Motion Override */
+@media (prefers-reduced-motion: reduce) {
+  .ease-overline-slide-right::before {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new hover animation utility: **ease-overline-slide-right**.

This animation creates an overline above an element that smoothly slides in from left to right on hover using a `::before` pseudo-element.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/ease-overline-slide-right/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A lightweight overline hover animation where a line appears above the element and expands from left to right.

### How does a developer use it?

```html
<a href="#" class="ease-overline-slide-right">
  Hover Me
</a>
```

### Why does it fit EaseMotion CSS?

This feature follows the EaseMotion CSS philosophy by providing a simple, reusable, human-readable animation utility that enhances user interaction with minimal markup and pure CSS.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

* Uses a `::before` pseudo-element positioned above the target element.
* Supports customization through the `--ease-overline-color` CSS variable.
* Includes documentation and usage examples.
* Fixes #17207
