### PR TITLE
feat: add pure css hardware accelerated split screen horizontal hover…

### DIFF
--- a/submissions/examples/split-screen-reveal-pr/README.md
+++ b/submissions/examples/split-screen-reveal-pr/README.md
@@ -1,0 +1,10 @@
+# CSS-Only Split Screen Hover Reveal
+
+### What does this do?
+Splits the browser screen symmetrically down the center line upon mouse hover interaction tracking, sliding the left and right halves sideways out of view to display underlying hero content structures.
+
+### How is it used?
+Incorporate a root tracking block (`.split-reveal-container`) housing two sister `.reveal-curtain` panel layers alongside a baseline nested layout element marked as `.underlay-content`.
+
+### Why is it useful?
+It provides a high-end web gate design component entirely inside native browser translation tracks, bypassing bloated third-party scroll-jacking or canvas layout scripts.

--- a/submissions/examples/split-screen-reveal-pr/demo.html
+++ b/submissions/examples/split-screen-reveal-pr/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Split Screen Hover Reveal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="split-reveal-container">
+    
+    <div class="reveal-curtain curtain-left">
+      <h1 class="curtain-title">SPLIT</h1>
+    </div>
+
+    <div class="underlay-content">
+      <h2>Welcome to EaseMotion</h2>
+      <p>You have successfully unmasked the architectural underlay deck. This premium cinematic interaction operates with maximum fluid frame rate performance using pure CSS layout composition vectors.</p>
+    </div>
+
+    <div class="reveal-curtain curtain-right">
+      <h1 class="curtain-title">SCREEN</h1>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/split-screen-reveal-pr/style.css
+++ b/submissions/examples/split-screen-reveal-pr/style.css
@@ -1,0 +1,126 @@
+/* submissions/examples/split-screen-reveal-pr/style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #030712;
+  color: #ffffff;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+/* ==========================================================================
+   Core Engine: Split Screen Hover Reveal Layout Wrapper
+   ========================================================================== */
+.split-reveal-container {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+/* Underlay Content: Revealed completely underneath the split sheets */
+.underlay-content {
+  text-align: center;
+  max-width: 600px;
+  padding: 2rem;
+  z-index: 10;
+  transform: scale(0.95);
+  opacity: 0;
+  transition: transform 0.6s cubic-bezier(0.25, 1, 0.5, 1), 
+              opacity 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Master Split Curtain Layer Blueprint */
+.reveal-curtain {
+  position: absolute;
+  top: 0;
+  width: 50vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  background-color: #0f172a;
+  z-index: 20;
+  will-change: transform;
+  transition: transform 0.7s cubic-bezier(0.85, 0, 0.15, 1);
+}
+
+/* Left Half Section Panel */
+.curtain-left {
+  left: 0;
+  justify-content: flex-end;
+  border-right: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+/* Right Half Section Panel */
+.curtain-right {
+  right: 0;
+  justify-content: flex-start;
+}
+
+/* Giant Typography Splitting Anchors */
+.curtain-title {
+  font-size: 5vw;
+  font-weight: 900;
+  text-transform: uppercase;
+  color: #f8fafc;
+  margin: 0;
+  padding: 0 1rem;
+  letter-spacing: -0.04em;
+  white-space: nowrap;
+}
+
+/* ==========================================================================
+   State Machine: Hover Interactive Actions
+   ========================================================================== */
+
+/* Slide the left side completely past the left viewport boundary edge */
+.split-reveal-container:hover .curtain-left {
+  transform: translateX(-100%);
+}
+
+/* Slide the right side completely past the right viewport boundary edge */
+.split-reveal-container:hover .curtain-right {
+  transform: translateX(100%);
+}
+
+/* Bring the hidden underlay back into target view and scale coordinates */
+.split-reveal-container:hover .underlay-content {
+  transform: scale(1);
+  opacity: 1;
+}
+
+/* Decorative Underlay Typography styling rules */
+.underlay-content h2 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  margin: 0 0 1rem 0;
+  background: linear-gradient(to right, #60a5fa, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.underlay-content p {
+  font-size: 1.1rem;
+  color: #94a3b8;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Accessibility settings */
+@media (prefers-reduced-motion: reduce) {
+  .reveal-curtain, .underlay-content {
+    transition: none !important;
+  }
+  .split-reveal-container:hover .reveal-curtain {
+    opacity: 0; /* Fade out gracefully instead of translation shift */
+  }
+}


### PR DESCRIPTION
Closes #17822

split-screen-reveal – CSS-Only Split Screen Hover Reveal
A split-screen gateway component layout that slides horizontally outwards to the viewport margins upon container hover events, revealing hidden content underlays.

Files added
submissions/examples/split-screen-reveal-pr/demo.html

submissions/examples/split-screen-reveal-pr/style.css

submissions/examples/split-screen-reveal-pr/README.md

How it works
Sets two adjacent panels at absolute coordinates spanning exactly half the active window width space (50vw).

Employs the will-change: transform hint parameter to instruct browser paint systems to offload the translations directly onto optimized GPU composition layers.

Intercepts cursor focus coordinates via hover tracks to initiate smooth translateX(-100%) and translateX(100%) panel displacement sweeps simultaneously.

Enhances tracking aesthetics by applying an entry scale transformation onto the text underlay block, and shields user preferences accurately under explicit @media (prefers-reduced-motion: reduce) opacity cross-fades.