### PR TITLE
feat: add stateful css-only multi-plane backdrop-filter depth of fiel…

### DIFF
--- a/submissions/examples/multi-plane-dof-pr/README.md
+++ b/submissions/examples/multi-plane-dof-pr/README.md
@@ -1,0 +1,10 @@
+# CSS-Only Multi-Plane backdrop-filter Depth-of-Field Effect
+
+### What does this do?
+Simulates a fluid physical camera lens depth-of-field effect across multi-tiered spatial components using layered layout structures and state tracking.
+
+### How is it used?
+Incorporate structural classes (`.plane-near`, `.plane-mid`, `.plane-far`) inside a perspective container stage, controlling state selection transitions via parent input elements.
+
+### Why is it useful?
+It provides standard dashboard designs with high-end cinematic dimension using optimized CSS processing engines, avoiding resource-heavy WebGL renderers or heavy scripts.

--- a/submissions/examples/multi-plane-dof-pr/demo.html
+++ b/submissions/examples/multi-plane-dof-pr/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Multi-Plane Depth-of-Field Effect</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="focal-controller">
+    <label id="lbl-near">
+      <input type="radio" name="focal-selector" id="focus-near" style="display:none;">
+      <span>Foreground Plane</span>
+    </label>
+    <label id="lbl-mid">
+      <input type="radio" name="focal-selector" id="focus-mid" style="display:none;" checked>
+      <span>Focal Subject</span>
+    </label>
+    <label id="lbl-far">
+      <input type="radio" name="focal-selector" id="focus-far" style="display:none;">
+      <span>Background Plane</span>
+    </label>
+  </div>
+
+  <div class="dof-stage">
+    
+    <div class="plane plane-far">
+      <h3>Distant Matrix</h3>
+      <p>Deep atmospheric infrastructure variables calculating telemetry indexes.</p>
+    </div>
+
+    <div class="plane plane-mid">
+      <h3>Active Subject</h3>
+      <p>The primary interface layer anchored in crisp, pin-sharp focal perspective alignment tracks.</p>
+    </div>
+
+    <div class="plane plane-near">
+      <h3>Proximal Edge</h3>
+      <p>Immediate spatial foreground blocks mimicking lens bokeh blur structures.</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/multi-plane-dof-pr/style.css
+++ b/submissions/examples/multi-plane-dof-pr/style.css
@@ -1,0 +1,128 @@
+/* submissions/examples/multi-plane-dof-pr/style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #030712;
+  color: #ffffff;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+/* Controller Board Layout */
+.focal-controller {
+  display: flex;
+  gap: 1.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 3rem;
+  z-index: 100;
+}
+
+.focal-controller label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  color: #94a3b8;
+  transition: color 0.2s ease;
+}
+
+.focal-controller input:checked + span {
+  color: #38bdf8;
+  text-shadow: 0 0 10px rgba(56, 189, 248, 0.3);
+}
+
+/* ==========================================================================
+   Core Engine: Multi-Plane Depth-of-Field Stage
+   ========================================================================== */
+.dof-stage {
+  position: relative;
+  width: 600px;
+  height: 400px;
+  background: radial-gradient(circle at center, #1e1b4b 0%, #090514 100%);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  perspective: 1000px; /* Establishes natural 3D depth field mapping */
+}
+
+/* Abstract Plane Blueprints */
+.plane {
+  position: absolute;
+  border-radius: 16px;
+  padding: 2rem;
+  width: 280px;
+  box-sizing: border-box;
+  will-change: backdrop-filter, transform, filter;
+  transition: 
+    backdrop-filter 0.6s cubic-bezier(0.25, 1, 0.5, 1),
+    transform 0.6s cubic-bezier(0.25, 1, 0.5, 1),
+    filter 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Layer 1: Near Plane (Foreground Layer) */
+.plane-near {
+  transform: translateZ(200px) translateX(-60px) translateY(40px);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 30px 60px rgba(0,0,0,0.4);
+  z-index: 30;
+}
+
+/* Layer 2: Mid Plane (Subject Layer) */
+.plane-mid {
+  transform: translateZ(0px);
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+  z-index: 20;
+}
+
+/* Layer 3: Far Plane (Background Layer) */
+.plane-far {
+  transform: translateZ(-200px) translateX(80px) translateY(-40px);
+  background: rgba(255, 255, 255, 0.01);
+  border: 1px solid rgba(255, 255, 255, 0.03);
+  z-index: 10;
+}
+
+/* ==========================================================================
+   State Machine: Native :has() Focal Routing Matrices
+   ========================================================================== */
+
+/* State A: Near Focus Checked */
+body:has(#focus-near:checked) .plane-near { backdrop-filter: blur(0px); filter: blur(0px); transform: translateZ(200px) translateX(-60px) translateY(40px) scale(1); }
+body:has(#focus-near:checked) .plane-mid  { backdrop-filter: blur(8px); filter: blur(4px); transform: translateZ(0px) scale(0.95); }
+body:has(#focus-near:checked) .plane-far  { backdrop-filter: blur(16px); filter: blur(10px); transform: translateZ(-200px) translateX(80px) translateY(-40px) scale(0.9); }
+
+/* State B: Mid Focus Checked (Default Rest Profile) */
+body:has(#focus-mid:checked) .plane-near { backdrop-filter: blur(12px); filter: blur(6px); transform: translateZ(240px) translateX(-60px) translateY(40px) scale(1.08); } /* Bokeh expansion scale */
+body:has(#focus-mid:checked) .plane-mid  { backdrop-filter: blur(0px); filter: blur(0px); transform: translateZ(0px) scale(1); }
+body:has(#focus-mid:checked) .plane-far  { backdrop-filter: blur(8px); filter: blur(5px); transform: translateZ(-200px) translateX(80px) translateY(-40px) scale(0.95); }
+
+/* State C: Far Focus Checked */
+body:has(#focus-far:checked) .plane-near { backdrop-filter: blur(20px); filter: blur(12px); transform: translateZ(260px) translateX(-60px) translateY(40px) scale(1.15); }
+body:has(#focus-far:checked) .plane-mid  { backdrop-filter: blur(8px); filter: blur(4px); transform: translateZ(0px) scale(0.92); }
+body:has(#focus-far:checked) .plane-far  { backdrop-filter: blur(0px); filter: blur(0px); transform: translateZ(-200px) translateX(80px) translateY(-40px) scale(1.05); }
+
+/* Typography styling inside cards */
+.plane h3 { margin: 0 0 0.5rem 0; font-size: 1.1rem; font-weight: 700; }
+.plane p { margin: 0; font-size: 0.8rem; color: #94a3b8; line-height: 1.5; }
+.plane-mid h3 { color: #38bdf8; }
+
+/* Accessibility fallback override */
+@media (prefers-reduced-motion: reduce) {
+  .plane { transition: none !important; }
+}


### PR DESCRIPTION
Closes #17865

multi-plane-dof – Multi-Plane Depth-of-Field Effect
A simulated cinematic camera lens depth-of-field layout system built using multiple layered backdrop-filter planes driven entirely via CSS :has() parent state selectors.

Files added
submissions/examples/multi-plane-dof-pr/demo.html

submissions/examples/multi-plane-dof-pr/style.css

submissions/examples/multi-plane-dof-pr/README.md

How it works
Establishes three unique coordinate layers (near, mid, far) inside a 3D perspective environment pipeline.

Intercepts radio switch interaction toggles using the native CSS parent :has() selector map to dynamically alter variables without touching JavaScript.

Drives backdrop-filter: blur() and standard filter: blur() simultaneously, scaling background values up to simulate natural photographic bokeh expansions when components move completely out of focus.

Employs will-change: backdrop-filter parameters to route the pixel translations directly to hardware composition tracks, and honors prefers-reduced-motion: reduce settings by turning off spatial translation transitions instantly.