### PR TITLE
feat(examples): add CSS-Only Checkmark Draw Animation

### DIFF
--- a/submissions/examples/animated-checkmark-draw/README.md
+++ b/submissions/examples/animated-checkmark-draw/README.md
@@ -1,0 +1,37 @@
+# Animated Checkmark Draw
+
+## What does it do?
+An SVG-style path drawing animation for a success checkmark, done purely in CSS.
+
+## Features
+- Checkmark path progressively draws itself using `stroke-dasharray` / `stroke-dashoffset`
+- Runs once on load using CSS keyframes
+- Pure CSS, no JavaScript
+
+## Usage
+```html
+<svg class="checkmark" viewBox="0 0 52 52">
+  <path class="checkmark-path" d="M14 27l7 7 16-16"/>
+</svg>
+```
+
+```css
+.checkmark-path {
+  stroke-dasharray: 50;
+  stroke-dashoffset: 50;
+  animation: draw 0.6s ease-out forwards;
+}
+
+@keyframes draw {
+  to { stroke-dashoffset: 0; }
+}
+```
+
+## Browser Support
+- Chrome 1+, Firefox 3.5+, Safari 3.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/animated-checkmark-draw/demo.html
+++ b/submissions/examples/animated-checkmark-draw/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Checkmark Draw — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin-bottom: 1rem; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>CSS-Only Checkmark Draw</h1>
+  <p class="subtitle">An SVG-style path drawing animation for a success checkmark — pure CSS, no JavaScript.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">The checkmark draws itself on page load</p>
+    <div class="checkmark-container">
+      <svg class="checkmark" viewBox="0 0 52 52">
+        <path class="checkmark-path" d="M14 27l7 7 16-16"/>
+      </svg>
+    </div>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p>Uses <code>stroke-dasharray</code> and <code>stroke-dashoffset</code> with a CSS keyframe animation to simulate the path being drawn progressively.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/animated-checkmark-draw/style.css
+++ b/submissions/examples/animated-checkmark-draw/style.css
@@ -1,0 +1,62 @@
+/* ============================================================
+   EaseMotion CSS — Animated Checkmark Draw
+   SVG-style path drawing animation for success checkmark
+   ============================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+h1 { color: #ffffff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+.subtitle { color: #9ca3af; margin-bottom: 2rem; }
+
+section {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h2 { color: #ffffff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+.sec-desc { font-size: 0.85rem; color: #9ca3af; margin-bottom: 1rem; }
+
+.checkmark-container {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 0;
+}
+
+.checkmark {
+  width: 100px;
+  height: 100px;
+}
+
+.checkmark-path {
+  fill: none;
+  stroke: #22c55e;
+  stroke-width: 5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 50;
+  stroke-dashoffset: 50;
+  animation: draw 0.6s ease-out forwards;
+}
+
+@keyframes draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+p { color: #9ca3af; line-height: 1.8; }
+code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }


### PR DESCRIPTION
## Description

An SVG-style path drawing animation for a success checkmark — pure CSS, no JavaScript.

## Requirements
- [x] demo.html with minimal HTML structure
- [x] style.css with styles and keyframes
- [x] Strictly CSS-only (no JavaScript)

## Files
- `demo.html` — checkmark SVG with draw animation
- `style.css` — stroke-dasharray/dashoffset keyframe animation
- `README.md` — documentation

## Related Issue
Closes #17818