### PR TITLE
demo: scrollbar layout shift in modals — scrollbar-gutter fix

### DIFF
--- a/submissions/examples/fix-modal-scrollbar-shift/README.md
+++ b/submissions/examples/fix-modal-scrollbar-shift/README.md
@@ -1,0 +1,9 @@
+# fix modal scrollbar shift
+
+1. **What does this do?** Demonstrates the layout shift caused by `body.style.overflow = 'hidden'` in `core/modal.js` when the scrollbar disappears, and shows how `scrollbar-gutter: stable` (or padding compensation) prevents the jump.
+
+2. **How is it used?** Open `demo.html`, scroll down so the page scrollbar is visible, then click "open modal (broken)" — the page width jumps ~15px. Click "open modal (fixed)" and the width stays stable because space for the scrollbar is reserved.
+
+3. **Why is it useful?** The layout shift is jarring and makes the modal feel glitchy. The proposed fix — adding `scrollbar-gutter: stable` to `<html>` or compensating with `padding-right` — keeps the page stable when modals open, matching user expectations for a polished UI framework.
+
+fixes #18794

--- a/submissions/examples/fix-modal-scrollbar-shift/demo.html
+++ b/submissions/examples/fix-modal-scrollbar-shift/demo.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>modal scrollbar shift demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="wrap">
+
+<h1>scrollbar layout shift in modals</h1>
+<p class="sub">
+  Issue <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/18794">#18794</a> —
+  <code>body.style.overflow = 'hidden'</code> removes the scrollbar,
+  causing the page to jump ~15px right. Proposed fix: <code>scrollbar-gutter: stable</code>.
+</p>
+
+<div class="card">
+  <h2>before (broken)</h2>
+  <p><span class="tag tag-bad">shift</span>
+  <code>overflow: hidden</code> removes scrollbar → layout jumps right.</p>
+  <div class="row">
+    <button class="btn btn-danger" onclick="openModal(false)">open modal (broken)</button>
+    <button class="btn btn-primary" onclick="closeModal()">close modal</button>
+  </div>
+</div>
+
+<div class="card">
+  <h2>after (fixed with scrollbar-gutter)</h2>
+  <p><span class="tag tag-good">stable</span>
+  <code>scrollbar-gutter: stable</code> on body reserves space for the
+  scrollbar at all times — no layout shift.</p>
+  <div class="row">
+    <button class="btn btn-primary" onclick="openModal(true)">open modal (fixed)</button>
+    <button class="btn btn-primary" onclick="closeModal()">close modal</button>
+  </div>
+</div>
+
+<div class="measure">
+  page width: <span id="widthDisplay">measuring...</span> &nbsp;|&nbsp;
+  scrollbar visible: <span id="sbDisplay">yes</span> &nbsp;|&nbsp;
+  body offset: <span id="offsetDisplay">0px</span>
+</div>
+
+<pre>
+/* proposed change to core/modal.js */
+body.style.overflow = 'hidden';
+/* add: */ document.documentElement.style.scrollbarGutter = 'stable';
+</pre>
+
+<pre>
+/* alternative CSS-only approach (no JS change needed) */
+html { scrollbar-gutter: stable; }
+</pre>
+
+<div class="long-content">
+  <p>line 1 — scroll down to make sure the scrollbar is visible</p>
+  <p>line 2</p><p>line 3</p><p>line 4</p><p>line 5</p>
+  <p>line 6</p><p>line 7</p><p>line 8</p><p>line 9</p><p>line 10</p>
+  <p>line 11</p><p>line 12</p><p>line 13</p><p>line 14</p><p>line 15</p>
+  <p>line 16</p><p>line 17</p><p>line 18</p><p>line 19</p><p>line 20</p>
+</div>
+
+</div>
+
+<div class="modal-overlay" id="modal">
+  <div class="modal-box">
+    <h3>modal open</h3>
+    <p>notice whether the page content jumps when this opens</p>
+    <button class="btn btn-primary" onclick="closeModal()">close</button>
+  </div>
+</div>
+
+<script>
+function getSbWidth() {
+  return window.innerWidth - document.documentElement.clientWidth;
+}
+
+function updateMeasurements() {
+  const w = document.documentElement.clientWidth;
+  const sb = getSbWidth();
+  document.getElementById('widthDisplay').textContent = w + 'px';
+  document.getElementById('sbDisplay').textContent = sb > 0 ? 'yes (' + sb + 'px)' : 'no';
+  document.getElementById('offsetDisplay').textContent =
+    document.body.style.paddingRight || '0px';
+}
+
+let fixActive = false;
+
+function openModal(fixed) {
+  fixActive = fixed;
+  const body = document.body;
+  const sb = getSbWidth();
+
+  if (fixed) {
+    body.classList.add('fix-active');
+    body.style.paddingRight = sb + 'px';
+  }
+
+  body.style.overflow = 'hidden';
+  document.getElementById('modal').classList.add('open');
+  updateMeasurements();
+}
+
+function closeModal() {
+  const body = document.body;
+  body.style.overflow = '';
+  body.style.paddingRight = '';
+  body.classList.remove('fix-active');
+  document.getElementById('modal').classList.remove('open');
+  updateMeasurements();
+}
+
+updateMeasurements();
+window.addEventListener('resize', updateMeasurements);
+</script>
+</body>
+</html>

--- a/submissions/examples/fix-modal-scrollbar-shift/style.css
+++ b/submissions/examples/fix-modal-scrollbar-shift/style.css
@@ -1,0 +1,141 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  line-height: 1.5;
+  color: #1e293b;
+}
+.wrap {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+h1 {
+  font-size: 1.6rem;
+  margin-bottom: 0.25rem;
+}
+.sub {
+  color: #64748b;
+  margin-bottom: 1.5rem;
+}
+h2 {
+  font-size: 1.1rem;
+  margin: 1.5rem 0 0.5rem;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 0.3rem;
+}
+.row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin: 0.75rem 0;
+}
+.btn {
+  padding: 0.6rem 1.2rem;
+  border: 0;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btn-primary {
+  background: #6c63ff;
+  color: #fff;
+}
+.btn-primary:hover {
+  background: #5a52e0;
+}
+.btn-danger {
+  background: #ef4444;
+  color: #fff;
+}
+.btn-danger:hover {
+  background: #dc2626;
+}
+.measure {
+  position: relative;
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  font-size: 0.9rem;
+}
+.measure span {
+  font-weight: 700;
+}
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.modal-overlay.open {
+  display: flex;
+}
+.modal-box {
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+}
+.modal-box h3 {
+  margin-bottom: 0.75rem;
+}
+.modal-box p {
+  font-size: 0.9rem;
+  color: #475569;
+  margin-bottom: 1rem;
+}
+.long-content p {
+  margin-bottom: 0.6rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+code {
+  background: #f1f5f9;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-size: 0.85em;
+}
+pre {
+  background: #1e293b;
+  color: #e2e8f0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  font-size: 0.8rem;
+  margin: 0.5rem 0;
+}
+.card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+.tag {
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  margin-right: 0.4rem;
+  text-transform: uppercase;
+}
+.tag-bad { background: #fca5a5; color: #991b1b; }
+.tag-good { background: #86efac; color: #166534; }
+
+/* scrollbar-gutter fix applied to .fix-active */
+.fix-active {
+  scrollbar-gutter: stable;
+}


### PR DESCRIPTION
Shows how `body.style.overflow = "hidden"` in `core/modal.js` removes the scrollbar and shifts the page layout ~15px right. Demonstrates the fix using `scrollbar-gutter: stable` or padding compensation.

Fixes #18794

Only adds new files under `submissions/examples/`.