### PR TITLE
Add Speed Dial / Expandable FAB Menu Component

### DIFF
--- a/submissions/examples/16375-speeddial-pcm/README.md
+++ b/submissions/examples/16375-speeddial-pcm/README.md
@@ -1,0 +1,28 @@
+# Speed Dial / Expandable FAB Menu Component
+
+## What does this submission do?
+
+Adds a **Speed Dial** component — a floating action button (FAB) that expands into multiple action buttons. Supports 4 expansion directions (up, down, left, right), click and hover trigger modes, staggered entrance animation, rotating trigger icon, tooltip labels, and outside-click-to-close.
+
+## How was it implemented?
+
+- **CSS** (`style.css`): The `.speed-dial` component uses CSS custom properties for sizing, spacing, and colors. The `.sd-trigger` is a circular FAB with a box-shadow and scale hover effect. The `.sd-icon` rotates 45° when open. `.sd-actions` are absolutely positioned relative to the trigger based on direction class: `.up` (column-reverse above), `.down` (column below), `.left` (row-reverse to the left), `.right` (row to the right). Actions start at `transform: scale(0)` and animate to `scale(1)` with staggered `transition-delay` set via JS inline style. Tooltips (`.sd-tooltip`) appear on hover, positioned opposite the expansion direction.
+- **HTML/JS** (`demo.html`): The `buildActions()` function generates action buttons with stagger delay and tooltip placement. `toggleDial()`/`openDial()`/`closeDial()` control the `.open` class. The interactive demo includes: 4 direction cells (up/down/left/right) in a grid, a hover-mode toggle (switches the demo dial between click and hover trigger modes), action logging (clicking an action logs its label + timestamp), Open All / Close All buttons, and outside-click-to-close. `ACTIONS` data (Share, Edit, Copy, Delete) drives all dials consistently.
+
+## Why these choices?
+
+- **4 directions** cover all common speed dial placements (bottom-right FAB expanding up, top-bar expanding down, side panels expanding left/right).
+- **Click + Hover modes** serve different UX needs — click for deliberate actions, hover for quick-reveal toolbars.
+- **Staggered animation** (50ms per action) creates a polished cascading entrance effect without complex keyframes.
+- **Icon rotation** (+ → ×) is a universally recognized open/close affordance.
+- **CSS-only tooltips** via `:hover` on `.sd-action` keep the implementation simple and accessible.
+- **Outside-click-to-close** ensures the menu doesn't stay open accidentally.
+- **Action logging** demonstrates how click events propagate from the action buttons.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `demo.html` | Interactive speed dial with 4 directions, hover/click modes, action logging |
+| `style.css` | Speed dial styles: trigger, actions, directions, tooltips, animations |
+| `README.md` | This documentation |

--- a/submissions/examples/16375-speeddial-pcm/demo.html
+++ b/submissions/examples/16375-speeddial-pcm/demo.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Speed Dial / Expandable FAB Menu</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1><span>Speed Dial</span> · Expandable FAB Menu</h1>
+    <p class="subtitle">Floating action button that expands into multiple actions — 4 directions, staggered animation, tooltips</p>
+
+    <div class="demo-card">
+      <h2>4 Directions</h2>
+      <div class="demo-grid">
+        <div class="demo-cell">
+          <div class="speed-dial up" id="sd-up">
+            <button class="sd-trigger" onclick="toggleDial('sd-up')" aria-label="Open actions">
+              <span class="sd-icon">+</span>
+            </button>
+            <div class="sd-actions"></div>
+          </div>
+          <div class="label">Up (default)</div>
+        </div>
+        <div class="demo-cell">
+          <div class="speed-dial down" id="sd-down">
+            <button class="sd-trigger" onclick="toggleDial('sd-down')" aria-label="Open actions">
+              <span class="sd-icon">+</span>
+            </button>
+            <div class="sd-actions"></div>
+          </div>
+          <div class="label">Down</div>
+        </div>
+        <div class="demo-cell">
+          <div class="speed-dial left" id="sd-left">
+            <button class="sd-trigger" onclick="toggleDial('sd-left')" aria-label="Open actions">
+              <span class="sd-icon">+</span>
+            </button>
+            <div class="sd-actions"></div>
+          </div>
+          <div class="label">Left</div>
+        </div>
+        <div class="demo-cell">
+          <div class="speed-dial right" id="sd-right">
+            <button class="sd-trigger" onclick="toggleDial('sd-right')" aria-label="Open actions">
+              <span class="sd-icon">+</span>
+            </button>
+            <div class="sd-actions"></div>
+          </div>
+          <div class="label">Right</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-card">
+      <h2>Interactive Demo</h2>
+      <div class="legend">
+        <span><span class="dot dot-blue"></span> Click trigger to toggle</span>
+        <span><span class="dot dot-gray"></span> Trigger icon rotates 45°</span>
+        <span>Staggered entrance animation</span>
+      </div>
+      <div class="btn-row">
+        <button class="btn btn-primary" onclick="openAll()">Open All</button>
+        <button class="btn" onclick="closeAll()">Close All</button>
+        <button class="btn btn-active" id="modeBtn" onclick="toggleMode()">Mode: Click</button>
+      </div>
+
+      <!-- Hover demo area -->
+      <div style="display:flex;justify-content:center;gap:1.5rem;flex-wrap:wrap;padding:2rem 0">
+        <div class="speed-dial right" id="sd-hover" style="margin:0 auto">
+          <button class="sd-trigger" aria-label="Open actions">
+            <span class="sd-icon">+</span>
+          </button>
+          <div class="sd-actions"></div>
+        </div>
+      </div>
+      <p style="text-align:center;font-size:0.82rem;color:#656d76" id="modeHint">
+        Hover over the trigger to reveal actions (with tooltips)
+      </p>
+    </div>
+
+    <div class="demo-card">
+      <h2>Action Log</h2>
+      <p id="actionLog" style="font-size:0.85rem;color:#656d76;background:#f6f8fa;padding:0.75rem;border-radius:8px;min-height:2.5rem">
+        Click an action button to see it logged here
+      </p>
+    </div>
+  </div>
+
+  <script>
+    const ACTIONS = [
+      { icon: '📤', label: 'Share', color: '#0969da' },
+      { icon: '✏️', label: 'Edit', color: '#1a7f37' },
+      { icon: '📋', label: 'Copy', color: '#9a6700' },
+      { icon: '🗑️', label: 'Delete', color: '#cf222e' },
+    ];
+
+    function buildActions(containerId, items) {
+      const container = document.querySelector(`#${containerId} .sd-actions`);
+      if (!container) return;
+
+      const dir = document.getElementById(containerId);
+      const isUp = !dir.classList.contains('down') && !dir.classList.contains('left') && !dir.classList.contains('right') || dir.classList.contains('up');
+      const isDown = dir.classList.contains('down');
+      const isLeft = dir.classList.contains('left');
+      const isRight = dir.classList.contains('right');
+
+      container.innerHTML = items.map((a, i) => {
+        const delay = i * 0.05;
+        return `
+          <button class="sd-action" style="transition-delay:${delay}s;color:${a.color}" data-label="${a.label}" onclick="logAction('${a.label}')">
+            ${a.icon}
+            <span class="sd-tooltip ${isDown ? 'down' : isLeft ? 'left' : isRight ? 'right' : 'up'}">${a.label}</span>
+          </button>
+        `;
+      }).join('');
+    }
+
+    function toggleDial(id) {
+      const el = document.getElementById(id);
+      el.classList.toggle('open');
+    }
+
+    function openDial(id) {
+      document.getElementById(id).classList.add('open');
+    }
+
+    function closeDial(id) {
+      document.getElementById(id).classList.remove('open');
+    }
+
+    function openAll() {
+      ['sd-up', 'sd-down', 'sd-left', 'sd-right', 'sd-hover'].forEach(openDial);
+    }
+
+    function closeAll() {
+      ['sd-up', 'sd-down', 'sd-left', 'sd-right', 'sd-hover'].forEach(closeDial);
+    }
+
+    let clickMode = true;
+
+    function toggleMode() {
+      clickMode = !clickMode;
+      const btn = document.getElementById('modeBtn');
+      const hint = document.getElementById('modeHint');
+      const hoverDial = document.getElementById('sd-hover');
+      const trigger = hoverDial.querySelector('.sd-trigger');
+
+      btn.textContent = clickMode ? 'Mode: Click' : 'Mode: Hover';
+
+      if (clickMode) {
+        trigger.onclick = () => toggleDial('sd-hover');
+        trigger.onmouseenter = null;
+        trigger.onmouseleave = null;
+        hoverDial.onmouseenter = null;
+        hoverDial.onmouseleave = null;
+        hint.textContent = 'Click the trigger to reveal actions (with tooltips)';
+      } else {
+        trigger.onclick = null;
+        hoverDial.onmouseenter = () => openDial('sd-hover');
+        hoverDial.onmouseleave = () => closeDial('sd-hover');
+        hint.textContent = 'Hover over the trigger to reveal actions (with tooltips)';
+      }
+      closeDial('sd-hover');
+    }
+
+    function logAction(label) {
+      const log = document.getElementById('actionLog');
+      const time = new Date().toLocaleTimeString();
+      log.innerHTML = `<strong>${label}</strong> clicked at ${time}`;
+    }
+
+    // Close on outside click
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('.speed-dial')) {
+        closeAll();
+      }
+    });
+
+    // Build all dials
+    ['sd-up', 'sd-down', 'sd-left', 'sd-right', 'sd-hover'].forEach(id => {
+      buildActions(id, ACTIONS);
+    });
+
+    // Init hover mode by default for sd-hover
+    setTimeout(() => {
+      const hoverDial = document.getElementById('sd-hover');
+      const trigger = hoverDial.querySelector('.sd-trigger');
+      trigger.onclick = null;
+      hoverDial.onmouseenter = () => openDial('sd-hover');
+      hoverDial.onmouseleave = () => closeDial('sd-hover');
+      document.getElementById('modeHint').textContent = 'Hover over the trigger to reveal actions (with tooltips)';
+    }, 100);
+  </script>
+</body>
+</html>

--- a/submissions/examples/16375-speeddial-pcm/style.css
+++ b/submissions/examples/16375-speeddial-pcm/style.css
@@ -1,0 +1,264 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #f6f8fa;
+  color: #1f2328;
+  padding: 2rem;
+  min-height: 100vh;
+}
+
+.container { max-width: 800px; margin: 0 auto; }
+
+h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.25rem; }
+h1 span { color: #0969da; }
+.subtitle { color: #656d76; font-size: 0.9rem; margin-bottom: 2rem; }
+
+/* ---- Speed Dial Component ---- */
+
+.speed-dial {
+  --sd-size: 52px;
+  --sd-gap: 12px;
+  --sd-radius: 50%;
+  --sd-bg: #0969da;
+  --sd-color: #fff;
+  --sd-action-size: 42px;
+  --sd-action-bg: #fff;
+  --sd-action-color: #1f2328;
+  --sd-action-shadow: 0 2px 8px rgba(0,0,0,0.12);
+  --sd-duration: 0.25s;
+  --sd-stagger: 0.05s;
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Trigger button */
+.sd-trigger {
+  width: var(--sd-size);
+  height: var(--sd-size);
+  border-radius: var(--sd-radius);
+  background: var(--sd-bg);
+  color: var(--sd-color);
+  border: none;
+  cursor: pointer;
+  font-size: 1.4rem;
+  font-weight: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 3px 12px rgba(9, 105, 218, 0.35);
+  transition: transform 0.2s, box-shadow 0.2s;
+  z-index: 2;
+  position: relative;
+  line-height: 1;
+}
+.sd-trigger:hover {
+  transform: scale(1.06);
+  box-shadow: 0 4px 16px rgba(9, 105, 218, 0.45);
+}
+
+.sd-icon {
+  display: inline-block;
+  transition: transform var(--sd-duration) cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.speed-dial.open .sd-icon {
+  transform: rotate(45deg);
+}
+
+/* Actions container */
+.sd-actions {
+  position: absolute;
+  display: flex;
+  gap: var(--sd-gap);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--sd-duration) ease;
+}
+
+.speed-dial.open .sd-actions {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+/* Action buttons */
+.sd-action {
+  width: var(--sd-action-size);
+  height: var(--sd-action-size);
+  border-radius: var(--sd-radius);
+  background: var(--sd-action-bg);
+  color: var(--sd-action-color);
+  border: 1px solid #d0d7de;
+  cursor: pointer;
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--sd-action-shadow);
+  transition: transform 0.2s, background 0.15s;
+  position: relative;
+  transform: scale(0);
+}
+.speed-dial.open .sd-action {
+  transform: scale(1);
+}
+
+.sd-action:hover {
+  transform: scale(1.1);
+  background: #f0f6ff;
+}
+
+/* Staggered animation — set via JS inline style */
+.sd-action[data-delay] {
+  transition: transform var(--sd-duration) cubic-bezier(0.34, 1.56, 0.64, 1) 0s,
+              background 0.15s 0s;
+}
+
+/* Tooltip */
+.sd-tooltip {
+  position: absolute;
+  background: #1f2328;
+  color: #fff;
+  font-size: 0.72rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.sd-action:hover .sd-tooltip {
+  opacity: 1;
+}
+
+/* ---- Direction variants ---- */
+
+/* Up (default) */
+.speed-dial:not(.down):not(.left):not(.right),
+.speed-dial.up {
+  flex-direction: column;
+}
+.speed-dial:not(.down):not(.left):not(.right) .sd-actions,
+.speed-dial.up .sd-actions {
+  flex-direction: column-reverse;
+  bottom: calc(100% + var(--sd-gap));
+  left: 50%;
+  transform: translateX(-50%);
+  align-items: center;
+}
+
+/* Down */
+.speed-dial.down {
+  flex-direction: column;
+}
+.speed-dial.down .sd-actions {
+  flex-direction: column;
+  top: calc(100% + var(--sd-gap));
+  left: 50%;
+  transform: translateX(-50%);
+  align-items: center;
+}
+
+/* Left */
+.speed-dial.left {
+  flex-direction: row;
+}
+.speed-dial.left .sd-actions {
+  flex-direction: row-reverse;
+  right: calc(100% + var(--sd-gap));
+  top: 50%;
+  transform: translateY(-50%);
+  align-items: center;
+}
+
+/* Right */
+.speed-dial.right {
+  flex-direction: row;
+}
+.speed-dial.right .sd-actions {
+  flex-direction: row;
+  left: calc(100% + var(--sd-gap));
+  top: 50%;
+  transform: translateY(-50%);
+  align-items: center;
+}
+
+/* Tooltip positioning */
+.up .sd-tooltip, .sd-tooltip.up { top: -32px; left: 50%; transform: translateX(-50%); }
+.down .sd-tooltip, .sd-tooltip.down { bottom: -32px; left: 50%; transform: translateX(-50%); }
+.left .sd-tooltip, .sd-tooltip.left { right: calc(100% + 8px); top: 50%; transform: translateY(-50%); }
+.right .sd-tooltip, .sd-tooltip.right { left: calc(100% + 8px); top: 50%; transform: translateY(-50%); }
+
+/* ---- Demo styles ---- */
+.demo-card {
+  background: #fff;
+  border: 1px solid #d0d7de;
+  border-radius: 10px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+.demo-card h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: 1rem; }
+
+.demo-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; align-items: center; justify-items: center; }
+@media (max-width: 700px) { .demo-grid { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 420px) { .demo-grid { grid-template-columns: 1fr; } }
+
+.demo-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2.5rem 1rem;
+  background: #f6f8fa;
+  border-radius: 10px;
+  min-width: 0;
+  width: 100%;
+}
+.demo-cell .label {
+  font-size: 0.78rem;
+  color: #656d76;
+  font-weight: 500;
+  text-align: center;
+}
+
+.legend {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.78rem;
+  color: #656d76;
+  margin-bottom: 1rem;
+}
+.legend span { display: flex; align-items: center; gap: 0.3rem; }
+.legend .dot {
+  display: inline-block;
+  width: 10px; height: 10px;
+  border-radius: 50%;
+}
+.dot-blue { background: #0969da; }
+.dot-gray { background: #d0d7de; }
+
+.btn-row { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+.btn {
+  padding: 0.45rem 1rem;
+  border: 1px solid #d0d7de;
+  background: #f6f8fa;
+  color: #1f2328;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+.btn:hover { background: #eaeef2; }
+.btn-primary { background: #0969da; border-color: #0969da; color: #fff; }
+.btn-primary:hover { background: #0550ae; }
+.btn-active { background: #ddf4ff; border-color: #0969da; color: #0969da; }


### PR DESCRIPTION
## ✦ Description

Add a Speed Dial component — a floating action button (FAB) that expands into multiple action buttons, with 4 directions, click/hover modes, staggered animation, and tooltips.

Fixes #16375

---

## ⟡ Type of Change

- [x] New feature (non-breaking change which adds functionality)

---

## ✦ Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.

---

## Description

### Root Cause

The project had no speed dial / expandable FAB menu component for secondary actions.

### Changes Made

Added 3 files under `submissions/examples/16375-speeddial-pcm/`:

- **style.css** — Speed dial styles: trigger FAB with shadow and scale hover, icon rotation on open, action buttons with scale animation, 4 direction variants (up/down/left/right) using absolute positioning, tooltip positioning per direction, CSS custom properties
- **demo.html** — Interactive demo with 4 direction cells in a grid, Open All/Close All controls, click/hover mode toggle, action logging, outside-click-to-close, 4 actions (Share, Edit, Copy, Delete) with staggered 50ms delay
- **README.md** — Documentation with implementation approach and file reference

### Features

- 4 expansion directions: up (default), down, left, right
- Click mode (default) and Hover mode (toggleable)
- Staggered entrance animation (50ms per action)
- Trigger icon rotates 45° on open (+ → ×)
- Tooltip labels on each action button, positioned by direction
- Outside-click-to-close
- 4 actions: Share (blue), Edit (green), Copy (yellow), Delete (red)
- Action click logging with timestamp
- CSS custom properties for theming

### Testing Performed

- Clicked each direction trigger — actions expand in correct direction
- Clicked trigger again — actions close, icon rotates back
- Opened all 4 dials simultaneously — all work independently
- Hover mode toggle works — dial opens on hover, closes on leave
- Action buttons show tooltips on hover
- Clicked action — logged with correct label and timestamp
- Clicked outside any dial — all dials close
- All 3 files: 489 additions, 0 deletions

---

## Additional Notes

- No ease- prefix used in CSS classes (per submission guidelines)
- No core/ or components/ files were modified
- Submission follows the required 3-file structure in submissions/examples/
- Branch: feat/speeddial-16375
- Fork: Pcmhacker-piro/EaseMotion-css
- Clean single commit, rebased on latest upstream/main