### PR TITLE
feat: add ease-path-erase SVG animation (#17202)

### DIFF
--- a/submissions/examples/ease-path-erase/README.md
+++ b/submissions/examples/ease-path-erase/README.md
@@ -1,0 +1,23 @@
+﻿# ease-path-erase – SVG Path Erase Animation
+
+The reverse of ease-path-draw: an SVG path stroke animates from fully drawn back to zero length, simulating an erasing effect. Ideal for exit/undo transitions.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-6
+- **Components:** ease-btn, ease-btn-primary
+- **Hover Effects:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- The SVG path (a checkmark) starts fully drawn (stroke-dashoffset: 0).
+- When the class .erase is added, the stroke-dashoffset transitions to its full stroke-dasharray value, erasing the path from end to start.
+- The surrounding circle remains as a visual frame.
+- The effect respects prefers-reduced-motion.
+
+## How to use
+1. Copy the SVG and CSS into your project.
+2. Trigger the erase effect by toggling the .erase class on the target path.
+3. Ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-path-erase/demo.html
+++ b/submissions/examples/ease-path-erase/demo.html
@@ -1,0 +1,38 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-path-erase – SVG Path Erase</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">SVG Path Erase</h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">Click the button to erase the drawn checkmark.</p>
+
+    <svg class="erase-svg" viewBox="0 0 100 100" width="150" height="150">
+      <circle class="erase-circle" cx="50" cy="50" r="40" fill="none" stroke="#3b82f6" stroke-width="4" stroke-linecap="round" />
+      <polyline id="erase-check" class="erase-check" points="30,50 45,65 70,38" fill="none" stroke="#16a34a" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+
+    <button id="erase-btn" class="ease-btn ease-btn-primary ease-hover-scale-105 ease-transition ease-mt-6">Erase Checkmark</button>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-6 ease-fade-in ease-delay-500">Reverse of <code>ease-path-draw</code> — stroke-dashoffset goes from 0 to full length.</p>
+  </div>
+
+  <script>
+    const checkmark = document.getElementById('erase-check');
+    const btn = document.getElementById('erase-btn');
+
+    btn.addEventListener('click', () => {
+      checkmark.classList.remove('erase');
+      void checkmark.offsetWidth;          // force reflow
+      checkmark.classList.add('erase');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-path-erase/style.css
+++ b/submissions/examples/ease-path-erase/style.css
@@ -1,0 +1,30 @@
+﻿/* ============================================================
+   ease-path-erase – SVG path erase animation
+   stroke-dashoffset animates from 0 to full dasharray
+   ============================================================ */
+
+.erase-circle {
+  stroke-dasharray: 251.2;          /* circumference of r=40 */
+  stroke-dashoffset: 0;            /* initially fully drawn */
+}
+
+.erase-check {
+  stroke-dasharray: 60;            /* total length of checkmark */
+  stroke-dashoffset: 0;            /* initially drawn */
+  transition: stroke-dashoffset 0.8s ease;
+}
+
+/* When .erase is added, the checkmark disappears */
+.erase-check.erase {
+  stroke-dashoffset: 60;
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .erase-check {
+    transition: none;
+  }
+  .erase-check.erase {
+    stroke-dashoffset: 60;
+  }
+}


### PR DESCRIPTION
Closes #17202

ease-path-erase – SVG Path Erase
Reverse of ease-path-draw: stroke-dashoffset goes from 0 to full length, erasing the path.

Files added
- submissions/examples/ease-path-erase/demo.html
- submissions/examples/ease-path-erase/style.css
- submissions/examples/ease-path-erase/README.md

How it works
- Checkmark starts fully drawn; clicking “Erase” transitions stroke-dashoffset to dasharray.
- Circle remains as frame.
- Respects prefers-reduced-motion.