### PR TITLE
feat(examples): add ease-stretch-in-vertical — vertical stretch reveal from top

### DIFF
--- a/submissions/examples/ease-stretch-in-vertical-v2/README.md
+++ b/submissions/examples/ease-stretch-in-vertical-v2/README.md
@@ -1,0 +1,33 @@
+# ease-stretch-in-vertical
+
+## What does it do?
+Element reveals itself by stretching vertically — `scaleY(0) → scaleY(1)` with `transform-origin: top`.
+
+## Features
+- `scaleY(0) → scaleY(1)` vertical stretch
+- `transform-origin: top` for dropdown-like reveal
+- 0.45s ease-out timing
+- Overflow hidden on parent container
+- Good for dropdown reveals and expandable panels
+
+## Usage
+```css
+.content {
+  transform-origin: top;
+  transform: scaleY(0);
+  transition: transform 0.45s ease-out;
+}
+
+.container:hover .content {
+  transform: scaleY(1);
+}
+```
+
+## Browser Support
+- Chrome 20+, Firefox 16+, Safari 6.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-stretch-in-vertical-v2/demo.html
+++ b/submissions/examples/ease-stretch-in-vertical-v2/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-stretch-in-vertical — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>ease-stretch-in-vertical</h1>
+  <p class="subtitle">Element reveals itself by stretching vertically from a thin line — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Hover the card to trigger the vertical stretch reveal</p>
+    <div class="stretch-card">
+      <div class="stretch-content">Expand</div>
+    </div>
+    <p class="replay-note">Move cursor away and back to replay.</p>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p>A <code>scaleY(0) → scaleY(1)</code> transition on the inner content with <code>transform-origin: top</code>. On hover, the content stretches down from the top edge like a dropdown reveal. The container clips overflow so the transition appears seamless.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-stretch-in-vertical-v2/style.css
+++ b/submissions/examples/ease-stretch-in-vertical-v2/style.css
@@ -1,0 +1,66 @@
+/* ============================================================
+   EaseMotion CSS — ease-stretch-in-vertical
+   Vertical stretch reveal from top
+   ============================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+.subtitle { color: #9ca3af; margin-bottom: 2rem; }
+
+section {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h2 { color: #ffffff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+.sec-desc { color: #9ca3af; font-size: 0.85rem; margin-bottom: 1rem; }
+
+.stretch-card {
+  width: 240px;
+  height: 160px;
+  margin: 0 auto;
+  overflow: hidden;
+  border-radius: 14px;
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  cursor: pointer;
+}
+
+.stretch-content {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #6366f1, #a78bfa);
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 1rem;
+  transform-origin: top;
+  transform: scaleY(0);
+  transition: transform 0.45s ease-out;
+}
+
+.stretch-card:hover .stretch-content {
+  transform: scaleY(1);
+}
+
+.replay-note { color: #6b7280; font-size: 0.8rem; margin-top: 1rem; }
+
+p { color: #9ca3af; line-height: 1.8; }
+code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }


### PR DESCRIPTION
## Description

Element reveals itself by stretching vertically — `scaleY(0) → scaleY(1)` with `transform-origin: top`. Good for dropdown reveals and expandable panels.

## Acceptance Criteria
- [x] scaleY(0) → scaleY(1)
- [x] transform-origin: top

## Files
- `demo.html` — hover card with vertical stretch reveal
- `style.css` — scaleY transition with overflow clip
- `README.md` — documentation

## Related Issue
Closes #11874

<!-- re-trigger label sync -->