### PR TITLE
feat: add outline-offset utilities

### DIFF
--- a/submissions/examples/outline-offset-utilities/README.md
+++ b/submissions/examples/outline-offset-utilities/README.md
@@ -1,0 +1,106 @@
+# Outline Offset Utilities
+
+An overview and guide for using CSS `outline-offset` utility classes to customize focus rings and outline borders.
+
+## Core Questions
+
+### What does this do?
+
+These utility classes map CSS `outline-offset` values to adjust the space/gap between an element's border edge and its outline ring.
+
+### How is it used?
+
+Apply the utility classes directly to interactive elements (like buttons, links, inputs, or cards) alongside an outline style:
+
+```html
+<button class="btn focus-outline outline-offset-2">Click Me</button>
+```
+
+### Why is it useful?
+
+It allows developers to refine keyboard focus indicators (`:focus-visible`) directly in the HTML, ensuring highly visible, non-cluttered accessibility focus rings that float neatly outside the element.
+
+---
+
+## Utility Classes
+
+| Class               | CSS Declaration        | Description                                                        |
+| :------------------ | :--------------------- | :----------------------------------------------------------------- |
+| `.outline-offset-0` | `outline-offset: 0;`   | Outline sits flush against the element's border edge (Default).    |
+| `.outline-offset-1` | `outline-offset: 1px;` | Creates a subtle 1px transparent gap outside the element.          |
+| `.outline-offset-2` | `outline-offset: 2px;` | Creates a standard 2px transparent gap outside the element.        |
+| `.outline-offset-4` | `outline-offset: 4px;` | Creates a wider 4px transparent gap outside the element.           |
+| `.outline-offset-8` | `outline-offset: 8px;` | Creates a distinct 8px transparent gap, floating the outline ring. |
+
+---
+
+## Detailed Explanation of `outline-offset`
+
+The `outline-offset` CSS property sets the space between an outline and the edge or border of an element.
+
+- **Outlines vs Borders**: An outline is drawn outside an element's border box. Unlike borders, outlines do **not** take up any space in the layout, so changing an outline's style or offset will never cause adjacent elements to shift or page reflows to occur.
+- **Positive vs Negative**: While our utilities focus on positive offsets (pushing the outline outwards), negative values (e.g. `outline-offset: -4px`) can draw the outline _inside_ the element's borders.
+- **Visual styling**: The outline-offset gap is transparent, showing the underlying background of the parent element.
+
+---
+
+## Accessibility Notes (WCAG 2.1 Focus Visibility)
+
+Focus visibility is a critical part of web accessibility (WCAG 2.1 Success Criterion 2.4.7). Keyboard-only users and those using assistive technology rely on focus rings to see where focus currently rests.
+
+- **Contrast & Visibility**: Setting a standard offset (like `.outline-offset-2`) helps focus rings stand out clearly, preventing them from blending with border elements.
+- **Do Not Remove Outlines**: Never apply `outline: none;` or `outline: 0;` without replacing it with an equivalent or superior focus indicator, as doing so completely breaks accessibility for keyboard navigators.
+
+---
+
+## Usage Examples
+
+### 1. Modern Button Focus Ring (2px Offset)
+
+```html
+<button class="btn" style="outline: 2px solid #8b5cf6; outline-offset: 2px;">
+  Interactive Button
+</button>
+```
+
+_Using utilities:_
+
+```html
+<button class="btn focus:outline focus:outline-offset-2">
+  Interactive Button
+</button>
+```
+
+### 2. Floating Card Highlight (8px Offset)
+
+Give a dashboard card a floating highlight ring when active:
+
+```html
+<div class="card outline-offset-8" style="outline: 2px dashed #06b6d4;">
+  <h3>Active Session Card</h3>
+</div>
+```
+
+---
+
+## Common Use Cases
+
+1. **Interactive Controls Focus**: Adding spacing to focus outlines on form fields, buttons, checkboxes, and anchor links.
+2. **Dashboard Grid Selection**: Highlighting currently selected grid items or charts with floating dashed borders.
+3. **Circular Avatars**: Creating a floating circle border around profile picture elements on hover or active states.
+4. **Media Galleries**: Surrounding photo tiles with a hover ring that sits outside the image frame without causing layout shifting.
+
+---
+
+## Browser Support Notes
+
+CSS `outline-offset` is universally supported by modern web browsers:
+
+- Chrome 15+
+- Edge 15+
+- Firefox 2+
+- Safari 7+
+- iOS Safari 7+
+- Android Browser 4.4+
+
+_Note: Internet Explorer (IE 11 and older) did not support `outline-offset`. Focus styles on older IE versions fall back to sitting flush against the element's border._

--- a/submissions/examples/outline-offset-utilities/demo.html
+++ b/submissions/examples/outline-offset-utilities/demo.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Outline Offset Utilities - EaseMotion CSS</title>
+    <meta
+      name="description"
+      content="A visual comparison of outline-offset utilities (0, 1px, 2px, 4px, 8px) on interactive buttons, input focus states, and card components."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>Outline Offset Utilities</h1>
+        <p class="subtitle">
+          CSS outline-offset utilities to adjust the spacing between an
+          element's border edge and its outline outline ring. Crucial for
+          polished keyboard focus accessibility.
+        </p>
+      </header>
+
+      <!-- Section 1: Persistent Outlines Comparison -->
+      <section>
+        <h2>Persistent Outlines Comparison</h2>
+        <div class="grid-showcase">
+          <!-- 0px Offset -->
+          <div class="comparison-card">
+            <div class="card-header">
+              <span class="card-title-text">0px Offset</span>
+              <span class="badge">.outline-offset-0</span>
+            </div>
+            <div class="card-content">
+              <div class="card-block demo-outline outline-offset-0">
+                Card Block
+              </div>
+              <button class="btn-demo demo-outline outline-offset-0">
+                Button Item
+              </button>
+            </div>
+            <p class="card-caption">
+              The outline sits directly flush against the element's outer border
+              box. No gap is visible.
+            </p>
+          </div>
+
+          <!-- 2px Offset -->
+          <div class="comparison-card">
+            <div class="card-header">
+              <span class="card-title-text">2px Offset</span>
+              <span class="badge">.outline-offset-2</span>
+            </div>
+            <div class="card-content">
+              <div class="card-block demo-outline outline-offset-2">
+                Card Block
+              </div>
+              <button class="btn-demo demo-outline outline-offset-2">
+                Button Item
+              </button>
+            </div>
+            <p class="card-caption">
+              A narrow, elegant 2px transparent gap separates the outline ring
+              from the element's edge.
+            </p>
+          </div>
+
+          <!-- 8px Offset -->
+          <div class="comparison-card">
+            <div class="card-header">
+              <span class="card-title-text">8px Offset</span>
+              <span class="badge">.outline-offset-8</span>
+            </div>
+            <div class="card-content" style="padding: 1.5rem 0">
+              <div class="card-block demo-outline outline-offset-8">
+                Card Block
+              </div>
+              <button class="btn-demo demo-outline outline-offset-8">
+                Button Item
+              </button>
+            </div>
+            <p class="card-caption">
+              A wide 8px gap separates the outline, creating a floating ring
+              effect. Ideal for isolated cards or profile frames.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Section 2: Interactive Focus Rings -->
+      <section>
+        <h2>Interactive Keyboard Focus Rings</h2>
+        <p
+          class="subtitle"
+          style="
+            text-align: left;
+            margin: -0.5rem 0 1.5rem 0;
+            font-size: 0.95rem;
+          "
+        >
+          Click or Tab into these form input fields to trigger the
+          <code>:focus</code> state, displaying focus rings with varying
+          offsets.
+        </p>
+
+        <div class="grid-showcase">
+          <!-- Input 0px -->
+          <div class="comparison-card">
+            <div class="card-header">
+              <span class="card-title-text">Flush Focus Ring</span>
+              <span class="badge accent">.outline-offset-0</span>
+            </div>
+            <div class="card-content">
+              <input
+                type="text"
+                class="input-demo outline-offset-0"
+                placeholder="Tab to Focus (0px)"
+                aria-label="Input field with 0px offset focus outline"
+              />
+            </div>
+            <p class="card-caption">
+              The cyan focus indicator sits right on the input border. Standard,
+              traditional focus style.
+            </p>
+          </div>
+
+          <!-- Input 2px -->
+          <div class="comparison-card">
+            <div class="card-header">
+              <span class="card-title-text">Standard Focus Ring</span>
+              <span class="badge accent">.outline-offset-2</span>
+            </div>
+            <div class="card-content">
+              <input
+                type="text"
+                class="input-demo outline-offset-2"
+                placeholder="Tab to Focus (2px)"
+                aria-label="Input field with 2px offset focus outline"
+              />
+            </div>
+            <p class="card-caption">
+              The focus ring has a 2px gap. This is the modern web accessibility
+              standard, keeping indicators highly visible.
+            </p>
+          </div>
+
+          <!-- Input 4px -->
+          <div class="comparison-card">
+            <div class="card-header">
+              <span class="card-title-text">Wide Focus Ring</span>
+              <span class="badge accent">.outline-offset-4</span>
+            </div>
+            <div class="card-content">
+              <input
+                type="text"
+                class="input-demo outline-offset-4"
+                placeholder="Tab to Focus (4px)"
+                aria-label="Input field with 4px offset focus outline"
+              />
+            </div>
+            <p class="card-caption">
+              The focus ring has a wider 4px gap, separating it clearly from the
+              control border to avoid visual clutter.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/outline-offset-utilities/style.css
+++ b/submissions/examples/outline-offset-utilities/style.css
@@ -1,0 +1,234 @@
+@import "https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap";
+
+:root {
+  --bg-dark: #070913;
+  --bg-panel: rgba(15, 18, 36, 0.75);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --color-primary: #8b5cf6;
+  --color-primary-glow: rgba(139, 92, 246, 0.2);
+  --color-accent: #06b6d4;
+  --color-accent-glow: rgba(6, 182, 212, 0.2);
+  --text-main: #f3f4f6;
+  --text-muted: #9ca3af;
+  --font-sans: "Outfit", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  padding: 3rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-image:
+    radial-gradient(
+      circle at 10% 15%,
+      rgba(139, 92, 246, 0.12) 0%,
+      transparent 45%
+    ),
+    radial-gradient(
+      circle at 90% 85%,
+      rgba(6, 182, 212, 0.12) 0%,
+      transparent 45%
+    );
+}
+
+.container {
+  max-width: 1000px;
+  width: 100%;
+  backdrop-filter: blur(20px);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  border-radius: 28px;
+  padding: 3rem 2.5rem;
+  box-shadow: 0 25px 60px -15px rgba(0, 0, 0, 0.7);
+}
+
+header {
+  text-align: center;
+  margin-bottom: 3.5rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  background: linear-gradient(135deg, #a78bfa, #8b5cf6, #06b6d4);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 2.5rem;
+  margin-bottom: 1.5rem;
+  border-left: 4px solid var(--color-primary);
+  padding-left: 0.75rem;
+  color: var(--text-main);
+}
+
+section {
+  margin-bottom: 3.5rem;
+}
+
+.grid-showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+}
+
+.comparison-card {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 0.5rem;
+}
+
+.card-title-text {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.badge {
+  background: rgba(139, 92, 246, 0.15);
+  color: var(--color-primary);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 6px;
+  font-family: monospace;
+}
+
+.badge.accent {
+  background: rgba(6, 182, 212, 0.15);
+  color: var(--color-accent);
+  border: 1px solid rgba(6, 182, 212, 0.3);
+}
+
+.card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1rem 0;
+  align-items: center;
+}
+
+.card-caption {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* Persistent Visible Outlines for comparison demo */
+.demo-outline {
+  outline: 2.5px solid var(--color-primary);
+}
+
+.demo-outline-accent {
+  outline: 2.5px solid var(--color-accent);
+}
+
+/* Interactive Elements inside cards */
+.btn-demo {
+  background: rgba(139, 92, 246, 0.1);
+  color: #c084fc;
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  padding: 0.6rem 1.5rem;
+  border-radius: 8px;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.input-demo {
+  background: rgba(0, 0, 0, 0.4);
+  color: var(--text-main);
+  border: 1px solid var(--border-color);
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 220px;
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  text-align: center;
+  transition: border-color 0.2s ease;
+}
+
+.input-demo:focus {
+  border-color: var(--color-accent);
+  outline: 2.5px solid var(--color-accent);
+}
+
+/* Focus indicator examples */
+.focus-demo:focus-visible {
+  outline: 2.5px solid var(--color-primary);
+}
+
+/* Simple solid card block for outline offset testing */
+.card-block {
+  width: 100px;
+  height: 60px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* =============================================
+   OUTLINE OFFSET UTILITY CLASSES
+   ============================================= */
+
+.outline-offset-0 {
+  outline-offset: 0;
+}
+
+.outline-offset-1 {
+  outline-offset: 1px;
+}
+
+.outline-offset-2 {
+  outline-offset: 2px;
+}
+
+.outline-offset-4 {
+  outline-offset: 4px;
+}
+
+.outline-offset-8 {
+  outline-offset: 8px;
+}


### PR DESCRIPTION
## Pull Request Description

Added a new utility example: **Outline Offset Utilities**.

This submission introduces reusable utility classes for controlling the spacing between an element and its outline using the CSS `outline-offset` property. The demo visually compares different offset values across buttons, inputs, and card components.

---

## Type of Change

* [x] 🧩 New component
* [ ] ✨ New animation / hover effect
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/outline-offset-utilities/`
* [x] Includes `demo.html`
* [x] Includes `style.css`
* [x] Includes `README.md`
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR

---

## Feature Description

### What does this add?

A collection of utility classes for applying different outline-offset values.

### How does a developer use it?

```html
<button class="outline-offset-4">
  Accessible Button
</button>
```

### Why does it fit EaseMotion CSS?

It provides simple utility classes that improve focus-state customization and accessibility while keeping styling easy to understand and reuse.

---

## Demo

* [x] Demo added (`demo.html` works directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari

---

## Notes for Maintainer

* Includes outline-offset-0, 1, 2, 4, and 8 utilities.
* Demonstrates practical accessibility and focus-ring use cases.
* Uses only files inside `submissions/examples/outline-offset-utilities/`.
* No existing repository files were modified.

Fixes #16586
