### PR TITLE
fix: add underline-link submission with no placeholder text

### DIFF
--- a/submissions/examples/underline-link/README.md
+++ b/submissions/examples/underline-link/README.md
@@ -1,0 +1,12 @@
+# Underline Link
+
+**What does this do?**
+A CSS-only underline link component.
+
+**How is it used?**
+``html
+<a href="#">Hover link</a>
+`` 
+
+**Why is it useful?**
+Lightweight, zero-dependency implementation.

--- a/submissions/examples/underline-link/demo.html
+++ b/submissions/examples/underline-link/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Underline Link</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <a href="#">Hover link</a>
+</body>
+</html>

--- a/submissions/examples/underline-link/style.css
+++ b/submissions/examples/underline-link/style.css
@@ -1,0 +1,27 @@
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0e17;
+}
+a {
+  color: #ff8906;
+  text-decoration: none;
+  font-size: 1.5rem;
+  position: relative;
+}
+a::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: #f25f4c;
+  transition: width 0.3s;
+}
+a:hover::after {
+  width: 100%;
+}


### PR DESCRIPTION
Closes #17730

Adds an underline-link hover effect submission with no placeholder text in README.