### PR TITLE
docs: remove duplicate “Align Self Utilities” section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,14 +505,6 @@ Applies a quick squish animation during hover, focus, and active interactions.
 <div class="ease-flex ease-flex-nowrap ease-gap-3">No wrap</div>
 <div class="ease-flex ease-flex-wrap-reverse ease-gap-3">Reverse wrap</div>
 
-<!-- Align self utilities -->
-<div class="ease-flex ease-items-stretch ease-gap-3">
-  <span class="ease-self-start">Start</span>
-  <span class="ease-self-center">Center</span>
-  <span class="ease-self-end">End</span>
-  <span class="ease-self-stretch">Stretch</span>
-</div>
-
 <!-- Responsive auto-fit grid (no media queries needed) -->
 <div class="ease-grid ease-grid-auto ease-gap-6">
   <div class="ease-card">Card 1</div>


### PR DESCRIPTION
## Pull Request Description

This PR removes a duplicate “Align Self Utilities” code block from the README.md under the “Layout Utilities” section.

The duplicated content was redundant and overlapped with the dedicated “Align Self Utilities” section, which already serves as the single source of truth.

By removing the duplicate block, the documentation is now cleaner, more consistent, and easier to navigate, without affecting any other part of the README or repository structure.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `README.md`
- [x] Removes only duplicated documentation content
- [x] Preserves existing formatting and structure
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no unrelated changes)

---

## Feature Description

**What does this add?**  
Removes duplicated documentation for Align Self utilities in the README.

**How does a developer use it?**  
No usage change — documentation only.

```html
<!-- No code changes introduced -->