### PR TITLE
feat(submission): add CSS-only halftone hover reveal effect

### DIFF
--- a/submissions/examples/halftone-hover-reveal-sk/README.md
+++ b/submissions/examples/halftone-hover-reveal-sk/README.md
@@ -1,0 +1,24 @@
+# Halftone Hover Reveal
+
+## What does this do?
+A CSS-only halftone dot screen overlays a card; hovering dissolves the dots and reveals the clean content underneath.
+
+## How is it used?
+Add the base class plus a variant modifier to any card element:
+
+```html
+<div class="halftone-card halftone-mono" tabindex="0">
+  <div class="card-body">
+    <h2>Title</h2>
+    <p>Content revealed on hover.</p>
+  </div>
+</div>
+```
+
+Available variants:
+- `halftone-mono` — flat dot screen on a solid background
+- `halftone-blend` — dark dots with `mix-blend-mode: multiply` over a gradient
+- `halftone-print` — entrance animation that plays on load, then clears on hover
+
+## Why is it useful?
+The halftone effect is built entirely from a `radial-gradient` repeating pattern on a `::before` pseudo-element. No canvas, no SVG filters, no JavaScript. On hover (or `:focus-within`), `background-size` scales up and `opacity` drops to zero, spacing the dots apart until they vanish. The print variant drives the inverse: `@keyframes` compresses the dot grid from 2px to 6px on load, then the hover transition clears it. Three configurable custom properties — `--dot-size`, `--dot-color`, `--transition-speed` — let developers restyle without touching the animation logic.

--- a/submissions/examples/halftone-hover-reveal-sk/demo.html
+++ b/submissions/examples/halftone-hover-reveal-sk/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Halftone Hover Reveal - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>Halftone Hover Reveal</h1>
+
+  <div class="demo-row">
+
+    <div>
+      <div class="halftone-card halftone-mono" tabindex="0">
+        <div class="card-body">
+          <h2>Monochrome</h2>
+          <p>A flat dot screen sits over the card. Hovering dissolves the dots and exposes the content underneath.</p>
+        </div>
+      </div>
+      <p class="card-label">hover to reveal</p>
+    </div>
+
+    <div>
+      <div class="halftone-card halftone-blend" tabindex="0">
+        <div class="card-body">
+          <h2>Blend Mode</h2>
+          <p>White dots using mix-blend-mode: multiply interact with the gradient background like a print overlay.</p>
+        </div>
+      </div>
+      <p class="card-label">hover to reveal</p>
+    </div>
+
+    <div>
+      <div class="halftone-card halftone-print" tabindex="0">
+        <div class="card-body">
+          <h2>Print Entrance</h2>
+          <p>On load, dots animate in from fine grain to coarse screen, simulating content being printed onto the page.</p>
+        </div>
+      </div>
+      <p class="card-label">hover to reveal &mdash; reload to replay</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/halftone-hover-reveal-sk/style.css
+++ b/submissions/examples/halftone-hover-reveal-sk/style.css
@@ -1,0 +1,183 @@
+:root {
+  --dot-size: 6px;
+  --dot-color: #1a1a2e;
+  --dot-fill: 42%;
+  --dot-gap-multiplier: 3.5;
+  --transition-speed: 0.5s;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  padding: 3rem 1.5rem;
+  background: #f0ece6;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+h1 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #1a1a2e;
+  margin: 0 0 0.25rem;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+/* ── Shared card base ───────────────────────────── */
+
+.halftone-card {
+  position: relative;
+  width: 260px;
+  border-radius: 14px;
+  overflow: hidden;
+  cursor: pointer;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+}
+
+.halftone-card .card-body {
+  padding: 2rem 1.75rem;
+  position: relative;
+  z-index: 1;
+}
+
+.halftone-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.halftone-card p {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  opacity: 0.8;
+}
+
+/* ── Halftone overlay (shared) ──────────────────── */
+
+.halftone-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(
+    circle,
+    var(--dot-color) var(--dot-fill),
+    transparent calc(var(--dot-fill) + 1%)
+  );
+  background-size: var(--dot-size) var(--dot-size);
+  transition:
+    background-size var(--transition-speed) ease,
+    opacity var(--transition-speed) ease;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.halftone-card:hover::before,
+.halftone-card:focus-within::before {
+  background-size:
+    calc(var(--dot-size) * var(--dot-gap-multiplier))
+    calc(var(--dot-size) * var(--dot-gap-multiplier));
+  opacity: 0;
+}
+
+/* ── Variant 1: Monochrome ──────────────────────── */
+
+.halftone-mono {
+  background: #e8f4fd;
+  color: #1a1a2e;
+}
+
+.halftone-mono::before {
+  --dot-color: rgba(26, 26, 46, 0.65);
+}
+
+.halftone-mono h2 { color: #1a1a2e; }
+
+/* ── Variant 2: Blend mode (multiply) ──────────── */
+
+.halftone-blend {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: #fff;
+}
+
+.halftone-blend::before {
+  --dot-color: rgba(0, 0, 0, 0.75);
+  mix-blend-mode: multiply;
+}
+
+.halftone-blend:hover::before,
+.halftone-blend:focus-within::before {
+  opacity: 0;
+}
+
+.halftone-blend h2 { color: #fff; }
+
+/* ── Variant 3: Print entrance animation ────────── */
+
+.halftone-print {
+  background: #fdf6ec;
+  color: #2d1a00;
+}
+
+.halftone-print::before {
+  --dot-color: rgba(45, 26, 0, 0.6);
+  background-size: 3px 3px;
+  animation: halftone-print-in 1.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+@keyframes halftone-print-in {
+  0% {
+    background-size: 2px 2px;
+    opacity: 1;
+  }
+  70% {
+    background-size: var(--dot-size) var(--dot-size);
+    opacity: 0.85;
+  }
+  100% {
+    background-size: var(--dot-size) var(--dot-size);
+    opacity: 0.85;
+  }
+}
+
+.halftone-print:hover::before,
+.halftone-print:focus-within::before {
+  animation: none;
+  background-size:
+    calc(var(--dot-size) * var(--dot-gap-multiplier))
+    calc(var(--dot-size) * var(--dot-gap-multiplier));
+  opacity: 0;
+}
+
+.halftone-print h2 { color: #2d1a00; }
+
+/* ── Label under each card ──────────────────────── */
+
+.card-label {
+  font-size: 0.75rem;
+  text-align: center;
+  color: #64748b;
+  margin-top: 0.5rem;
+  letter-spacing: 0.04em;
+}
+
+/* ── Reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .halftone-card::before {
+    animation: none;
+    transition: opacity 0.15s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS-only halftone dot screen reveal effect. Three card variants demonstrate different halftone techniques — all driven by `::before` pseudo-elements with `radial-gradient` repeating dot patterns. No JavaScript, no canvas, no external assets.

Closes #17857

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A repeating `radial-gradient` dot screen on a `::before` pseudo-element that dissolves on hover by transitioning `background-size` and `opacity`.

**How does a developer use it?**

```html
<div class="halftone-card halftone-mono" tabindex="0">
  <div class="card-body">
    <h2>Title</h2>
    <p>Revealed on hover.</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

Pure CSS, zero dependencies. The dot dissolution is one CSS transition — `background-size` scaling the dot grid apart until invisible. The print variant inverts this: `@keyframes` compresses dots inward on load. Custom properties (`--dot-size`, `--dot-color`, `--transition-speed`) expose the knobs without touching animation logic.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Blend mode variant uses `mix-blend-mode: multiply` with dark `rgba` dots so the halftone visibly darkens the gradient underneath — consistent with how print halftoning actually works on colored stock.