### PR TITLE
feat: add text-emphasis utilities

### DIFF
--- a/submissions/examples/text-emphasis-utilities-ap/README.md
+++ b/submissions/examples/text-emphasis-utilities-ap/README.md
@@ -1,0 +1,192 @@
+# Text Emphasis Utilities
+
+Configure repeating accent marks (dots, circles, triangles, sesames, and custom characters/emojis) over or under inline text runs using standard and shorthand CSS classes.
+
+This typography module contains fallback configurations for WebKit and standard rendering engines, allowing developers to emphasize words cleanly without background spans or bold font overrides.
+
+---
+
+## Table of Contents
+
+1. [What does this do?](#what-does-this-do)
+2. [Utility Class Reference](#utility-class-reference)
+3. [Why is it useful?](#why-is-it-useful)
+4. [How is it used?](#how-is-it-used)
+   - [Standard Circle Emphasis](#standard-circle-emphasis)
+   - [Hollow Triangle Emphasis](#hollow-triangle-emphasis)
+   - [Custom Emoji Emphasis](#custom-emoji-emphasis)
+5. [Technical Mechanics](#technical-mechanics)
+   - [Line-Height and Collisions](#line-height-and-collisions)
+   - [Prefix and Cross-Browser Fallbacks](#prefix-and-cross-browser-fallbacks)
+   - [East Asian Typography Roots](#east-asian-typography-roots)
+6. [Positioning Rules](#positioning-rules)
+7. [Accessibility & Best Practices](#accessibility--best-practices)
+8. [Tech Stack](#tech-stack)
+9. [Contribution Notes](#contribution-notes)
+
+---
+
+## What does this do?
+
+Apply decorative emphasis marks directly adjacent to inline text.
+
+Unlike underlines or highlights, emphasis marks (small icons, shapes, or emojis) repeat above or below every single letter/character in the styled text block (except spaces and punctuation). This provides a native typographic accent method derived from East Asian print layout traditions.
+
+The module provides full-length semantic class names and shorthand aliases for:
+
+- **Filled Shapes**: Solid circles, dots, triangles, and sesames.
+- **Hollow Shapes**: Outline-only (open) circles, dots, triangles, and sesames.
+- **Custom Strings**: repeating emojis (🔥, 💀) or symbols (★, ♥, ✔).
+- **Positional Layouts**: Aligning marks above (`over`) or below (`under`) text lines.
+
+---
+
+## Utility Class Reference
+
+We provide semantic standard classes and shorthand aliases.
+
+### 1. Shape Style Classes
+
+| Class Name (Standard)              | Shorthand Alias               | CSS Style Applied                            | Shape Result               |
+| :--------------------------------- | :---------------------------- | :------------------------------------------- | :------------------------- |
+| `text-emphasis-none`               | `emphasis-none`               | `text-emphasis-style: none;`                 | No marks (Default).        |
+| `text-emphasis-dot`                | `emphasis-dot`                | `text-emphasis-style: filled dot;`           | Solid small dots.          |
+| `text-emphasis-circle`             | `emphasis-circle`             | `text-emphasis-style: filled circle;`        | Solid large circles.       |
+| `text-emphasis-double-circle`      | `emphasis-double-circle`      | `text-emphasis-style: filled double-circle;` | Solid concentric circles.  |
+| `text-emphasis-triangle`           | `emphasis-triangle`           | `text-emphasis-style: filled triangle;`      | Solid small triangles.     |
+| `text-emphasis-sesame`             | `emphasis-sesame`             | `text-emphasis-style: filled sesame;`        | Solid diagonal dashes.     |
+| `text-emphasis-open-dot`           | `emphasis-open-dot`           | `text-emphasis-style: open dot;`             | Hollow small dots.         |
+| `text-emphasis-open-circle`        | `emphasis-open-circle`        | `text-emphasis-style: open circle;`          | Hollow large circles.      |
+| `text-emphasis-open-double-circle` | `emphasis-open-double-circle` | `text-emphasis-style: open double-circle;`   | Hollow concentric circles. |
+| `text-emphasis-open-triangle`      | `emphasis-open-triangle`      | `text-emphasis-style: open triangle;`        | Hollow small triangles.    |
+| `text-emphasis-open-sesame`        | `emphasis-open-sesame`        | `text-emphasis-style: open sesame;`          | Hollow diagonal dashes.    |
+
+### 2. Custom Symbol Classes
+
+| Class Name (Standard) | Shorthand Alias  | CSS Style Applied            | Symbol Result          |
+| :-------------------- | :--------------- | :--------------------------- | :--------------------- |
+| `text-emphasis-star`  | `emphasis-star`  | `text-emphasis-style: '★';`  | Repeating stars.       |
+| `text-emphasis-heart` | `emphasis-heart` | `text-emphasis-style: '♥';`  | Repeating hearts.      |
+| `text-emphasis-check` | `emphasis-check` | `text-emphasis-style: '✔';`  | Repeating check marks. |
+| `text-emphasis-fire`  | `emphasis-fire`  | `text-emphasis-style: '🔥';` | Repeating fire emojis. |
+
+### 3. Position Classes
+
+| Class Name (Standard)          | Shorthand Alias           | CSS Position Applied                   |
+| :----------------------------- | :------------------------ | :------------------------------------- |
+| `text-emphasis-position-over`  | `emphasis-position-over`  | `text-emphasis-position: over right;`  |
+| `text-emphasis-position-under` | `emphasis-position-under` | `text-emphasis-position: under right;` |
+
+---
+
+## Why is it useful?
+
+1. **Typographic Polish**: Emphasis marks offer a neat alternative to traditional underlines or background highlight blocks, creating a clean editorial layout.
+2. **Accented Copy**: Highlighting key keywords inside a long-form article using circles or dots keeps readers engaged with crucial metrics.
+3. **No Markup Bloat**: Adding emphasis marks traditionally required wrapping every single letter in a `<span>` tag. CSS text-emphasis performs this natively, keeping DOM nodes clean.
+4. **Cross-Browser Standard**: Combines standard properties with WebKit vendor-prefixes to ensure unified layouts on Chrome, Safari, and Firefox.
+
+---
+
+## How is it used?
+
+### Standard Circle Emphasis
+
+To add solid circles above key words in a paragraph (uses pink color accent):
+
+```html
+<p style="line-height: 2.2;">
+  We must prioritize
+  <span class="emphasis-circle emphasis-color-pink">performance metrics</span>
+  in the next build.
+</p>
+```
+
+### Hollow Triangle Emphasis
+
+To place hollow triangles under words (uses indigo color accent):
+
+```html
+<p style="line-height: 2.2;">
+  The transaction database logged a
+  <span
+    class="emphasis-open-triangle emphasis-position-under emphasis-color-indigo"
+    >success event</span
+  >.
+</p>
+```
+
+### Custom Emoji Emphasis
+
+To draw repeating fire emojis above a critical warning span:
+
+```html
+<p style="line-height: 2.2;">
+  Warning: <span class="emphasis-fire">Critical memory leak</span> detected in
+  main cluster.
+</p>
+```
+
+---
+
+## Technical Mechanics
+
+### Line-Height and Collisions
+
+Because emphasis marks are drawn outside the standard bounding box of inline text, they require extra space. If your paragraph has a normal line spacing (like `line-height: 1.4;`), emphasis marks will overlap with letters on the line above:
+
+```css
+/* Recommended container style */
+.emphasis-block {
+  line-height: 2.2 !important;
+}
+```
+
+Setting `line-height` to at least `2.0` ensures the spacing has enough breathing room for symbols to render without collision.
+
+### Prefix and Cross-Browser Fallbacks
+
+Modern browsers support `text-emphasis`, but WebKit engines (Safari, Chrome, Edge, Brave) historically required vendor prefixes. These utilities include fallbacks for seamless presentation:
+
+```css
+.emphasis-dot {
+  -webkit-text-emphasis-style: filled dot !important;
+  text-emphasis-style: filled dot !important;
+}
+```
+
+### East Asian Typography Roots
+
+This property was originally created to support Japanese (_kentou_ / emphasis dots) and Chinese (_bofu_) typographic rules. The browser handles character boundaries natively, drawing the marks correctly above each letter while ignoring spacing and punctuation marks.
+
+---
+
+## Positioning Rules
+
+In horizontal layouts, the emphasis marks default to `over right` (above the text). In vertical writing modes (common in Japanese/Chinese), the position aligns to the `right` side of the vertical text column.
+
+- Use `emphasis-position-over` to position marks above text lines.
+- Use `emphasis-position-under` to position marks below text lines (ideal when combining with overlines).
+
+---
+
+## Accessibility & Best Practices
+
+- **Reading Order**: Emphasis marks do not affect screen readers. Text content remains fully accessible as standard text strings.
+- **Contrast Compliance**: Sizing emphasis marks is managed by the browser relative to font size. Ensure you use high-contrast color classes (like `emphasis-color-pink` or `emphasis-color-emerald`) to guarantee visibility.
+- **Usage Limits**: Refrain from applying emphasis marks to massive, multi-paragraph text blocks. Reserve them for single words, key metrics, or warning spans, as excessive repeating icons can cause visual fatigue.
+
+---
+
+## Tech Stack
+
+- **HTML**: Semantic text nodes.
+- **CSS**: CSS Text Decoration Module Level 3, vendor-prefixed emphasis styling.
+- **Zero Dependencies**: Vanilla buildless CSS.
+
+---
+
+## Contribution Notes
+
+- The classes have been implemented in an isolated directory structure to prevent global compilation regressions.
+- Shorthand and semantic standard classes are provided to fit all coding styles.

--- a/submissions/examples/text-emphasis-utilities-ap/demo.html
+++ b/submissions/examples/text-emphasis-utilities-ap/demo.html
@@ -1,0 +1,554 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text Emphasis Utilities - EaseMotion CSS</title>
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&family=Outfit:wght@300;400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+
+    <!-- Core EaseMotion CSS (Optional but good to link) -->
+    <link rel="stylesheet" href="../../../core/variables.css" />
+    <link rel="stylesheet" href="../../../core/utilities.css" />
+    <link rel="stylesheet" href="../../../core/animations.css" />
+
+    <!-- Feature Stylesheet -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <!-- Header Hero Section -->
+      <header>
+        <div class="badge" style="margin-bottom: 1rem; display: inline-block">
+          Typography Module
+        </div>
+        <h1>Text Emphasis Utilities</h1>
+        <p>
+          Configure decorative accent marks (dots, circles, and custom strings)
+          over or under textual spans cleanly.
+        </p>
+      </header>
+
+      <!-- Quick Reference Table -->
+      <section class="demo-section" id="quick-reference">
+        <div class="section-header">
+          <h2 class="section-title">Quick Reference</h2>
+          <p class="section-desc">
+            Quickly check available classes, aliases, and emphasis styling
+            configurations.
+          </p>
+        </div>
+
+        <div class="table-container">
+          <table class="specs-table">
+            <thead>
+              <tr>
+                <th>Class Name (Standard)</th>
+                <th>Shorthand Alias</th>
+                <th>CSS Style Applied</th>
+                <th>Mark Representation</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="badge">.text-emphasis-none</span></td>
+                <td><span class="badge">.emphasis-none</span></td>
+                <td><code>text-emphasis-style: none;</code></td>
+                <td>No marks (Default).</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-dot</span></td>
+                <td><span class="badge">.emphasis-dot</span></td>
+                <td><code>text-emphasis-style: filled dot;</code></td>
+                <td>Solid small dots.</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-circle</span></td>
+                <td><span class="badge">.emphasis-circle</span></td>
+                <td><code>text-emphasis-style: filled circle;</code></td>
+                <td>Solid large circles.</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-triangle</span></td>
+                <td><span class="badge">.emphasis-triangle</span></td>
+                <td><code>text-emphasis-style: filled triangle;</code></td>
+                <td>Solid small triangles.</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-sesame</span></td>
+                <td><span class="badge">.emphasis-sesame</span></td>
+                <td><code>text-emphasis-style: filled sesame;</code></td>
+                <td>Solid diagonal dashes.</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-open-dot</span></td>
+                <td><span class="badge">.emphasis-open-dot</span></td>
+                <td><code>text-emphasis-style: open dot;</code></td>
+                <td>Hollow small dots.</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-open-circle</span></td>
+                <td><span class="badge">.emphasis-open-circle</span></td>
+                <td><code>text-emphasis-style: open circle;</code></td>
+                <td>Hollow large circles.</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-open-triangle</span></td>
+                <td><span class="badge">.emphasis-open-triangle</span></td>
+                <td><code>text-emphasis-style: open triangle;</code></td>
+                <td>Hollow small triangles.</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-open-sesame</span></td>
+                <td><span class="badge">.emphasis-open-sesame</span></td>
+                <td><code>text-emphasis-style: open sesame;</code></td>
+                <td>Hollow diagonal dashes.</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-star</span></td>
+                <td><span class="badge">.emphasis-star</span></td>
+                <td><code>text-emphasis-style: '★';</code></td>
+                <td>Custom star symbol character.</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-heart</span></td>
+                <td><span class="badge">.emphasis-heart</span></td>
+                <td><code>text-emphasis-style: '♥';</code></td>
+                <td>Custom heart symbol character.</td>
+              </tr>
+              <tr>
+                <td><span class="badge">.text-emphasis-fire</span></td>
+                <td><span class="badge">.emphasis-fire</span></td>
+                <td><code>text-emphasis-style: '🔥';</code></td>
+                <td>Custom fire emoji character.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Visual Wrapping Showcase -->
+      <section class="demo-section" id="visual-showcase">
+        <div class="section-header">
+          <h2 class="section-title">Visual Showcase</h2>
+          <p class="section-desc">
+            Observe the emphasis styles in body copy, alert texts, and custom
+            layout highlights.
+          </p>
+        </div>
+
+        <div class="showcase-grid">
+          <!-- Filled Shapes -->
+          <div class="showcase-card">
+            <div class="card-header">
+              <span class="card-title">1. Filled Shapes</span>
+              <span class="badge">Filled</span>
+            </div>
+            <p class="text-preview-box">
+              Use
+              <span class="emphasis-dot decoration-color-pink">dots</span> to
+              note details, or
+              <span class="emphasis-circle decoration-color-pink">circles</span>
+              for major points. Alternatively, use
+              <span class="emphasis-triangle decoration-color-pink"
+                >triangles</span
+              >
+              and
+              <span class="emphasis-sesame decoration-color-pink">sesames</span>
+              for distinct accents.
+            </p>
+            <p class="desc-text">
+              Filled typography shapes are the standard way to emphasize words
+              in vertical and East Asian layouts.
+            </p>
+          </div>
+
+          <!-- Open/Hollow Shapes -->
+          <div class="showcase-card">
+            <div class="card-header">
+              <span class="card-title">2. Hollow Shapes</span>
+              <span class="badge">Hollow</span>
+            </div>
+            <p class="text-preview-box">
+              Apply
+              <span class="emphasis-open-dot decoration-color-indigo"
+                >open dots</span
+              >
+              for subtle highlights,
+              <span class="emphasis-open-circle decoration-color-indigo"
+                >open circles</span
+              >,
+              <span class="emphasis-open-triangle decoration-color-indigo"
+                >open triangles</span
+              >, or
+              <span class="emphasis-open-sesame decoration-color-indigo"
+                >open sesames</span
+              >.
+            </p>
+            <p class="desc-text">
+              Hollow emphasis styles offer a lighter weight, preventing layouts
+              from looking too crowded.
+            </p>
+          </div>
+
+          <!-- Custom Strings -->
+          <div class="showcase-card">
+            <div class="card-header">
+              <span class="card-title">3. Custom Strings & Emojis</span>
+              <span class="badge">Custom</span>
+            </div>
+            <p class="text-preview-box">
+              Add
+              <span class="emphasis-star emphasis-color-amber">stars</span> to
+              showcase ratings,
+              <span class="emphasis-heart emphasis-color-pink">hearts</span> for
+              favorites,
+              <span class="emphasis-check emphasis-color-emerald">checks</span>
+              for success, or
+              <span class="emphasis-fire emphasis-color-pink">fire</span> for
+              alerts.
+            </p>
+            <p class="desc-text">
+              Enables emojis or single character strings to be drawn as
+              repeating emphasis marks over text.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Dynamic Sandbox Playground -->
+      <section class="demo-section" id="sandbox">
+        <div class="section-header">
+          <h2 class="section-title">Interactive Playground</h2>
+          <p class="section-desc">
+            Combine styles, shapes, colors, and positioning dynamically to
+            observe text rendering in real-time.
+          </p>
+        </div>
+
+        <div class="playground-grid">
+          <!-- Controls -->
+          <div class="playground-controls">
+            <!-- Style Class -->
+            <div class="control-group">
+              <span class="control-label">Emphasis Style:</span>
+              <div class="btn-group">
+                <button
+                  class="btn"
+                  id="btn-style-dot"
+                  onclick="setEmphasisStyle('dot')"
+                >
+                  emphasis-dot
+                </button>
+                <button
+                  class="btn active"
+                  id="btn-style-circle"
+                  onclick="setEmphasisStyle('circle')"
+                >
+                  emphasis-circle
+                </button>
+                <button
+                  class="btn"
+                  id="btn-style-open-triangle"
+                  onclick="setEmphasisStyle('open-triangle')"
+                >
+                  emphasis-open-triangle
+                </button>
+                <button
+                  class="btn"
+                  id="btn-style-star"
+                  onclick="setEmphasisStyle('star')"
+                >
+                  emphasis-star
+                </button>
+                <button
+                  class="btn"
+                  id="btn-style-fire"
+                  onclick="setEmphasisStyle('fire')"
+                >
+                  emphasis-fire
+                </button>
+              </div>
+            </div>
+
+            <!-- Position -->
+            <div class="control-group">
+              <span class="control-label">Position:</span>
+              <div class="btn-group" style="flex-direction: row; gap: 0.5rem">
+                <button
+                  class="btn active"
+                  style="flex: 1; text-align: center"
+                  id="btn-pos-over"
+                  onclick="setEmphasisPosition('over')"
+                >
+                  Over
+                </button>
+                <button
+                  class="btn"
+                  style="flex: 1; text-align: center"
+                  id="btn-pos-under"
+                  onclick="setEmphasisPosition('under')"
+                >
+                  Under
+                </button>
+              </div>
+            </div>
+
+            <!-- Color -->
+            <div class="control-group">
+              <span class="control-label">Color Accent:</span>
+              <div class="btn-group">
+                <button
+                  class="btn active"
+                  id="btn-color-pink"
+                  onclick="setEmphasisColor('pink')"
+                >
+                  Pink
+                </button>
+                <button
+                  class="btn"
+                  id="btn-color-indigo"
+                  onclick="setEmphasisColor('indigo')"
+                >
+                  Indigo
+                </button>
+                <button
+                  class="btn"
+                  id="btn-color-emerald"
+                  onclick="setEmphasisColor('emerald')"
+                >
+                  Emerald
+                </button>
+                <button
+                  class="btn"
+                  id="btn-color-amber"
+                  onclick="setEmphasisColor('amber')"
+                >
+                  Amber
+                </button>
+              </div>
+            </div>
+
+            <!-- Active Code output -->
+            <div class="control-group">
+              <span class="control-label">Active CSS Rules:</span>
+              <pre
+                style="
+                  background: var(--color-bg-base);
+                  padding: 0.75rem;
+                  border-radius: 6px;
+                  font-family: &quot;Fira Code&quot;, monospace;
+                  font-size: 0.8rem;
+                  color: var(--color-accent-pink);
+                  border: 1px solid var(--color-border-subtle);
+                "
+                id="active-rule"
+              >
+text-emphasis-style: filled circle;&#10;text-emphasis-position: over right;&#10;text-emphasis-color: #ec4899;</pre
+              >
+            </div>
+          </div>
+
+          <!-- Preview -->
+          <div class="playground-preview">
+            <div class="preview-container">
+              <p
+                style="
+                  font-size: 1.5rem;
+                  font-weight: 600;
+                  text-align: center;
+                  line-height: 2.5;
+                "
+              >
+                Toggle the sandbox dashboard to apply
+                <span
+                  class="emphasis-circle emphasis-position-over emphasis-color-pink"
+                  id="sandbox-text"
+                  >emphasis marks</span
+                >
+                dynamically.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Technical Guide -->
+      <section class="demo-section" id="technical-details">
+        <div class="section-header">
+          <h2 class="section-title">Technical Deep-Dive</h2>
+          <p class="section-desc">
+            Key requirements and localization properties to keep in mind when
+            using emphasis marks.
+          </p>
+        </div>
+
+        <div
+          style="
+            font-size: 0.95rem;
+            color: var(--color-text-secondary);
+            line-height: 1.7;
+          "
+        >
+          <h3
+            style="
+              color: var(--color-text-primary);
+              margin-bottom: 0.75rem;
+              font-size: 1.15rem;
+            "
+          >
+            1. Layout Flow and Line Heights
+          </h3>
+          <p style="margin-bottom: 1.5rem">
+            Adding emphasis marks above or under inline spans increases the
+            vertical dimension requirement for line heights. If paragraph
+            elements have a standard line height (e.g.
+            <code>line-height: 1.4</code>), the emphasis marks can overlap with
+            descending letters (like y, g, p) in the line above. It is
+            recommended to increase the container line height to at least
+            <code>2.0</code> on emphasized blocks.
+          </p>
+
+          <h3
+            style="
+              color: var(--color-text-primary);
+              margin-bottom: 0.75rem;
+              font-size: 1.15rem;
+            "
+          >
+            2. WebKit Prefix Requirements
+          </h3>
+          <p style="margin-bottom: 1.5rem">
+            While Firefox natively supports standard CSS properties like
+            <code>text-emphasis-style</code>, WebKit-based browsers (Safari,
+            Chrome, Edge, Brave) historically required vendor-prefixes:
+            <code>-webkit-text-emphasis-style</code>,
+            <code>-webkit-text-emphasis-color</code>, and
+            <code>-webkit-text-emphasis-position</code>. These utility classes
+            include both prefixed and standard declarations to guarantee
+            cross-browser compatibility.
+          </p>
+
+          <h3
+            style="
+              color: var(--color-text-primary);
+              margin-bottom: 0.75rem;
+              font-size: 1.15rem;
+            "
+          >
+            3. East Asian Typography Roots
+          </h3>
+          <p style="margin-bottom: 1.5rem">
+            CSS Text Emphasis originally emerged to support East Asian
+            typographic rules (specifically Japanese *kentou* and Chinese *bofu*
+            accent marks), where symbols are placed next to characters to convey
+            emphasis. The browser automatically handles character alignment,
+            placing the marks over or under standard text nodes while ignoring
+            spaces and punctuation.
+          </p>
+        </div>
+      </section>
+
+      <!-- Footer -->
+      <footer class="demo-footer">
+        <p>
+          EaseMotion CSS — Created by Saptarshi Sadhu & contributors. Released
+          under the MIT License.
+        </p>
+      </footer>
+    </div>
+
+    <!-- JavaScript controls -->
+    <script>
+      let activeStyle = "circle";
+      let activePos = "over";
+      let activeColor = "pink";
+
+      const colorMap = {
+        pink: "#ec4899",
+        indigo: "#6366f1",
+        emerald: "#10b981",
+        amber: "#f59e0b",
+      };
+
+      const styleMap = {
+        dot: "filled dot",
+        circle: "filled circle",
+        "open-triangle": "open triangle",
+        star: "'★'",
+        fire: "'🔥'",
+      };
+
+      function updateSandbox() {
+        const text = document.getElementById("sandbox-text");
+
+        // Reset classes
+        text.classList.remove(
+          "emphasis-dot",
+          "emphasis-circle",
+          "emphasis-open-triangle",
+          "emphasis-star",
+          "emphasis-fire"
+        );
+        text.classList.add("emphasis-" + activeStyle);
+
+        text.classList.remove(
+          "emphasis-position-over",
+          "emphasis-position-under"
+        );
+        text.classList.add("emphasis-position-" + activePos);
+
+        text.classList.remove(
+          "emphasis-color-pink",
+          "emphasis-color-indigo",
+          "emphasis-color-emerald",
+          "emphasis-color-amber"
+        );
+        text.classList.add("emphasis-color-" + activeColor);
+
+        // Update code output
+        const ruleBox = document.getElementById("active-rule");
+        ruleBox.textContent = `text-emphasis-style: ${styleMap[activeStyle]};\ntext-emphasis-position: ${activePos} right;\ntext-emphasis-color: ${colorMap[activeColor]};`;
+      }
+
+      function setEmphasisStyle(val) {
+        activeStyle = val;
+        document
+          .querySelectorAll(".control-group:first-child .btn")
+          .forEach((btn) => {
+            btn.classList.remove("active");
+          });
+        document.getElementById("btn-style-" + val).classList.add("active");
+        updateSandbox();
+      }
+
+      function setEmphasisPosition(val) {
+        activePos = val;
+        document
+          .querySelectorAll(".control-group:nth-child(2) .btn")
+          .forEach((btn) => {
+            btn.classList.remove("active");
+          });
+        document.getElementById("btn-pos-" + val).classList.add("active");
+        updateSandbox();
+      }
+
+      function setEmphasisColor(val) {
+        activeColor = val;
+        document
+          .querySelectorAll(".control-group:nth-child(3) .btn")
+          .forEach((btn) => {
+            btn.classList.remove("active");
+          });
+        document.getElementById("btn-color-" + val).classList.add("active");
+        updateSandbox();
+      }
+    </script>
+  </body>
+</html>

--- a/submissions/examples/text-emphasis-utilities-ap/style.css
+++ b/submissions/examples/text-emphasis-utilities-ap/style.css
@@ -1,0 +1,479 @@
+/* ============================================================
+   EaseMotion CSS — Text Emphasis Utilities
+   Applies visual emphasis marks (dots, circles, triangles,
+   sesames, custom emojis) to text blocks.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   DESIGN SYSTEM TOKENS & SYSTEM PROPERTIES
+   ------------------------------------------------------------ */
+:root {
+  --color-bg-base: #02040a;
+  --color-bg-surface: #0a0e1a;
+  --color-bg-surface-hover: #12182c;
+  --color-border-subtle: #1e294b;
+  --color-border-hover: #2e3d75;
+
+  --color-text-primary: #f8fafc;
+  --color-text-secondary: #94a3b8;
+  --color-text-muted: #64748b;
+
+  --color-accent-pink: #ec4899;
+  --color-accent-indigo: #6366f1;
+  --color-brand-gradient: linear-gradient(135deg, #ec4899 0%, #6366f1 100%);
+
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+  --shadow-xl:
+    0 20px 25px -5px rgba(0, 0, 0, 0.15), 0 8px 10px -6px rgba(0, 0, 0, 0.15);
+
+  --transition-smooth: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ------------------------------------------------------------
+   CORE SHAPE MARK UTILITIES (FILLED & OPEN SHAPES)
+   ------------------------------------------------------------ */
+.text-emphasis-none,
+.emphasis-none {
+  -webkit-text-emphasis-style: none !important;
+  text-emphasis-style: none !important;
+}
+
+.text-emphasis-dot,
+.emphasis-dot {
+  -webkit-text-emphasis-style: filled dot !important;
+  text-emphasis-style: filled dot !important;
+}
+
+.text-emphasis-circle,
+.emphasis-circle {
+  -webkit-text-emphasis-style: filled circle !important;
+  text-emphasis-style: filled circle !important;
+}
+
+.text-emphasis-double-circle,
+.emphasis-double-circle {
+  -webkit-text-emphasis-style: filled double-circle !important;
+  text-emphasis-style: filled double-circle !important;
+}
+
+.text-emphasis-triangle,
+.emphasis-triangle {
+  -webkit-text-emphasis-style: filled triangle !important;
+  text-emphasis-style: filled triangle !important;
+}
+
+.text-emphasis-sesame,
+.emphasis-sesame {
+  -webkit-text-emphasis-style: filled sesame !important;
+  text-emphasis-style: filled sesame !important;
+}
+
+/* Open (Hollow) variants */
+.text-emphasis-open-dot,
+.emphasis-open-dot {
+  -webkit-text-emphasis-style: open dot !important;
+  text-emphasis-style: open dot !important;
+}
+
+.text-emphasis-open-circle,
+.emphasis-open-circle {
+  -webkit-text-emphasis-style: open circle !important;
+  text-emphasis-style: open circle !important;
+}
+
+.text-emphasis-open-double-circle,
+.emphasis-open-double-circle {
+  -webkit-text-emphasis-style: open double-circle !important;
+  text-emphasis-style: open double-circle !important;
+}
+
+.text-emphasis-open-triangle,
+.emphasis-open-triangle {
+  -webkit-text-emphasis-style: open triangle !important;
+  text-emphasis-style: open triangle !important;
+}
+
+.text-emphasis-open-sesame,
+.emphasis-open-sesame {
+  -webkit-text-emphasis-style: open sesame !important;
+  text-emphasis-style: open sesame !important;
+}
+
+/* Custom String Emphasis Mark Utilities */
+.text-emphasis-star,
+.emphasis-star {
+  -webkit-text-emphasis-style: "★" !important;
+  text-emphasis-style: "★" !important;
+}
+
+.text-emphasis-heart,
+.emphasis-heart {
+  -webkit-text-emphasis-style: "♥" !important;
+  text-emphasis-style: "♥" !important;
+}
+
+.text-emphasis-check,
+.emphasis-check {
+  -webkit-text-emphasis-style: "✔" !important;
+  text-emphasis-style: "✔" !important;
+}
+
+.text-emphasis-fire,
+.emphasis-fire {
+  -webkit-text-emphasis-style: "🔥" !important;
+  text-emphasis-style: "🔥" !important;
+}
+
+/* ------------------------------------------------------------
+   POSITION UTILITIES
+   ------------------------------------------------------------ */
+.text-emphasis-position-over,
+.emphasis-position-over {
+  -webkit-text-emphasis-position: over right !important;
+  text-emphasis-position: over right !important;
+}
+
+.text-emphasis-position-under,
+.emphasis-position-under {
+  -webkit-text-emphasis-position: under right !important;
+  text-emphasis-position: under right !important;
+}
+
+/* ------------------------------------------------------------
+   COLOR UTILITIES
+   ------------------------------------------------------------ */
+.text-emphasis-color-pink,
+.emphasis-color-pink {
+  -webkit-text-emphasis-color: #ec4899 !important;
+  text-emphasis-color: #ec4899 !important;
+}
+
+.text-emphasis-color-indigo,
+.emphasis-color-indigo {
+  -webkit-text-emphasis-color: #6366f1 !important;
+  text-emphasis-color: #6366f1 !important;
+}
+
+.text-emphasis-color-emerald,
+.emphasis-color-emerald {
+  -webkit-text-emphasis-color: #10b981 !important;
+  text-emphasis-color: #10b981 !important;
+}
+
+.text-emphasis-color-amber,
+.emphasis-color-amber {
+  -webkit-text-emphasis-color: #f59e0b !important;
+  text-emphasis-color: #f59e0b !important;
+}
+
+.text-emphasis-color-cyan,
+.emphasis-color-cyan {
+  -webkit-text-emphasis-color: #06b6d4 !important;
+  text-emphasis-color: #06b6d4 !important;
+}
+
+/* ------------------------------------------------------------
+   BASE STYLE OVERRIDES
+   ------------------------------------------------------------ */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--color-bg-base);
+  color: var(--color-text-primary);
+  font-family:
+    "Outfit",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  line-height: 1.8;
+  padding: 4rem 2rem;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 4rem;
+  text-align: center;
+}
+
+header h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  background: var(--color-brand-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.75rem;
+}
+
+header p {
+  font-size: 1.2rem;
+  color: var(--color-text-secondary);
+  max-width: 650px;
+  margin: 0 auto;
+}
+
+/* ------------------------------------------------------------
+   DEMO SECTIONS & CARDS
+   ------------------------------------------------------------ */
+.demo-section {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 20px;
+  padding: 2.5rem;
+  margin-bottom: 3rem;
+  transition: var(--transition-smooth);
+  box-shadow: var(--shadow-lg);
+}
+
+.demo-section:hover {
+  border-color: var(--color-border-hover);
+  box-shadow: var(--shadow-xl);
+}
+
+.section-header {
+  margin-bottom: 2rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: 1rem;
+}
+
+.section-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.section-desc {
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+/* ------------------------------------------------------------
+   TEXT ALIGN CARD LAYOUTS
+   ------------------------------------------------------------ */
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+}
+
+.showcase-card {
+  background: rgba(255, 255, 255, 0.015);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 0.75rem;
+}
+
+.card-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.badge {
+  font-family: monospace;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  background: rgba(236, 72, 153, 0.15);
+  color: var(--color-accent-pink);
+  border: 1px solid rgba(236, 72, 153, 0.25);
+}
+
+.text-preview-box {
+  font-size: 1.15rem;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  padding: 1rem 0;
+  line-height: 2.2; /* Expand line spacing to avoid emphasis overlapping lines */
+}
+
+.desc-text {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  margin-top: 0.5rem;
+}
+
+/* ------------------------------------------------------------
+   PLAYGROUND SYSTEM
+   ------------------------------------------------------------ */
+.playground-grid {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 2rem;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.playground-controls {
+  background: rgba(255, 255, 255, 0.01);
+  border-right: 1px solid var(--color-border-subtle);
+  padding: 1.5rem;
+}
+
+.control-group {
+  margin-bottom: 2rem;
+}
+
+.control-group:last-child {
+  margin-bottom: 0;
+}
+
+.control-label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.btn-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.btn {
+  background: var(--color-bg-base);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
+  font-family: inherit;
+  font-size: 0.9rem;
+  padding: 0.6rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: var(--transition-smooth);
+}
+
+.btn:hover {
+  border-color: var(--color-border-hover);
+  color: var(--color-text-primary);
+}
+
+.btn.active {
+  background: var(--color-accent-pink);
+  border-color: var(--color-accent-pink);
+  color: #fff;
+}
+
+.playground-preview {
+  padding: 2.5rem;
+  background: var(--color-bg-base);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview-container {
+  width: 100%;
+}
+
+/* ------------------------------------------------------------
+   QUICK SPECS TABLE
+   ------------------------------------------------------------ */
+.table-container {
+  overflow-x: auto;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+}
+
+.specs-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.specs-table th,
+.specs-table td {
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.specs-table th {
+  background: rgba(255, 255, 255, 0.015);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.specs-table td {
+  color: var(--color-text-secondary);
+}
+
+.specs-table code {
+  font-family: "Fira Code", monospace;
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  color: var(--color-accent-pink);
+}
+
+.specs-table tr:last-child td {
+  border-bottom: none;
+}
+
+/* ------------------------------------------------------------
+   FOOTER
+   ------------------------------------------------------------ */
+.demo-footer {
+  margin-top: 5rem;
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 2rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+/* ------------------------------------------------------------
+   RESPONSIVE DESIGN ADAPTATIONS
+   ------------------------------------------------------------ */
+@media (max-width: 850px) {
+  body {
+    padding: 2rem 1rem;
+  }
+  header h1 {
+    font-size: 2.25rem;
+  }
+  .playground-grid {
+    grid-template-columns: 1fr;
+  }
+  .playground-controls {
+    border-right: none;
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+  .demo-section {
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
### Description
This PR adds text-emphasis utilities to EaseMotion CSS, allowing developers to configure repeating typography accent marks (`emphasis-dot`, `emphasis-circle`, `emphasis-triangle`, `emphasis-sesame`, open hollow variants, and custom star/heart/fire/check emojis) over or under inline text runs.

This submission has **1225 lines of changes**, which satisfies the line count requirement (500+ lines) for the level:advanced badge.

### Checklist
- [x] Folder added inside `submissions/examples/` with name `text-emphasis-utilities-ap`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Verified with `npm test`

Closes #16600