### PR TITLE
feat: add image-rendering utilities

### DIFF
--- a/submissions/examples/image-rendering-utilities-wk/README.md
+++ b/submissions/examples/image-rendering-utilities-wk/README.md
@@ -1,0 +1,23 @@
+# Image Rendering Utility Classes
+
+## What does this do?
+
+This adds utility classes to configure image upscaling algorithms in EaseMotion CSS. It provides control over whether scaled images appear smooth/blurred (default browser interpolation) or sharp/blocky (nearest-neighbor scaling, perfect for retro pixel art).
+
+## How is it used?
+
+Apply these scaling utility classes on images (`<img>`), canvas, or graphics elements:
+
+```html
+<img src="retro-sprite.png" class="ease-image-render-pixelated" />
+```
+
+Available classes:
+
+- `.ease-image-render-auto`: Scaling using the browser's default smooth algorithm (bilinear or bicubic interpolation).
+- `.ease-image-render-crisp`: Scaling preserving high contrast and edge crispness. Uses vendor prefixes (`-moz-crisp-edges`, `-webkit-optimize-contrast`, and `crisp-edges`) for cross-browser safety.
+- `.ease-image-render-pixelated`: Scaling using a nearest-neighbor algorithm, causing pixels to look blocky and retro.
+
+## Why is it useful?
+
+It gives developers control over image quality rendering, allowing sharp presentation of low-resolution retro sprites, pixel art icons, barcodes, and medical images without browser-induced blurriness.

--- a/submissions/examples/image-rendering-utilities-wk/demo.html
+++ b/submissions/examples/image-rendering-utilities-wk/demo.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — Image Rendering Utilities Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-container">
+      <header class="demo-header">
+        <span class="demo-badge">Scaling & Rendering Utility</span>
+        <h1 class="demo-title">Image Rendering Utilities</h1>
+        <p class="demo-description">
+          Demonstrating image-rendering algorithms. Notice how low-resolution or
+          pixel art images scale up differently depending on the rendering
+          utility.
+        </p>
+      </header>
+
+      <!-- Toolbar Controls -->
+      <section class="demo-controls">
+        <div class="control-group">
+          <span class="control-label">Zoom Scale:</span>
+          <div class="btn-group">
+            <button class="control-btn" onclick="setScale(8)">8x Zoom</button>
+            <button class="control-btn active" onclick="setScale(16)">
+              16x Zoom
+            </button>
+            <button class="control-btn" onclick="setScale(24)">24x Zoom</button>
+          </div>
+        </div>
+
+        <div class="control-group theme-group">
+          <label class="toggle-switch">
+            <input type="checkbox" id="dark-mode-toggle" />
+            <span class="slider"></span>
+          </label>
+          <span class="toggle-label">Dark Mode</span>
+        </div>
+      </section>
+
+      <!-- Demo Grid -->
+      <div class="demo-grid">
+        <!-- Card 1: Auto -->
+        <div class="demo-card">
+          <div class="card-header">
+            <h2 class="card-headline">image-render-auto</h2>
+            <code class="class-name">.ease-image-render-auto</code>
+          </div>
+          <p class="card-desc">
+            The browser uses its default bilinear/bicubic scaling algorithm,
+            resulting in a smooth, blurry image when upscaled.
+          </p>
+          <div class="canvas-wrapper">
+            <img
+              class="pixel-art-img ease-image-render-auto"
+              alt="Pixel Art (Auto)"
+            />
+          </div>
+          <span class="box-status status-danger">Blurry / Smoothed out</span>
+        </div>
+
+        <!-- Card 2: Pixelated -->
+        <div class="demo-card">
+          <div class="card-header">
+            <h2 class="card-headline">image-render-pixelated</h2>
+            <code class="class-name">.ease-image-render-pixelated</code>
+          </div>
+          <p class="card-desc">
+            The image is scaled using the nearest-neighbor algorithm, preserving
+            sharp pixel blocks (ideal for retro pixel art).
+          </p>
+          <div class="canvas-wrapper">
+            <img
+              class="pixel-art-img ease-image-render-pixelated"
+              alt="Pixel Art (Pixelated)"
+            />
+          </div>
+          <span class="box-status status-success"
+            >Crisp Pixels (Pixelated)</span
+          >
+        </div>
+
+        <!-- Card 3: Crisp-Edges -->
+        <div class="demo-card">
+          <div class="card-header">
+            <h2 class="card-headline">image-render-crisp</h2>
+            <code class="class-name">.ease-image-render-crisp</code>
+          </div>
+          <p class="card-desc">
+            Scales while preserving contrast and sharp borders. Leverages
+            crisp-edges vendor prefixes for cross-browser support.
+          </p>
+          <div class="canvas-wrapper">
+            <img
+              class="pixel-art-img ease-image-render-crisp"
+              alt="Pixel Art (Crisp-Edges)"
+            />
+          </div>
+          <span class="box-status status-success"
+            >Crisp Pixels (Crisp-Edges)</span
+          >
+        </div>
+      </div>
+    </main>
+
+    <script>
+      // Dynamically generate a 16x16 retro pixel art heart
+      window.addEventListener("DOMContentLoaded", () => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 16;
+        canvas.height = 16;
+        const ctx = canvas.getContext("2d");
+
+        ctx.clearRect(0, 0, 16, 16);
+
+        // Draw red heart outline and fill
+        ctx.fillStyle = "#ef4444";
+        ctx.fillRect(3, 3, 3, 3);
+        ctx.fillRect(4, 2, 2, 1);
+        ctx.fillRect(2, 4, 1, 3);
+
+        ctx.fillRect(10, 3, 3, 3);
+        ctx.fillRect(10, 2, 2, 1);
+        ctx.fillRect(13, 4, 1, 3);
+
+        ctx.fillRect(3, 6, 10, 3);
+        ctx.fillRect(4, 9, 8, 2);
+        ctx.fillRect(5, 11, 6, 2);
+        ctx.fillRect(7, 13, 2, 2);
+
+        // Highlight
+        ctx.fillStyle = "#fee2e2";
+        ctx.fillRect(4, 3, 1, 1);
+        ctx.fillRect(11, 3, 1, 1);
+
+        const dataUrl = canvas.toDataURL();
+        document.querySelectorAll(".pixel-art-img").forEach((img) => {
+          img.src = dataUrl;
+        });
+
+        // Apply default scale
+        setScale(16);
+      });
+
+      function setScale(factor) {
+        const images = document.querySelectorAll(".pixel-art-img");
+        images.forEach((img) => {
+          img.style.width = factor * 16 + "px";
+          img.style.height = factor * 16 + "px";
+        });
+
+        const buttons = document.querySelectorAll(
+          ".control-group:first-child .control-btn"
+        );
+        buttons.forEach((btn) => btn.classList.remove("active"));
+        event.target.classList.add("active");
+      }
+
+      // Dark mode toggle
+      const toggle = document.getElementById("dark-mode-toggle");
+      toggle.addEventListener("change", () => {
+        if (toggle.checked) {
+          document.body.classList.add("dark-theme");
+        } else {
+          document.body.classList.remove("dark-theme");
+        }
+      });
+      if (
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+      ) {
+        toggle.checked = true;
+        document.body.classList.add("dark-theme");
+      }
+    </script>
+  </body>
+</html>

--- a/submissions/examples/image-rendering-utilities-wk/style.css
+++ b/submissions/examples/image-rendering-utilities-wk/style.css
@@ -1,0 +1,331 @@
+/* ============================================================
+   EaseMotion CSS — image-rendering utilities
+   ============================================================ */
+
+/* Design Tokens & Theme Variables */
+:root {
+  --ease-font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --ease-color-bg: #f8fafc;
+  --ease-color-surface: #ffffff;
+  --ease-color-text: #0f172a;
+  --ease-color-muted: #64748b;
+  --ease-color-border: #e2e8f0;
+  --ease-color-primary: #6c63ff;
+  --ease-color-primary-alpha: rgba(108, 99, 255, 0.08);
+
+  --ease-radius-md: 12px;
+  --ease-radius-sm: 6px;
+  --ease-speed-fast: 150ms;
+  --ease-speed-medium: 300ms;
+  --ease-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.05);
+  --ease-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.dark-theme {
+  --ease-color-bg: #0b1121;
+  --ease-color-surface: #141e33;
+  --ease-color-text: #f1f5f9;
+  --ease-color-muted: #94a3b8;
+  --ease-color-border: #1e293b;
+  --ease-color-primary-alpha: rgba(108, 99, 255, 0.15);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: var(--ease-font-sans);
+  min-height: 100vh;
+  transition:
+    background-color var(--ease-speed-medium) var(--ease-ease),
+    color var(--ease-speed-medium) var(--ease-ease);
+  display: flex;
+  justify-content: center;
+}
+
+.demo-container {
+  max-width: 1200px;
+  width: 100%;
+  padding: 3rem 1.5rem;
+}
+
+/* Header Section */
+.demo-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.demo-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ease-color-primary);
+  background-color: var(--ease-color-primary-alpha);
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  margin-bottom: 0.75rem;
+}
+
+.demo-title {
+  font-size: 2.25rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.demo-description {
+  font-size: 1rem;
+  color: var(--ease-color-muted);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+/* Toolbar controls */
+.demo-controls {
+  background-color: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: var(--ease-radius-md);
+  padding: 1.5rem;
+  box-shadow: var(--ease-shadow-sm);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 2.5rem;
+}
+
+.control-group {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.control-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.btn-group {
+  display: inline-flex;
+  border-radius: var(--ease-radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--ease-color-border);
+}
+
+.control-btn {
+  background: var(--ease-color-surface);
+  border: none;
+  color: var(--ease-color-text);
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  outline: none;
+  transition:
+    background var(--ease-speed-fast) var(--ease-ease),
+    color var(--ease-speed-fast) var(--ease-ease);
+}
+
+.control-btn:not(:last-child) {
+  border-right: 1px solid var(--ease-color-border);
+}
+
+.control-btn.active {
+  background: var(--ease-color-primary);
+  color: #ffffff;
+}
+
+.control-btn:focus-visible {
+  background: var(--ease-color-primary-alpha);
+  outline: 2px solid var(--ease-color-primary);
+  z-index: 2;
+}
+
+/* Dark mode toggle */
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #cbd5e1;
+  transition: var(--ease-speed-fast) var(--ease-ease);
+  border-radius: 9999px;
+}
+
+.slider::before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 4px;
+  bottom: 4px;
+  background-color: #ffffff;
+  transition: var(--ease-speed-fast) var(--ease-ease);
+  border-radius: 50%;
+}
+
+.toggle-switch input:checked + .slider {
+  background-color: var(--ease-color-primary);
+}
+
+.toggle-switch input:checked + .slider::before {
+  transform: translateX(20px);
+}
+
+.toggle-switch input:focus-visible + .slider {
+  box-shadow: 0 0 0 3px var(--ease-color-primary-alpha);
+}
+
+.toggle-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  user-select: none;
+}
+
+/* Demo Grid */
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+}
+
+.demo-card {
+  background-color: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: var(--ease-radius-md);
+  padding: 2rem;
+  box-shadow: var(--ease-shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.card-headline {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.class-name {
+  font-size: 0.85rem;
+  color: var(--ease-color-primary);
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+  background-color: var(--ease-color-primary-alpha);
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  align-self: flex-start;
+}
+
+.card-desc {
+  font-size: 0.875rem;
+  color: var(--ease-color-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* Container containing the image */
+.canvas-wrapper {
+  background-color: var(--ease-color-bg);
+  border: 1px solid var(--ease-color-border);
+  border-radius: var(--ease-radius-sm);
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  transition: background-color var(--ease-speed-medium) var(--ease-ease);
+}
+
+.pixel-art-img {
+  max-width: 100%;
+  transition:
+    width var(--ease-speed-medium) var(--ease-ease),
+    height var(--ease-speed-medium) var(--ease-ease);
+}
+
+.box-status {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 0.35rem;
+  border-radius: 4px;
+  margin-top: auto;
+}
+
+.status-danger {
+  background-color: #fee2e2;
+  color: #ef4444;
+}
+
+.dark-theme .status-danger {
+  background-color: rgba(239, 68, 68, 0.15);
+}
+
+.status-success {
+  background-color: #dcfce7;
+  color: #10b981;
+}
+
+.dark-theme .status-success {
+  background-color: rgba(16, 185, 129, 0.15);
+}
+
+/* ────────────────────────────────────────────────────────────
+   Image Rendering Utility Classes
+   ──────────────────────────────────────────────────────────── */
+
+.ease-image-render-auto {
+  image-rendering: auto !important;
+}
+
+.ease-image-render-crisp {
+  image-rendering: -moz-crisp-edges !important;
+  image-rendering: -webkit-optimize-contrast !important;
+  image-rendering: crisp-edges !important;
+}
+
+.ease-image-render-pixelated {
+  image-rendering: pixelated !important;
+}
+
+/* Responsive reduction rules */
+@media (prefers-reduced-motion: reduce) {
+  body,
+  .slider,
+  .slider::before,
+  .pixel-art-img,
+  .control-btn {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces a self-contained showcase of new image-rendering utilities under `submissions/examples/image-rendering-utilities-wk/` to resolve issue #16571.

It defines utility classes to configure image upscaling algorithms in EaseMotion CSS.

**Utilities introduced:**
- `.ease-image-render-auto`: Scaling using the browser's default smooth algorithm (bilinear or bicubic interpolation).
- `.ease-image-render-crisp`: Scaling preserving high contrast and edge crispness. Uses vendor prefixes (`-moz-crisp-edges`, `-webkit-optimize-contrast`, and `crisp-edges`) for cross-browser safety.
- `.ease-image-render-pixelated`: Scaling using a nearest-neighbor algorithm, causing pixels to look blocky and retro (perfect for pixel art).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component / utility
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  * Spacing block-axis logical layout utilities.

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/image-rendering-utilities-wk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Configuration utility classes for upscaling algorithms of images, canvases, and vector assets.

**How does a developer use it?**
Add scaling utility classes to low-resolution or pixel art icons to preserve their sharp, crisp blocked style:
```html
<img src="retro-sprite.png" class="ease-image-render-pixelated" />
