### PR TITLE
feat: add focus-visible animated outline-offset focus aura collection…

### DIFF
--- a/submissions/examples/focus-aura-collection-pr/README.md
+++ b/submissions/examples/focus-aura-collection-pr/README.md
@@ -1,0 +1,10 @@
+# CSS-Only Animated outline-offset Focus Aura Collection
+
+### What does this do?
+Provides a production-grade collection of keyboard focus interactive indicators driving `outline-offset` properties from negative insets out to expanded visual aura bounds.
+
+### How is it used?
+Apply focus tracking variables (`.aura-expand`, `.aura-pulse`, etc.) onto interactive layout button components. Effects initialize safely on native `:focus-visible` triggers.
+
+### Why is it useful?
+It upgrades accessibility compliance rings into highly immersive micro-interactions using native browser styling targets rather than un-parsable hidden `box-shadow` configurations.

--- a/submissions/examples/focus-aura-collection-pr/demo.html
+++ b/submissions/examples/focus-aura-collection-pr/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Animated Focus Aura Collection</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div style="text-align: center; margin-bottom: 1.5rem; max-width: 500px;">
+    <h1 style="font-size: 1.75rem; font-weight: 800; margin: 0 0 0.5rem 0;">Focus Aura Matrix</h1>
+    <p style="color: #64748b; font-size: 0.95rem; line-height: 1.6;">
+      Press <kbd style="background: #1e293b; padding: 0.2rem 0.4rem; border-radius: 4px; font-family: monospace;">TAB</kbd> on your keyboard to test focus indicators.
+    </p>
+  </div>
+
+  <div class="demo-grid">
+    <button class="aura-btn aura-expand">Expanding Aura</button>
+    <button class="aura-btn aura-pulse">Pulse Ring</button>
+    <button class="aura-btn aura-sweep">Sweep Transition</button>
+    <button class="aura-btn aura-neon">Neon Glow</button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/focus-aura-collection-pr/style.css
+++ b/submissions/examples/focus-aura-collection-pr/style.css
@@ -1,0 +1,121 @@
+/* submissions/examples/focus-aura-collection-pr/style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #030712;
+  color: #ffffff;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2.5rem;
+  max-width: 800px;
+  padding: 2rem;
+}
+
+/* Base structural buttons */
+.aura-btn {
+  background-color: #0f172a;
+  color: #ffffff;
+  border: 1px solid #334155;
+  padding: 1.25rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: center;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.aura-btn:hover {
+  background-color: #1e293b;
+  border-color: #475569;
+}
+
+/* Remove standard focus outline only when it's safe to handle natively */
+.aura-btn:focus {
+  outline: none;
+}
+
+/* ==========================================================================
+   Aura Suite 1: Expanding Aura
+   ========================================================================== */
+.aura-expand:focus-visible {
+  outline: 3px solid #06b6d4;
+  animation: auraExpandEffect 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes auraExpandEffect {
+  from { outline-offset: -6px; }
+  to { outline-offset: 6px; }
+}
+
+/* ==========================================================================
+   Aura Suite 2: Pulse Ring (Sonar)
+   ========================================================================== */
+.aura-pulse:focus-visible {
+  outline: 3px solid #3b82f6;
+  animation: auraPulseEffect 1.4s cubic-bezier(0.25, 1, 0.5, 1) infinite;
+}
+
+@keyframes auraPulseEffect {
+  0% { outline-offset: -3px; opacity: 1; }
+  100% { outline-offset: 12px; opacity: 0; }
+}
+
+/* ==========================================================================
+   Aura Suite 3: Inset-to-Outset Sweep
+   ========================================================================== */
+.aura-sweep:focus-visible {
+  outline: 3px solid transparent;
+  animation: auraSweepEffect 0.5s ease-out forwards;
+}
+
+@keyframes auraSweepEffect {
+  from {
+    outline-offset: -6px;
+    outline-color: rgba(139, 92, 246, 0.2);
+  }
+  to {
+    outline-offset: 5px;
+    outline-color: rgba(139, 92, 246, 1);
+  }
+}
+
+/* ==========================================================================
+   Aura Suite 4: Neon Glow Aura
+   ========================================================================== */
+.aura-neon:focus-visible {
+  outline: 3px solid #f59e0b;
+  box-shadow: 0 0 0 rgba(245, 158, 11, 0);
+  animation: auraNeonEffect 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+}
+
+@keyframes auraNeonEffect {
+  from {
+    outline-offset: -4px;
+  }
+  to {
+    outline-offset: 4px;
+    box-shadow: 0 0 25px rgba(245, 158, 11, 0.45);
+  }
+}
+
+/* ==========================================================================
+   Accessibility: Respect user prefers-reduced-motion profiles
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .aura-btn:focus-visible {
+    animation: none !important;
+    outline: 3px solid currentColor !important;
+    outline-offset: 4px !important;
+  }
+}


### PR DESCRIPTION
Closes #17867

focus-aura-collection – Animated Focus Aura Collection
A collection of four high-fidelity focus indicators animated dynamically via native outline-offset parameters to elevate access compliance aesthetics.

Files added
submissions/examples/focus-aura-collection-pr/demo.html

submissions/examples/focus-aura-collection-pr/style.css

submissions/examples/focus-aura-collection-pr/README.md

How it works
Triggers animation tracks strictly on :focus-visible to protect standard cursor click actions from messy rendering ring pops.

Controls vector boundaries by animating the browser's native outline-offset from inside the border (-6px) to the outside layout canvas (+6px).

Implements independent structural approaches including continuous sonar pulsing loops and crisp layered neon glows.

Protects accessibility requirements via explicit @media (prefers-reduced-motion: reduce) rules that drop computational rendering frames while keeping baseline indicator lines clearly visible.