### PR TITLE
fix: add progress-ring-detailed-v2 submission with detailed README

### DIFF
--- a/submissions/examples/progress-ring-detailed-v2/README.md
+++ b/submissions/examples/progress-ring-detailed-v2/README.md
@@ -1,0 +1,13 @@
+# Progress Ring Detailed
+
+A CSS progress ring showing percentage completion using conic-gradient.
+
+## Features
+
+- Visual progress indicator
+- Conic gradient fill
+- No JavaScript required
+
+## Usage
+
+Include style.css and demo.html in your project.

--- a/submissions/examples/progress-ring-detailed-v2/demo.html
+++ b/submissions/examples/progress-ring-detailed-v2/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Progress Ring Detailed</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ring"></div>
+</body>
+</html>

--- a/submissions/examples/progress-ring-detailed-v2/style.css
+++ b/submissions/examples/progress-ring-detailed-v2/style.css
@@ -1,0 +1,29 @@
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0e17;
+}
+.ring {
+  width: 6rem;
+  height: 6rem;
+  border-radius: 50%;
+  background: conic-gradient(#ff8906 0deg 270deg, #2d2d44 270deg 360deg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ring::after {
+  content: "75%";
+  width: 4.5rem;
+  height: 4.5rem;
+  background: #0f0e17;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fffffe;
+  font-weight: 700;
+}


### PR DESCRIPTION
Closes #17728

Adds a progress-ring-detailed-v2 submission under submissions/examples/progress-ring-detailed-v2/ with proper multi-line CSS, DOCTYPE, and README.