### PR TITLE
feat(submission): add CSS-only mask-composite layered mask wipe collection

### DIFF
--- a/submissions/examples/mask-composite-wipe-sk/README.md
+++ b/submissions/examples/mask-composite-wipe-sk/README.md
@@ -1,0 +1,23 @@
+# mask-composite Wipe Collection
+
+## What does this do?
+Four hover-triggered reveal animations built on `mask-composite`, demonstrating how stacking two CSS mask layers and controlling their composite mode produces reveals impossible with a single mask.
+
+## How is it used?
+Apply a variant class to any card element:
+
+```html
+<div class="mask-card mask-intersect" tabindex="0">
+  <div class="card-bg"></div>
+  <div class="card-content">Your content</div>
+</div>
+```
+
+Available variants:
+- `mask-intersect` — donut iris: only the ring between two expanding circles is revealed
+- `mask-subtract` — linear sweep with a fixed circular cut-out punched through it
+- `mask-exclude` — x-ray: pixels under exactly one mask layer show; overlapping areas re-hide
+- `mask-add` — two independent circles expand and then merge into a full reveal
+
+## Why is it useful?
+`mask-composite` unlocks a class of reveals that a single `mask-image` layer cannot produce. The donut iris, for example, requires two radial gradients: one blocking the centre, one blocking the outer ring — `intersect` shows only the overlap between the two opaque areas. `@property` registers `--r1` and `--r2` as `<percentage>` types so the browser can properly interpolate them inside `mask-image` definitions. Cross-browser note: WebKit uses `-webkit-mask-composite` with different value names (`source-in`, `source-out`, `xor`, `source-over`) while the standard uses `intersect`, `subtract`, `exclude`, `add` — both are included. Animations are paused by default and start on `:hover` / `:focus-within`.

--- a/submissions/examples/mask-composite-wipe-sk/demo.html
+++ b/submissions/examples/mask-composite-wipe-sk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>mask-composite Wipe Collection - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>mask-composite Wipe Collection</h1>
+  <p style="font-size:0.8rem;color:#64748b;margin-top:0.5rem;">Hover each card to trigger the reveal</p>
+
+  <div class="grid">
+
+    <!-- Variant 1: intersect = donut iris -->
+    <div>
+      <div class="mask-card mask-intersect" tabindex="0">
+        <div class="card-bg"></div>
+        <div class="card-content">
+          <h2>Donut Iris</h2>
+          <p>Only the ring between two circles is revealed.</p>
+          <span class="mode-badge">mask-composite: intersect</span>
+        </div>
+      </div>
+      <p class="card-label">hover to play</p>
+    </div>
+
+    <!-- Variant 2: subtract = sweep with punch-out -->
+    <div>
+      <div class="mask-card mask-subtract" tabindex="0">
+        <div class="card-bg"></div>
+        <div class="card-content">
+          <h2>Subtract Wipe</h2>
+          <p>A linear sweep with a circular cut punched through it.</p>
+          <span class="mode-badge">mask-composite: subtract</span>
+        </div>
+      </div>
+      <p class="card-label">hover to play</p>
+    </div>
+
+    <!-- Variant 3: exclude = x-ray inversion -->
+    <div>
+      <div class="mask-card mask-exclude" tabindex="0">
+        <div class="card-bg"></div>
+        <div class="card-content">
+          <h2>X-Ray Exclude</h2>
+          <p>Pixels covered by exactly one mask layer are shown; overlap hides.</p>
+          <span class="mode-badge">mask-composite: exclude</span>
+        </div>
+      </div>
+      <p class="card-label">hover to play</p>
+    </div>
+
+    <!-- Variant 4: add = two circles merge -->
+    <div>
+      <div class="mask-card mask-add" tabindex="0">
+        <div class="card-bg"></div>
+        <div class="card-content">
+          <h2>Double Expand</h2>
+          <p>Two circles grow independently then merge into one reveal.</p>
+          <span class="mode-badge">mask-composite: add</span>
+        </div>
+      </div>
+      <p class="card-label">hover to play</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/mask-composite-wipe-sk/style.css
+++ b/submissions/examples/mask-composite-wipe-sk/style.css
@@ -1,0 +1,257 @@
+@property --r1 {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+
+@property --r2 {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+
+@property --sweep {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: #0f0f1a;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #e2e8f0;
+}
+
+h1 {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
+}
+
+/* ── Shared card ────────────────────────────────── */
+
+.mask-card {
+  width: 240px;
+  height: 200px;
+  border-radius: 14px;
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.mask-card .card-bg {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+}
+
+.mask-card .card-content {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1.25rem;
+  text-align: center;
+  z-index: 1;
+}
+
+.mask-card h2 {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mask-card p {
+  font-size: 0.78rem;
+  opacity: 0.75;
+  line-height: 1.5;
+}
+
+.mode-badge {
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  margin-top: 0.25rem;
+}
+
+.card-label {
+  text-align: center;
+  font-size: 0.7rem;
+  color: #64748b;
+  margin-top: 0.4rem;
+  letter-spacing: 0.06em;
+}
+
+/* ── Variant 1: Intersect — Donut Iris Wipe ─────── */
+
+.mask-intersect .card-bg {
+  background: linear-gradient(135deg, #6366f1, #a855f7);
+}
+
+.mask-intersect .card-content {
+  background: linear-gradient(135deg, #1e1b4b, #2e1065);
+  border-radius: inherit;
+  /* Layer 1: opaque ring starting at --r1 */
+  /* Layer 2: opaque circle up to --r2     */
+  /* intersect = show only where BOTH are opaque → the ring between r1 and r2 */
+  -webkit-mask-image:
+    radial-gradient(circle, transparent var(--r1), black calc(var(--r1) + 0.5%)),
+    radial-gradient(circle, black var(--r2), transparent calc(var(--r2) + 0.5%));
+  -webkit-mask-composite: source-in;
+  mask-image:
+    radial-gradient(circle, transparent var(--r1), black calc(var(--r1) + 0.5%)),
+    radial-gradient(circle, black var(--r2), transparent calc(var(--r2) + 0.5%));
+  mask-composite: intersect;
+  animation: iris-open 2s ease-out forwards;
+  animation-play-state: paused;
+}
+
+.mask-intersect:hover .card-content,
+.mask-intersect:focus-within .card-content {
+  animation-play-state: running;
+}
+
+@keyframes iris-open {
+  0%   { --r1: 0%;  --r2: 0%;  }
+  35%  { --r1: 0%;  --r2: 48%; }
+  100% { --r1: 28%; --r2: 85%; }
+}
+
+/* ── Variant 2: Subtract Wipe ───────────────────── */
+
+.mask-subtract .card-bg {
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+}
+
+.mask-subtract .card-content {
+  background: linear-gradient(135deg, #451a03, #450a0a);
+  border-radius: inherit;
+  /* Layer 1: left-side linear sweep (the "ink" being revealed)       */
+  /* Layer 2: small circle cut-out punched from layer 1 (subtracted)  */
+  -webkit-mask-image:
+    linear-gradient(to right, black var(--sweep), transparent calc(var(--sweep) + 2%)),
+    radial-gradient(circle 60px at 50% 50%, black 95%, transparent 96%);
+  -webkit-mask-composite: source-out;
+  mask-image:
+    linear-gradient(to right, black var(--sweep), transparent calc(var(--sweep) + 2%)),
+    radial-gradient(circle 60px at 50% 50%, black 95%, transparent 96%);
+  mask-composite: subtract;
+  animation: sweep-in 1.8s ease-out forwards;
+  animation-play-state: paused;
+}
+
+.mask-subtract:hover .card-content,
+.mask-subtract:focus-within .card-content {
+  animation-play-state: running;
+}
+
+@keyframes sweep-in {
+  from { --sweep: 0%; }
+  to   { --sweep: 100%; }
+}
+
+/* ── Variant 3: Exclude — X-Ray ────────────────── */
+
+.mask-exclude .card-bg {
+  background: linear-gradient(135deg, #10b981, #06b6d4);
+}
+
+.mask-exclude .card-content {
+  background: linear-gradient(135deg, #022c22, #083344);
+  border-radius: inherit;
+  /* exclude = show pixels covered by exactly ONE mask layer            */
+  /* Two expanding circles: where they overlap, content is hidden again */
+  -webkit-mask-image:
+    radial-gradient(circle, black var(--r1), transparent calc(var(--r1) + 0.5%)),
+    radial-gradient(circle 55px at 38% 40%, black 95%, transparent 96%);
+  -webkit-mask-composite: xor;
+  mask-image:
+    radial-gradient(circle, black var(--r1), transparent calc(var(--r1) + 0.5%)),
+    radial-gradient(circle 55px at 38% 40%, black 95%, transparent 96%);
+  mask-composite: exclude;
+  animation: xray-open 2s ease-out forwards;
+  animation-play-state: paused;
+}
+
+.mask-exclude:hover .card-content,
+.mask-exclude:focus-within .card-content {
+  animation-play-state: running;
+}
+
+@keyframes xray-open {
+  from { --r1: 0%; }
+  to   { --r1: 80%; }
+}
+
+/* ── Variant 4: Add — Double Expand ────────────── */
+
+.mask-add .card-bg {
+  background: linear-gradient(135deg, #ec4899, #8b5cf6);
+}
+
+.mask-add .card-content {
+  background: linear-gradient(135deg, #2d0018, #1e0038);
+  border-radius: inherit;
+  /* add = union of both mask layers, but luminance clamped to 1       */
+  /* Two circles at different positions both expand independently       */
+  -webkit-mask-image:
+    radial-gradient(circle 1px at 30% 40%, black var(--r1), transparent calc(var(--r1) + 0.5%)),
+    radial-gradient(circle 1px at 70% 60%, black var(--r2), transparent calc(var(--r2) + 0.5%));
+  -webkit-mask-composite: source-over;
+  mask-image:
+    radial-gradient(circle 1px at 30% 40%, black var(--r1), transparent calc(var(--r1) + 0.5%)),
+    radial-gradient(circle 1px at 70% 60%, black var(--r2), transparent calc(var(--r2) + 0.5%));
+  mask-composite: add;
+  animation: double-expand 2.2s ease-out forwards;
+  animation-play-state: paused;
+}
+
+.mask-add:hover .card-content,
+.mask-add:focus-within .card-content {
+  animation-play-state: running;
+}
+
+@keyframes double-expand {
+  0%   { --r1: 0%;  --r2: 0%;  }
+  40%  { --r1: 55%; --r2: 10%; }
+  100% { --r1: 90%; --r2: 90%; }
+}
+
+/* ── Reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .mask-card .card-content {
+    animation: none !important;
+    -webkit-mask-image: none !important;
+    mask-image: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Four hover-triggered card reveals using `mask-composite` — a CSS property that composites two mask layers like Photoshop blend modes. Each variant demonstrates a different composite mode: `intersect` produces a donut iris, `subtract` sweeps in with a punch-out hole, `exclude` creates an x-ray inversion, and `add` expands two independent circles that merge. `@property` registers the radius values as `<percentage>` types so they interpolate inside `mask-image` definitions. Includes `-webkit-mask-composite` with WebKit alias values for Safari.

Closes #17860

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A collection of reveals using `mask-composite` modes that are impossible with a single mask layer.

**How does a developer use it?**

```html
<div class="mask-card mask-intersect" tabindex="0">
  <div class="card-bg"></div>
  <div class="card-content">Content</div>
</div>
```

**Why does it fit EaseMotion CSS?**

Each effect is a single `@keyframes` block animating registered custom properties — no JavaScript, no canvas. Animations are paused by default and play on `:hover` / `:focus-within`, making them keyboard-accessible.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

WebKit (`-webkit-mask-composite`) uses different value names than the standard spec. README documents the mapping: `source-in`=`intersect`, `source-out`=`subtract`, `xor`=`exclude`, `source-over`=`add`. Both are included in each rule.