### PR TITLE
feat: add caret-color utilities

### DIFF
--- a/submissions/examples/caret-color-utilities/README.md
+++ b/submissions/examples/caret-color-utilities/README.md
@@ -1,0 +1,99 @@
+# Caret Color Utilities
+
+An overview and guide for using CSS `caret-color` utility classes to customize insertion cursor colors inside form controls.
+
+## Core Questions
+
+### What does this do?
+
+These utility classes specify the color of the text insertion cursor (caret) inside editable elements like `<input>` fields or `<textarea>` boxes.
+
+### How is it used?
+
+Apply the utility classes directly to any text input or textarea element:
+
+```html
+<input type="text" class="input-field cc-primary" placeholder="Type here..." />
+```
+
+### Why is it useful?
+
+It allows developers to theme insertion cursors to match branding designs, improve focus visibility, and change caret colors dynamically during form validation states (e.g. green for valid fields and red for error alerts).
+
+---
+
+## Utility Classes
+
+| Class         | CSS Declaration         | Description / Use Case                                       |
+| :------------ | :---------------------- | :----------------------------------------------------------- |
+| `.cc-auto`    | `caret-color: auto;`    | Uses browser-default caret colors (Default).                 |
+| `.cc-primary` | `caret-color: #3b82f6;` | Sets a blue caret matching primary brand colors.             |
+| `.cc-success` | `caret-color: #22c55e;` | Sets a green caret for success, matching validated fields.   |
+| `.cc-danger`  | `caret-color: #ef4444;` | Sets a red caret, highlighting form input validation errors. |
+| `.cc-warning` | `caret-color: #f59e0b;` | Sets a yellow caret, highlighting pending input states.      |
+
+---
+
+## Explanation of `caret-color` & Accessibility
+
+The `caret-color` CSS property specifies the color of the text cursor in inputs, textareas, or elements with `contenteditable` attributes.
+
+- **Focus Visibility & Usability**: In dark-themed applications, standard default cursors can sometimes blend into input fields or have low contrast, making it difficult for keyboard users to track their insertion focus. Styling carets with vibrant, theme-compliant colors guarantees they remain visible.
+- **Contrast Ratios**: When overriding caret colors, ensure that the selected color maintains a high contrast ratio (typically at least 3:1) relative to the input field background color to guarantee visibility under standard accessibility standards (WCAG).
+
+---
+
+## Usage Examples
+
+### 1. Highlight Valid Email (Success State)
+
+```html
+<input
+  type="email"
+  class="input-field cc-success"
+  placeholder="email@example.com"
+/>
+```
+
+### 2. Error Input Focus (Danger State)
+
+```html
+<input
+  type="text"
+  class="input-field cc-danger"
+  placeholder="Required Field"
+  style="border-color: #ef4444;"
+/>
+```
+
+### 3. Styled Contact Box Textarea (Primary State)
+
+```html
+<textarea
+  class="textarea-field cc-primary"
+  placeholder="Write your message..."
+></textarea>
+```
+
+---
+
+## Common Use Cases
+
+1. **Dynamic Form Validation States**: Toggling caretaker classes dynamically (e.g. switching from `.cc-primary` to `.cc-danger` when validation errors are present in real-time).
+2. **Dashboard Search Bars**: Applying the brand's primary color highlight on key search inputs to emphasize focused user interaction.
+3. **Muted Backdrop Fields**: Adjusting caret colors in nested widgets to fit with darker visual aesthetics.
+
+---
+
+## Browser Support Notes
+
+CSS `caret-color` is supported by all modern desktop and mobile browsers:
+
+- Chrome 57+
+- Edge 79+
+- Firefox 53+
+- Safari 11.1+
+- iOS Safari 11.3+
+- Android Browser 57+
+
+_Note: Internet Explorer does not support `caret-color`. In older browsers, caret colors fall back to the browser-default coloring._

--- a/submissions/examples/caret-color-utilities/demo.html
+++ b/submissions/examples/caret-color-utilities/demo.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Caret Color Utilities - EaseMotion CSS</title>
+    <meta
+      name="description"
+      content="A visual comparison of CSS caret-color utilities (auto, primary, success, danger, warning) inside text input fields and textareas."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>Caret Color Utilities</h1>
+        <p class="subtitle">
+          CSS caret-color utilities to customize the color of the text insertion
+          cursor. Improve focus tracking, error reporting, and visual branding
+          in form fields.
+        </p>
+      </header>
+
+      <!-- Info Explanation Box -->
+      <section>
+        <div class="info-box">
+          <strong>What does caret-color do?</strong><br />
+          The <code>caret-color</code> property controls the color of the text
+          insertion cursor (caret) inside editable elements like
+          <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code>.
+          Adjusting this color creates high-contrast cursors matching your form
+          states. <br /><br />
+          <em
+            >Instructions: Click into each field below and type text to view the
+            insertion cursor color.</em
+          >
+        </div>
+      </section>
+
+      <!-- Showcase Forms Grid -->
+      <section>
+        <h2>Input Caret Demos</h2>
+        <div class="form-grid">
+          <!-- cc-auto -->
+          <div class="form-card">
+            <div class="card-header-bar">
+              <span class="card-title">Default Cursor</span>
+              <span class="badge">.cc-auto</span>
+            </div>
+            <input
+              type="text"
+              class="input-field cc-auto"
+              placeholder="Click here to type..."
+              value="Default Browser Caret"
+            />
+            <p class="card-caption">
+              Uses the browser's default caret color (typically white or light
+              gray in dark themes).
+            </p>
+          </div>
+
+          <!-- cc-primary -->
+          <div class="form-card">
+            <div class="card-header-bar">
+              <span class="card-title">Primary Brand Focus</span>
+              <span class="badge primary">.cc-primary</span>
+            </div>
+            <input
+              type="text"
+              class="input-field cc-primary"
+              placeholder="Click here to type..."
+              value="Blue Caret Cursor"
+            />
+            <p class="card-caption">
+              Applies a blue insertion caret to match secondary links and
+              primary action states.
+            </p>
+          </div>
+
+          <!-- cc-success -->
+          <div class="form-card">
+            <div class="card-header-bar">
+              <span class="card-title">Success / Validated Input</span>
+              <span class="badge success">.cc-success</span>
+            </div>
+            <input
+              type="text"
+              class="input-field cc-success"
+              placeholder="Click here to type..."
+              value="Green Caret Cursor"
+            />
+            <p class="card-caption">
+              Applies a green cursor. Excellent for validated fields or checkout
+              input success.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Showcase Textarea Grid -->
+      <section>
+        <h2>Textarea Caret Demos</h2>
+        <div class="form-grid">
+          <!-- cc-danger -->
+          <div class="form-card">
+            <div class="card-header-bar">
+              <span class="card-title">Danger / Validation Error</span>
+              <span class="badge danger">.cc-danger</span>
+            </div>
+            <textarea
+              class="textarea-field cc-danger"
+              placeholder="Type here..."
+            >
+Warning: This message box contains a red validation alert cursor.</textarea
+            >
+            <p class="card-caption">
+              Applies a red caret, immediately drawing attention to fields with
+              validation errors or issues.
+            </p>
+          </div>
+
+          <!-- cc-warning -->
+          <div class="form-card">
+            <div class="card-header-bar">
+              <span class="card-title">Warning / Alert State</span>
+              <span class="badge warning">.cc-warning</span>
+            </div>
+            <textarea
+              class="textarea-field cc-warning"
+              placeholder="Type here..."
+            >
+Warning: Yellow cursor warning state.</textarea
+            >
+            <p class="card-caption">
+              Applies a yellow caret cursor, indicating a pending validation
+              check or warnings.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/caret-color-utilities/style.css
+++ b/submissions/examples/caret-color-utilities/style.css
@@ -1,0 +1,247 @@
+@import "https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap";
+
+:root {
+  --bg-dark: #070913;
+  --bg-panel: rgba(15, 18, 36, 0.75);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --color-primary: #3b82f6;
+  --color-success: #22c55e;
+  --color-danger: #ef4444;
+  --color-warning: #f59e0b;
+  --text-main: #f3f4f6;
+  --text-muted: #9ca3af;
+  --font-sans: "Outfit", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  padding: 3rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-image:
+    radial-gradient(
+      circle at 10% 15%,
+      rgba(59, 130, 246, 0.1) 0%,
+      transparent 45%
+    ),
+    radial-gradient(
+      circle at 90% 85%,
+      rgba(34, 197, 94, 0.08) 0%,
+      transparent 45%
+    );
+}
+
+.container {
+  max-width: 900px;
+  width: 100%;
+  backdrop-filter: blur(20px);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  border-radius: 28px;
+  padding: 3rem 2.5rem;
+  box-shadow: 0 25px 60px -15px rgba(0, 0, 0, 0.7);
+}
+
+header {
+  text-align: center;
+  margin-bottom: 3.5rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  background: linear-gradient(135deg, #60a5fa, #3b82f6, #10b981);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 2.5rem;
+  margin-bottom: 1.5rem;
+  border-left: 4px solid var(--color-primary);
+  padding-left: 0.75rem;
+  color: var(--text-main);
+}
+
+section {
+  margin-bottom: 3.5rem;
+}
+
+/* Grid Layout for Forms */
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+}
+
+.form-card {
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  transition: border-color 0.2s ease;
+}
+
+.form-card:focus-within {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.card-header-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 0.5rem;
+}
+
+.card-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.badge {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 6px;
+  font-family: monospace;
+}
+
+.badge.primary {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  border-color: rgba(59, 130, 246, 0.3);
+}
+
+.badge.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
+.badge.danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: #f87171;
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+.badge.warning {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+  border-color: rgba(245, 158, 11, 0.3);
+}
+
+/* Styled Inputs and Textareas */
+.input-field,
+.textarea-field {
+  background: rgba(0, 0, 0, 0.4);
+  color: var(--text-main);
+  border: 1px solid var(--border-color);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  outline: none;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.input-field:focus,
+.textarea-field:focus {
+  border-color: rgba(255, 255, 255, 0.25);
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.05);
+}
+
+/* Focus color matching caret helper */
+.input-field.cc-primary:focus {
+  border-color: rgba(59, 130, 246, 0.5);
+}
+
+.input-field.cc-success:focus {
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.input-field.cc-danger:focus {
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
+.input-field.cc-warning:focus {
+  border-color: rgba(245, 158, 11, 0.5);
+}
+
+.textarea-field {
+  height: 90px;
+  resize: none;
+}
+
+.card-caption {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* Info Box */
+.info-box {
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: 12px;
+  padding: 1.25rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #93c5fd;
+}
+
+/* =============================================
+   CARET COLOR UTILITY CLASSES
+   ============================================= */
+
+.cc-auto {
+  caret-color: auto;
+}
+
+.cc-primary {
+  caret-color: #3b82f6;
+}
+
+.cc-success {
+  caret-color: #22c55e;
+}
+
+.cc-danger {
+  caret-color: #ef4444;
+}
+
+.cc-warning {
+  caret-color: #f59e0b;
+}


### PR DESCRIPTION
## Pull Request Description

Added a new utility example: **Caret Color Utilities**.

This submission introduces reusable utility classes for customizing text cursor (caret) colors in form controls using the CSS `caret-color` property.

---

## Type of Change

* [x] 🧩 New component
* [ ] ✨ New animation / hover effect
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other

---

## Submission Checklist

* [x] All changes are inside the example folder
* [x] Includes `demo.html`
* [x] Includes `style.css`
* [x] Includes `README.md`
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR

---

## Feature Description

### What does this add?

Utility classes for customizing caret colors in inputs and textareas.

### How does a developer use it?

```html
<input class="cc-primary" type="text" />
<textarea class="cc-success"></textarea>
```

### Why does it fit EaseMotion CSS?

It provides simple, reusable, human-readable utility classes that improve form customization without requiring custom CSS.

---

## Demo

* [x] Demo added (`demo.html` works directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari

---

## Notes for Maintainer

* Demonstrates multiple caret color utilities.
* Includes form and textarea examples.
* No existing repository files were modified.
* Contains only new files inside the example directory.

Fixes #16616
