### PR TITLE
feat(tooling): add automated broken link checker for docs site

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,0 +1,40 @@
+name: Broken Link Checker
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check links in docs directory
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: >-
+            --format detailed
+            --no-progress
+            --exclude-loopback
+            --docs/**/*.md
+            --docs/**/*.html
+            README.md
+        id: lychee
+
+      - name: Create issue on broken links
+        if: steps.lychee.outputs.exit_code != 0
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('lychee/out.md', 'utf8');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '🔗 Broken links detected in documentation',
+              body: `## Broken Links Report\n\nThe weekly link check found broken links in the docs.\n\n${report}\n\n---\n_Generated automatically by the Broken Link Checker workflow._`,
+              labels: ['docs', 'bug']
+            });


### PR DESCRIPTION
## Description

CI workflow that checks all links in docs for 404s on a weekly schedule using lycheeverse/lychee-action.

## Acceptance Criteria
- [x] GitHub Action using a link-checker tool
- [x] Runs weekly via schedule trigger
- [x] Opens an issue automatically if broken links found

## Files
- `.github/workflows/broken-link-check.yml` — weekly link checker

## Related Issue
Closes #13650