### PR TITLE
feat: add list-style-position utilities

### DIFF
--- a/submissions/examples/list-style-position-utilities/README.md
+++ b/submissions/examples/list-style-position-utilities/README.md
@@ -1,0 +1,71 @@
+# Spacing: List Style Position Utilities
+
+Logical CSS utilities controlling marker positioning relative to list element text blocks.
+
+## What does this do?
+
+It implements utility classes (`.lsp-inside` and `.lsp-outside`) that control whether list markers (bullets or numbers) render inside or outside the text content block.
+
+## How is it used?
+
+Add `.lsp-inside` or `.lsp-outside` directly to any `<ul>` or `<ol>` elements:
+
+```html
+<ul class="lsp-inside">
+  <li>Point A</li>
+  <li>Point B</li>
+</ul>
+```
+
+## Why is it useful?
+
+It provides list layout control directly in HTML without writing custom stylesheets. This helps maintain design system layout grids and keeps lists consistent across complex text articles.
+
+---
+
+## Overview
+
+List elements default to browser-specific alignment configurations. By using list-style position utilities, developers can enforce clean grid boundaries (outside) or inline flowing text structures (inside) easily.
+
+## Utility Class Table
+
+| Class          | CSS Rules Applied               | Stacking / Flow Behavior                                                     |
+| :------------- | :------------------------------ | :--------------------------------------------------------------------------- |
+| `.lsp-inside`  | `list-style-position: inside;`  | Bullet/number sits inside the content block, text wraps underneath it.       |
+| `.lsp-outside` | `list-style-position: outside;` | Bullet/number sits outside the content block, text wraps vertically aligned. |
+
+## Usage Examples
+
+### 1. Sequential Steps (Inside)
+
+```html
+<ol class="lsp-inside">
+  <li>Enter credentials.</li>
+  <li>Confirm security credentials and complete multi-factor auth setup.</li>
+</ol>
+```
+
+### 2. Bulleted Lists (Outside)
+
+```html
+<ul class="lsp-outside">
+  <li>Item A</li>
+  <li>Item B (neatly aligned vertical boundary text block)</li>
+</ul>
+```
+
+## Difference between Inside and Outside
+
+- **`inside`**: The marker acts like an inline text element. If list content overflows onto a new line, the wrapped line starts directly below the marker. This is excellent for space-constrained blocks.
+- **`outside`**: The marker sits completely outside the content boundaries. If list content overflows onto a new line, the wrapped line starts vertically aligned with the first character of the preceding line. This is the preferred typography layout for text-heavy content like articles.
+
+## Browser Support Notes
+
+`list-style-position` is a CSS Level 1 specification and has 100% universal support across all desktop, mobile, and legacy web browsers.
+
+## Common Use Cases
+
+- Navigation menus with list markers.
+- Multi-step wizards and sequences.
+- Structured blog articles and text layout panels.
+- Content dropdown accordion bullet controls.

--- a/submissions/examples/list-style-position-utilities/demo.html
+++ b/submissions/examples/list-style-position-utilities/demo.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>List Style Position Utilities - EaseMotion CSS</title>
+    <meta
+      name="description"
+      content="A demonstration comparing list-style-position: inside and list-style-position: outside on ordered and unordered lists."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>List Style Position Utilities</h1>
+        <p class="subtitle">
+          CSS list utilities controlling how bullet markers are aligned relative
+          to text block boundaries. Essential for neat alignments and
+          text-wrapping designs.
+        </p>
+      </header>
+
+      <!-- Comparison 1: Unordered Lists -->
+      <section>
+        <h2>1. Unordered Lists Comparison</h2>
+        <div class="comparison-grid">
+          <!-- Unordered List - Inside -->
+          <div class="comparison-card">
+            <div class="card-title-bar">
+              <span class="card-title-text">Unordered List (Inside)</span>
+              <span class="badge">.lsp-inside</span>
+            </div>
+            <div class="marker-highlight-box">
+              <ul class="demo-list lsp-inside">
+                <li>First point of discussion which is relatively short.</li>
+                <li>
+                  A much longer list item demonstrating multi-line wrapping.
+                  Notice how the second line wraps completely underneath the
+                  bullet point marker rather than aligning with the text
+                  boundary of the first line.
+                </li>
+                <li>Third point of discussion.</li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- Unordered List - Outside -->
+          <div class="comparison-card">
+            <div class="card-title-bar">
+              <span class="card-title-text">Unordered List (Outside)</span>
+              <span class="badge badge--accent">.lsp-outside</span>
+            </div>
+            <div class="marker-highlight-box">
+              <ul class="demo-list lsp-outside">
+                <li>First point of discussion which is relatively short.</li>
+                <li>
+                  A much longer list item demonstrating multi-line wrapping.
+                  Notice how the bullet point marker hangs completely outside
+                  the boundary box of the wrapped text, keeping the vertical
+                  line alignment clean.
+                </li>
+                <li>Third point of discussion.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Comparison 2: Ordered Lists -->
+      <section>
+        <h2>2. Ordered Lists Comparison</h2>
+        <div class="comparison-grid">
+          <!-- Ordered List - Inside -->
+          <div class="comparison-card">
+            <div class="card-title-bar">
+              <span class="card-title-text">Ordered List (Inside)</span>
+              <span class="badge">.lsp-inside</span>
+            </div>
+            <div class="marker-highlight-box">
+              <ol class="demo-list lsp-inside">
+                <li>First step in the sequence of actions.</li>
+                <li>
+                  A longer instruction demonstrating multi-line wrapping
+                  behavior. Under the inside rule, the number marker wraps
+                  seamlessly alongside the content text, flowing like inline
+                  text.
+                </li>
+                <li>Third step in the sequence of actions.</li>
+              </ol>
+            </div>
+          </div>
+
+          <!-- Ordered List - Outside -->
+          <div class="comparison-card">
+            <div class="card-title-bar">
+              <span class="card-title-text">Ordered List (Outside)</span>
+              <span class="badge badge--accent">.lsp-outside</span>
+            </div>
+            <div class="marker-highlight-box">
+              <ol class="demo-list lsp-outside">
+                <li>First step in the sequence of actions.</li>
+                <li>
+                  A longer instruction demonstrating multi-line wrapping
+                  behavior. The number markers remain neatly aligned outside the
+                  text content block, keeping a clean gutter indicator layout.
+                </li>
+                <li>Third step in the sequence of actions.</li>
+              </ol>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/list-style-position-utilities/style.css
+++ b/submissions/examples/list-style-position-utilities/style.css
@@ -1,0 +1,178 @@
+@import "https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap";
+
+:root {
+  --bg-dark: #070913;
+  --bg-panel: rgba(15, 18, 36, 0.75);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --color-primary: #8b5cf6;
+  --color-primary-glow: rgba(139, 92, 246, 0.2);
+  --color-accent: #06b6d4;
+  --color-accent-glow: rgba(6, 182, 212, 0.2);
+  --text-main: #f3f4f6;
+  --text-muted: #9ca3af;
+  --font-sans: "Outfit", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  padding: 3rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-image:
+    radial-gradient(
+      circle at 10% 15%,
+      rgba(139, 92, 246, 0.12) 0%,
+      transparent 45%
+    ),
+    radial-gradient(
+      circle at 90% 85%,
+      rgba(6, 182, 212, 0.12) 0%,
+      transparent 45%
+    );
+}
+
+.container {
+  max-width: 900px;
+  width: 100%;
+  backdrop-filter: blur(20px);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  border-radius: 28px;
+  padding: 3rem 2.5rem;
+  box-shadow: 0 25px 60px -15px rgba(0, 0, 0, 0.7);
+}
+
+header {
+  text-align: center;
+  margin-bottom: 3.5rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  background: linear-gradient(135deg, #a78bfa, #8b5cf6, #06b6d4);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  border-left: 4px solid var(--color-primary);
+  padding-left: 0.75rem;
+  color: var(--text-main);
+}
+
+section {
+  margin-bottom: 3.5rem;
+}
+
+/* Side-by-Side Comparison Layout */
+.comparison-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 768px) {
+  .comparison-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.comparison-card {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--border-color);
+  border-radius: 18px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.card-title-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 0.75rem;
+}
+
+.card-title-text {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.badge {
+  background: rgba(139, 92, 246, 0.15);
+  color: var(--color-primary);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 20px;
+  font-family: monospace;
+}
+
+.badge--accent {
+  background: rgba(6, 182, 212, 0.15);
+  color: var(--color-accent);
+  border: 1px solid rgba(6, 182, 212, 0.3);
+}
+
+/* List styling inside cards */
+.demo-list {
+  padding-left: 2rem;
+  color: var(--text-main);
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.demo-list li {
+  margin-bottom: 0.75rem;
+  padding: 0.25rem;
+  background: rgba(255, 255, 255, 0.015);
+  border-radius: 4px;
+}
+
+/* Highlight boxes around bullet markers to make differences visual */
+.marker-highlight-box {
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  padding: 0.5rem;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+/* =============================================
+   LIST-STYLE-POSITION UTILITY CLASSES
+   ============================================= */
+
+.lsp-inside {
+  list-style-position: inside;
+}
+
+.lsp-outside {
+  list-style-position: outside;
+}


### PR DESCRIPTION
## Pull Request Description

Added a new utility example: **list-style-position utilities**.

This submission introduces utility classes for controlling marker positioning in ordered and unordered lists using the CSS `list-style-position` property.

**Note:** This submission is contained entirely within a new example folder and does not modify or delete any existing repository files.

---

## Type of Change

* [x] 🧩 New component
* [ ] ✨ New animation / hover effect
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/list-style-position-utilities/`
* [x] Includes `demo.html`
* [x] Includes `style.css`
* [x] Includes `README.md`
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR

---

## Feature Description

**What does this add?**

Utility classes for applying `list-style-position: inside` and `list-style-position: outside`.

**How does a developer use it?**

```html
<ul class="lsp-inside">
  <li>Item One</li>
  <li>Item Two</li>
</ul>
```

**Why does it fit EaseMotion CSS?**

It provides simple, reusable utility classes that help developers control list marker layout and readability.

---

## Demo

* [x] Demo added (`demo.html` works directly in browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari

---

## Notes for Maintainer

* Includes `.lsp-inside` and `.lsp-outside`.
* Demonstrates ordered and unordered lists.
* Includes wrapping text examples for visual comparison.
* Uses only new files under `submissions/examples/list-style-position-utilities/`.
* No existing repository files were modified.

Fixes #16578
