### PR TITLE
feat: add clip-path shape utilities

### DIFF
--- a/submissions/examples/clip-path-shape-utilities/README.md
+++ b/submissions/examples/clip-path-shape-utilities/README.md
@@ -1,0 +1,117 @@
+# Clip Path Shape Utilities
+
+An overview and guide for using CSS `clip-path` utility classes to crop element boundaries into custom shapes.
+
+## Core Questions
+
+### What does this do?
+
+These utility classes map CSS `clip-path` properties to define visible clipping regions, shaping rectangular elements into circles, ellipses, triangles, diamonds, hexagons, or stars.
+
+### How is it used?
+
+Apply the utility classes directly to wrapper containers or layout blocks (such as images, background grids, or cards):
+
+```html
+<div class="profile-card cp-circle">
+  <img src="user-portrait.jpg" alt="User face" />
+</div>
+```
+
+### Why is it useful?
+
+It allows developer-controlled visual cropping directly in the HTML without needing graphics editing software (like Photoshop) or canvas elements, maintaining responsive element resizing automatically.
+
+---
+
+## Utility Classes
+
+| Class          | CSS Declaration                                                             | Shape Rendered                                     |
+| :------------- | :-------------------------------------------------------------------------- | :------------------------------------------------- |
+| `.cp-circle`   | `clip-path: circle(50%);`                                                   | A perfect circle fitting inside the element's box. |
+| `.cp-ellipse`  | `clip-path: ellipse(50% 35%);`                                              | A centered oval shape.                             |
+| `.cp-triangle` | `clip-path: polygon(50% 0%, 0% 100%, 100% 100%);`                           | An upright symmetric triangle.                     |
+| `.cp-diamond`  | `clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);`                   | A centered 4-point diamond.                        |
+| `.cp-hexagon`  | `clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);` | A flat-topped symmetric hexagon.                   |
+| `.cp-star`     | `clip-path: polygon(50% 0%, ...);`                                          | A classic 5-pointed star.                          |
+
+---
+
+## Detailed Explanation of `clip-path`
+
+The `clip-path` property creates a clipping region that sets the visible area of an element. The area inside the region is shown, while the area outside is hidden from paint operations.
+
+- **Interaction Boundaries**: Interaction events (like `hover`, `click`, and focus states) are also restricted to the clipped region. Clicking outside the clipped path area (even if inside the original rectangular element box) will not trigger click events.
+- **Percentages vs Absolute Coordinate Units**: Using percentages (e.g. `50% 0%`) in polygons allows shapes to scale fluidly with element resizing, while pixel lengths (e.g. `50px 0px`) create rigid geometries.
+
+---
+
+## Usage Examples
+
+### 1. Hexagon Social Avatar Card
+
+```html
+<div
+  class="avatar-container cp-hexagon"
+  style="width: 100px; height: 100px; overflow: hidden;"
+>
+  <img
+    src="avatar.jpg"
+    alt="User profile photo"
+    style="width: 100%; height: 100%; object-fit: cover;"
+  />
+</div>
+```
+
+### 2. Triangular Media Play Button
+
+```html
+<button
+  class="play-btn cp-triangle"
+  style="width: 60px; height: 60px; background: #22c55e;"
+>
+  Play
+</button>
+```
+
+### 3. Star Highlight Product Badge
+
+```html
+<div
+  class="sale-badge cp-star"
+  style="width: 80px; height: 80px; background: gold; display: flex; align-items: center; justify-content: center;"
+>
+  <span>New!</span>
+</div>
+```
+
+---
+
+## Accessibility Considerations
+
+- **Alt Text Representation**: Keep relevant alternative labels (`alt` attributes on images, or descriptive `aria-label` indicators on buttons) active. Clipping an element does not impact screen reader text content, but changing the shape could change how users read text inside them.
+- **Contrast Ratios**: Check that clipped elements maintain high contrast against parent container background colors.
+
+---
+
+## Common Use Cases
+
+1. **Creative User Avatars**: Replacing standard circular profile photos with hexagons or octagons.
+2. **Featured Product Labels**: Clipping discount badges into diamonds or stars to highlight sales items.
+3. **Angled Landing Header Sections**: Clipping banner card edges using polygons to create diagonal borders.
+4. **Custom Keycap / Icon Containers**: Framing navigation icons inside diamonds or circles.
+
+---
+
+## Browser Support Notes
+
+CSS `clip-path` is fully supported across all modern mobile and desktop browsers:
+
+- Chrome 55+
+- Edge 79+
+- Firefox 54+
+- Safari 9.1+
+- iOS Safari 9.3+
+- Android Browser 55+
+
+_Note: Older browsers like IE 11 did not support CSS shape functions. In unsupported environments, the crop falls back to standard rectangular border layouts._

--- a/submissions/examples/clip-path-shape-utilities/demo.html
+++ b/submissions/examples/clip-path-shape-utilities/demo.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Clip Path Shape Utilities - EaseMotion CSS</title>
+    <meta
+      name="description"
+      content="A demonstration of CSS clip-path shape utilities (circle, ellipse, triangle, diamond, hexagon, star) on interactive gradient cards and UI components."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>Clip Path Shape Utilities</h1>
+        <p class="subtitle">
+          CSS clip-path utilities to create complex geometric shapes and clip
+          outer margins. Perfect for decorative headers, custom avatars, and
+          polygonal buttons.
+        </p>
+      </header>
+
+      <!-- Info Explanation Box -->
+      <section>
+        <div class="info-box">
+          <strong>What is clip-path?</strong><br />
+          The <code>clip-path</code> CSS property creates a clipping region that
+          defines what part of an element should be visible. Anything outside
+          the path is hidden from rendering, allowing you to crop rectangular
+          blocks into custom circles, ellipses, or complex polygons.
+          <br /><br />
+          <em
+            >Hover over the shapes below to trigger micro-scaling
+            animations.</em
+          >
+        </div>
+      </section>
+
+      <!-- Section 1: Grid of Shapes -->
+      <section>
+        <h2>Geometric Clip Shapes</h2>
+        <div class="shapes-grid">
+          <!-- Circle -->
+          <div class="shape-card">
+            <div class="card-header-bar">
+              <span class="card-title">Circle Shape</span>
+              <span class="badge">.cp-circle</span>
+            </div>
+            <div class="shape-viewport">
+              <div class="clipped-block cp-circle"></div>
+            </div>
+            <p class="card-caption">
+              Crops the element into a perfect circle with a radius of 50% from
+              the center point.
+            </p>
+          </div>
+
+          <!-- Ellipse -->
+          <div class="shape-card">
+            <div class="card-header-bar">
+              <span class="card-title">Ellipse Shape</span>
+              <span class="badge">.cp-ellipse</span>
+            </div>
+            <div class="shape-viewport">
+              <div class="clipped-block cp-ellipse"></div>
+            </div>
+            <p class="card-caption">
+              Crops the element into an oval with a 50% horizontal and 35%
+              vertical radius.
+            </p>
+          </div>
+
+          <!-- Triangle -->
+          <div class="shape-card">
+            <div class="card-header-bar">
+              <span class="card-title">Triangle Shape</span>
+              <span class="badge">.cp-triangle</span>
+            </div>
+            <div class="shape-viewport">
+              <div class="clipped-block cp-triangle"></div>
+            </div>
+            <p class="card-caption">
+              Crops the element using a 3-point polygon to form a symmetric
+              upright triangle.
+            </p>
+          </div>
+
+          <!-- Diamond -->
+          <div class="shape-card">
+            <div class="card-header-bar">
+              <span class="card-title">Diamond Shape</span>
+              <span class="badge">.cp-diamond</span>
+            </div>
+            <div class="shape-viewport">
+              <div class="clipped-block cp-diamond"></div>
+            </div>
+            <p class="card-caption">
+              Crops the element using a 4-point polygon to form a centered
+              vertical diamond.
+            </p>
+          </div>
+
+          <!-- Hexagon -->
+          <div class="shape-card">
+            <div class="card-header-bar">
+              <span class="card-title">Hexagon Shape</span>
+              <span class="badge">.cp-hexagon</span>
+            </div>
+            <div class="shape-viewport">
+              <div class="clipped-block cp-hexagon"></div>
+            </div>
+            <p class="card-caption">
+              Crops the element using a 6-point polygon to form a flat-topped
+              hexagon shape.
+            </p>
+          </div>
+
+          <!-- Star -->
+          <div class="shape-card">
+            <div class="card-header-bar">
+              <span class="card-title">Star Shape</span>
+              <span class="badge">.cp-star</span>
+            </div>
+            <div class="shape-viewport">
+              <div class="clipped-block cp-star"></div>
+            </div>
+            <p class="card-caption">
+              Crops the element using a 10-point polygon to form a classic
+              5-pointed star.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Section 2: Real World UI Showcase -->
+      <section>
+        <h2>Practical UI Components</h2>
+        <div class="ui-showcase-grid">
+          <!-- Profile Card -->
+          <div class="ui-card">
+            <div class="ui-title-bar">
+              <span class="card-title">Profile Avatar</span>
+              <span class="badge">Hexagon Profile</span>
+            </div>
+            <div class="avatar-wrapper cp-hexagon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                <circle cx="50" cy="40" r="16" fill="white" opacity="0.8" />
+                <path
+                  d="M25 80c0-15 10-22 25-22s25 7 25 22H25z"
+                  fill="white"
+                  opacity="0.8"
+                />
+              </svg>
+            </div>
+            <p class="card-caption" style="font-size: 0.8rem">
+              Using <code>.cp-hexagon</code> on a user profile picture container
+              for a clean, non-circular modern visual style.
+            </p>
+          </div>
+
+          <!-- Price Tag / Coupon -->
+          <div class="ui-card">
+            <div class="ui-title-bar">
+              <span class="card-title">Discount Badge</span>
+              <span class="badge">Diamond Tag</span>
+            </div>
+            <div class="decor-badge cp-diamond">
+              <span>20% OFF</span>
+            </div>
+            <p class="card-caption" style="font-size: 0.8rem">
+              Using <code>.cp-diamond</code> on badge overlays to create dynamic
+              discount tags or sales labels.
+            </p>
+          </div>
+
+          <!-- Polygonal Button -->
+          <div class="ui-card">
+            <div class="ui-title-bar">
+              <span class="card-title">Polygonal Button</span>
+              <span class="badge">Triangle Pointer</span>
+            </div>
+            <button
+              class="clip-btn cp-triangle"
+              aria-label="Triangle shaped pointer button"
+            >
+              PLAY
+            </button>
+            <p class="card-caption" style="font-size: 0.8rem">
+              Using <code>.cp-triangle</code> rotated or aligned on buttons to
+              create styled call-to-actions like media play controls.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/clip-path-shape-utilities/style.css
+++ b/submissions/examples/clip-path-shape-utilities/style.css
@@ -1,0 +1,301 @@
+@import "https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap";
+
+:root {
+  --bg-dark: #070913;
+  --bg-panel: rgba(15, 18, 36, 0.75);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --color-primary: #8b5cf6;
+  --color-accent: #06b6d4;
+  --text-main: #f3f4f6;
+  --text-muted: #9ca3af;
+  --font-sans: "Outfit", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  padding: 3rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-image:
+    radial-gradient(
+      circle at 10% 15%,
+      rgba(139, 92, 246, 0.12) 0%,
+      transparent 45%
+    ),
+    radial-gradient(
+      circle at 90% 85%,
+      rgba(6, 182, 212, 0.12) 0%,
+      transparent 45%
+    );
+}
+
+.container {
+  max-width: 1050px;
+  width: 100%;
+  backdrop-filter: blur(20px);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  border-radius: 28px;
+  padding: 3rem 2.5rem;
+  box-shadow: 0 25px 60px -15px rgba(0, 0, 0, 0.7);
+}
+
+header {
+  text-align: center;
+  margin-bottom: 3.5rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  background: linear-gradient(135deg, #a78bfa, #8b5cf6, #06b6d4);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 2.5rem;
+  margin-bottom: 1.5rem;
+  border-left: 4px solid var(--color-primary);
+  padding-left: 0.75rem;
+  color: var(--text-main);
+}
+
+section {
+  margin-bottom: 3.5rem;
+}
+
+/* Responsive Grid for Shapes */
+.shapes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.25rem;
+}
+
+.shape-card {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+  transition:
+    border-color 0.3s ease,
+    transform 0.3s ease;
+}
+
+.shape-card:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-4px);
+}
+
+.card-header-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 0.5rem;
+}
+
+.card-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.badge {
+  background: rgba(139, 92, 246, 0.15);
+  color: var(--color-primary);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 6px;
+  font-family: monospace;
+}
+
+/* Shape Display Container */
+.shape-viewport {
+  width: 150px;
+  height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+/* Inner Colorful Block to be clipped */
+.clipped-block {
+  width: 120px;
+  height: 120px;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary),
+    var(--color-accent)
+  );
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.clipped-block:hover {
+  transform: scale(1.08);
+}
+
+/* Extra backgrounds for style variance */
+.shape-card:nth-child(2n) .clipped-block {
+  background: linear-gradient(135deg, #06b6d4, #10b981);
+}
+
+.shape-card:nth-child(3n) .clipped-block {
+  background: linear-gradient(135deg, #ec4899, #8b5cf6);
+}
+
+.card-caption {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+  text-align: center;
+}
+
+/* Real World UI Examples Grid */
+.ui-showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.25rem;
+}
+
+.ui-card {
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.ui-title-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 0.5rem;
+}
+
+/* Profile Avatar Example */
+.avatar-wrapper {
+  width: 100px;
+  height: 100px;
+  background: rgba(139, 92, 246, 0.2);
+  padding: 4px;
+}
+
+.avatar-wrapper svg {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #a78bfa, #06b6d4);
+  display: block;
+}
+
+/* Decorative Card Badge */
+.decor-badge {
+  width: 80px;
+  height: 80px;
+  background: linear-gradient(135deg, #fbbf24, #f59e0b);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: black;
+}
+
+/* Clip Path Button */
+.clip-btn {
+  background: #ef4444;
+  color: white;
+  border: none;
+  padding: 0.6rem 2rem;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+/* Info Box */
+.info-box {
+  background: rgba(139, 92, 246, 0.08);
+  border: 1px solid rgba(139, 92, 246, 0.2);
+  border-radius: 12px;
+  padding: 1.25rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #d8b4fe;
+}
+
+/* =============================================
+   CLIP-PATH SHAPE UTILITY CLASSES
+   ============================================= */
+
+.cp-circle {
+  clip-path: circle(50%);
+}
+
+.cp-ellipse {
+  clip-path: ellipse(50% 35%);
+}
+
+.cp-triangle {
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+}
+
+.cp-diamond {
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}
+
+.cp-hexagon {
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+}
+
+.cp-star {
+  clip-path: polygon(
+    50% 0%,
+    61% 35%,
+    98% 35%,
+    68% 57%,
+    79% 91%,
+    50% 70%,
+    21% 91%,
+    32% 57%,
+    2% 35%,
+    39% 35%
+  );
+}


### PR DESCRIPTION
## Pull Request Description

Added a new utility example: **Clip Path Shape Utilities**.

This submission introduces reusable utility classes for creating common geometric shapes using the CSS `clip-path` property.

---

## Type of Change

* [x] 🧩 New component
* [ ] ✨ New animation / hover effect
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other

---

## Submission Checklist

* [x] All changes are inside the example folder
* [x] Includes `demo.html`
* [x] Includes `style.css`
* [x] Includes `README.md`
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR

---

## Feature Description

### What does this add?

Utility classes for creating reusable clipped shapes using CSS clip-path.

### How does a developer use it?

```html
<div class="cp-circle"></div>
<div class="cp-hexagon"></div>
<div class="cp-star"></div>
```

### Why does it fit EaseMotion CSS?

It provides simple, reusable utility classes that help developers create modern geometric UI elements without writing custom clip-path definitions.

---

## Demo

* [x] Demo added (`demo.html` works directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari

---

## Notes for Maintainer

* Includes circle, ellipse, triangle, diamond, hexagon, and star utilities.
* Demonstrates practical visual applications.
* Responsive dark-themed demo included.
* No existing repository files were modified.
* Contains only new files inside the example directory.

Fixes #16618
