### PR TITLE
feat: add accent-color form styling example (#15542)

### DIFF
--- a/submissions/examples/ease-accent-color-forms/README.md
+++ b/submissions/examples/ease-accent-color-forms/README.md
@@ -1,0 +1,21 @@
+# Native Accent Color Form Styling (`ease-accent-color-forms`)
+
+A demonstration of the modern CSS `accent-color` property, allowing developers to instantly theme native browser checkboxes, radio buttons, and range sliders without rebuilding them from scratch using complex `div` and `span` overlays.
+
+## 🚀 Features & EaseMotion Showcase
+
+- **Zero-Markup Theming**: Themes the actual native `<input type="checkbox">` elements, preserving all native accessibility and keyboard interactions.
+- **Dynamic CSS Variables**: Uses `--ease-accent` allowing the entire form's theme to change via a single variable update.
+- **Accessible Focus**: Includes enhanced `:focus-visible` styling tied dynamically to the accent color.
+
+## 🛠️ Usage
+
+This demo is self-contained. Open `demo.html` in your browser. All required CSS is inside `style.css`.
+
+```html
+<form style="--ease-accent: #a855f7;">
+  <!-- Instantly themed purple! -->
+  <input type="checkbox" class="ease-accent" checked>
+  <input type="radio" class="ease-accent" checked>
+  <input type="range" class="ease-accent">
+</form>

--- a/submissions/examples/ease-accent-color-forms/demo.html
+++ b/submissions/examples/ease-accent-color-forms/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Accent Color Forms | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>Native Form Theming</h2>
+      <p>Using the modern CSS <code>accent-color</code> property to instantly theme native checkboxes, radios, and range inputs without custom HTML wrappers.</p>
+    </div>
+
+    <!-- Theme Selection -->
+    <div class="theme-selector">
+      <label>Choose Theme:</label>
+      <div class="theme-buttons">
+        <button class="theme-btn theme-btn--blue active" onclick="setTheme('#3b82f6', this)">Blue</button>
+        <button class="theme-btn theme-btn--purple" onclick="setTheme('#a855f7', this)">Purple</button>
+        <button class="theme-btn theme-btn--emerald" onclick="setTheme('#10b981', this)">Emerald</button>
+        <button class="theme-btn theme-btn--rose" onclick="setTheme('#f43f5e', this)">Rose</button>
+      </div>
+    </div>
+
+    <!-- Themed Form Elements -->
+    <form class="themed-form" id="demoForm">
+      
+      <!-- Checkboxes -->
+      <div class="form-group">
+        <label class="group-label">Notifications</label>
+        <label class="control-label">
+          <input type="checkbox" checked class="ease-accent"> Email Updates
+        </label>
+        <label class="control-label">
+          <input type="checkbox" checked class="ease-accent"> Push Notifications
+        </label>
+      </div>
+
+      <!-- Radio Buttons -->
+      <div class="form-group">
+        <label class="group-label">Delivery Method</label>
+        <label class="control-label">
+          <input type="radio" name="delivery" checked class="ease-accent"> Standard (3-5 days)
+        </label>
+        <label class="control-label">
+          <input type="radio" name="delivery" class="ease-accent"> Express (1-2 days)
+        </label>
+      </div>
+
+      <!-- Range Slider -->
+      <div class="form-group">
+        <label class="group-label">Volume Level</label>
+        <input type="range" min="0" max="100" value="75" class="ease-accent ease-range">
+      </div>
+
+    </form>
+  </div>
+
+  <script>
+    // JS used ONLY for the interactive demo to switch the CSS custom property live
+    function setTheme(color, btn) {
+      document.getElementById('demoForm').style.setProperty('--ease-accent', color);
+      
+      document.querySelectorAll('.theme-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-accent-color-forms/style.css
+++ b/submissions/examples/ease-accent-color-forms/style.css
@@ -1,0 +1,140 @@
+/* ========================================================================
+   Component: ease-accent-color-forms
+   ======================================================================== */
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+/* Demo UI Styles */
+.demo-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 500px;
+  padding: 40px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  margin-bottom: 30px;
+  text-align: center;
+}
+
+.demo-header h2 { margin-top: 0; color: #0f172a; font-size: 1.75rem; margin-bottom: 8px;}
+.demo-header p { color: #64748b; margin: 0; font-size: 1rem; line-height: 1.5; }
+
+/* Theme Selector (Demo only) */
+.theme-selector {
+  background: #f1f5f9;
+  padding: 16px;
+  border-radius: 12px;
+  margin-bottom: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.theme-selector label {
+  font-weight: 600;
+  color: #334155;
+  font-size: 0.9rem;
+}
+
+.theme-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+.theme-btn {
+  flex: 1;
+  padding: 8px;
+  border: 2px solid transparent;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  color: white;
+  transition: transform 0.1s, opacity 0.2s;
+}
+
+.theme-btn:hover { opacity: 0.9; }
+.theme-btn:active { transform: scale(0.95); }
+.theme-btn.active { outline: 3px solid #cbd5e1; outline-offset: 2px; }
+
+.theme-btn--blue { background: #3b82f6; }
+.theme-btn--purple { background: #a855f7; }
+.theme-btn--emerald { background: #10b981; }
+.theme-btn--rose { background: #f43f5e; }
+
+/* ------------------------------------------------------------------------
+   Form Layout 
+   ------------------------------------------------------------------------ */
+
+.themed-form {
+  --ease-accent: #3b82f6; /* Default theme */
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.group-label {
+  font-weight: 600;
+  color: #0f172a;
+  font-size: 1.05rem;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 8px;
+}
+
+.control-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  color: #334155;
+  font-size: 0.95rem;
+}
+
+/* ------------------------------------------------------------------------
+   Accent Color Core Classes
+   ------------------------------------------------------------------------ */
+
+/* The magic class! Instantly themes the native input controls */
+.ease-accent {
+  accent-color: var(--ease-accent);
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+/* Interactive focus states for accessibility */
+.ease-accent:focus-visible {
+  outline: 3px solid var(--ease-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Range input specifics to make it fit */
+.ease-range {
+  width: 100%;
+  margin-top: 8px;
+}
+
+.ease-range:focus-visible {
+  border-radius: 10px;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15542 by providing an example of dynamically styling native form inputs using the modern `accent-color` CSS property.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-accent-color-forms/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It adds a demonstration component (`.ease-accent`) that instantly themes native checkboxes, radio buttons, and range sliders using `accent-color: var(--ease-accent)`.

**How does a developer use it?**

```html
<form style="--ease-accent: #f43f5e;">
  <input type="checkbox" class="ease-accent"> 
</form>
