### PR TITLE
fix: remove continue-on-error from CI lint steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
 
       - name: Run HTMLHint on Changed HTML Files
         if: steps.changed-files.outputs.any_changed == 'true'
-        continue-on-error: true
         run: |
           changed_html=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | tr ' ' '\n' | grep '\.html$' || true)
           existing_html=""
@@ -67,7 +66,6 @@ jobs:
 
       - name: Run Stylelint on Changed CSS Files
         if: steps.changed-files.outputs.any_changed == 'true'
-        continue-on-error: true
         run: |
           changed_css=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | tr ' ' '\n' | grep '\.css$' || true)
           existing_css=""
@@ -83,3 +81,4 @@ jobs:
           else
             echo "No CSS files to lint."
           fi
+


### PR DESCRIPTION
Closes #17740

## Problem
Both HTMLHint and Stylelint lint steps in ci.yml have \continue-on-error: true\, which silently swallows any linting failures. The CI shows as green even when lint errors exist.

## Change
Removed \continue-on-error: true\ from both lint steps so that lint failures properly fail the CI workflow.