### PR TITLE
feat(submission): add multi-plane backdrop-filter depth-of-field demo

### DIFF
--- a/submissions/examples/backdrop-depth-of-field-sk/README.md
+++ b/submissions/examples/backdrop-depth-of-field-sk/README.md
@@ -1,0 +1,27 @@
+# Multi-Plane backdrop-filter Depth-of-Field
+
+## What does this do?
+
+Two demos that simulate a camera depth-of-field effect using `backdrop-filter: blur()` without JavaScript.
+
+**Demo 1 — Animated focus pull**: A scene divided into three vertical planes (near / mid / far). Keyframe animations cycle which plane has `blur(0px)` (sharp) while the other two receive increasing blur, mimicking a rack focus in cinematography.
+
+**Demo 2 — Hover card stack**: Three cards at different CSS `translateZ` depths. On hover, `backdrop-filter: blur()` increases on back cards and drops to zero on the front card, simulating shallow depth-of-field as the front card "comes into focus."
+
+## How it works
+
+`backdrop-filter` blurs what is rendered *behind* an element. The background bokeh blobs (radial-gradient) act as the scene. Each frosted plane/card sits on top and applies variable blur to everything behind it:
+
+```css
+@keyframes focus-near {
+  0%,  20% { backdrop-filter: blur(0px)  brightness(1.1); } /* sharp  */
+  33%, 66% { backdrop-filter: blur(8px)  brightness(0.7); } /* soft   */
+  80%, 100%{ backdrop-filter: blur(14px) brightness(0.5); } /* blurred*/
+}
+```
+
+`brightness()` is stacked alongside `blur()` to darken out-of-focus planes, reinforcing the depth cue.
+
+## Browser note
+
+`backdrop-filter` requires the element to create a stacking context. It also requires a real background source — it has no visible effect on elements where nothing is rendered behind them.

--- a/submissions/examples/backdrop-depth-of-field-sk/demo.html
+++ b/submissions/examples/backdrop-depth-of-field-sk/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>backdrop-filter Depth of Field - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Demo 1: Animated focus pull across 3 planes -->
+  <div>
+    <p class="demo-label">Animated focus pull — three planes</p>
+    <div class="scene">
+      <div class="scene-bg"></div>
+      <div class="plane plane-near">
+        <span class="plane-tag">Near</span>
+        <span class="plane-label">Front</span>
+      </div>
+      <div class="plane plane-mid">
+        <span class="plane-tag">Mid</span>
+        <span class="plane-label">Middle</span>
+      </div>
+      <div class="plane plane-far">
+        <span class="plane-tag">Far</span>
+        <span class="plane-label">Back</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo 2: Hover depth-of-field card stack -->
+  <div class="card-stack-wrap">
+    <p class="demo-label">Hover to focus — card stack</p>
+    <div class="card-stack-bg"></div>
+    <div class="card-stack">
+      <div class="depth-card card-back">
+        <span class="card-depth-tag">z &minus;60px</span>
+        <span>Background</span>
+      </div>
+      <div class="depth-card card-mid">
+        <span class="card-depth-tag">z &minus;24px</span>
+        <span>Midground</span>
+      </div>
+      <div class="depth-card card-front">
+        <span class="card-depth-tag">z 0</span>
+        <span>In Focus</span>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/backdrop-depth-of-field-sk/style.css
+++ b/submissions/examples/backdrop-depth-of-field-sk/style.css
@@ -1,0 +1,237 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: #080c14;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4rem;
+  padding: 3rem 1.5rem;
+}
+
+/* ── Demo label ─────────────────────────────────── */
+
+.demo-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #334155;
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+/* ═══════════════════════════════════════════════════
+   DEMO 1 — Animated focus pull
+   Three planes at different z-depths. The animation
+   cycles which plane is "in focus" by adjusting
+   backdrop-filter: blur() on each frosted pane.
+═══════════════════════════════════════════════════ */
+
+.scene {
+  position: relative;
+  width: min(600px, 90vw);
+  height: 260px;
+  perspective: 800px;
+  overflow: hidden;
+  border-radius: 16px;
+}
+
+/* Shared background: colourful bokeh blobs */
+.scene-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 120px 80px at 15% 40%, oklch(60% 0.28 20deg) 0%, transparent 70%),
+    radial-gradient(ellipse 90px 90px at 50% 60%, oklch(60% 0.28 160deg) 0%, transparent 70%),
+    radial-gradient(ellipse 110px 70px at 80% 35%, oklch(60% 0.28 260deg) 0%, transparent 70%),
+    radial-gradient(ellipse 70px 100px at 30% 80%, oklch(60% 0.28 310deg) 0%, transparent 70%),
+    radial-gradient(ellipse 80px 60px at 70% 80%, oklch(60% 0.28 80deg) 0%, transparent 70%),
+    #0d1421;
+  animation: bg-drift 8s ease-in-out infinite alternate;
+}
+
+@keyframes bg-drift {
+  from { background-position: 0 0; }
+  to   { filter: hue-rotate(30deg); }
+}
+
+/* Three frosted planes at different z-positions */
+.plane {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 33.333%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  border-right: 1px solid rgba(255,255,255,0.06);
+  /* backdrop-filter controlled per plane via keyframes */
+  transition: backdrop-filter 0.6s ease;
+}
+
+.plane-near  { left: 0; animation: focus-near  3s ease-in-out infinite; }
+.plane-mid   { left: 33.333%; animation: focus-mid   3s ease-in-out infinite; }
+.plane-far   { left: 66.666%; border-right: none; animation: focus-far   3s ease-in-out infinite; }
+
+/* Each plane is in focus at a different time in the 3s cycle */
+@keyframes focus-near {
+  0%,  20%        { backdrop-filter: blur(0px)  brightness(1.1); }
+  33%, 66%        { backdrop-filter: blur(8px)  brightness(0.7); }
+  80%, 100%       { backdrop-filter: blur(14px) brightness(0.5); }
+}
+@keyframes focus-mid {
+  0%,  20%        { backdrop-filter: blur(10px) brightness(0.6); }
+  33%, 66%        { backdrop-filter: blur(0px)  brightness(1.1); }
+  80%, 100%       { backdrop-filter: blur(10px) brightness(0.6); }
+}
+@keyframes focus-far {
+  0%,  20%        { backdrop-filter: blur(14px) brightness(0.5); }
+  33%, 66%        { backdrop-filter: blur(8px)  brightness(0.7); }
+  80%, 100%       { backdrop-filter: blur(0px)  brightness(1.1); }
+}
+
+.plane-tag {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.5);
+}
+
+.plane-label {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 8px rgba(0,0,0,0.8);
+}
+
+/* ═══════════════════════════════════════════════════
+   DEMO 2 — Hover depth-of-field card stack
+   Cards stacked with translateZ. Hovering the stack
+   focuses the top card by removing blur; sibling
+   cards remain blurred.
+═══════════════════════════════════════════════════ */
+
+.card-stack {
+  position: relative;
+  width: min(360px, 90vw);
+  height: 220px;
+  perspective: 700px;
+  cursor: pointer;
+}
+
+.depth-card {
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #fff;
+  text-shadow: 0 1px 6px rgba(0,0,0,0.6);
+  transition:
+    transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
+    backdrop-filter 0.5s ease,
+    opacity 0.5s ease;
+}
+
+.card-back {
+  background: oklch(50% 0.22 280deg / 0.55);
+  backdrop-filter: blur(12px);
+  transform: translateZ(-60px) scale(0.88);
+  opacity: 0.6;
+}
+.card-mid {
+  background: oklch(55% 0.2 200deg / 0.6);
+  backdrop-filter: blur(6px);
+  transform: translateZ(-24px) scale(0.94);
+  opacity: 0.8;
+}
+.card-front {
+  background: oklch(62% 0.2 145deg / 0.7);
+  backdrop-filter: blur(0px);
+  transform: translateZ(0px) scale(1);
+  opacity: 1;
+}
+
+/* On hover, fan the stack and keep front sharp */
+.card-stack:hover .card-back  {
+  transform: translateZ(-80px) scale(0.84) translateY(12px);
+  backdrop-filter: blur(16px);
+  opacity: 0.45;
+}
+.card-stack:hover .card-mid   {
+  transform: translateZ(-30px) scale(0.92) translateY(6px);
+  backdrop-filter: blur(8px);
+  opacity: 0.65;
+}
+.card-stack:hover .card-front {
+  transform: translateZ(20px) scale(1.03);
+  backdrop-filter: blur(0px);
+  opacity: 1;
+}
+
+.card-depth-tag {
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+/* Scene bg needed behind card-stack for backdrop-filter to work */
+.card-stack-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
+.card-stack-bg {
+  position: absolute;
+  inset: -20px;
+  border-radius: 20px;
+  background:
+    radial-gradient(ellipse 180px 120px at 30% 40%, oklch(55% 0.3 280deg) 0%, transparent 65%),
+    radial-gradient(ellipse 140px 100px at 70% 60%, oklch(55% 0.3 160deg) 0%, transparent 65%),
+    #0d1421;
+  z-index: -1;
+}
+
+/* ── Reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .plane,
+  .plane-near,
+  .plane-mid,
+  .plane-far {
+    animation: none;
+    backdrop-filter: blur(0px);
+  }
+  .bg-drift { animation: none; }
+  .depth-card,
+  .card-stack:hover .card-back,
+  .card-stack:hover .card-mid,
+  .card-stack:hover .card-front {
+    transition: none;
+    transform: none;
+    backdrop-filter: none;
+  }
+}


### PR DESCRIPTION
## What

Adds `submissions/examples/backdrop-depth-of-field-sk/` — two CSS-only demos that simulate a camera depth-of-field effect using `backdrop-filter: blur()` and `brightness()`.

## How it works

**Animated focus pull** — a scene split into three vertical planes. Each plane has its own `@keyframes` that cycles `blur(0px)` (in focus) at a different time in the animation cycle, so the "sharp plane" migrates from Near → Mid → Far continuously.

**Hover card stack** — three cards at `translateZ(-60px)`, `translateZ(-24px)`, and `translateZ(0)`. On `:hover`, `backdrop-filter: blur()` increases on the back cards and drops to zero on the front, while `scale` and `translateZ` fan them apart. The result simulates shallow depth-of-field as the front card comes forward.

`brightness()` is chained with `blur()` to darken out-of-focus elements, matching how real camera bokeh works.

## Files

| File | Purpose |
|---|---|
| `style.css` | Scene layout, three-plane focus keyframes, card stack hover transitions, reduced motion |
| `demo.html` | Two independent demo sections |
| `README.md` | Explains the technique and `backdrop-filter` stacking context requirement |

Closes #17865