### PR TITLE
fix: differentiate docs/ from examples/ in submission validator

### DIFF
--- a/.github/workflows/submission-validator.yml
+++ b/.github/workflows/submission-validator.yml
@@ -152,11 +152,14 @@ jobs:
               });
             }
 
-            const requiredFiles = {
-              'demo.html': 'Interactive demo showcasing your feature',
-              'style.css': 'CSS styles for the demo',
-              'README.md': 'Documentation and usage guide'
-            };
+                        const isDocsFolder = folder.startsWith('submissions/docs/');
+            const requiredFiles = isDocsFolder
+              ? { 'README.md': 'Documentation file' }
+              : {
+                  'demo.html': 'Interactive demo showcasing your feature',
+                  'style.css': 'CSS styles for the demo',
+                  'README.md': 'Documentation and usage guide'
+                };
 
             if (casingErrors.length > 0) {
               failures.push({ folder: 'Casing Violations (Windows Compatibility)', casingErrors, missing: [], present: [] });


### PR DESCRIPTION
Closes #17739

## Problem
The submission validator treats \submissions/docs/\ identically to \submissions/examples/\, requiring \demo.html\, \style.css\, and \README.md\. Documentation-only submissions incorrectly get flagged for missing interactive demo files.

## Change
Added a check for docs/ vs examples/ subdirectory. For docs/ folders, only \README.md\ is required. For examples/ folders, all 3 files (\demo.html\, \style.css\, \README.md\) remain required.