### PR TITLE
feat: add animated address autocomplete dropdown (#17604)

### DIFF
--- a/submissions/examples/address-autocomplete-collection/README.md
+++ b/submissions/examples/address-autocomplete-collection/README.md
@@ -1,0 +1,193 @@
+# Animated Address Autocomplete Dropdown
+
+A pure-CSS animated suggestion dropdown for address/location inputs. Styles the suggestion list and all interaction states — scale + fade entrance, sliding keyboard highlight, shimmer loading skeleton, empty-state shake, and focus glow — independent of whatever geocoding API supplies the actual suggestions.
+
+---
+
+## Preview
+
+| State | Behaviour |
+|-------|-----------|
+| Focus | Input border glows with a purple ring |
+| Open | Dropdown scales + fades in below the input |
+| Hover | Row background transitions smoothly |
+| Active | Purple bg + sliding left accent bar on keyboard highlight |
+| Loading | Shimmer skeleton rows while fetching |
+| Empty | Dropdown shakes briefly to signal no matches |
+| Close | Scale + fade exit animation |
+
+---
+
+## Files
+
+```
+submissions/examples/address-autocomplete-collection/
+├── demo.html    ← self-contained live demo (mock data, no API key needed)
+├── style.css    ← all animation classes
+└── README.md
+```
+
+---
+
+## Classes
+
+| Class | Description |
+|-------|-------------|
+| `ease-address-wrapper` | Relative-positioned container for input + dropdown |
+| `ease-address-input` | Input field; border-glow on focus via `box-shadow` |
+| `ease-address-dropdown` | Suggestion list; scale + fade entrance via `@keyframes ease-addr-enter` |
+| `ease-address-item` | Suggestion row; hover background transition |
+| `ease-address-item-active` | Keyboard-highlighted row; purple bg + sliding left accent bar |
+| `ease-address-empty-shake` | Add to dropdown when no results; plays `@keyframes ease-addr-shake` |
+
+---
+
+## Usage
+
+```html
+<div class="ease-address-wrapper">
+  <input
+    class="ease-address-input"
+    type="text"
+    placeholder="Start typing an address…"
+    role="combobox"
+    aria-autocomplete="list"
+    aria-expanded="false"
+    aria-controls="addressDropdown"
+  />
+
+  <ul
+    class="ease-address-dropdown"
+    id="addressDropdown"
+    role="listbox"
+    hidden
+  >
+    <li class="ease-address-item ease-address-item-active" role="option">
+      <span class="ease-address-item-icon">📍</span>
+      <span class="ease-address-item-body">
+        <span class="ease-address-item-main">221B Baker Street</span>
+        <span class="ease-address-item-sub">London, NW1 6XE, UK</span>
+      </span>
+    </li>
+    <li class="ease-address-item" role="option">
+      <span class="ease-address-item-icon">📍</span>
+      <span class="ease-address-item-body">
+        <span class="ease-address-item-main">221 Baker Avenue</span>
+        <span class="ease-address-item-sub">Manchester, M14 5TH, UK</span>
+      </span>
+    </li>
+  </ul>
+</div>
+```
+
+### Close with exit animation
+
+```js
+function hideDropdown() {
+  dropdown.classList.add('is-closing');
+  setTimeout(() => {
+    dropdown.setAttribute('hidden', '');
+    dropdown.classList.remove('is-closing');
+  }, 200); // matches --ease-addr-duration
+}
+```
+
+### Empty-state shake
+
+```js
+dropdown.classList.remove('ease-address-empty-shake');
+void dropdown.offsetWidth; // force reflow to restart animation
+dropdown.classList.add('ease-address-empty-shake');
+```
+
+---
+
+## Animation Details
+
+### Dropdown entrance — `ease-addr-enter`
+```css
+@keyframes ease-addr-enter {
+  from { opacity: 0; transform: scaleY(0.92) translateY(-6px); }
+  to   { opacity: 1; transform: scaleY(1)    translateY(0); }
+}
+```
+
+### Dropdown exit — `ease-addr-leave`
+```css
+@keyframes ease-addr-leave {
+  from { opacity: 1; transform: scaleY(1)    translateY(0); }
+  to   { opacity: 0; transform: scaleY(0.92) translateY(-6px); }
+}
+```
+
+### Active accent bar — `ease-addr-bar-in`
+```css
+.ease-address-item-active::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 15%; height: 70%; width: 3px;
+  background: var(--ease-addr-item-active-bar);
+  animation: ease-addr-bar-in 160ms ease forwards;
+}
+```
+
+### Empty shake — `ease-addr-shake`
+```css
+@keyframes ease-addr-shake {
+  0%   { transform: translateX(0); }
+  20%  { transform: translateX(-6px); }
+  40%  { transform: translateX(6px); }
+  60%  { transform: translateX(-4px); }
+  80%  { transform: translateX(4px); }
+  100% { transform: translateX(0); }
+}
+```
+
+### Shimmer skeleton
+```css
+@keyframes ease-addr-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+```
+
+---
+
+## Theming
+
+All colours are CSS custom properties on `:root`:
+
+```css
+:root {
+  --ease-addr-border-focus:     #6366f1;
+  --ease-addr-shadow-focus:     0 0 0 3px rgba(99,102,241,0.15);
+  --ease-addr-item-active:      #ede9fe;
+  --ease-addr-item-active-bar:  #7c3aed;
+  --ease-addr-match-color:      #6366f1;
+}
+```
+
+---
+
+## Accessibility
+
+- `role="combobox"` on input, `aria-autocomplete="list"`, `aria-expanded` toggled
+- `role="listbox"` on dropdown, `role="option"` on each item
+- `aria-selected` updated on keyboard navigation
+- `aria-activedescendant` links input to the active item
+- `mousedown` + `e.preventDefault()` keeps input focused on item click
+- `Escape` closes the dropdown
+- `prefers-reduced-motion` disables all transitions and animations
+
+---
+
+## Browser Support
+
+Chrome 90+, Firefox 90+, Safari 15+. Uses standard CSS `@keyframes`, `transform`, `opacity`, and CSS custom properties.
+
+---
+
+## Contributor
+
+**@thakurakanksha288** — GSSoC 2026 participant  
+Issue: [#17604](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/17604)

--- a/submissions/examples/address-autocomplete-collection/demo.html
+++ b/submissions/examples/address-autocomplete-collection/demo.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Address Autocomplete — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-label">EaseMotion CSS — Address Autocomplete Dropdown</p>
+  <p class="demo-hint">Type an address below — try "baker", "park", "main", or "elm"</p>
+
+  <div class="ease-address-wrapper" id="wrapper">
+    <input
+      class="ease-address-input"
+      id="addressInput"
+      type="text"
+      placeholder="Start typing an address…"
+      autocomplete="off"
+      role="combobox"
+      aria-autocomplete="list"
+      aria-expanded="false"
+      aria-controls="addressDropdown"
+      aria-activedescendant=""
+    />
+
+    <ul
+      class="ease-address-dropdown"
+      id="addressDropdown"
+      role="listbox"
+      aria-label="Address suggestions"
+      hidden
+    ></ul>
+  </div>
+
+  <script>
+    /* ── Mock address data (replace with real geocoding API) ── */
+    const ADDRESSES = [
+      { main: "221B Baker Street",       sub: "London, NW1 6XE, UK" },
+      { main: "221 Baker Avenue",        sub: "Manchester, M14 5TH, UK" },
+      { main: "22 Baker Court",          sub: "Bristol, BS1 3AB, UK" },
+      { main: "1 Park Lane",             sub: "London, W1K 1RB, UK" },
+      { main: "10 Park Avenue",          sub: "New York, NY 10016, USA" },
+      { main: "Park Road",               sub: "Birmingham, B1 2JU, UK" },
+      { main: "42 Main Street",          sub: "Springfield, IL 62701, USA" },
+      { main: "Main Road",               sub: "Leeds, LS1 2AB, UK" },
+      { main: "7 Elm Drive",             sub: "Edinburgh, EH1 2NG, UK" },
+      { main: "Elm Street",              sub: "Springwood, OH 44512, USA" },
+      { main: "15 Oxford Street",        sub: "London, W1D 2HB, UK" },
+      { main: "Oxford Road",             sub: "Manchester, M13 9PL, UK" },
+      { main: "30 Victoria Road",        sub: "Glasgow, G42 7AA, UK" },
+      { main: "Victoria Street",         sub: "Liverpool, L2 6RE, UK" },
+      { main: "9 Highfield Lane",        sub: "Sheffield, S10 4GH, UK" },
+    ];
+
+    const input    = document.getElementById('addressInput');
+    const dropdown = document.getElementById('addressDropdown');
+    let activeIdx  = -1;
+    let items      = [];
+    let closeTimer = null;
+
+    /* ── Filter suggestions ──────────────────────────────── */
+    function getSuggestions(query) {
+      const q = query.trim().toLowerCase();
+      if (!q) return [];
+      return ADDRESSES.filter(a =>
+        a.main.toLowerCase().includes(q) ||
+        a.sub.toLowerCase().includes(q)
+      ).slice(0, 6);
+    }
+
+    /* ── Highlight matched text ──────────────────────────── */
+    function highlight(text, query) {
+      const idx = text.toLowerCase().indexOf(query.toLowerCase());
+      if (idx === -1) return escHtml(text);
+      return (
+        escHtml(text.slice(0, idx)) +
+        '<mark>' + escHtml(text.slice(idx, idx + query.length)) + '</mark>' +
+        escHtml(text.slice(idx + query.length))
+      );
+    }
+
+    function escHtml(s) {
+      return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    }
+
+    /* ── Render dropdown ─────────────────────────────────── */
+    function renderDropdown(suggestions, query) {
+      dropdown.innerHTML = '';
+      activeIdx = -1;
+
+      if (suggestions.length === 0) {
+        // Empty state
+        const empty = document.createElement('li');
+        empty.className = 'ease-address-empty';
+        empty.textContent = 'No addresses found';
+        dropdown.appendChild(empty);
+        showDropdown();
+        // Shake
+        dropdown.classList.remove('ease-address-empty-shake');
+        void dropdown.offsetWidth; // reflow to restart animation
+        dropdown.classList.add('ease-address-empty-shake');
+        dropdown.addEventListener('animationend', () => {
+          dropdown.classList.remove('ease-address-empty-shake');
+        }, { once: true });
+        return;
+      }
+
+      suggestions.forEach((addr, i) => {
+        const li = document.createElement('li');
+        li.className = 'ease-address-item';
+        li.id = `addr-opt-${i}`;
+        li.setAttribute('role', 'option');
+        li.setAttribute('aria-selected', 'false');
+        li.innerHTML = `
+          <span class="ease-address-item-icon">📍</span>
+          <span class="ease-address-item-body">
+            <span class="ease-address-item-main">${highlight(addr.main, query)}</span>
+            <span class="ease-address-item-sub">${escHtml(addr.sub)}</span>
+          </span>
+        `;
+        li.addEventListener('mousedown', e => {
+          e.preventDefault();
+          selectItem(i, suggestions);
+        });
+        li.addEventListener('mousemove', () => {
+          setActive(i);
+        });
+        dropdown.appendChild(li);
+      });
+
+      // Footer
+      const footer = document.createElement('div');
+      footer.className = 'ease-address-footer';
+      footer.innerHTML = 'Powered by mock data';
+      dropdown.appendChild(footer);
+
+      items = dropdown.querySelectorAll('.ease-address-item');
+      showDropdown();
+    }
+
+    /* ── Show / hide dropdown ────────────────────────────── */
+    function showDropdown() {
+      clearTimeout(closeTimer);
+      dropdown.classList.remove('is-closing');
+      dropdown.removeAttribute('hidden');
+      input.setAttribute('aria-expanded', 'true');
+    }
+
+    function hideDropdown() {
+      if (dropdown.hasAttribute('hidden')) return;
+      dropdown.classList.add('is-closing');
+      input.setAttribute('aria-expanded', 'false');
+      input.setAttribute('aria-activedescendant', '');
+      closeTimer = setTimeout(() => {
+        dropdown.setAttribute('hidden', '');
+        dropdown.classList.remove('is-closing');
+      }, 200);
+    }
+
+    /* ── Set active item ─────────────────────────────────── */
+    function setActive(idx) {
+      items.forEach((el, i) => {
+        el.classList.toggle('ease-address-item-active', i === idx);
+        el.setAttribute('aria-selected', i === idx ? 'true' : 'false');
+      });
+      activeIdx = idx;
+      input.setAttribute('aria-activedescendant', idx >= 0 ? `addr-opt-${idx}` : '');
+    }
+
+    /* ── Select an item ──────────────────────────────────── */
+    function selectItem(idx, suggestions) {
+      const addr = suggestions[idx];
+      input.value = addr.main + ', ' + addr.sub;
+      hideDropdown();
+      input.focus();
+    }
+
+    /* ── Input handler ───────────────────────────────────── */
+    let debounce;
+    input.addEventListener('input', () => {
+      clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        const q = input.value;
+        if (!q.trim()) { hideDropdown(); return; }
+
+        // Show shimmer while "fetching"
+        dropdown.innerHTML = `
+          <div class="ease-address-skeleton">
+            <div class="ease-address-skeleton-row"></div>
+            <div class="ease-address-skeleton-row"></div>
+            <div class="ease-address-skeleton-row"></div>
+          </div>`;
+        showDropdown();
+
+        // Simulate async API delay
+        setTimeout(() => {
+          renderDropdown(getSuggestions(q), q);
+        }, 300);
+      }, 120);
+    });
+
+    /* ── Keyboard navigation ─────────────────────────────── */
+    input.addEventListener('keydown', e => {
+      if (dropdown.hasAttribute('hidden')) return;
+      const count = items.length;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActive((activeIdx + 1) % count);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActive((activeIdx - 1 + count) % count);
+      } else if (e.key === 'Enter' && activeIdx >= 0) {
+        e.preventDefault();
+        const suggestions = getSuggestions(input.value);
+        if (suggestions[activeIdx]) selectItem(activeIdx, suggestions);
+      } else if (e.key === 'Escape') {
+        hideDropdown();
+      }
+    });
+
+    /* ── Close on outside click ──────────────────────────── */
+    document.addEventListener('mousedown', e => {
+      if (!e.target.closest('#wrapper')) hideDropdown();
+    });
+
+    input.addEventListener('focus', () => {
+      if (input.value.trim()) {
+        renderDropdown(getSuggestions(input.value), input.value);
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/address-autocomplete-collection/style.css
+++ b/submissions/examples/address-autocomplete-collection/style.css
@@ -1,0 +1,339 @@
+/* ============================================================
+   EaseMotion CSS — Animated Address Autocomplete Dropdown
+   submissions/examples/address-autocomplete-collection/style.css
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --ease-addr-bg:           #ffffff;
+  --ease-addr-border:       #e2e8f0;
+  --ease-addr-border-focus: #6366f1;
+  --ease-addr-shadow-focus: 0 0 0 3px rgba(99,102,241,0.15);
+  --ease-addr-text:         #1e293b;
+  --ease-addr-subtext:      #64748b;
+  --ease-addr-placeholder:  #94a3b8;
+  --ease-addr-dropdown-bg:  #ffffff;
+  --ease-addr-dropdown-shadow: 0 8px 30px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.06);
+  --ease-addr-item-hover:   #f8fafc;
+  --ease-addr-item-active:  #ede9fe;
+  --ease-addr-item-active-text: #5b21b6;
+  --ease-addr-item-active-bar:  #7c3aed;
+  --ease-addr-match-color:  #6366f1;
+  --ease-addr-icon-color:   #94a3b8;
+  --ease-addr-radius:       10px;
+  --ease-addr-duration:     200ms;
+  --ease-addr-easing:       cubic-bezier(0.4, 0, 0.2, 1);
+  --page-bg:                #f1f5f9;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-addr-bg:              #1e293b;
+    --ease-addr-border:          #334155;
+    --ease-addr-border-focus:    #818cf8;
+    --ease-addr-shadow-focus:    0 0 0 3px rgba(129,140,248,0.2);
+    --ease-addr-text:            #f1f5f9;
+    --ease-addr-subtext:         #94a3b8;
+    --ease-addr-placeholder:     #475569;
+    --ease-addr-dropdown-bg:     #1e293b;
+    --ease-addr-dropdown-shadow: 0 8px 30px rgba(0,0,0,0.5), 0 2px 8px rgba(0,0,0,0.3);
+    --ease-addr-item-hover:      #334155;
+    --ease-addr-item-active:     #3b0764;
+    --ease-addr-item-active-text:#c4b5fd;
+    --ease-addr-item-active-bar: #a78bfa;
+    --ease-addr-match-color:     #a78bfa;
+    --ease-addr-icon-color:      #475569;
+    --page-bg:                   #0f172a;
+  }
+}
+
+/* ── Page shell ──────────────────────────────────────────── */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--page-bg);
+  color: var(--ease-addr-text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4rem 1rem;
+  gap: 0.5rem;
+}
+
+.demo-label {
+  font-size: 0.75rem;
+  color: var(--ease-addr-subtext);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.demo-hint {
+  font-size: 0.8125rem;
+  color: var(--ease-addr-subtext);
+  margin-bottom: 1.5rem;
+}
+
+/* ── Wrapper ─────────────────────────────────────────────── */
+.ease-address-wrapper {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+}
+
+/* ── Input ───────────────────────────────────────────────── */
+.ease-address-input {
+  width: 100%;
+  padding: 0.75rem 1rem 0.75rem 2.75rem;
+  background: var(--ease-addr-bg);
+  border: 1.5px solid var(--ease-addr-border);
+  border-radius: var(--ease-addr-radius);
+  font-size: 0.9375rem;
+  color: var(--ease-addr-text);
+  font-family: inherit;
+  outline: none;
+  transition:
+    border-color var(--ease-addr-duration) var(--ease-addr-easing),
+    box-shadow   var(--ease-addr-duration) var(--ease-addr-easing);
+}
+
+.ease-address-input::placeholder {
+  color: var(--ease-addr-placeholder);
+}
+
+.ease-address-input:focus {
+  border-color: var(--ease-addr-border-focus);
+  box-shadow: var(--ease-addr-shadow-focus);
+}
+
+/* Pin icon inside input */
+.ease-address-wrapper::before {
+  content: "📍";
+  position: absolute;
+  left: 0.85rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1rem;
+  pointer-events: none;
+  z-index: 1;
+  /* only show when dropdown is not open */
+  transition: opacity var(--ease-addr-duration) var(--ease-addr-easing);
+}
+
+/* ── Dropdown container ──────────────────────────────────── */
+.ease-address-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  background: var(--ease-addr-dropdown-bg);
+  border: 1px solid var(--ease-addr-border);
+  border-radius: var(--ease-addr-radius);
+  box-shadow: var(--ease-addr-dropdown-shadow);
+  list-style: none;
+  padding: 6px;
+  z-index: 100;
+  overflow: hidden;
+
+  /* Entrance: scale + fade */
+  transform-origin: top center;
+  animation: ease-addr-enter var(--ease-addr-duration) var(--ease-addr-easing) forwards;
+}
+
+@keyframes ease-addr-enter {
+  from {
+    opacity: 0;
+    transform: scaleY(0.92) translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: scaleY(1) translateY(0);
+  }
+}
+
+/* Exit */
+.ease-address-dropdown.is-closing {
+  animation: ease-addr-leave var(--ease-addr-duration) var(--ease-addr-easing) forwards;
+  pointer-events: none;
+}
+
+@keyframes ease-addr-leave {
+  from {
+    opacity: 1;
+    transform: scaleY(1) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: scaleY(0.92) translateY(-6px);
+  }
+}
+
+/* Hidden */
+.ease-address-dropdown[hidden] {
+  display: none;
+}
+
+/* ── Empty state shake ───────────────────────────────────── */
+.ease-address-empty-shake {
+  animation: ease-addr-shake 400ms var(--ease-addr-easing);
+}
+
+@keyframes ease-addr-shake {
+  0%   { transform: translateX(0); }
+  20%  { transform: translateX(-6px); }
+  40%  { transform: translateX(6px); }
+  60%  { transform: translateX(-4px); }
+  80%  { transform: translateX(4px); }
+  100% { transform: translateX(0); }
+}
+
+/* ── Suggestion item ─────────────────────────────────────── */
+.ease-address-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: 7px;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition:
+    background var(--ease-addr-duration) var(--ease-addr-easing),
+    color var(--ease-addr-duration) var(--ease-addr-easing);
+  list-style: none;
+}
+
+.ease-address-item:hover {
+  background: var(--ease-addr-item-hover);
+}
+
+.ease-address-item-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--ease-addr-icon-color);
+}
+
+.ease-address-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.ease-address-item-main {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ease-addr-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color var(--ease-addr-duration) var(--ease-addr-easing);
+}
+
+/* Highlighted match text inside item */
+.ease-address-item-main mark {
+  background: transparent;
+  color: var(--ease-addr-match-color);
+  font-weight: 700;
+}
+
+.ease-address-item-sub {
+  font-size: 0.75rem;
+  color: var(--ease-addr-subtext);
+}
+
+/* ── Active (keyboard-highlighted) item ──────────────────── */
+.ease-address-item-active {
+  background: var(--ease-addr-item-active);
+}
+
+.ease-address-item-active .ease-address-item-main {
+  color: var(--ease-addr-item-active-text);
+}
+
+/* Sliding left accent bar */
+.ease-address-item-active::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 15%;
+  height: 70%;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--ease-addr-item-active-bar);
+  animation: ease-addr-bar-in 160ms var(--ease-addr-easing) forwards;
+}
+
+@keyframes ease-addr-bar-in {
+  from { opacity: 0; transform: scaleY(0); }
+  to   { opacity: 1; transform: scaleY(1); }
+}
+
+/* ── Dropdown footer ─────────────────────────────────────── */
+.ease-address-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 6px 10px 2px;
+  border-top: 1px solid var(--ease-addr-border);
+  margin-top: 4px;
+  font-size: 0.65rem;
+  color: var(--ease-addr-subtext);
+}
+
+/* ── Loading skeleton ────────────────────────────────────── */
+.ease-address-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 4px;
+}
+
+.ease-address-skeleton-row {
+  height: 38px;
+  border-radius: 7px;
+  background: linear-gradient(
+    90deg,
+    var(--ease-addr-border) 25%,
+    var(--ease-addr-item-hover) 50%,
+    var(--ease-addr-border) 75%
+  );
+  background-size: 200% 100%;
+  animation: ease-addr-shimmer 1.2s infinite;
+}
+
+@keyframes ease-addr-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ── Empty message ───────────────────────────────────────── */
+.ease-address-empty {
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.8125rem;
+  color: var(--ease-addr-subtext);
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-address-input,
+  .ease-address-dropdown,
+  .ease-address-dropdown.is-closing,
+  .ease-address-item,
+  .ease-address-item-active::before,
+  .ease-address-skeleton-row {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## 🎯 Feature: Animated Address Autocomplete Dropdown

### Summary

| Item | Detail |
|------|--------|
| Component | Animated Address Autocomplete Dropdown |
| Folder | `submissions/examples/address-autocomplete-collection/` |
| Files | `demo.html`, `style.css`, `README.md` |
| Dependencies | Zero — pure CSS + minimal JS for keyboard nav only |
| Issue | Closes #17604 |

### Implemented Classes

| Class | Behaviour |
|-------|-----------|
| `ease-address-input` | Border-glow on focus via `box-shadow` transition |
| `ease-address-dropdown` | Scale + fade entrance via `@keyframes ease-addr-enter` |
| `ease-address-item` | Suggestion row; hover background transition |
| `ease-address-item-active` | Purple bg + sliding left accent bar on keyboard highlight |
| `ease-address-empty-shake` | Horizontal shake animation when no results found |

### Animations
- **Entrance/exit** — `scaleY + opacity` via `@keyframes`
- **Active bar** — slides in with `scaleY` keyframe
- **Empty shake** — horizontal translateX shake signals no matches
- **Shimmer skeleton** — gradient sweep while loading suggestions

### Variants
- ✅ Light mode
- ✅ Dark mode (`prefers-color-scheme: dark`)
- ✅ `prefers-reduced-motion` — all transitions and animations disabled

### Accessibility
- `role="combobox"` + `aria-expanded` + `aria-autocomplete="list"` on input
- `role="listbox"` + `role="option"` on items
- `aria-selected` + `aria-activedescendant` updated on navigation
- Keyboard: `↑` `↓` navigate · `Enter` selects · `Escape` closes

### Contributor
**@thakurakanksha288** — GSSoC 2026 participant ✅