### PR TITLE
fix: add profile-card-no-external submission with no CDN

### DIFF
--- a/submissions/examples/profile-card-no-external/README.md
+++ b/submissions/examples/profile-card-no-external/README.md
@@ -1,0 +1,14 @@
+# Profile Card No CDN
+
+A simple profile card component with no external CDN dependencies.
+
+## Features
+
+- Avatar with initial letter
+- Name and role display
+- Dark theme styling
+- Zero external dependencies
+
+## Usage
+
+Include style.css and demo.html in your project.

--- a/submissions/examples/profile-card-no-external/demo.html
+++ b/submissions/examples/profile-card-no-external/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profile Card</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="card">
+    <div class="avatar">A</div>
+    <div class="name">Alex Rivera</div>
+    <div class="role">UI Designer</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/profile-card-no-external/style.css
+++ b/submissions/examples/profile-card-no-external/style.css
@@ -1,0 +1,38 @@
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0e17;
+  font-family: system-ui, sans-serif;
+}
+.card {
+  background: #1a1a2e;
+  padding: 2rem;
+  border-radius: 1rem;
+  text-align: center;
+  color: #fffffe;
+  border: 1px solid #2d2d44;
+}
+.avatar {
+  width: 5rem;
+  height: 5rem;
+  background: #ff8906;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1rem;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #0f0e17;
+}
+.name {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+.role {
+  color: #72757e;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
Closes #17732

Adds a profile-card-no-external submission under submissions/examples/profile-card-no-external/ with proper multi-line CSS, DOCTYPE, and README.