### PR TITLE
feat: add resize utilities

### DIFF
--- a/submissions/examples/resize-utilities-ap/README.md
+++ b/submissions/examples/resize-utilities-ap/README.md
@@ -1,0 +1,27 @@
+# Resize Utilities
+
+## 1. What does this do?
+
+Provides utility classes to control whether and how an element is resizable by the user (`none`, `horizontal`, `vertical`, or `both`), managing the necessary `overflow` property automatically.
+
+## 2. How is it used?
+
+Apply one of the resize classes to a block-level element:
+
+```html
+<!-- Prevent resizing (default) -->
+<textarea class="resize-none"></textarea>
+
+<!-- Allow resizing horizontally -->
+<div class="resize-x">Horizontal resize content</div>
+
+<!-- Allow resizing vertically -->
+<div class="resize-y">Vertical resize content</div>
+
+<!-- Allow resizing both horizontally and vertically -->
+<div class="resize">Resizable content area</div>
+```
+
+## 3. Why is it useful?
+
+It aligns with EaseMotion CSS's philosophy of providing utility classes to eliminate boilerplate styling. Standard CSS requires setting `overflow` to something other than `visible` for `resize` to work, which is a common source of confusion; these utility classes handle that requirement transparently, giving developers instant resizable containers with zero hassle.

--- a/submissions/examples/resize-utilities-ap/demo.html
+++ b/submissions/examples/resize-utilities-ap/demo.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Resize Utilities — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+    <!-- Include Outfit Font from Google Fonts for premium look -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;700;800&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="demo-container">
+      <header>
+        <h1>Resize Utilities</h1>
+        <p class="subtitle">
+          Control element resizability natively with simple CSS classes.
+        </p>
+      </header>
+
+      <div class="grid-layout">
+        <!-- Both Resize -->
+        <div class="card">
+          <h3 class="card-title">Resize Both</h3>
+          <p class="card-desc">Allows both horizontal and vertical resizing.</p>
+          <div class="resize-box resize">
+            <div>
+              <p style="margin: 0; font-size: 0.95rem">
+                Drag the handle in the bottom-right corner to resize this box in
+                both directions.
+              </p>
+            </div>
+            <span class="resize-indicator">.resize</span>
+          </div>
+        </div>
+
+        <!-- Horizontal Resize -->
+        <div class="card">
+          <h3 class="card-title">Resize Horizontal</h3>
+          <p class="card-desc">Restricts resizing to the horizontal axis.</p>
+          <div class="resize-box resize-x">
+            <div>
+              <p style="margin: 0; font-size: 0.95rem">
+                You can drag the handle to resize this box only horizontally.
+              </p>
+            </div>
+            <span class="resize-indicator">.resize-x</span>
+          </div>
+        </div>
+
+        <!-- Vertical Resize -->
+        <div class="card">
+          <h3 class="card-title">Resize Vertical</h3>
+          <p class="card-desc">Restricts resizing to the vertical axis.</p>
+          <div class="resize-box resize-y">
+            <div>
+              <p style="margin: 0; font-size: 0.95rem">
+                You can drag the handle to resize this box only vertically.
+              </p>
+            </div>
+            <span class="resize-indicator">.resize-y</span>
+          </div>
+        </div>
+
+        <!-- Resize None (Textarea) -->
+        <div class="card">
+          <h3 class="card-title">Resize None</h3>
+          <p class="card-desc">
+            Disables resizability (often used to lock textareas).
+          </p>
+          <textarea
+            class="resize-box resize-none"
+            placeholder="This textarea is locked and cannot be resized..."
+          ></textarea>
+        </div>
+      </div>
+
+      <div class="interactive-demo">
+        <h2>Why use these utilities?</h2>
+        <p
+          style="
+            color: var(--text-secondary);
+            max-width: 650px;
+            margin: 0 auto 1.5rem auto;
+            font-size: 0.95rem;
+            line-height: 1.6;
+          "
+        >
+          In CSS, the <code>resize</code> property only works if the element's
+          <code>overflow</code> is set to something other than
+          <code>visible</code> (like <code>auto</code> or <code>scroll</code>).
+          EaseMotion's utilities handle this requirement automatically, making
+          native resizing seamless.
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/resize-utilities-ap/style.css
+++ b/submissions/examples/resize-utilities-ap/style.css
@@ -1,0 +1,178 @@
+/* ============================================================
+   EaseMotion CSS — Resize Utilities
+   Utility classes to control element resizability
+   ============================================================ */
+
+/* Core Utilities */
+.resize-none {
+  resize: none !important;
+}
+
+.resize-x {
+  resize: horizontal !important;
+  overflow: auto !important;
+}
+
+.resize-y {
+  resize: vertical !important;
+  overflow: auto !important;
+}
+
+.resize {
+  resize: both !important;
+  overflow: auto !important;
+}
+
+.resize-both {
+  resize: both !important;
+  overflow: auto !important;
+}
+
+/* Demo Styling (Self-contained, beautiful, premium design) */
+:root {
+  --bg-primary: #0a0a0c;
+  --bg-secondary: #121216;
+  --bg-tertiary: #181820;
+  --border-color: #262630;
+  --border-hover: #3b3b4f;
+  --text-primary: #f3f4f6;
+  --text-secondary: #9ca3af;
+  --accent-color: #6366f1;
+  --accent-gradient: linear-gradient(135deg, #6366f1, #a855f7);
+  --success-color: #10b981;
+}
+
+body {
+  margin: 0;
+  padding: 3rem 1.5rem;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: "Outfit", "Inter", system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+.demo-container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 3rem;
+  text-align: center;
+}
+
+h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem 0;
+  background: var(--accent-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  margin-bottom: 3rem;
+}
+
+.card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 1.5rem;
+  transition:
+    border-color 0.3s ease,
+    box-shadow 0.3s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.card:hover {
+  border-color: var(--border-hover);
+  box-shadow: 0 10px 30px -10px rgba(99, 102, 241, 0.1);
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 0.25rem 0;
+  color: var(--text-primary);
+}
+
+.card-desc {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0 0 1.25rem 0;
+}
+
+/* Resizable Boxes */
+.resize-box {
+  background: var(--bg-tertiary);
+  border: 1px dashed var(--border-color);
+  border-radius: 12px;
+  padding: 1.25rem;
+  min-height: 120px;
+  min-width: 180px;
+  max-width: 100%;
+  max-height: 400px;
+  color: var(--text-primary);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  box-sizing: border-box;
+}
+
+/* Custom visual styling cues */
+.resize-box::-webkit-resizer {
+  background-color: var(--accent-color);
+  border-radius: 4px;
+}
+
+.resize-indicator {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-family: monospace;
+  align-self: flex-start;
+  background: rgba(99, 102, 241, 0.1);
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+textarea.resize-box {
+  width: 100%;
+  height: 120px;
+  resize: none;
+  font-family: inherit;
+  font-size: 0.9rem;
+  border: 1px solid var(--border-color);
+  outline: none;
+}
+
+textarea.resize-box:focus {
+  border-color: var(--accent-color);
+}
+
+.interactive-demo {
+  margin-top: 3rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.interactive-demo h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}


### PR DESCRIPTION
### Description
This PR adds native resize utility classes to EaseMotion CSS, allowing users to control element resizability (`none`, `horizontal`, `vertical`, `both`) easily.

### Checklist
- [x] Folder added inside `submissions/examples/` with name `resize-utilities-ap`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Verified with `npm test`

Closes #16591