### PR TITLE
docs: add common mistakes anti-patterns page (#13642)

### DIFF
--- a/submissions/examples/common-mistakes/README.md
+++ b/submissions/examples/common-mistakes/README.md
@@ -1,0 +1,23 @@
+﻿# Common Mistakes – EaseMotion Anti‑Patterns
+
+A documentation resource that illustrates four frequent mistakes when using EaseMotion CSS, along with the correct approaches. Each anti‑pattern is presented as a card with a live demo comparison.
+
+## Anti‑Patterns covered
+
+1. **Animating non‑GPU properties** – using left/	op instead of 	ransform: translate().
+2. **Forgetting nimation-fill-mode** – missing orwards causes snap‑back.
+3. **Hard‑coding styles** – overriding component colors directly instead of using --ease-* CSS variables.
+4. **Stacking conflicting animation classes** – applying two classes that both animate opacity/	ransform.
+
+## EaseMotion classes used in the demo
+- **Layout:** ease-container, ease-grid, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-mx-auto, ease-gap-4, ease-gap-6, ease-py-16
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-lg, ease-font-semibold, ease-text-sm, ease-text-gray-400, ease-text-gray-500
+- **Spacing:** ease-mb-2, ease-mb-4, ease-mb-8, ease-mt-8, ease-p-6
+- **Components:** ease-card, ease-btn, ease-btn-primary, ease-btn-ghost, ease-badge
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How to use
+1. Open demo.html in any modern browser to see the comparisons.
+2. Copy the corrected patterns into your own projects.
+3. Ensure the path to easemotion.css is correct.

--- a/submissions/examples/common-mistakes/demo.html
+++ b/submissions/examples/common-mistakes/demo.html
@@ -1,0 +1,78 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Common Mistakes – EaseMotion Anti‑Patterns</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">Common Mistakes with EaseMotion</h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Avoid these frequent anti‑patterns to keep your animations smooth and predictable.
+    </p>
+
+    <div class="ease-grid ease-grid-cols-1 ease-md-grid-cols-2 ease-gap-6 ease-max-w-4xl ease-mx-auto">
+
+      <!-- Mistake 1: Animating non-GPU properties -->
+      <div class="mistake-card ease-card ease-p-6 ease-text-left ease-fade-in">
+        <h3 class="ease-text-lg ease-font-semibold ease-mb-2">❌ Animating <code>left</code> / <code>top</code></h3>
+        <p class="ease-text-sm ease-text-gray-500 ease-mb-4">
+          Moving an element with <code>left</code> or <code>margin-left</code> forces layout recalculations,
+          causing jank. Use <code>transform: translateX()</code> instead.
+        </p>
+        <div class="demo-row ease-flex ease-gap-4 ease-items-center">
+          <span class="bad-move ease-btn ease-btn-ghost">Bad</span>
+          <span class="good-move ease-btn ease-btn-primary">Good</span>
+        </div>
+      </div>
+
+      <!-- Mistake 2: Forgetting animation-fill-mode -->
+      <div class="mistake-card ease-card ease-p-6 ease-text-left ease-fade-in">
+        <h3 class="ease-text-lg ease-font-semibold ease-mb-2">❌ Missing <code>animation-fill-mode</code></h3>
+        <p class="ease-text-sm ease-text-gray-500 ease-mb-4">
+          Without <code>forwards</code>, an element snaps back to its original state after the animation.
+        </p>
+        <div class="demo-row ease-flex ease-gap-4 ease-items-center">
+          <span class="bad-fill ease-btn ease-btn-ghost">Snaps back</span>
+          <span class="good-fill ease-btn ease-btn-primary">Stays in place</span>
+        </div>
+      </div>
+
+      <!-- Mistake 3: Overriding without CSS vars -->
+      <div class="mistake-card ease-card ease-p-6 ease-text-left ease-fade-in">
+        <h3 class="ease-text-lg ease-font-semibold ease-mb-2">❌ Hard‑coding colors instead of using <code>--ease-*</code></h3>
+        <p class="ease-text-sm ease-text-gray-500 ease-mb-4">
+          Directly overwriting component styles makes theming impossible. Use
+          <code>--ease-highlight-color</code> to keep customisation safe.
+        </p>
+        <div class="demo-row ease-flex ease-gap-4 ease-items-center">
+          <span class="bad-theme ease-badge">Hard‑coded</span>
+          <span class="good-theme ease-badge" style="--ease-highlight-color: #10b981;">Themable</span>
+        </div>
+      </div>
+
+      <!-- Mistake 4: Stacking conflicting animation classes -->
+      <div class="mistake-card ease-card ease-p-6 ease-text-left ease-fade-in">
+        <h3 class="ease-text-lg ease-font-semibold ease-mb-2">❌ Stacking <code>ease-fade-in</code> + <code>ease-slide-up</code></h3>
+        <p class="ease-text-sm ease-text-gray-500 ease-mb-4">
+          Both set <code>opacity</code> and <code>transform</code>, causing one to override the other.
+          Use a single combined animation class or custom keyframe.
+        </p>
+        <div class="demo-row ease-flex ease-gap-4 ease-items-center">
+          <span class="bad-stack ease-btn ease-btn-ghost">Conflicting</span>
+          <span class="good-stack ease-btn ease-btn-primary">Single class</span>
+        </div>
+      </div>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Learn more in the official EaseMotion documentation.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/common-mistakes/style.css
+++ b/submissions/examples/common-mistakes/style.css
@@ -1,0 +1,84 @@
+﻿/* ============================================================
+   Common Mistakes – Demo styles for anti-pattern cards
+   ============================================================ */
+
+.mistake-card {
+  background: #ffffff;
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+}
+
+/* Mistake 1: Bad move uses left, Good move uses transform */
+.bad-move {
+  animation: bad-move-left 2s infinite;
+}
+.good-move {
+  animation: good-move-translate 2s infinite;
+}
+@keyframes bad-move-left {
+  0%   { left: 0; }
+  50%  { left: 30px; }
+  100% { left: 0; }
+}
+@keyframes good-move-translate {
+  0%   { transform: translateX(0); }
+  50%  { transform: translateX(30px); }
+  100% { transform: translateX(0); }
+}
+
+/* Mistake 2: Bad fill forgets forwards */
+.bad-fill {
+  animation: pop-in 1.5s;                /* no fill-mode */
+}
+.good-fill {
+  animation: pop-in 1.5s forwards;
+}
+@keyframes pop-in {
+  0%   { opacity: 0; transform: scale(0.5); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+/* Mistake 3: Hard‑coded theme vs CSS variable */
+.bad-theme {
+  background: #3b82f6;
+  color: #fff;
+  padding: 0.3em 0.8em;
+  border-radius: 0.5rem;
+  font-weight: 600;
+}
+.good-theme {
+  --ease-highlight-color: var(--ease-highlight-color, #3b82f6);
+  background: var(--ease-highlight-color);
+  color: #fff;
+  padding: 0.3em 0.8em;
+  border-radius: 0.5rem;
+  font-weight: 600;
+}
+
+/* Mistake 4: Stacking conflicting animation classes */
+.bad-stack {
+  animation: fade-in 1s, slide-up 1s;    /* conflicts */
+}
+.good-stack {
+  animation: fade-slide-in 1s forwards;
+}
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes slide-up {
+  from { transform: translateY(20px); }
+  to   { transform: translateY(0); }
+}
+@keyframes fade-slide-in {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .bad-move, .good-move, .bad-fill, .good-fill,
+  .bad-stack, .good-stack {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Closes #13642

Common Mistakes – EaseMotion Anti‑Patterns
Documentation page covering four common mistakes with live comparison demos.

Files added
- submissions/examples/common-mistakes/demo.html
- submissions/examples/common-mistakes/style.css
- submissions/examples/common-mistakes/README.md

Anti‑patterns covered
1. Animating non‑GPU properties
2. Forgetting animation‑fill‑mode
3. Overriding without CSS vars
4. Stacking conflicting animation classes

Each mistake shows a bad vs. good example directly in the demo.