### PR TITLE
feat(submission): add animated marker staggered pulse list

### DIFF
--- a/submissions/examples/animated-marker-pulse-list-sk/README.md
+++ b/submissions/examples/animated-marker-pulse-list-sk/README.md
@@ -1,0 +1,35 @@
+# Animated ::marker Staggered Pulse List
+
+## What does this do?
+
+Three list variants where each item's bullet pulses independently using a staggered `animation-delay`. Each list item sets `--i` inline; the CSS multiplies it against a fixed delay step so items beat sequentially rather than in unison.
+
+## How is it used?
+
+Set `--i` on each `<li>` to control its phase offset:
+
+```html
+<ul class="pulse-list dot-list">
+  <li style="--i:0">First item</li>
+  <li style="--i:1">Second item</li>
+  <li style="--i:2">Third item</li>
+</ul>
+```
+
+The CSS reads it as:
+
+```css
+animation-delay: calc(var(--i, 0) * 0.22s);
+```
+
+## Variants
+
+| Class | Marker type | Core technique |
+|---|---|---|
+| `dot-list` | Round dot | `box-shadow` ripple expansion |
+| `hue-list` | Colour disc | `@property --pulse-hue` angle interpolation |
+| `tick-list` | Dash tick | `scaleX` stretch with `transform-origin: left` |
+
+## Why `::before` instead of `::marker`?
+
+CSS `::marker` pseudo-element animation is inconsistently implemented across browsers — many properties (including `transform`) are not animatable on `::marker`. Using `::before` with `position: absolute` gives full animation support while achieving the same visual role.

--- a/submissions/examples/animated-marker-pulse-list-sk/demo.html
+++ b/submissions/examples/animated-marker-pulse-list-sk/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Marker Pulse List - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Variant 1: dot pulse with ripple -->
+  <div class="demo-section">
+    <p class="demo-label">Dot pulse — ripple ring</p>
+    <ul class="pulse-list dot-list">
+      <li style="--i:0">CSS custom property interpolation</li>
+      <li style="--i:1">Staggered animation delays via <code>--i</code></li>
+      <li style="--i:2">Ripple using box-shadow animation</li>
+      <li style="--i:3">Perceptually uniform oklch color</li>
+      <li style="--i:4">No JavaScript required</li>
+    </ul>
+  </div>
+
+  <!-- Variant 2: hue-shifting disc -->
+  <div class="demo-section">
+    <p class="demo-label">Hue shift — spectrum cycle</p>
+    <ul class="pulse-list hue-list">
+      <li style="--i:0">@property enables hue interpolation</li>
+      <li style="--i:1">Each marker cycles the full spectrum</li>
+      <li style="--i:2">Phase offset creates a wave cascade</li>
+      <li style="--i:3">Chroma stays constant through rotation</li>
+      <li style="--i:4">Smooth without discrete color jumps</li>
+    </ul>
+  </div>
+
+  <!-- Variant 3: dash tick -->
+  <div class="demo-section">
+    <p class="demo-label">Tick dash — scaleX pulse</p>
+    <ul class="pulse-list tick-list">
+      <li style="--i:0">Horizontal dash stretches on beat</li>
+      <li style="--i:1">transform-origin: left — anchored start</li>
+      <li style="--i:2">cubic-bezier for snappy feel</li>
+      <li style="--i:3">Opacity fade at peak extension</li>
+      <li style="--i:4">Reduced motion: animation disabled</li>
+    </ul>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/animated-marker-pulse-list-sk/style.css
+++ b/submissions/examples/animated-marker-pulse-list-sk/style.css
@@ -1,0 +1,153 @@
+@property --marker-scale {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 1;
+}
+
+@property --marker-opacity {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 1;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: #0c0f1a;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3rem;
+  padding: 3rem 1.5rem;
+}
+
+/* ── Section wrapper ─────────────────────────────── */
+
+.demo-section {
+  width: 100%;
+  max-width: 480px;
+}
+
+.demo-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #475569;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #1e293b;
+}
+
+/* ── Shared list base ───────────────────────────── */
+
+.pulse-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.pulse-list li {
+  padding-left: 2rem;
+  position: relative;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #cbd5e1;
+}
+
+/* ::marker alternative — we use ::before because
+   CSS ::marker animation support is still inconsistent */
+.pulse-list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  border-radius: 50%;
+  animation: marker-pulse 1.8s ease-in-out infinite;
+  animation-delay: calc(var(--i, 0) * 0.22s);
+}
+
+/* ── Variant 1: dot pulse ───────────────────────── */
+
+.dot-list li::before {
+  width: 8px;
+  height: 8px;
+  background: oklch(65% 0.2 210deg);
+  box-shadow: 0 0 0 0 oklch(65% 0.2 210deg / 0.6);
+}
+
+@keyframes marker-pulse {
+  0%, 100% {
+    transform: translateY(-50%) scale(1);
+    box-shadow: 0 0 0 0 oklch(65% 0.2 210deg / 0.6);
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(-50%) scale(1.55);
+    box-shadow: 0 0 0 6px oklch(65% 0.2 210deg / 0);
+    opacity: 0.85;
+  }
+}
+
+/* ── Variant 2: hue-shifting disc ───────────────── */
+
+@property --pulse-hue {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+.hue-list li::before {
+  width: 9px;
+  height: 9px;
+  background: oklch(68% 0.22 var(--pulse-hue));
+  animation: hue-marker 2.4s ease-in-out infinite;
+  animation-delay: calc(var(--i, 0) * 0.3s);
+}
+
+@keyframes hue-marker {
+  0%   { --pulse-hue: 0deg;   transform: translateY(-50%) scale(1);    opacity: 1; }
+  50%  { --pulse-hue: 180deg; transform: translateY(-50%) scale(1.6);  opacity: 0.8; }
+  100% { --pulse-hue: 360deg; transform: translateY(-50%) scale(1);    opacity: 1; }
+}
+
+/* ── Variant 3: dash tick ───────────────────────── */
+
+.tick-list li::before {
+  content: "";
+  width: 14px;
+  height: 3px;
+  border-radius: 2px;
+  background: oklch(70% 0.18 145deg);
+  top: 50%;
+  transform: translateY(-50%) scaleX(1);
+  transform-origin: left center;
+  animation: tick-pulse 1.6s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  animation-delay: calc(var(--i, 0) * 0.18s);
+}
+
+@keyframes tick-pulse {
+  0%, 100% { transform: translateY(-50%) scaleX(1);   opacity: 1; }
+  45%       { transform: translateY(-50%) scaleX(1.7); opacity: 0.6; }
+  55%       { transform: translateY(-50%) scaleX(1.7); opacity: 0.6; }
+}
+
+/* ── Reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .pulse-list li::before {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What

Adds `submissions/examples/animated-marker-pulse-list-sk/` — three list variants where each item's bullet pulses independently with a staggered delay driven entirely by CSS custom properties.

## How it works

Each `<li>` carries `--i` inline. The CSS computes `animation-delay: calc(var(--i, 0) * Ns)` so items beat one after another rather than in unison — a wave effect with zero JavaScript.

`::before` is used instead of `::marker` because `transform` and `box-shadow` are not animatable on `::marker` in most browsers.

## Variants

| Variant | Marker | Technique |
|---|---|---|
| Dot pulse | Round disc | `box-shadow` radius expansion (ripple ring) |
| Hue shift | Colour disc | `@property --pulse-hue` angle → `oklch()` |
| Tick dash | Horizontal bar | `scaleX` with `transform-origin: left` |

## Files

| File | Purpose |
|---|---|
| `style.css` | Three variant rules, stagger calc, `prefers-reduced-motion` |
| `demo.html` | Three lists of 5 items each, `--i` 0-4 per item |
| `README.md` | Explains `::before` choice and stagger pattern |

Closes #17864