### PR TITLE
fix(style.css): add standard background-clip property for compatibility

### DIFF
--- a/submissions/examples/button-aria-label-fix/README.md
+++ b/submissions/examples/button-aria-label-fix/README.md
@@ -1,0 +1,12 @@
+# Button Accessibility: aria-label Fix
+
+## Problem
+Icon-only buttons in README examples lack `aria-label` attributes. Screen readers announce them as generic "button" with no context.
+
+## Solution
+Add `aria-label` to all icon-only buttons:
+
+```html
+&lt;button class="ease-btn ease-btn-primary" aria-label="Search"&gt;
+    &lt;span&gt;🔍&lt;/span&gt;
+&lt;/button&gt;

--- a/submissions/examples/button-aria-label-fix/demo.html
+++ b/submissions/examples/button-aria-label-fix/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Button Accessibility Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Button Accessibility: aria-label Fix</h1>
+        
+        <div class="section">
+            <h2>❌ Before (No aria-label)</h2>
+            <div class="box bad">
+                <button class="icon-btn">
+                    <span class="icon">🔍</span>
+                </button>
+                <p class="note">Screen reader says: "Button" (no context)</p>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>✅ After (With aria-label)</h2>
+            <div class="box good">
+                <button class="icon-btn" aria-label="Search">
+                    <span class="icon">🔍</span>
+                </button>
+                <p class="note">Screen reader says: "Search, button"</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/button-aria-label-fix/style.css
+++ b/submissions/examples/button-aria-label-fix/style.css
@@ -1,0 +1,71 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #0f172a;
+    color: #e2e8f0;
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 40px 20px;
+}
+
+h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 30px;
+    text-align: center;
+    background: linear-gradient(135deg, #f97316, #ec4899);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+h2 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 15px;
+    color: #94a3b8;
+}
+
+.section {
+    margin-bottom: 30px;
+}
+
+.box {
+    padding: 20px;
+    border-radius: 8px;
+    border: 2px solid;
+}
+
+.box.bad {
+    border-color: #ef4444;
+    background: #1e293b;
+}
+
+.box.good {
+    border-color: #22c55e;
+    background: #1e293b;
+}
+
+.icon-btn {
+    padding: 12px 16px;
+    font-size: 1.2rem;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    background: #f97316;
+}
+
+.note {
+    margin-top: 10px;
+    font-size: 0.9rem;
+    color: #cbd5e1;
+}


### PR DESCRIPTION
## Summary
Submits an accessibility fix for button examples in README.md to add `aria-label` attributes to icon-only buttons.

## Problem
Icon-only buttons in the README documentation lack `aria-label` attributes. Screen readers announce them as generic "button" with no context, making them unusable for visually impaired users.

Example of current code:
```html
<button class="ease-btn ease-btn-primary">
    <span>🔍</span>
</button>