### PR TITLE
feat(examples): add ease-hover-sink — element sinks downward on hover

### DIFF
--- a/submissions/examples/ease-hover-sink/README.md
+++ b/submissions/examples/ease-hover-sink/README.md
@@ -1,0 +1,9 @@
+# Ease Hover Sink
+
+A CSS-only button that simulates a physical press by sinking down on hover.
+
+On hover, the button moves down `translateY(4px)` and its `box-shadow` reduces, creating the illusion of being pressed into a surface. Active state pushes it further to `translateY(6px)` with no shadow.
+
+## Usage
+
+Add the `.sink-button` class to any button element. Variants like `.secondary` and `.danger` are available for different color schemes.

--- a/submissions/examples/ease-hover-sink/demo.html
+++ b/submissions/examples/ease-hover-sink/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ease Hover Sink</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Sink Button</h1>
+    <p>Hover the button to see it sink down</p>
+    <div class="button-group">
+      <button class="sink-button">Primary Action</button>
+      <button class="sink-button secondary">Secondary</button>
+      <button class="sink-button danger">Danger</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-hover-sink/style.css
+++ b/submissions/examples/ease-hover-sink/style.css
@@ -1,0 +1,69 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container {
+  text-align: center;
+}
+
+h1 {
+  color: #ffffff;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin-bottom: 2rem;
+  color: #9ca3af;
+}
+
+.button-group {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.sink-button {
+  background: #1a1a1a;
+  color: #ffffff;
+  border: 1px solid #2a2a2a;
+  border-radius: 0.75rem;
+  padding: 0.875rem 2rem;
+  font-size: 1rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+.sink-button:hover {
+  transform: translateY(4px);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.sink-button:active {
+  transform: translateY(6px);
+  box-shadow: none;
+}
+
+.sink-button.secondary {
+  border-color: #6366f1;
+  color: #6366f1;
+}
+
+.sink-button.danger {
+  border-color: #ef4444;
+  color: #ef4444;
+}


### PR DESCRIPTION
## Description

Element moves downward on hover, like being pressed into a surface — `translateY(4px)` with reduced `box-shadow`.

## Acceptance Criteria
- [x] translateY(4px) on :hover
- [x] box-shadow reduces or disappears
- [x] Simulates press effect

## Files
- `demo.html` — sink button demo
- `style.css` — sink animation styles
- `README.md` — documentation

## Related Issue
Closes #12535

<!-- re-trigger label sync -->