### PR TITLE
fix: lower tooltip z-index to prevent bleed-through over modal overlays

### DIFF
--- a/submissions/examples/tooltip-zindex-fix-ag/README.md
+++ b/submissions/examples/tooltip-zindex-fix-ag/README.md
@@ -1,0 +1,21 @@
+# Tooltip Z-Index Fix (Issue #18337)
+
+## What does this do?
+Demonstrates a corrected z-index hierarchy where tooltips use `z-index: 500` and modal overlays use `z-index: 1000`, ensuring that tooltips on background elements never bleed through active modal overlays.
+
+## How is it used?
+```html
+<!-- Tooltip (z-index: 500 — stays behind modal) -->
+<div class="ease-tooltip-wrapper">
+  <button>Hover</button>
+  <div class="ease-tooltip">Tip text</div>
+</div>
+
+<!-- Modal (z-index: 1000 — always on top) -->
+<div class="ease-modal-overlay is-active">
+  <div class="ease-modal">...</div>
+</div>
+```
+
+## Why is it useful?
+Setting `z-index: 9999` on tooltips globally causes them to float above every other element, including modal overlays that are meant to capture all interaction. By establishing a consistent stacking context (tooltips at 500, modals at 1000), the UI hierarchy remains predictable and modals correctly block all background interaction.

--- a/submissions/examples/tooltip-zindex-fix-ag/demo.html
+++ b/submissions/examples/tooltip-zindex-fix-ag/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tooltip Z-Index Fix Demo — Issue #18337</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Tooltip Z-Index Fix — Issue #18337</h1>
+    <p>Background tooltips no longer bleed through modal overlays.</p>
+
+    <div class="demo-tooltip-wrapper">
+      <button class="demo-trigger">Hover Me (has tooltip)</button>
+      <div class="demo-tooltip">I should NOT appear above the modal!</div>
+    </div>
+
+    <button class="demo-open-btn" onclick="document.getElementById('modal').classList.add('is-active')">
+      Open Modal
+    </button>
+  </main>
+
+  <div id="modal" class="demo-modal-overlay">
+    <div class="demo-modal">
+      <h2>Modal Dialog</h2>
+      <p>The tooltip behind this modal should not be visible or interactive.</p>
+      <button class="demo-close-btn" onclick="document.getElementById('modal').classList.remove('is-active')">
+        Close Modal
+      </button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tooltip-zindex-fix-ag/style.css
+++ b/submissions/examples/tooltip-zindex-fix-ag/style.css
@@ -1,0 +1,101 @@
+body {
+  font-family: system-ui, sans-serif;
+  padding: 2rem;
+  background: #f8fafc;
+}
+h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+p { color: #64748b; margin-bottom: 1.5rem; }
+
+.demo-trigger {
+  padding: 0.5rem 1.25rem;
+  background: #f1f5f9;
+  border: 1.5px solid #cbd5e1;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+/* Tooltip: z-index should be BELOW typical modal z-index (1000–1050) */
+.demo-tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+  margin-bottom: 1.5rem;
+}
+
+.demo-tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  background: #1e293b;
+  color: #fff;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  /* FIX: z-index 500 — below modal overlay (z-index: 1000) */
+  z-index: 500;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  pointer-events: none;
+}
+
+.demo-tooltip-wrapper:hover .demo-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+.demo-open-btn {
+  display: block;
+  padding: 0.5rem 1.25rem;
+  background: #6c63ff;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+/* Modal: z-index must be ABOVE tooltip (z-index: 500) */
+.demo-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* FIX: z-index: 1000 — always above tooltips */
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, visibility 0s linear 0.25s;
+}
+
+.demo-modal-overlay.is-active {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.25s ease, visibility 0s linear 0s;
+}
+
+.demo-modal {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 2rem;
+  max-width: 420px;
+  width: 90%;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+.demo-modal h2 { margin: 0 0 0.75rem; font-size: 1.25rem; }
+.demo-modal p { color: #64748b; margin-bottom: 1.5rem; font-size: 0.95rem; }
+
+.demo-close-btn {
+  padding: 0.5rem 1.25rem;
+  background: #6c63ff;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## What this fixes

Closes #18337

**Bug:** Tooltips use a global `z-index: 9999` which causes them to render above modal overlays, making background tooltips visible and interactive even when a modal is open.

**Fix demonstrated:** Establishes a consistent stacking context — tooltips at `z-index: 500` and modal overlays at `z-index: 1000` — ensuring modals always render above tooltips.

## Checklist
- [x] Only files inside `submissions/examples/` are modified
- [x] All three required files included (`demo.html`, `style.css`, `README.md`)
- [x] PR is focused on one fix
- [x] No changes to `core/` or `components/`