### PR TITLE
feat: manual implementation of placeholder-shown utilities #18635

### DIFF
--- a/submissions/examples/placeholder-shown-unique-18635/README.md
+++ b/submissions/examples/placeholder-shown-unique-18635/README.md
@@ -1,0 +1,2 @@
+# Placeholder-Shown Utilities
+Manual implementation for #18635. Provides utility classes for targeting empty input fields via the :placeholder-shown pseudo-class.

--- a/submissions/examples/placeholder-shown-unique-18635/demo.html
+++ b/submissions/examples/placeholder-shown-unique-18635/demo.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <input type="text" placeholder="Type something..." class="ph-shown-border">
+</body>
+</html>

--- a/submissions/examples/placeholder-shown-unique-18635/style.css
+++ b/submissions/examples/placeholder-shown-unique-18635/style.css
@@ -1,0 +1,15 @@
+/* Placeholder-shown utilities for #18635 */
+/* Applies style when the input is empty and placeholder is visible */
+.ph-shown-border:placeholder-shown {
+  border-color: #fca5a5;
+}
+
+.ph-shown-opacity:placeholder-shown {
+  opacity: 0.6;
+}
+
+input {
+  padding: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `:placeholder-shown` pseudo-class utilities (Issue #18635). These tokens provide a lightweight way to apply specific styles to form fields that haven't been interacted with yet, improving the discoverability of required fields.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/placeholder-shown-unique-18635/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Adds `.ph-shown-border` and `.ph-shown-opacity` examples.
- Enables declarative styling for initial form states.

Closes #18635