### PR TITLE
feat: add clip-path-polygon utilities (#15092)

### DIFF
--- a/submissions/examples/ease-clip-path-polygons/README.md
+++ b/submissions/examples/ease-clip-path-polygons/README.md
@@ -1,0 +1,18 @@
+# Geometric Clip-Path Utilities (`ease-clip-path-polygons`)
+
+A set of structural CSS utilities leveraging `clip-path: polygon()` to instantly generate common geometric shapes out of standard DOM elements.
+
+## 🚀 Features & EaseMotion Showcase
+
+- **Zero Images/SVG**: Creates crisp, scalable geometry entirely in CSS without external assets.
+- **Animation Ready**: `clip-path` properties can be cleanly transitioned and animated natively by the browser.
+- **Drop-Shadow Compatible**: Shows how to use `filter: drop-shadow()` to apply shadows to clipped elements (since `box-shadow` gets clipped!).
+- **Core Shapes**: Includes `triangle`, `diamond`, `pentagon`, and `hexagon` utilities.
+
+## 🛠️ Usage
+
+This demo is self-contained. Open `demo.html` in your browser. All required CSS is inside `style.css`.
+
+```html
+<!-- Simply apply the class to an element with width and height -->
+<div class="clip-path-polygon-hexagon" style="width: 100px; height: 100px; background: blue;"></div>

--- a/submissions/examples/ease-clip-path-polygons/demo.html
+++ b/submissions/examples/ease-clip-path-polygons/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Clip-Path Polygons | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>Geometric Clip-Path Utilities</h2>
+      <p>Create native geometric shapes instantly using <code>clip-path: polygon()</code>. No images or SVG required!</p>
+    </div>
+
+    <div class="shapes-grid">
+      
+      <!-- Triangle -->
+      <div class="shape-card">
+        <div class="shape-wrapper">
+          <div class="ease-shape clip-path-polygon-triangle"></div>
+        </div>
+        <div class="shape-label">Triangle</div>
+      </div>
+
+      <!-- Diamond -->
+      <div class="shape-card">
+        <div class="shape-wrapper">
+          <div class="ease-shape clip-path-polygon-diamond"></div>
+        </div>
+        <div class="shape-label">Diamond</div>
+      </div>
+
+      <!-- Pentagon -->
+      <div class="shape-card">
+        <div class="shape-wrapper">
+          <div class="ease-shape clip-path-polygon-pentagon"></div>
+        </div>
+        <div class="shape-label">Pentagon</div>
+      </div>
+
+      <!-- Hexagon -->
+      <div class="shape-card">
+        <div class="shape-wrapper">
+          <div class="ease-shape clip-path-polygon-hexagon"></div>
+        </div>
+        <div class="shape-label">Hexagon</div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-clip-path-polygons/style.css
+++ b/submissions/examples/ease-clip-path-polygons/style.css
@@ -1,0 +1,101 @@
+/* ========================================================================
+   Component: ease-clip-path-polygons
+   ======================================================================== */
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+/* Demo UI Styles */
+.demo-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 800px;
+  padding: 50px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  margin-bottom: 50px;
+  text-align: center;
+}
+
+.demo-header h2 { margin-top: 0; color: #0f172a; font-size: 2rem; margin-bottom: 12px;}
+.demo-header p { color: #64748b; margin: 0; font-size: 1.1rem; line-height: 1.6; }
+
+.shapes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 40px;
+  justify-items: center;
+}
+
+.shape-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.shape-label {
+  font-weight: 600;
+  color: #334155;
+  font-size: 1.1rem;
+}
+
+/* Base shape container for the demo */
+.shape-wrapper {
+  width: 140px;
+  height: 140px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  /* IMPORTANT: Add a subtle drop shadow using filter since clip-path cuts off box-shadow */
+  filter: drop-shadow(0 10px 15px rgba(59, 130, 246, 0.3));
+}
+
+.ease-shape {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #60a5fa 0%, #3b82f6 100%);
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  cursor: pointer;
+}
+
+.ease-shape:hover {
+  transform: scale(1.1) rotate(5deg);
+}
+
+/* ------------------------------------------------------------------------
+   Clip-Path Polygon Utilities
+   ------------------------------------------------------------------------ */
+
+.clip-path-polygon-triangle {
+  /* Points: top-center, bottom-right, bottom-left */
+  clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+}
+
+.clip-path-polygon-diamond {
+  /* Points: top-center, right-center, bottom-center, left-center */
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}
+
+.clip-path-polygon-pentagon {
+  /* Points: top-center, right-upper, right-lower, left-lower, left-upper */
+  clip-path: polygon(50% 0%, 100% 38%, 82% 100%, 18% 100%, 0% 38%);
+}
+
+.clip-path-polygon-hexagon {
+  /* Points: top-left, top-right, right-center, bottom-right, bottom-left, left-center */
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15092 by adding pure CSS `clip-path` polygon utilities for standard geometric shapes.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-clip-path-polygons/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It adds standard geometric clipping utility classes (`.clip-path-polygon-triangle`, `.clip-path-polygon-diamond`, `.clip-path-polygon-pentagon`, `.clip-path-polygon-hexagon`).

**How does a developer use it?**

```html
<div class="clip-path-polygon-hexagon bg-blue-500 w-24 h-24"></div>
