### PR TITLE
feat: add css-only backdrop-filter frosted glassmorphism profile card…

### DIFF
--- a/submissions/examples/frosted-glass-card-pr/README.md
+++ b/submissions/examples/frosted-glass-card-pr/README.md
@@ -1,0 +1,10 @@
+# CSS-Only Frosted Glass Profile Card
+
+### What does this do?
+Implements a beautiful user component layout that overlays background color environments through a crisp, frosted crystal visual glass refraction block.
+
+### How is it used?
+Apply the structural utility identifier `.glass-profile-card` directly onto content container tags. Ensure backgrounds contain vibrant color meshes to highlight the absorption ratio.
+
+### Why is it useful?
+It creates high-end atmospheric layering inside a browser view without loading asset images, managing opacity gradients directly alongside native layout composite properties.

--- a/submissions/examples/frosted-glass-card-pr/demo.html
+++ b/submissions/examples/frosted-glass-card-pr/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Frosted Glass Profile Card</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="glass-profile-card">
+    <div class="avatar-container">
+      <div class="profile-avatar">AY</div>
+    </div>
+    <h2>Aditya Yadav</h2>
+    <p>AI Engineer & Creative Developer</p>
+    <button class="profile-action-btn">Connect Profile</button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/frosted-glass-card-pr/style.css
+++ b/submissions/examples/frosted-glass-card-pr/style.css
@@ -1,0 +1,111 @@
+/* submissions/examples/frosted-glass-card-pr/style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  /* High-contrast colorful mesh background to highlight the frosted glass absorption */
+  background: radial-gradient(circle at 20% 20%, #4f46e5 0%, transparent 40%),
+              radial-gradient(circle at 80% 80%, #db2777 0%, transparent 40%),
+              #090514;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+/* ==========================================================================
+   Core Engine: Glassmorphism Frosted Profile Card
+   ========================================================================== */
+.glass-profile-card {
+  width: 320px;
+  background: rgba(255, 255, 255, 0.05); /* Soft semi-transparent surface anchor */
+  border-radius: 24px;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  
+  /* The Secret Sauce: Native hardware-accelerated blur window */
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  
+  /* Semi-transparent crisp border creating the glass edge prism illusion */
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  
+  /* Smooth scale-up entrance timeline initialization */
+  opacity: 0;
+  transform: translateY(20px) scale(0.95);
+  animation: glassCardEntrance 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes glassCardEntrance {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Profile Avatar Wrapper */
+.avatar-container {
+  position: relative;
+  width: 96px;
+  height: 96px;
+  margin: 0 auto 1.5rem auto;
+}
+
+.profile-avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6366f1, #a855f7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #ffffff;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+/* Typography styles inside the frosted layer */
+.glass-profile-card h2 {
+  margin: 0 0 0.35rem 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #ffffff;
+  letter-spacing: -0.01em;
+}
+
+.glass-profile-card p {
+  margin: 0 0 1.75rem 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+/* Interactive Action Button inside Glass Matrix */
+.profile-action-btn {
+  background: #ffffff;
+  color: #090514;
+  border: none;
+  padding: 0.75rem 2rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-action-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(255, 255, 255, 0.15);
+}
+
+/* Accessibility overrides */
+@media (prefers-reduced-motion: reduce) {
+  .glass-profile-card {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
Closes #17823

frosted-glass-card – CSS-Only Frosted Glass Profile Card
An elegant profile presentation asset built entirely using pure CSS glassmorphism styling layers and fluid scale-in entry keyframe rules.

Files added
submissions/examples/frosted-glass-card-pr/demo.html

submissions/examples/frosted-glass-card-pr/style.css

submissions/examples/frosted-glass-card-pr/README.md

How it works
Employs native backdrop-filter: blur(16px) settings to smoothly diffuse underlying document background mesh values directly through the block layer.

Wraps container panels inside an absolute translucent white color perimeter (rgba(255, 255, 255, 0.13)) to emulate a crisp photographic glass reflection boundary line.

Uses an optimized cubic-bezier transform path (translateY + scale) to float elements gracefully into visual context upon initial document initialization.

Handles performance optimizations on standard hardware composition vectors, and supports accessibility parameters safely via automated @media (prefers-reduced-motion: reduce) override tracks.