### PR TITLE
feat(tooling): add Discord webhook for first-time contributor onboarding

### DIFF
--- a/.github/workflows/discord-onboard.yml
+++ b/.github/workflows/discord-onboard.yml
@@ -1,0 +1,50 @@
+name: Discord Onboarding — First-Time Contributor
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  onboard:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if first merged PR
+        id: first-pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const username = context.payload.pull_request.user.login;
+
+            const { data: prs } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              creator: username,
+              state: 'all',
+              per_page: 100,
+            });
+
+            const mergedPrs = prs.filter(
+              pr => pr.pull_request && pr.pull_request.merged_at !== null
+            );
+
+            core.setOutput('is_first', mergedPrs.length === 1 ? 'true' : 'false');
+            core.setOutput('username', username);
+            core.setOutput('pr_title', context.payload.pull_request.title);
+            core.setOutput('pr_url', context.payload.pull_request.html_url);
+
+      - name: Send Discord notification
+        if: steps.first-pr.outputs.is_first == 'true'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_ONBOARD_WEBHOOK }}
+          USERNAME: ${{ steps.first-pr.outputs.username }}
+          PR_TITLE: ${{ steps.first-pr.outputs.pr_title }}
+          PR_URL: ${{ steps.first-pr.outputs.pr_url }}
+        run: |
+          curl -H "Content-Type: application/json" \
+            -X POST \
+            -d "{
+              \"content\": \"🎉 Welcome @${USERNAME}! Your first PR **${PR_TITLE}** has been merged! Thank you for contributing to EaseMotion CSS. ${PR_URL}\"
+            }" \
+            "$DISCORD_WEBHOOK"


### PR DESCRIPTION
## Description

GitHub Action that posts a welcome message to Discord when a first-time contributor's PR is merged.

## Acceptance Criteria
- [x] Triggered on PR merge
- [x] Checks if it's contributor's first merged PR
- [x] Posts celebratory message to Discord webhook

## Files
- `.github/workflows/discord-onboard.yml` — workflow that fires on merged PRs

## Notes
Requires `DISCORD_ONBOARD_WEBHOOK` repository secret to be set.

## Related Issue
Closes #13653