### PR TITLE
feat: add ease-slide-out-right animation (#17167)

### DIFF
--- a/submissions/examples/ease-slide-out-right/README.md
+++ b/submissions/examples/ease-slide-out-right/README.md
@@ -1,0 +1,23 @@
+﻿# ease-slide-out-right – Slide Out Right Exit
+
+A simple exit animation: the element slides to the right while fading out. Perfect for dismissing items or confirming actions.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-mx-auto, ease-gap-4
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-lg, ease-font-semibold, ease-text-sm, ease-text-gray-400, ease-text-gray-500
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-2, ease-mt-6, ease-mt-8, ease-p-8
+- **Components:** ease-card, ease-btn, ease-btn-primary, ease-btn-secondary
+- **Hover:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- The card starts with 	ransform: translateX(0) and opacity: 1.
+- Adding the class .exit triggers a CSS transition that moves the card 40px to the right and fades it to transparent over 0.3 seconds with an ease-in curve.
+- A “Reset” button removes the class, bringing the card back instantly.
+- The effect respects prefers-reduced-motion: the element simply disappears without sliding.
+
+## How to use
+1. Add the class slide-out-card to any dismissible element.
+2. Toggle the class exit via JavaScript to animate the exit.
+3. Copy style.css into your project and ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-slide-out-right/demo.html
+++ b/submissions/examples/ease-slide-out-right/demo.html
@@ -1,0 +1,40 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-slide-out-right – Slide Out Right Exit</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">Slide Out Right</h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">Click the button to make the card slide out to the right and fade.</p>
+
+    <div id="slide-box" class="slide-out-card ease-card ease-p-8 ease-mx-auto ease-max-w-xs ease-shadow-md">
+      <p class="ease-text-lg ease-font-semibold">Goodbye!</p>
+      <p class="ease-text-sm ease-text-gray-500 ease-mt-2">Sliding right…</p>
+    </div>
+
+    <div class="ease-flex ease-justify-center ease-gap-4 ease-mt-8">
+      <button id="slide-btn" class="ease-btn ease-btn-primary ease-hover-scale-105 ease-transition">Slide Out</button>
+      <button id="reset-btn" class="ease-btn ease-btn-secondary ease-hover-scale-105 ease-transition">Reset</button>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-6 ease-fade-in ease-delay-500"><code>translateX(0) → translateX(40px)</code> + <code>opacity(0)</code> in 0.3s ease‑in.</p>
+  </div>
+
+  <script>
+    const box = document.getElementById('slide-box');
+    document.getElementById('slide-btn').addEventListener('click', () => {
+      box.classList.add('exit');
+    });
+    document.getElementById('reset-btn').addEventListener('click', () => {
+      box.classList.remove('exit');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-slide-out-right/style.css
+++ b/submissions/examples/ease-slide-out-right/style.css
@@ -1,0 +1,29 @@
+﻿/* ============================================================
+   ease-slide-out-right – Slide out to the right and fade
+   translateX + opacity transition, 0.3s ease-in
+   ============================================================ */
+
+.slide-out-card {
+  background: #ffffff;
+  border-radius: 1rem;
+  opacity: 1;
+  transform: translateX(0);
+  transition: transform 0.3s ease-in, opacity 0.3s ease-in;
+}
+
+.slide-out-card.exit {
+  opacity: 0;
+  transform: translateX(40px);
+  pointer-events: none;                /* prevent clicks while hidden */
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .slide-out-card {
+    transition: none;
+  }
+  .slide-out-card.exit {
+    opacity: 0;
+    transform: translateX(0);
+  }
+}


### PR DESCRIPTION
Closes #17167

ease-slide-out-right – Slide Out Right Exit
Element slides 40px to the right and fades out in 0.3s ease‑in.

Files added
- submissions/examples/ease-slide-out-right/demo.html
- submissions/examples/ease-slide-out-right/style.css
- submissions/examples/ease-slide-out-right/README.md

How it works
- CSS transition on transform and opacity.
- .exit class triggers the animation.
- Reset button brings the card back.
- Respects prefers-reduced-motion.