### PR TITLE
demo: regex minification breaks complex CSS — proposed lightningcss fix

### DIFF
--- a/submissions/examples/fix-css-minification/README.md
+++ b/submissions/examples/fix-css-minification/README.md
@@ -1,0 +1,9 @@
+# fix regex css minification
+
+1. **What does this do?** Shows how the regex-based `minifyCss` function in `scripts/build-minified-css.mjs` strips important whitespace from values like `grid-template-areas`, `calc()`, `clamp()`, and multi-property functions. The proposed fix is to swap it for `lightningcss`, which parses CSS into an AST and minifies safely.
+
+2. **How is it used?** Open `demo.html` — each section shows a CSS property that the old regex minifier breaks (tagged "broken") alongside the correct rendering that an AST minifier (like lightningcss) produces.
+
+3. **Why is it useful?** The current `minifyCss` regex `/\s*([{}:;,>])\s*/g` is too aggressive. It does not understand CSS grammar — it treats all whitespace as removable, but `grid-template-areas` quoted strings, operator spacing in `calc()`, and multi-value functions depend on specific whitespace. An AST-based tool like lightningcss (used by Parcel, Next.js, and others) knows the grammar and only strips whitespace that is truly safe to remove. This keeps `easemotion.min.css` small without silently producing invalid CSS.
+
+fixes #18795

--- a/submissions/examples/fix-css-minification/demo.html
+++ b/submissions/examples/fix-css-minification/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>regex minifier bug demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="demo-wrap">
+
+<h1>CSS minifier bug: spaces that matter</h1>
+<p>The regex-based <code>minifyCss</code> in <code>scripts/build-minified-css.mjs</code> strips whitespace
+that is semantically important in modern CSS. Below are properties that get mangled.</p>
+
+<h2>grid-template-areas</h2>
+<div class="card bad">
+  <span class="tag tag-red">broken</span>
+  <code>grid-template-areas: "top top top" "left middle right"</code>
+  becomes <code>"top top top""left middle right"</code> (invalid)
+</div>
+<pre>grid-template-areas:
+  "top    top    top"
+  "left   middle right"
+  "bottom bottom bottom"</pre>
+<div class="layout">
+  <div class="block-a">top</div>
+  <div class="block-b">left</div>
+  <div class="block-c">middle</div>
+  <div class="block-d">right</div>
+  <div class="block-e">bottom</div>
+</div>
+<div class="card good"><span class="tag tag-green">ok</span> lightningcss preserves quoted strings as-is</div>
+
+<h2>calc()</h2>
+<div class="card bad">
+  <span class="tag tag-red">broken</span>
+  <code>calc(100% - 3rem)</code> → <code>calc(100%-3rem)</code>
+</div>
+<div class="shrinky"><code>width: calc(100% - 3rem)</code> — needs spaces around minus</div>
+
+<h2>clamp()</h2>
+<div class="card good">
+  <span class="tag tag-green">ok</span>
+  <code>font-size: clamp(0.9rem, 3vw, 1.5rem)</code>
+</div>
+<div class="responsive-text">this text uses clamp() for fluid sizing</div>
+
+<h2>multi-layer background</h2>
+<div class="picture">linear-gradient + radial-gradient</div>
+
+<h2>filter and transform chains</h2>
+<div style="display:flex; gap:1rem; margin:0.75rem 0;">
+  <div class="sq effect-one">filter</div>
+  <div class="sq effect-two">xform</div>
+</div>
+
+</div>
+</body>
+</html>

--- a/submissions/examples/fix-css-minification/style.css
+++ b/submissions/examples/fix-css-minification/style.css
@@ -1,0 +1,129 @@
+.demo-wrap {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  line-height: 1.6;
+}
+h1 {
+  font-size: 1.75rem;
+  margin-bottom: 0.25rem;
+}
+h2 {
+  font-size: 1.15rem;
+  margin: 2rem 0 0.75rem;
+  border-bottom: 2px solid #e2e8f0;
+  padding-bottom: 0.35rem;
+}
+.card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+.tag {
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-right: 0.5rem;
+}
+.tag-red { background: #fca5a5; color: #991b1b; }
+.tag-green { background: #86efac; color: #166534; }
+.bad { background: #fef2f2; border-color: #fca5a5; }
+.good { background: #f0fdf4; border-color: #86efac; }
+
+/* Complex CSS that regex minifier would break */
+.layout {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-areas:
+    "top top top"
+    "left middle right"
+    "bottom bottom bottom";
+  gap: 0.5rem;
+}
+.block-a { grid-area: top; }
+.block-b { grid-area: left; }
+.block-c { grid-area: middle; }
+.block-d { grid-area: right; }
+.block-e { grid-area: bottom; }
+
+.layout div {
+  background: #a09af8;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+  border-radius: 0.25rem;
+  font-weight: 600;
+}
+
+.shrinky {
+  width: calc(100% - 3rem);
+  background: #e0e7ff;
+  padding: 0.75rem;
+  border-radius: 0.25rem;
+}
+
+.responsive-text {
+  font-size: clamp(0.9rem, 3vw, 1.5rem);
+  background: #fae8ff;
+  padding: 0.75rem;
+  border-radius: 0.25rem;
+}
+
+.picture {
+  width: 100%;
+  height: 80px;
+  border-radius: 0.5rem;
+  background:
+    linear-gradient(160deg, #667eea 0%, #764ba2 60%),
+    radial-gradient(circle at 30% 60%, rgba(255,255,255,0.15) 0%, transparent 60%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: bold;
+}
+
+.effect-one {
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.12)) brightness(1.1) saturate(0.95);
+}
+
+.effect-two {
+  transform: translate3d(0, 0, 0) scale(1.04) rotate(1deg);
+}
+
+.sq {
+  width: 70px;
+  height: 70px;
+  background: #6c63ff;
+  border-radius: 0.5rem;
+  color: #fff;
+  font-weight: bold;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+pre {
+  background: #1e293b;
+  color: #e2e8f0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  font-size: 0.8rem;
+  margin: 0.75rem 0;
+}
+code {
+  background: #f1f5f9;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-size: 0.85em;
+}


### PR DESCRIPTION
Shows how `grid-template-areas`, `calc()`, `clamp()`, multi-background, filter, and transform chains break under the current regex-based `minifyCss`. Proposes swapping to `lightningcss` AST-based minification.

Fixes #18795

Only adds new files under `submissions/examples/`.