### PR TITLE
feat: manual implementation of list-style-position utilities #16648

### DIFF
--- a/submissions/examples/list-style-pos-unique-16648/README.md
+++ b/submissions/examples/list-style-pos-unique-16648/README.md
@@ -1,0 +1,2 @@
+# List Style Position Utilities
+Manual implementation for #16648. Provides utility classes for list marker placement.

--- a/submissions/examples/list-style-pos-unique-16648/demo.html
+++ b/submissions/examples/list-style-pos-unique-16648/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <ul class="list-inside">
+    <li>This bullet is inside the text block.</li>
+    <li>It wraps differently than outside markers.</li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/list-style-pos-unique-16648/style.css
+++ b/submissions/examples/list-style-pos-unique-16648/style.css
@@ -1,0 +1,8 @@
+/* List-style-position utilities for #16648 */
+.list-inside { list-style-position: inside; }
+.list-outside { list-style-position: outside; }
+
+ul {
+  border: 1px solid #e2e8f0;
+  padding: 1rem;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `list-style-position` utilities (Issue #16648). These tokens allow developers to toggle list marker placement between `inside` and `outside`, providing greater control over list item alignment and typography.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/list-style-pos-unique-16648/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Adds `.list-inside` and `.list-outside`.
- Essential for controlling text alignment and indentation in nested list structures.

Closes #16648