### PR TITLE
feat: add neon-switch-toggle submission

### DIFF
--- a/submissions/examples/neon-switch-toggle/README.md
+++ b/submissions/examples/neon-switch-toggle/README.md
@@ -1,0 +1,14 @@
+# Neon Switch Toggle
+
+A CSS-only neon-styled toggle switch component with glow effects on active state.
+
+## Features
+
+- Pure CSS toggle with neon glow effect
+- Smooth slide animation on thumb
+- Glow box-shadow on checked state
+- JavaScript only for label text update
+
+## Usage
+
+Include `demo.html` and `style.css` in your project. The toggle uses a hidden checkbox input with a styled track and thumb. Toggle the checkbox to see the neon glow effect.

--- a/submissions/examples/neon-switch-toggle/demo.html
+++ b/submissions/examples/neon-switch-toggle/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neon Switch Toggle</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <div class="toggle-wrapper">
+      <label class="neon-toggle">
+        <input type="checkbox">
+        <span class="track">
+          <span class="thumb"></span>
+        </span>
+      </label>
+      <span class="state-label">Off</span>
+    </div>
+  </div>
+  <script>
+    const toggle = document.querySelector('.neon-toggle input');
+    const label = document.querySelector('.state-label');
+    toggle.addEventListener('change', function () {
+      label.textContent = this.checked ? 'On' : 'Off';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/neon-switch-toggle/style.css
+++ b/submissions/examples/neon-switch-toggle/style.css
@@ -1,0 +1,59 @@
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0a0a0f;
+  font-family: system-ui, sans-serif;
+}
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.toggle-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.neon-toggle input {
+  display: none;
+}
+.neon-toggle .track {
+  display: block;
+  width: 3.5rem;
+  height: 2rem;
+  background: #1a1a2e;
+  border-radius: 1rem;
+  cursor: pointer;
+  transition: background 0.3s;
+  position: relative;
+  border: 1px solid #2d2d44;
+}
+.neon-toggle .thumb {
+  position: absolute;
+  top: 0.2rem;
+  left: 0.2rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  background: #4a4a6a;
+  border-radius: 50%;
+  transition: all 0.3s;
+}
+.neon-toggle input:checked + .track {
+  background: #0f0e17;
+  border-color: #ff8906;
+  box-shadow: 0 0 12px rgba(255, 137, 6, 0.5), 0 0 24px rgba(255, 137, 6, 0.2);
+}
+.neon-toggle input:checked + .track .thumb {
+  left: 1.8rem;
+  background: #ff8906;
+  box-shadow: 0 0 8px rgba(255, 137, 6, 0.8);
+}
+.state-label {
+  color: #72757e;
+  font-size: 1rem;
+  font-weight: 500;
+  transition: color 0.3s;
+}


### PR DESCRIPTION
## Summary

Adds a neon-styled toggle switch component with CSS glow effects.

### Files
- submissions/examples/neon-switch-toggle/demo.html — interactive demo with toggle interaction
- submissions/examples/neon-switch-toggle/style.css — 59 lines of original CSS with neon glow box-shadow
- submissions/examples/neon-switch-toggle/README.md — usage documentation

### Checklist
- [x] All 3 required files present
- [x] demo.html has DOCTYPE, html, head, body
- [x] style.css has 59 non-empty lines (original, no template fingerprint)
- [x] README.md has proper content