### PR TITLE
feat: add slide-out-bottom exit animation with delay variants

### DIFF
--- a/submissions/examples/slide-out-bottom-ms07/README.md
+++ b/submissions/examples/slide-out-bottom-ms07/README.md
@@ -1,0 +1,22 @@
+# Slide Out Bottom (Exit Animation)
+
+1. **What does this do?**
+   Slides an element downward while fading it out — an exit animation that moves the element 40px down and to `opacity: 0` as it leaves view. The slid-out, faded state holds once the animation finishes, rather than snapping back into place.
+
+2. **How is it used?**
+   Add the `slideoutbottom-playing` class to an element to trigger the exit. In this demo, clicking a box toggles the class via JS (removing it first to allow replay), but in real usage it would typically be added right before an element is removed from the DOM or hidden. Stagger multiple elements with a delay variant: `slideoutbottom-delay-1`, `slideoutbottom-delay-2`, or `slideoutbottom-delay-3` (150ms / 300ms / 450ms).
+
+   ```html
+   <div class="slideoutbottom-box slideoutbottom-delay-2">Goodbye</div>
+   <!-- add `slideoutbottom-playing` via JS right before removing/hiding the element -->
+   ```
+
+3. **Why is this useful?**
+   It rounds out the Exit animations set alongside a plain fade-out with a directional variant — useful for dismissible cards, toasts, or list items where downward motion communicates "this is leaving" more clearly than a flat fade. It composes with the same delay-class system as the rest of the library, so staggering a list of exiting elements stays simple.
+
+### Notes for the maintainer
+- This resolves the `ease-slide-out-bottom` issue, but is submitted as an unprefixed standalone demo (`slideoutbottom-*` naming) per the contribution guidelines, since adding a class directly into the core Motion Library under `// Exit animations` is maintainer territory. The animation in `style.css` (`slideoutbottom-slide` keyframe + `.slideoutbottom-playing`) is written to be a near-literal drop-in for `.ease-slide-out-bottom` — happy to adjust the travel distance/timing on integration.
+- Box sizing, border, and label layout intentionally match the `fade-out-ms07` submission so the two read as a consistent pair within the Exit animations group.
+- Delay classes (`slideoutbottom-delay-1/2/3`) only apply `animation-delay` while `.slideoutbottom-playing` is active, composing cleanly without separate keyframes per delay.
+- `prefers-reduced-motion: reduce` skips straight to the slid-out, faded end state instead of animating.
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/slide-out-bottom-ms07/demo.html
+++ b/submissions/examples/slide-out-bottom-ms07/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Slide Out Bottom — Exit Animation Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <main class="slideoutbottom-demo-wrapper">
+
+    <p class="slideoutbottom-demo-hint">Click any box to play its slide-out-bottom exit animation. Click "Replay all" to reset.</p>
+
+    <div class="slideoutbottom-demo-grid">
+
+      <div class="slideoutbottom-box" data-replayable>
+        <span class="slideoutbottom-box-label">slide-out-bottom</span>
+        <span class="slideoutbottom-box-sub">no delay</span>
+      </div>
+
+      <div class="slideoutbottom-box slideoutbottom-delay-1" data-replayable>
+        <span class="slideoutbottom-box-label">slide-out-bottom</span>
+        <span class="slideoutbottom-box-sub">delay-1 (150ms)</span>
+      </div>
+
+      <div class="slideoutbottom-box slideoutbottom-delay-2" data-replayable>
+        <span class="slideoutbottom-box-label">slide-out-bottom</span>
+        <span class="slideoutbottom-box-sub">delay-2 (300ms)</span>
+      </div>
+
+      <div class="slideoutbottom-box slideoutbottom-delay-3" data-replayable>
+        <span class="slideoutbottom-box-label">slide-out-bottom</span>
+        <span class="slideoutbottom-box-sub">delay-3 (450ms)</span>
+      </div>
+
+    </div>
+
+    <button class="slideoutbottom-replay-btn" type="button" id="replayAllBtn">↺ Replay all</button>
+
+  </main>
+
+  <script>
+    (function () {
+      const boxes = Array.from(document.querySelectorAll('[data-replayable]'));
+      const replayAllBtn = document.getElementById('replayAllBtn');
+
+      function playSlideOut(box) {
+        // Remove and re-add the class so the animation can replay even if
+        // it's already in its finished (slid-out) state.
+        box.classList.remove('slideoutbottom-playing');
+        box.classList.remove('slideoutbottom-finished');
+        // Force a reflow so the browser registers the class removal
+        // before we add it back — required to restart a CSS animation.
+        void box.offsetWidth;
+        box.classList.add('slideoutbottom-playing');
+      }
+
+      boxes.forEach((box) => {
+        box.addEventListener('click', () => playSlideOut(box));
+
+        box.addEventListener('animationend', () => {
+          box.classList.add('slideoutbottom-finished');
+        });
+      });
+
+      replayAllBtn.addEventListener('click', () => {
+        boxes.forEach((box) => playSlideOut(box));
+      });
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/slide-out-bottom-ms07/style.css
+++ b/submissions/examples/slide-out-bottom-ms07/style.css
@@ -1,0 +1,148 @@
+/* ===================================================================
+   Slide Out Bottom — exit animation demo styles
+   Class names are unprefixed on purpose; the maintainer will rename
+   the core animation to ease-slide-out-bottom during integration.
+   =================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0b0f19;
+  color: #e7e9ee;
+}
+
+.slideoutbottom-demo-wrapper {
+  padding: 56px 24px;
+  text-align: center;
+  /* Give the boxes room to slide down without the page itself scrolling */
+  overflow: hidden;
+}
+
+.slideoutbottom-demo-hint {
+  font-size: 0.85rem;
+  color: #8b93a7;
+  margin: 0 0 28px;
+}
+
+.slideoutbottom-demo-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 32px;
+  /* Keep a clipping context per-box rather than on the grid, so each
+     box's own slide travel isn't cut off by a shared boundary. */
+}
+
+/* ---------------------------------------------------------------
+   Box — consistent with the existing fade-out exit-animation boxes
+   (fixed size, centered label, rounded corners, accent border) so
+   this reads as part of the same Exit animations family.
+   --------------------------------------------------------------- */
+
+.slideoutbottom-box {
+  width: 160px;
+  height: 110px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  background: #161b29;
+  border: 1px solid #6c63ff44;
+  border-radius: 12px;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 0.2s ease;
+}
+
+.slideoutbottom-box:hover {
+  border-color: #6c63ffaa;
+}
+
+.slideoutbottom-box-label {
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: #f3f4f7;
+}
+
+.slideoutbottom-box-sub {
+  font-size: 0.72rem;
+  color: #8b93a7;
+}
+
+/* ---------------------------------------------------------------
+   The exit animation itself.
+   This is the part the maintainer would promote into the core
+   Motion Library as `.ease-slide-out-bottom`.
+   --------------------------------------------------------------- */
+
+@keyframes slideoutbottom-slide {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(40px);
+    opacity: 0;
+  }
+}
+
+.slideoutbottom-box.slideoutbottom-playing {
+  animation: slideoutbottom-slide 0.45s cubic-bezier(0.36, 0, 0.66, -0.05) forwards;
+}
+
+/* Hold the slid-out, faded state after the animation completes,
+   instead of snapping back — this is what makes "removed from view"
+   behavior visible rather than just a quick blink. */
+.slideoutbottom-box.slideoutbottom-finished {
+  transform: translateY(40px);
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ---------------------------------------------------------------
+   Delay variants — composable with the slide-out animation so it
+   can be staggered across a group of elements, consistent with the
+   delay classes used by the rest of the Motion Library (entrance
+   and other exit animations alike).
+   --------------------------------------------------------------- */
+
+.slideoutbottom-delay-1.slideoutbottom-playing { animation-delay: 0.15s; }
+.slideoutbottom-delay-2.slideoutbottom-playing { animation-delay: 0.3s; }
+.slideoutbottom-delay-3.slideoutbottom-playing { animation-delay: 0.45s; }
+
+/* ---------------------------------------------------------------
+   Replay control
+   --------------------------------------------------------------- */
+
+.slideoutbottom-replay-btn {
+  background: #6c63ff;
+  color: #fff;
+  border: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 10px 20px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease;
+}
+
+.slideoutbottom-replay-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px -8px #6c63ffaa;
+}
+
+/* Respect users who prefer reduced motion — resolve straight to the
+   end state instead of animating the slide + fade. */
+@media (prefers-reduced-motion: reduce) {
+  .slideoutbottom-box.slideoutbottom-playing {
+    animation: none !important;
+    transform: translateY(40px);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a slide-out-bottom exit animation as a self-contained example —
an element slides 40px downward while fading out — with replayable
demo boxes and three composable delay variants for staggering.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/slide-out-bottom-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An exit animation that slides an element 40px downward while fading
it to `opacity: 0`, holding the slid-out state once finished, with
three delay variants for staggering.

**How does a developer use it?**

```html
<div class="slideoutbottom-box slideoutbottom-delay-2">Goodbye</div>
<!-- add `slideoutbottom-playing` via JS right before removing/hiding the element -->
```

**Why does it fit EaseMotion CSS?**

It rounds out the Exit animations set with a directional variant
alongside a plain fade-out — useful for dismissible cards, toasts, or
list items where downward motion reads as "leaving" more clearly than
a flat fade. Composes with the same delay-class system as the rest of
the library.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This resolves the `ease-slide-out-bottom` issue, but is submitted as
an unprefixed standalone demo (`slideoutbottom-*` naming) per the
contribution guidelines, since adding a class directly into the core
Motion Library under `// Exit animations` is maintainer territory. The
animation here (`slideoutbottom-slide` keyframe + `.slideoutbottom-playing`)
is written to be a near-literal drop-in for `.ease-slide-out-bottom`.
Box sizing/border/label layout intentionally matches the
`fade-out-ms07` submission so the two read as a consistent pair.
`prefers-reduced-motion` skips straight to the slid-out, faded end
state.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/17963