### PR TITLE
feat: add scroll-snap-type utilities (#15912)

### DIFF
--- a/submissions/examples/ease-scroll-snap-utilities/README.md
+++ b/submissions/examples/ease-scroll-snap-utilities/README.md
@@ -1,0 +1,25 @@
+# CSS Scroll Snap Utilities (`ease-scroll-snap-utilities`)
+
+A collection of CSS utility classes for implementing smooth, native browser scroll-snapping without relying on bulky JavaScript carousel libraries.
+
+## 🚀 Features & EaseMotion Showcase
+
+- **Zero JavaScript**: Build highly performant image carousels, horizontal lists, and paginated sections using only CSS `scroll-snap`.
+- **Accessibility Friendly**: Retains native browser scrolling mechanics, meaning trackpads, touchscreens, and keyboards all work flawlessly out of the box. Includes `:focus-visible` styling for the scroll containers.
+- **Modifiers Included**: Provides utilities for axes (`x`, `y`), strictness (`mandatory`, `proximity`), and alignment (`start`, `center`).
+
+## 🛠️ Usage
+
+This demo is self-contained. Open `demo.html` in your browser. All required CSS is inside `style.css`.
+
+To create a horizontal gallery that snaps to the center of each item:
+```html
+<!-- 1. Apply snap axis and strictness to the scrollable container -->
+<div class="ease-snap-x-mandatory" style="display: flex; overflow-x: auto;">
+  
+  <!-- 2. Apply snap alignment to the children -->
+  <div class="ease-snap-center">Card 1</div>
+  <div class="ease-snap-center">Card 2</div>
+  <div class="ease-snap-center">Card 3</div>
+
+</div>

--- a/submissions/examples/ease-scroll-snap-utilities/demo.html
+++ b/submissions/examples/ease-scroll-snap-utilities/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Scroll Snap Utilities | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>CSS Scroll Snap Utilities</h2>
+      <p>Create smooth, native carousels and paginated layouts using zero JavaScript. Drag or scroll the containers below to see the elements lock into place!</p>
+    </div>
+
+    <!-- Example 1: Horizontal Mandatory Snap (Carousel) -->
+    <div class="demo-section">
+      <div class="section-header">
+        <h3>Horizontal Gallery (Mandatory Snap to Center)</h3>
+        <code>.ease-snap-x-mandatory</code> + <code>.ease-snap-center</code>
+      </div>
+      
+      <!-- The magic snap container -->
+      <div class="gallery ease-snap-x-mandatory" tabindex="0">
+        <div class="gallery-item ease-snap-center" style="background: #3b82f6;">1</div>
+        <div class="gallery-item ease-snap-center" style="background: #a855f7;">2</div>
+        <div class="gallery-item ease-snap-center" style="background: #f43f5e;">3</div>
+        <div class="gallery-item ease-snap-center" style="background: #10b981;">4</div>
+        <div class="gallery-item ease-snap-center" style="background: #f59e0b;">5</div>
+      </div>
+    </div>
+
+    <!-- Example 2: Vertical Proximity Snap (List) -->
+    <div class="demo-section">
+      <div class="section-header">
+        <h3>Vertical List (Proximity Snap to Start)</h3>
+        <code>.ease-snap-y-proximity</code> + <code>.ease-snap-start</code>
+      </div>
+      
+      <!-- The magic snap container -->
+      <div class="vertical-list ease-snap-y-proximity" tabindex="0">
+        <div class="list-item ease-snap-start">Section A</div>
+        <div class="list-item ease-snap-start">Section B</div>
+        <div class="list-item ease-snap-start">Section C</div>
+        <div class="list-item ease-snap-start">Section D</div>
+        <div class="list-item ease-snap-start">Section E</div>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scroll-snap-utilities/style.css
+++ b/submissions/examples/ease-scroll-snap-utilities/style.css
@@ -1,0 +1,140 @@
+/* ========================================================================
+   Component: ease-scroll-snap-utilities
+   ======================================================================== */
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+/* Demo UI Styles */
+.demo-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 700px;
+  padding: 40px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-header h2 { margin-top: 0; color: #0f172a; font-size: 1.75rem; margin-bottom: 8px;}
+.demo-header p { color: #64748b; margin: 0; font-size: 1rem; line-height: 1.5; }
+
+.section-header {
+  margin-bottom: 16px;
+}
+.section-header h3 { margin: 0 0 8px 0; color: #334155; font-size: 1.1rem; }
+.section-header code { background: #f1f5f9; padding: 4px 8px; border-radius: 6px; font-size: 0.85rem; color: #e21d48; font-weight: 600;}
+
+/* ------------------------------------------------------------------------
+   Scroll Snap Utility Classes
+   ------------------------------------------------------------------------ */
+
+/* Container Setup */
+.ease-snap-x-mandatory {
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  /* Smooth scrolling when clicking anchors or using JS scrollBy */
+  scroll-behavior: smooth;
+  /* Hide scrollbar for cleaner look */
+  scrollbar-width: none;
+}
+.ease-snap-x-mandatory::-webkit-scrollbar { display: none; }
+
+.ease-snap-y-proximity {
+  overflow-y: auto;
+  overflow-x: hidden;
+  scroll-snap-type: y proximity;
+  scroll-behavior: smooth;
+}
+
+/* Accessibility Focus Ring on Containers */
+.ease-snap-x-mandatory:focus-visible,
+.ease-snap-y-proximity:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+/* Children Alignments */
+.ease-snap-center {
+  scroll-snap-align: center;
+  scroll-snap-stop: always; /* Force stop on each element so user can't fly past them */
+}
+
+.ease-snap-start {
+  scroll-snap-align: start;
+}
+
+/* ------------------------------------------------------------------------
+   Layout Demo Styles
+   ------------------------------------------------------------------------ */
+
+/* Horizontal Gallery */
+.gallery {
+  display: flex;
+  gap: 20px;
+  padding: 20px 0; /* padding creates visual space for snapping */
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+}
+
+.gallery-item {
+  flex: 0 0 80%; /* Takes up 80% of container, leaving 20% to peek next item */
+  height: 200px;
+  border-radius: 12px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 3rem;
+  font-weight: 700;
+  color: white;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}
+
+/* Add pseudo-padding to the start and end of the flex container so the first/last items can center cleanly! */
+.gallery::before,
+.gallery::after {
+  content: '';
+  flex: 0 0 10%;
+}
+
+/* Vertical List */
+.vertical-list {
+  height: 250px; /* Fixed height to force overflow */
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.list-item {
+  height: 100px;
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #334155;
+  border-bottom: 1px solid #e2e8f0;
+  background: white;
+}
+
+.list-item:last-child {
+  border-bottom: none;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15912 by providing native CSS scroll-snapping utility classes, allowing developers to build interactive carousels and paginated lists without JavaScript.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-scroll-snap-utilities/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It adds a suite of `.ease-snap-*` utility classes that orchestrate CSS `scroll-snap-type` and `scroll-snap-align`.

**How does a developer use it?**

```html
<div class="ease-snap-x-mandatory flex overflow-x-auto">
  <div class="ease-snap-center">Card 1</div>
  <div class="ease-snap-center">Card 2</div>
</div>
