### PR TITLE
feat(examples): add ease-blur-out — element blurs and fades simultaneously (exit)

### DIFF
--- a/submissions/examples/ease-blur-out-v2/README.md
+++ b/submissions/examples/ease-blur-out-v2/README.md
@@ -1,0 +1,30 @@
+# ease-blur-out
+
+## What does it do?
+Element exit animation: blurs and fades out together — `blur(0) → blur(12px) + opacity(0)`.
+
+## Features
+- `filter: blur(12px)` + `opacity: 0` exit transition
+- 0.4s ease-in timing
+- Replays on hover
+
+## Usage
+```css
+.element {
+  transition: filter 0.4s ease-in, opacity 0.4s ease-in;
+}
+
+.element:hover {
+  filter: blur(12px);
+  opacity: 0;
+}
+```
+
+## Browser Support
+- Chrome 53+, Firefox 49+, Safari 9.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-blur-out-v2/demo.html
+++ b/submissions/examples/ease-blur-out-v2/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-blur-out — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; text-align: center; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin: 0 0 1rem; font-family: monospace; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-blur-out</h1>
+  <p class="subtitle">Element exit animation: blurs and fades out together — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Hover the card to trigger the blur-out exit</p>
+    <div class="blur-card">Hover Me</div>
+    <p style="color:#6b7280;font-size:0.8rem;margin-top:1rem;">Move cursor away and hover again to replay.</p>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p style="color:#9ca3af;line-height:1.8;">On <code>:hover</code>, the element transitions from <code>blur(0) + opacity(1)</code> to <code>blur(12px) + opacity(0)</code> using ease-in 0.4s timing.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-blur-out-v2/style.css
+++ b/submissions/examples/ease-blur-out-v2/style.css
@@ -1,0 +1,25 @@
+/* ============================================================
+   EaseMotion CSS — ease-blur-out
+   Element exit: blurs and fades simultaneously
+   ============================================================ */
+
+.blur-card {
+  width: 240px;
+  height: 140px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #6366f1, #a78bfa);
+  border-radius: 14px;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: filter 0.4s ease-in, opacity 0.4s ease-in;
+}
+
+.blur-card:hover {
+  filter: blur(12px);
+  opacity: 0;
+}


### PR DESCRIPTION
## Description

Element exit animation: blurs and fades out together — `blur(0) → blur(12px) + opacity(0)` — pure CSS, no JavaScript.

## Acceptance Criteria
- [x] filter: blur(0) → blur(12px) + opacity(0)
- [x] ease-in 0.4s

## Files
- `demo.html` — hover card with blur-out exit
- `style.css` — filter + opacity transition
- `README.md` — documentation

## Related Issue
Closes #17216