### PR TITLE
fix: prevent .ease-chip text overflow with ellipsis truncation

### DIFF
--- a/submissions/examples/chip-overflow-fix-ag/README.md
+++ b/submissions/examples/chip-overflow-fix-ag/README.md
@@ -1,0 +1,14 @@
+# Chip Text Overflow Fix (Issue #18335)
+
+## What does this do?
+Demonstrates the corrected `.ease-chip` pattern that prevents long unbroken strings from overflowing their container by applying `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap` alongside a `max-width: 100%` constraint.
+
+## How is it used?
+```html
+<div style="display: flex; width: 200px;">
+  <span class="ease-chip">SuperLongTagNameThatExceedsNormalBounds</span>
+</div>
+```
+
+## Why is it useful?
+Without `overflow: hidden` + `text-overflow: ellipsis` + `white-space: nowrap`, any chip containing a long unbroken string (like a URL, hash, or camelCase word) will push past its flex container and overlap sibling elements. This fix ensures chips always stay within their bounds and degrade gracefully with an ellipsis.

--- a/submissions/examples/chip-overflow-fix-ag/demo.html
+++ b/submissions/examples/chip-overflow-fix-ag/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chip Overflow Fix Demo — Issue #18335</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Chip Text Overflow Fix — Issue #18335</h1>
+    <p>Chips with long unbroken strings now show an ellipsis instead of overflowing.</p>
+
+    <section>
+      <h2>Constrained container (200px)</h2>
+      <div class="chip-row">
+        <span class="demo-chip">Normal</span>
+        <span class="demo-chip">ThisIsAnExtremelyLongStringThatWouldHaveOverflowedBefore</span>
+        <span class="demo-chip">Another</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>Mixed lengths</h2>
+      <div class="chip-row chip-row--wide">
+        <span class="demo-chip">React</span>
+        <span class="demo-chip">SuperLongTagNameThatExceedsNormalBounds</span>
+        <span class="demo-chip">Vue</span>
+        <span class="demo-chip">Angular</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/chip-overflow-fix-ag/style.css
+++ b/submissions/examples/chip-overflow-fix-ag/style.css
@@ -1,0 +1,40 @@
+body {
+  font-family: system-ui, sans-serif;
+  padding: 2rem;
+  background: #f8fafc;
+}
+h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+h2 { font-size: 1rem; color: #475569; margin-bottom: 0.75rem; }
+p { color: #64748b; margin-bottom: 1.5rem; }
+section { margin-bottom: 2rem; }
+
+.chip-row {
+  display: flex;
+  gap: 0.5rem;
+  width: 200px;
+  border: 1px dashed #cbd5e1;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+}
+
+.chip-row--wide {
+  width: 360px;
+}
+
+/* FIX: .ease-chip needs overflow + text-overflow + max-width + white-space */
+.demo-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  background: #e0e7ff;
+  color: #3730a3;
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+
+  /* THE FIX — these three together prevent overflow */
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## What this fixes

Closes #18335

**Bug:** `.ease-chip` does not include `overflow: hidden`, `text-overflow: ellipsis`, or `white-space: nowrap`. Any chip containing a long unbroken string (e.g. URL, hash, camelCase) breaks out of its flex container and overlaps siblings.

**Fix demonstrated:** Adds `max-width: 100%`, `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap` to constrain chip text gracefully.

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included (`demo.html`, `style.css`, `README.md`)
- [x] PR is focused on one fix
- [x] No changes to `core/` or `components/`