### PR TITLE
fix: add properly structured scroll-to-top submission with demo.html

### DIFF
--- a/submissions/examples/scroll-to-top-v1/README.md
+++ b/submissions/examples/scroll-to-top-v1/README.md
@@ -1,0 +1,16 @@
+# Scroll to Top
+
+**What does this do?**
+A fixed scroll-to-top button that appears at the bottom-right corner and smoothly scrolls the page to the top when clicked.
+
+**How is it used?**
+```html
+<button class="scroll-to-top" id="scrollBtn">↑ Top</button>
+<script>
+  document.getElementById('scrollBtn')
+    .addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+</script>
+```
+
+**Why is it useful?**
+Improves navigation on long-scrolling pages by giving users a quick way to return to the top without manual scrolling.

--- a/submissions/examples/scroll-to-top-v1/demo.html
+++ b/submissions/examples/scroll-to-top-v1/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll to Top</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="content">
+    <p>Scroll down to see the button</p>
+    <div class="spacer"></div>
+    <button class="scroll-to-top" id="scrollBtn">↑ Top</button>
+  </div>
+  <script>
+    const btn = document.getElementById('scrollBtn');
+    btn.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+  </script>
+</body>
+</html>

--- a/submissions/examples/scroll-to-top-v1/style.css
+++ b/submissions/examples/scroll-to-top-v1/style.css
@@ -1,0 +1,39 @@
+body {
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  min-height: 200vh;
+  background: #0f0e17;
+  color: #fff;
+  display: flex;
+  justify-content: center;
+}
+
+.content {
+  text-align: center;
+  padding-top: 2rem;
+}
+
+.spacer {
+  height: 150vh;
+}
+
+.scroll-to-top {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: none;
+  background: #ff8906;
+  color: #0f0e17;
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: transform 0.2s, opacity 0.2s;
+  opacity: 0.8;
+}
+
+.scroll-to-top:hover {
+  transform: scale(1.1);
+  opacity: 1;
+}


### PR DESCRIPTION
﻿Closes #17718

## Fix
Created a properly structured scroll-to-top submission at `submissions/examples/scroll-to-top-v1/` that demonstrates the correct file structure:
- `demo.html` — self-contained HTML demo with DOCTYPE, html, head, body, title
- `style.css` — meaningful CSS with 15+ lines of rules
- `README.md` — documentation with all 3 required sections

This serves as a reference example for the broken `submissions/examples/scroll to top/` folder which uses `index.html` instead of `demo.html`.

**Note:** Only submissions inside submissions/examples/ are accepted right now.
