### PR TITLE
feat: add ease-pop-in animation (#17173)

### DIFF
--- a/submissions/examples/ease-pop-in/README.md
+++ b/submissions/examples/ease-pop-in/README.md
@@ -1,0 +1,23 @@
+﻿# ease-pop-in – Pop In Entrance
+
+A playful entrance animation where an element scales up from nothing with a slight overshoot, then settles to its final size, giving a spring‑like pop effect.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-mx-auto
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-lg, ease-font-semibold, ease-text-sm, ease-text-gray-400, ease-text-gray-500
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-2, ease-mt-6, ease-mt-8, ease-p-8
+- **Components:** ease-card, ease-btn, ease-btn-primary
+- **Hover:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- The element starts with 	ransform: scale(0) and opacity: 0.
+- When the class pop is added, a @keyframes pop-in-overshoot plays: the element scales up to 1.1 (overshoot) and then eases back to 1, while opacity goes from 0 to 1.
+- The animation is triggered via JavaScript (class toggle) and can be replayed.
+- Respects prefers-reduced-motion by instantly showing the element at full size.
+
+## How to use
+1. Add the class pop-box to any container.
+2. Toggle the pop class to trigger the effect.
+3. Copy style.css into your project and ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-pop-in/demo.html
+++ b/submissions/examples/ease-pop-in/demo.html
@@ -1,0 +1,38 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-pop-in – Pop In Entrance</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">Pop In</h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">Click the button to pop the card into existence.</p>
+
+    <div id="pop-box" class="pop-box ease-card ease-p-8 ease-mx-auto ease-max-w-xs ease-shadow-md">
+      <p class="ease-text-lg ease-font-semibold">Surprise!</p>
+      <p class="ease-text-sm ease-text-gray-500 ease-mt-2">scale + opacity pop</p>
+    </div>
+
+    <button id="pop-btn" class="ease-btn ease-btn-primary ease-hover-scale-105 ease-transition ease-mt-8">Pop In</button>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-6 ease-fade-in ease-delay-500">
+      <code>scale(0) → scale(1.1) → scale(1)</code> with spring feel.
+    </p>
+  </div>
+
+  <script>
+    const box = document.getElementById('pop-box');
+    document.getElementById('pop-btn').addEventListener('click', () => {
+      box.classList.remove('pop');
+      void box.offsetWidth;          // force reflow to restart animation
+      box.classList.add('pop');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-pop-in/style.css
+++ b/submissions/examples/ease-pop-in/style.css
@@ -1,0 +1,36 @@
+﻿/* ============================================================
+   ease-pop-in – Pop In Entrance
+   scale(0) → scale(1.1) → scale(1) + opacity 0→1
+   ============================================================ */
+
+.pop-box {
+  background: #ffffff;
+  border-radius: 1rem;
+  transform: scale(0);
+  opacity: 0;
+  transition: transform 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55), opacity 0.3s ease;
+}
+
+.pop-box.pop {
+  transform: scale(1);
+  opacity: 1;
+  animation: pop-in-overshoot 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+@keyframes pop-in-overshoot {
+  0%   { transform: scale(0); opacity: 0; }
+  60%  { transform: scale(1.1); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .pop-box {
+    transition: none;
+  }
+  .pop-box.pop {
+    animation: none;
+    transform: scale(1);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Closes #17173

ease-pop-in – Pop In Entrance
scale(0) → scale(1.1) → scale(1) with opacity 0→1 for a spring pop effect.

Files added
- submissions/examples/ease-pop-in/demo.html
- submissions/examples/ease-pop-in/style.css
- submissions/examples/ease-pop-in/README.md

How it works
- CSS keyframes with overshoot for a spring feel.
- Triggered by .pop class; JavaScript reset enables replay.
- Respects prefers-reduced-motion.