### PR TITLE
fix: correct lint config trigger paths in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
       - '**/*.html'
       - 'scripts/**'
       - '.github/workflows/ci.yml'
-      - 'stylelint.config.json'
-      - 'htmlhint.config.json'
+      - '.github/workflows/stylelint.config.json'
+      - '.github/workflows/htmlhint.config.json'
   pull_request:
     branches: [ main ]
     paths:
@@ -17,8 +17,8 @@ on:
       - '**/*.html'
       - 'scripts/**'
       - '.github/workflows/ci.yml'
-      - 'stylelint.config.json'
-      - 'htmlhint.config.json'
+      - '.github/workflows/stylelint.config.json'
+      - '.github/workflows/htmlhint.config.json'
 
 permissions:
   contents: read
@@ -83,3 +83,4 @@ jobs:
           else
             echo "No CSS files to lint."
           fi
+


### PR DESCRIPTION
Closes #17741

## Problem
The ci.yml workflow triggers on \stylelint.config.json\ and \htmlhint.config.json\ at the project root, but the actual config files are at \.github/workflows/stylelint.config.json\ and \.github/workflows/htmlhint.config.json\. The trigger paths are dead — workflow never re-runs when lint configs change.

## Change
Updated trigger paths to \.github/workflows/stylelint.config.json\ and \.github/workflows/htmlhint.config.json\ to match actual file locations.