### PR TITLE
Add Bottom Sheet / Slide-up Drawer Component

### DIFF
--- a/submissions/examples/16378-bottomsheet-pcm/README.md
+++ b/submissions/examples/16378-bottomsheet-pcm/README.md
@@ -1,0 +1,29 @@
+# Bottom Sheet / Slide-up Drawer Component
+
+## What does this submission do?
+
+Adds a **Bottom Sheet** component — a modal panel that slides up from the bottom of the screen, commonly used for share sheets, action menus, filters, and contextual menus on mobile and desktop interfaces.
+
+## How was it implemented?
+
+- **CSS** (`style.css`): The `.sheet` component is a fixed-position overlay (`inset: 0`) with flexbox alignment to push the panel to the bottom. The `.sheet-backdrop` provides a semi-transparent overlay that fades in. The `.sheet-panel` slides up using `transform: translateY(100%) → translateY(0)` with a cubic-bezier easing. CSS custom properties (`--sheet-max-height`, `--sheet-radius`, `--sheet-handle-w`, `--sheet-handle-h`, `--sheet-duration`, `--sheet-bg`, `--sheet-backdrop`) allow full theming. Snap levels are controlled by `.snap-25`, `.snap-50`, `.snap-75` classes that limit `max-height`. The `.sheet-handle` is a grab cursor area with a pill-shaped indicator. `.sheet-header` contains the title and close button. `.sheet-content` scrolls independently with `-webkit-overflow-scrolling: touch` for smooth mobile scrolling.
+- **HTML/JS** (`demo.html`): Four bottom sheet instances demonstrate different use cases. The `BottomSheet` JavaScript class handles: open/close with class toggling, body scroll locking, drag-to-dismiss via both touch and mouse events on the handle (with a 100px threshold), Escape key to close, backdrop click to close, and focus on the close button when opened. Four trigger buttons open: Share Sheet (social sharing options), Filters (search refinement), Action Menu (item actions), and an Expanded Settings sheet at 75% snap height.
+
+## Why these choices?
+
+- **Slide-up with cubic-bezier** matches the Material Design bottom sheet spec and feels natural.
+- **Drag-to-dismiss** via the handle provides the expected mobile interaction pattern (both touch and mouse).
+- **Snap points** (25%, 50%, 75%) give content-aware height control — the 75% snap is used for the expanded settings sheet with more content.
+- **CSS custom properties** allow consumers to customize radius, max height, colors, and animation duration without overriding selectors.
+- **Backdrop click + Escape key** ensure multiple dismissal methods for accessibility.
+- **Focus trap** on the close button when opened helps keyboard users.
+- **Body scroll lock** prevents background scrolling while the sheet is open.
+- **Transition on transform only** (not `all`) ensures smooth 60fps animation by avoiding layout triggers.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `demo.html` | Interactive bottom sheet with 4 demos: share, filters, actions, expanded settings |
+| `style.css` | Sheet styles: backdrop, panel, handle, header, content, snap levels, animations |
+| `README.md` | This documentation |

--- a/submissions/examples/16378-bottomsheet-pcm/demo.html
+++ b/submissions/examples/16378-bottomsheet-pcm/demo.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bottom Sheet / Slide-up Drawer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1><span>Bottom Sheet</span> · Slide-up Drawer</h1>
+    <p class="subtitle">Modal panel that slides up from the bottom with drag-to-dismiss and snap points</p>
+
+    <!-- Triggers -->
+    <div class="demo-card">
+      <h2>Open a Bottom Sheet</h2>
+      <div class="demo-grid">
+        <div class="sheet-trigger" onclick="openSheet('share')">
+          <span class="icon">📤</span> Share Sheet
+        </div>
+        <div class="sheet-trigger" onclick="openSheet('filters')">
+          <span class="icon">🔍</span> Filters
+        </div>
+        <div class="sheet-trigger" onclick="openSheet('actions')">
+          <span class="icon">⚡</span> Action Menu
+        </div>
+        <div class="sheet-trigger" onclick="openSheet('expanded')">
+          <span class="icon">📋</span> Expanded (75%)
+        </div>
+      </div>
+    </div>
+
+    <!-- Features -->
+    <div class="demo-card">
+      <h2>Features</h2>
+      <div class="demo-grid">
+        <div class="inline-demo">← Drag handle to dismiss</div>
+        <div class="inline-demo">Esc key to close</div>
+        <div class="inline-demo">Click backdrop → close</div>
+        <div class="inline-demo">Snap points: 25%/50%/75%/100%</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ SHARE SHEET ============ -->
+  <div class="sheet" id="sheet-share" role="dialog" aria-modal="true" aria-labelledby="share-title">
+    <div class="sheet-backdrop" onclick="closeSheet('share')"></div>
+    <div class="sheet-panel">
+      <div class="sheet-handle" id="handle-share"></div>
+      <div class="sheet-header">
+        <h2 id="share-title">Share</h2>
+        <button class="sheet-close" onclick="closeSheet('share')" aria-label="Close">&times;</button>
+      </div>
+      <div class="sheet-content">
+        <p>Share this page with others</p>
+        <div class="demo-item"><span class="icon">📋</span><div><div class="label">Copy Link</div><div class="desc">Copy to clipboard</div></div></div>
+        <div class="demo-item"><span class="icon">✉️</span><div><div class="label">Email</div><div class="desc">Send via email</div></div></div>
+        <div class="demo-item"><span class="icon">💬</span><div><div class="label">Messages</div><div class="desc">Share in messaging</div></div></div>
+        <div class="demo-item"><span class="icon">🐦</span><div><div class="label">Twitter</div><div class="desc">Post to Twitter</div></div></div>
+        <div class="demo-item"><span class="icon">📘</span><div><div class="label">Facebook</div><div class="desc">Share on Facebook</div></div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ FILTERS SHEET ============ -->
+  <div class="sheet" id="sheet-filters" role="dialog" aria-modal="true" aria-labelledby="filter-title">
+    <div class="sheet-backdrop" onclick="closeSheet('filters')"></div>
+    <div class="sheet-panel">
+      <div class="sheet-handle" id="handle-filters"></div>
+      <div class="sheet-header">
+        <h2 id="filter-title">Filters</h2>
+        <button class="sheet-close" onclick="closeSheet('filters')" aria-label="Close">&times;</button>
+      </div>
+      <div class="sheet-content">
+        <p>Refine your results</p>
+        <div class="demo-item"><span class="icon">📅</span><div><div class="label">Date Range</div><div class="desc">Last 30 days</div></div></div>
+        <div class="demo-item"><span class="icon">🏷️</span><div><div class="label">Category</div><div class="desc">All categories</div></div></div>
+        <div class="demo-item"><span class="icon">⭐</span><div><div class="label">Rating</div><div class="desc">4+ stars</div></div></div>
+        <div class="demo-item"><span class="icon">💰</span><div><div class="label">Price Range</div><div class="desc">$10 – $100</div></div></div>
+        <div class="demo-item"><span class="icon">📍</span><div><div class="label">Location</div><div class="desc">Within 10 miles</div></div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ ACTIONS SHEET ============ -->
+  <div class="sheet" id="sheet-actions" role="dialog" aria-modal="true" aria-labelledby="actions-title">
+    <div class="sheet-backdrop" onclick="closeSheet('actions')"></div>
+    <div class="sheet-panel">
+      <div class="sheet-handle" id="handle-actions"></div>
+      <div class="sheet-header">
+        <h2 id="actions-title">Actions</h2>
+        <button class="sheet-close" onclick="closeSheet('actions')" aria-label="Close">&times;</button>
+      </div>
+      <div class="sheet-content">
+        <p>Choose an action</p>
+        <div class="demo-item"><span class="icon">✏️</span><div><div class="label">Edit</div><div class="desc">Modify this item</div></div></div>
+        <div class="demo-item"><span class="icon">📌</span><div><div class="label">Pin</div><div class="desc">Pin to top</div></div></div>
+        <div class="demo-item"><span class="icon">🔁</span><div><div class="label">Duplicate</div><div class="desc">Create a copy</div></div></div>
+        <div class="demo-item"><span class="icon">📥</span><div><div class="label">Archive</div><div class="desc">Move to archive</div></div></div>
+        <div class="demo-item" style="color:#cf222e"><span class="icon">🗑️</span><div><div class="label">Delete</div><div class="desc">Permanently delete</div></div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ EXPANDED SHEET ============ -->
+  <div class="sheet snap-75" id="sheet-expanded" role="dialog" aria-modal="true" aria-labelledby="expanded-title">
+    <div class="sheet-backdrop" onclick="closeSheet('expanded')"></div>
+    <div class="sheet-panel">
+      <div class="sheet-handle" id="handle-expanded"></div>
+      <div class="sheet-header">
+        <h2 id="expanded-title">Settings</h2>
+        <button class="sheet-close" onclick="closeSheet('expanded')" aria-label="Close">&times;</button>
+      </div>
+      <div class="sheet-content">
+        <p>All settings available in this expanded sheet.</p>
+        <div class="demo-item"><span class="icon">🔔</span><div><div class="label">Notifications</div><div class="desc">Push, email, SMS preferences</div></div></div>
+        <div class="demo-item"><span class="icon">🔒</span><div><div class="label">Privacy</div><div class="desc">Data sharing & visibility</div></div></div>
+        <div class="demo-item"><span class="icon">🎨</span><div><div class="label">Appearance</div><div class="desc">Theme, font, layout</div></div></div>
+        <div class="demo-item"><span class="icon">🌐</span><div><div class="label">Language</div><div class="desc">English (US)</div></div></div>
+        <div class="demo-item"><span class="icon">🔐</span><div><div class="label">Security</div><div class="desc">Password, 2FA, sessions</div></div></div>
+        <div class="demo-item"><span class="icon">💾</span><div><div class="label">Storage</div><div class="desc">Manage data & cache</div></div></div>
+        <div class="demo-item"><span class="icon">ℹ️</span><div><div class="label">About</div><div class="desc">Version 2.1.0</div></div></div>
+        <p style="margin-top:0.75rem;padding-top:0.75rem;border-top:1px solid #eaeef2;font-size:0.8rem;color:#8b949e;">
+          This sheet uses snap-75 (75vh max height). Scroll to see all content.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const sheets = {};
+
+    function initSheet(name) {
+      const el = document.getElementById('sheet-' + name);
+      if (!el) return;
+      const handle = document.getElementById('handle-' + name);
+      const panel = el.querySelector('.sheet-panel');
+
+      let startY = 0, currentY = 0, isDragging = false;
+
+      function onStart(y) {
+        if (el.classList.contains('open')) {
+          isDragging = true;
+          startY = y;
+          currentY = 0;
+          panel.style.transition = 'none';
+        }
+      }
+
+      function onMove(y) {
+        if (!isDragging) return;
+        currentY = y - startY;
+        if (currentY < 0) currentY = 0;
+        panel.style.transform = 'translateY(' + currentY + 'px)';
+      }
+
+      function onEnd() {
+        if (!isDragging) return;
+        isDragging = false;
+        panel.style.transition = '';
+        panel.style.transform = '';
+        if (currentY > 100) {
+          closeSheet(name);
+        }
+        currentY = 0;
+      }
+
+      // Touch events
+      handle.addEventListener('touchstart', (e) => onStart(e.touches[0].clientY), { passive: true });
+      document.addEventListener('touchmove', (e) => {
+        if (isDragging) onMove(e.touches[0].clientY);
+      }, { passive: true });
+      document.addEventListener('touchend', onEnd, { passive: true });
+
+      // Mouse events
+      handle.addEventListener('mousedown', (e) => onStart(e.clientY));
+      document.addEventListener('mousemove', (e) => { if (isDragging) onMove(e.clientY); });
+      document.addEventListener('mouseup', onEnd);
+
+      sheets[name] = { el, panel };
+    }
+
+    function openSheet(name) {
+      const s = sheets[name];
+      if (!s) return;
+      s.el.classList.add('open');
+      document.body.style.overflow = 'hidden';
+      // Focus trap — focus the close button
+      const closeBtn = s.el.querySelector('.sheet-close');
+      if (closeBtn) setTimeout(() => closeBtn.focus(), 100);
+      // Lock scroll on panel
+      s.panel.addEventListener('touchmove', preventScroll, { passive: false });
+    }
+
+    function closeSheet(name) {
+      const s = sheets[name];
+      if (!s) return;
+      s.el.classList.remove('open');
+      document.body.style.overflow = '';
+      s.panel.removeEventListener('touchmove', preventScroll);
+    }
+
+    function preventScroll(e) {
+      // Only prevent when dragging handle, not when scrolling content
+      if (!e.target.closest('.sheet-content')) {
+        e.preventDefault();
+      }
+    }
+
+    // Init all sheets
+    ['share', 'filters', 'actions', 'expanded'].forEach(name => {
+      initSheet(name);
+      // Escape to close
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') closeSheet(name);
+      });
+    });
+
+    // Open via data attributes — just in case
+    document.querySelectorAll('[data-sheet]').forEach(el => {
+      el.addEventListener('click', () => openSheet(el.dataset.sheet));
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/16378-bottomsheet-pcm/style.css
+++ b/submissions/examples/16378-bottomsheet-pcm/style.css
@@ -1,0 +1,217 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #f6f8fa;
+  color: #1f2328;
+  padding: 2rem;
+  min-height: 100vh;
+}
+
+.container { max-width: 800px; margin: 0 auto; }
+
+h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.25rem; }
+h1 span { color: #0969da; }
+.subtitle { color: #656d76; font-size: 0.9rem; margin-bottom: 2rem; }
+
+/* ---- Bottom Sheet ---- */
+
+.sheet {
+  --sheet-max-height: 85vh;
+  --sheet-radius: 16px;
+  --sheet-handle-w: 40px;
+  --sheet-handle-h: 4px;
+  --sheet-duration: 0.35s;
+  --sheet-bg: #fff;
+  --sheet-backdrop: rgba(0, 0, 0, 0.45);
+
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: flex-end;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.sheet.open {
+  visibility: visible;
+  pointer-events: auto;
+}
+
+/* Backdrop */
+.sheet-backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--sheet-backdrop);
+  opacity: 0;
+  transition: opacity var(--sheet-duration) ease;
+}
+.sheet.open .sheet-backdrop { opacity: 1; }
+
+/* Panel */
+.sheet-panel {
+  position: relative;
+  width: 100%;
+  max-height: var(--sheet-max-height);
+  background: var(--sheet-bg);
+  border-radius: var(--sheet-radius) var(--sheet-radius) 0 0;
+  transform: translateY(100%);
+  transition: transform var(--sheet-duration) cubic-bezier(0.32, 0.72, 0, 1);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 -8px 30px rgba(0, 0, 0, 0.12);
+}
+.sheet.open .sheet-panel { transform: translateY(0); }
+
+/* Snap levels */
+.sheet.snap-25 .sheet-panel { max-height: 25vh; }
+.sheet.snap-50 .sheet-panel { max-height: 50vh; }
+.sheet.snap-75 .sheet-panel { max-height: 75vh; }
+.sheet.snap-100 .sheet-panel { max-height: var(--sheet-max-height); }
+
+/* Handle */
+.sheet-handle {
+  display: flex;
+  justify-content: center;
+  padding: 10px 0 6px;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  flex-shrink: 0;
+}
+.sheet-handle:active { cursor: grabbing; }
+.sheet-handle::after {
+  content: '';
+  width: var(--sheet-handle-w);
+  height: var(--sheet-handle-h);
+  background: #d0d7de;
+  border-radius: 2px;
+  transition: background 0.2s;
+}
+.sheet-handle:hover::after { background: #8b949e; }
+
+/* Header */
+.sheet-header {
+  display: flex;
+  align-items: center;
+  padding: 0 1.25rem 0.75rem;
+  flex-shrink: 0;
+  border-bottom: 1px solid #eaeef2;
+}
+
+.sheet-header h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  flex: 1;
+  color: #1f2328;
+}
+
+.sheet-close {
+  background: none;
+  border: none;
+  font-size: 1.3rem;
+  color: #656d76;
+  cursor: pointer;
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  line-height: 1;
+  transition: color 0.2s, background 0.2s;
+}
+.sheet-close:hover {
+  color: #1f2328;
+  background: #eaeef2;
+}
+
+/* Content */
+.sheet-content {
+  padding: 1rem 1.25rem 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+  -webkit-overflow-scrolling: touch;
+}
+
+.sheet-content p {
+  font-size: 0.88rem;
+  color: #656d76;
+  margin-bottom: 0.75rem;
+  line-height: 1.55;
+}
+
+.sheet-content .demo-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.sheet-content .demo-item:hover { background: #f6f8fa; }
+.sheet-content .demo-item .icon { font-size: 1.3rem; }
+.sheet-content .demo-item .label { font-size: 0.88rem; font-weight: 500; }
+.sheet-content .demo-item .desc { font-size: 0.75rem; color: #656d76; }
+
+/* ---- Demo styles ---- */
+.demo-card {
+  background: #fff;
+  border: 1px solid #d0d7de;
+  border-radius: 10px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+.demo-card h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: 1rem; }
+
+.demo-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+@media (max-width: 600px) { .demo-grid { grid-template-columns: 1fr; } }
+
+.sheet-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d0d7de;
+  background: #f6f8fa;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: #1f2328;
+  transition: background 0.2s, border-color 0.2s;
+}
+.sheet-trigger:hover { background: #eaeef2; border-color: #8b949e; }
+.sheet-trigger .icon { font-size: 1.2rem; }
+
+.inline-demo {
+  padding: 1rem;
+  background: #f6f8fa;
+  border: 1px dashed #d0d7de;
+  border-radius: 8px;
+  text-align: center;
+  font-size: 0.85rem;
+  color: #656d76;
+}
+
+.btn {
+  padding: 0.45rem 1rem;
+  border: 1px solid #d0d7de;
+  background: #f6f8fa;
+  color: #1f2328;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+.btn:hover { background: #eaeef2; }
+.btn-primary { background: #0969da; border-color: #0969da; color: #fff; }
+.btn-primary:hover { background: #0550ae; }
+
+.btn-row { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 1rem; }


### PR DESCRIPTION
## ✦ Description

Add a Bottom Sheet component — a modal panel that slides up from the bottom of the screen, with drag-to-dismiss, snap points, backdrop click-to-close, and keyboard support.

Fixes #16378

---

## ⟡ Type of Change

- [x] New feature (non-breaking change which adds functionality)

---

## ✦ Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.

---

## Description

### Root Cause

The project had no bottom sheet component for mobile-style slide-up panels, share sheets, action menus, or filter drawers.

### Changes Made

Added 3 files under `submissions/examples/16378-bottomsheet-pcm/`:

- **style.css** — Sheet styles: fixed backdrop overlay, slide-up panel with cubic-bezier transition, drag handle (touch + mouse), header with close button, scrollable content, snap levels (25%/50%/75%), CSS custom properties for theming
- **demo.html** — 4 interactive bottom sheet instances: Share Sheet (social options), Filters (search refinement), Action Menu (CRUD actions), Expanded Settings (75% snap height). JS handles open/close, drag-to-dismiss with 100px threshold, Escape key, backdrop click, focus trap, body scroll lock
- **README.md** — Documentation with implementation approach and file reference

### Features

- Slide-up entrance animation (translateY)
- Drag to dismiss via handle (touch + mouse)
- Backdrop overlay with click-to-close
- Escape key to close
- Focus trap on open
- Snap points: 25%, 50%, 75% max-height
- CSS custom properties: max-height, radius, handle size, colors, duration
- Body scroll lock when open
- 4 demo instances with real-world content

### Testing Performed

- Clicked each trigger button — sheet slides up with smooth animation
- Dragged handle down past 100px — sheet closes
- Dragged handle down less than 100px — sheet snaps back
- Clicked backdrop — sheet closes
- Pressed Escape — sheet closes
- Scrollable content in expanded sheet works correctly
- Body scroll is locked while sheet is open
- Multiple sheets can be opened/closed independently
- All 3 files: 471 additions, 0 deletions

---

## Additional Notes

- No ease- prefix used in CSS classes (per submission guidelines)
- No core/ or components/ files were modified
- Submission follows the required 3-file structure in submissions/examples/
- Branch: feat/bottomsheet-16378
- Fork: Pcmhacker-piro/EaseMotion-css
- Clean single commit, rebased on latest upstream/main