### PR TITLE
feat(examples): add ease-glow-pulse-green — green glow pulse for success states

### DIFF
--- a/submissions/examples/ease-glow-pulse-green/README.md
+++ b/submissions/examples/ease-glow-pulse-green/README.md
@@ -1,0 +1,9 @@
+# Ease Glow Pulse Green
+
+A CSS-only success card that pulses with a green glow on hover using the `--ease-success-color` variable (`#22c55e`).
+
+The glow animation runs 3 times using `box-shadow` with an opacity pulse effect, then stops.
+
+## Usage
+
+Add the `.success-card` class to any element. Hovering triggers the `glow-pulse` keyframe animation. Customize the glow color by overriding `--ease-success-color`.

--- a/submissions/examples/ease-glow-pulse-green/demo.html
+++ b/submissions/examples/ease-glow-pulse-green/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ease Glow Pulse Green</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <div class="success-card">
+      <div class="icon">&#10003;</div>
+      <h2>Success!</h2>
+      <p>Your action was completed successfully.</p>
+    </div>
+    <p class="hint">Hover the card to see the glow pulse</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-glow-pulse-green/style.css
+++ b/submissions/examples/ease-glow-pulse-green/style.css
@@ -1,0 +1,68 @@
+:root {
+  --ease-success-color: #22c55e;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container {
+  text-align: center;
+}
+
+.success-card {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 1rem;
+  padding: 3rem 2.5rem;
+  width: 320px;
+  transition: border-color 0.3s;
+}
+
+.success-card:hover {
+  animation: glow-pulse 1.5s ease-out 3;
+}
+
+.icon {
+  font-size: 3rem;
+  color: var(--ease-success-color);
+  margin-bottom: 1rem;
+}
+
+h2 {
+  color: #ffffff;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  color: #9ca3af;
+  line-height: 1.5;
+}
+
+.hint {
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+}
+
+@keyframes glow-pulse {
+  0%, 100% {
+    box-shadow: 0 0 5px rgba(34, 197, 94, 0.3);
+    border-color: #2a2a2a;
+  }
+  50% {
+    box-shadow: 0 0 30px rgba(34, 197, 94, 0.7), 0 0 60px rgba(34, 197, 94, 0.3);
+    border-color: var(--ease-success-color);
+  }
+}


### PR DESCRIPTION
## Description

Element pulses with a green glow to indicate success using `box-shadow` with `--ease-success-color`.

## Acceptance Criteria
- [x] box-shadow with green color, opacity pulse
- [x] 3 pulses then stops
- [x] --ease-success-color variable

## Files
- `demo.html` — green glow pulse demo
- `style.css` — glow pulse animation styles
- `README.md` — documentation

## Related Issue
Closes #17183

<!-- re-trigger label sync -->