### PR TITLE
feat(examples): add ease-counter-down — number counts down to zero

### DIFF
--- a/submissions/examples/ease-counter-down/README.md
+++ b/submissions/examples/ease-counter-down/README.md
@@ -1,0 +1,9 @@
+# Ease Counter Down
+
+A CSS-only animated counter that counts down from a configurable starting value to 0 on hover.
+
+Uses `@property` to register `--ease-count-from` as an animatable integer, then leverages `counter-reset` and `content: counter()` to display the animated value.
+
+## Usage
+
+Set `--ease-count-from` on any `.counter-card` element to define the starting value. Hover to trigger the countdown animation.

--- a/submissions/examples/ease-counter-down/demo.html
+++ b/submissions/examples/ease-counter-down/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ease Counter Down</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Counter Down</h1>
+    <p>Hover over a card to count down</p>
+    <div class="card-grid">
+      <div class="counter-card" style="--ease-count-from: 5;">
+        <div class="counter"></div>
+        <span class="label">From 5</span>
+      </div>
+      <div class="counter-card" style="--ease-count-from: 10;">
+        <div class="counter"></div>
+        <span class="label">From 10</span>
+      </div>
+      <div class="counter-card" style="--ease-count-from: 20;">
+        <div class="counter"></div>
+        <span class="label">From 20</span>
+      </div>
+      <div class="counter-card" style="--ease-count-from: 50;">
+        <div class="counter"></div>
+        <span class="label">From 50</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-counter-down/style.css
+++ b/submissions/examples/ease-counter-down/style.css
@@ -1,0 +1,84 @@
+@property --ease-count-from {
+  syntax: "<integer>";
+  inherits: true;
+  initial-value: 0;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container {
+  text-align: center;
+}
+
+h1 {
+  color: #ffffff;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin-bottom: 2rem;
+  color: #9ca3af;
+}
+
+.card-grid {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.counter-card {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 1rem;
+  padding: 2rem;
+  width: 160px;
+  cursor: pointer;
+  transition: border-color 0.3s;
+}
+
+.counter-card:hover {
+  border-color: #6366f1;
+}
+
+.counter-card .counter {
+  font-size: 3rem;
+  font-weight: 700;
+  color: #ffffff;
+  counter-reset: count var(--ease-count-from);
+}
+
+.counter-card:hover .counter {
+  animation: countdown 3s linear forwards;
+}
+
+.counter-card .counter::after {
+  content: counter(count);
+}
+
+@keyframes countdown {
+  to {
+    counter-reset: count 0;
+  }
+}
+
+.label {
+  display: block;
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+  color: #9ca3af;
+}


### PR DESCRIPTION
## Description

Number counts down from a starting value to 0 using CSS `@property` animation — `counter-reset` + `content: counter()`.

## Acceptance Criteria
- [x] @property --ease-count-from (integer)
- [x] counter-reset + content: counter()
- [x] Pure CSS number countdown

## Files
- `demo.html` — countdown demo cards
- `style.css` — counter animation styles
- `README.md` — documentation

## Related Issue
Closes #17203

<!-- re-trigger label sync -->