### PR TITLE
feat(submission): add @property oklch hue-cascade animated cards

### DIFF
--- a/submissions/examples/property-oklch-hue-cascade-sk/README.md
+++ b/submissions/examples/property-oklch-hue-cascade-sk/README.md
@@ -1,0 +1,20 @@
+# @property OKLCH Hue-Cascade
+
+## What does this do?
+Five cards cascade through the full color spectrum using `oklch()`, with each card offset in the hue cycle via `animation-delay`. A second row does the same in `hsl()` to show the perceptual brightness difference.
+
+## How is it used?
+Set `--i` on each card to offset its phase in the animation:
+
+```html
+<div class="hue-card oklch-card" style="--i:0"></div>
+<div class="hue-card oklch-card" style="--i:1"></div>
+<div class="hue-card oklch-card" style="--i:2"></div>
+```
+
+## Why is it useful?
+Two things are demonstrated simultaneously:
+
+**`@property` for color animation**: without registering `--hue` as `syntax: "<angle>"`, CSS treats it as an opaque string. The browser cannot interpolate between `0deg` and `360deg` — the color either jumps or does not animate at all. `@property` fixes this by giving the engine the type information it needs for proper mod-360 interpolation.
+
+**oklch perceptual uniformity**: in `hsl()`, yellow (`hsl(60deg)`) is visually much brighter than blue (`hsl(240deg)`) at the same lightness value. In `oklch()`, `L` is a perceptually uniform lightness channel — every hue at `oklch(65% 0.22 Hdeg)` appears equally bright. This makes rainbow effects, theme gradients, and color cascades more visually balanced without manual per-hue lightness tweaks.

--- a/submissions/examples/property-oklch-hue-cascade-sk/demo.html
+++ b/submissions/examples/property-oklch-hue-cascade-sk/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>@property OKLCH Hue Cascade - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Row 1: OKLCH with @property -->
+  <div class="section">
+    <div class="section-header">
+      <h2>OKLCH + @property</h2>
+      <p>
+        Perceptually uniform — equal perceived brightness at every hue.
+        <code>@property</code> enables true angle interpolation.
+      </p>
+    </div>
+    <div class="card-row">
+      <div class="hue-card oklch-card" style="--i:0" data-label="0deg"></div>
+      <div class="hue-card oklch-card" style="--i:1" data-label="72deg"></div>
+      <div class="hue-card oklch-card" style="--i:2" data-label="144deg"></div>
+      <div class="hue-card oklch-card" style="--i:3" data-label="216deg"></div>
+      <div class="hue-card oklch-card" style="--i:4" data-label="288deg"></div>
+    </div>
+  </div>
+
+  <hr class="divider">
+
+  <!-- Row 2: HSL comparison -->
+  <div class="section">
+    <div class="section-header">
+      <h2>HSL comparison</h2>
+      <p>
+        Same hue cascade in HSL. Note the brightness spikes at yellow
+        and dips at blue &mdash; HSL is not perceptually uniform.
+      </p>
+    </div>
+    <div class="card-row">
+      <div class="hue-card hsl-card" style="--i:0" data-label="0deg"></div>
+      <div class="hue-card hsl-card" style="--i:1" data-label="72deg"></div>
+      <div class="hue-card hsl-card" style="--i:2" data-label="144deg"></div>
+      <div class="hue-card hsl-card" style="--i:3" data-label="216deg"></div>
+      <div class="hue-card hsl-card" style="--i:4" data-label="288deg"></div>
+    </div>
+  </div>
+
+  <div class="caption-strip">
+    <span><span class="dot dot-oklch"></span> OKLCH — uniform lightness</span>
+    <span><span class="dot dot-hsl"></span> HSL — uneven lightness</span>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/property-oklch-hue-cascade-sk/style.css
+++ b/submissions/examples/property-oklch-hue-cascade-sk/style.css
@@ -1,0 +1,208 @@
+/* Register --hue as an animatable <angle> type.
+   Without this, the browser treats it as a string and
+   cannot interpolate between 0deg and 360deg. */
+@property --hue {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: #09090f;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3rem;
+  padding: 3rem 1.5rem;
+}
+
+/* ── Section layout ─────────────────────────────── */
+
+.section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  max-width: 680px;
+}
+
+.section-header {
+  text-align: center;
+}
+
+.section-header h2 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  margin-bottom: 0.25rem;
+}
+
+.section-header p {
+  font-size: 0.73rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
+/* ── Card row ───────────────────────────────────── */
+
+.card-row {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* ── Individual hue card ────────────────────────── */
+
+.hue-card {
+  width: 90px;
+  height: 110px;
+  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
+}
+
+.hue-card::after {
+  content: attr(data-label);
+  position: absolute;
+  bottom: 0.4rem;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+/* ── OKLCH variant ─────────────────────────────── */
+/* @property enables smooth hue interpolation through the full 360deg circle */
+
+.oklch-card {
+  background: oklch(65% 0.22 var(--hue));
+  animation: hue-spin 4s linear infinite;
+  /* Each card starts at a different point in the cycle */
+  animation-delay: calc(var(--i, 0) * -0.8s);
+}
+
+/* A subtle inner ring using a darker shade of the same hue */
+.oklch-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.12) 0%,
+    transparent 60%
+  );
+  border-radius: inherit;
+}
+
+/* ── HSL variant ────────────────────────────────── */
+/* --hue is NOT registered for HSL cards, so the animation
+   just sees two string values — no interpolation occurs.
+   The effect is a discrete jump instead of a smooth transition.
+   We demonstrate this by animating a separate --hue-hsl variable
+   that IS registered but used via calc() — even then, HSL shows
+   perceptual non-uniformity at yellow/blue endpoints. */
+
+@property --hue-hsl {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+.hsl-card {
+  /* hsl() accepts deg directly */
+  background: hsl(var(--hue-hsl) 70% 55%);
+  animation: hue-spin-hsl 4s linear infinite;
+  animation-delay: calc(var(--i, 0) * -0.8s);
+}
+
+.hsl-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.12) 0%,
+    transparent 60%
+  );
+  border-radius: inherit;
+}
+
+@keyframes hue-spin {
+  from { --hue: 0deg;   }
+  to   { --hue: 360deg; }
+}
+
+@keyframes hue-spin-hsl {
+  from { --hue-hsl: 0deg;   }
+  to   { --hue-hsl: 360deg; }
+}
+
+/* ── Comparison divider ─────────────────────────── */
+
+.divider {
+  width: 100%;
+  max-width: 680px;
+  border: none;
+  border-top: 1px solid #1e293b;
+}
+
+/* ── Caption strip ──────────────────────────────── */
+
+.caption-strip {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  font-size: 0.7rem;
+  color: #64748b;
+}
+
+.caption-strip span {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dot-oklch {
+  background: oklch(65% 0.22 180deg);
+}
+
+.dot-hsl {
+  background: hsl(180deg, 70%, 55%);
+}
+
+/* ── Reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .oklch-card,
+  .hsl-card {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What

Adds `submissions/examples/property-oklch-hue-cascade-sk/` — a CSS-only demo showing `@property` angle interpolation used to drive smooth hue rotation in `oklch()`.

## How it works

`--hue` is registered as `syntax: "<angle>"` so the browser can interpolate mod-360 through `oklch(65% 0.22 var(--hue))`. Without the `@property` declaration the browser treats `--hue` as a string and the animation breaks.

Five cards share the same `hue-spin` keyframe (`0deg → 360deg`) but each has `animation-delay: calc(var(--i, 0) * -0.8s)`, spreading them 72deg apart at any given moment.

A second row runs the identical cascade in `hsl()` to illustrate perceptual non-uniformity — yellow spikes bright, blue looks dim — while the oklch row maintains even perceived lightness at every hue.

## Files

| File | Purpose |
|---|---|
| `style.css` | `@property --hue` + `@property --hue-hsl`, card layout, both keyframes, `prefers-reduced-motion` |
| `demo.html` | Two rows of 5 cards with `--i` 0-4, OKLCH top, HSL bottom, caption strip |
| `README.md` | Explains angle interpolation requirement and oklch perceptual uniformity |

Closes #17863