### PR TITLE
feat: add sticky section headers example (#15545)

### DIFF
--- a/submissions/examples/ease-sticky-headers/README.md
+++ b/submissions/examples/ease-sticky-headers/README.md
@@ -1,0 +1,29 @@
+# CSS Sticky Section Headers (`ease-sticky-headers`)
+
+A pure CSS implementation of sticky headers for scrolling lists and sections, utilizing `position: sticky` and modern `backdrop-filter` for a premium glassmorphism effect.
+
+## 🚀 Features & EaseMotion Showcase
+
+- **Pure CSS**: Zero JavaScript required for the sticking mechanism.
+- **Glassmorphism**: Uses `backdrop-filter: blur()` to create a beautiful frosted glass effect as content scrolls underneath.
+- **Native Performance**: `position: sticky` runs off the main thread, ensuring buttery smooth 60fps scrolling.
+- **Interactive List Items**: Pairs perfectly with standard CSS `:hover` animations for list items.
+
+## 🛠️ Usage
+
+This demo is self-contained. Open `demo.html` in your browser. All required CSS is inside `style.css`.
+
+```html
+<!-- The scroll container needs overflow-y: auto -->
+<div class="scroll-container">
+  
+  <section class="list-section">
+    <!-- The header gets the sticky class -->
+    <h3 class="ease-sticky-header">A</h3>
+    <ul>
+      <li>Apple</li>
+      <li>Apricot</li>
+    </ul>
+  </section>
+
+</div>

--- a/submissions/examples/ease-sticky-headers/demo.html
+++ b/submissions/examples/ease-sticky-headers/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Sticky Section Headers | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>CSS Sticky Section Headers</h2>
+      <p>Scroll down the list below. The headers will stick to the top smoothly using pure CSS <code>position: sticky</code>.</p>
+    </div>
+
+    <div class="scroll-container">
+      
+      <!-- Section 1 -->
+      <section class="list-section">
+        <h3 class="ease-sticky-header">A</h3>
+        <ul class="list-items">
+          <li>Apple</li>
+          <li>Apricot</li>
+          <li>Avocado</li>
+          <li>Almond</li>
+          <li>Artichoke</li>
+        </ul>
+      </section>
+
+      <!-- Section 2 -->
+      <section class="list-section">
+        <h3 class="ease-sticky-header">B</h3>
+        <ul class="list-items">
+          <li>Banana</li>
+          <li>Blueberry</li>
+          <li>Blackberry</li>
+          <li>Broccoli</li>
+          <li>Brussels Sprout</li>
+        </ul>
+      </section>
+
+      <!-- Section 3 -->
+      <section class="list-section">
+        <h3 class="ease-sticky-header">C</h3>
+        <ul class="list-items">
+          <li>Cherry</li>
+          <li>Coconut</li>
+          <li>Carrot</li>
+          <li>Cauliflower</li>
+          <li>Cucumber</li>
+        </ul>
+      </section>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-sticky-headers/style.css
+++ b/submissions/examples/ease-sticky-headers/style.css
@@ -1,0 +1,105 @@
+/* ========================================================================
+   Component: ease-sticky-header
+   ======================================================================== */
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+/* Demo UI Styles */
+.demo-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 400px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 600px;
+}
+
+.demo-header {
+  padding: 30px 30px 20px 30px;
+  border-bottom: 1px solid #e2e8f0;
+  background: white;
+  z-index: 20;
+}
+
+.demo-header h2 { margin-top: 0; color: #0f172a; font-size: 1.5rem; margin-bottom: 8px;}
+.demo-header p { color: #64748b; margin: 0; font-size: 0.95rem; line-height: 1.5; }
+
+/* Scroll Container */
+.scroll-container {
+  flex: 1;
+  overflow-y: auto;
+  scroll-behavior: smooth;
+  position: relative;
+  /* Customize scrollbar */
+  scrollbar-width: thin;
+  scrollbar-color: #cbd5e1 transparent;
+}
+.scroll-container::-webkit-scrollbar { width: 6px; }
+.scroll-container::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 10px; }
+
+/* ------------------------------------------------------------------------
+   Sticky Header Core Classes
+   ------------------------------------------------------------------------ */
+
+.list-section {
+  position: relative;
+  /* Ensures the header knows when to un-stick (when the section ends) */
+}
+
+/* The magic sticky class */
+.ease-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  margin: 0;
+  padding: 12px 30px;
+  background-color: rgba(241, 245, 249, 0.85); /* Semi-transparent for blur */
+  backdrop-filter: blur(12px); /* Modern frosted glass effect */
+  -webkit-backdrop-filter: blur(12px);
+  color: #3b82f6;
+  font-size: 1.25rem;
+  font-weight: 700;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+  transition: background-color 0.3s, box-shadow 0.3s;
+}
+
+/* List Items & Animations */
+.list-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.list-items li {
+  padding: 16px 30px;
+  border-bottom: 1px solid #f1f5f9;
+  color: #334155;
+  font-weight: 500;
+  transition: background-color 0.2s, padding-left 0.2s;
+  cursor: pointer;
+}
+
+/* Add a nice hover transform to items to fit EaseMotion styling */
+.list-items li:hover {
+  background-color: #f8fafc;
+  padding-left: 36px;
+  color: #0f172a;
+}
+
+.list-items li:last-child {
+  border-bottom: none;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15545 by providing a pure CSS sticky section header example utilizing `position: sticky` and `backdrop-filter`.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-sticky-headers/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It adds a smooth, JS-free scrolling container where section headers stick to the top of the viewport (`.ease-sticky-header`).

**How does a developer use it?**

```html
<div class="scroll-container">
  <section class="list-section">
    <h3 class="ease-sticky-header">Header</h3>
    <!-- list items -->
  </section>
</div>
