### PR TITLE
feat: add field-sizing auto growing inputs example (#15435)

### DIFF
--- a/submissions/examples/ease-auto-growing-input/README.md
+++ b/submissions/examples/ease-auto-growing-input/README.md
@@ -1,0 +1,20 @@
+# CSS Auto-Growing Inputs (`ease-auto-growing-input`)
+
+A demonstration of the modern CSS `field-sizing: content` property, allowing form fields to automatically resize based on user input without requiring any JavaScript.
+
+## 🚀 Features & EaseMotion Showcase
+
+- **Zero JS Auto-Resize**: Textareas and inputs expand natively based on typed content length or line breaks.
+- **Accessible Design**: Includes clear `:focus` and `:focus-visible` styling (conforming to our strict accessibility guidelines).
+- **Responsive Guardrails**: Utilizes `min-width` and `max-width` to prevent fields from collapsing when empty or breaking layouts when excessively long.
+
+## 🛠️ Usage
+
+This demo is self-contained. Open `demo.html` in your browser. All required CSS is inside `style.css`.
+
+```html
+<!-- Input that grows horizontally -->
+<input type="text" class="ease-auto-grow" placeholder="Type here..." />
+
+<!-- Textarea that grows vertically -->
+<textarea class="ease-auto-grow" placeholder="Type multiple lines..."></textarea>

--- a/submissions/examples/ease-auto-growing-input/demo.html
+++ b/submissions/examples/ease-auto-growing-input/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Auto-Growing Inputs | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>Auto-Growing Inputs</h2>
+      <p>Using the modern CSS <code>field-sizing: content</code> property, these fields grow automatically as you type. Zero JavaScript required!</p>
+    </div>
+
+    <div class="form-group">
+      <label for="auto-input">Auto-expanding Input (Single Line)</label>
+      <input type="text" id="auto-input" class="ease-auto-grow" placeholder="Type a long sentence here..." />
+    </div>
+
+    <div class="form-group">
+      <label for="auto-textarea">Auto-expanding Textarea (Multi-line)</label>
+      <textarea id="auto-textarea" class="ease-auto-grow" placeholder="Type multiple lines of text here..."></textarea>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-auto-growing-input/style.css
+++ b/submissions/examples/ease-auto-growing-input/style.css
@@ -1,0 +1,88 @@
+/* ========================================================================
+   Component: ease-auto-growing-input
+   ======================================================================== */
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+/* Demo UI Styles */
+.demo-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 600px;
+  padding: 40px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  margin-bottom: 40px;
+  text-align: center;
+}
+
+.demo-header h2 { margin-top: 0; color: #0f172a; font-size: 1.75rem; margin-bottom: 8px;}
+.demo-header p { color: #64748b; margin: 0; font-size: 1rem; line-height: 1.5; }
+
+.form-group {
+  margin-bottom: 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #334155;
+  margin-bottom: 8px;
+}
+
+/* ------------------------------------------------------------------------
+   Auto-Grow Core Classes
+   ------------------------------------------------------------------------ */
+
+/* The magic auto-growing class */
+.ease-auto-grow {
+  /* Modern CSS feature for auto-sizing */
+  field-sizing: content;
+  
+  /* Fallback minimum widths/heights so they aren't totally invisible when empty */
+  min-width: 250px;
+  max-width: 100%;
+  
+  /* Beautiful EaseMotion styling */
+  padding: 12px 16px;
+  font-family: inherit;
+  font-size: 1rem;
+  color: #1e293b;
+  background-color: #f1f5f9;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  outline: none;
+  resize: none; /* Disable manual resize handle since it auto-grows */
+  
+  /* Smooth transitions for focus states */
+  transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+/* Accessibility Focus States (Required by submission validator) */
+.ease-auto-grow:focus,
+.ease-auto-grow:focus-visible {
+  background-color: white;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.ease-auto-grow::placeholder {
+  color: #94a3b8;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15435 by providing a completely JS-free auto-growing textarea and input example using the modern `field-sizing: content` CSS property.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-auto-growing-input/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It showcases how to create dynamic, auto-expanding form fields utilizing purely CSS via the `field-sizing: content` property.

**How does a developer use it?**

```html
<textarea class="ease-auto-grow" placeholder="Type and watch it grow..."></textarea>
