### PR TITLE
feat: add pure css retro crt monitor scanline and phosphor flicker ef…

### DIFF
--- a/submissions/examples/retro-crt-effect-pr/README.md
+++ b/submissions/examples/retro-crt-effect-pr/README.md
@@ -1,0 +1,10 @@
+# CSS-Only Retro CRT Monitor Effect
+
+### What does this do?
+Simulates the iconic visual qualities of a vintage CRT glass computer monitor—including horizontal scanlines, organic ambient panel flicker, and vignette edge curvature shadowing—using raw style attributes.
+
+### How is it used?
+Wrap text-content windows inside a `.crt-monitor-container` bezel mask housing an inner `.crt-screen` filter engine layout.
+
+### Why is it useful?
+It provides creative applications, retro video game dashboards, and stylized terminal UI interfaces with high-fidelity vintage aesthetics utilizing performant background gradient parameters rather than using heavy canvas image filters.

--- a/submissions/examples/retro-crt-effect-pr/demo.html
+++ b/submissions/examples/retro-crt-effect-pr/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Retro CRT Monitor Effect</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="crt-monitor-container">
+    
+    <div class="crt-screen">
+      <div class="terminal-header">
+        SYS.OPERATIONS // TERMINAL_DECK_A
+      </div>
+      <div class="terminal-text">
+        > LOAD "EASE_MOTION_ENGINE",8,1<br>
+        > INITIALIZING PHOSPHOR MATRIX VECTORS...<br>
+        > SCANLINES MOUNTED ON HARDWARE LAYER COMPOSITIONS.<br>
+        > SYSTEM STABLE. AWAITING TELEMETRY ENTRY INPUT<span class="blink-cursor"></span>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/retro-crt-effect-pr/style.css
+++ b/submissions/examples/retro-crt-effect-pr/style.css
@@ -1,0 +1,113 @@
+/* submissions/examples/retro-crt-effect-pr/style.css */
+
+body {
+  font-family: 'Courier New', Courier, monospace;
+  background-color: #05070a;
+  color: #33ff33; /* Classic phosphor green tint */
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+/* ==========================================================================
+   Core Engine: CRT Terminal Chassis Screen Layout
+   ========================================================================== */
+.crt-monitor-container {
+  position: relative;
+  width: 640px;
+  height: 440px;
+  background-color: #0c100c;
+  border: 16px solid #1a1a1a; /* Thick monitor bezel */
+  border-radius: 32px;
+  box-shadow: 
+    0 25px 50px -12px rgba(0, 0, 0, 0.8),
+    inset 0 0 40px rgba(0, 0, 0, 0.9);
+  overflow: hidden;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+/* Base CRT Screen Layer Filters */
+.crt-screen {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  animation: crtPhosphorFlicker 0.15s infinite;
+}
+
+/* Layer 1: Symmetrical Vignette Glass Curve Overlay */
+.crt-screen::before {
+  content: " ";
+  display: block;
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(0,0,0,0) 60%, rgba(0,0,0,0.75) 100%);
+  z-index: 30;
+  pointer-events: none;
+}
+
+/* Layer 2: Tight Repeating Scanline Pattern Layer */
+.crt-screen::after {
+  content: " ";
+  display: block;
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    rgba(18, 16, 16, 0) 0px,
+    rgba(18, 16, 16, 0) 1px,
+    rgba(0, 0, 0, 0.25) 2px,
+    rgba(0, 0, 0, 0.25) 3px
+  );
+  background-size: 100% 4px;
+  z-index: 20;
+  pointer-events: none;
+}
+
+/* ==========================================================================
+   Animation Timelines: Phosphor Glow & Scanning Deflection
+   ========================================================================== */
+@keyframes crtPhosphorFlicker {
+  0%   { opacity: 0.985; }
+  50%  { opacity: 1.000; }
+  100% { opacity: 0.992; }
+}
+
+/* Decorative terminal content styling rules */
+.terminal-header {
+  border-bottom: 2px solid #33ff33;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1.5rem;
+  font-weight: bold;
+}
+
+.terminal-text {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  text-shadow: 0 0 4px rgba(51, 255, 51, 0.55);
+}
+
+.blink-cursor {
+  display: inline-block;
+  width: 10px;
+  height: 1.2rem;
+  background-color: #33ff33;
+  margin-left: 4px;
+  vertical-align: middle;
+  animation: terminalCursorBlink 0.8s steps(2, start) infinite;
+}
+
+@keyframes terminalCursorBlink {
+  to { visibility: hidden; }
+}
+
+/* Accessibility handling */
+@media (prefers-reduced-motion: reduce) {
+  .crt-screen, .blink-cursor {
+    animation: none !important;
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
Closes #17659

retro-crt-effect – CSS-Only Retro CRT Monitor Effect
A nostalgic, stylized user component layout replicating the aesthetic physics of vintage cathode-ray tube terminals using optimized background gradients and minimal flicker animations.

Files added
submissions/examples/retro-crt-effect-pr/demo.html

submissions/examples/retro-crt-effect-pr/style.css

submissions/examples/retro-crt-effect-pr/README.md

How it works
Replicates horizontal cathode-ray beam loops by stretching a micro repeating-linear-gradient() slice structure smoothly over the viewing canvas.

Simulates physical glass tube edge distortions by stacking a high-intensity radial-gradient() vignette mask layer directly over the content coordinates.

Uses low-frequency opacity adjustments (crtPhosphorFlicker) to add an organic, retro phosphor hum without triggering layout layout thrashing.

Preserves user readability boundaries by turning off the global animation loop completely under standard access rules matching @media (prefers-reduced-motion: reduce).