### PR TITLE
feat: manual implementation of subgrid utilities #18427

### DIFF
--- a/submissions/examples/subgrid-unique-18427/README.md
+++ b/submissions/examples/subgrid-unique-18427/README.md
@@ -1,0 +1,2 @@
+# Subgrid Utilities
+Manual implementation for #18427. Provides utility classes to enable subgrid track inheritance.

--- a/submissions/examples/subgrid-unique-18427/demo.html
+++ b/submissions/examples/subgrid-unique-18427/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="parent-grid">
+    <div class="nested-item grid-cols-subgrid">
+      <div>Child A</div>
+      <div>Child B</div>
+      <div>Child C</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/subgrid-unique-18427/style.css
+++ b/submissions/examples/subgrid-unique-18427/style.css
@@ -1,0 +1,14 @@
+/* Subgrid utilities for #18427 */
+.grid-cols-subgrid { grid-template-columns: subgrid; }
+.grid-rows-subgrid { grid-template-rows: subgrid; }
+
+.parent-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.nested-item {
+  grid-column: span 3;
+  display: grid;
+  grid-template-columns: subgrid;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `subgrid` utilities (Issue #18427). These tokens allow nested grid containers to inherit the track definitions of their parent, enabling precise alignment of child elements across complex grid layouts without needing to re-define track sizes.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/subgrid-unique-18427/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Adds `.grid-cols-subgrid` and `.grid-rows-subgrid`.
- Simplifies alignment for nested card layouts and component systems.

Closes #18427