### PR TITLE
feat(examples): add ease-scroll-scale — element scales based on scroll progress

### DIFF
--- a/submissions/examples/ease-scroll-scale-v2/README.md
+++ b/submissions/examples/ease-scroll-scale-v2/README.md
@@ -1,0 +1,31 @@
+# ease-scroll-scale
+
+## What does it do?
+Element scale tied to scroll progress — `scale(0.8) → scale(1)` across scroll range using `animation-timeline: scroll()`.
+
+## Features
+- Scroll-driven scaling using CSS `animation-timeline: scroll()`
+- `@supports` fallback for non-supporting browsers
+- Pure CSS, no JavaScript
+
+## Usage
+```css
+.element {
+  animation: scrollScale linear;
+  animation-timeline: scroll(root);
+}
+
+@keyframes scrollScale {
+  from { scale: 0.8; }
+  to   { scale: 1; }
+}
+```
+
+## Browser Support
+- `animation-timeline: scroll()` — Chrome 115+, Edge 115+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` and scroll.

--- a/submissions/examples/ease-scroll-scale-v2/demo.html
+++ b/submissions/examples/ease-scroll-scale-v2/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-scroll-scale — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>ease-scroll-scale</h1>
+  <p class="subtitle">Element scales based on scroll progress — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Scroll the page to see the element scale from 0.8x to 1x</p>
+    <div class="scroll-demo">
+      <div class="scaling-element">Resize</div>
+    </div>
+    <div class="scroll-spacer"></div>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p>Uses <code>animation-timeline: scroll()</code> to drive <code>scale(0.8) → scale(1)</code> as you scroll. Falls back to a static styled element when scroll-driven animations are unsupported.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-scale-v2/style.css
+++ b/submissions/examples/ease-scroll-scale-v2/style.css
@@ -1,0 +1,66 @@
+/* ============================================================
+   EaseMotion CSS — ease-scroll-scale
+   Element scales based on scroll position
+   ============================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+.subtitle { color: #9ca3af; margin-bottom: 2rem; }
+
+section {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h2 { color: #ffffff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+.sec-desc { color: #9ca3af; font-size: 0.85rem; margin-bottom: 1rem; }
+
+.scroll-demo {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 3rem 0;
+}
+
+.scaling-element {
+  width: 120px;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #6366f1, #a78bfa);
+  border-radius: 14px;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 1rem;
+  scale: 0.8;
+  animation: scrollScale linear;
+  animation-timeline: scroll(root);
+}
+
+@keyframes scrollScale {
+  from { scale: 0.8; }
+  to   { scale: 1; }
+}
+
+.scroll-spacer {
+  height: 150vh;
+}
+
+p { color: #9ca3af; line-height: 1.8; }
+code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }


### PR DESCRIPTION
## Description

Element scale tied to scroll progress — `scale(0.8) → scale(1)` across scroll range using `animation-timeline: scroll()`.

## Acceptance Criteria
- [x] animation-timeline: scroll()
- [x] scale(0.8) → scale(1) across scroll range
- [x] @supports fallback

## Files
- `demo.html` — scaling element driven by scroll
- `style.css` — scroll-driven scale animation with fallback
- `README.md` — documentation

## Related Issue
Closes #13660