### PR TITLE
fix: compensate for scrollbar width when opening modals (#18794)

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -17,6 +17,8 @@
         const escapedHashSelector = '#' + CSS.escape(hash.substring(1));
         const overlay = document.querySelector(escapedHashSelector + '.ease-modal-overlay');
         if (overlay) {
+          const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+          body.style.paddingRight = scrollbarWidth + 'px';
           body.style.overflow = 'hidden';
 
           previousFocusedElement = document.activeElement;
@@ -41,6 +43,7 @@
 
     // If no active modal is found
     body.style.overflow = '';
+    body.style.paddingRight = '';
 
     if (
       previousFocusedElement &&
@@ -128,3 +131,4 @@
     checkModal();
   }
 })();
+


### PR DESCRIPTION
Fixes #18794.

This PR fixes the jarring layout shift that occurs when `overflow: hidden` is applied to the body, removing the scrollbar and pushing content to the right.

**Changes Included:**
- Dynamically calculated the width of the user's vertical scrollbar.
- Applied the exact scrollbar width as `padding-right` to the `body` when the modal is active, effectively preventing any layout shift.
