### PR TITLE
fix: add submission with README.md (uppercase R)

### DIFF
--- a/submissions/examples/pulse-ring-loader/README.md
+++ b/submissions/examples/pulse-ring-loader/README.md
@@ -1,0 +1,12 @@
+# Pulse Ring Loader
+
+**What does this do?**
+A pure CSS spinning ring loader with no external dependencies, using only border and animation properties for a smooth loading indicator.
+
+**How is it used?**
+```html
+<div class="loader-ring"></div>
+```
+
+**Why is it useful?**
+Provides a lightweight, zero-dependency loading spinner that works in any project without JavaScript or external libraries.

--- a/submissions/examples/pulse-ring-loader/demo.html
+++ b/submissions/examples/pulse-ring-loader/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pulse Ring Loader</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="loader-ring"></div>
+</body>
+</html>

--- a/submissions/examples/pulse-ring-loader/style.css
+++ b/submissions/examples/pulse-ring-loader/style.css
@@ -1,0 +1,21 @@
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0e17;
+}
+
+.loader-ring {
+  width: 4rem;
+  height: 4rem;
+  border: 4px solid #2d2d44;
+  border-top-color: #ff8906;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
Closes #17720

## Fix
Created `submissions/examples/pulse-ring-loader/` with `README.md` using correct uppercase casing (not lowercase `readme.md`).

On case-sensitive filesystems (Linux — used by GitHub Actions CI), `readme.md` differs from `README.md` and the CI validator fails to detect it as the required documentation file.

This demonstrates the correct file naming convention.

**Note:** Only submissions inside submissions/examples/ are accepted right now.
