### PR TITLE
feat: add CSS scroll-driven animation utilities (issue #16395)

### DIFF
--- a/submissions/examples/scroll-driven-animations-miller/README.md
+++ b/submissions/examples/scroll-driven-animations-miller/README.md
@@ -1,0 +1,57 @@
+# CSS Scroll-Driven Animation Utilities
+
+## What does this do?
+Utility classes built on the native CSS Scroll-Driven Animations API (`animation-timeline: scroll()` and `animation-timeline: view()`). Animations are driven directly by scroll position — no `IntersectionObserver`, no scroll event listeners, no JavaScript at all.
+
+## Classes included
+
+| Class | Effect | Timeline |
+|---|---|---|
+| `.ease-scroll-progress-bar` | Fixed top bar that fills as the whole page scrolls | `scroll(root)` |
+| `.ease-scroll-reveal` | Fade-in-up tied to scroll position | `view()` |
+| `.ease-scroll-parallax` | Continuous drift while element is in view | `view()` |
+| `.ease-scroll-zoom` | Scales up as element enters viewport | `view()` |
+| `.ease-scroll-blur` | Unblurs as element scrolls into view | `view()` |
+| `.ease-view-reveal` | Generic fade + slide-up reveal | `view()` |
+| `.ease-view-slide-in-left` / `.ease-view-slide-in-right` | Directional slide-in on view entry | `view()` |
+
+## Usage
+
+```html
+<!-- Fixed progress bar, place once near top of <body> -->
+<div class="ease-scroll-progress-bar"></div>
+
+<!-- Reveal on scroll — no JS needed -->
+<div class="ease-scroll-reveal">
+  <h2>This fades and slides up as you scroll to it</h2>
+</div>
+
+<!-- Directional slide-ins -->
+<div class="ease-view-slide-in-left">Slides from the left</div>
+<div class="ease-view-slide-in-right">Slides from the right</div>
+
+<!-- Parallax drift -->
+<h2 class="ease-scroll-parallax">Moves as the page scrolls</h2>
+```
+
+## Fallback — `.ease-scroll-fallback`
+For browsers without `animation-timeline` support, the `@supports not (animation-timeline: scroll())` block forces all reveal/zoom/blur/slide classes to their final visible state (opacity 1, no transform, no blur) instead of staying stuck at their `from` keyframe. The progress bar is hidden entirely since there's no scroll position to drive it. Apply `.ease-scroll-fallback` to any custom element that needs the same static fallback behavior.
+
+```css
+@supports not (animation-timeline: scroll()) {
+  .ease-scroll-fallback {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+```
+
+## Browser support
+Chrome 115+, Edge 115+. Firefox and Safari do not yet support `animation-timeline` — the `@supports` fallback ensures content remains fully visible and accessible regardless.
+
+## prefers-reduced-motion
+All scroll-driven animations are disabled under `prefers-reduced-motion: reduce`, immediately showing the final state (no blur, full opacity, no transform offset).
+
+## Why it fits EaseMotion CSS?
+This is the most modern, JavaScript-free way to build scroll-driven motion in CSS today. Zero scroll event listeners, zero layout thrashing, zero IntersectionObserver polyfills — animations are native and GPU-composited. Fits EaseMotion's animation-first, composable philosophy with human-readable class names throughout.

--- a/submissions/examples/scroll-driven-animations-miller/demo.html
+++ b/submissions/examples/scroll-driven-animations-miller/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Scroll-Driven Animation Utilities — Submission Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- Fixed scroll progress bar -->
+  <div class="ease-scroll-progress-bar"></div>
+
+  <div class="demo-spacer">↓ Scroll down to see scroll-driven animations ↓</div>
+
+  <section class="demo-section">
+    <div class="demo-card ease-scroll-reveal">
+      <span class="demo-tag">.ease-scroll-reveal</span>
+      <h2>Fade-in-up tied to scroll</h2>
+      <p>This card animates based on its position in the viewport — not on time. Scroll up and down to scrub the animation directly.</p>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <div class="demo-card ease-scroll-zoom">
+      <span class="demo-tag">.ease-scroll-zoom</span>
+      <h2>Zoom in as it enters view</h2>
+      <p>Scales from 0.8 to 1.0 as the element enters the viewport, driven entirely by scroll position via animation-timeline: view().</p>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <div class="demo-card ease-scroll-blur">
+      <span class="demo-tag">.ease-scroll-blur</span>
+      <h2>Unblur on scroll</h2>
+      <p>Starts blurred and sharpens as you scroll it into view. No JavaScript blur calculation needed.</p>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <div class="demo-card ease-view-slide-in-left">
+      <span class="demo-tag">.ease-view-slide-in-left</span>
+      <h2>Slides in from the left</h2>
+      <p>Uses animation-range: entry 0% entry 70% so the slide completes before the element is fully in view.</p>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <div class="demo-card ease-view-slide-in-right">
+      <span class="demo-tag">.ease-view-slide-in-right</span>
+      <h2>Slides in from the right</h2>
+      <p>Mirror of slide-in-left — useful for alternating left/right reveal patterns down a page.</p>
+    </div>
+  </section>
+
+  <section class="demo-section">
+    <div class="demo-card ease-view-reveal">
+      <span class="demo-tag">.ease-view-reveal</span>
+      <h2>Generic view-timeline reveal</h2>
+      <p>The base reveal utility — fade + slide-up, driven by animation-timeline: view() across the full entry range.</p>
+    </div>
+  </section>
+
+  <section class="demo-section" style="overflow: hidden;">
+    <div class="demo-card">
+      <span class="demo-tag">.ease-scroll-parallax</span>
+      <h2 class="ease-scroll-parallax">This text drifts upward</h2>
+      <p>Driven by animation-timeline: view() with animation-range: cover 0% cover 100% — moves continuously across the full time the element is in view.</p>
+    </div>
+  </section>
+
+  <div class="demo-spacer">End of demo — scroll back up to replay</div>
+
+  <div style="padding: 40px 24px; max-width: 640px; margin: 0 auto;">
+    <h3 style="font-size: 14px; text-transform: uppercase; letter-spacing: 0.05em; color: #94a3b8;">Browser Support</h3>
+    <table style="width: 100%; border-collapse: collapse; font-size: 13px; margin-top: 12px;">
+      <tr style="background:#f1f5f9;"><th style="padding:8px 12px; text-align:left; border:1px solid #e2e8f0;">Browser</th><th style="padding:8px 12px; text-align:left; border:1px solid #e2e8f0;">Support</th></tr>
+      <tr><td style="padding:8px 12px; border:1px solid #e2e8f0;">Chrome 115+</td><td style="padding:8px 12px; border:1px solid #e2e8f0; color:#22c55e; font-weight:700;">✓ Full</td></tr>
+      <tr><td style="padding:8px 12px; border:1px solid #e2e8f0;">Edge 115+</td><td style="padding:8px 12px; border:1px solid #e2e8f0; color:#22c55e; font-weight:700;">✓ Full</td></tr>
+      <tr><td style="padding:8px 12px; border:1px solid #e2e8f0;">Firefox</td><td style="padding:8px 12px; border:1px solid #e2e8f0; color:#ef4444; font-weight:700;">✗ Not yet — falls back via @supports</td></tr>
+      <tr><td style="padding:8px 12px; border:1px solid #e2e8f0;">Safari</td><td style="padding:8px 12px; border:1px solid #e2e8f0; color:#ef4444; font-weight:700;">✗ Not yet — falls back via @supports</td></tr>
+    </table>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/scroll-driven-animations-miller/style.css
+++ b/submissions/examples/scroll-driven-animations-miller/style.css
@@ -1,0 +1,198 @@
+/* CSS Scroll-Driven Animation Utilities */
+/* Uses the native Scroll-Driven Animations API — animation-timeline: scroll() / view() */
+/* Zero JavaScript for the animation itself */
+
+:root {
+  --ease-primary: #7c3aed;
+}
+
+/* ─── Progress bar — animation-timeline: scroll(root) ─ */
+@keyframes ease-scroll-grow {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(1); }
+}
+
+.ease-scroll-progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: var(--ease-primary);
+  transform-origin: left;
+  animation: ease-scroll-grow linear;
+  animation-timeline: scroll(root);
+  z-index: 9999;
+}
+
+/* ─── Scroll reveal — fade + slide tied to scroll position */
+@keyframes ease-scroll-reveal-kf {
+  from { opacity: 0; transform: translateY(40px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.ease-scroll-reveal {
+  animation: ease-scroll-reveal-kf linear;
+  animation-timeline: view();
+  animation-range: entry 0% entry 60%;
+}
+
+/* ─── Scroll parallax — element moves slower/faster than scroll */
+@keyframes ease-scroll-parallax-kf {
+  from { transform: translateY(0); }
+  to   { transform: translateY(-60px); }
+}
+
+.ease-scroll-parallax {
+  animation: ease-scroll-parallax-kf linear;
+  animation-timeline: view();
+  animation-range: cover 0% cover 100%;
+}
+
+/* ─── Scroll zoom — scales up as element enters viewport */
+@keyframes ease-scroll-zoom-kf {
+  from { transform: scale(0.8); opacity: 0; }
+  to   { transform: scale(1);   opacity: 1; }
+}
+
+.ease-scroll-zoom {
+  animation: ease-scroll-zoom-kf linear;
+  animation-timeline: view();
+  animation-range: entry 0% entry 70%;
+}
+
+/* ─── Scroll blur — unblurs as element scrolls into view ─ */
+@keyframes ease-scroll-blur-kf {
+  from { filter: blur(12px); opacity: 0; }
+  to   { filter: blur(0);    opacity: 1; }
+}
+
+.ease-scroll-blur {
+  animation: ease-scroll-blur-kf linear;
+  animation-timeline: view();
+  animation-range: entry 0% entry 80%;
+}
+
+/* ─── View reveal — generic view-timeline driven reveal ── */
+@keyframes ease-reveal {
+  from { opacity: 0; transform: translateY(24px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.ease-view-reveal {
+  animation: ease-reveal linear;
+  animation-timeline: view();
+  animation-range: entry 0% entry 100%;
+}
+
+/* ─── View slide-in — from left/right on view entry ─────── */
+@keyframes ease-view-slide-in-left-kf {
+  from { opacity: 0; transform: translateX(-80px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-view-slide-in-right-kf {
+  from { opacity: 0; transform: translateX(80px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+.ease-view-slide-in-left {
+  animation: ease-view-slide-in-left-kf linear;
+  animation-timeline: view();
+  animation-range: entry 0% entry 70%;
+}
+
+.ease-view-slide-in-right {
+  animation: ease-view-slide-in-right-kf linear;
+  animation-timeline: view();
+  animation-range: entry 0% entry 70%;
+}
+
+/* ─── Fallback for browsers without scroll-timeline support */
+/* Without @supports, animation-timeline is simply ignored and
+   the element stays at its `from` keyframe state (invisible/blurred).
+   This fallback forces a visible, static end-state instead. */
+@supports not (animation-timeline: scroll()) {
+  .ease-scroll-progress-bar {
+    display: none; /* no scroll position available — hide rather than show stuck at 0 */
+  }
+
+  .ease-scroll-reveal,
+  .ease-scroll-zoom,
+  .ease-scroll-blur,
+  .ease-view-reveal,
+  .ease-view-slide-in-left,
+  .ease-view-slide-in-right,
+  .ease-scroll-fallback {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    filter: none;
+  }
+}
+
+/* ─── prefers-reduced-motion ─────────────────────────────
+   Scroll-driven animations can be just as motion-heavy as
+   time-based ones — disable and show final state. */
+@media (prefers-reduced-motion: reduce) {
+  .ease-scroll-progress-bar,
+  .ease-scroll-reveal,
+  .ease-scroll-parallax,
+  .ease-scroll-zoom,
+  .ease-scroll-blur,
+  .ease-view-reveal,
+  .ease-view-slide-in-left,
+  .ease-view-slide-in-right {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+    filter: none !important;
+  }
+}
+
+/* ─── Demo page layout (not part of the utility classes) ─ */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+}
+.demo-section {
+  min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 24px;
+  gap: 16px;
+  text-align: center;
+}
+.demo-card {
+  background: #fff;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 32px 40px;
+  max-width: 480px;
+  box-shadow: 0 10px 30px rgba(15,23,42,0.06);
+}
+.demo-tag {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: #ede9fe;
+  color: #5b21b6;
+  margin-bottom: 14px;
+}
+.demo-spacer {
+  height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #94a3b8;
+  font-size: 13px;
+}


### PR DESCRIPTION
## Pull Request Description
Adds utility classes built on the native CSS Scroll-Driven Animations API (animation-timeline: scroll() / view()). Includes ease-scroll-progress-bar, ease-scroll-reveal, ease-scroll-parallax, ease-scroll-zoom, ease-scroll-blur, ease-view-reveal, and ease-view-slide-in-left/right. Zero JavaScript — no IntersectionObserver, no scroll listeners. Includes @supports fallback and prefers-reduced-motion support.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/examples/scroll-driven-animations-miller/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
Seven scroll-driven animation utilities using `animation-timeline: scroll(root)` for the progress bar and `animation-timeline: view()` for all element-level reveals — fade, zoom, blur, parallax, and directional slide-ins.

**How does a developer use it?**
```html
<div class="ease-scroll-progress-bar"></div>

<div class="ease-scroll-reveal">Fades and slides up on scroll</div>
<div class="ease-view-slide-in-left">Slides from the left on scroll</div>
<h2 class="ease-scroll-parallax">Drifts as the page scrolls</h2>
```

**Why does it fit EaseMotion CSS?**
The most modern JS-free scroll motion API available — GPU-composited, no scroll event listeners, no layout thrashing. Fully composable, human-readable class names matching the exact spec proposed in the issue.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox *(no animation-timeline support yet — graceful fallback via @supports, content remains fully visible)*
- [x] Edge
- [ ] Safari *(no animation-timeline support yet — same fallback applies)*

---
## Notes for Maintainer
All view-timeline classes use `animation-range: entry 0% entry X%` tuned per-effect (60–100%) so reveals complete before the element is fully centered, matching natural scroll reveal timing. The progress bar uses `transform: scaleX()` with `transform-origin: left` rather than `width` for GPU compositing. Fallback hides the progress bar entirely (no scroll position without API support) and forces all other classes to their final visible state via `@supports not (animation-timeline: scroll())`. A reusable `.ease-scroll-fallback` class is also provided for custom elements. prefers-reduced-motion disables every animation in this set and shows the final state immediately.

Closes #16395