### PR TITLE
feat: add ease-sliding-underline-hover animation (#17820)

### DIFF
--- a/submissions/examples/ease-sliding-underline-hover/README.md
+++ b/submissions/examples/ease-sliding-underline-hover/README.md
@@ -1,0 +1,21 @@
+﻿# ease-sliding-underline-hover – Sliding Underline Hover Effect
+
+A pure CSS navigation link hover effect where an underline slides in from the left and exits to the right. No JavaScript required.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-gap-8, ease-flex-wrap, ease-py-16
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-8
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How it works
+- Each link has an ::after pseudo‑element acting as an underline, initially hidden (scaleX(0)).
+- On hover, the underline scales in from the left (	ransform-origin: left).
+- When the mouse leaves, the underline scales out to the right (	ransform-origin: right), creating a sliding exit effect.
+- All transitions use ease timing and respect prefers-reduced-motion.
+
+## How to use
+1. Add the class slide-underline to any link.
+2. Copy style.css into your project.
+3. Ensure the path to easemotion.css is correct.

--- a/submissions/examples/ease-sliding-underline-hover/demo.html
+++ b/submissions/examples/ease-sliding-underline-hover/demo.html
@@ -1,0 +1,32 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-sliding-underline-hover – Sliding Underline Effect</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">Sliding Underline Hover</h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Hover over the links – the underline slides in from the left and exits to the right.
+    </p>
+
+    <nav class="ease-flex ease-justify-center ease-gap-8 ease-flex-wrap">
+      <a href="#" class="slide-underline">Home</a>
+      <a href="#" class="slide-underline">About</a>
+      <a href="#" class="slide-underline">Services</a>
+      <a href="#" class="slide-underline">Portfolio</a>
+      <a href="#" class="slide-underline">Contact</a>
+    </nav>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Pure CSS — uses <code>::after</code> pseudo‑element with <code>transform: scaleX</code>.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-sliding-underline-hover/style.css
+++ b/submissions/examples/ease-sliding-underline-hover/style.css
@@ -1,0 +1,51 @@
+﻿/* ============================================================
+   ease-sliding-underline-hover – Sliding underline hover effect
+   Underline slides in from left, exits to right on hover
+   ============================================================ */
+
+/* Link base styling */
+.slide-underline {
+  position: relative;
+  text-decoration: none;
+  color: #1e40af;
+  font-weight: 600;
+  padding-bottom: 0.2em;
+  transition: color 0.3s ease;
+}
+
+.slide-underline:hover {
+  color: #1d4ed8;
+}
+
+/* Underline element */
+.slide-underline::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: #3b82f6;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+}
+
+/* On hover, slide in from left */
+.slide-underline:hover::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+/* On unhover, slide out to right */
+.slide-underline:not(:hover)::after {
+  transform: scaleX(0);
+  transform-origin: right;
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .slide-underline::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #17820

ease-sliding-underline-hover – Sliding Underline Hover Effect
A pure CSS navigation link hover where an underline slides in from the left and exits to the right.

Files added
- submissions/examples/ease-sliding-underline-hover/demo.html
- submissions/examples/ease-sliding-underline-hover/style.css
- submissions/examples/ease-sliding-underline-hover/README.md

How it works
- ::after pseudo‑element with scaleX animation.
- transform-origin switches between left (hover) and right (unhover) for the sliding effect.
- Fully CSS‑only, respects prefers-reduced-motion.