### PR TITLE
fix: prevent empty string restore when easemotion.min.css is missing

### DIFF
--- a/scripts/validate-bundle.mjs
+++ b/scripts/validate-bundle.mjs
@@ -53,10 +53,18 @@ if (build.error || build.status !== 0) {
 const rebuiltBundle = await readFile(bundlePath, "utf8");
 
 if (originalBundle !== rebuiltBundle) {
+  if (originalBundle === "") {
+    throw new Error(
+      `${path.relative(rootDir, bundlePath)} was missing. Run \`npm run build\` to create it.`,
+    );
+  }
   await writeFile(bundlePath, originalBundle, "utf8");
   throw new Error(
     `${path.relative(rootDir, bundlePath)} is stale. Run \`npm run build\` and commit the regenerated bundle.`,
   );
+} is stale. Run \`npm run build\` and commit the regenerated bundle.`,
+  );
 }
 
 console.log("easemotion.min.css is up to date.");
+


### PR DESCRIPTION
Closes #17747

Problem: When easemotion.min.css does not exist at validation start, originalBundle defaults to empty string. If the build creates the file and the content differs from empty string, the script writes the empty string back over the newly built bundle, effectively deleting it.

Change: Added a check that when originalBundle is empty (file did not exist), the script throws immediately with a helpful message instead of restoring an empty string.