### PR TITLE
feat: add ease-glow-pulse-red animation (#17184)

### DIFF
--- a/submissions/examples/ease-glow-pulse-red/README.md
+++ b/submissions/examples/ease-glow-pulse-red/README.md
@@ -1,0 +1,23 @@
+﻿# ease-glow-pulse-red – Red Glow Pulse
+
+A red box‑shadow pulse animation designed for error or alert states. The glow plays three cycles and then stops, drawing immediate attention without being endless.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-mx-auto
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-lg, ease-font-semibold, ease-text-sm, ease-text-gray-400, ease-text-gray-500
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-2, ease-mt-8, ease-p-8
+- **Components:** ease-card
+- **Effects:** ease-shadow-md
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How it works
+- Uses a @keyframes red-glow-pulse that oscillates the ox-shadow between a soft red and a stronger red.
+- The animation is limited to 3 iterations, then stops.
+- The glow colour is customisable via the --ease-error-glow-color custom property (default: gba(239, 68, 68, 0.6)).
+- Respects prefers-reduced-motion by showing a static glow.
+
+## How to use
+1. Add the class glow-pulse-red to any element you want to draw attention to.
+2. Optionally override --ease-error-glow-color with a custom colour.
+3. Copy style.css into your project and ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-glow-pulse-red/demo.html
+++ b/submissions/examples/ease-glow-pulse-red/demo.html
@@ -1,0 +1,32 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-glow-pulse-red – Red Glow Pulse</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">
+      Red Glow Pulse
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      This card pulses with a red glow to indicate an error or alert state.
+    </p>
+
+    <!-- Glowing element -->
+    <div class="glow-pulse-red ease-card ease-p-8 ease-mx-auto ease-max-w-xs ease-shadow-md">
+      <p class="ease-text-lg ease-font-semibold">Error</p>
+      <p class="ease-text-sm ease-text-gray-500 ease-mt-2">Something went wrong!</p>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Glow color controlled by <code>--ease-error-glow-color</code> (default red). Plays 3 cycles.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-glow-pulse-red/style.css
+++ b/submissions/examples/ease-glow-pulse-red/style.css
@@ -1,0 +1,25 @@
+﻿/* ============================================================
+   ease-glow-pulse-red – Red glow pulse for error/alert
+   box-shadow animation with --ease-error-glow-color
+   3 cycles then stops
+   ============================================================ */
+
+.glow-pulse-red {
+  --ease-error-glow-color: rgba(239, 68, 68, 0.6);
+  background: #ffffff;
+  border-radius: 1rem;
+  animation: red-glow-pulse 1.5s ease-in-out 3;   /* play exactly 3 cycles */
+}
+
+@keyframes red-glow-pulse {
+  0%, 100% { box-shadow: 0 0 8px var(--ease-error-glow-color); }
+  50%      { box-shadow: 0 0 25px var(--ease-error-glow-color); }
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .glow-pulse-red {
+    animation: none;
+    box-shadow: 0 0 12px var(--ease-error-glow-color);
+  }
+}


### PR DESCRIPTION
Closes #17184

ease-glow-pulse-red – Red Glow Pulse
Red box‑shadow pulse for error/alert states, plays 3 cycles then stops.

Files added
- submissions/examples/ease-glow-pulse-red/demo.html
- submissions/examples/ease-glow-pulse-red/style.css
- submissions/examples/ease-glow-pulse-red/README.md

How it works
- CSS keyframes animate box-shadow intensity.
- Animation runs exactly 3 times.
- Custom property --ease-error-glow-color controls colour.
- Respects prefers-reduced-motion.