### PR TITLE
feat: add backdrop-filter utilities (#16684)

### DIFF
--- a/submissions/examples/backdrop-filter-itssagarK/README.md
+++ b/submissions/examples/backdrop-filter-itssagarK/README.md
@@ -1,0 +1,5 @@
+# Backdrop Filter Utilities
+
+1. What does this do? Adds backdrop-filter utility classes to apply graphical effects like blurring, brightness, contrast, grayscale, saturation, and sepia to the area behind an element.
+2. How is it used? Apply classes like `.backdrop-blur-md` or `.backdrop-grayscale` to semi-transparent overlay elements.
+3. Why is it useful? It enables gorgeous glassmorphism designs and improves overlay text readability by dynamically filtering the background content.

--- a/submissions/examples/backdrop-filter-itssagarK/demo.html
+++ b/submissions/examples/backdrop-filter-itssagarK/demo.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Backdrop Filter Utilities - EaseMotion CSS</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <div class="bg-image"></div>
+
+    <div class="container">
+      <header class="header">
+        <h1>Backdrop Filter Utilities</h1>
+        <p class="subtitle">
+          Premium glassmorphism effects applied to elements with CSS filters.
+        </p>
+      </header>
+
+      <div class="filter-grid">
+        <div class="glass-card backdrop-blur-sm">
+          <h3>Backdrop Blur SM</h3>
+          <p>blur(4px)</p>
+        </div>
+
+        <div class="glass-card backdrop-blur-md">
+          <h3>Backdrop Blur MD</h3>
+          <p>blur(8px)</p>
+        </div>
+
+        <div class="glass-card backdrop-blur-lg">
+          <h3>Backdrop Blur LG</h3>
+          <p>blur(16px)</p>
+        </div>
+
+        <div class="glass-card backdrop-blur-xl">
+          <h3>Backdrop Blur XL</h3>
+          <p>blur(24px)</p>
+        </div>
+
+        <div class="glass-card backdrop-brightness-50">
+          <h3>Backdrop Brightness</h3>
+          <p>brightness(0.5)</p>
+        </div>
+
+        <div class="glass-card backdrop-contrast-150">
+          <h3>Backdrop Contrast</h3>
+          <p>contrast(1.5)</p>
+        </div>
+
+        <div class="glass-card backdrop-grayscale">
+          <h3>Backdrop Grayscale</h3>
+          <p>grayscale(1)</p>
+        </div>
+
+        <div class="glass-card backdrop-sepia">
+          <h3>Backdrop Sepia</h3>
+          <p>sepia(1)</p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/backdrop-filter-itssagarK/style.css
+++ b/submissions/examples/backdrop-filter-itssagarK/style.css
@@ -1,0 +1,213 @@
+/* Design System Custom Properties */
+:root {
+  --ease-color-bg: #0b0f19;
+  --ease-color-surface: rgba(255, 255, 255, 0.08);
+  --ease-color-text: #f3f4f6;
+  --ease-color-muted: #9ca3af;
+  --ease-color-primary: #6366f1;
+  --ease-color-secondary: #a855f7;
+  --ease-color-border: rgba(255, 255, 255, 0.15);
+  --ease-radius-md: 12px;
+  --ease-radius-lg: 24px;
+  --ease-shadow-md: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
+  --ease-font-sans: "Outfit", "Inter", system-ui, sans-serif;
+  --ease-ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: var(--ease-font-sans);
+  overflow-x: hidden;
+}
+
+/* Background image/pattern showcase */
+.bg-image {
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(
+      ellipse at 20% 30%,
+      rgba(99, 102, 241, 0.35) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse at 80% 70%,
+      rgba(168, 85, 247, 0.3) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse at 50% 50%,
+      rgba(59, 130, 246, 0.2) 0%,
+      transparent 70%
+    ),
+    #0b0f19;
+  z-index: -1;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 60px 20px;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  background: linear-gradient(
+    135deg,
+    var(--ease-color-primary),
+    var(--ease-color-secondary)
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 12px;
+  letter-spacing: -0.03em;
+}
+
+.header .subtitle {
+  font-size: 1.1rem;
+  color: var(--ease-color-muted);
+}
+
+.filter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.glass-card {
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: var(--ease-radius-md);
+  padding: 24px;
+  box-shadow: var(--ease-shadow-md);
+  text-align: center;
+  transition:
+    transform 0.2s var(--ease-ease),
+    border-color 0.2s var(--ease-ease);
+}
+
+.glass-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--ease-color-primary);
+}
+
+.glass-card h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.glass-card p {
+  font-size: 0.8rem;
+  color: var(--ease-color-muted);
+}
+
+/* Backdrop Filter Utilities */
+.backdrop-blur-none {
+  backdrop-filter: blur(0px);
+  -webkit-backdrop-filter: blur(0px);
+}
+
+.backdrop-blur-sm {
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.backdrop-blur-md {
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.backdrop-blur-lg {
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.backdrop-blur-xl {
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+}
+
+.backdrop-brightness-50 {
+  backdrop-filter: brightness(0.5);
+  -webkit-backdrop-filter: brightness(0.5);
+}
+
+.backdrop-brightness-100 {
+  backdrop-filter: brightness(1);
+  -webkit-backdrop-filter: brightness(1);
+}
+
+.backdrop-brightness-150 {
+  backdrop-filter: brightness(1.5);
+  -webkit-backdrop-filter: brightness(1.5);
+}
+
+.backdrop-contrast-50 {
+  backdrop-filter: contrast(0.5);
+  -webkit-backdrop-filter: contrast(0.5);
+}
+
+.backdrop-contrast-100 {
+  backdrop-filter: contrast(1);
+  -webkit-backdrop-filter: contrast(1);
+}
+
+.backdrop-contrast-150 {
+  backdrop-filter: contrast(1.5);
+  -webkit-backdrop-filter: contrast(1.5);
+}
+
+.backdrop-grayscale {
+  backdrop-filter: grayscale(1);
+  -webkit-backdrop-filter: grayscale(1);
+}
+
+.backdrop-hue-rotate-90 {
+  backdrop-filter: hue-rotate(90deg);
+  -webkit-backdrop-filter: hue-rotate(90deg);
+}
+
+.backdrop-invert {
+  backdrop-filter: invert(1);
+  -webkit-backdrop-filter: invert(1);
+}
+
+.backdrop-opacity-50 {
+  backdrop-filter: opacity(0.5);
+  -webkit-backdrop-filter: opacity(0.5);
+}
+
+.backdrop-saturate-150 {
+  backdrop-filter: saturate(1.5);
+  -webkit-backdrop-filter: saturate(1.5);
+}
+
+.backdrop-sepia {
+  backdrop-filter: sepia(1);
+  -webkit-backdrop-filter: sepia(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .backdrop-blur-sm,
+  .backdrop-blur-md,
+  .backdrop-blur-lg,
+  .backdrop-blur-xl {
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+  }
+}


### PR DESCRIPTION
This PR closes Issue #16684 

  • PR Title:  feat: add backdrop-filter utilities (#16684) 
  • Short Description:
    ### Description
    Adds a set of backdrop-filter utility classes to apply visual effects (blur,
  brightness, contrast, grayscale, saturate, sepia) to backgrounds behind semi-transparent
  elements.
    
    ### Utilities Added
    - `.backdrop-blur-sm` / `.backdrop-blur-md` / `.backdrop-blur-lg` / `.backdrop-blur-
  xl` / `.backdrop-blur-none`
    - `.backdrop-brightness-50` / `.backdrop-brightness-100` / `.backdrop-brightness-150`
    - `.backdrop-contrast-50` / `.backdrop-contrast-100` / `.backdrop-contrast-150`
    - `.backdrop-grayscale`
    - `.backdrop-hue-rotate-90`
    - `.backdrop-invert`
    - `.backdrop-opacity-50`
    - `.backdrop-saturate-150`
    - `.backdrop-sepia`
    