### PR TITLE
feat: add scroll event fallback for older browsers (#18793)

### DIFF
--- a/core/reveal.js
+++ b/core/reveal.js
@@ -15,9 +15,13 @@
   if (prefersReducedMotion) {
     var readyReduced = function () {
       var els = document.querySelectorAll('.' + revealClass);
-      Array.prototype.forEach.call(els, function (el) {
-        el.classList.add(activeClass);
-      });
+      var handleFallbackScroll = function() {
+        Array.prototype.forEach.call(els, function (el) {
+          if (isCentered(el)) el.classList.add(activeClass);
+        });
+      };
+      window.addEventListener('scroll', handleFallbackScroll);
+      handleFallbackScroll();
     };
 
     if (document.readyState === 'loading') {
@@ -62,9 +66,13 @@
   } else {
     var readyFallback = function () {
       var els = document.querySelectorAll('.' + revealClass);
-      Array.prototype.forEach.call(els, function (el) {
-        el.classList.add(activeClass);
-      });
+      var handleFallbackScroll = function() {
+        Array.prototype.forEach.call(els, function (el) {
+          if (isCentered(el)) el.classList.add(activeClass);
+        });
+      };
+      window.addEventListener('scroll', handleFallbackScroll);
+      handleFallbackScroll();
     };
 
     if (document.readyState === 'loading') {
@@ -74,3 +82,4 @@
     }
   }
 })();
+


### PR DESCRIPTION
Fixes #18793.

This PR enhances the fallback experience for older browsers that do not support `IntersectionObserver`.

**Changes Included:**
- Replaced the static fallback (which simply revealed all elements immediately on load) with a functional `scroll` event listener that safely reveals elements as they enter the viewport.
