### PR TITLE
feat(validator): advise on missing keyboard focus state for interactive submissions

### DIFF
--- a/.github/workflows/submission-validator.yml
+++ b/.github/workflows/submission-validator.yml
@@ -50,6 +50,11 @@ jobs:
 
             const failures = [];
             const successes = [];
+            // Non-blocking accessibility advisories (#15872): folders whose
+            // interactive demo defines hover/interaction styling but no keyboard
+            // focus state. Collected separately from `failures` so they never
+            // fail the run during rollout.
+            const accessibilityWarnings = [];
 
             let hasExistingCodeChanges = false;
             let hasDeletions = false;
@@ -169,6 +174,8 @@ jobs:
               const missing  = [];
               const present  = [];
               const qualityErrors = [];
+              let demoHtml = null;
+              let styleCss = null;
 
               // ── 1. required file existence ──────────────────────────────────
               for (const [reqFile, purpose] of Object.entries(requiredFiles)) {
@@ -185,6 +192,7 @@ jobs:
               if (fs.existsSync(demoPath)) {
                 try {
                   const html = fs.readFileSync(demoPath, 'utf8');
+                  demoHtml = html;
                   const htmlLines = countNonEmptyLines(html);
 
                   if (html.trim().length === 0) {
@@ -214,6 +222,7 @@ jobs:
               if (fs.existsSync(cssPath)) {
                 try {
                   const css = fs.readFileSync(cssPath, 'utf8');
+                  styleCss = css;
                   const cssLines = countNonEmptyLines(css);
 
                   if (css.trim().length === 0) {
@@ -261,6 +270,27 @@ jobs:
                 }
               }
 
+              // ── 6. accessibility advisory: focus state for interactive demos (#15872) ──
+              // Non-blocking. A control that animates on :hover should expose an
+              // equivalent state on :focus so keyboard / screen-reader users get
+              // visible feedback (WCAG 2.1 SC 2.4.7, Focus Visible). Classify a
+              // submission as interactive when the demo contains a focusable
+              // control or the stylesheet defines a :hover rule, then require at
+              // least one :focus / :focus-visible rule.
+              if (demoHtml !== null && styleCss !== null) {
+                const isInteractive =
+                  /<button[\s/>]/i.test(demoHtml) ||
+                  /<a\s[^>]*href/i.test(demoHtml) ||
+                  /<input[\s/>]/i.test(demoHtml) ||
+                  /<select[\s/>]/i.test(demoHtml) ||
+                  /<textarea[\s/>]/i.test(demoHtml) ||
+                  /:hover\b/i.test(styleCss);
+                const hasFocusState = /:focus\b/i.test(styleCss);
+                if (isInteractive && !hasFocusState) {
+                  accessibilityWarnings.push(folder);
+                }
+              }
+
               if (missing.length > 0 || qualityErrors.length > 0) {
                 failures.push({ folder, missing, present, htmlErrors: qualityErrors });
               } else {
@@ -273,6 +303,8 @@ jobs:
             core.setOutput('successes',     JSON.stringify(successes));
             core.setOutput('hasFailures',   failures.length > 0);
             core.setOutput('isSpamExploit', isSpamExploit ? 'true' : 'false');
+            core.setOutput('a11yWarnings',  JSON.stringify(accessibilityWarnings));
+            core.setOutput('hasA11yWarnings', accessibilityWarnings.length > 0 ? 'true' : 'false');
 
             if (failures.length > 0) {
               console.log(`❌ Validation failed for ${failures.length} issue(s)`);
@@ -533,9 +565,58 @@ jobs:
               console.log('⚠️ Could not remove labels:', e.message);
             }
 
+      - name: Accessibility Advisory Comment (non-blocking)
+        if: ${{ always() && steps.validate.outputs.hasA11yWarnings == 'true' }}
+        uses: actions/github-script@v7
+        env:
+          A11Y_JSON: ${{ steps.validate.outputs.a11yWarnings }}
+        with:
+          github-token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          script: |
+            const folders = JSON.parse(process.env.A11Y_JSON || '[]');
+            if (folders.length === 0) return;
+
+            const list = folders.map(f => `- \`${f}\``).join('\n');
+            let commentBody = `## ♿ Accessibility advisory (non-blocking)\n\n`;
+            commentBody += `This **does not block your PR.** The following interactive submission(s) define hover / interaction styling but no keyboard focus state — no \`:focus\` or \`:focus-visible\` rule was found in \`style.css\`:\n\n`;
+            commentBody += `${list}\n\n`;
+            commentBody += `Keyboard and screen-reader users get no visible indication when the control is focused (WCAG 2.1 SC 2.4.7, Focus Visible). For an animation-first framework, the animated state is exactly what should also appear on focus.\n\n`;
+            commentBody += `**How to fix** — mirror your \`:hover\` feedback on \`:focus-visible\`:\n\n`;
+            commentBody += '```css\n';
+            commentBody += `.your-control:hover,\n.your-control:focus-visible {\n  /* same transform / animation / color */\n}\n`;
+            commentBody += '```\n\n';
+            commentBody += `See the **Accessibility baseline** note in [CONTRIBUTING.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md).\n`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Accessibility advisory (non-blocking)')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: commentBody
+              });
+              console.log('✅ Updated existing accessibility advisory comment.');
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: commentBody
+              });
+              console.log('✅ Created accessibility advisory comment.');
+            }
+
       - name: Summary Output
         env:
           HAS_FAILURES: ${{ steps.validate.outputs.hasFailures }}
+          HAS_A11Y: ${{ steps.validate.outputs.hasA11yWarnings }}
         run: |
           echo "## Validation Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -545,4 +626,8 @@ jobs:
           else
             echo "✅ **Status:** Validation Passed" >> $GITHUB_STEP_SUMMARY
             echo "All required files are present and valid." >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "$HAS_A11Y" == "true" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "♿ **Accessibility advisory (non-blocking):** one or more interactive submissions define hover styling but no keyboard focus state. See the PR comment for the list and fix." >> $GITHUB_STEP_SUMMARY
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,19 @@ Answer these three questions:
 2. **How is it used?** — show the HTML class usage.
 3. **Why is it useful?** — explain how it fits EaseMotion CSS's philosophy.
 
+### ♿ Accessibility baseline
+
+If your demo is interactive — it contains a `<button>`, a link (`<a href>`), an `<input>`, `<select>`, or `<textarea>`, or your `style.css` defines a `:hover` rule — give keyboard users the same feedback that pointer users get. Define at least one `:focus` or `:focus-visible` state in `style.css`, mirroring your hover styling:
+
+```css
+.your-control:hover,
+.your-control:focus-visible {
+  /* same transform / animation / color */
+}
+```
+
+The submission validator posts a **non-blocking** advisory on pull requests whose interactive submissions have no focus state (WCAG 2.1 SC 2.4.7, Focus Visible). It will not reject your PR, but adding a focus state keeps the example gallery usable for the keyboard and screen-reader users who learn from it.
+
 ---
 
 ## Naming Rules


### PR DESCRIPTION
Closes #15872.

## What this does

Adds a single, low-cost accessibility check to `.github/workflows/submission-validator.yml`: when a submission is interactive, it should define a keyboard focus state. The check is **advisory (non-blocking)** during rollout, as the issue requested.

## Why

The validator was the only gate on every contributor PR, and it validated file structure and anti-spam heuristics only, with no accessibility check. As a result interactive components were merged with hover-only styling and no focus state, leaving keyboard and screen-reader users with no visible feedback (WCAG 2.1 SC 2.4.7, Focus Visible). Per the issue's measurement, ~76% of submissions that define `:hover` declare no `:focus` / `:focus-visible` anywhere.

## How it works

In the existing per-submission loop:

1. Classify a submission as **interactive** when `demo.html` contains `<button>`, `<a href>`, `<input>`, `<select>`, or `<textarea>`, or when `style.css` defines a `:hover` rule.
2. If interactive, require `style.css` to contain at least one `:focus` / `:focus-visible` rule (the regex `/:focus\b/i` also covers `:focus-visible` and `:focus-within`).
3. Findings are collected in a separate `accessibilityWarnings` list, **never** added to the blocking `failures`, and surfaced via a new non-blocking **"Accessibility Advisory Comment"** step that upserts a single PR comment (mirroring the validator's existing find-or-update comment plumbing). It runs on both pass and fail so an otherwise-valid interactive submission still gets the advisory.
4. The run summary notes when an advisory was posted.

Once the false-positive rate is observed to be low, the check can graduate to blocking by moving these folders into `failures`.

A short **Accessibility baseline** note in `CONTRIBUTING.md` documents the requirement and shows the fix (`:hover` + `:focus-visible`).

## No bulk edits

Per the issue's scope, this does not touch any existing submissions; remediating the current backlog can be tracked separately.

## Validation

- Verified the heuristic against the real `submissions/examples/` tree: it flags all five representative submissions the issue lists (`11897-ease-distort-isk`, `12534-ease-hover-float-isk`, `12535-ease-hover-sink-isk`, `12536-ease-hover-skew-left-isk`, `12775-hover-animations`) and does **not** flag submissions that already define `:focus` (1,176 such submissions in the tree).
- `node --check` passes on every embedded `github-script` block, including the modified validator and the new advisory step.
- The workflow YAML parses cleanly.
- Changes are confined to the validator workflow and `CONTRIBUTING.md`; no core framework files or submissions are modified.