### PR TITLE
feat: add fade-out exit animation with delay variants

### DIFF
--- a/submissions/examples/fade-out-ms07/README.md
+++ b/submissions/examples/fade-out-ms07/README.md
@@ -1,0 +1,22 @@
+# Fade Out (Exit Animation)
+
+1. **What does this do?**
+   Fades an element from `opacity: 1` to `opacity: 0` when it's removed or hidden — the exit counterpart to an entrance fade-in animation. The faded-out state holds at `opacity: 0` once the animation finishes, rather than snapping back.
+
+2. **How is it used?**
+   Add the `fadeout-playing` class to an element to trigger the fade-out. In this demo, clicking a box toggles the class via JS (and removes it first to allow replay), but in real usage it would typically be added right before an element is removed from the DOM or hidden. Stagger multiple elements by combining it with a delay variant: `fadeout-delay-1`, `fadeout-delay-2`, or `fadeout-delay-3` (150ms / 300ms / 450ms).
+
+   ```html
+   <div class="fadeout-box fadeout-delay-2">Goodbye</div>
+   <!-- add `fadeout-playing` via JS right before removing/hiding the element -->
+   ```
+
+3. **Why is this useful?**
+   Every Motion Library currently has entrance animations (fade-in, slide-in, etc.) but no symmetric exit counterpart — anything fading out today has to be hand-rolled. This fills that gap as a small, composable primitive: a clean single-purpose animation that pairs with the existing delay-class system rather than introducing a new one, matching the framework's "small, composable, hover/interaction-driven" philosophy.
+
+### Notes for the maintainer
+- This resolves the `ease-fade-out` issue, but is submitted as an unprefixed standalone demo (`fadeout-*` naming) per the contribution guidelines, since adding a class directly into the core Motion Library under `// Exit animations` is maintainer territory. The animation in `style.css` (`fadeout-fade` keyframe + `.fadeout-playing`) is written to be a near-literal drop-in for `.ease-fade-out` — happy to adjust naming/timing on integration.
+- The demo boxes intentionally match the size/border/label layout style used by other entrance-animation demos in the library, so it reads as a matched pair with `ease-fade-in`.
+- Delay classes (`fadeout-delay-1/2/3`) only apply `animation-delay` while `.fadeout-playing` is active, so they compose cleanly without needing separate keyframes.
+- `prefers-reduced-motion: reduce` skips straight to the faded-out end state instead of animating.
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/fade-out-ms07/demo.html
+++ b/submissions/examples/fade-out-ms07/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fade Out — Exit Animation Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <main class="fadeout-demo-wrapper">
+
+    <p class="fadeout-demo-hint">Click any box to play its fade-out exit animation. Click "Replay all" to reset.</p>
+
+    <div class="fadeout-demo-grid">
+
+      <div class="fadeout-box" data-replayable>
+        <span class="fadeout-box-label">fade-out</span>
+        <span class="fadeout-box-sub">no delay</span>
+      </div>
+
+      <div class="fadeout-box fadeout-delay-1" data-replayable>
+        <span class="fadeout-box-label">fade-out</span>
+        <span class="fadeout-box-sub">delay-1 (150ms)</span>
+      </div>
+
+      <div class="fadeout-box fadeout-delay-2" data-replayable>
+        <span class="fadeout-box-label">fade-out</span>
+        <span class="fadeout-box-sub">delay-2 (300ms)</span>
+      </div>
+
+      <div class="fadeout-box fadeout-delay-3" data-replayable>
+        <span class="fadeout-box-label">fade-out</span>
+        <span class="fadeout-box-sub">delay-3 (450ms)</span>
+      </div>
+
+    </div>
+
+    <button class="fadeout-replay-btn" type="button" id="replayAllBtn">↺ Replay all</button>
+
+  </main>
+
+  <script>
+    (function () {
+      const boxes = Array.from(document.querySelectorAll('[data-replayable]'));
+      const replayAllBtn = document.getElementById('replayAllBtn');
+
+      function playFadeOut(box) {
+        // Remove and re-add the class so the animation can replay even if
+        // it's already in its finished (faded) state.
+        box.classList.remove('fadeout-playing');
+        box.classList.remove('fadeout-finished');
+        // Force a reflow so the browser registers the class removal
+        // before we add it back — required to restart a CSS animation.
+        void box.offsetWidth;
+        box.classList.add('fadeout-playing');
+      }
+
+      boxes.forEach((box) => {
+        box.addEventListener('click', () => playFadeOut(box));
+
+        box.addEventListener('animationend', () => {
+          box.classList.add('fadeout-finished');
+        });
+      });
+
+      replayAllBtn.addEventListener('click', () => {
+        boxes.forEach((box) => playFadeOut(box));
+      });
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/fade-out-ms07/style.css
+++ b/submissions/examples/fade-out-ms07/style.css
@@ -1,0 +1,135 @@
+/* ===================================================================
+   Fade Out — exit animation demo styles
+   Class names are unprefixed on purpose; the maintainer will rename
+   the core animation to ease-fade-out during integration.
+   =================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0b0f19;
+  color: #e7e9ee;
+}
+
+.fadeout-demo-wrapper {
+  padding: 56px 24px;
+  text-align: center;
+}
+
+.fadeout-demo-hint {
+  font-size: 0.85rem;
+  color: #8b93a7;
+  margin: 0 0 28px;
+}
+
+.fadeout-demo-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+/* ---------------------------------------------------------------
+   Box — consistent with the existing entrance-animation boxes
+   used elsewhere in the Motion Library demos (fixed size, centered
+   label, rounded corners, accent border).
+   --------------------------------------------------------------- */
+
+.fadeout-box {
+  width: 160px;
+  height: 110px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  background: #161b29;
+  border: 1px solid #6c63ff44;
+  border-radius: 12px;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 0.2s ease;
+}
+
+.fadeout-box:hover {
+  border-color: #6c63ffaa;
+}
+
+.fadeout-box-label {
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: #f3f4f7;
+}
+
+.fadeout-box-sub {
+  font-size: 0.72rem;
+  color: #8b93a7;
+}
+
+/* ---------------------------------------------------------------
+   The exit animation itself.
+   This is the part the maintainer would promote into the core
+   Motion Library as `.ease-fade-out`.
+   --------------------------------------------------------------- */
+
+@keyframes fadeout-fade {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+.fadeout-box.fadeout-playing {
+  animation: fadeout-fade 0.4s ease forwards;
+}
+
+/* Hold the faded-out state after the animation completes, instead
+   of snapping back to opacity:1 — this is what makes "remove or
+   hide on exit" behavior visible rather than just a quick blink. */
+.fadeout-box.fadeout-finished {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ---------------------------------------------------------------
+   Delay variants — composable with the fade-out animation so it
+   can be staggered across a group of elements, consistent with
+   the delay classes already used by entrance animations.
+   --------------------------------------------------------------- */
+
+.fadeout-delay-1.fadeout-playing { animation-delay: 0.15s; }
+.fadeout-delay-2.fadeout-playing { animation-delay: 0.3s; }
+.fadeout-delay-3.fadeout-playing { animation-delay: 0.45s; }
+
+/* ---------------------------------------------------------------
+   Replay control
+   --------------------------------------------------------------- */
+
+.fadeout-replay-btn {
+  background: #6c63ff;
+  color: #fff;
+  border: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 10px 20px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease;
+}
+
+.fadeout-replay-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px -8px #6c63ffaa;
+}
+
+/* Respect users who prefer reduced motion — resolve straight to the
+   end state instead of animating the transition out. */
+@media (prefers-reduced-motion: reduce) {
+  .fadeout-box.fadeout-playing {
+    animation: none !important;
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS exit (fade-out) animation as a self-contained example —
the missing counterpart to an entrance fade-in — with replayable demo
boxes and three composable delay variants for staggering.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/fade-out-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fade-out exit animation (`opacity: 1 → 0`) that holds at its faded
end state once finished, with three delay variants for staggering
multiple elements.

**How does a developer use it?**

```html
<div class="fadeout-box fadeout-delay-2">Goodbye</div>
<!-- add `fadeout-playing` via JS right before removing/hiding the element -->
```

**Why does it fit EaseMotion CSS?**

Entrance animations like fade-in already exist in the Motion Library,
but there's no symmetric exit counterpart — this fills that gap as a
small, single-purpose primitive that composes with a delay-class
system rather than introducing a new one.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This resolves the `ease-fade-out` issue, but is submitted as an
unprefixed standalone demo (`fadeout-*` naming) per the contribution
guidelines, since adding a class directly into the core Motion Library
under `// Exit animations` is maintainer territory. The animation here
(`fadeout-fade` keyframe + `.fadeout-playing`) is written to be a
near-literal drop-in for `.ease-fade-out` — happy to adjust naming or
timing on integration. Delay classes (`fadeout-delay-1/2/3`) only
apply `animation-delay` while `.fadeout-playing` is active, so they
compose cleanly without separate keyframes. `prefers-reduced-motion`
skips straight to the faded-out end state.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/17959