### PR TITLE
fix: use fresh issue data instead of stale context payload in claim handler

### DIFF
--- a/.github/scripts/autoClaimHandle.js
+++ b/.github/scripts/autoClaimHandle.js
@@ -43,14 +43,14 @@ async function handleClaim({ github, context }) {
     return;
   }
 
-  const currentAssignees = context.payload.issue.assignees.map((a) =>
+  const currentAssignees = issue.assignees.map((a) =>
     a.login.toLowerCase()
   );
-  const issueLabels = context.payload.issue.labels.map((l) =>
+  const issueLabels = issue.labels.map((l) =>
     l.name.toLowerCase()
   );
-  const issueTitle = (context.payload.issue.title || "").toLowerCase();
-  const issueBody = (context.payload.issue.body || "").toLowerCase();
+  const issueTitle = (issue.title || "").toLowerCase();
+  const issueBody = (issue.body || "").toLowerCase();
 
   const isSubmissionIssue =
     issueLabels.some(
@@ -118,3 +118,4 @@ async function handleClaim({ github, context }) {
 }
 
 module.exports = { handleClaim };
+


### PR DESCRIPTION
Closes #17745

## Problem
The claim handler refetches the issue to check if it's closed (line 30), but then uses \context.payload.issue.assignees\ (the STALE webhook payload) for the assignee check. Two users claiming simultaneously could both see no assignees and both get assigned.

## Change
Replaced all \context.payload.issue.*\ references with fresh data from the refetched \issue\ object: \issue.assignees\, \issue.labels\, \issue.title\, \issue.body\.