### PR TITLE
fix: add pagination to rate limiter fallback and align docs

### DIFF
--- a/.github/workflows/pr-rate-limiter.yml
+++ b/.github/workflows/pr-rate-limiter.yml
@@ -21,7 +21,7 @@ jobs:
             const prAuthor = context.payload.pull_request.user.login;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const DAILY_LIMIT = 70;
+            const DAILY_LIMIT = 70; // Actual limit is 70 PRs per day per contributor
             
             console.log(`Checking PR count for author "${prAuthor}"...`);
             
@@ -45,10 +45,10 @@ jobs:
               console.log(`Found ${totalCount} PRs submitted by @${prAuthor} in the last 24 hours.`);
             } catch (err) {
               console.log(`Error calling search API: ${err.message}`);
-              // Fallback: list pulls and filter
-              const pulls = await github.rest.pulls.list({ owner, repo, state: 'all', per_page: 100 });
+                            // Fallback: paginate through all pulls and filter
+              const allPulls = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'all', per_page: 100 });
               const limitMs = Date.now() - 24 * 60 * 60 * 1000;
-              const matchingPulls = pulls.data.filter(p => p.user.login === prAuthor && new Date(p.created_at).getTime() >= limitMs);
+              const matchingPulls = allPulls.filter(p => p.user.login === prAuthor && new Date(p.created_at).getTime() >= limitMs);
               totalCount = matchingPulls.length;
               console.log(`Fallback: Found ${totalCount} PRs in last 100 items.`);
             }
@@ -95,3 +95,4 @@ jobs:
             } else {
               console.log(`User @${prAuthor} is within limit (${totalCount}/${DAILY_LIMIT}).`);
             }
+


### PR DESCRIPTION
Closes #17743

## Problem
1. The fallback PR list fetch only gets 100 results without pagination — users with more than 100 PRs in 24 hours bypass the limit due to undercounting.
2. Code comment mentions 25 but the actual limit is 70 — confusing mismatch.

## Changes
1. Replaced the fallback with \github.paginate\ to fetch all PRs, not just the first 100.
2. Updated the comment to clearly state the actual limit is 70.