### PR TITLE
feat(utilities): add ease-clamp-1 through ease-clamp-6 line clamp utilities with CSS custom property variant and pure CSS read-more toggle 

### DIFF
--- a/submissions/examples/line-clamp-texts/README.md
+++ b/submissions/examples/line-clamp-texts/README.md
@@ -1,0 +1,136 @@
+# CSS Line Clamp — Text Truncation Utility
+
+**Issue:** #15571  
+**Folder:** `submissions/examples/line-clamp-text/`  
+**Type:** Feature — new utility  
+**Label:** `good first issue` `GSSoC-26`
+
+---
+
+## What this adds
+
+A pure CSS multi-line text truncation utility using `-webkit-line-clamp`.
+Zero JavaScript. Dark mode via CSS tokens. Widely supported across all
+modern browsers (Chrome 14+, Firefox 68+, Safari 5+, Edge 17+).
+
+---
+
+## Classes
+
+| Class | Lines shown |
+|---|---|
+| `ease-clamp-1` | 1 line |
+| `ease-clamp-2` | 2 lines |
+| `ease-clamp-3` | 3 lines |
+| `ease-clamp-4` | 4 lines |
+| `ease-clamp-5` | 5 lines |
+| `ease-clamp-6` | 6 lines |
+| `ease-clamp` | Reads `--ease-clamp-lines` token (default: 3) |
+| `ease-clamp--custom` | Set any count via inline `--ease-clamp-lines` |
+
+---
+
+## Usage
+
+```html
+<!-- Fixed line counts -->
+<p class="ease-clamp-2">Long text truncated to 2 lines...</p>
+<p class="ease-clamp-3">Long text truncated to 3 lines...</p>
+
+<!-- Base class — uses :root token -->
+<p class="ease-clamp">Uses --ease-clamp-lines (default 3)...</p>
+
+<!-- Custom count via inline variable -->
+<p class="ease-clamp--custom" style="--ease-clamp-lines: 7">
+  Truncated to 7 lines...
+</p>
+
+<!-- Pure CSS Read More toggle — no JavaScript -->
+<div class="ease-clamp-expand">
+  <input type="checkbox" id="expand-1" class="ease-clamp-toggle" />
+  <p class="ease-clamp-3 ease-clamp-content">Long text here...</p>
+  <label for="expand-1" class="ease-clamp-btn"></label>
+</div>
+```
+
+> ⚠️ **Toggle HTML order matters** — `input`, `p.ease-clamp-content`,
+> and `label.ease-clamp-btn` must be siblings in that exact order for
+> the CSS `~` sibling selector to work.
+
+---
+
+## How It Works
+
+Three CSS properties must always appear together to enable line clamping:
+
+```css
+.ease-clamp-3 {
+  overflow: hidden;               /* clips overflowing text */
+  display: -webkit-box;           /* enables line-clamp box model */
+  -webkit-box-orient: vertical;   /* stacks lines vertically */
+  -webkit-line-clamp: 3;          /* sets the line limit */
+  line-clamp: 3;                  /* standard property alongside vendor */
+}
+```
+
+The "Read More" expand toggle uses a hidden `<input type="checkbox">`
+as a pure CSS state holder. When checked, the sibling selector
+`~ .ease-clamp-content` removes the clamp:
+
+```css
+.ease-clamp-toggle:checked ~ .ease-clamp-content {
+  display: block;
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+  overflow: visible;
+}
+```
+
+---
+
+## Dark Mode
+
+All colors use CSS custom properties that auto-switch via
+`@media (prefers-color-scheme: dark)`:
+
+```css
+:root {
+  --ease-color-surface:    #ffffff;
+  --ease-color-text:       #1e293b;
+  --ease-color-text-muted: #64748b;
+  --ease-color-border:     #e2e8f0;
+  --ease-color-primary:    #6c63ff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-color-surface:    #1e1e2e;
+    --ease-color-text:       #cdd6f4;
+    --ease-color-text-muted: #a6adc8;
+    --ease-color-border:     #313244;
+  }
+}
+```
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `style.css` | All clamp utility classes + tokens + expand toggle |
+| `demo.html` | Live demo — all 6 fixed classes, expand toggle, custom variant |
+| `README.md` | Documentation |
+
+---
+
+## Acceptance Criteria
+
+- [x] `ease-clamp-1` through `ease-clamp-6` utility classes
+- [x] Base `ease-clamp` class using `--ease-clamp-lines` token
+- [x] `ease-clamp--custom` for any line count via inline variable
+- [x] Pure CSS "Read More / Show Less" expand toggle
+- [x] Standard `line-clamp` alongside `-webkit-line-clamp`
+- [x] Dark mode via CSS tokens
+- [x] Zero JavaScript
+- [x] No `core/` or `components/` files modified

--- a/submissions/examples/line-clamp-texts/demo.html
+++ b/submissions/examples/line-clamp-texts/demo.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Line Clamp — Text Truncation Utility</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Segoe UI', system-ui, sans-serif;
+      background: var(--ease-color-surface);
+      color: var(--ease-color-text);
+      padding: 3rem 1.5rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 3rem;
+      min-height: 100vh;
+      transition: background 0.3s, color 0.3s;
+    }
+
+    /* Page title */
+    .page-title {
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .page-title h1 {
+      font-size: 1.9rem;
+      font-weight: 800;
+      letter-spacing: -0.02em;
+    }
+
+    .page-title h1 span {
+      color: var(--ease-color-primary);
+    }
+
+    .page-title p {
+      font-size: 0.9rem;
+      color: var(--ease-color-text-muted);
+    }
+
+    /* Section */
+    .demo-section {
+      width: 100%;
+      max-width: 900px;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .section-label {
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--ease-color-text-muted);
+      border-bottom: 1px solid var(--ease-color-border);
+      padding-bottom: 0.5rem;
+    }
+
+    /* Grid */
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+      gap: 1rem;
+    }
+
+    /* Code snippet */
+    .code-snippet {
+      font-family: 'Cascadia Code', 'Fira Code', monospace;
+      font-size: 0.72rem;
+      background: var(--ease-color-border);
+      color: var(--ease-color-primary);
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+      display: inline-block;
+      margin-top: 0.5rem;
+    }
+
+    /* Expand demo */
+    .expand-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1rem;
+    }
+
+    /* Custom variant demo */
+    .custom-demo {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .custom-input-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .custom-input-row label {
+      font-size: 0.85rem;
+      color: var(--ease-color-text-muted);
+    }
+
+    .custom-input-row input[type="range"] {
+      accent-color: var(--ease-color-primary);
+    }
+
+    .custom-input-row span {
+      font-size: 0.85rem;
+      font-weight: 700;
+      color: var(--ease-color-primary);
+      min-width: 1.5rem;
+    }
+
+    /* Motion note */
+    .motion-note {
+      font-size: 0.78rem;
+      color: var(--ease-color-text-muted);
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="page-title">
+    <h1>CSS <span>Line Clamp</span> Utility</h1>
+    <p>Pure CSS multi-line text truncation — ease-clamp-1 through ease-clamp-6 + expand toggle. Zero JavaScript.</p>
+  </div>
+
+  <!-- 1. Fixed line counts -->
+  <div class="demo-section">
+    <span class="section-label">Fixed Line Count — ease-clamp-1 through ease-clamp-6</span>
+    <div class="card-grid">
+
+      <div class="clamp-card">
+        <span class="clamp-badge">1 line</span>
+        <h3 class="clamp-card-title">Single Line Clamp</h3>
+        <p class="clamp-card-text ease-clamp-1">
+          This paragraph will be truncated to exactly one line no matter how long the text gets — perfect for table cells, tag labels, and compact list items where space is very limited.
+        </p>
+        <span class="code-snippet">ease-clamp-1</span>
+      </div>
+
+      <div class="clamp-card">
+        <span class="clamp-badge">2 lines</span>
+        <h3 class="clamp-card-title">Two Line Clamp</h3>
+        <p class="clamp-card-text ease-clamp-2">
+          Great for card subtitles and preview text. Keeps layouts consistent when content varies in length — two lines strikes a balance between giving context and saving vertical space on the page.
+        </p>
+        <span class="code-snippet">ease-clamp-2</span>
+      </div>
+
+      <div class="clamp-card">
+        <span class="clamp-badge">3 lines</span>
+        <h3 class="clamp-card-title">Three Line Clamp</h3>
+        <p class="clamp-card-text ease-clamp-3">
+          The most common truncation length for blog previews, news feeds, and product descriptions. Three lines give readers enough context to decide whether to click through for the full article or description content.
+        </p>
+        <span class="code-snippet">ease-clamp-3</span>
+      </div>
+
+      <div class="clamp-card">
+        <span class="clamp-badge">4 lines</span>
+        <h3 class="clamp-card-title">Four Line Clamp</h3>
+        <p class="clamp-card-text ease-clamp-4">
+          Ideal for sidebar widgets, featured article teasers, and anywhere you want to show a bit more content. Four lines give a generous preview while still keeping the layout tidy and uniform across all cards in your grid.
+        </p>
+        <span class="code-snippet">ease-clamp-4</span>
+      </div>
+
+      <div class="clamp-card">
+        <span class="clamp-badge">5 lines</span>
+        <h3 class="clamp-card-title">Five Line Clamp</h3>
+        <p class="clamp-card-text ease-clamp-5">
+          Used in editorial layouts, long-form previews, and content-rich cards where you want the reader to get substantial context before hitting the ellipsis. Five lines still look clean and avoid the card feeling overly crowded with dense paragraphs.
+        </p>
+        <span class="code-snippet">ease-clamp-5</span>
+      </div>
+
+      <div class="clamp-card">
+        <span class="clamp-badge">6 lines</span>
+        <h3 class="clamp-card-title">Six Line Clamp</h3>
+        <p class="clamp-card-text ease-clamp-6">
+          The maximum fixed utility. Great for full-width cards, featured sections, and anywhere you have more horizontal space. Six lines give nearly a full paragraph of preview — readers get a thorough introduction without scrolling. Works well for documentation previews and wiki summaries.
+        </p>
+        <span class="code-snippet">ease-clamp-6</span>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- 2. Read more expand toggle -->
+  <div class="demo-section">
+    <span class="section-label">Pure CSS "Read More" Expand Toggle — Zero JavaScript</span>
+    <div class="expand-grid">
+
+      <div class="clamp-card">
+        <span class="clamp-badge">Expand toggle</span>
+        <h3 class="clamp-card-title">Blog Preview</h3>
+        <div class="ease-clamp-expand">
+          <input type="checkbox" id="expand-1" class="ease-clamp-toggle" />
+          <p class="clamp-card-text ease-clamp-3 ease-clamp-content">
+            EaseMotion CSS is a zero-dependency animation library built entirely in CSS. It ships utility classes that map directly to keyframe animations, giving developers instant access to fade, slide, bounce, shake, float, and dozens more effects — without writing a single line of JavaScript. The library is designed to be composable: combine speed, delay, and loop variants freely to create exactly the motion you need.
+          </p>
+          <label for="expand-1" class="ease-clamp-btn"></label>
+        </div>
+      </div>
+
+      <div class="clamp-card">
+        <span class="clamp-badge">Expand toggle</span>
+        <h3 class="clamp-card-title">Product Description</h3>
+        <div class="ease-clamp-expand">
+          <input type="checkbox" id="expand-2" class="ease-clamp-toggle" />
+          <p class="clamp-card-text ease-clamp-3 ease-clamp-content">
+            The Mechanical Keyboard Pro features a full aluminum chassis, hot-swap PCB, per-key RGB backlighting with 16.8 million colors, and Bluetooth 5.0 for wireless connectivity up to 10 meters. It ships with tactile brown switches pre-installed, though the hot-swap sockets accept MX-compatible switches of any type. Battery life is rated at 72 hours on a single charge with RGB disabled.
+          </p>
+          <label for="expand-2" class="ease-clamp-btn"></label>
+        </div>
+      </div>
+
+      <div class="clamp-card">
+        <span class="clamp-badge">Expand toggle</span>
+        <h3 class="clamp-card-title">User Review</h3>
+        <div class="ease-clamp-expand">
+          <input type="checkbox" id="expand-3" class="ease-clamp-toggle" />
+          <p class="clamp-card-text ease-clamp-3 ease-clamp-content">
+            Absolutely love this library. I've been using it on three production projects now and the developer experience is unmatched. Being able to just drop a class name and get a polished animation instantly has saved my team hours of work every sprint. The dark mode support with CSS tokens is particularly well thought out — everything just adapts automatically.
+          </p>
+          <label for="expand-3" class="ease-clamp-btn"></label>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- 3. Custom property variant -->
+  <div class="demo-section">
+    <span class="section-label">Custom Property Variant — Set Any Line Count via CSS Variable</span>
+    <div class="clamp-card custom-demo">
+      <h3 class="clamp-card-title">ease-clamp--custom with inline --ease-clamp-lines</h3>
+      <div class="custom-input-row">
+        <label for="line-range">Lines:</label>
+        <input
+          type="range"
+          id="line-range"
+          min="1" max="10" value="4"
+          oninput="
+            document.getElementById('line-count').textContent = this.value;
+            document.getElementById('custom-text').style.setProperty('--ease-clamp-lines', this.value);
+          "
+        />
+        <span id="line-count">4</span>
+      </div>
+      <p
+        id="custom-text"
+        class="clamp-card-text ease-clamp--custom"
+        style="--ease-clamp-lines: 4;"
+      >
+        Drag the slider above to change how many lines are shown. This demonstrates the ease-clamp--custom class which reads the --ease-clamp-lines CSS custom property. You can set this property inline on the element or from any parent scope — making it easy to build dynamic, configurable truncation into design system components without hardcoding a specific line count. The flexibility here is particularly useful for CMS-driven content where editors control how much preview text appears in listing pages.
+      </p>
+      <span class="code-snippet">ease-clamp--custom + style="--ease-clamp-lines: N"</span>
+    </div>
+  </div>
+
+  <!-- 4. Base ease-clamp with token -->
+  <div class="demo-section">
+    <span class="section-label">Base ease-clamp Class — Uses --ease-clamp-lines Token (default: 3)</span>
+    <div class="clamp-card">
+      <h3 class="clamp-card-title">ease-clamp (base class)</h3>
+      <p class="clamp-card-text ease-clamp">
+        This paragraph uses the bare <code>.ease-clamp</code> class which reads <code>--ease-clamp-lines</code> from the token system (default: 3). Override it globally on <code>:root</code> to change all base clamp elements at once — useful for design system theming where line counts are defined centrally rather than per-element.
+      </p>
+      <span class="code-snippet">ease-clamp (inherits --ease-clamp-lines: 3)</span>
+    </div>
+  </div>
+
+  <p class="motion-note">
+    All truncation is pure CSS — no JavaScript required. Dark mode adapts automatically via <code>prefers-color-scheme</code>.
+  </p>
+
+</body>
+</html>

--- a/submissions/examples/line-clamp-texts/style.css
+++ b/submissions/examples/line-clamp-texts/style.css
@@ -1,0 +1,203 @@
+/* === CSS Line Clamp — Text Truncation Utility ===
+   Fixes #15571
+
+   Pure CSS multi-line text truncation using -webkit-line-clamp.
+   Widely supported: Chrome 14+, Firefox 68+, Safari 5+, Edge 17+.
+   Zero JavaScript. Dark mode via tokens.
+
+   Usage:
+     <p class="ease-clamp-2">Long text...</p>
+     <p class="ease-clamp-3">Long text...</p>
+     <p class="ease-clamp--custom" style="--ease-clamp-lines:4">Long text...</p>
+*/
+
+
+/* ── Tokens ────────────────────────────────────────────────── */
+:root {
+  --ease-clamp-lines:      3;
+  --ease-color-surface:    #ffffff;
+  --ease-color-text:       #1e293b;
+  --ease-color-text-muted: #64748b;
+  --ease-color-border:     #e2e8f0;
+  --ease-color-primary:    #6c63ff;
+  --ease-radius-md:        8px;
+  --ease-shadow-sm:        0 1px 4px rgba(0,0,0,0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-color-surface:    #1e1e2e;
+    --ease-color-text:       #cdd6f4;
+    --ease-color-text-muted: #a6adc8;
+    --ease-color-border:     #313244;
+    --ease-shadow-sm:        0 1px 4px rgba(0,0,0,0.3);
+  }
+}
+
+
+/* ── Base clamp ─────────────────────────────────────────────── */
+.ease-clamp {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--ease-clamp-lines, 3);
+  line-clamp: var(--ease-clamp-lines, 3);
+}
+
+
+/* ── Fixed line-count utility classes ───────────────────────── */
+
+.ease-clamp-1 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+}
+
+.ease-clamp-2 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+}
+
+.ease-clamp-3 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+}
+
+.ease-clamp-4 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+}
+
+.ease-clamp-5 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+  line-clamp: 5;
+}
+
+.ease-clamp-6 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 6;
+  line-clamp: 6;
+}
+
+
+/* ── CSS custom property variant ────────────────────────────── */
+/* Set --ease-clamp-lines inline for any count:
+   <p class="ease-clamp--custom" style="--ease-clamp-lines:8"> */
+.ease-clamp--custom {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--ease-clamp-lines);
+  line-clamp: var(--ease-clamp-lines);
+}
+
+
+/* ── "Read more" expand pattern ─────────────────────────────── */
+/*
+  Pure CSS expand toggle using hidden checkbox + label.
+  No JavaScript required.
+
+  ⚠️  IMPORTANT — siblings must be in this exact order:
+
+    <div class="ease-clamp-expand">
+      <input type="checkbox" id="expand-1" class="ease-clamp-toggle" />
+      <p class="ease-clamp-3 ease-clamp-content">Long text...</p>
+      <label for="expand-1" class="ease-clamp-btn"></label>
+    </div>
+*/
+
+.ease-clamp-expand {
+  position: relative;
+}
+
+/* Hide checkbox visually but keep in DOM for ~ selector */
+.ease-clamp-toggle {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* When checked — remove clamp */
+.ease-clamp-toggle:checked ~ .ease-clamp-content {
+  display: block;
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+  overflow: visible;
+}
+
+/* Toggle button */
+.ease-clamp-btn {
+  display: inline-block;
+  margin-top: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--ease-color-primary);
+  cursor: pointer;
+  user-select: none;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.ease-clamp-btn:hover {
+  text-decoration: underline;
+}
+
+/* Dynamic label text via ::after — no font-size:0 hack */
+.ease-clamp-toggle:not(:checked) ~ .ease-clamp-btn::after {
+  content: 'Read more';
+}
+
+.ease-clamp-toggle:checked ~ .ease-clamp-btn::after {
+  content: 'Show less';
+}
+
+
+/* ── Demo card styles ────────────────────────────────────────── */
+.clamp-card {
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: var(--ease-radius-md);
+  padding: 1.25rem;
+  box-shadow: var(--ease-shadow-sm);
+  color: var(--ease-color-text);
+}
+
+.clamp-card-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.clamp-card-text {
+  font-size: 0.875rem;
+  line-height: 1.65;
+  color: var(--ease-color-text-muted);
+  margin: 0;
+}
+
+.clamp-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 0.12rem 0.5rem;
+  border-radius: 999px;
+  background: var(--ease-color-primary);
+  color: #fff;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary

Fixes #15571

Adds a complete CSS line clamp text truncation utility under
`submissions/examples/line-clamp-text/` with:

- `ease-clamp-1` through `ease-clamp-6` fixed line count classes
- Base `ease-clamp` class reading `--ease-clamp-lines` token
- `ease-clamp--custom` for any count via inline CSS variable
- Pure CSS "Read More / Show Less" expand toggle — zero JavaScript
- Dark mode via CSS custom property tokens
- Standard `line-clamp` alongside `-webkit-line-clamp`

---

## Acceptance Criteria (from issue)

- [x] ease-clamp-1 through ease-clamp-6 utility classes
- [x] Base ease-clamp class using --ease-clamp-lines token
- [x] ease-clamp--custom for any line count via inline variable
- [x] Pure CSS Read More / Show Less expand toggle
- [x] Standard line-clamp alongside -webkit-line-clamp
- [x] Dark mode via CSS tokens
- [x] Zero JavaScript
- [x] No core/ or components/ files modified