### PR TITLE
feat: add ease-scratch-card-reveal CSS-only effect (#17817)

### DIFF
--- a/submissions/examples/ease-scratch-card-reveal/README.md
+++ b/submissions/examples/ease-scratch-card-reveal/README.md
@@ -1,0 +1,22 @@
+﻿# ease-scratch-card-reveal – CSS‑Only Scratch Card
+
+A pure CSS scratch card effect where hovering over the card reveals a hidden prize. No JavaScript – uses mix-blend-mode and opacity transitions.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-mx-auto, ease-py-16
+- **Background:** ease-bg-gray-100
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-2xl, ease-font-bold, ease-text-white, ease-text-sm, ease-font-semibold, ease-text-gray-200, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-8
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How it works
+- The card has two layers: a prize text (bottom) and an overlay (top) that obscures it.
+- The overlay uses mix-blend-mode: multiply to blend with the background, hiding the prize.
+- On hover, the overlay's opacity transitions to 0, revealing the prize, and the blend mode is reset to normal for a clean reveal.
+- All interactions are purely CSS – no JavaScript required.
+- Respects prefers-reduced-motion by removing transitions.
+
+## How to use
+1. Copy the HTML and CSS into your project.
+2. Ensure the path to easemotion.css is correct.
+3. Open demo.html in any modern browser and hover over the card.

--- a/submissions/examples/ease-scratch-card-reveal/demo.html
+++ b/submissions/examples/ease-scratch-card-reveal/demo.html
@@ -1,0 +1,33 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-scratch-card-reveal – CSS‑Only Scratch Card</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-100 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">Scratch Card Reveal</h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">Hover over the card to reveal the prize underneath – pure CSS!</p>
+
+    <!-- Scratch card container -->
+    <div class="scratch-card ease-mx-auto">
+      <!-- Prize text (hidden under the overlay) -->
+      <div class="scratch-prize ease-text-2xl ease-font-bold ease-text-white">🎉 You won 50% off!</div>
+
+      <!-- Overlay that hides the prize -->
+      <div class="scratch-overlay">
+        <span class="scratch-label ease-text-sm ease-font-semibold ease-text-gray-200">Hover to scratch</span>
+      </div>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Uses <code>mix-blend-mode</code> and opacity transition – no JavaScript.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scratch-card-reveal/style.css
+++ b/submissions/examples/ease-scratch-card-reveal/style.css
@@ -1,0 +1,69 @@
+﻿/* ============================================================
+   ease-scratch-card-reveal – CSS‑Only Scratch Card
+   Uses mix-blend-mode + opacity transition on hover
+   ============================================================ */
+
+.scratch-card {
+  position: relative;
+  width: 280px;
+  height: 180px;
+  border-radius: 1rem;
+  overflow: hidden;
+  background: #6d28d9;            /* prize background visible after reveal */
+  box-shadow: 0 8px 20px rgba(0,0,0,0.12);
+  cursor: pointer;
+}
+
+/* Prize text – placed behind the overlay */
+.scratch-prize {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  text-align: center;
+  padding: 0 1rem;
+  z-index: 1;
+}
+
+/* The scratchable overlay */
+.scratch-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #374151;            /* dark cover */
+  /* Mix blend mode to obscure the prize (multiply with the background) */
+  mix-blend-mode: multiply;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.5s ease, mix-blend-mode 0.5s ease;
+}
+
+/* On hover, the overlay fades out, revealing the prize */
+.scratch-card:hover .scratch-overlay {
+  opacity: 0;
+  mix-blend-mode: normal;         /* clean separation */
+}
+
+/* Label on the overlay */
+.scratch-label {
+  transition: opacity 0.3s ease;
+}
+
+.scratch-card:hover .scratch-label {
+  opacity: 0;
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .scratch-overlay {
+    transition: none;
+  }
+  .scratch-card:hover .scratch-overlay {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
Closes #17817

ease-scratch-card-reveal – CSS‑Only Scratch Card Reveal
A pure CSS scratch card effect using mix-blend-mode and hover to reveal a hidden prize.

Files added
- submissions/examples/ease-scratch-card-reveal/demo.html
- submissions/examples/ease-scratch-card-reveal/style.css
- submissions/examples/ease-scratch-card-reveal/README.md

How it works
- Two-layer card: prize text beneath an overlay.
- Overlay uses mix-blend-mode: multiply to obscure content.
- Hover triggers opacity 0 and blend mode normal, revealing the prize.
- Fully CSS-only, respects prefers-reduced-motion.