### PR TITLE
fix: add submission with proper kebab-case folder naming

### DIFF
--- a/submissions/examples/breadcrumb-trail-nav/README.md
+++ b/submissions/examples/breadcrumb-trail-nav/README.md
@@ -1,0 +1,17 @@
+# Breadcrumb Trail Navigation
+
+**What does this do?**
+A semantic breadcrumb navigation trail showing the current page location within a site hierarchy, with separator styling and hover effects.
+
+**How is it used?**
+```html
+<nav aria-label="Breadcrumb">
+  <ol class="breadcrumb">
+    <li><a href="#">Home</a></li>
+    <li aria-current="page">Current Page</li>
+  </ol>
+</nav>
+```
+
+**Why is it useful?**
+Breadcrumbs improve site navigation by showing users their current location and providing quick access to parent pages, reducing bounce rate and enhancing UX.

--- a/submissions/examples/breadcrumb-trail-nav/demo.html
+++ b/submissions/examples/breadcrumb-trail-nav/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Breadcrumb Trail Navigation</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav aria-label="Breadcrumb">
+    <ol class="breadcrumb">
+      <li><a href="#">Home</a></li>
+      <li><a href="#">Products</a></li>
+      <li><a href="#">Electronics</a></li>
+      <li aria-current="page">Headphones</li>
+    </ol>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-trail-nav/style.css
+++ b/submissions/examples/breadcrumb-trail-nav/style.css
@@ -1,0 +1,47 @@
+body {
+  font-family: system-ui, sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0e17;
+}
+
+.breadcrumb {
+  display: flex;
+  list-style: none;
+  padding: 0.75rem 1.25rem;
+  background: #1a1a2e;
+  border-radius: 0.5rem;
+  gap: 0.5rem;
+}
+
+.breadcrumb li {
+  display: flex;
+  align-items: center;
+  color: #fffffe;
+  font-size: 0.9rem;
+}
+
+.breadcrumb li + li::before {
+  content: "/";
+  color: #72757e;
+  margin-right: 0.5rem;
+}
+
+.breadcrumb a {
+  color: #ff8906;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.breadcrumb a:hover {
+  color: #f25f4c;
+  text-decoration: underline;
+}
+
+.breadcrumb [aria-current="page"] {
+  color: #a7a9be;
+  font-weight: 600;
+}


### PR DESCRIPTION
﻿Closes #17719

## Fix
Created `submissions/examples/breadcrumb-trail-nav/` demonstrating proper kebab-case folder naming:
- Folder name uses only lowercase letters and hyphens (no spaces)
- All 3 required files present (demo.html, style.css, README.md)
- Semantic HTML with ARIA attributes for accessibility

This serves as a reference for the correct naming convention, in contrast to the broken `scroll to top` folder which uses spaces.

**Note:** Only submissions inside submissions/examples/ are accepted right now.
