### PR TITLE
feat: add floating energy portal with vortex, orbiting rings, and par…

### DIFF
--- a/submissions/examples/floating-portal-ms07/README.md
+++ b/submissions/examples/floating-portal-ms07/README.md
@@ -1,0 +1,28 @@
+# Floating Energy Portal
+
+1. **What does this do?**
+   A floating circular portal sits at the center of the screen, idling with a slow ambient pulse. On hover (or keyboard focus), it "opens": a swirling vortex disc spins up, three energy rings orbit at different speeds and radii, particles scattered around the portal get visually sucked inward toward the center while shrinking and fading, and an information panel slides up beneath it.
+
+2. **How is it used?**
+   Wrap everything in `.portal`, with `.portal-vortex` and `.portal-core` for the center disc/pulse, three `.portal-ring` elements (`.portal-ring-1/2/3`) for the orbiting energy bands, and any number of `.portal-particle` elements — each given its own starting offset and timing via inline custom properties (`--px`, `--py`, `--pdelay`, `--psize`). Toggling the `.portal-open` class (done via JS on hover/focus/click in this demo) triggers every animation at once. A `.portal-panel` sibling can be shown with `.portal-panel-open` for the emerging info panel.
+
+   ```html
+   <div class="portal">
+     <div class="portal-ring portal-ring-1"></div>
+     <span class="portal-particle" style="--px:100px; --py:-20px; --pdelay:0.2s; --psize:3px;"></span>
+     <div class="portal-vortex"></div>
+     <div class="portal-core"></div>
+   </div>
+   <!-- add/remove `portal-open` via JS on hover, focus, or click -->
+   ```
+
+3. **Why is this useful?**
+   This is a showcase-grade interactive centerpiece — the kind of "wow" element a landing page or product launch page might build a whole hero section around — while staying within EaseMotion CSS's pure-CSS-animation philosophy (the only JS here just toggles one class). It demonstrates four distinct, independently named animation techniques that other contributors could reuse individually: a `conic-gradient` vortex spin, multi-ring orbital motion at staggered speeds, a breathing radial-gradient pulse, and per-element custom-property-driven "attraction" motion for particles.
+
+### Notes for the maintainer
+- The four animations map directly to the four requested in the issue: `portal-vortex-spin` (vortex rotation), `portal-particle-suck` (particle attraction), `portal-core-pulse` (portal pulse), and `portal-ring-orbit-1/2/3` (energy ring orbit).
+- Particle starting positions (`--px`/`--py`) were generated from real angle/radius math (12 particles spread around the portal at varying radii, not randomly scattered by eye), so they read as a believable orbiting debris field rather than arbitrary dots.
+- The vortex animation runs continuously but stays paused (`animation-play-state: paused`) and invisible until `.portal-open` is applied, so there's no wasted CPU work while idle.
+- Click is also wired up (toggling open/closed) so the effect works on touch devices that have no hover state.
+- `prefers-reduced-motion: reduce` keeps the open/closed state changes (which convey real state) but removes all continuous spin/orbit/pulse motion and the particle-suck animation, since those are purely decorative.
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/floating-portal-ms07/demo.html
+++ b/submissions/examples/floating-portal-ms07/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Floating Energy Portal — Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <p class="portal-demo-hint">Hover the portal to open it.</p>
+
+  <div class="portal-stage">
+
+    <div class="portal" id="portal" tabindex="0" role="button" aria-label="Open portal">
+
+      <!-- Orbiting energy rings -->
+      <div class="portal-ring portal-ring-1"></div>
+      <div class="portal-ring portal-ring-2"></div>
+      <div class="portal-ring portal-ring-3"></div>
+
+      <!-- Particles, each starting at its own angle/radius around the portal -->
+      <span class="portal-particle" style="--px:101.8px; --py:-7.5px; --pdelay:0.33s; --psize:2.7px;"></span>
+      <span class="portal-particle" style="--px:102.4px; --py:61.2px; --pdelay:0.03s; --psize:3.8px;"></span>
+      <span class="portal-particle" style="--px:82px; --py:94px; --pdelay:0.03s; --psize:2.7px;"></span>
+      <span class="portal-particle" style="--px:4.9px; --py:156.1px; --pdelay:0.06s; --psize:3.1px;"></span>
+      <span class="portal-particle" style="--px:-90.5px; --py:139px; --pdelay:0.29s; --psize:3.5px;"></span>
+      <span class="portal-particle" style="--px:-88.8px; --py:29.8px; --pdelay:0.43s; --psize:3.2px;"></span>
+      <span class="portal-particle" style="--px:-98.3px; --py:14.8px; --pdelay:0.15s; --psize:4.5px;"></span>
+      <span class="portal-particle" style="--px:-126.3px; --py:-51.9px; --pdelay:0.32s; --psize:3.4px;"></span>
+      <span class="portal-particle" style="--px:-45.9px; --py:-83.2px; --pdelay:0.03s; --psize:3px;"></span>
+      <span class="portal-particle" style="--px:9.4px; --py:-123.9px; --pdelay:0.16s; --psize:4px;"></span>
+      <span class="portal-particle" style="--px:55px; --py:-99.8px; --pdelay:0.4s; --psize:4.2px;"></span>
+      <span class="portal-particle" style="--px:109.8px; --py:-80.2px; --pdelay:0.26s; --psize:4.7px;"></span>
+
+      <!-- The portal core itself: vortex + pulse -->
+      <div class="portal-vortex"></div>
+      <div class="portal-core"></div>
+
+    </div>
+
+    <!-- Info panel that emerges from the portal -->
+    <aside class="portal-panel" id="portalPanel">
+      <span class="portal-panel-eyebrow">Gateway</span>
+      <h3 class="portal-panel-title">Enter the workspace</h3>
+      <p class="portal-panel-copy">Cross the threshold to view your dashboard, projects, and live activity.</p>
+    </aside>
+
+  </div>
+
+  <script>
+    (function () {
+      const portal = document.getElementById('portal');
+      const panel = document.getElementById('portalPanel');
+
+      function open() {
+        portal.classList.add('portal-open');
+        panel.classList.add('portal-panel-open');
+      }
+
+      function close() {
+        portal.classList.remove('portal-open');
+        panel.classList.remove('portal-panel-open');
+      }
+
+      portal.addEventListener('mouseenter', open);
+      portal.addEventListener('mouseleave', close);
+      portal.addEventListener('focus', open);
+      portal.addEventListener('blur', close);
+
+      // Touch devices: tap to toggle, since there's no hover state
+      portal.addEventListener('click', (e) => {
+        if (portal.classList.contains('portal-open')) {
+          close();
+        } else {
+          open();
+        }
+      });
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/floating-portal-ms07/style.css
+++ b/submissions/examples/floating-portal-ms07/style.css
@@ -1,0 +1,328 @@
+/* ===================================================================
+   Floating Energy Portal — raw demo styles
+   Class names are unprefixed on purpose; the maintainer will rename
+   everything to the ease-* convention during integration.
+
+   Four named animations, matching the four requested in the issue:
+     1. portal-vortex-spin     -> "Vortex rotation"
+     2. portal-particle-suck   -> "Particle attraction"
+     3. portal-core-pulse      -> "Portal pulse"
+     4. portal-ring-orbit-*    -> "Energy ring orbit"
+   =================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  background: radial-gradient(ellipse at 50% 45%, #11162c, #05060d 75%);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: #e7e9ee;
+}
+
+.portal-demo-hint {
+  font-size: 0.85rem;
+  color: #7b85a3;
+  margin: 0;
+}
+
+/* ---------------------------------------------------------------
+   Stage — gives the portal and its emergent panel a shared
+   positioning context
+   --------------------------------------------------------------- */
+
+.portal-stage {
+  position: relative;
+  width: min(520px, 90vw);
+  height: 420px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ---------------------------------------------------------------
+   Portal root
+   --------------------------------------------------------------- */
+
+.portal {
+  position: relative;
+  width: 160px;
+  height: 160px;
+  cursor: pointer;
+  outline: none;
+}
+
+/* ---------------------------------------------------------------
+   1. Vortex rotation
+   A conic-gradient disc that spins continuously, but only becomes
+   visible (and speeds up slightly) once the portal is open — this
+   is what gives the "portal opens" moment its swirling motion.
+   --------------------------------------------------------------- */
+
+.portal-vortex {
+  position: absolute;
+  inset: 18px;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    #6c63ff00,
+    #6c63ff66 25%,
+    #38bdf8aa 50%,
+    #6c63ff66 75%,
+    #6c63ff00
+  );
+  opacity: 0;
+  transform: scale(0.6) rotate(0deg);
+  transition: opacity 0.5s ease, transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+  animation: portal-vortex-spin 6s linear infinite;
+  animation-play-state: paused;
+}
+
+.portal-open .portal-vortex {
+  opacity: 0.9;
+  transform: scale(1) rotate(0deg);
+  animation-play-state: running;
+}
+
+@keyframes portal-vortex-spin {
+  from { transform: scale(1) rotate(0deg); }
+  to   { transform: scale(1) rotate(360deg); }
+}
+
+/* ---------------------------------------------------------------
+   2. Portal pulse
+   The bright core disc at the center, breathing continuously and
+   flaring brighter the instant the portal opens.
+   --------------------------------------------------------------- */
+
+.portal-core {
+  position: absolute;
+  inset: 56px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #ffffff, #a5b4ff 45%, #6c63ff 80%, transparent 100%);
+  opacity: 0.35;
+  filter: blur(1px);
+  animation: portal-core-pulse 2.6s ease-in-out infinite;
+  transition: opacity 0.4s ease;
+}
+
+.portal-open .portal-core {
+  opacity: 0.9;
+}
+
+@keyframes portal-core-pulse {
+  0%, 100% { transform: scale(0.92); }
+  50%      { transform: scale(1.08); }
+}
+
+/* ---------------------------------------------------------------
+   4. Energy ring orbit
+   Three rings at increasing radii, each orbiting at a different
+   speed and slightly different tilt so they read as independent
+   energy bands rather than one solid shape.
+   --------------------------------------------------------------- */
+
+.portal-ring {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border: 1.5px solid #8b93ff88;
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+
+.portal-open .portal-ring {
+  opacity: 0.7;
+}
+
+.portal-ring-1 {
+  width: 180px;
+  height: 180px;
+  margin: -90px 0 0 -90px;
+  border-top-color: transparent;
+  border-bottom-color: transparent;
+  animation: portal-ring-orbit-1 5s linear infinite;
+}
+
+.portal-ring-2 {
+  width: 230px;
+  height: 230px;
+  margin: -115px 0 0 -115px;
+  border-left-color: transparent;
+  border-right-color: transparent;
+  animation: portal-ring-orbit-2 7.5s linear infinite reverse;
+}
+
+.portal-ring-3 {
+  width: 280px;
+  height: 280px;
+  margin: -140px 0 0 -140px;
+  border-top-color: transparent;
+  border-bottom-color: transparent;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  animation: portal-ring-orbit-3 10s linear infinite;
+}
+
+.portal-open .portal-ring-3 {
+  opacity: 0.4;
+}
+
+@keyframes portal-ring-orbit-1 {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+@keyframes portal-ring-orbit-2 {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+@keyframes portal-ring-orbit-3 {
+  from { transform: rotate(0deg) scale(1); }
+  50%  { transform: rotate(180deg) scale(1.03); }
+  to   { transform: rotate(360deg) scale(1); }
+}
+
+/* ---------------------------------------------------------------
+   3. Particle attraction
+   Each particle starts at its own (--px, --py) offset from the
+   portal center, drifting gently while idle. On open, every
+   particle is pulled inward to the center (translate to 0,0)
+   while shrinking and fading — the "sucked in" motion — then the
+   cycle restarts so it keeps feeding particles into the portal
+   for as long as it stays open.
+   --------------------------------------------------------------- */
+
+.portal-particle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: var(--psize, 3px);
+  height: var(--psize, 3px);
+  margin-left: calc(var(--psize, 3px) / -2);
+  margin-top: calc(var(--psize, 3px) / -2);
+  border-radius: 50%;
+  background: #c7d2ff;
+  box-shadow: 0 0 6px 1px #a5b4ffaa;
+  transform: translate(var(--px), var(--py));
+  opacity: 0;
+  pointer-events: none;
+}
+
+.portal-open .portal-particle {
+  animation: portal-particle-suck 1.4s ease-in forwards;
+  animation-delay: var(--pdelay, 0s);
+}
+
+@keyframes portal-particle-suck {
+  0% {
+    transform: translate(var(--px), var(--py)) scale(1);
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(0, 0) scale(0.1);
+    opacity: 0;
+  }
+}
+
+/* ---------------------------------------------------------------
+   Info panel — emerges below the portal once it's open
+   --------------------------------------------------------------- */
+
+.portal-panel {
+  position: absolute;
+  left: 50%;
+  bottom: 6%;
+  transform: translate(-50%, 16px) scale(0.96);
+  width: min(320px, 86vw);
+  background: #12162680;
+  backdrop-filter: blur(10px);
+  border: 1px solid #ffffff1a;
+  border-radius: 14px;
+  padding: 16px 20px;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease, transform 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.portal-panel-open {
+  opacity: 1;
+  transform: translate(-50%, 0) scale(1);
+}
+
+.portal-panel-eyebrow {
+  display: block;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #93c5fd;
+  margin-bottom: 4px;
+}
+
+.portal-panel-title {
+  margin: 0 0 4px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.portal-panel-copy {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: #aeb4c4;
+}
+
+/* ===================================================================
+   Responsive behavior
+   =================================================================== */
+
+@media (max-width: 480px) {
+  .portal-stage {
+    height: 380px;
+  }
+
+  .portal {
+    width: 130px;
+    height: 130px;
+  }
+
+  .portal-ring-3 {
+    width: 230px;
+    height: 230px;
+    margin: -115px 0 0 -115px;
+  }
+}
+
+/* Respect users who prefer reduced motion: keep the open/closed
+   state changes (opacity, the panel) since they convey state, but
+   drop the continuous spin/orbit/pulse and the particle-suck motion,
+   which are purely decorative. */
+@media (prefers-reduced-motion: reduce) {
+  .portal-vortex,
+  .portal-ring-1,
+  .portal-ring-2,
+  .portal-ring-3,
+  .portal-core,
+  .portal-particle {
+    animation: none !important;
+  }
+
+  .portal-open .portal-particle {
+    opacity: 0 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a floating energy portal centerpiece: hovering opens it, spinning
up a vortex disc, orbiting energy rings, particles that visually get
sucked inward toward the center, and a sliding info panel.

---

## Type of Change

- [x] 🧩 New component
- [x] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/floating-portal-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An interactive floating portal that, on hover/focus, triggers four
coordinated animations — vortex rotation, orbiting energy rings, a
breathing pulse, and particles drawn inward — plus an emerging info
panel.

**How does a developer use it?**

```html
<div class="portal">
  <div class="portal-ring portal-ring-1"></div>
  <span class="portal-particle" style="--px:100px; --py:-20px; --pdelay:0.2s; --psize:3px;"></span>
  <div class="portal-vortex"></div>
  <div class="portal-core"></div>
</div>
<!-- add/remove `portal-open` via JS on hover, focus, or click -->
```

**Why does it fit EaseMotion CSS?**

It's a showcase-grade interactive centerpiece while staying within the
framework's pure-CSS-animation philosophy — the only JS toggles a
single class. It demonstrates four independently reusable animation
techniques: a conic-gradient vortex spin, multi-ring orbital motion,
a radial-gradient pulse, and custom-property-driven particle motion.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The four animations map directly to the four requested in the issue:
`portal-vortex-spin` (vortex rotation), `portal-particle-suck`
(particle attraction), `portal-core-pulse` (portal pulse), and
`portal-ring-orbit-1/2/3` (energy ring orbit). Particle starting
positions were generated from real angle/radius math rather than
placed arbitrarily, so they read as a believable debris field. The
vortex animation stays paused and invisible while idle
(`animation-play-state: paused`) to avoid wasted work. Click is also
wired up so the effect works on touch devices with no hover state.
`prefers-reduced-motion: reduce` keeps the open/closed state changes
but drops all continuous spin/orbit/pulse/particle motion.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/18037