### PR TITLE
feat(examples): add CSS-Only Infinite Image Carousel

### DIFF
--- a/submissions/examples/infinite-image-carousel/README.md
+++ b/submissions/examples/infinite-image-carousel/README.md
@@ -1,0 +1,44 @@
+# Infinite Image Carousel
+
+## What does it do?
+An infinitely scrolling horizontal image carousel with no JavaScript — pure CSS.
+
+## Features
+- Seamless infinite loop using content duplication + `translateX(-50%)`
+- Works with any images (demo uses colored placeholder cards)
+- Pure CSS, no JavaScript
+
+## Usage
+```html
+<div class="carousel">
+  <div class="carousel-track">
+    <img src="image1.jpg" alt=""/>
+    <img src="image2.jpg" alt=""/>
+    <!-- Duplicate the set for seamless loop -->
+    <img src="image1.jpg" alt=""/>
+    <img src="image2.jpg" alt=""/>
+  </div>
+</div>
+```
+
+```css
+.carousel { overflow: hidden; }
+.carousel-track {
+  display: flex;
+  width: fit-content;
+  animation: scroll 12s linear infinite;
+}
+@keyframes scroll {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+```
+
+## Browser Support
+- Chrome 1+, Firefox 3.5+, Safari 3.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/infinite-image-carousel/demo.html
+++ b/submissions/examples/infinite-image-carousel/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Infinite Image Carousel — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    h1 { color: #fff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #9ca3af; margin-bottom: 2rem; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #fff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin-bottom: 1rem; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>CSS-Only Infinite Image Carousel</h1>
+  <p class="subtitle">An infinitely scrolling horizontal image carousel with no JavaScript.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Cards scroll infinitely to the left</p>
+    <div class="carousel">
+      <div class="carousel-track">
+        <div class="carousel-slide" style="background:#6366f1;">🏔️</div>
+        <div class="carousel-slide" style="background:#a78bfa;">🌊</div>
+        <div class="carousel-slide" style="background:#f472b6;">🌸</div>
+        <div class="carousel-slide" style="background:#34d399;">🌿</div>
+        <div class="carousel-slide" style="background:#f59e0b;">🌅</div>
+        <div class="carousel-slide" style="background:#6366f1;">🏔️</div>
+        <div class="carousel-slide" style="background:#a78bfa;">🌊</div>
+        <div class="carousel-slide" style="background:#f472b6;">🌸</div>
+        <div class="carousel-slide" style="background:#34d399;">🌿</div>
+        <div class="carousel-slide" style="background:#f59e0b;">🌅</div>
+      </div>
+    </div>
+    <p style="color:#6b7280;font-size:0.8rem;margin-top:1rem;">Placeholder cards with emoji — swap with real images.</p>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p>The track contains two copies of the slide set, and <code>translateX(-50%)</code> loops the scroll seamlessly. Overflow is hidden on the container. No JavaScript needed.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/infinite-image-carousel/style.css
+++ b/submissions/examples/infinite-image-carousel/style.css
@@ -1,0 +1,48 @@
+/* ============================================================
+   EaseMotion CSS — Infinite Image Carousel
+   Infinitely scrolling horizontal image carousel
+   ============================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  padding: 4rem 1rem;
+  text-align: center;
+}
+
+.carousel {
+  overflow: hidden;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  border-radius: 14px;
+  border: 1px solid #2a2a2a;
+}
+
+.carousel-track {
+  display: flex;
+  gap: 0;
+  width: fit-content;
+  animation: carousel-scroll 12s linear infinite;
+}
+
+.carousel-slide {
+  flex: 0 0 200px;
+  height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 3rem;
+  border-right: 2px solid rgba(0, 0, 0, 0.2);
+}
+
+@keyframes carousel-scroll {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+
+p { color: #9ca3af; line-height: 1.8; margin-top: 1rem; }
+code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }


### PR DESCRIPTION
## Description

An infinitely scrolling horizontal image carousel with no JavaScript — pure CSS.

## Requirements
- [x] demo.html with minimal HTML structure
- [x] style.css with styles and keyframes
- [x] Strictly CSS-only (no JavaScript)

## Files
- `demo.html` — carousel with placeholder cards
- `style.css` — translateX keyframe animation for seamless loop
- `README.md` — documentation

## Related Issue
Closes #17813