### PR TITLE
feat: add transform-box utilities

### DIFF
--- a/submissions/examples/transform-box-utilities/README.md
+++ b/submissions/examples/transform-box-utilities/README.md
@@ -1,0 +1,80 @@
+# Transform-Box Utilities
+
+A lightweight collection of atomic CSS `transform-box` utility classes designed to control the layout box used to calculate transform origins and coordinates. These utilities are essential when working with CSS transitions and animations on SVG elements (e.g., shape-centered vs. viewport-centered rotation) or HTML box-model elements (e.g., content-based vs. border-inclusive pivot offsets).
+
+## Features
+
+- **Pure CSS implementation** (no JavaScript required for core functionality).
+- **EaseMotion Naming Standard**: clear atomic classes with the `.ease-transform-box-` prefix.
+- **SVG-Optimized**: supports `fill-box`, `stroke-box`, and `view-box` for complex path transformations.
+- **HTML Box-Model Support**: supports `content-box` and `border-box` to adjust pivot coordinate offsets.
+- **Developer-Friendly Documentation**: includes explicit use-cases and interactive layouts.
+
+## Available Utility Classes
+
+| Class Name | CSS Rule | Description / Use Case |
+| :--- | :--- | :--- |
+| `ease-transform-box-fill` / `ease-transform-box-fill-box` | `transform-box: fill-box;` | Uses the shape's object bounding box as the reference box. Ideal for rotating SVG paths/shapes around their own center. |
+| `ease-transform-box-stroke` / `ease-transform-box-stroke-box` | `transform-box: stroke-box;` | Uses the shape's bounding box including its stroke width. Helpful for thick-bordered vector elements. |
+| `ease-transform-box-view` / `ease-transform-box-view-box` | `transform-box: view-box;` | Uses the nearest SVG viewport container as the reference box. Ideal for orbital motions around the canvas center. |
+| `ease-transform-box-border` / `ease-transform-box-border-box` | `transform-box: border-box;` | Uses the element's border box boundary for transform operations. Default behavior for HTML block-level elements. |
+| `ease-transform-box-content` / `ease-transform-box-content-box` | `transform-box: content-box;` | Uses the element's content box (inside padding and border boundaries) for transform origin points. |
+
+## Usage Examples
+
+### 1. SVG Center Rotation (`fill-box`)
+By default, SVG shapes calculate their `transform-origin` relative to the entire SVG canvas (`view-box`), causing them to orbit instead of spin. Adding `ease-transform-box-fill` centers the transformation inside the shape's own bounding box:
+
+```html
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <!-- Gear rotates cleanly on its own axis -->
+  <g class="ease-transform-box-fill" style="transform-origin: center; animation: spin 4s linear infinite;">
+    <circle cx="140" cy="140" r="20" fill="indigo" />
+    <!-- gear teeth paths here -->
+  </g>
+</svg>
+```
+
+### 2. SVG Orbital Rotation (`view-box`)
+If you want an SVG element to orbit around the viewport's center, use `ease-transform-box-view`:
+
+```html
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <!-- Planet orbits around the center of the SVG canvas -->
+  <circle cx="150" cy="100" r="10" fill="orange"
+          class="ease-transform-box-view" 
+          style="transform-origin: center; animation: spin 8s linear infinite;" />
+</svg>
+```
+
+### 3. HTML Box-Model Pivot Shift (`content-box`)
+For HTML elements, you can shift the transform origin inside the padding and borders by changing the reference box to `content-box`:
+
+```html
+<!-- Rotates relative to the inner content area top-left corner (ignoring padding and borders) -->
+<div class="ease-transform-box-content" style="transform-origin: 0 0; padding: 20px; border: 10px solid black;">
+  旋转框 (Content Box Origin)
+</div>
+```
+
+## Why is it Useful?
+
+1. **Resolves SVG Origin Bugs**: Prior to CSS `transform-box`, animating individual SVG paths was notoriously difficult because browsers defaulted to canvas coordinate space.
+2. **Eliminates Magic Spacing Offsets**: Using `fill-box` saves you from calculating absolute coordinate values for `transform-origin` on irregular shape groups.
+3. **Ensures Box-Model Alignment**: When designing nested hover-scaling components, switching HTML reference boxes guarantees that elements scale from content areas rather than borders.
+
+## Browser Support
+
+| Browser | Supported | Notes |
+| :--- | :---: | :--- |
+| **Chrome** | ✅ | Full support (v55+) |
+| **Firefox** | ✅ | Full support (v53+) |
+| **Safari** | ✅ | Full support (v11+) |
+| **Edge** | ✅ | Full support (v79+) |
+
+---
+
+**Submitted by:** @EaseMotion Community  
+**Date:** 2026-06-23  
+**Status:** Ready for review  
+**Type:** Pure CSS Utilities / Layout  

--- a/submissions/examples/transform-box-utilities/demo.html
+++ b/submissions/examples/transform-box-utilities/demo.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Transform-Box Utilities - EaseMotion CSS</title>
+  <!-- Link to the stylesheet -->
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-container">
+    <header>
+      <span class="badge">Layout & Transform Utilities</span>
+      <h1>Transform-Box Utilities</h1>
+      <p>Control the reference layout box used to calculate transform origins and coordinates. Essential for centering SVG rotations and aligning HTML box-model rotations.</p>
+    </header>
+
+    <div class="showcase-grid">
+      
+      <!-- SVG Transform Showcase -->
+      <section class="showcase-card" id="svg-showcase">
+        <h2 class="section-title"><span>🎨</span> SVG Reference Box</h2>
+        <p class="section-subtitle">Toggle how the rotating gear calculates its center pivot: around its own boundaries (fill-box) or the SVG viewport (view-box).</p>
+        
+        <div class="controls-group">
+          <span class="control-label">Select Utility Class:</span>
+          <div class="selector-buttons">
+            <button class="selector-btn active" id="btn-svg-fill" data-class="ease-transform-box-fill">ease-transform-box-fill</button>
+            <button class="selector-btn" id="btn-svg-view" data-class="ease-transform-box-view">ease-transform-box-view</button>
+          </div>
+        </div>
+
+        <div class="canvas-container">
+          <span class="canvas-badge">SVG Viewport (0 0 200 200)</span>
+          <!-- Guidelines indicating SVG center -->
+          <div class="guideline-x"></div>
+          <div class="guideline-y"></div>
+          
+          <svg class="demo-svg" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+            <!-- Viewport border -->
+            <rect x="0" y="0" width="200" height="200" fill="none" stroke="rgba(255, 255, 255, 0.1)" stroke-dasharray="4 4" />
+            
+            <!-- Rotating Gear Group -->
+            <!-- Bounding Box Center of this group is (140, 140) -->
+            <g id="rotating-gear" class="svg-element spin-animation ease-transform-box-fill">
+              <!-- Outer teeth -->
+              <rect x="135" y="112" width="10" height="15" rx="2" class="gear-outer" transform="rotate(0 140 140)" />
+              <rect x="135" y="112" width="10" height="15" rx="2" class="gear-outer" transform="rotate(45 140 140)" />
+              <rect x="135" y="112" width="10" height="15" rx="2" class="gear-outer" transform="rotate(90 140 140)" />
+              <rect x="135" y="112" width="10" height="15" rx="2" class="gear-outer" transform="rotate(135 140 140)" />
+              <rect x="135" y="112" width="10" height="15" rx="2" class="gear-outer" transform="rotate(180 140 140)" />
+              <rect x="135" y="112" width="10" height="15" rx="2" class="gear-outer" transform="rotate(225 140 140)" />
+              <rect x="135" y="112" width="10" height="15" rx="2" class="gear-outer" transform="rotate(270 140 140)" />
+              <rect x="135" y="112" width="10" height="15" rx="2" class="gear-outer" transform="rotate(315 140 140)" />
+              
+              <!-- Main body -->
+              <circle cx="140" cy="140" r="22" class="gear-outer" />
+              <circle cx="140" cy="140" r="16" class="gear-inner" />
+              <!-- Core hole -->
+              <circle cx="140" cy="140" r="6" fill="#0b0f19" />
+            </g>
+
+            <!-- Dynamic Active Pivot Dot -->
+            <circle id="svg-pivot-dot" class="pivot-indicator" cx="140" cy="140" r="4" />
+          </svg>
+        </div>
+
+        <div class="code-display">
+          <code class="code-text" id="svg-code-text">&lt;g class="ease-transform-box-fill"&gt;</code>
+          <button class="copy-btn" data-target="svg-code-text">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+            <span>Copy</span>
+          </button>
+        </div>
+      </section>
+
+      <!-- HTML Box-Model Showcase -->
+      <section class="showcase-card alt" id="html-showcase">
+        <h2 class="section-title"><span>📦</span> HTML Box Model Reference</h2>
+        <p class="section-subtitle">Toggle how the swinging element rotates from top-left (0,0): content-box (inside border/padding) vs border-box (outermost corner).</p>
+        
+        <div class="controls-group">
+          <span class="control-label">Select Utility Class:</span>
+          <div class="selector-buttons">
+            <button class="selector-btn active" id="btn-html-border" data-class="ease-transform-box-border">ease-transform-box-border</button>
+            <button class="selector-btn" id="btn-html-content" data-class="ease-transform-box-content">ease-transform-box-content</button>
+          </div>
+        </div>
+
+        <div class="canvas-container">
+          <span class="canvas-badge">Swing Origin (0,0)</span>
+          
+          <div class="html-element-wrapper">
+            <!-- Guidelines outlining box borders -->
+            <div id="html-outline-highlight" class="box-outline-highlight"></div>
+            
+            <!-- Swing Box element -->
+            <div id="swing-box" class="html-box swing-animation ease-transform-box-border">
+              <div class="inner-content-box">TEXT</div>
+            </div>
+            
+            <!-- Active Pivot Dot Overlay -->
+            <div id="html-pivot-dot" class="html-pivot-dot"></div>
+          </div>
+        </div>
+
+        <div class="code-display">
+          <code class="code-text" id="html-code-text">&lt;div class="ease-transform-box-border"&gt;</code>
+          <button class="copy-btn" data-target="html-code-text">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+            <span>Copy</span>
+          </button>
+        </div>
+      </section>
+
+    </div>
+
+    <footer>
+      <p>EaseMotion-css &copy; 2026. Ready for GSSoC contribution.</p>
+    </footer>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      
+      // === SVG DEMO INTERACTION ===
+      const btnSvgFill = document.getElementById('btn-svg-fill');
+      const btnSvgView = document.getElementById('btn-svg-view');
+      const rotatingGear = document.getElementById('rotating-gear');
+      const svgPivotDot = document.getElementById('svg-pivot-dot');
+      const svgCodeText = document.getElementById('svg-code-text');
+
+      function updateSvgDemo(mode) {
+        rotatingGear.classList.remove('ease-transform-box-fill', 'ease-transform-box-view');
+        if (mode === 'fill') {
+          btnSvgFill.classList.add('active');
+          btnSvgView.classList.remove('active');
+          rotatingGear.classList.add('ease-transform-box-fill');
+          svgCodeText.textContent = '<g class="ease-transform-box-fill">';
+          // Fill Box center is shape bbox center (140, 140)
+          svgPivotDot.setAttribute('cx', '140');
+          svgPivotDot.setAttribute('cy', '140');
+        } else {
+          btnSvgFill.classList.remove('active');
+          btnSvgView.classList.add('active');
+          rotatingGear.classList.add('ease-transform-box-view');
+          svgCodeText.textContent = '<g class="ease-transform-box-view">';
+          // View Box center is SVG viewport center (100, 100)
+          svgPivotDot.setAttribute('cx', '100');
+          svgPivotDot.setAttribute('cy', '100');
+        }
+      }
+
+      btnSvgFill.addEventListener('click', () => updateSvgDemo('fill'));
+      btnSvgView.addEventListener('click', () => updateSvgDemo('view'));
+
+
+      // === HTML DEMO INTERACTION ===
+      const btnHtmlBorder = document.getElementById('btn-html-border');
+      const btnHtmlContent = document.getElementById('btn-html-content');
+      const swingBox = document.getElementById('swing-box');
+      const htmlPivotDot = document.getElementById('html-pivot-dot');
+      const htmlOutlineHighlight = document.getElementById('html-outline-highlight');
+      const htmlCodeText = document.getElementById('html-code-text');
+
+      function updateHtmlDemo(mode) {
+        swingBox.classList.remove('ease-transform-box-border', 'ease-transform-box-content');
+        if (mode === 'border') {
+          btnHtmlBorder.classList.add('active');
+          btnHtmlContent.classList.remove('active');
+          swingBox.classList.add('ease-transform-box-border');
+          htmlCodeText.textContent = '<div class="ease-transform-box-border">';
+          
+          // Border-box top-left corner is at (20px, 20px)
+          htmlPivotDot.style.left = '20px';
+          htmlPivotDot.style.top = '20px';
+          
+          // Highlight border box dimensions
+          htmlOutlineHighlight.style.left = '20px';
+          htmlOutlineHighlight.style.top = '20px';
+          htmlOutlineHighlight.style.width = '140px';
+          htmlOutlineHighlight.style.height = '140px';
+        } else {
+          btnHtmlBorder.classList.remove('active');
+          btnHtmlContent.classList.add('active');
+          swingBox.classList.add('ease-transform-box-content');
+          htmlCodeText.textContent = '<div class="ease-transform-box-content">';
+          
+          // Content-box top-left corner is at (50px, 50px) because of 10px border + 20px padding
+          htmlPivotDot.style.left = '50px';
+          htmlPivotDot.style.top = '50px';
+          
+          // Highlight content box dimensions
+          htmlOutlineHighlight.style.left = '50px';
+          htmlOutlineHighlight.style.top = '50px';
+          htmlOutlineHighlight.style.width = '80px';
+          htmlOutlineHighlight.style.height = '80px';
+        }
+      }
+
+      btnHtmlBorder.addEventListener('click', () => updateHtmlDemo('border'));
+      btnHtmlContent.addEventListener('click', () => updateHtmlDemo('content'));
+
+      // Initialize HTML Box highlight dimensions
+      updateHtmlDemo('border');
+
+
+      // === COPY BUTTON HELPER ===
+      const copyBtns = document.querySelectorAll('.copy-btn');
+      copyBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const targetId = btn.getAttribute('data-target');
+          const codeEl = document.getElementById(targetId);
+          const rawText = codeEl.textContent.match(/class="([^"]+)"/)[1];
+          
+          navigator.clipboard.writeText(rawText).then(() => {
+            const span = btn.querySelector('span');
+            const originalText = span.textContent;
+            span.textContent = 'Copied!';
+            btn.style.backgroundColor = 'rgba(99, 102, 241, 0.2)';
+            
+            setTimeout(() => {
+              span.textContent = originalText;
+              btn.style.backgroundColor = 'rgba(255, 255, 255, 0.05)';
+            }, 1500);
+          }).catch(err => {
+            console.error('Failed to copy class: ', err);
+          });
+        });
+      });
+
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/transform-box-utilities/style.css
+++ b/submissions/examples/transform-box-utilities/style.css
@@ -1,0 +1,452 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+
+/* ============================================================
+   DESIGN TOKENS & UTILITIES: Transform-Box
+   ============================================================ */
+
+/* --- UTILITY CLASSES --- */
+
+/* Content-Box: Layout box matches the content box */
+.ease-transform-box-content,
+.ease-transform-box-content-box {
+  transform-box: content-box !important;
+}
+
+/* Border-Box: Layout box matches the border box */
+.ease-transform-box-border,
+.ease-transform-box-border-box {
+  transform-box: border-box !important;
+}
+
+/* Fill-Box: Layout box matches the object bounding box (SVG shapes) */
+.ease-transform-box-fill,
+.ease-transform-box-fill-box {
+  transform-box: fill-box !important;
+}
+
+/* Stroke-Box: Layout box matches the stroke bounding box (SVG shapes) */
+.ease-transform-box-stroke,
+.ease-transform-box-stroke-box {
+  transform-box: stroke-box !important;
+}
+
+/* View-Box: Layout box matches the nearest SVG viewport box */
+.ease-transform-box-view,
+.ease-transform-box-view-box {
+  transform-box: view-box !important;
+}
+
+
+/* ============================================================
+   PRESENTATION & SHOWCASE STYLES
+   ============================================================ */
+
+:root {
+  --bg-primary: #0b0f19;
+  --bg-secondary: #161b2a;
+  --bg-card: #1f263b;
+  --accent-color: #6366f1;
+  --accent-secondary: #f43f5e; /* Rose / Coral */
+  --text-primary: #f3f4f6;
+  --text-secondary: #9ca3af;
+  --text-muted: #6b7280;
+  --border-color: #2d3748;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.demo-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+/* Header Styling */
+header {
+  text-align: center;
+  margin-bottom: 4rem;
+}
+
+.badge {
+  display: inline-block;
+  background: rgba(99, 102, 241, 0.15);
+  color: #818cf8;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+header h1 {
+  font-family: 'Outfit', sans-serif;
+  font-size: 2.75rem;
+  font-weight: 800;
+  margin: 0 0 1rem 0;
+  background: linear-gradient(135deg, #ffffff 40%, #a5b4fc 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+header p {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+/* Grid Showcase Layout */
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(480px, 1fr));
+  gap: 2.5rem;
+  margin-bottom: 3.5rem;
+}
+
+@media (max-width: 1024px) {
+  .showcase-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Showcase Card */
+.showcase-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.5);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.showcase-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, var(--accent-color), #a5b4fc);
+}
+
+.showcase-card.alt::before {
+  background: linear-gradient(90deg, var(--accent-secondary), #fca5a5);
+}
+
+.section-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.section-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+.section-title span {
+  color: var(--accent-color);
+}
+
+.showcase-card.alt .section-title span {
+  color: var(--accent-secondary);
+}
+
+/* Controls / Selector Buttons */
+.controls-group {
+  margin-bottom: 1.5rem;
+}
+
+.control-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+  display: block;
+}
+
+.selector-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.selector-btn {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  padding: 0.5rem 1rem;
+  border-radius: 0.35rem;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.85rem;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.selector-btn:hover {
+  border-color: var(--accent-color);
+  color: var(--text-primary);
+}
+
+.showcase-card.alt .selector-btn:hover {
+  border-color: var(--accent-secondary);
+}
+
+.selector-btn.active {
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+  color: white;
+  box-shadow: 0 4px 10px rgba(99, 102, 241, 0.25);
+}
+
+.showcase-card.alt .selector-btn.active {
+  background: var(--accent-secondary);
+  border-color: var(--accent-secondary);
+  box-shadow: 0 4px 10px rgba(244, 63, 94, 0.25);
+}
+
+/* Visual Canvas Layout */
+.canvas-container {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 2rem;
+  min-height: 280px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 1.5rem;
+}
+
+.canvas-badge {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+/* Guidelines for Reference Grid */
+.guideline-x, .guideline-y {
+  position: absolute;
+  background: rgba(255, 255, 255, 0.05);
+  pointer-events: none;
+}
+.guideline-x {
+  left: 0;
+  right: 0;
+  height: 1px;
+  top: 50%;
+}
+.guideline-y {
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  left: 50%;
+}
+
+/* ============================================================
+   SVG ROTATION DEMO SPECIFICS
+   ============================================================ */
+
+.demo-svg {
+  width: 220px;
+  height: 220px;
+  overflow: visible;
+}
+
+/* Gears rotating */
+.svg-element {
+  transform-origin: center; /* 50% 50% */
+  /* Smooth transition helper to show shifts */
+  transition: transform-box 0.4s ease;
+}
+
+.gear-inner {
+  fill: #818cf8;
+}
+
+.gear-outer {
+  fill: #4f46e5;
+}
+
+/* Spin animation for visual tracking */
+.spin-animation {
+  animation: spin 8s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Pivot Dot Indicator Overlay (SVG) */
+.pivot-indicator {
+  fill: var(--accent-secondary);
+  stroke: white;
+  stroke-width: 1.5px;
+  filter: drop-shadow(0 0 4px rgba(244, 63, 94, 0.6));
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ============================================================
+   HTML BOX MODEL DEMO SPECIFICS
+   ============================================================ */
+
+.html-element-wrapper {
+  position: relative;
+  width: 160px;
+  height: 160px;
+}
+
+.html-box {
+  width: 80px;
+  height: 80px;
+  padding: 20px;
+  border: 10px solid #f43f5e;
+  background: rgba(244, 63, 94, 0.15);
+  border-radius: 4px;
+  
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-align: center;
+  color: #fca5a5;
+  box-sizing: content-box; /* Set content-box explicitly so border + padding are outside width/height */
+  
+  transform-origin: 0 0; /* Top-Left Origin */
+  transition: transform-box 0.4s ease;
+}
+
+.inner-content-box {
+  width: 100%;
+  height: 100%;
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Swing animation to clearly demonstrate the difference in pivot point */
+.swing-animation {
+  animation: swing 4s ease-in-out infinite;
+}
+
+@keyframes swing {
+  0%, 100% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: rotate(45deg);
+  }
+}
+
+/* Visual Dot Overlay for HTML pivot point */
+.html-pivot-dot {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background-color: #6366f1;
+  border: 1.5px solid white;
+  border-radius: 50%;
+  box-shadow: 0 0 6px rgba(99, 102, 241, 0.8);
+  pointer-events: none;
+  z-index: 10;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Guidelines highlighting current layout box */
+.box-outline-highlight {
+  position: absolute;
+  border: 1.5px dashed rgba(99, 102, 241, 0.4);
+  pointer-events: none;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Code Display Block */
+.code-display {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #07090e;
+  border-radius: 0.5rem;
+  padding: 0.85rem 1.15rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.code-text {
+  color: #a5b4fc;
+}
+
+.showcase-card.alt .code-text {
+  color: #fca5a5;
+}
+
+.copy-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-secondary);
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.3rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 500;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.copy-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Footer Styling */
+footer {
+  text-align: center;
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
Closes #16689
## Pull Request Description

Added transform-box utilities for EaseMotion CSS to control transform reference boxes for SVG and HTML elements.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/transform-box-utilities/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Adds CSS transform-box utility classes that allow developers to control transform reference boxes.

**How does a developer use it?**

```html
<div class="ease-transform-box-border"></div>

<svg>
  <g class="ease-transform-box-fill"></g>
</svg>

