### PR TITLE
fix: add prefers-reduced-motion handling to all loaders for a11y #17463

### DIFF
--- a/submissions/fix-loaders-reduced-motion/README.md
+++ b/submissions/fix-loaders-reduced-motion/README.md
@@ -1,0 +1,21 @@
+# Fix: Loaders Missing `prefers-reduced-motion` Handling
+
+## Issue
+
+The loaders component (`components/loaders.css`) defines four animated elements (`.ease-loader-spin`, `.ease-loader-pulse`, `.ease-loader-ping`, `.ease-loader-dot`) but has no `@media (prefers-reduced-motion: reduce)` block. Users who prefer reduced motion will still see continuously spinning, pulsing, and bouncing loader animations — a violation of WCAG 2.3.3.
+
+## Root Cause
+
+The initial implementation of the loaders focused on the animation keyframes but forgot to include the standard accessibility media query to pause them.
+
+## Fix
+
+Add a `prefers-reduced-motion` media query that sets `animation: none` on all loader classes, ensuring compliance with accessibility standards.
+
+## Files Changed
+
+- `components/loaders.css` — Add `@media (prefers-reduced-motion: reduce)` block to disable animations.
+
+## Demo
+
+Open `demo.html` to see the loaders. If your operating system is set to "reduce motion", the loaders will be static.

--- a/submissions/fix-loaders-reduced-motion/demo.html
+++ b/submissions/fix-loaders-reduced-motion/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Loaders Reduced Motion</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+      font-family: var(--ease-font-sans);
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+    }
+    h1 { font-size: 1.5rem; }
+    p { color: var(--ease-color-muted); max-width: 520px; text-align: center; }
+    .demo-grid {
+      display: flex;
+      gap: 2rem;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      background: var(--ease-color-surface);
+      border-radius: var(--ease-radius-lg);
+      border: 1px solid var(--ease-color-neutral-200);
+    }
+  </style>
+</head>
+<body>
+  <h1>Fix: Loaders Reduced Motion</h1>
+  <p>If your OS settings have "Reduce Motion" enabled, these loaders will stay static instead of animating.</p>
+
+  <div class="demo-grid">
+    <div class="ease-loader-spin"></div>
+    <div class="ease-loader-pulse"></div>
+    <div class="ease-loader-ping"></div>
+    <div class="ease-loader-dot"></div>
+  </div>
+</body>
+</html>

--- a/submissions/fix-loaders-reduced-motion/style.css
+++ b/submissions/fix-loaders-reduced-motion/style.css
@@ -1,0 +1,22 @@
+/* =============================================================
+   Fix: Loaders Missing prefers-reduced-motion Handling
+   
+   The loaders component lacks a prefers-reduced-motion query,
+   causing continuous animations for users who have requested
+   reduced motion (violating WCAG 2.3.3).
+   
+   FIX:
+   Add a media query to disable all loader animations when
+   reduced motion is preferred.
+   ============================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-loader-spin,
+  .ease-loader-pulse,
+  .ease-loader-ping,
+  .ease-loader-dot,
+  .ease-loader-dot::before,
+  .ease-loader-dot::after {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Fix: Loaders Missing `prefers-reduced-motion` Handling

Closes #17463

### Problem
The loaders component (`components/loaders.css`) defines four animated elements 
(`.ease-loader-spin`, `.ease-loader-pulse`, `.ease-loader-ping`, `.ease-loader-dot`) 
but has **no `@media (prefers-reduced-motion: reduce)` block**. 

Users who prefer reduced motion will still see continuously spinning, pulsing, and 
bouncing loader animations — a direct violation of WCAG 2.3.3.

### Solution
Added a `prefers-reduced-motion: reduce` media query that sets `animation: none !important` 
on all loader classes and their pseudo-elements, ensuring compliance with accessibility 
standards.

### Files Added
- `submissions/fix-loaders-reduced-motion/style.css` — Reduced motion patch
- `submissions/fix-loaders-reduced-motion/demo.html` — Interactive demo
- `submissions/fix-loaders-reduced-motion/README.md` — Documentation

### Testing
Open `demo.html`. If your operating system is set to "reduce motion", the loaders 
will render as static shapes instead of animating.
