### PR TITLE
fix: disable cancel-in-progress for auto-merge concurrency

### DIFF
--- a/.github/workflows/auto-merge-submissions.yml
+++ b/.github/workflows/auto-merge-submissions.yml
@@ -18,7 +18,7 @@ permissions:
 
 concurrency:
   group: auto-merge-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   gather-prs:
@@ -649,4 +649,5 @@ jobs:
               exit $exit_code
             fi
           fi
+
 


### PR DESCRIPTION
Closes #17742

## Problem
The auto-merge workflow has \cancel-in-progress: true\ on its concurrency group. For scheduled runs, the concurrency group resolves to \github.run_id\ (no PR number), so all matrix jobs share the same group. The first job cancels all others — only 1 PR gets processed per scheduled run.

## Change
Set \cancel-in-progress: false\ so each matrix job runs independently during scheduled sweeps.