### PR TITLE
feat(examples): add ease-text-pop-up — words pop up in sequence

### DIFF
--- a/submissions/examples/ease-text-pop-up/README.md
+++ b/submissions/examples/ease-text-pop-up/README.md
@@ -1,0 +1,35 @@
+# ease-text-pop-up
+
+## What does it do?
+Each word pops upward into view one by one — a staggered entrance animation using `translateY(100%) → translateY(0)`.
+
+## Features
+- Each word span: `translateY(100%) → 0` with staggered `transition-delay`
+- `overflow: hidden` on per-word container
+- `--ease-word-stagger-delay` CSS custom property (default: 0.12s)
+- Pure CSS, no JavaScript
+
+## Usage
+```css
+.word-wrap {
+  overflow: hidden;
+}
+.word {
+  transform: translateY(100%);
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.container:hover .word {
+  transform: translateY(0);
+}
+.word-wrap:nth-child(2) .word { transition-delay: 0.12s; }
+/* repeat for each word */
+```
+
+## Browser Support
+- Chrome 1+, Firefox 3.5+, Safari 3.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-text-pop-up/demo.html
+++ b/submissions/examples/ease-text-pop-up/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-text-pop-up — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; background: #0f0f0f; color: #d1d5db; font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; text-align: center; }
+    h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    p.subtitle { line-height: 1.7; margin-bottom: 2rem; color: #9ca3af; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #ffffff; font-size: 1.1rem; margin: 0 0 0.5rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin-bottom: 1rem; }
+    .code-block { background: #2a2a2a; padding: 1rem; border-radius: 8px; text-align: left; overflow-x: auto; font-size: 0.85rem; color: #e5e7eb; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>ease-text-pop-up</h1>
+  <p class="subtitle">Each word pops upward into view one by one — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Words pop up in sequence on hover</p>
+    <div class="pop-up-text">
+      <span class="word-wrap"><span class="word">Hello</span></span>
+      <span class="word-wrap"><span class="word">world</span></span>
+      <span class="word-wrap"><span class="word">from</span></span>
+      <span class="word-wrap"><span class="word">CSS</span></span>
+    </div>
+    <p style="color:#6b7280;font-size:0.8rem;margin-top:1rem;">Hover the text to replay.</p>
+  </section>
+
+  <section>
+    <h2>Customization</h2>
+    <p>Adjust stagger delay via CSS custom property:</p>
+    <pre class="code-block">--ease-word-stagger-delay: 0.12s;</pre>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-text-pop-up/style.css
+++ b/submissions/examples/ease-text-pop-up/style.css
@@ -1,0 +1,41 @@
+/* ============================================================
+   EaseMotion CSS — ease-text-pop-up
+   Each word pops upward into view one by one
+   ============================================================ */
+
+:root {
+  --ease-word-stagger-delay: 0.12s;
+}
+
+.pop-up-text {
+  display: inline-flex;
+  gap: 0.4em;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #ffffff;
+  cursor: pointer;
+  padding: 2rem 0;
+}
+
+.word-wrap {
+  display: inline-block;
+  overflow: hidden;
+  vertical-align: bottom;
+}
+
+.word {
+  display: inline-block;
+  transform: translateY(100%);
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.pop-up-text:hover .word {
+  transform: translateY(0);
+}
+
+.word-wrap:nth-child(1) .word { transition-delay: calc(var(--ease-word-stagger-delay) * 0); }
+.word-wrap:nth-child(2) .word { transition-delay: calc(var(--ease-word-stagger-delay) * 1); }
+.word-wrap:nth-child(3) .word { transition-delay: calc(var(--ease-word-stagger-delay) * 2); }
+.word-wrap:nth-child(4) .word { transition-delay: calc(var(--ease-word-stagger-delay) * 3); }
+.word-wrap:nth-child(5) .word { transition-delay: calc(var(--ease-word-stagger-delay) * 4); }
+.word-wrap:nth-child(6) .word { transition-delay: calc(var(--ease-word-stagger-delay) * 5); }


### PR DESCRIPTION
## Description

Each word pops upward into view one by one — staggered entrance animation using `translateY(100%) → translateY(0)`.

## Acceptance Criteria
- [x] Each word span: translateY(100%) → 0 with staggered delay
- [x] overflow hidden on container per word
- [x] `--ease-word-stagger-delay` CSS custom property

## Files
- `demo.html` — staggered word pop-up demo
- `style.css` — staggered transition with overflow clip
- `README.md` — documentation

## Related Issue
Closes #17212