### PR TITLE
feat: add animated slash-command menu component (#17550)

### DIFF
--- a/submissions/examples/slash-command-menu/README.md
+++ b/submissions/examples/slash-command-menu/README.md
@@ -1,0 +1,167 @@
+# Animated Slash-Command Menu
+
+A Notion-style "/" trigger menu for editors and comment boxes. Type `/` in any editable field and a floating command palette appears — animated entrance, keyboard-navigable highlight, confirm flash on selection, and smooth exit. All visual states are pure CSS; JavaScript only handles triggering and keyboard wiring.
+
+---
+
+## Preview
+
+| State | Behaviour |
+|-------|-----------|
+| Open | Scale + fade entrance anchored below the caret |
+| Navigate | Active row highlights with a sliding left accent bar |
+| Select | Brief scale-flash on the row, then menu exits |
+| Close | Scale + fade exit (Escape, selection, or `/` deleted) |
+
+---
+
+## Files
+
+```
+submissions/examples/slash-command-menu/
+├── demo.html    ← self-contained live demo
+├── style.css    ← all animation classes
+└── README.md
+```
+
+---
+
+## Classes
+
+| Class | Description |
+|-------|-------------|
+| `ease-slash-menu` | Floating container; scale + fade entrance via `@keyframes ease-slash-enter` |
+| `ease-slash-item` | Individual command row; hover background transition |
+| `ease-slash-item-active` | Keyboard-highlighted row; purple bg + sliding left accent bar |
+| `ease-slash-item-select` | Confirm-flash `@keyframes` on Enter/click before menu closes |
+| `ease-slash-menu-exit` | Scale + fade exit; add this class to trigger close animation |
+
+---
+
+## Usage
+
+```html
+<div class="ease-slash-menu" role="listbox" aria-label="Slash commands">
+  <div class="ease-slash-item ease-slash-item-active" role="option" data-command="text">
+    <span class="ease-slash-item-icon">📝</span>
+    <div class="ease-slash-item-info">
+      <span class="ease-slash-item-name">Text</span>
+      <span class="ease-slash-item-desc">Plain paragraph</span>
+    </div>
+  </div>
+  <div class="ease-slash-item" role="option" data-command="heading1">
+    <span class="ease-slash-item-icon">H1</span>
+    <div class="ease-slash-item-info">
+      <span class="ease-slash-item-name">Heading 1</span>
+      <span class="ease-slash-item-desc">Large section header</span>
+    </div>
+  </div>
+  <!-- more items… -->
+</div>
+```
+
+### Minimal JS wiring
+
+```js
+// Show on "/"
+editor.addEventListener('input', () => {
+  if (lastChar === '/') showMenu();
+});
+
+// Navigate with arrow keys
+editor.addEventListener('keydown', e => {
+  if (e.key === 'ArrowDown') moveHighlight(1);
+  if (e.key === 'ArrowUp')   moveHighlight(-1);
+  if (e.key === 'Enter')     selectActiveItem();
+  if (e.key === 'Escape')    closeMenu();
+});
+
+// Close with exit animation
+function closeMenu() {
+  menu.classList.add('ease-slash-menu-exit');
+  menu.addEventListener('animationend', () => {
+    menu.setAttribute('hidden', '');
+    menu.classList.remove('ease-slash-menu-exit');
+  }, { once: true });
+}
+```
+
+---
+
+## Animation Details
+
+### Entrance — `ease-slash-enter`
+```css
+@keyframes ease-slash-enter {
+  from { opacity: 0; transform: scale(0.92) translateY(-6px); }
+  to   { opacity: 1; transform: scale(1)    translateY(0); }
+}
+```
+
+### Exit — `ease-slash-leave`
+```css
+@keyframes ease-slash-leave {
+  from { opacity: 1; transform: scale(1)    translateY(0); }
+  to   { opacity: 0; transform: scale(0.92) translateY(-6px); }
+}
+```
+
+### Active accent bar — slides in on highlight
+```css
+.ease-slash-item-active::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 20%; height: 60%; width: 3px;
+  background: var(--ease-slash-active-bar);
+  animation: ease-slash-bar-in 180ms ease forwards;
+}
+```
+
+### Selection flash — `ease-slash-item-select`
+```css
+@keyframes ease-slash-flash {
+  0%   { background: var(--ease-slash-active-bg); }
+  40%  { background: var(--ease-slash-flash-bg); transform: scale(0.98); }
+  100% { background: var(--ease-slash-active-bg); transform: scale(1); }
+}
+```
+
+---
+
+## Theming
+
+All colours are CSS custom properties on `:root`:
+
+```css
+:root {
+  --ease-slash-bg:          #ffffff;
+  --ease-slash-active-bg:   #ede9fe;
+  --ease-slash-active-bar:  #7c3aed;
+  --ease-slash-flash-bg:    #ddd6fe;
+}
+```
+
+Override per-instance to match any brand palette.
+
+---
+
+## Accessibility
+
+- `role="listbox"` on the menu, `role="option"` on each item
+- `aria-label` on the menu container
+- `aria-expanded` should be toggled on the trigger element
+- Keyboard: `↑` `↓` navigate, `Enter` selects, `Escape` closes
+- `prefers-reduced-motion` disables all transitions and animations
+
+---
+
+## Browser Support
+
+Chrome 90+, Firefox 90+, Safari 15+. Uses standard CSS `@keyframes`, `transform`, and `opacity` — no experimental features.
+
+---
+
+## Contributor
+
+**@thakurakanksha288** — GSSoC 2026 participant  
+Issue: [#17550](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/17550)

--- a/submissions/examples/slash-command-menu/demo.html
+++ b/submissions/examples/slash-command-menu/demo.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Slash-Command Menu — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-label">EaseMotion CSS — Slash-Command Menu</p>
+  <p class="demo-hint">Type <strong>/</strong> in the editor below to open the menu. Use ↑ ↓ to navigate, Enter to select, Escape to close.</p>
+
+  <div class="editor-wrap">
+    <textarea
+      class="editor"
+      id="editor"
+      placeholder="Start typing… press / to open the command menu"
+      rows="4"
+      spellcheck="false"
+    ></textarea>
+
+    <!-- Slash-command menu (hidden by default) -->
+    <div
+      class="ease-slash-menu"
+      id="slashMenu"
+      role="listbox"
+      aria-label="Slash commands"
+      hidden
+    >
+      <!-- Filter indicator -->
+      <div class="ease-slash-filter">
+        <span class="ease-slash-filter-icon">🔍</span>
+        <span class="ease-slash-filter-text" id="filterText">/</span>
+      </div>
+
+      <div class="ease-slash-section">Basic blocks</div>
+
+      <div class="ease-slash-item" role="option" data-command="text">
+        <span class="ease-slash-item-icon">📝</span>
+        <div class="ease-slash-item-info">
+          <span class="ease-slash-item-name">Text</span>
+          <span class="ease-slash-item-desc">Plain paragraph</span>
+        </div>
+        <span class="ease-slash-kbd">↵</span>
+      </div>
+
+      <div class="ease-slash-item" role="option" data-command="heading1">
+        <span class="ease-slash-item-icon">H1</span>
+        <div class="ease-slash-item-info">
+          <span class="ease-slash-item-name">Heading 1</span>
+          <span class="ease-slash-item-desc">Large section header</span>
+        </div>
+        <span class="ease-slash-kbd">↵</span>
+      </div>
+
+      <div class="ease-slash-item" role="option" data-command="heading2">
+        <span class="ease-slash-item-icon">H2</span>
+        <div class="ease-slash-item-info">
+          <span class="ease-slash-item-name">Heading 2</span>
+          <span class="ease-slash-item-desc">Medium section header</span>
+        </div>
+        <span class="ease-slash-kbd">↵</span>
+      </div>
+
+      <div class="ease-slash-section">Content</div>
+
+      <div class="ease-slash-item" role="option" data-command="bullet">
+        <span class="ease-slash-item-icon">•</span>
+        <div class="ease-slash-item-info">
+          <span class="ease-slash-item-name">Bullet list</span>
+          <span class="ease-slash-item-desc">Unordered list</span>
+        </div>
+        <span class="ease-slash-kbd">↵</span>
+      </div>
+
+      <div class="ease-slash-item" role="option" data-command="numbered">
+        <span class="ease-slash-item-icon">1.</span>
+        <div class="ease-slash-item-info">
+          <span class="ease-slash-item-name">Numbered list</span>
+          <span class="ease-slash-item-desc">Ordered list</span>
+        </div>
+        <span class="ease-slash-kbd">↵</span>
+      </div>
+
+      <div class="ease-slash-item" role="option" data-command="todo">
+        <span class="ease-slash-item-icon">☑️</span>
+        <div class="ease-slash-item-info">
+          <span class="ease-slash-item-name">To-do list</span>
+          <span class="ease-slash-item-desc">Track tasks with checkboxes</span>
+        </div>
+        <span class="ease-slash-kbd">↵</span>
+      </div>
+
+      <div class="ease-slash-item" role="option" data-command="image">
+        <span class="ease-slash-item-icon">🖼️</span>
+        <div class="ease-slash-item-info">
+          <span class="ease-slash-item-name">Image</span>
+          <span class="ease-slash-item-desc">Upload or embed an image</span>
+        </div>
+        <span class="ease-slash-kbd">↵</span>
+      </div>
+
+      <div class="ease-slash-item" role="option" data-command="code">
+        <span class="ease-slash-item-icon">💻</span>
+        <div class="ease-slash-item-info">
+          <span class="ease-slash-item-name">Code block</span>
+          <span class="ease-slash-item-desc">Syntax-highlighted code</span>
+        </div>
+        <span class="ease-slash-kbd">↵</span>
+      </div>
+
+      <div class="ease-slash-item" role="option" data-command="divider">
+        <span class="ease-slash-item-icon">—</span>
+        <div class="ease-slash-item-info">
+          <span class="ease-slash-item-name">Divider</span>
+          <span class="ease-slash-item-desc">Horizontal rule</span>
+        </div>
+        <span class="ease-slash-kbd">↵</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast notification for selected command -->
+  <div id="toast" style="
+    position:fixed; bottom:2rem; left:50%; transform:translateX(-50%) translateY(20px);
+    background:#1e293b; color:#f1f5f9; padding:0.5rem 1.25rem;
+    border-radius:999px; font-size:0.8125rem; font-weight:500;
+    opacity:0; transition:opacity 200ms ease, transform 200ms ease;
+    pointer-events:none; white-space:nowrap;
+  " id="toast"></div>
+
+  <script>
+    const editor   = document.getElementById('editor');
+    const menu     = document.getElementById('slashMenu');
+    const filterEl = document.getElementById('filterText');
+    const items    = () => [...menu.querySelectorAll('.ease-slash-item')];
+    const toast    = document.getElementById('toast');
+
+    let activeIdx  = 0;
+    let slashStart = -1;
+    let closing    = false;
+
+    /* ── Show menu ────────────────────────────────────────── */
+    function showMenu() {
+      menu.removeAttribute('hidden');
+      menu.classList.remove('ease-slash-menu-exit');
+      closing = false;
+      activeIdx = 0;
+      highlightItem(activeIdx);
+    }
+
+    /* ── Close menu ───────────────────────────────────────── */
+    function closeMenu() {
+      if (closing) return;
+      closing = true;
+      menu.classList.add('ease-slash-menu-exit');
+      menu.addEventListener('animationend', () => {
+        menu.setAttribute('hidden', '');
+        menu.classList.remove('ease-slash-menu-exit');
+        closing = false;
+        slashStart = -1;
+        filterEl.textContent = '/';
+      }, { once: true });
+    }
+
+    /* ── Highlight a row ──────────────────────────────────── */
+    function highlightItem(idx) {
+      items().forEach((el, i) => {
+        el.classList.toggle('ease-slash-item-active', i === idx);
+      });
+    }
+
+    /* ── Selection flash + toast ──────────────────────────── */
+    function selectItem(el) {
+      el.classList.add('ease-slash-item-select');
+      el.addEventListener('animationend', () => {
+        el.classList.remove('ease-slash-item-select');
+        closeMenu();
+      }, { once: true });
+
+      // Remove the slash trigger text from editor
+      const val = editor.value;
+      editor.value = val.slice(0, slashStart) + val.slice(editor.selectionStart);
+
+      showToast('Inserted: ' + el.dataset.command);
+    }
+
+    /* ── Toast ────────────────────────────────────────────── */
+    function showToast(msg) {
+      toast.textContent = msg;
+      toast.style.opacity = '1';
+      toast.style.transform = 'translateX(-50%) translateY(0)';
+      setTimeout(() => {
+        toast.style.opacity = '0';
+        toast.style.transform = 'translateX(-50%) translateY(20px)';
+      }, 1800);
+    }
+
+    /* ── Editor input: detect "/" ─────────────────────────── */
+    editor.addEventListener('input', () => {
+      const val    = editor.value;
+      const cursor = editor.selectionStart;
+      const last   = val[cursor - 1];
+
+      if (last === '/' && menu.hasAttribute('hidden')) {
+        slashStart = cursor - 1;
+        showMenu();
+        return;
+      }
+
+      if (!menu.hasAttribute('hidden')) {
+        // Update filter display
+        const typed = val.slice(slashStart, cursor);
+        filterEl.textContent = typed || '/';
+
+        // If slash was deleted, close
+        if (cursor <= slashStart || !typed.startsWith('/')) {
+          closeMenu();
+        }
+      }
+    });
+
+    /* ── Keyboard navigation ──────────────────────────────── */
+    editor.addEventListener('keydown', e => {
+      if (menu.hasAttribute('hidden')) return;
+
+      const list = items();
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIdx = (activeIdx + 1) % list.length;
+        highlightItem(activeIdx);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIdx = (activeIdx - 1 + list.length) % list.length;
+        highlightItem(activeIdx);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        selectItem(list[activeIdx]);
+      } else if (e.key === 'Escape') {
+        closeMenu();
+      }
+    });
+
+    /* ── Mouse click on item ──────────────────────────────── */
+    menu.addEventListener('mousedown', e => {
+      const item = e.target.closest('.ease-slash-item');
+      if (!item) return;
+      e.preventDefault();
+      selectItem(item);
+    });
+
+    /* ── Hover syncs activeIdx ────────────────────────────── */
+    menu.addEventListener('mousemove', e => {
+      const item = e.target.closest('.ease-slash-item');
+      if (!item) return;
+      activeIdx = items().indexOf(item);
+      highlightItem(activeIdx);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/slash-command-menu/style.css
+++ b/submissions/examples/slash-command-menu/style.css
@@ -1,0 +1,313 @@
+/* ============================================================
+   EaseMotion CSS — Animated Slash-Command Menu
+   submissions/examples/slash-command-menu/style.css
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --ease-slash-bg:          #ffffff;
+  --ease-slash-border:      #e2e8f0;
+  --ease-slash-shadow:      0 8px 30px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.08);
+  --ease-slash-text:        #1e293b;
+  --ease-slash-subtext:     #64748b;
+  --ease-slash-hover-bg:    #f1f5f9;
+  --ease-slash-active-bg:   #ede9fe;
+  --ease-slash-active-text: #5b21b6;
+  --ease-slash-active-bar:  #7c3aed;
+  --ease-slash-flash-bg:    #ddd6fe;
+  --ease-slash-radius:      10px;
+  --ease-slash-duration:    200ms;
+  --ease-slash-easing:      cubic-bezier(0.4, 0, 0.2, 1);
+
+  --editor-bg:    #f8fafc;
+  --editor-border:#e2e8f0;
+  --editor-text:  #1e293b;
+  --page-bg:      #f1f5f9;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-slash-bg:          #1e293b;
+    --ease-slash-border:      #334155;
+    --ease-slash-shadow:      0 8px 30px rgba(0,0,0,0.4), 0 2px 8px rgba(0,0,0,0.3);
+    --ease-slash-text:        #f1f5f9;
+    --ease-slash-subtext:     #94a3b8;
+    --ease-slash-hover-bg:    #334155;
+    --ease-slash-active-bg:   #3b0764;
+    --ease-slash-active-text: #c4b5fd;
+    --ease-slash-active-bar:  #a78bfa;
+    --ease-slash-flash-bg:    #4c1d95;
+    --editor-bg:    #0f172a;
+    --editor-border:#1e293b;
+    --editor-text:  #f1f5f9;
+    --page-bg:      #0f172a;
+  }
+}
+
+/* ── Page shell ──────────────────────────────────────────── */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--page-bg);
+  color: var(--editor-text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3rem 1rem;
+  gap: 1rem;
+}
+
+.demo-label {
+  font-size: 0.8rem;
+  color: var(--ease-slash-subtext);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.demo-hint {
+  font-size: 0.8125rem;
+  color: var(--ease-slash-subtext);
+  margin-top: -0.25rem;
+}
+
+/* ── Editor area ─────────────────────────────────────────── */
+.editor-wrap {
+  position: relative;
+  width: 100%;
+  max-width: 560px;
+}
+
+.editor {
+  width: 100%;
+  min-height: 120px;
+  padding: 1rem 1.25rem;
+  background: var(--editor-bg);
+  border: 1.5px solid var(--editor-border);
+  border-radius: 10px;
+  font-size: 1rem;
+  color: var(--editor-text);
+  line-height: 1.6;
+  resize: none;
+  outline: none;
+  font-family: inherit;
+  transition: border-color var(--ease-slash-duration) var(--ease-slash-easing);
+}
+
+.editor:focus {
+  border-color: var(--ease-slash-active-bar);
+}
+
+.editor::placeholder {
+  color: var(--ease-slash-subtext);
+  opacity: 0.7;
+}
+
+/* ── Slash-command menu container ────────────────────────── */
+.ease-slash-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 1rem;
+  width: 260px;
+  background: var(--ease-slash-bg);
+  border: 1px solid var(--ease-slash-border);
+  border-radius: var(--ease-slash-radius);
+  box-shadow: var(--ease-slash-shadow);
+  padding: 6px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+
+  /* Entrance: scale + fade in */
+  transform-origin: top left;
+  animation: ease-slash-enter var(--ease-slash-duration) var(--ease-slash-easing) forwards;
+}
+
+@keyframes ease-slash-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.92) translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+/* Exit state — add .ease-slash-menu-exit class via JS */
+.ease-slash-menu-exit {
+  animation: ease-slash-leave var(--ease-slash-duration) var(--ease-slash-easing) forwards;
+  pointer-events: none;
+}
+
+@keyframes ease-slash-leave {
+  from {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.92) translateY(-6px);
+  }
+}
+
+/* Hidden (removed from layout after exit animation) */
+.ease-slash-menu[hidden] {
+  display: none;
+}
+
+/* ── Section label inside menu ───────────────────────────── */
+.ease-slash-section {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ease-slash-subtext);
+  padding: 6px 10px 2px;
+}
+
+/* ── Individual command row ──────────────────────────────── */
+.ease-slash-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition:
+    background var(--ease-slash-duration) var(--ease-slash-easing),
+    color var(--ease-slash-duration) var(--ease-slash-easing),
+    transform 120ms var(--ease-slash-easing);
+}
+
+.ease-slash-item:hover {
+  background: var(--ease-slash-hover-bg);
+}
+
+.ease-slash-item-icon {
+  font-size: 1rem;
+  width: 24px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.ease-slash-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.ease-slash-item-name {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--ease-slash-text);
+  line-height: 1.2;
+  transition: color var(--ease-slash-duration) var(--ease-slash-easing);
+}
+
+.ease-slash-item-desc {
+  font-size: 0.7rem;
+  color: var(--ease-slash-subtext);
+  line-height: 1.2;
+}
+
+/* ── Active (keyboard-highlighted) row ───────────────────── */
+.ease-slash-item-active {
+  background: var(--ease-slash-active-bg);
+}
+
+.ease-slash-item-active .ease-slash-item-name {
+  color: var(--ease-slash-active-text);
+}
+
+/* Left accent bar slides in */
+.ease-slash-item-active::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 20%;
+  height: 60%;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--ease-slash-active-bar);
+  animation: ease-slash-bar-in 180ms var(--ease-slash-easing) forwards;
+}
+
+@keyframes ease-slash-bar-in {
+  from { opacity: 0; transform: scaleY(0); }
+  to   { opacity: 1; transform: scaleY(1); }
+}
+
+/* ── Selection confirm flash ─────────────────────────────── */
+.ease-slash-item-select {
+  animation: ease-slash-flash 320ms var(--ease-slash-easing) forwards;
+}
+
+@keyframes ease-slash-flash {
+  0%   { background: var(--ease-slash-active-bg); }
+  40%  { background: var(--ease-slash-flash-bg); transform: scale(0.98); }
+  100% { background: var(--ease-slash-active-bg); transform: scale(1); }
+}
+
+/* ── Keyboard shortcut badge ─────────────────────────────── */
+.ease-slash-kbd {
+  margin-left: auto;
+  font-size: 0.6rem;
+  font-weight: 600;
+  background: var(--ease-slash-border);
+  color: var(--ease-slash-subtext);
+  border-radius: 4px;
+  padding: 2px 5px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity var(--ease-slash-duration) var(--ease-slash-easing);
+}
+
+.ease-slash-item-active .ease-slash-kbd {
+  opacity: 1;
+}
+
+/* ── Filter input inside menu ────────────────────────────── */
+.ease-slash-filter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--ease-slash-border);
+  margin-bottom: 4px;
+}
+
+.ease-slash-filter-icon {
+  color: var(--ease-slash-subtext);
+  font-size: 0.75rem;
+}
+
+.ease-slash-filter-text {
+  font-size: 0.8rem;
+  color: var(--ease-slash-text);
+  font-family: inherit;
+  min-width: 0;
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-slash-menu,
+  .ease-slash-menu-exit,
+  .ease-slash-item,
+  .ease-slash-item-active::before,
+  .ease-slash-item-select,
+  .ease-slash-kbd {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## 🎯 Feature: Animated Slash-Command Menu

### Summary

| Item | Detail |
|------|--------|
| Component | Animated Slash-Command Menu |
| Folder | `submissions/examples/slash-command-menu/` |
| Files | `demo.html`, `style.css`, `README.md` |
| Dependencies | Zero — pure CSS + minimal JS for keyboard wiring only |
| Issue | Closes #17550 |

---

### Implemented Classes

| Class | Behaviour |
|-------|-----------|
| `ease-slash-menu` | Floating container; scale + fade entrance anchored near caret |
| `ease-slash-item` | Individual command row; hover background transition |
| `ease-slash-item-active` | Keyboard-highlighted row; purple bg + sliding left accent bar |
| `ease-slash-item-select` | Confirm-flash on Enter/click before menu closes |
| `ease-slash-menu-exit` | Scale + fade exit triggered by adding this class |

---

### Animation Details

- **Entrance** — `scale(0.92) + opacity 0 → 1` via `@keyframes ease-slash-enter`
- **Exit** — reverse scale + fade via `@keyframes ease-slash-leave`
- **Active bar** — 3px left accent bar slides in with `scaleY` on keyboard highlight
- **Selection flash** — scale + background pulse via `@keyframes ease-slash-flash`

---

### Variants

- ✅ Light mode
- ✅ Dark mode (`prefers-color-scheme: dark`)
- ✅ `prefers-reduced-motion` — all transitions and animations disabled

---

### Accessibility

- `role="listbox"` on menu, `role="option"` on each item
- Keyboard: `↑` `↓` navigate · `Enter` selects · `Escape` closes
- Hover syncs keyboard highlight index
- `prefers-reduced-motion` respected

---

### Contributor
**@thakurakanksha288** — GSSoC 2026 participant ✅