### PR TITLE
feat(submission): add conic-gradient starburst animated loaders

### DIFF
--- a/submissions/examples/conic-starburst-loaders-sk/README.md
+++ b/submissions/examples/conic-starburst-loaders-sk/README.md
@@ -1,0 +1,46 @@
+# Conic-Gradient Starburst Animated Loaders
+
+## What does this do?
+
+Four CSS-only loading spinners built from `conic-gradient`, each demonstrating a different animation technique.
+
+| Loader | Technique |
+|---|---|
+| Starburst ring | Alternating colour/transparent conic sectors + `mask-image` donut + `rotate` |
+| Sweep arc | `@property --sweep` as `<angle>` drives the arc stop in `conic-gradient()` |
+| Pizza spin | 8-sector spectrum + `hue-rotate` filter cycling while spinning |
+| Pulse burst | 16-sector starburst with `scale` + `opacity` pulse layered on rotation |
+
+## How the starburst ring works
+
+```css
+background: conic-gradient(
+  oklch(65% 0.25 210deg) 0deg 30deg,
+  transparent            30deg 60deg,
+  /* ... repeated every 60deg ... */
+);
+mask-image: radial-gradient(
+  circle,
+  transparent 24px,   /* hollow centre */
+  black 25px,
+  black 38px,         /* ring band */
+  transparent 39px    /* outer edge */
+);
+```
+
+The `mask-image` cuts the filled circle into a ring shape. Rotating the whole element gives the spinning effect without touching the gradient.
+
+## How the sweep arc works
+
+`@property --sweep` is registered as `syntax: "<angle>"` so it can be interpolated by `@keyframes`. The conic-gradient uses `var(--sweep)` as the colour-stop boundary:
+
+```css
+background: conic-gradient(
+  oklch(68% 0.22 145deg) 0deg var(--sweep),
+  oklch(68% 0.22 145deg / 0.15) var(--sweep) 360deg
+);
+@keyframes sweep-fill {
+  from { --sweep: 0deg; }
+  to   { --sweep: 360deg; }
+}
+```

--- a/submissions/examples/conic-starburst-loaders-sk/demo.html
+++ b/submissions/examples/conic-starburst-loaders-sk/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Conic-Gradient Starburst Loaders - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="loader-row">
+
+    <!-- Loader 1: Rotating starburst ring -->
+    <div class="loader-wrap">
+      <div class="starburst" role="status" aria-label="Loading"></div>
+      <span class="loader-tag">Starburst ring</span>
+    </div>
+
+    <!-- Loader 2: Sweeping arc via @property -->
+    <div class="loader-wrap">
+      <div class="sweep-ring" role="status" aria-label="Loading"></div>
+      <span class="loader-tag">Sweep arc</span>
+    </div>
+
+    <!-- Loader 3: Hue-rotating pizza sectors -->
+    <div class="loader-wrap">
+      <div class="pizza-spin" role="status" aria-label="Loading"></div>
+      <span class="loader-tag">Pizza spin</span>
+    </div>
+
+    <!-- Loader 4: Pulsing starburst -->
+    <div class="loader-wrap">
+      <div class="pulse-starburst" role="status" aria-label="Loading"></div>
+      <span class="loader-tag">Pulse burst</span>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/conic-starburst-loaders-sk/style.css
+++ b/submissions/examples/conic-starburst-loaders-sk/style.css
@@ -1,0 +1,221 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: #090c18;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4rem;
+  padding: 3rem 1.5rem;
+}
+
+/* ── Layout ─────────────────────────────────────── */
+
+.loader-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3rem;
+  flex-wrap: wrap;
+}
+
+.loader-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.loader-tag {
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #334155;
+}
+
+/* ═══════════════════════════════════════════════════
+   LOADER 1 — Rotating starburst
+   conic-gradient creates alternating transparent/colour
+   sectors. Rotation animates the whole gradient.
+═══════════════════════════════════════════════════ */
+
+.starburst {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: conic-gradient(
+    oklch(65% 0.25 210deg)   0deg   30deg,
+    transparent              30deg  60deg,
+    oklch(65% 0.25 210deg)   60deg  90deg,
+    transparent              90deg  120deg,
+    oklch(65% 0.25 210deg)   120deg 150deg,
+    transparent              150deg 180deg,
+    oklch(65% 0.25 210deg)   180deg 210deg,
+    transparent              210deg 240deg,
+    oklch(65% 0.25 210deg)   240deg 270deg,
+    transparent              270deg 300deg,
+    oklch(65% 0.25 210deg)   300deg 330deg,
+    transparent              330deg 360deg
+  );
+  animation: starburst-spin 1.2s linear infinite;
+  mask-image: radial-gradient(
+    circle,
+    transparent 24px,
+    black 25px,
+    black 38px,
+    transparent 39px
+  );
+  -webkit-mask-image: radial-gradient(
+    circle,
+    transparent 24px,
+    black 25px,
+    black 38px,
+    transparent 39px
+  );
+}
+
+@keyframes starburst-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ═══════════════════════════════════════════════════
+   LOADER 2 — Sweeping arc (progress ring style)
+   conic-gradient from 0deg to animated angle creates
+   a filling arc. @property animates the stop position.
+═══════════════════════════════════════════════════ */
+
+@property --sweep {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+.sweep-ring {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: conic-gradient(
+    oklch(68% 0.22 145deg) 0deg var(--sweep),
+    oklch(68% 0.22 145deg / 0.15) var(--sweep) 360deg
+  );
+  animation: sweep-fill 1.5s ease-in-out infinite alternate;
+  mask-image: radial-gradient(
+    circle,
+    transparent 26px,
+    black 27px,
+    black 38px,
+    transparent 39px
+  );
+  -webkit-mask-image: radial-gradient(
+    circle,
+    transparent 26px,
+    black 27px,
+    black 38px,
+    transparent 39px
+  );
+}
+
+@keyframes sweep-fill {
+  from { --sweep: 0deg; }
+  to   { --sweep: 360deg; }
+}
+
+/* ═══════════════════════════════════════════════════
+   LOADER 3 — Hue-rotating pizza spinner
+   Repeating conic sectors rotate while hue-rotate
+   shifts colour so the whole thing feels alive.
+═══════════════════════════════════════════════════ */
+
+.pizza-spin {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: conic-gradient(
+    oklch(65% 0.24 0deg)    0deg  45deg,
+    oklch(65% 0.24 45deg)   45deg 90deg,
+    oklch(65% 0.24 90deg)   90deg 135deg,
+    oklch(65% 0.24 135deg)  135deg 180deg,
+    oklch(65% 0.24 180deg)  180deg 225deg,
+    oklch(65% 0.24 225deg)  225deg 270deg,
+    oklch(65% 0.24 270deg)  270deg 315deg,
+    oklch(65% 0.24 315deg)  315deg 360deg
+  );
+  animation: pizza-rotate 2s linear infinite;
+}
+
+@keyframes pizza-rotate {
+  from { transform: rotate(0deg);   filter: hue-rotate(0deg); }
+  to   { transform: rotate(360deg); filter: hue-rotate(360deg); }
+}
+
+/* ═══════════════════════════════════════════════════
+   LOADER 4 — Pulsing starburst scale + opacity
+   Same starburst structure but adds a scale/opacity
+   pulse so it breathes while spinning.
+═══════════════════════════════════════════════════ */
+
+.pulse-starburst {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: conic-gradient(
+    oklch(70% 0.26 310deg)   0deg   22.5deg,
+    transparent              22.5deg 45deg,
+    oklch(70% 0.26 310deg)   45deg  67.5deg,
+    transparent              67.5deg 90deg,
+    oklch(70% 0.26 310deg)   90deg  112.5deg,
+    transparent              112.5deg 135deg,
+    oklch(70% 0.26 310deg)   135deg 157.5deg,
+    transparent              157.5deg 180deg,
+    oklch(70% 0.26 310deg)   180deg 202.5deg,
+    transparent              202.5deg 225deg,
+    oklch(70% 0.26 310deg)   225deg 247.5deg,
+    transparent              247.5deg 270deg,
+    oklch(70% 0.26 310deg)   270deg 292.5deg,
+    transparent              292.5deg 315deg,
+    oklch(70% 0.26 310deg)   315deg 337.5deg,
+    transparent              337.5deg 360deg
+  );
+  animation: pulse-burst 1.6s ease-in-out infinite;
+  mask-image: radial-gradient(
+    circle,
+    transparent 20px,
+    black 21px,
+    black 38px,
+    transparent 39px
+  );
+  -webkit-mask-image: radial-gradient(
+    circle,
+    transparent 20px,
+    black 21px,
+    black 38px,
+    transparent 39px
+  );
+}
+
+@keyframes pulse-burst {
+  0%, 100% { transform: rotate(0deg)   scale(1);    opacity: 1; }
+  50%       { transform: rotate(180deg) scale(1.15); opacity: 0.7; }
+}
+
+/* ── Reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .starburst,
+  .sweep-ring,
+  .pizza-spin,
+  .pulse-starburst {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What

Adds `submissions/examples/conic-starburst-loaders-sk/` — four CSS-only loading spinners built from `conic-gradient`, each using a different animation technique.

## Loaders

**Starburst ring** — alternating colour/transparent conic sectors every 30deg, with a `mask-image` radial gradient cutting it into a ring. The element rotates.

**Sweep arc** — `@property --sweep` registered as `<angle>` drives the colour-stop boundary inside `conic-gradient()`. `@keyframes` animates `--sweep` from `0deg` to `360deg`, growing a filled arc without JavaScript.

**Pizza spin** — 8 sectors each at their own oklch hue (0/45/90…315deg). A `hue-rotate` filter animates simultaneously with the rotation, so the whole spectrum shifts as it spins.

**Pulse burst** — 16-sector starburst with `scale` and `opacity` pulse layered on top of rotation for a breathing effect.

## Files

| File | Purpose |
|---|---|
| `style.css` | All four loader variants, `@property --sweep`, keyframes, reduced motion |
| `demo.html` | Single row of all four with labels and `role="status"` |
| `README.md` | Explains conic sector construction and sweep arc technique |

Closes #17866