### PR TITLE
feat: add constellation star map navigation

### DIFF
--- a/submissions/examples/constellation-nav-ms07/README.md
+++ b/submissions/examples/constellation-nav-ms07/README.md
@@ -1,0 +1,26 @@
+# Constellation Navigation
+
+1. **What does this do?**
+   Replaces a traditional nav menu with a "living" star map: navigation items are stars positioned across an SVG canvas. Hovering or focusing a star lights up connection lines to its nearest neighbors, sends a traveling energy pulse along those lines, gently drifts the other stars to make the layout feel alive, promotes the hovered star into a glowing "command node," and slides in an info panel describing that destination.
+
+2. **How is it used?**
+   The whole thing lives inside `.constellation-nav`, wrapping an SVG `.constellation-canvas`. Each nav item is a `.constellation-star` group (with `data-star="name"` and a `tabindex` for keyboard access) containing a glow circle, a core circle, and a text label. Connections between stars are plain SVG `<line>` elements tagged `.constellation-link` with `data-link="a-b"`, plus a matching `.constellation-pulse` circle for the traveling-energy effect. A small vanilla JS snippet toggles `constellation-star-active` / `constellation-link-active` / `constellation-pulse-active` on hover/focus and writes the destination's title/copy into `.constellation-panel`.
+
+   ```html
+   <g class="constellation-star" data-star="products" data-cx="320" data-cy="130" tabindex="0" role="link" aria-label="Products">
+     <circle class="constellation-star-glow" cx="320" cy="130" r="22"></circle>
+     <circle class="constellation-star-core" cx="320" cy="130" r="6"></circle>
+     <text class="constellation-star-label" x="320" y="100">Products</text>
+   </g>
+   ```
+
+3. **Why is this useful?**
+   It's a striking, fully-animated alternative navigation pattern for landing pages, portfolios, or product showcases that want something more memorable than a standard menu, while staying true to EaseMotion CSS's "pure CSS animation, vanilla JS only for state toggling" approach. It also demonstrates several techniques other contributors might reuse: per-segment pulse-travel keyframes generated from real coordinates, the CSS `r` property for animating SVG circle radius, and a layout that gracefully degrades under `prefers-reduced-motion`.
+
+### Notes for the maintainer
+- The five star positions and their connecting links were computed as actual nearest-neighbor pairs (`home↔products`, `home↔docs`, `products↔about`, `docs↔contact`, `about↔contact`) rather than placed arbitrarily, so the constellation shape is structurally coherent, not random scatter.
+- The "constellation rearranges itself" behavior is a small per-star random drift (±7px) applied to the *non-active* stars whenever any star becomes active — large enough to feel alive, small enough that stars never drift off their click targets or overlap.
+- Each `.constellation-pulse` has its own `@keyframes` because each link has different SVG coordinates; this is the simplest way to get a pulse to travel along an exact path without introducing `<animateMotion>` or a JS-driven `requestAnimationFrame` loop.
+- `prefers-reduced-motion: reduce` removes the traveling pulse and the per-star drift (purely decorative motion) but keeps the lit-up connection lines and the command-node highlight, since those convey actual state.
+- Stars are keyboard accessible via `tabindex="0"` and respond to `focus`/`blur` the same way as `mouseenter`/`mouseleave`.
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/constellation-nav-ms07/demo.html
+++ b/submissions/examples/constellation-nav-ms07/demo.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Constellation Navigation — Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div class="constellation-nav" id="constellationNav">
+
+    <p class="constellation-hint">Hover or focus a star to wake the constellation.</p>
+
+    <svg class="constellation-canvas" id="constellationCanvas" viewBox="0 0 800 500" preserveAspectRatio="xMidYMid meet">
+
+      <!-- Background ambient dust -->
+      <g class="constellation-dust" aria-hidden="true">
+        <circle cx="80" cy="80" r="1.4"></circle>
+        <circle cx="700" cy="60" r="1.2"></circle>
+        <circle cx="650" cy="430" r="1.6"></circle>
+        <circle cx="60" cy="420" r="1.2"></circle>
+        <circle cx="420" cy="40" r="1.3"></circle>
+        <circle cx="430" cy="460" r="1.4"></circle>
+        <circle cx="240" cy="60" r="1.1"></circle>
+        <circle cx="750" cy="250" r="1.3"></circle>
+        <circle cx="40" cy="250" r="1.1"></circle>
+      </g>
+
+      <!-- Connection lines, drawn between every linked star pair.
+           Hidden by default; lit up via CSS when either endpoint
+           is the active star. -->
+      <g class="constellation-links">
+        <line class="constellation-link" data-link="home-products" x1="140" y1="250" x2="320" y2="130"></line>
+        <line class="constellation-link" data-link="home-docs"     x1="140" y1="250" x2="320" y2="370"></line>
+        <line class="constellation-link" data-link="products-about" x1="320" y1="130" x2="560" y2="130"></line>
+        <line class="constellation-link" data-link="docs-contact"   x1="320" y1="370" x2="560" y2="370"></line>
+        <line class="constellation-link" data-link="about-contact"  x1="560" y1="130" x2="560" y2="370"></line>
+
+        <!-- Pulse dots that travel along each line when activated -->
+        <circle class="constellation-pulse" data-pulse="home-products" r="3"></circle>
+        <circle class="constellation-pulse" data-pulse="home-docs" r="3"></circle>
+        <circle class="constellation-pulse" data-pulse="products-about" r="3"></circle>
+        <circle class="constellation-pulse" data-pulse="docs-contact" r="3"></circle>
+        <circle class="constellation-pulse" data-pulse="about-contact" r="3"></circle>
+      </g>
+
+      <!-- Star nodes (the actual nav items) -->
+      <g class="constellation-stars">
+
+        <g class="constellation-star" data-star="home" data-cx="140" data-cy="250" tabindex="0" role="link" aria-label="Home">
+          <circle class="constellation-star-glow" cx="140" cy="250" r="22"></circle>
+          <circle class="constellation-star-core" cx="140" cy="250" r="6"></circle>
+          <text class="constellation-star-label" x="140" y="282">Home</text>
+        </g>
+
+        <g class="constellation-star" data-star="products" data-cx="320" data-cy="130" tabindex="0" role="link" aria-label="Products">
+          <circle class="constellation-star-glow" cx="320" cy="130" r="22"></circle>
+          <circle class="constellation-star-core" cx="320" cy="130" r="6"></circle>
+          <text class="constellation-star-label" x="320" y="100">Products</text>
+        </g>
+
+        <g class="constellation-star" data-star="docs" data-cx="320" data-cy="370" tabindex="0" role="link" aria-label="Docs">
+          <circle class="constellation-star-glow" cx="320" cy="370" r="22"></circle>
+          <circle class="constellation-star-core" cx="320" cy="370" r="6"></circle>
+          <text class="constellation-star-label" x="320" y="402">Docs</text>
+        </g>
+
+        <g class="constellation-star" data-star="about" data-cx="560" data-cy="130" tabindex="0" role="link" aria-label="About">
+          <circle class="constellation-star-glow" cx="560" cy="130" r="22"></circle>
+          <circle class="constellation-star-core" cx="560" cy="130" r="6"></circle>
+          <text class="constellation-star-label" x="560" y="100">About</text>
+        </g>
+
+        <g class="constellation-star" data-star="contact" data-cx="560" data-cy="370" tabindex="0" role="link" aria-label="Contact">
+          <circle class="constellation-star-glow" cx="560" cy="370" r="22"></circle>
+          <circle class="constellation-star-core" cx="560" cy="370" r="6"></circle>
+          <text class="constellation-star-label" x="560" y="402">Contact</text>
+        </g>
+
+      </g>
+
+    </svg>
+
+    <!-- Info panel that emerges from the active star -->
+    <aside class="constellation-panel" id="constellationPanel" aria-live="polite">
+      <span class="constellation-panel-eyebrow" data-field="eyebrow">Command Node</span>
+      <h3 class="constellation-panel-title" data-field="title">—</h3>
+      <p class="constellation-panel-copy" data-field="copy">Hover a star to preview its destination.</p>
+    </aside>
+
+  </div>
+
+  <script>
+    (function () {
+      const root = document.getElementById('constellationNav');
+      const canvas = document.getElementById('constellationCanvas');
+      const stars = Array.from(canvas.querySelectorAll('.constellation-star'));
+      const links = Array.from(canvas.querySelectorAll('.constellation-link'));
+      const panel = document.getElementById('constellationPanel');
+
+      const panelContent = {
+        home:     { title: 'Home',     copy: 'Return to the overview and recent activity.' },
+        products: { title: 'Products', copy: 'Browse the full component and utility catalog.' },
+        docs:     { title: 'Docs',     copy: 'Read setup guides and the class reference.' },
+        about:    { title: 'About',    copy: 'Learn about the project and its philosophy.' },
+        contact:  { title: 'Contact',  copy: 'Reach the maintainer or join the community.' },
+      };
+
+      // Each star drifts slightly when the constellation "rearranges" —
+      // small per-star offsets so the layout subtly reshuffles without
+      // ever losing its structure or becoming hard to click.
+      const driftSeeds = {};
+      stars.forEach((star) => {
+        driftSeeds[star.dataset.star] = {
+          dx: (Math.random() - 0.5) * 14,
+          dy: (Math.random() - 0.5) * 14,
+        };
+      });
+
+      function setActive(starName) {
+        stars.forEach((star) => {
+          const isActive = star.dataset.star === starName;
+          star.classList.toggle('constellation-star-active', isActive);
+
+          if (!starName) {
+            star.style.transform = '';
+            return;
+          }
+
+          if (isActive) {
+            star.style.transform = '';
+          } else {
+            const seed = driftSeeds[star.dataset.star];
+            star.style.transform = `translate(${seed.dx}px, ${seed.dy}px)`;
+          }
+        });
+
+        links.forEach((link) => {
+          const [a, b] = link.dataset.link.split('-');
+          const isLit = starName && (a === starName || b === starName);
+          link.classList.toggle('constellation-link-active', isLit);
+        });
+
+        canvas.querySelectorAll('.constellation-pulse').forEach((pulse) => {
+          const [a, b] = pulse.dataset.pulse.split('-');
+          const isLit = starName && (a === starName || b === starName);
+          pulse.classList.toggle('constellation-pulse-active', isLit);
+        });
+
+        if (starName && panelContent[starName]) {
+          panel.querySelector('[data-field="title"]').textContent = panelContent[starName].title;
+          panel.querySelector('[data-field="copy"]').textContent = panelContent[starName].copy;
+          panel.classList.add('constellation-panel-open');
+        } else {
+          panel.classList.remove('constellation-panel-open');
+        }
+      }
+
+      stars.forEach((star) => {
+        star.addEventListener('mouseenter', () => setActive(star.dataset.star));
+        star.addEventListener('focus', () => setActive(star.dataset.star));
+        star.addEventListener('mouseleave', () => setActive(null));
+        star.addEventListener('blur', () => setActive(null));
+      });
+
+      root.addEventListener('mouseleave', () => setActive(null));
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/constellation-nav-ms07/style.css
+++ b/submissions/examples/constellation-nav-ms07/style.css
@@ -1,0 +1,266 @@
+/* ===================================================================
+   Constellation Navigation — raw demo styles
+   Class names are unprefixed on purpose; the maintainer will rename
+   everything to the ease-* convention during integration.
+   =================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(ellipse at 50% 30%, #11162c, #05060d 70%);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: #e7e9ee;
+}
+
+/* ---------------------------------------------------------------
+   Outer frame
+   --------------------------------------------------------------- */
+
+.constellation-nav {
+  position: relative;
+  width: min(900px, 94vw);
+  padding: 20px 0 0;
+}
+
+.constellation-hint {
+  text-align: center;
+  font-size: 0.82rem;
+  color: #7b85a3;
+  margin: 0 0 8px;
+}
+
+.constellation-canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+/* ---------------------------------------------------------------
+   Ambient dust — small fixed background stars, decorative only
+   --------------------------------------------------------------- */
+
+.constellation-dust circle {
+  fill: #ffffff;
+  opacity: 0.35;
+}
+
+/* ---------------------------------------------------------------
+   Links — hidden until either endpoint star is active
+   --------------------------------------------------------------- */
+
+.constellation-link {
+  stroke: #6c63ff;
+  stroke-width: 1.2;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.constellation-link-active {
+  opacity: 0.55;
+}
+
+/* Energy pulse traveling along an activated link.
+   Each pulse has its own keyframe because each line has different
+   start/end coordinates in the SVG's user-space. */
+
+.constellation-pulse {
+  fill: #a5b4ff;
+  opacity: 0;
+  filter: blur(0.4px);
+}
+
+.constellation-pulse-active[data-pulse="home-products"] {
+  animation: constellation-travel-home-products 1.1s ease-in-out infinite;
+}
+.constellation-pulse-active[data-pulse="home-docs"] {
+  animation: constellation-travel-home-docs 1.1s ease-in-out infinite;
+}
+.constellation-pulse-active[data-pulse="products-about"] {
+  animation: constellation-travel-products-about 1.3s ease-in-out infinite;
+}
+.constellation-pulse-active[data-pulse="docs-contact"] {
+  animation: constellation-travel-docs-contact 1.3s ease-in-out infinite;
+}
+.constellation-pulse-active[data-pulse="about-contact"] {
+  animation: constellation-travel-about-contact 1.2s ease-in-out infinite;
+}
+
+@keyframes constellation-travel-home-products {
+  0%   { transform: translate(140px, 250px); opacity: 0; }
+  15%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { transform: translate(320px, 130px); opacity: 0; }
+}
+
+@keyframes constellation-travel-home-docs {
+  0%   { transform: translate(140px, 250px); opacity: 0; }
+  15%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { transform: translate(320px, 370px); opacity: 0; }
+}
+
+@keyframes constellation-travel-products-about {
+  0%   { transform: translate(320px, 130px); opacity: 0; }
+  15%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { transform: translate(560px, 130px); opacity: 0; }
+}
+
+@keyframes constellation-travel-docs-contact {
+  0%   { transform: translate(320px, 370px); opacity: 0; }
+  15%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { transform: translate(560px, 370px); opacity: 0; }
+}
+
+@keyframes constellation-travel-about-contact {
+  0%   { transform: translate(560px, 130px); opacity: 0; }
+  15%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { transform: translate(560px, 370px); opacity: 0; }
+}
+
+/* ---------------------------------------------------------------
+   Star nodes
+   --------------------------------------------------------------- */
+
+.constellation-star {
+  cursor: pointer;
+  outline: none;
+  transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.constellation-star-glow {
+  fill: #6c63ff;
+  opacity: 0.12;
+  transition: opacity 0.3s ease, r 0.3s ease;
+}
+
+.constellation-star-core {
+  fill: #cbd1ff;
+  transition: fill 0.3s ease, r 0.3s ease, filter 0.3s ease;
+}
+
+.constellation-star-label {
+  text-anchor: middle;
+  font-size: 13px;
+  font-weight: 600;
+  fill: #8b93a7;
+  transition: fill 0.3s ease, font-size 0.3s ease;
+  user-select: none;
+}
+
+/* Hover / focus on a star, even before "active" class settles in,
+   gives immediate feedback */
+.constellation-star:hover .constellation-star-glow,
+.constellation-star:focus .constellation-star-glow {
+  opacity: 0.28;
+}
+
+/* The selected star becomes the "command node" */
+.constellation-star-active .constellation-star-glow {
+  opacity: 0.5;
+  r: 30;
+}
+
+.constellation-star-active .constellation-star-core {
+  fill: #ffffff;
+  r: 8;
+  filter: drop-shadow(0 0 6px #a5b4ffcc);
+}
+
+.constellation-star-active .constellation-star-label {
+  fill: #ffffff;
+  font-size: 14px;
+}
+
+/* ---------------------------------------------------------------
+   Info panel — emerges near the bottom of the canvas
+   --------------------------------------------------------------- */
+
+.constellation-panel {
+  position: absolute;
+  left: 50%;
+  bottom: -18px;
+  transform: translate(-50%, 12px);
+  width: min(360px, 84vw);
+  background: #12162680;
+  backdrop-filter: blur(10px);
+  border: 1px solid #ffffff1a;
+  border-radius: 14px;
+  padding: 16px 20px;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.constellation-panel-open {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.constellation-panel-eyebrow {
+  display: block;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #93c5fd;
+  margin-bottom: 4px;
+}
+
+.constellation-panel-title {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.constellation-panel-copy {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: #aeb4c4;
+}
+
+/* ===================================================================
+   Responsive behavior
+   =================================================================== */
+
+@media (max-width: 600px) {
+  .constellation-nav {
+    padding-bottom: 90px; /* room for the panel below the canvas */
+  }
+
+  .constellation-panel {
+    bottom: -70px;
+  }
+
+  .constellation-star-label {
+    font-size: 11px;
+  }
+}
+
+/* Respect users who prefer reduced motion: keep the connections and
+   command-node highlight (they convey state), but drop the travelling
+   pulse and the per-star drift, since those are purely decorative
+   motion rather than state-bearing. */
+@media (prefers-reduced-motion: reduce) {
+  .constellation-pulse-active {
+    animation: none !important;
+    opacity: 0 !important;
+  }
+
+  .constellation-star {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Replaces a traditional nav menu with an animated SVG "constellation":
nav items are stars that connect to their nearest neighbors, send a
traveling energy pulse, drift the rest of the layout, and promote the
hovered star into a glowing command node with a sliding info panel.

---

## Type of Change

- [x] 🧩 New component
- [x] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/constellation-nav-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An interactive star-map navigation pattern where hovering/focusing a
star lights up its connections, animates a traveling pulse along
them, drifts the other stars, and reveals an info panel for that
destination.

**How does a developer use it?**

```html
<g class="constellation-star" data-star="products" data-cx="320" data-cy="130" tabindex="0" role="link" aria-label="Products">
  <circle class="constellation-star-glow" cx="320" cy="130" r="22"></circle>
  <circle class="constellation-star-core" cx="320" cy="130" r="6"></circle>
  <text class="constellation-star-label" x="320" y="100">Products</text>
</g>
```

**Why does it fit EaseMotion CSS?**

It's a memorable, fully-animated nav alternative for landing pages and
showcases, built with pure CSS animation and vanilla JS only for state
toggling — consistent with the framework's philosophy. It also
demonstrates reusable techniques (per-segment pulse-travel keyframes,
animating SVG circle radius via the CSS `r` property, graceful
`prefers-reduced-motion` degradation).

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Star positions and links were computed as real nearest-neighbor pairs
(home↔products, home↔docs, products↔about, docs↔contact,
about↔contact), so the constellation shape is structurally
coherent rather than random scatter. The "rearranges itself" effect
is a small ±7px random drift applied to non-active stars, kept small
enough that nothing drifts off its click target. Each pulse uses its
own `@keyframes` since each link has different SVG coordinates — the
simplest way to get exact path-following without
`<animateMotion>` or a JS `requestAnimationFrame` loop.
`prefers-reduced-motion: reduce` drops the pulse and drift but keeps
the lit connections and command-node highlight, since those convey
actual state. Stars are keyboard-accessible via `tabindex` and respond
to `focus`/`blur` the same as hover.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/18005