### PR TITLE
Add Split Button / Button Group / Segmented Control Component

### DIFF
--- a/submissions/examples/16382-split-btn-pcm/README.md
+++ b/submissions/examples/16382-split-btn-pcm/README.md
@@ -1,0 +1,51 @@
+# Split Button / Button Group / Segmented Control Component
+
+1. **What does this do?** Provides three related button components: a **button group** that joins buttons without gaps, a **split button** combining a primary action with a dropdown menu of related options (with divider and danger item support), and a **segmented control** displaying mutually exclusive options as connected radio-based segments with active state highlighting.
+
+2. **How is it used?** Add the appropriate HTML structure with classes. For split button, call `toggleSplit(id)` to open/close the menu. For segmented control, wrap radio inputs in `<label class="segment">` with `role="radiogroup"` on the container.
+
+```html
+<!-- Button Group -->
+<div class="btn-group">
+  <button class="btn primary">Save</button>
+  <button class="btn primary">Edit</button>
+  <button class="btn primary">Delete</button>
+</div>
+
+<!-- Split Button -->
+<div class="split-btn">
+  <button class="btn primary">Save</button>
+  <button class="split-btn-toggle" onclick="toggleSplit(this)">
+    <span class="split-btn-arrow">▾</span>
+  </button>
+  <div class="split-btn-menu">
+    <button class="split-btn-item">Save as Draft</button>
+    <hr class="split-btn-divider">
+    <button class="split-btn-item danger">Discard</button>
+  </div>
+</div>
+
+<!-- Segmented Control -->
+<div class="segmented-control" role="radiogroup">
+  <label class="segment">
+    <input type="radio" name="view" value="list" checked hidden>
+    <span class="segment-label">List</span>
+  </label>
+  <label class="segment">
+    <input type="radio" name="view" value="grid" hidden>
+    <span class="segment-label">Grid</span>
+  </label>
+</div>
+```
+
+3. **Why is it useful?** Split buttons and segmented controls are common UI patterns in dashboards, toolbars, and settings panels — but implementing the connected border radii, dropdown positioning, radio-based selection, and accessibility from scratch is tedious. These components provide production-ready implementations with proper ARIA roles, keyboard support, and visual states.
+
+### Components
+
+| Component | Classes | Features |
+|---|---|---|
+| Button Group | `.btn-group` | Connected buttons, 0 gaps, smart border-radius |
+| Split Button | `.split-btn`, `.split-btn-toggle`, `.split-btn-menu`, `.split-btn-item` | Dropdown toggle, arrow rotation, divider, danger item, click-outside close |
+| Segmented Control | `.segmented-control`, `.segment`, `.segment-label` | Hidden radio inputs, ARIA radiogroup, checked highlight, focus-visible |
+
+Fixes #16382

--- a/submissions/examples/16382-split-btn-pcm/demo.html
+++ b/submissions/examples/16382-split-btn-pcm/demo.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Split Button / Button Group / Segmented Control</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+
+  <h1>🔘 Split Button &amp; Segmented Control</h1>
+  <p class="subtitle">Split button with primary action + dropdown menu, button groups with connected segments, and radio-based segmented control with active state.</p>
+
+  <!-- 1. Button Group -->
+  <div class="section">
+    <h2>Button Group</h2>
+    <p>Connected buttons without gaps — buttons are joined via <code>border-radius: 0</code> on middle items with <code>margin-inline-start: -1px</code>.</p>
+    <div class="demo-row">
+      <div class="btn-group">
+        <button class="btn primary">Save</button>
+        <button class="btn primary">Edit</button>
+        <button class="btn primary">Delete</button>
+      </div>
+      <div class="btn-group">
+        <button class="btn">Left</button>
+        <button class="btn">Center</button>
+        <button class="btn">Right</button>
+      </div>
+      <div class="btn-group">
+        <button class="btn success">Approve</button>
+        <button class="btn danger">Reject</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2. Split Button -->
+  <div class="section">
+    <h2>Split Button</h2>
+    <p>Primary action with a toggle arrow that opens a dropdown menu of related options. Click the arrow to toggle the menu. Includes divider and danger item support.</p>
+    <div class="demo-row">
+      <div class="split-btn" id="split-save">
+        <button class="btn primary" onclick="alert('Saved!')">Save</button>
+        <button class="split-btn-toggle" onclick="toggleSplit('split-save')" aria-label="More options">
+          <span class="split-btn-arrow">▾</span>
+        </button>
+        <div class="split-btn-menu">
+          <button class="split-btn-item" onclick="alert('Saved as draft')">📝 Save as Draft</button>
+          <button class="split-btn-item" onclick="alert('Saved and published!')">🚀 Save and Publish</button>
+          <hr class="split-btn-divider">
+          <button class="split-btn-item danger" onclick="alert('Discarded')">🗑️ Discard</button>
+        </div>
+      </div>
+
+      <div class="split-btn" id="split-share">
+        <button class="btn" onclick="alert('Shared!')">Share</button>
+        <button class="btn" onclick="toggleSplit('split-share')" style="border-start-start-radius:0;border-end-start-radius:0;padding-inline:0.6rem" aria-label="Share options">
+          <span class="split-btn-arrow">▾</span>
+        </button>
+        <div class="split-btn-menu">
+          <button class="split-btn-item" onclick="alert('Copied link')">🔗 Copy Link</button>
+          <button class="split-btn-item" onclick="alert('Shared via email')">✉️ Email</button>
+          <button class="split-btn-item" onclick="alert('Shared on Twitter')">🐦 Twitter</button>
+        </div>
+      </div>
+    </div>
+    <p class="status-text" id="split-status">Click the arrow ▾ to open split button menu</p>
+  </div>
+
+  <!-- 3. Segmented Control -->
+  <div class="section">
+    <h2>Segmented Control</h2>
+    <p>Radio-based mutually exclusive segments using hidden inputs. Uses <code>role="radiogroup"</code> for accessibility. Active segment gets highlighted background.</p>
+
+    <div style="margin-bottom:1rem">
+      <p style="font-size:0.82rem;color:#94a3b8;margin-bottom:0.5rem">View mode:</p>
+      <div class="segmented-control" role="radiogroup" aria-label="View mode">
+        <label class="segment">
+          <input type="radio" name="view" value="list" checked onchange="updateSegment(this)">
+          <span class="segment-label">📋 List</span>
+        </label>
+        <label class="segment">
+          <input type="radio" name="view" value="grid" onchange="updateSegment(this)">
+          <span class="segment-label">🔲 Grid</span>
+        </label>
+        <label class="segment">
+          <input type="radio" name="view" value="table" onchange="updateSegment(this)">
+          <span class="segment-label">📊 Table</span>
+        </label>
+      </div>
+      <div class="segment-result" id="segment-result">Selected: List</div>
+    </div>
+
+    <div>
+      <p style="font-size:0.82rem;color:#94a3b8;margin-bottom:0.5rem">Sort by:</p>
+      <div class="segmented-control" role="radiogroup" aria-label="Sort order">
+        <label class="segment">
+          <input type="radio" name="sort" value="alpha" onchange="updateSort(this)">
+          <span class="segment-label">A–Z</span>
+        </label>
+        <label class="segment">
+          <input type="radio" name="sort" value="date" checked onchange="updateSort(this)">
+          <span class="segment-label">📅 Date</span>
+        </label>
+        <label class="segment">
+          <input type="radio" name="sort" value="size" onchange="updateSort(this)">
+          <span class="segment-label">📦 Size</span>
+        </label>
+      </div>
+      <div class="segment-result" id="sort-result">Selected: Date</div>
+    </div>
+  </div>
+
+  <!-- 4. API Reference -->
+  <div class="section">
+    <h2>📖 API Reference</h2>
+    <table>
+      <tr><th>Component</th><th>Class</th><th>Description</th></tr>
+      <tr><td>Button Group</td><td><code>.btn-group</code></td><td>Container that joins buttons without gaps</td></tr>
+      <tr><td>Split Button</td><td><code>.split-btn</code></td><td>Primary action + dropdown toggle container</td></tr>
+      <tr><td></td><td><code>.split-btn-toggle</code></td><td>Arrow button to toggle menu</td></tr>
+      <tr><td></td><td><code>.split-btn-arrow</code></td><td>Arrow icon, rotates 180° when open</td></tr>
+      <tr><td></td><td><code>.split-btn-menu</code></td><td>Dropdown menu (positioned below)</td></tr>
+      <tr><td></td><td><code>.split-btn-item</code></td><td>Menu item with hover state</td></tr>
+      <tr><td></td><td><code>.split-btn-item.danger</code></td><td>Destructive action item (red)</td></tr>
+      <tr><td></td><td><code>.split-btn-divider</code></td><td>Horizontal divider in menu</td></tr>
+      <tr><td></td><td><code>.split-btn.open</code></td><td>State class — menu visible + arrow rotated</td></tr>
+      <tr><td>Segmented Control</td><td><code>.segmented-control</code></td><td>Radio group container with role="radiogroup"</td></tr>
+      <tr><td></td><td><code>.segment</code></td><td>Label wrapping hidden radio input</td></tr>
+      <tr><td></td><td><code>.segment-label</code></td><td>Visible segment label with checked state</td></tr>
+    </table>
+  </div>
+
+</div>
+
+<script>
+function toggleSplit(id) {
+  var el = document.getElementById(id);
+  var isOpen = el.classList.contains('open');
+  document.querySelectorAll('.split-btn.open').forEach(function(s) {
+    s.classList.remove('open');
+  });
+  if (!isOpen) el.classList.add('open');
+  document.getElementById('split-status').textContent = isOpen ? 'Menu closed' : 'Menu open — click item to select';
+}
+
+document.addEventListener('click', function(e) {
+  if (!e.target.closest('.split-btn')) {
+    document.querySelectorAll('.split-btn.open').forEach(function(s) {
+      s.classList.remove('open');
+    });
+    document.getElementById('split-status').textContent = 'Click the arrow ▾ to open split button menu';
+  }
+});
+
+function updateSegment(input) {
+  document.getElementById('segment-result').textContent = 'Selected: ' + input.value.charAt(0).toUpperCase() + input.value.slice(1);
+}
+
+function updateSort(input) {
+  document.getElementById('sort-result').textContent = 'Selected: ' + input.value.charAt(0).toUpperCase() + input.value.slice(1);
+}
+</script>
+
+</body>
+</html>

--- a/submissions/examples/16382-split-btn-pcm/style.css
+++ b/submissions/examples/16382-split-btn-pcm/style.css
@@ -1,0 +1,340 @@
+/* ===============================
+   Split Button / Button Group / Segmented Control
+   =============================== */
+
+/* ── Button Group ── */
+.btn-group {
+  display: inline-flex;
+}
+
+.btn-group .btn {
+  border-radius: 0;
+  margin: 0;
+}
+
+.btn-group .btn:first-child {
+  border-start-start-radius: 6px;
+  border-end-start-radius: 6px;
+}
+
+.btn-group .btn:last-child {
+  border-start-end-radius: 6px;
+  border-end-end-radius: 6px;
+}
+
+.btn-group .btn + .btn {
+  margin-inline-start: -1px;
+}
+
+/* ── Split Button ── */
+.split-btn {
+  position: relative;
+  display: inline-flex;
+}
+
+.split-btn .btn-primary {
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
+  border-inline-end: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.split-btn-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-inline: 0.6rem;
+  border: 1px solid rgba(167, 139, 250, 0.3);
+  background: linear-gradient(135deg, #7c3aed, #6366f1);
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.8rem;
+  border-start-end-radius: 6px;
+  border-end-end-radius: 6px;
+  transition: opacity 0.2s;
+}
+
+.split-btn-toggle:hover {
+  opacity: 0.9;
+}
+
+.split-btn-arrow {
+  display: inline-block;
+  transition: transform 0.2s;
+  font-size: 0.7rem;
+}
+
+.split-btn.open .split-btn-arrow {
+  transform: rotate(180deg);
+}
+
+/* Dropdown menu */
+.split-btn-menu {
+  position: absolute;
+  inset-block-start: 100%;
+  inset-inline-start: 0;
+  margin-block-start: 4px;
+  min-width: 180px;
+  background: var(--menu-bg, #1e1e3f);
+  border: 1px solid var(--menu-border, rgba(255, 255, 255, 0.1));
+  border-radius: 8px;
+  padding: 0.35rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 50;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-4px);
+  transition: opacity 0.2s, transform 0.2s;
+}
+
+.split-btn.open .split-btn-menu {
+  opacity: 1;
+  pointer-events: all;
+  transform: translateY(0);
+}
+
+.split-btn-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.45rem 0.75rem;
+  border: none;
+  background: transparent;
+  color: #cbd5e1;
+  font-size: 0.82rem;
+  text-align: start;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.15s;
+  gap: 0.5rem;
+}
+
+.split-btn-item:hover {
+  background: rgba(124, 58, 237, 0.15);
+  color: #e2e8f0;
+}
+
+.split-btn-item.danger {
+  color: #f87171;
+}
+
+.split-btn-item.danger:hover {
+  background: rgba(239, 68, 68, 0.15);
+}
+
+.split-btn-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 0.25rem 0.5rem;
+  border: none;
+}
+
+/* ── Segmented Control ── */
+.segmented-control {
+  display: inline-flex;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 2px;
+  gap: 2px;
+}
+
+.segment {
+  position: relative;
+}
+
+.segment input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.segment-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.82rem;
+  color: #94a3b8;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+  gap: 0.35rem;
+}
+
+.segment input:checked + .segment-label {
+  background: rgba(124, 58, 237, 0.25);
+  color: #c4b5fd;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.segment input:focus-visible + .segment-label {
+  outline: 2px solid #7c3aed;
+  outline-offset: 1px;
+}
+
+.segment-label:hover {
+  color: #e2e8f0;
+}
+
+/* ── Demo styles ── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: linear-gradient(135deg, #0f0c29, #1a1a3e, #24243e);
+  color: #e2e8f0;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.container {
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 0.3rem;
+  background: linear-gradient(90deg, #a78bfa, #60a5fa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+}
+
+.section {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.section h2 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #c4b5fd;
+}
+
+.section > p {
+  color: #94a3b8;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin: 0.75rem 0;
+}
+
+.btn {
+  padding: 0.45rem 1.2rem;
+  border: 1px solid rgba(167, 139, 250, 0.3);
+  background: rgba(167, 139, 250, 0.1);
+  color: #c4b5fd;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.82rem;
+  transition: all 0.2s;
+}
+
+.btn:hover {
+  background: rgba(167, 139, 250, 0.2);
+  border-color: rgba(167, 139, 250, 0.5);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, #7c3aed, #6366f1);
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn.primary:hover { opacity: 0.9; }
+
+.btn.success {
+  background: rgba(34, 197, 94, 0.15);
+  border-color: rgba(34, 197, 94, 0.25);
+  color: #34d399;
+}
+
+.btn.danger {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.25);
+  color: #f87171;
+}
+
+.btn.outline {
+  background: transparent;
+  border-color: rgba(167, 139, 250, 0.4);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.5rem 0;
+}
+
+th, td {
+  padding: 0.4rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.82rem;
+}
+
+th {
+  color: #a78bfa;
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+td { color: #cbd5e1; }
+
+code {
+  padding: 0.12rem 0.35rem;
+  background: rgba(167, 139, 250, 0.15);
+  border: 1px solid rgba(167, 139, 250, 0.25);
+  border-radius: 4px;
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: 0.78rem;
+  color: #c4b5fd;
+}
+
+.status-text {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin-top: 0.5rem;
+}
+
+.segment-result {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: #a78bfa;
+}
+
+@media (max-width: 768px) {
+  body { padding: 1rem; }
+}


### PR DESCRIPTION
## ✦ Description

Add three related button components: button group (connected buttons without gaps), split button (primary action with dropdown menu, arrow rotation, divider, danger items, click-outside close), and segmented control (radio-based mutually exclusive segments with active highlight and ARIA radiogroup).

Fixes #16382

---

## ⟡ Type of Change

- [x] New feature (non-breaking change which adds functionality)

---

## ✦ Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.

---

## Description

### Root Cause
EaseMotion CSS lacks split button, button group, and segmented control components — common UI patterns for dashboards, toolbars, and settings panels.

### Changes Made

Added 3 files under `submissions/examples/16382-split-btn-pcm/`:

- **style.css** — .btn-group (connected border-radii, -1px margin join), .split-btn (relative container, toggle with arrow rotation, positioned dropdown with transition, .danger item, .divider), .segmented-control (radio-based, hidden inputs, checked highlight, focus-visible ring), and demo layout
- **demo.html** — 4 sections: Button Group (3 variants), Split Button (Save + Share with menu items/divider/danger), Segmented Control (View mode + Sort by with live selection display), and API reference table
- **README.md** — Documentation with usage examples and component reference

### Features

- **Button Group**: Connected buttons with smart border-radius (first → start, last → end), margin overlap eliminates gaps
- **Split Button**: Primary action + toggle with arrow rotation, positioned dropdown menu, divider support, .danger item variant, click-outside-to-close, single-open behavior
- **Segmented Control**: Hidden radio inputs with ARIA radiogroup, label-based click, checked state with highlighted background and shadow, focus-visible keyboard support

### Testing Performed

- Opened `demo.html` directly in browser
- Verified button group renders 3 variants (primary, default, success/danger)
- Verified split button toggle opens/closes menu with arrow rotation
- Verified click-outside closes all open menus
- Verified single-open behavior (only one menu open at a time)
- Verified segmented control radio selection updates display text
- Verified keyboard tab navigation reaches hidden radio inputs
- All 3 files: 558 additions, 0 deletions

---

## Additional Notes

- No `ease-` prefix used in CSS classes (per submission guidelines)
- No core/ or components/ files were modified
- Submission follows the required 3-file structure in submissions/examples/
- Branch: feat/split-btn-16382
- Fork: Pcmhacker-piro/EaseMotion-css
- Clean single commit, rebased on latest upstream/main