### PR TITLE
feat: add animated flowing gradient text effect

### DIFF
--- a/submissions/examples/animated-gradient-text-ms07/README.md
+++ b/submissions/examples/animated-gradient-text-ms07/README.md
@@ -1,0 +1,20 @@
+# Animated Gradient Text
+
+1. **What does this do?**
+   Fills text with a wide, multi-color gradient that continuously flows across the letters in a smooth, repeating loop — pure CSS, no JavaScript involved.
+
+2. **How is it used?**
+   Apply `.gradient-text` to any heading or text element.
+
+   ```html
+   <h1 class="gradient-text">Flowing Gradient Text</h1>
+   ```
+
+3. **Why is this useful?**
+   Animated gradient text is a popular treatment for hero headings, brand callouts, and feature highlights — it draws the eye without needing any extra markup or JS. It's a clean fit for EaseMotion CSS's pure-CSS, animation-first philosophy: a single class, one keyframe, zero dependencies.
+
+### Notes for the maintainer
+- The flow effect works by making the gradient much wider than the text (`background-size: 300% 100%`) and animating `background-position`, rather than animating the gradient's colors directly — this keeps it smooth and GPU-friendly with a single, simple keyframe.
+- `background-clip: text` (with the `-webkit-` prefix for broader support) clips the gradient to the glyph shapes; `color: transparent` / `-webkit-text-fill-color: transparent` hide the fallback text color underneath.
+- `prefers-reduced-motion: reduce` stops the panning but keeps the static gradient fill, since the color treatment itself isn't motion.
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/animated-gradient-text-ms07/demo.html
+++ b/submissions/examples/animated-gradient-text-ms07/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Animated Gradient Text — Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <h1 class="gradient-text">Flowing Gradient Text</h1>
+
+  <p class="gradient-text gradient-text-sm">Works at any font size, including smaller body copy.</p>
+
+</body>
+</html>

--- a/submissions/examples/animated-gradient-text-ms07/style.css
+++ b/submissions/examples/animated-gradient-text-ms07/style.css
@@ -1,0 +1,87 @@
+/* ===================================================================
+   Animated Gradient Text — raw demo styles
+   Class names are unprefixed on purpose; the maintainer will rename
+   everything to the ease-* convention during integration.
+   Pure CSS — no JavaScript involved anywhere in this effect.
+   =================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: #0b0f19;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+/* ---------------------------------------------------------------
+   The effect itself.
+   A wide gradient background is clipped to the text shape, then
+   continuously panned by animating background-position — this is
+   what produces the "flowing" look, since the gradient itself
+   never changes, only the visible window into it.
+   --------------------------------------------------------------- */
+
+.gradient-text {
+  margin: 0;
+  font-size: 3rem;
+  font-weight: 800;
+  background: linear-gradient(
+    90deg,
+    #6c63ff,
+    #38bdf8,
+    #22c55e,
+    #f59e0b,
+    #f472b6,
+    #6c63ff
+  );
+  background-size: 300% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: gradient-text-flow 6s linear infinite;
+}
+
+@keyframes gradient-text-flow {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 300% 50%;
+  }
+}
+
+/* Smaller variant, just to show the effect still reads clearly at
+   body-copy sizes and not only on large display headings. */
+.gradient-text-sm {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+/* ---------------------------------------------------------------
+   Responsive behavior
+   --------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .gradient-text {
+    font-size: 2rem;
+    text-align: center;
+  }
+}
+
+/* Respect users who prefer reduced motion — keep the gradient fill
+   itself (it's still a nice static look) but stop the panning. */
+@media (prefers-reduced-motion: reduce) {
+  .gradient-text {
+    animation: none;
+    background-position: 0% 50%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure-CSS animated gradient text effect — a multi-color
gradient continuously flows across the text in a smooth, repeating
loop, with no JavaScript involved.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/animated-gradient-text-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A continuously flowing animated gradient fill for text, built entirely
with CSS (`background-clip: text` + an animated `background-position`).

**How does a developer use it?**

```html
<h1 class="gradient-text">Flowing Gradient Text</h1>
```

**Why does it fit EaseMotion CSS?**

It's a popular treatment for hero headings and brand callouts that
needs zero extra markup or JS — a single class and one keyframe,
fully in line with the framework's pure-CSS, animation-first
philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The flow effect works by making the gradient much wider than the text
(`background-size: 300% 100%`) and animating `background-position`,
rather than animating gradient colors directly — keeps it smooth with
a single simple keyframe. `background-clip: text` (with `-webkit-`
prefix for broader support) clips the gradient to the glyphs.
`prefers-reduced-motion: reduce` stops the panning but keeps the
static gradient fill.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/17936