### PR TITLE
feat(utilities): add CSS line clamp text truncation utility — ease-clamp-1 to -6, custom property variant, pure CSS read-more toggle

### DIFF
--- a/submissions/examples/line-clamp-text/README.md
+++ b/submissions/examples/line-clamp-text/README.md
@@ -1,0 +1,76 @@
+# CSS Line Clamp — Text Truncation Utility
+
+**Fixes:** Issue #15571
+
+## Overview
+
+A self-contained CSS line clamp text truncation example under
+`submissions/examples/line-clamp-text/`. Provides fixed utility
+classes (`.ease-clamp-1` through `.ease-clamp-6`), a CSS custom
+property variant for any line count, and a pure CSS "Read more"
+expand toggle — all with zero JavaScript.
+
+## Usage
+
+```html
+<!-- Fixed classes -->
+<p class="ease-clamp-1">Truncated at 1 line</p>
+<p class="ease-clamp-2">Truncated at 2 lines</p>
+<p class="ease-clamp-3">Truncated at 3 lines</p>
+
+<!-- Any line count via CSS custom property -->
+<p class="ease-clamp" style="--ease-clamp-lines: 4">
+  Truncated at 4 lines
+</p>
+
+<!-- Pure CSS Read more toggle -->
+<div class="ease-clamp-expand">
+  <input type="checkbox" id="expand-1" class="ease-clamp-toggle" />
+  <p class="ease-clamp-3 ease-clamp-content">Long text here...</p>
+  <label for="expand-1" class="ease-clamp-btn"></label>
+</div>
+```
+
+## Classes
+
+| Class | Lines |
+|---|---|
+| `.ease-clamp-1` | 1 |
+| `.ease-clamp-2` | 2 |
+| `.ease-clamp-3` | 3 (most common) |
+| `.ease-clamp-4` | 4 |
+| `.ease-clamp-5` | 5 |
+| `.ease-clamp-6` | 6 |
+| `.ease-clamp` | Custom via `--ease-clamp-lines` |
+
+## How It Works
+
+```css
+.ease-clamp-3 {
+  overflow: hidden;              /* clip overflow */
+  display: -webkit-box;          /* enable line-clamp model */
+  -webkit-box-orient: vertical;  /* stack lines vertically */
+  -webkit-line-clamp: 3;         /* limit to 3 lines + ellipsis */
+}
+```
+
+All three properties must appear together — removing any one breaks
+the effect in at least one browser.
+
+## Browser Support
+
+| Browser | Support |
+|---|---|
+| Chrome 14+ | ✅ |
+| Firefox 68+ | ✅ |
+| Safari 5+ | ✅ |
+| Edge 17+ | ✅ |
+
+## Acceptance Criteria
+
+- [x] `.ease-clamp-1` through `.ease-clamp-6` utility classes
+- [x] `.ease-clamp` with `--ease-clamp-lines` custom property
+- [x] Pure CSS "Read more" expand toggle (no JavaScript)
+- [x] Dark mode via CSS tokens
+- [x] Browser support documented
+- [x] Self-contained under `submissions/examples/line-clamp-text/`

--- a/submissions/examples/line-clamp-text/demo.html
+++ b/submissions/examples/line-clamp-text/demo.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Line Clamp — Text Truncation #15571</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: var(--ease-color-surface, #f8fafc);
+      color: var(--ease-color-text, #1e293b);
+      margin: 0;
+      padding: 3rem 1.5rem;
+
+      --ease-color-surface: #f8fafc;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f0f17; --ease-color-surface: #1e1e2e; }
+    }
+
+    .page { max-width: 780px; margin: 0 auto; }
+
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+
+    h2 {
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--ease-color-text-muted, #64748b);
+      margin: 2.5rem 0 0.75rem;
+      border-bottom: 1px solid var(--ease-color-border, #e2e8f0);
+      padding-bottom: 0.4rem;
+    }
+
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+    }
+
+    /* Range slider */
+    .slider-row {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    input[type=range] { flex: 1; accent-color: #6c63ff; }
+
+    #line-count-display {
+      font-weight: 600;
+      min-width: 1.5rem;
+      color: #6c63ff;
+    }
+
+    .note {
+      background: var(--ease-color-surface, #fff);
+      border-left: 3px solid #6c63ff;
+      border-radius: 0 8px 8px 0;
+      padding: 0.875rem 1rem;
+      font-size: 0.875rem;
+      margin-top: 1.5rem;
+      line-height: 1.65;
+    }
+
+    .note code {
+      background: rgba(0,0,0,0.06);
+      border-radius: 4px;
+      padding: 0.1rem 0.35rem;
+      font-size: 0.82em;
+      font-family: ui-monospace, monospace;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .note code { background: rgba(255,255,255,0.08); }
+    }
+
+    pre {
+      background: #0f172a;
+      color: #e2e8f0;
+      border-radius: 8px;
+      padding: 1.25rem;
+      overflow-x: auto;
+      font-size: 0.82rem;
+      line-height: 1.6;
+      font-family: ui-monospace, monospace;
+      margin-top: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+<div class="page">
+
+  <h1>CSS Line Clamp — Text Truncation</h1>
+  <p style="color:var(--ease-color-text-muted,#64748b); margin-top:0.25rem;">
+    Fixes <strong>#15571</strong> — self-contained example under
+    <code>submissions/examples/line-clamp-text/</code>.
+    Pure CSS multi-line truncation. Zero JavaScript for the clamp itself.
+  </p>
+
+  <!-- Fixed line-count classes -->
+  <h2>Fixed Line-Count Classes</h2>
+  <div class="card-grid">
+
+    <div class="clamp-card">
+      <span class="clamp-badge">.ease-clamp-1</span>
+      <p class="clamp-card-text ease-clamp-1">
+        This paragraph will be truncated after exactly one line no matter
+        how much content is written inside it. The ellipsis appears at the end.
+      </p>
+    </div>
+
+    <div class="clamp-card">
+      <span class="clamp-badge">.ease-clamp-2</span>
+      <p class="clamp-card-text ease-clamp-2">
+        This paragraph will be truncated after exactly two lines. It gives a
+        bit more context than a single line while still keeping the card height
+        predictable and consistent across a grid layout.
+      </p>
+    </div>
+
+    <div class="clamp-card">
+      <span class="clamp-badge">.ease-clamp-3</span>
+      <p class="clamp-card-text ease-clamp-3">
+        Three lines of text are commonly used in blog post cards and article
+        previews. This gives enough content to understand the topic without
+        overwhelming the reader. The rest is hidden with an ellipsis at the end
+        of line three, keeping layout tight and scannable.
+      </p>
+    </div>
+
+    <div class="clamp-card">
+      <span class="clamp-badge">.ease-clamp-4</span>
+      <p class="clamp-card-text ease-clamp-4">
+        Four lines work well for product descriptions or long summary text
+        where a bit more context is beneficial. The card height remains uniform
+        because all cards in the grid clamp at the same number of lines,
+        regardless of the actual text length inside each card.
+      </p>
+    </div>
+
+    <div class="clamp-card">
+      <span class="clamp-badge">.ease-clamp-5</span>
+      <p class="clamp-card-text ease-clamp-5">
+        Five lines are sometimes used for longer previews like news articles,
+        email summaries, or support ticket descriptions. Even with five lines,
+        the layout stays predictable and the grid remains aligned. Any content
+        beyond five lines is hidden by overflow:hidden and the ellipsis
+        character is displayed to signal truncation to the reader.
+      </p>
+    </div>
+
+    <div class="clamp-card">
+      <span class="clamp-badge">.ease-clamp-6</span>
+      <p class="clamp-card-text ease-clamp-6">
+        Six lines provide a generous preview for content-heavy components like
+        README excerpts, changelog entries, or comment threads. The height is
+        still capped and predictable. Combined with a "Read more" link, this
+        pattern avoids both truncating too aggressively and exposing walls of
+        text in a UI component designed for scanning rather than reading.
+      </p>
+    </div>
+
+  </div>
+
+  <!-- CSS custom property / dynamic demo -->
+  <h2>Dynamic — CSS Custom Property</h2>
+  <div class="slider-row">
+    <label>Lines:</label>
+    <input type="range" min="1" max="8" value="3" id="line-slider"
+      oninput="document.getElementById('line-count-display').textContent=this.value;
+               document.getElementById('dynamic-text').style.setProperty('--ease-clamp-lines', this.value)" />
+    <span id="line-count-display">3</span>
+  </div>
+  <div class="clamp-card">
+    <p class="clamp-card-text ease-clamp" id="dynamic-text"
+       style="--ease-clamp-lines: 3;">
+      This paragraph responds to the slider above. Set
+      <code>--ease-clamp-lines</code> on any element that has the
+      <code>.ease-clamp</code> class and the line count updates instantly.
+      No JavaScript animation — just a CSS custom property being changed.
+      You can set this on a parent element to control multiple children,
+      or set it inline as shown here for per-element control. This makes
+      the line clamp utility flexible enough for any design system or
+      component library without hardcoding any specific line count.
+    </p>
+  </div>
+
+  <!-- Read more pattern -->
+  <h2>Pure CSS "Read more" Expand Toggle</h2>
+  <p style="font-size:0.85rem; color:var(--ease-color-text-muted,#64748b);">
+    No JavaScript — uses hidden checkbox + <code>:checked</code> selector.
+  </p>
+
+  <div class="clamp-card" style="max-width:480px;">
+    <div class="ease-clamp-expand">
+      <input type="checkbox" id="expand-demo" class="ease-clamp-toggle" />
+      <p class="clamp-card-text ease-clamp-3 ease-clamp-content">
+        EaseMotion CSS is a lightweight, animation-first CSS framework
+        built for the modern web. It provides utility classes for fade,
+        slide, zoom, bounce, float, typewriter, and skeleton effects —
+        all with zero JavaScript, full dark mode support, and
+        prefers-reduced-motion accessibility built in. Every component
+        follows the ease-* naming convention for predictable, collision-free
+        class names. The framework is designed to be dropped into any project
+        without build tools, bundlers, or configuration.
+      </p>
+      <label for="expand-demo" class="ease-clamp-btn"></label>
+    </div>
+  </div>
+
+  <!-- Code reference -->
+  <h2>Quick Reference</h2>
+  <pre><code>&lt;!-- Fixed classes --&gt;
+&lt;p class="ease-clamp-1"&gt;One line&lt;/p&gt;
+&lt;p class="ease-clamp-2"&gt;Two lines&lt;/p&gt;
+&lt;p class="ease-clamp-3"&gt;Three lines&lt;/p&gt;
+
+&lt;!-- CSS custom property (any number) --&gt;
+&lt;p class="ease-clamp" style="--ease-clamp-lines: 4"&gt;Four lines&lt;/p&gt;
+
+&lt;!-- Read more toggle (no JS) --&gt;
+&lt;div class="ease-clamp-expand"&gt;
+  &lt;input type="checkbox" id="expand-1" class="ease-clamp-toggle" /&gt;
+  &lt;p class="ease-clamp-3 ease-clamp-content"&gt;Long text...&lt;/p&gt;
+  &lt;label for="expand-1" class="ease-clamp-btn"&gt;&lt;/label&gt;
+&lt;/div&gt;</code></pre>
+
+  <div class="note">
+    <strong>Browser support:</strong> <code>-webkit-line-clamp</code> is supported
+    in Chrome 14+, Firefox 68+, Safari 5+, and Edge 17+ — effectively all modern
+    browsers. The <code>-webkit-</code> prefix is still required even in non-WebKit
+    browsers because the unprefixed <code>line-clamp</code> property is part of the
+    CSS Overflow Level 4 spec and not yet widely available.<br /><br />
+    <strong>The three required properties</strong> must always appear together:
+    <code>overflow: hidden</code>, <code>display: -webkit-box</code>, and
+    <code>-webkit-box-orient: vertical</code>.
+  </div>
+
+</div>
+</body>
+</html>

--- a/submissions/examples/line-clamp-text/style.css
+++ b/submissions/examples/line-clamp-text/style.css
@@ -8,7 +8,7 @@
    Usage:
      <p class="ease-clamp-2">Long text...</p>
      <p class="ease-clamp-3">Long text...</p>
-     <p class="ease-clamp ease-clamp--4">Long text...</p>
+     <p class="ease-clamp--custom" style="--ease-clamp-lines:4">Long text...</p>
 */
 
 
@@ -35,29 +35,24 @@
 }
 
 
-/* ── Base clamp mixin ──────────────────────────────────────── */
-/*
-  The three properties must always appear together:
-  1. overflow: hidden          — clips overflowing text
-  2. display: -webkit-box      — enables line-clamp box model
-  3. -webkit-box-orient: vertical — stacks lines vertically
-  4. -webkit-line-clamp: N     — sets the line limit
-*/
+/* ── Base clamp ─────────────────────────────────────────────── */
 .ease-clamp {
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: var(--ease-clamp-lines, 3);
+  line-clamp: var(--ease-clamp-lines, 3);
 }
 
 
-/* ── Fixed line-count utility classes ──────────────────────── */
+/* ── Fixed line-count utility classes ───────────────────────── */
 
 .ease-clamp-1 {
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 1;
+  line-clamp: 1;
 }
 
 .ease-clamp-2 {
@@ -65,6 +60,7 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
 }
 
 .ease-clamp-3 {
@@ -72,6 +68,7 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
+  line-clamp: 3;
 }
 
 .ease-clamp-4 {
@@ -79,6 +76,7 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 4;
+  line-clamp: 4;
 }
 
 .ease-clamp-5 {
@@ -86,6 +84,7 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 5;
+  line-clamp: 5;
 }
 
 .ease-clamp-6 {
@@ -93,29 +92,33 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 6;
+  line-clamp: 6;
 }
 
 
-/* ── CSS custom property variant ──────────────────────────── */
-/* Set --ease-clamp-lines inline for any count */
+/* ── CSS custom property variant ────────────────────────────── */
+/* Set --ease-clamp-lines inline for any count:
+   <p class="ease-clamp--custom" style="--ease-clamp-lines:8"> */
 .ease-clamp--custom {
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: var(--ease-clamp-lines);
+  line-clamp: var(--ease-clamp-lines);
 }
 
 
-/* ── "Read more" expand pattern ───────────────────────────── */
+/* ── "Read more" expand pattern ─────────────────────────────── */
 /*
   Pure CSS expand toggle using hidden checkbox + label.
   No JavaScript required.
 
-  HTML pattern:
+  ⚠️  IMPORTANT — siblings must be in this exact order:
+
     <div class="ease-clamp-expand">
       <input type="checkbox" id="expand-1" class="ease-clamp-toggle" />
       <p class="ease-clamp-3 ease-clamp-content">Long text...</p>
-      <label for="expand-1" class="ease-clamp-btn">Read more</label>
+      <label for="expand-1" class="ease-clamp-btn"></label>
     </div>
 */
 
@@ -123,14 +126,21 @@
   position: relative;
 }
 
+/* Hide checkbox visually but keep in DOM for ~ selector */
 .ease-clamp-toggle {
-  display: none;
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
 }
 
-/* When checkbox is checked: remove line-clamp */
+/* When checked — remove clamp */
 .ease-clamp-toggle:checked ~ .ease-clamp-content {
-  -webkit-line-clamp: unset;
   display: block;
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+  overflow: visible;
 }
 
 /* Toggle button */
@@ -142,32 +152,24 @@
   cursor: pointer;
   user-select: none;
   font-weight: 500;
+  text-decoration: none;
 }
 
 .ease-clamp-btn:hover {
   text-decoration: underline;
 }
 
-/* Change label text when expanded */
-.ease-clamp-toggle:checked ~ .ease-clamp-btn::after {
-  content: 'Show less';
-}
-
+/* Dynamic label text via ::after — no font-size:0 hack */
 .ease-clamp-toggle:not(:checked) ~ .ease-clamp-btn::after {
   content: 'Read more';
 }
 
-/* Hide the default label text — use ::after only */
-.ease-clamp-btn {
-  font-size: 0;
-}
-
-.ease-clamp-btn::after {
-  font-size: 0.85rem;
+.ease-clamp-toggle:checked ~ .ease-clamp-btn::after {
+  content: 'Show less';
 }
 
 
-/* ── Demo card styles ──────────────────────────────────────── */
+/* ── Demo card styles ────────────────────────────────────────── */
 .clamp-card {
   background: var(--ease-color-surface);
   border: 1px solid var(--ease-color-border);

--- a/submissions/examples/line-clamp-text/style.css
+++ b/submissions/examples/line-clamp-text/style.css
@@ -1,0 +1,201 @@
+/* === CSS Line Clamp — Text Truncation Utility ===
+   Fixes #15571
+
+   Pure CSS multi-line text truncation using -webkit-line-clamp.
+   Widely supported: Chrome 14+, Firefox 68+, Safari 5+, Edge 17+.
+   Zero JavaScript. Dark mode via tokens.
+
+   Usage:
+     <p class="ease-clamp-2">Long text...</p>
+     <p class="ease-clamp-3">Long text...</p>
+     <p class="ease-clamp ease-clamp--4">Long text...</p>
+*/
+
+
+/* ── Tokens ────────────────────────────────────────────────── */
+:root {
+  --ease-clamp-lines:      3;
+  --ease-color-surface:    #ffffff;
+  --ease-color-text:       #1e293b;
+  --ease-color-text-muted: #64748b;
+  --ease-color-border:     #e2e8f0;
+  --ease-color-primary:    #6c63ff;
+  --ease-radius-md:        8px;
+  --ease-shadow-sm:        0 1px 4px rgba(0,0,0,0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-color-surface:    #1e1e2e;
+    --ease-color-text:       #cdd6f4;
+    --ease-color-text-muted: #a6adc8;
+    --ease-color-border:     #313244;
+    --ease-shadow-sm:        0 1px 4px rgba(0,0,0,0.3);
+  }
+}
+
+
+/* ── Base clamp mixin ──────────────────────────────────────── */
+/*
+  The three properties must always appear together:
+  1. overflow: hidden          — clips overflowing text
+  2. display: -webkit-box      — enables line-clamp box model
+  3. -webkit-box-orient: vertical — stacks lines vertically
+  4. -webkit-line-clamp: N     — sets the line limit
+*/
+.ease-clamp {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--ease-clamp-lines, 3);
+}
+
+
+/* ── Fixed line-count utility classes ──────────────────────── */
+
+.ease-clamp-1 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+}
+
+.ease-clamp-2 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.ease-clamp-3 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.ease-clamp-4 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+}
+
+.ease-clamp-5 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+}
+
+.ease-clamp-6 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 6;
+}
+
+
+/* ── CSS custom property variant ──────────────────────────── */
+/* Set --ease-clamp-lines inline for any count */
+.ease-clamp--custom {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--ease-clamp-lines);
+}
+
+
+/* ── "Read more" expand pattern ───────────────────────────── */
+/*
+  Pure CSS expand toggle using hidden checkbox + label.
+  No JavaScript required.
+
+  HTML pattern:
+    <div class="ease-clamp-expand">
+      <input type="checkbox" id="expand-1" class="ease-clamp-toggle" />
+      <p class="ease-clamp-3 ease-clamp-content">Long text...</p>
+      <label for="expand-1" class="ease-clamp-btn">Read more</label>
+    </div>
+*/
+
+.ease-clamp-expand {
+  position: relative;
+}
+
+.ease-clamp-toggle {
+  display: none;
+}
+
+/* When checkbox is checked: remove line-clamp */
+.ease-clamp-toggle:checked ~ .ease-clamp-content {
+  -webkit-line-clamp: unset;
+  display: block;
+}
+
+/* Toggle button */
+.ease-clamp-btn {
+  display: inline-block;
+  margin-top: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--ease-color-primary);
+  cursor: pointer;
+  user-select: none;
+  font-weight: 500;
+}
+
+.ease-clamp-btn:hover {
+  text-decoration: underline;
+}
+
+/* Change label text when expanded */
+.ease-clamp-toggle:checked ~ .ease-clamp-btn::after {
+  content: 'Show less';
+}
+
+.ease-clamp-toggle:not(:checked) ~ .ease-clamp-btn::after {
+  content: 'Read more';
+}
+
+/* Hide the default label text — use ::after only */
+.ease-clamp-btn {
+  font-size: 0;
+}
+
+.ease-clamp-btn::after {
+  font-size: 0.85rem;
+}
+
+
+/* ── Demo card styles ──────────────────────────────────────── */
+.clamp-card {
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: var(--ease-radius-md);
+  padding: 1.25rem;
+  box-shadow: var(--ease-shadow-sm);
+  color: var(--ease-color-text);
+}
+
+.clamp-card-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.clamp-card-text {
+  font-size: 0.875rem;
+  line-height: 1.65;
+  color: var(--ease-color-text-muted);
+  margin: 0;
+}
+
+.clamp-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 0.12rem 0.5rem;
+  border-radius: 999px;
+  background: var(--ease-color-primary);
+  color: #fff;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Pull Request Description

This submission adds a self-contained CSS line clamp text truncation
example under `submissions/examples/line-clamp-text/` as requested
in issue #15571.

Provides:
- `.ease-clamp-1` through `.ease-clamp-6` fixed utility classes
- `.ease-clamp` with `--ease-clamp-lines` CSS custom property for any line count
- Pure CSS "Read more" expand toggle using hidden checkbox + `:checked` selector
- Dark mode support via CSS tokens
- Zero JavaScript

---

## Type of Change

- [ ] 🎭 New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] My files are inside `submissions/examples/line-clamp-text/`
- [x] I have included `style.css`, `demo.html`, and `README.md`
- [x] My code follows the `.ease-*` naming convention
- [x] Dark mode is supported via CSS custom properties
- [x] `prefers-reduced-motion` is not applicable (no animations)
- [x] Zero JavaScript used for the clamp effect itself
- [x] No changes made to `core/` or `components/` files

Fixes #15571