### PR TITLE
fix: add error handling and fresh issue fetch to unclaim handler

### DIFF
--- a/.github/scripts/autoUnclaimHandler.js
+++ b/.github/scripts/autoUnclaimHandler.js
@@ -3,43 +3,59 @@ async function handleUnclaim({ github, context }) {
   const { owner, repo } = context.repo;
   const issueNumber = context.payload.issue.number;
   const commenter = context.payload.comment.user.login;
-  const issueState = context.payload.issue.state;
 
-  if (issueState === 'closed') {
+  // Fetch the latest issue state to prevent race conditions
+  const { data: issue } = await github.rest.issues.get({
+    owner,
+    repo,
+    issue_number: issueNumber,
+  });
+
+  if (issue.state === 'closed') {
     await github.rest.issues.createComment({
       owner,
       repo,
       issue_number: issueNumber,
-      body: `🔒 **Oops!** This issue is closed. Commands can only be used on open issues.`,
+      body: 🔒 **Oops!** This issue is closed. Commands can only be used on open issues.,
     });
     return;
   }
 
-  const currentAssignees = context.payload.issue.assignees.map((a) => a.login.toLowerCase());
+  const currentAssignees = issue.assignees.map((a) => a.login.toLowerCase());
 
   if (!currentAssignees.includes(commenter.toLowerCase())) {
     await github.rest.issues.createComment({
       owner,
       repo,
       issue_number: issueNumber,
-      body: `🤔 **Wait a second!** @${commenter}, you aren't currently assigned to this issue, so there is nothing to unclaim! 🤷‍♂️`,
+      body: 🤔 **Wait a second!** @, you aren't currently assigned to this issue, so there is nothing to unclaim! 🤷‍♂️,
     });
     return;
   }
 
-  await github.rest.issues.removeAssignees({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    assignees: [commenter],
-  });
+  try {
+    await github.rest.issues.removeAssignees({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      assignees: [commenter],
+    });
 
-  await github.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    body: `✅ **Unclaimed!** You have successfully been unassigned from this issue, @${commenter}. Thanks for freeing it up! 🙌\n\n> 🔓 **Status:** This issue is now open and available for others to claim. 🚀`,
-  });
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      body: ✅ **Unclaimed!** You have successfully been unassigned from this issue, @. Thanks for freeing it up! 🙌\n\n> 🔓 **Status:** This issue is now open and available for others to claim. 🚀,
+    });
+  } catch (err) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      body: ❌ **Error:** Failed to unassign @. Please try again or contact a maintainer. Error: ,
+    });
+    console.error('Unclaim error:', err.message);
+  }
 }
 
 module.exports = { handleUnclaim };


### PR DESCRIPTION
Closes #17746

## Problem
1. \emoveAssignees\ API call has no try-catch — network/permissions errors cause an unhandled rejection.
2. Uses stale \context.payload.issue.state\ and \context.payload.issue.assignees\ — same race condition as the claim handler.

## Changes
1. Wrapped the API call in try-catch with a user-friendly error comment.
2. Added fresh issue fetch and uses \issue.state\ and \issue.assignees\ from the fetched data.