### PR TITLE
feat: add ease-highlight-box animation (#17209)

### DIFF
--- a/submissions/examples/ease-highlight-box/README.md
+++ b/submissions/examples/ease-highlight-box/README.md
@@ -1,0 +1,24 @@
+﻿# ease-highlight-box – Box Highlight Behind Element
+
+A colored highlight rectangle that expands from left to right behind an element, like a marker pen effect. The color is customisable via a CSS custom property.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-inline-block, ease-relative
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-2xl, ease-font-semibold, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-6, ease-mt-8
+- **Components:** ease-btn, ease-btn-primary
+- **Hover Effects:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- The element uses a ::before pseudo‑element for the highlight box, initially scaled to 0 width (scaleX(0)) with 	ransform-origin: left.
+- When the highlight class is added (via button click), the pseudo‑element transitions to scaleX(1), expanding the box behind the text.
+- The highlight colour is set by --ease-highlight-bg-color (default: soft yellow #fef08a).
+- The box is placed behind the text (z-index: -1).
+- The animation respects prefers-reduced-motion.
+
+## How to use
+1. Add the class highlight-text to any text element and optionally set --ease-highlight-bg-color for a custom colour.
+2. Toggle the highlight class via JavaScript to trigger the effect.
+3. Copy style.css into your project and ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-highlight-box/demo.html
+++ b/submissions/examples/ease-highlight-box/demo.html
@@ -1,0 +1,44 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-highlight-box – Box Highlight Behind Element</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">Highlight Box</h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Click the button to see a colored highlight appear behind the text.
+    </p>
+
+    <!-- Highlighted text element -->
+    <p id="highlight-target" class="highlight-text ease-text-2xl ease-font-semibold ease-inline-block ease-relative">
+      Important Announcement
+    </p>
+
+    <button id="highlight-btn" class="ease-btn ease-btn-primary ease-hover-scale-105 ease-transition ease-mt-8">
+      Highlight
+    </button>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-6 ease-fade-in ease-delay-500">
+      Uses <code>::before</code> with <code>scaleX</code> from 0 to 1, colored via <code>--ease-highlight-bg-color</code>.
+    </p>
+  </div>
+
+  <script>
+    const target = document.getElementById('highlight-target');
+    const btn = document.getElementById('highlight-btn');
+
+    btn.addEventListener('click', () => {
+      target.classList.remove('highlight');
+      void target.offsetWidth;          // force reflow to restart
+      target.classList.add('highlight');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-highlight-box/style.css
+++ b/submissions/examples/ease-highlight-box/style.css
@@ -1,0 +1,38 @@
+﻿/* ============================================================
+   ease-highlight-box – Colored box highlight behind element
+   Uses ::before pseudo-element with scaleX animation
+   Custom property --ease-highlight-bg-color
+   ============================================================ */
+
+.highlight-text {
+  --ease-highlight-bg-color: #fef08a;   /* soft yellow */
+  position: relative;
+}
+
+/* The highlight box behind the text */
+.highlight-text::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--ease-highlight-bg-color);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.4s ease;
+  z-index: -1;
+  border-radius: 0.25rem;
+}
+
+/* When .highlight is added, the box expands */
+.highlight-text.highlight::before {
+  transform: scaleX(1);
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .highlight-text::before {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #17209

ease-highlight-box – Box Highlight Behind Element
A colored highlight expands behind text via ::before scaleX animation, customisable with --ease-highlight-bg-color.

Files added
- submissions/examples/ease-highlight-box/demo.html
- submissions/examples/ease-highlight-box/style.css
- submissions/examples/ease-highlight-box/README.md

How it works
- ::before pseudo-element with scaleX(0)→scaleX(1) transition.
- Color controlled by custom property.
- Respects prefers-reduced-motion.