### PR TITLE
feat: add ease-animated-tooltip-bounce animation (#17814)

### DIFF
--- a/submissions/examples/ease-animated-tooltip-bounce/README.md
+++ b/submissions/examples/ease-animated-tooltip-bounce/README.md
@@ -1,0 +1,23 @@
+﻿# ease-animated-tooltip-bounce – CSS‑Only Bouncing Tooltip
+
+A tooltip that appears with a playful bounce animation when hovering over a trigger element. Purely CSS – no JavaScript required.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-py-16
+- **Background:** ease-bg-gray-100
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-8
+- **Components:** ease-btn, ease-btn-primary
+- **Hover:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- The tooltip is a <span> positioned absolutely above the button, hidden by default (isibility: hidden, opacity: 0).
+- On hover of the wrapper, the tooltip becomes visible and plays the 	ooltip-bounce keyframe: it slides up slightly, overshoots past its final position, and settles back.
+- The arrow triangle is created with a ::after pseudo‑element using borders.
+- All animations respect prefers-reduced-motion, falling back to a simple fade in.
+
+## How to use
+1. Copy the HTML and CSS into your project.
+2. Ensure the path to easemotion.css is correct.
+3. Open demo.html in any modern browser and hover over the button.

--- a/submissions/examples/ease-animated-tooltip-bounce/demo.html
+++ b/submissions/examples/ease-animated-tooltip-bounce/demo.html
@@ -1,0 +1,29 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-animated-tooltip-bounce – Bouncing Tooltip</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-100 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">Bouncing Tooltip</h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">Hover over the button to see the tooltip bounce in.</p>
+
+    <!-- Trigger element -->
+    <div class="tooltip-wrapper ease-inline-block ease-relative">
+      <button class="ease-btn ease-btn-primary ease-hover-scale-105 ease-transition">Hover me</button>
+      <!-- Tooltip bubble -->
+      <span class="tooltip-bubble ease-absolute ease-bottom-full ease-left-1/2 ease--translate-x-1/2 ease-mb-2">
+        Hello! I'm a tooltip
+      </span>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">Pure CSS – no JavaScript. Uses <code>@keyframes</code> for the bounce.</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-animated-tooltip-bounce/style.css
+++ b/submissions/examples/ease-animated-tooltip-bounce/style.css
@@ -1,0 +1,91 @@
+﻿/* ============================================================
+   ease-animated-tooltip-bounce – Tooltip with bounce entrance
+   ============================================================ */
+
+/* Wrapper to position the tooltip */
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+/* Tooltip bubble – hidden by default */
+.tooltip-bubble {
+  visibility: hidden;
+  opacity: 0;
+  background: #1e293b;
+  color: #fff;
+  white-space: nowrap;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Arrow triangle */
+.tooltip-bubble::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border: 5px solid transparent;
+  border-top-color: #1e293b;
+}
+
+/* Show on hover with bounce animation */
+.tooltip-wrapper:hover .tooltip-bubble {
+  visibility: visible;
+  opacity: 1;
+  animation: tooltip-bounce 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+@keyframes tooltip-bounce {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(10px);
+  }
+  60% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(-5px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+/* Helper classes for positioning (mirror EaseMotion but not in core) */
+.ease-inline-block {
+  display: inline-block;
+}
+.ease-relative {
+  position: relative;
+}
+.ease-absolute {
+  position: absolute;
+}
+.ease-bottom-full {
+  bottom: 100%;
+}
+.ease-left-1\/2 {
+  left: 50%;
+}
+.ease--translate-x-1\/2 {
+  transform: translateX(-50%);
+}
+.ease-mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-wrapper:hover .tooltip-bubble {
+    animation: none;
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}


### PR DESCRIPTION
Closes #17814

ease-animated-tooltip-bounce – CSS‑Only Bouncing Tooltip
A tooltip that appears with a bounce animation on hover, no JavaScript required.

Files added
- submissions/examples/ease-animated-tooltip-bounce/demo.html
- submissions/examples/ease-animated-tooltip-bounce/style.css
- submissions/examples/ease-animated-tooltip-bounce/README.md

How it works
- Tooltip is hidden until the wrapper is hovered.
- A @keyframes animation gives a playful bounce (slide up + overshoot).
- Arrow triangle included via ::after.
- Respects prefers-reduced-motion.