### PR TITLE
feat(examples): add ease-stretch-in-vertical — stretch in from top to bottom

### DIFF
--- a/submissions/examples/ease-stretch-in-vertical/README.md
+++ b/submissions/examples/ease-stretch-in-vertical/README.md
@@ -1,67 +1,9 @@
-# ease-stretch-in-vertical
+# Ease Stretch In Vertical
 
-A lightweight CSS animation that smoothly stretches an element into view vertically — scaling from 0 to full height with a fade-in effect.
+A CSS-only dropdown menu that reveals itself by stretching vertically from a thin line at the top.
 
----
-
-## Preview
-
-The element scales in from the top, expanding vertically while fading in.
-
----
+Uses `transform: scaleY(0)` to `scaleY(1)` with `transform-origin: top` for a natural drop-down reveal effect. Ideal for menus, notifications, and dropdown panels.
 
 ## Usage
 
-1. Link the stylesheet in your HTML:
-
-```html
-<link rel="stylesheet" href="style.css">
-```
-
-2. Add the class to any element:
-
-```html
-<div class="ease-stretch-in-vertical">
-  Hello World
-</div>
-```
-
----
-
-## Animation Details
-
-| Property         | Value         |
-|------------------|---------------|
-| Duration         | 0.5s          |
-| Easing           | ease          |
-| Transform        | scaleY(0 → 1) |
-| Opacity          | 0 → 1         |
-| Transform Origin | top           |
-| Fill Mode        | forwards      |
-
----
-
-## Files
-
-| File        | Description                       |
-|-------------|-----------------------------------|
-| `style.css` | Contains the animation keyframes  |
-| `demo.html` | Live demo of the animation        |
-
----
-
-## Contributing
-
-Contributions are welcome! Feel free to open an issue or submit a pull request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/my-animation`)
-3. Commit your changes (`git commit -m 'Add my animation'`)
-4. Push to the branch (`git push origin feature/my-animation`)
-5. Open a Pull Request
-
----
-
-## License
-
-MIT
+Wrap a `.trigger` element and a `.dropdown` container in a `.dropdown-wrapper`. Hovering the wrapper triggers the vertical stretch animation.

--- a/submissions/examples/ease-stretch-in-vertical/demo.html
+++ b/submissions/examples/ease-stretch-in-vertical/demo.html
@@ -3,31 +3,23 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ease-stretch-in-vertical Demo</title>
+  <title>Ease Stretch In Vertical</title>
   <link rel="stylesheet" href="style.css">
-  <style>
-    body {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      min-height: 100vh;
-      background: #0b0f19;
-      font-family: sans-serif;
-    }
-    .box {
-      width: 200px;
-      background: #38bdf8;
-      color: #000;
-      padding: 20px;
-      border-radius: 8px;
-      text-align: center;
-      font-weight: bold;
-    }
-  </style>
 </head>
 <body>
-  <div class="box ease-stretch-in-vertical">
-    Stretch In ↕
+  <div class="container">
+    <h1>Vertical Stretch Reveal</h1>
+    <p>Hover the trigger to reveal the dropdown</p>
+    <div class="dropdown-wrapper">
+      <button class="trigger">Menu &#9662;</button>
+      <div class="dropdown">
+        <a href="#">Profile</a>
+        <a href="#">Settings</a>
+        <a href="#">Billing</a>
+        <a href="#">Team</a>
+        <a href="#">Logout</a>
+      </div>
+    </div>
   </div>
 </body>
 </html>

--- a/submissions/examples/ease-stretch-in-vertical/style.css
+++ b/submissions/examples/ease-stretch-in-vertical/style.css
@@ -1,15 +1,85 @@
-.ease-stretch-in-vertical {
-  animation: easeStretchInVertical 0.5s ease forwards;
-  transform-origin: top;
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
-@keyframes easeStretchInVertical {
-  0% {
-    transform: scaleY(0);
-    opacity: 0;
-  }
-  100% {
-    transform: scaleY(1);
-    opacity: 1;
-  }
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container {
+  text-align: center;
+}
+
+h1 {
+  color: #ffffff;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin-bottom: 2rem;
+  color: #9ca3af;
+}
+
+.dropdown-wrapper {
+  display: inline-block;
+  position: relative;
+}
+
+.trigger {
+  background: #1a1a1a;
+  color: #ffffff;
+  border: 1px solid #2a2a2a;
+  border-radius: 0.75rem;
+  padding: 0.875rem 2rem;
+  font-size: 1rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.3s;
+}
+
+.trigger:hover {
+  border-color: #6366f1;
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  right: 0;
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  transform: scaleY(0);
+  transform-origin: top;
+  transition: transform 0.3s ease;
+}
+
+.dropdown-wrapper:hover .dropdown {
+  transform: scaleY(1);
+}
+
+.dropdown a {
+  display: block;
+  padding: 0.75rem 1.5rem;
+  color: #d1d5db;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s;
+}
+
+.dropdown a:hover {
+  background: #2a2a2a;
+  color: #ffffff;
+}
+
+.dropdown a:not(:last-child) {
+  border-bottom: 1px solid #2a2a2a;
 }


### PR DESCRIPTION
## Description

Element reveals itself by stretching vertically from a thin line — `scaleY(0) → scaleY(1)` with `transform-origin: top`.

## Acceptance Criteria
- [x] scaleY(0) → scaleY(1)
- [x] transform-origin: top
- [x] Good for dropdown reveals

## Files
- `demo.html` — stretch-in-vertical demo
- `style.css` — stretch animation styles
- `README.md` — documentation

## Related Issue
Closes #11874

<!-- re-trigger label sync -->