### PR TITLE
feat(examples): add CSS-Only Morphing Submit Button

### DIFF
--- a/submissions/examples/morphing-submit-button/README.md
+++ b/submissions/examples/morphing-submit-button/README.md
@@ -1,0 +1,43 @@
+# Morphing Submit Button
+
+## What does it do?
+A submit button that morphs into a loading spinner on `:active` — pure CSS, no JavaScript.
+
+## Features
+- Shrinks from rectangle to circle on `:active`
+- Text fades out, spinner fades in via `::after`
+- Smooth transitions for the morph
+- Enhances form UX with immediate CSS-only feedback
+
+## Usage
+```html
+<button class="morph-btn">Submit</button>
+```
+
+```css
+.morph-btn {
+  transition: width 0.35s ease, border-radius 0.35s ease;
+}
+.morph-btn:active {
+  width: 54px;
+  border-radius: 50%;
+  color: transparent;
+}
+.morph-btn::after {
+  /* spinner styles */
+  opacity: 0;
+}
+.morph-btn:active::after {
+  opacity: 1;
+  animation: spin 0.6s linear infinite;
+}
+```
+
+## Browser Support
+- Chrome 1+, Firefox 3.5+, Safari 3.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/morphing-submit-button/demo.html
+++ b/submissions/examples/morphing-submit-button/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Morphing Submit Button — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    h1 { color: #fff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+    .subtitle { color: #9ca3af; margin-bottom: 2rem; }
+    section { background: #1a1a1a; border: 1px solid #2a2a2a; border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    h2 { color: #fff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+    .sec-desc { font-size: 0.85rem; color: #9ca3af; margin-bottom: 1rem; }
+    code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <h1>CSS-Only Morphing Submit Button</h1>
+  <p class="subtitle">A submit button that morphs into a loading spinner seamlessly — pure CSS.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Click and hold (or :active) the button to see it morph</p>
+    <button class="morph-btn">Submit</button>
+    <p style="color:#6b7280;font-size:0.8rem;margin-top:1rem;">Use <code>:active</code> state — click and hold to see the spinner.</p>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p>On <code>:active</code>, the button shrinks to a circle, hides the text, and reveals a spinning border via <code>::after</code>. Uses <code>transition</code> for the morph and <code>animation</code> for the spin.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/morphing-submit-button/style.css
+++ b/submissions/examples/morphing-submit-button/style.css
@@ -1,0 +1,62 @@
+/* ============================================================
+   EaseMotion CSS — Morphing Submit Button
+   Button morphs into a loading spinner on :active
+   ============================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  padding: 4rem 1rem;
+  text-align: center;
+}
+
+.morph-btn {
+  position: relative;
+  width: 180px;
+  height: 54px;
+  padding: 0 2rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: #6366f1;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: width 0.35s ease, border-radius 0.35s ease, padding 0.35s ease;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.morph-btn:active {
+  width: 54px;
+  border-radius: 50%;
+  padding: 0;
+  color: transparent;
+  pointer-events: none;
+}
+
+.morph-btn::after {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.morph-btn:active::after {
+  opacity: 1;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+p { color: #9ca3af; line-height: 1.8; margin-top: 1rem; }
+code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }


### PR DESCRIPTION
## Description

A submit button that morphs into a loading spinner on `:active` — pure CSS, no JavaScript.

## Requirements
- [x] demo.html with minimal HTML structure
- [x] style.css with styles and keyframes
- [x] Strictly CSS-only (no JavaScript)

## Files
- `demo.html` — morphing button demo
- `style.css` — width/border-radius morph + spinner animation
- `README.md` — documentation

## Related Issue
Closes #17648