### PR TITLE
feat(submission): add overscroll-behavior scroll containment showcase

### DIFF
--- a/submissions/examples/overscroll-behavior-showcase-sk/README.md
+++ b/submissions/examples/overscroll-behavior-showcase-sk/README.md
@@ -1,0 +1,21 @@
+# overscroll-behavior Showcase
+
+## What does this do?
+A side-by-side visual demo of all three `overscroll-behavior` values (`auto`, `contain`, `none`), with CSS-animated indicators that activate on `:focus` to show what happens when the inner scroll reaches its boundary.
+
+## How is it used?
+Apply the value directly to any scrollable container:
+
+```html
+<!-- Scroll leaks to parent (default) -->
+<div class="scroll-box box-auto" tabindex="0">...</div>
+
+<!-- Scroll contained, no leak -->
+<div class="scroll-box box-contain" tabindex="0">...</div>
+
+<!-- No chain and no bounce -->
+<div class="scroll-box box-none" tabindex="0">...</div>
+```
+
+## Why is it useful?
+`overscroll-behavior` is the CSS-native fix for the modal scroll-chain problem — when scrolling a modal or sidebar causes the page behind it to also scroll. Developers commonly reach for JavaScript scroll-lock libraries when a single CSS property solves it. This demo makes the difference between `auto`, `contain`, and `none` visually explicit: the animated arrow (auto) shows scroll leaking out, the CONTAINED pulse (contain) shows the boundary being hit and stopped, and the hard-stop bar (none) shows scroll terminating with no bounce. Indicators are driven purely by the `:focus` state on the scroll box combined with the sibling `~` selector and `@keyframes` — no JavaScript.

--- a/submissions/examples/overscroll-behavior-showcase-sk/demo.html
+++ b/submissions/examples/overscroll-behavior-showcase-sk/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>overscroll-behavior Showcase - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>overscroll-behavior Showcase</h1>
+  <p class="subtitle">
+    Click a scroll box and scroll to the end to see how each value affects scroll chaining.
+    The page is intentionally tall so leaking is visible.
+  </p>
+
+  <div class="demo-grid">
+
+    <!-- auto -->
+    <div class="demo-col">
+      <span class="col-label label-auto">
+        auto
+        <span class="value-tag">overscroll-behavior: auto</span>
+      </span>
+      <div class="scroll-box box-auto" tabindex="0" aria-label="Scroll container with overscroll-behavior auto">
+        <div class="scroll-item">Item 1</div>
+        <div class="scroll-item">Item 2</div>
+        <div class="scroll-item">Item 3</div>
+        <div class="scroll-item">Item 4</div>
+        <div class="scroll-item">Item 5</div>
+        <div class="scroll-item">Item 6</div>
+        <div class="scroll-item">Item 7</div>
+        <div class="scroll-item">Item 8 — end</div>
+      </div>
+      <div class="indicator indicator-auto">
+        <span class="arrow" aria-hidden="true">&#8595;</span>
+        <span class="label-text">scroll leaks to page</span>
+      </div>
+      <p class="explainer">
+        Default. When the list ends, scroll momentum passes through to the parent page.
+      </p>
+    </div>
+
+    <!-- contain -->
+    <div class="demo-col">
+      <span class="col-label label-contain">
+        contain
+        <span class="value-tag">overscroll-behavior: contain</span>
+      </span>
+      <div class="scroll-box box-contain" tabindex="0" aria-label="Scroll container with overscroll-behavior contain">
+        <div class="scroll-item">Item 1</div>
+        <div class="scroll-item">Item 2</div>
+        <div class="scroll-item">Item 3</div>
+        <div class="scroll-item">Item 4</div>
+        <div class="scroll-item">Item 5</div>
+        <div class="scroll-item">Item 6</div>
+        <div class="scroll-item">Item 7</div>
+        <div class="scroll-item">Item 8 — end</div>
+      </div>
+      <div class="indicator indicator-contain">
+        <span class="blocked-text" aria-hidden="true">CONTAINED</span>
+        <span class="label-text">scroll stays inside</span>
+      </div>
+      <p class="explainer">
+        Scroll is trapped inside this box. Parent page never receives the event.
+        Rubber-band bounce still occurs on the inner container.
+      </p>
+    </div>
+
+    <!-- none -->
+    <div class="demo-col">
+      <span class="col-label label-none">
+        none
+        <span class="value-tag">overscroll-behavior: none</span>
+      </span>
+      <div class="scroll-box box-none" tabindex="0" aria-label="Scroll container with overscroll-behavior none">
+        <div class="scroll-item">Item 1</div>
+        <div class="scroll-item">Item 2</div>
+        <div class="scroll-item">Item 3</div>
+        <div class="scroll-item">Item 4</div>
+        <div class="scroll-item">Item 5</div>
+        <div class="scroll-item">Item 6</div>
+        <div class="scroll-item">Item 7</div>
+        <div class="scroll-item">Item 8 — end</div>
+      </div>
+      <div class="indicator indicator-none">
+        <span class="stop-bar" aria-hidden="true"></span>
+        <span class="label-text">hard stop, no bounce</span>
+      </div>
+      <p class="explainer">
+        No scroll chaining and no rubber-band bounce. Scroll simply stops.
+        Use for full-page scroll-hijack UIs.
+      </p>
+    </div>
+
+  </div>
+
+  <p class="page-scroll-note">page scroll — try scrolling past the list end in each box</p>
+
+</body>
+</html>

--- a/submissions/examples/overscroll-behavior-showcase-sk/style.css
+++ b/submissions/examples/overscroll-behavior-showcase-sk/style.css
@@ -1,0 +1,260 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3rem 1.5rem 6rem;
+  gap: 2.5rem;
+  /* tall enough to scroll so auto-leaking is visible */
+  min-height: 200vh;
+}
+
+h1 {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.subtitle {
+  font-size: 0.8rem;
+  color: #475569;
+  text-align: center;
+  max-width: 480px;
+  line-height: 1.6;
+}
+
+/* ── Three-column demo grid ─────────────────────── */
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 820px;
+}
+
+/* ── Individual demo column ─────────────────────── */
+
+.demo-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.col-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.col-label.label-auto    { color: #f59e0b; }
+.col-label.label-contain { color: #22c55e; }
+.col-label.label-none    { color: #60a5fa; }
+
+.value-tag {
+  display: block;
+  font-size: 0.62rem;
+  font-family: ui-monospace, monospace;
+  opacity: 0.6;
+  margin-top: 0.15rem;
+  text-align: center;
+}
+
+/* ── Scroll box ─────────────────────────────────── */
+
+.scroll-box {
+  height: 200px;
+  overflow-y: scroll;
+  border-radius: 10px;
+  padding: 0.5rem;
+  scroll-behavior: smooth;
+}
+
+.scroll-box:focus {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.box-auto {
+  overscroll-behavior: auto;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  color: #fde68a;
+}
+
+.box-contain {
+  overscroll-behavior: contain;
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  color: #bbf7d0;
+}
+
+.box-none {
+  overscroll-behavior: none;
+  background: rgba(96, 165, 250, 0.08);
+  border: 1px solid rgba(96, 165, 250, 0.3);
+  color: #bfdbfe;
+}
+
+.scroll-item {
+  padding: 0.55rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  margin-bottom: 0.35rem;
+  background: rgba(255, 255, 255, 0.05);
+  user-select: none;
+}
+
+/* ── Indicator area below each box ─────────────── */
+
+.indicator {
+  height: 48px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  position: relative;
+  overflow: hidden;
+}
+
+/* auto: shows animated leak arrow when box is focused */
+.indicator-auto {
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px dashed rgba(245, 158, 11, 0.3);
+  color: #f59e0b;
+}
+
+.indicator-auto .arrow {
+  position: absolute;
+  font-size: 1.1rem;
+  opacity: 0;
+}
+
+.box-auto:focus ~ .indicator-auto .arrow {
+  animation: leak-down 1.2s ease-in-out infinite;
+}
+
+@keyframes leak-down {
+  0%   { opacity: 0; transform: translateY(-8px); }
+  30%  { opacity: 1; }
+  100% { opacity: 0; transform: translateY(14px); }
+}
+
+.indicator-auto .label-text { font-size: 0.65rem; opacity: 0.6; }
+.box-auto:focus ~ .indicator-auto .label-text { opacity: 0; }
+
+/* contain: shows BLOCKED flash when box is focused */
+.indicator-contain {
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px dashed rgba(34, 197, 94, 0.3);
+  color: #22c55e;
+}
+
+.blocked-text {
+  position: absolute;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  opacity: 0;
+}
+
+.box-contain:focus ~ .indicator-contain .blocked-text {
+  animation: blocked-pulse 1.8s ease-out infinite;
+}
+
+@keyframes blocked-pulse {
+  0%   { opacity: 0; transform: scale(0.85); }
+  15%  { opacity: 1; transform: scale(1.05); color: #4ade80; }
+  40%  { opacity: 1; transform: scale(1);    color: #22c55e; }
+  80%  { opacity: 0.4; }
+  100% { opacity: 0; }
+}
+
+.indicator-contain .label-text { font-size: 0.65rem; opacity: 0.6; }
+.box-contain:focus ~ .indicator-contain .label-text { opacity: 0; }
+
+/* none: shows hard stop indicator when focused */
+.indicator-none {
+  background: rgba(96, 165, 250, 0.08);
+  border: 1px dashed rgba(96, 165, 250, 0.3);
+  color: #60a5fa;
+}
+
+.stop-bar {
+  position: absolute;
+  width: 60%;
+  height: 3px;
+  background: #60a5fa;
+  border-radius: 2px;
+  opacity: 0;
+  transform: scaleX(0);
+}
+
+.box-none:focus ~ .indicator-none .stop-bar {
+  animation: hard-stop 1.6s ease-out infinite;
+}
+
+@keyframes hard-stop {
+  0%   { opacity: 0; transform: scaleX(0);   }
+  20%  { opacity: 1; transform: scaleX(1.1); }
+  35%  { opacity: 1; transform: scaleX(0.95);}
+  60%  { opacity: 1; transform: scaleX(1);   }
+  100% { opacity: 0; transform: scaleX(1);   }
+}
+
+.indicator-none .label-text { font-size: 0.65rem; opacity: 0.6; }
+.box-none:focus ~ .indicator-none .label-text { opacity: 0; }
+
+/* ── Explanation cards ──────────────────────────── */
+
+.explainer {
+  font-size: 0.72rem;
+  line-height: 1.55;
+  color: #64748b;
+  text-align: center;
+  padding: 0 0.25rem;
+}
+
+/* ── Page scroll indicator ──────────────────────── */
+
+.page-scroll-note {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.7rem;
+  color: #334155;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+/* ── Reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .arrow,
+  .blocked-text,
+  .stop-bar {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Visual side-by-side demo of `overscroll-behavior: auto | contain | none`. Each column has a scrollable list and a CSS-animated indicator below it that activates when the box is focused — a downward-arrow animation for `auto` (scroll leaks out), a "CONTAINED" pulse for `contain` (boundary hit), and a hard-stop bar for `none` (no bounce, no chain). Indicators are driven entirely by `:focus` + sibling `~` selector + `@keyframes`. Page is intentionally tall so scroll chaining is observable.

Closes #17862

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An educational motion demo that makes `overscroll-behavior` values visually distinguishable through CSS-animated feedback indicators.

**How does a developer use it?**

```html
<div class="scroll-box box-contain" tabindex="0">...</div>
```

**Why does it fit EaseMotion CSS?**

All animation logic is CSS-only. The `:focus ~ .indicator` sibling pattern means zero JavaScript drives the state transitions.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The page body has `min-height: 200vh` deliberately so scroll chaining from the `auto` box is physically observable (page scrolls behind the box).