### PR TITLE
feat: manual implementation of where-selector utilities #18630

### DIFF
--- a/submissions/examples/where-selector-unique-18630/README.md
+++ b/submissions/examples/where-selector-unique-18630/README.md
@@ -1,0 +1,2 @@
+# Where-Selector Utilities
+Manual implementation for #18630. Provides utility examples for leveraging the :where() zero-specificity pseudo-class.

--- a/submissions/examples/where-selector-unique-18630/demo.html
+++ b/submissions/examples/where-selector-unique-18630/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Base Heading</h1>
+  <ul>
+    <li>Easy to override list item</li>
+  </ul>
+</body>
+</html>

--- a/submissions/examples/where-selector-unique-18630/style.css
+++ b/submissions/examples/where-selector-unique-18630/style.css
@@ -1,0 +1,14 @@
+/* Where-selector utilities for #18630 */
+
+/* Using :where() ensures these defaults have 0 specificity.
+  They are easily overridden by any other class or tag selector.
+*/
+:where(h1, h2, h3) {
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+:where(ul, ol) {
+  padding-left: 1.5rem;
+  list-style-position: inside;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `:where()` pseudo-class utilities (Issue #18630). By using `:where()`, we can establish default base styles that have zero specificity, allowing developers to easily override them without fighting CSS specificity rules.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/where-selector-unique-18630/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Provides patterns for low-specificity base styling.
- Demonstrates how to reset common elements without hindering customization.

Closes #18630