### PR TITLE
Add Print Stylesheet Module (@media print)

### DIFF
--- a/submissions/examples/16373-print-stylesheet-pcm/README.md
+++ b/submissions/examples/16373-print-stylesheet-pcm/README.md
@@ -1,0 +1,37 @@
+# Print Stylesheet Module (@media print)
+
+## What does this submission do?
+
+Adds a dedicated **print stylesheet module** that ensures pages using EaseMotion render properly when printed. Hides UI chrome (navbars, sidebars, footers, toasts, FABs, modals, ads, videos), ensures black-on-white readability, reveals link URLs, prevents page breaks inside cards/tables/images, controls orphans/widows, and provides 5 print utility classes.
+
+## How was it implemented?
+
+- **CSS** (`style.css`): All print rules are wrapped in `@media print`. Key rules:
+  - **Hide non-essential**: `.navbar`, `.sidebar`, `.footer`, `.toast`, `.fab`, `.modal`, `.banner`, `.ad`, `.no-print`, `iframe`, `video`, `nav`, `aside` — all `display: none !important`.
+  - **Readability**: `body { color: #000; background: #fff; font-size: 12pt }`, `* { box-shadow: none; text-shadow: none; background: transparent }`.
+  - **Link URLs**: `a[href]::after { content: " (" attr(href) ")"; font-size: 0.8em }` — skips anchor links (`href="#"`) and javascript links.
+  - **Page breaks**: `.card`, `table`, `tr`, `td`, `th`, `img`, `pre`, `blockquote`, `.print-break-inside` get `page-break-inside: avoid`.
+  - **Orphans/widows**: `p, li { orphans: 3; widows: 3 }`.
+  - **Page margins**: `@page { margin: 2cm }`.
+  - **Print utility classes**: `.no-print` (hide on print), `.print-only` (show only on print), `.print-break-before`, `.print-break-after`, `.print-break-inside`.
+  - **Table improvements**: collapse borders, 1px solid black borders, padding.
+  - **Code wrapping**: `pre, code { white-space: pre-wrap; word-wrap: break-word }`.
+  - **Headings**: `h1-h4 { page-break-after: avoid }`.
+- **HTML/JS** (`demo.html`): A full page layout demonstrating screen vs print behavior: navbar, banner, sidebar, footer, FAB, and toast are marked `.no-print` (hidden when printed). Main content has cards, a table, and links — the table shows screen vs print feature comparison. A `.print-only` box (invisible on screen, blue-bordered on print) shows a timestamp. A "Print this page" button triggers `window.print()`. A utility class reference table documents all 5 classes.
+
+## Why these choices?
+
+- **`@media print`** is the standard CSS approach — no JS required, works with browser's native print dialog.
+- **Hiding all UI chrome** by default ensures developers don't need to manually mark every element — just add `.no-print` to anything that should stay hidden.
+- **Link URL disclosure** (`::after`) helps readers see where links go on a printed page where they can't click.
+- **Page break avoidance** on cards and tables prevents awkward splits that waste paper and reduce readability.
+- **Print utility classes** give developers fine-grained control (force breaks, show print-only content, protect specific elements).
+- **12pt font size** is the standard print size for comfortable reading.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `demo.html` | Full page layout demonstrating print vs screen: navbar, sidebar, cards, table, print-only content, FAB, toast |
+| `style.css` | Complete @media print stylesheet + 5 utility classes + demo styles |
+| `README.md` | This documentation |

--- a/submissions/examples/16373-print-stylesheet-pcm/demo.html
+++ b/submissions/examples/16373-print-stylesheet-pcm/demo.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Print Stylesheet Module</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <!-- Navbar (hidden in print) -->
+    <header class="navbar">
+      <span class="brand">EaseMotion</span>
+      <span class="link">Docs</span>
+      <span class="link">Components</span>
+      <span class="link">Examples</span>
+      <span class="link" style="margin-left:auto">Sign In</span>
+    </header>
+
+    <!-- Banner -->
+    <div class="banner no-print">
+      📢 <strong>Print Demo</strong> — Use <kbd>Ctrl+P</kbd> or the button below to see print styles in action.
+    </div>
+
+    <h1><span>Print Stylesheet</span> · <span style="font-size:0.9rem;color:#656d76;font-weight:400">@media print module</span></h1>
+    <p class="subtitle">Optimized for printing: hides UI chrome, shows link URLs, black-on-white, no page breaks inside content</p>
+
+    <!-- Print controls (hidden in print) -->
+    <div class="btn-row print-controls no-print" style="margin-bottom:1.5rem">
+      <button class="btn btn-primary" onclick="window.print()">🖨️ Print this page</button>
+    </div>
+
+    <!-- Main content area -->
+    <div style="display:grid;grid-template-columns:1fr 220px;gap:1rem;align-items:start">
+      <div>
+        <!-- Article -->
+        <div class="demo-card">
+          <h2>Article Content</h2>
+          <p>
+            This is the main article content. When printing, the sidebar, navbar,
+            footer, and other UI chrome will be hidden automatically. Link URLs
+            will appear after each anchor tag. For example:
+            <a href="https://easemotion.dev/docs">EaseMotion Documentation</a>
+            and <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css">GitHub Repository</a>.
+          </p>
+          <p>
+            Cards and tables will not break across pages. The print stylesheet
+            ensures <strong>black text on white background</strong>, removes all
+            shadows and background images to save ink, and sets appropriate margins.
+          </p>
+
+          <h3 style="margin-top:1rem;margin-bottom:0.5rem">Feature Table</h3>
+          <table>
+            <tr><th>Feature</th><th>Screen</th><th>Print</th></tr>
+            <tr><td>Navbar</td><td>Visible</td><td>Hidden</td></tr>
+            <tr><td>Sidebar</td><td>Visible</td><td>Hidden</td></tr>
+            <tr><td>Footer</td><td>Visible</td><td>Hidden</td></tr>
+            <tr><td>Link URLs</td><td>Not shown</td><td>Shown after text</td></tr>
+            <tr><td>Colors</td><td>Theme colors</td><td>Black on white</td></tr>
+            <tr><td>Page break</td><td>N/A</td><td>Avoided in cards</td></tr>
+          </table>
+        </div>
+
+        <!-- Card grid -->
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.75rem">
+          <div class="card">
+            <h3>Installation</h3>
+            <p><code>npm install easemotion-css</code></p>
+            <p>Import the stylesheet and start using components.</p>
+            <a href="https://easemotion.dev/docs/install">Installation guide →</a>
+          </div>
+          <div class="card">
+            <h3>Components</h3>
+            <p>Buttons, cards, modals, toasts, steppers, tree views, and more.</p>
+            <a href="https://easemotion.dev/docs/components">Component docs →</a>
+          </div>
+          <div class="card">
+            <h3>Themes</h3>
+            <p>Customize with CSS variables — colors, spacing, typography.</p>
+            <a href="https://easemotion.dev/docs/themes">Theme guide →</a>
+          </div>
+          <div class="card">
+            <h3>Utilities</h3>
+            <p>Responsive visibility, drag-and-drop, print, and accessibility utilities.</p>
+            <a href="https://easemotion.dev/docs/utilities">Utility docs →</a>
+          </div>
+        </div>
+
+        <!-- Print-only content -->
+        <div class="print-only" style="margin-top:1rem;padding:1rem;border:2px solid #0969da;border-radius:8px">
+          <p style="color:#0969da;font-weight:600">📄 This content is <code>.print-only</code> — only visible when printed.</p>
+          <p style="font-size:0.82rem;color:#656d76">Generated: <span id="printDate"></span> · Page 1 of 1</p>
+        </div>
+      </div>
+
+      <!-- Sidebar (hidden in print) -->
+      <aside class="sidebar">
+        <strong>📋 On This Page</strong><br><br>
+        <span style="display:block;padding:0.2rem 0">Article Content</span>
+        <span style="display:block;padding:0.2rem 0">Feature Table</span>
+        <span style="display:block;padding:0.2rem 0">Related Links</span>
+        <span style="display:block;padding:0.2rem 0">Documentation</span>
+        <br>
+        <span style="font-size:0.75rem;color:#656d76">⏱ Last updated: June 2026</span>
+      </aside>
+    </div>
+
+    <!-- Print utility reference -->
+    <div class="demo-card" style="margin-top:1.5rem">
+      <h2>Print Utility Classes</h2>
+      <table>
+        <tr><th>Class</th><th>Effect</th></tr>
+        <tr><td><code>.no-print</code></td><td>Hide element when printing</td></tr>
+        <tr><td><code>.print-only</code></td><td>Only show when printing (hidden on screen)</td></tr>
+        <tr><td><code>.print-break-before</code></td><td>Force page break before element</td></tr>
+        <tr><td><code>.print-break-after</code></td><td>Force page break after element</td></tr>
+        <tr><td><code>.print-break-inside</code></td><td>Avoid page break inside element</td></tr>
+      </table>
+    </div>
+
+    <!-- Footer (hidden in print) -->
+    <footer class="footer no-print">
+      EaseMotion CSS · Print Stylesheet Demo · Press <kbd>Ctrl+P</kbd> to test
+    </footer>
+  </div>
+
+  <!-- Floating elements that disappear in print -->
+  <button class="fab no-print" aria-label="Floating action button">+</button>
+  <div class="toast no-print">📬 Page is print-ready!</div>
+
+  <script>
+    document.getElementById('printDate').textContent = new Date().toLocaleDateString('en-US', {
+      year: 'numeric', month: 'long', day: 'numeric'
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/16373-print-stylesheet-pcm/style.css
+++ b/submissions/examples/16373-print-stylesheet-pcm/style.css
@@ -1,0 +1,323 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #f6f8fa;
+  color: #1f2328;
+  padding: 2rem;
+  min-height: 100vh;
+}
+
+.container { max-width: 800px; margin: 0 auto; }
+
+h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.25rem; }
+h1 span { color: #0969da; }
+.subtitle { color: #656d76; font-size: 0.9rem; margin-bottom: 2rem; }
+
+/* =============================================
+   Print Stylesheet Module (@media print)
+   ============================================= */
+
+@media print {
+  /* Hide non-essential UI components */
+  .navbar,
+  .sidebar,
+  .footer,
+  .toast,
+  .fab,
+  .modal,
+  .banner,
+  .ad,
+  .no-print,
+  .btn-row,
+  .vp-indicator,
+  .vp-width,
+  header select,
+  header button,
+  nav,
+  aside,
+  .print-controls,
+  iframe,
+  video {
+    display: none !important;
+  }
+
+  /* Base readability */
+  body {
+    color: #000 !important;
+    background: #fff !important;
+    font-size: 12pt !important;
+    line-height: 1.5 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  * {
+    box-shadow: none !important;
+    text-shadow: none !important;
+    background: transparent !important;
+  }
+
+  /* Page margins */
+  @page {
+    margin: 2cm;
+  }
+
+  /* Link URLs */
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #555 !important;
+    font-weight: normal;
+  }
+
+  a[href^="#"]::after,
+  a[href^="javascript"]::after {
+    content: none;
+  }
+
+  /* Prevent breaks inside elements */
+  .card,
+  table,
+  tr,
+  td,
+  th,
+  img,
+  pre,
+  blockquote,
+  .print-break-inside {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  /* Orphan/widow control */
+  p,
+  li {
+    orphans: 3;
+    widows: 3;
+  }
+
+  /* Page break utility classes */
+  .print-break-before {
+    page-break-before: always;
+    break-before: page;
+  }
+
+  .print-break-after {
+    page-break-after: always;
+    break-after: page;
+  }
+
+  /* Print-only content */
+  .print-only {
+    display: block !important;
+  }
+
+  /* Table improvements */
+  table {
+    border-collapse: collapse !important;
+    width: 100% !important;
+  }
+
+  th, td {
+    border: 1px solid #000 !important;
+    padding: 6pt !important;
+  }
+
+  /* Image fit */
+  img {
+    max-width: 100% !important;
+    page-break-inside: avoid;
+  }
+
+  /* Code blocks wrap */
+  pre, code {
+    white-space: pre-wrap !important;
+    word-wrap: break-word !important;
+  }
+
+  /* Headings on own page if needed */
+  h1, h2, h3, h4 {
+    page-break-after: avoid;
+  }
+}
+
+/* =============================================
+   Print utility classes (screen + print)
+   ============================================= */
+
+.print-only {
+  display: none;
+}
+
+.print-break-before,
+.print-break-after,
+.print-break-inside {
+  /* These only take effect in @media print */
+}
+
+/* =============================================
+   Demo styles
+   ============================================= */
+
+.demo-card {
+  background: #fff;
+  border: 1px solid #d0d7de;
+  border-radius: 10px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.demo-card h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.demo-card > p {
+  color: #656d76;
+  font-size: 0.82rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.5;
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: #0969da;
+  color: #fff;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  font-size: 0.88rem;
+}
+.navbar .brand { font-weight: 700; }
+.navbar .link { opacity: 0.85; cursor: pointer; }
+.navbar .link:hover { opacity: 1; }
+
+.sidebar {
+  background: #ddf4ff;
+  border: 1px solid #b3e0ff;
+  border-radius: 8px;
+  padding: 1rem;
+  font-size: 0.85rem;
+  color: #0550ae;
+  margin-bottom: 1rem;
+}
+
+.card {
+  border: 1px solid #d0d7de;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background: #fff;
+}
+.card h3 { font-size: 0.95rem; margin-bottom: 0.4rem; }
+.card p { font-size: 0.82rem; color: #656d76; }
+
+.footer {
+  text-align: center;
+  padding: 1.5rem;
+  border-top: 1px solid #d0d7de;
+  font-size: 0.78rem;
+  color: #8b949e;
+  margin-top: 2rem;
+}
+
+.fab {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #0969da;
+  color: #fff;
+  border: none;
+  font-size: 1.3rem;
+  cursor: pointer;
+  box-shadow: 0 3px 12px rgba(9,105,218,0.35);
+}
+
+.toast {
+  position: fixed;
+  bottom: 5rem;
+  right: 2rem;
+  padding: 0.75rem 1rem;
+  background: #1f2328;
+  color: #fff;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-box {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 12px;
+  max-width: 360px;
+  box-shadow: 0 8px 30px rgba(0,0,0,0.15);
+}
+
+.banner {
+  background: #fff8c5;
+  border: 1px solid #f5d94e;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  color: #9a6700;
+  margin-bottom: 1rem;
+}
+
+table { width: 100%; border-collapse: collapse; margin: 0.5rem 0; }
+th, td { padding: 0.4rem 0.75rem; text-align: left; border-bottom: 1px solid #eaeef2; font-size: 0.82rem; }
+th { color: #656d76; font-weight: 600; font-size: 0.7rem; text-transform: uppercase; }
+
+code {
+  padding: 0.1rem 0.3rem;
+  background: rgba(9, 105, 218, 0.08);
+  border-radius: 3px;
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: 0.78rem;
+  color: #0969da;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 600;
+}
+.badge-print { background: #ddf4ff; color: #0969da; }
+
+.btn-row { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 1rem; }
+.btn {
+  padding: 0.45rem 1rem;
+  border: 1px solid #d0d7de;
+  background: #f6f8fa;
+  color: #1f2328;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+.btn:hover { background: #eaeef2; }
+.btn-primary { background: #0969da; border-color: #0969da; color: #fff; }
+.btn-primary:hover { background: #0550ae; }


### PR DESCRIPTION
## ✦ Description

Add a dedicated print stylesheet module (@media print) that ensures pages render properly when printed — hides UI chrome, black-on-white, link URLs, page break control, and 5 utility classes.

Fixes #16373

---

## ⟡ Type of Change

- [x] New feature (non-breaking change which adds functionality)

---

## ✦ Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.

---

## Description

### Root Cause

Pages using EaseMotion had no print-specific styles — printing resulted in wasted ink, broken layouts, hidden links, and awkward page breaks inside cards and tables.

### Changes Made

Added 3 files under `submissions/examples/16373-print-stylesheet-pcm/`:

- **style.css** — Complete @media print stylesheet: hides navbars/sidebars/footers/toasts/FABs/modals/ads/videos, sets black-on-white with 12pt font, removes shadows/backgrounds, reveals link URLs via ::after, prevents page breaks inside cards/tables/images/pre/blockquote, controls orphans/widows (3), sets 2cm @page margins, improves table borders for print, wraps code, and provides 5 utility classes
- **demo.html** — Full page layout with navbar, banner, sidebar, cards, feature table, FAB, toast, print-only content box, print button, and utility class reference table
- **README.md** — Documentation with implementation approach and file reference

### Features

- Hides non-essential UI: .navbar, .sidebar, .footer, .toast, .fab, .modal, .banner, .ad, iframe, video
- Black text on white background, 12pt, 1.5 line-height
- Removes all box-shadows, text-shadows, and background colors to save ink
- Reveals link URLs after anchor tags (skips # and javascript: links)
- Prevents page breaks inside cards, tables, images, pre, blockquote
- Controls orphans and widows at 3 lines
- 2cm page margins via @page
- 5 utility classes: .no-print, .print-only, .print-break-before, .print-break-after, .print-break-inside
- Table border improvements for print
- Code pre-wrap for print
- Heading page-break-after: avoid

### Testing Performed

- Pressed Ctrl+P — print preview shows only main content, no navbar/sidebar/footer/FAB/toast
- Link URLs appear after anchor text in print preview
- Cards and table do not break across pages
- Print-only content appears in print preview (hidden on screen)
- Utility class reference confirms all 5 classes
- All 3 files: 497 additions, 0 deletions

---

## Additional Notes

- No ease- prefix used in CSS classes (per submission guidelines)
- No core/ or components/ files were modified
- Submission follows the required 3-file structure in submissions/examples/
- Branch: feat/print-stylesheet-16373
- Fork: Pcmhacker-piro/EaseMotion-css
- Clean single commit, rebased on latest upstream/main