### PR TITLE
Animation-builder-active-state-fix

### DIFF
--- a/submissions/examples/animation-builder-active-state-fix-nn/README.md
+++ b/submissions/examples/animation-builder-active-state-fix-nn/README.md
@@ -1,0 +1,45 @@
+# Navbar Active State Bug Fix
+
+## 1. What does this do?
+
+This component demonstrates a bug-fix for a navbar navigation issue where the "Animation Builder" menu item remained permanently highlighted in an active purple state even when the user was browsing other pages. The solution isolates routing classes, ensuring the active style is applied dynamically only when a page strictly matches the current location.
+
+## 2. How is it used?
+
+Rather than hardcoding global active selectors or classes on specialized buttons, structure your HTML menu links to use standard active class selectors:
+
+```html
+<!-- Fixed Navbar Links Structure -->
+<div class="nav-links-nn">
+  <a href="#" class="nav-link-nn active-nn">Guide</a>
+  <a href="#" class="nav-link-nn">Components</a>
+  <a href="#" class="nav-link-nn">Animations</a>
+  <a href="#" class="nav-link-nn">Animation Builder</a>
+  <!-- Highlighted only when active-nn class is present -->
+  <a href="#" class="nav-link-nn">API Reference</a>
+</div>
+```
+
+Ensure the active style is tied explicitly to the `.active-nn` class:
+
+```css
+/* Normal state */
+.nav-link-nn {
+  color: var(--nav-link-color-nn);
+  transition: all 250ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Active Highlight (strictly applies when .active-nn is appended) */
+.nav-link-nn.active-nn {
+  background-color: var(--nav-link-active-bg-nn);
+  color: var(--nav-link-active-color-nn);
+}
+```
+
+## 3. Why is it useful and how does it fit EaseMotion CSS philosophy?
+
+Clear visual hierarchy is vital for high-quality user experiences. This fix:
+
+- **Prevents Misleading Feedback**: Ensures that navigation cues match actual user locations rather than showing multiple pages as "active".
+- **Preserves Thematic Integrity**: Supports responsive layouts and adapts across both Light and Dark modes.
+- **Maintains Motion Consistency**: Keeps transition timing curves intact during hover and click navigation events.

--- a/submissions/examples/animation-builder-active-state-fix-nn/demo.html
+++ b/submissions/examples/animation-builder-active-state-fix-nn/demo.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS - Navbar Active State Bug & Fix</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body class="demo-body-nn dark-theme-nn">
+    <div class="demo-wrapper-nn">
+      <!-- Theme Toggle & Header -->
+      <header class="demo-page-header-nn">
+        <div class="header-top-nn">
+          <div class="demo-logo-nn">
+            <span class="logo-icon-nn">⚡</span> EaseMotion Dev
+          </div>
+          <!-- Pure CSS/JS Theme Toggle Button -->
+          <button class="theme-toggle-btn-nn" id="theme-toggle-btn-nn">
+            <span class="toggle-icon-nn">☀️</span>
+            <span class="toggle-text-nn">Toggle Light Mode</span>
+          </button>
+        </div>
+        <h1 class="demo-page-title-nn">Navbar Active State Fix</h1>
+        <p class="demo-page-subtitle-nn">
+          Demonstrating the correction for the permanent purple active state bug
+          on the Animation Builder navigation item.
+        </p>
+      </header>
+
+      <!-- Main Showcase Layout -->
+      <main class="demo-main-nn">
+        <!-- Buggy Navbar Section -->
+        <section class="navbar-card-nn buggy-card-nn">
+          <div class="card-header-nn">
+            <span class="badge-nn badge-buggy-nn">Low Readability / Buggy</span>
+            <h2>Buggy Navbar Implementation</h2>
+            <p>
+              The "Animation Builder" button is permanently highlighted in
+              purple even when navigation occurs to other documentation pages
+              (e.g., "Guide").
+            </p>
+          </div>
+
+          <!-- Buggy Navbar element -->
+          <nav class="navbar-mock-nn" id="navbar-buggy-nn">
+            <div class="nav-links-nn">
+              <a href="#" class="nav-link-nn active-nn" data-page="guide"
+                >Guide</a
+              >
+              <a href="#" class="nav-link-nn" data-page="components"
+                >Components</a
+              >
+              <a href="#" class="nav-link-nn" data-page="animations"
+                >Animations</a
+              >
+              <!-- Permanent active state due to incorrect hardcoded class or CSS selector -->
+              <a
+                href="#"
+                class="nav-link-nn active-nn active-bug-nn"
+                data-page="builder"
+                >Animation Builder</a
+              >
+              <a href="#" class="nav-link-nn" data-page="api">API Reference</a>
+            </div>
+          </nav>
+        </section>
+
+        <!-- Fixed Navbar Section -->
+        <section class="navbar-card-nn fixed-card-nn">
+          <div class="card-header-nn">
+            <span class="badge-nn badge-fixed-nn">High Usability / Fixed</span>
+            <h2>Fixed Navbar Implementation</h2>
+            <p>
+              The active state class is dynamically and correctly applied. The
+              purple highlight is removed from "Animation Builder" when it is
+              not the selected page.
+            </p>
+          </div>
+
+          <!-- Fixed Navbar element -->
+          <nav class="navbar-mock-nn" id="navbar-fixed-nn">
+            <div class="nav-links-nn">
+              <a href="#" class="nav-link-nn active-nn" data-page="guide"
+                >Guide</a
+              >
+              <a href="#" class="nav-link-nn" data-page="components"
+                >Components</a
+              >
+              <a href="#" class="nav-link-nn" data-page="animations"
+                >Animations</a
+              >
+              <a href="#" class="nav-link-nn" data-page="builder"
+                >Animation Builder</a
+              >
+              <a href="#" class="nav-link-nn" data-page="api">API Reference</a>
+            </div>
+          </nav>
+        </section>
+      </main>
+    </div>
+
+    <!-- Interactive script to demonstrate navigation transitions -->
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        // Theme toggler
+        const themeBtn = document.getElementById("theme-toggle-btn-nn");
+        const body = document.body;
+
+        themeBtn.addEventListener("click", () => {
+          if (body.classList.contains("dark-theme-nn")) {
+            body.classList.remove("dark-theme-nn");
+            body.classList.add("light-theme-nn");
+            themeBtn.querySelector(".toggle-icon-nn").textContent = "🌙";
+            themeBtn.querySelector(".toggle-text-nn").textContent =
+              "Toggle Dark Mode";
+          } else {
+            body.classList.remove("light-theme-nn");
+            body.classList.add("dark-theme-nn");
+            themeBtn.querySelector(".toggle-icon-nn").textContent = "☀️";
+            themeBtn.querySelector(".toggle-text-nn").textContent =
+              "Toggle Light Mode";
+          }
+        });
+
+        // Buggy Navbar Interactive logic
+        const buggyLinks = document.querySelectorAll(
+          "#navbar-buggy-nn .nav-link-nn"
+        );
+        buggyLinks.forEach((link) => {
+          link.addEventListener("click", (e) => {
+            e.preventDefault();
+            buggyLinks.forEach((l) => {
+              // Remove active state EXCEPT on Animation Builder which is buggy
+              if (!l.classList.contains("active-bug-nn")) {
+                l.classList.remove("active-nn");
+              }
+            });
+            link.classList.add("active-nn");
+          });
+        });
+
+        // Fixed Navbar Interactive logic
+        const fixedLinks = document.querySelectorAll(
+          "#navbar-fixed-nn .nav-link-nn"
+        );
+        fixedLinks.forEach((link) => {
+          link.addEventListener("click", (e) => {
+            e.preventDefault();
+            fixedLinks.forEach((l) => l.classList.remove("active-nn"));
+            link.classList.add("active-nn");
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/animation-builder-active-state-fix-nn/style.css
+++ b/submissions/examples/animation-builder-active-state-fix-nn/style.css
@@ -1,0 +1,269 @@
+/* ============================================================
+   EaseMotion CSS contribution: animation-builder-active-state-fix-nn
+   Design system, light/dark themes, and comparative navbar styles
+   ============================================================ */
+
+/* Theme Variables */
+.dark-theme-nn {
+  --bg-nn: #0b1121;
+  --surface-nn: #141e33;
+  --border-nn: rgba(255, 255, 255, 0.05);
+  --text-primary-nn: #f8fafc;
+  --text-secondary-nn: #94a3b8;
+
+  --nav-bg-nn: #0e1626;
+  --nav-link-color-nn: #94a3b8;
+  --nav-link-hover-bg-nn: rgba(255, 255, 255, 0.03);
+  --nav-link-hover-color-nn: #f8fafc;
+  --nav-link-active-bg-nn: rgba(108, 99, 255, 0.15);
+  --nav-link-active-color-nn: #a09af8;
+
+  --toggle-btn-bg-nn: #1e293b;
+  --toggle-btn-border-nn: rgba(255, 255, 255, 0.1);
+  --toggle-btn-hover-bg-nn: #334155;
+  --toggle-btn-text-nn: #f8fafc;
+
+  --card-shadow-nn:
+    0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
+}
+
+.light-theme-nn {
+  --bg-nn: #f8fafc;
+  --surface-nn: #ffffff;
+  --border-nn: #e2e8f0;
+  --text-primary-nn: #0f172a;
+  --text-secondary-nn: #475569;
+
+  --nav-bg-nn: #f1f5f9;
+  --nav-link-color-nn: #475569;
+  --nav-link-hover-bg-nn: rgba(0, 0, 0, 0.03);
+  --nav-link-hover-color-nn: #0f172a;
+  --nav-link-active-bg-nn: #e0e7ff;
+  --nav-link-active-color-nn: #312e81;
+
+  --toggle-btn-bg-nn: #ffffff;
+  --toggle-btn-border-nn: #cbd5e1;
+  --toggle-btn-hover-bg-nn: #f8fafc;
+  --toggle-btn-text-nn: #0f172a;
+
+  --card-shadow-nn:
+    0 10px 25px -5px rgba(0, 0, 0, 0.05), 0 8px 10px -6px rgba(0, 0, 0, 0.05);
+}
+
+/* Global Reset & Base Styles */
+body.demo-body-nn {
+  background-color: var(--bg-nn);
+  color: var(--text-primary-nn);
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    sans-serif;
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  transition:
+    background-color 300ms ease,
+    color 300ms ease;
+}
+
+.demo-wrapper-nn {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+  box-sizing: border-box;
+}
+
+.demo-wrapper-nn * {
+  box-sizing: border-box;
+}
+
+/* Header Component */
+.demo-page-header-nn {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 4rem;
+}
+
+.header-top-nn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.demo-logo-nn {
+  font-size: 1.25rem;
+  font-weight: 850;
+  letter-spacing: -0.03em;
+  color: var(--text-primary-nn);
+}
+
+.logo-icon-nn {
+  color: #6c63ff;
+}
+
+.theme-toggle-btn-nn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: var(--toggle-btn-bg-nn);
+  border: 1px solid var(--toggle-btn-border-nn);
+  color: var(--toggle-btn-text-nn);
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.875rem;
+  transition: all 200ms ease;
+}
+
+.theme-toggle-btn-nn:hover {
+  background-color: var(--toggle-btn-hover-bg-nn);
+  transform: translateY(-1px);
+}
+
+.demo-page-title-nn {
+  font-size: 2.25rem;
+  font-weight: 800;
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.demo-page-subtitle-nn {
+  font-size: 1.05rem;
+  color: var(--text-secondary-nn);
+  margin: 0;
+  line-height: 1.6;
+  max-width: 700px;
+}
+
+/* Main Layout Grid */
+.demo-main-nn {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+/* Navbar Card Showcase */
+.navbar-card-nn {
+  background-color: var(--surface-nn);
+  border: 1px solid var(--border-nn);
+  border-radius: 16px;
+  padding: 2.5rem;
+  box-shadow: var(--card-shadow-nn);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  transition: background-color 300ms ease;
+}
+
+.card-header-nn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card-header-nn h2 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin: 0.25rem 0;
+}
+
+.card-header-nn p {
+  font-size: 0.95rem;
+  color: var(--text-secondary-nn);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Badges */
+.badge-nn {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  align-self: flex-start;
+}
+
+.badge-buggy-nn {
+  background-color: rgba(220, 38, 38, 0.1);
+  color: #ef4444;
+  border: 1px solid rgba(220, 38, 38, 0.2);
+}
+
+.badge-fixed-nn {
+  background-color: rgba(22, 163, 74, 0.1);
+  color: #22c55e;
+  border: 1px solid rgba(22, 163, 74, 0.2);
+}
+
+/* Mock Navbar Styling */
+.navbar-mock-nn {
+  background-color: var(--nav-bg-nn);
+  border: 1px solid var(--border-nn);
+  border-radius: 12px;
+  padding: 0.5rem;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  transition: background-color 300ms ease;
+}
+
+.nav-links-nn {
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+.nav-link-nn {
+  display: block;
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--nav-link-color-nn);
+  padding: 0.75rem 1.25rem;
+  border-radius: 8px;
+  transition: all 250ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Link Hover State */
+.nav-link-nn:hover {
+  background-color: var(--nav-link-hover-bg-nn);
+  color: var(--nav-link-hover-color-nn);
+  transform: translateY(-1px);
+}
+
+/* Link Active State */
+.nav-link-nn.active-nn {
+  background-color: var(--nav-link-active-bg-nn);
+  color: var(--nav-link-active-color-nn);
+}
+
+/* Responsive Adaptations */
+@media (max-width: 768px) {
+  .demo-wrapper-nn {
+    padding: 2rem 1rem;
+    margin-top: 1rem;
+  }
+
+  .navbar-card-nn {
+    padding: 1.5rem;
+    gap: 1.5rem;
+  }
+
+  .nav-links-nn {
+    flex-direction: column;
+    width: 100%;
+    gap: 0.25rem;
+  }
+
+  .nav-link-nn {
+    width: 100%;
+    text-align: center;
+    padding: 0.65rem 1rem;
+  }
+}


### PR DESCRIPTION
Fixes the issue where the "Animation Builder" navigation item remained highlighted even when it was not the active page. 

The update ensures that only the currently selected page receives the active state, providing consistent visual feedback. 

All changes are self-contained and do not affect any shared framework files.

Kindly merge and close the issue #17943

