### PR TITLE
feat: add perspective-3d CSS demo (#15911)

### DIFF
--- a/submissions/examples/ease-perspective-3d/README.md
+++ b/submissions/examples/ease-perspective-3d/README.md
@@ -1,0 +1,27 @@
+# CSS 3D Perspective Utilities (`ease-perspective-3d`)
+
+A demonstration of using CSS `perspective` and `transform-style: preserve-3d` to create immersive spatial interactions and flip cards natively in the browser.
+
+## 🚀 Features & EaseMotion Showcase
+
+- **Native 3D Engine**: Avoids heavy WebGL rendering by utilizing the browser's native hardware-accelerated CSS 3D capabilities.
+- **`preserve-3d` Context**: Shows how to maintain true 3D spatial relationships between parent and child elements.
+- **Interactive Depth**: Demonstrates `translateZ()` to push elements forward, creating realistic parallax tilt effects without JS calculating mouse coordinates.
+- **Accessibility Friendly**: Fully integrates `prefers-reduced-motion` to disable the 3D spinning for vestibular safety, and maps `:focus-within` so keyboard users can trigger the flips!
+
+## 🛠️ Usage
+
+This demo is self-contained. Open `demo.html` in your browser. All required CSS is inside `style.css`.
+
+To create a 3D context, wrap your animating element in a perspective container:
+```html
+<!-- 1. Establish the camera focal point -->
+<div class="ease-perspective-container">
+  
+  <!-- 2. Tell children to stay in 3D space, not flatten -->
+  <div class="card ease-preserve-3d">
+    <div class="front">Front</div>
+    <div class="back">Back</div>
+  </div>
+
+</div>

--- a/submissions/examples/ease-perspective-3d/demo.html
+++ b/submissions/examples/ease-perspective-3d/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS 3D Perspective Demo | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>Native 3D Perspective</h2>
+      <p>Using CSS <code>perspective</code> and <code>transform-style: preserve-3d</code> to create immersive depth and realistic spatial interactions without WebGL.</p>
+    </div>
+
+    <div class="cards-grid">
+      
+      <!-- Example 1: 3D Flip Card -->
+      <div class="demo-section">
+        <h3>3D Flip Card</h3>
+        
+        <!-- The perspective container -->
+        <div class="ease-perspective-container">
+          <div class="flip-card" tabindex="0">
+            <div class="flip-card-inner ease-preserve-3d">
+              <div class="flip-card-front">
+                <span class="icon">🎁</span>
+                <h4>Hover to Reveal</h4>
+              </div>
+              <div class="flip-card-back">
+                <span class="icon">✨</span>
+                <h4>Surprise!</h4>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Example 2: 3D Tilt Card -->
+      <div class="demo-section">
+        <h3>3D Tilt Depth</h3>
+        
+        <!-- The perspective container -->
+        <div class="ease-perspective-container">
+          <div class="tilt-card ease-preserve-3d" tabindex="0">
+            <div class="tilt-layer tilt-layer--bg"></div>
+            <div class="tilt-layer tilt-layer--fg">
+              <h3>Floating Element</h3>
+              <p>Translating Z-axis</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-perspective-3d/style.css
+++ b/submissions/examples/ease-perspective-3d/style.css
@@ -1,0 +1,201 @@
+/* ========================================================================
+   Component: ease-perspective-3d
+   ======================================================================== */
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+/* Demo UI Styles */
+.demo-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 800px;
+  padding: 50px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  margin-bottom: 50px;
+  text-align: center;
+}
+
+.demo-header h2 { margin-top: 0; color: #0f172a; font-size: 2rem; margin-bottom: 12px;}
+.demo-header p { color: #64748b; margin: 0; font-size: 1.1rem; line-height: 1.6; }
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 40px;
+  justify-items: center;
+}
+
+.demo-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.demo-section h3 {
+  margin: 0 0 20px 0;
+  color: #334155;
+  font-size: 1.2rem;
+}
+
+/* Accessibility Focus Ring */
+.flip-card:focus-visible,
+.tilt-card:focus-visible {
+  outline: 3px solid #3b82f6;
+  outline-offset: 4px;
+  border-radius: 16px;
+}
+
+/* ------------------------------------------------------------------------
+   Core 3D Perspective Utilities
+   ------------------------------------------------------------------------ */
+
+/* 
+  Creates the 3D space. 
+  1000px is a standard focal length for UI elements.
+*/
+.ease-perspective-container {
+  perspective: 1000px;
+  width: 100%;
+  max-width: 250px;
+}
+
+/* 
+  Forces children to exist in the same 3D space rather than being flattened
+*/
+.ease-preserve-3d {
+  transform-style: preserve-3d;
+}
+
+/* ------------------------------------------------------------------------
+   Example 1: 3D Flip Card
+   ------------------------------------------------------------------------ */
+
+.flip-card {
+  background-color: transparent;
+  width: 100%;
+  height: 300px;
+  border-radius: 16px;
+  cursor: pointer;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.flip-card:hover .flip-card-inner,
+.flip-card:focus-within .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front, .flip-card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  -webkit-backface-visibility: hidden; /* Safari */
+  backface-visibility: hidden;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}
+
+.flip-card-front {
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  color: white;
+}
+
+.flip-card-back {
+  background: linear-gradient(135deg, #a855f7 0%, #7e22ce 100%);
+  color: white;
+  transform: rotateY(180deg);
+}
+
+.flip-card-front .icon, .flip-card-back .icon { font-size: 4rem; margin-bottom: 10px; }
+.flip-card-front h4, .flip-card-back h4 { margin: 0; font-size: 1.25rem; font-weight: 600; }
+
+/* ------------------------------------------------------------------------
+   Example 2: 3D Tilt Depth Card
+   ------------------------------------------------------------------------ */
+
+.tilt-card {
+  position: relative;
+  width: 100%;
+  height: 300px;
+  border-radius: 16px;
+  transition: transform 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  cursor: pointer;
+}
+
+/* Adding a subtle 3D rotation on hover */
+.tilt-card:hover,
+.tilt-card:focus-within {
+  transform: rotateX(20deg) rotateY(-20deg);
+}
+
+.tilt-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  transition: transform 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.6s ease;
+}
+
+.tilt-layer--bg {
+  background: linear-gradient(135deg, #f43f5e 0%, #e11d48 100%);
+}
+
+.tilt-layer--fg {
+  color: white;
+  text-align: center;
+  /* Push this layer forward in 3D space! */
+  transform: translateZ(50px);
+}
+
+.tilt-card:hover .tilt-layer--bg,
+.tilt-card:focus-within .tilt-layer--bg {
+  box-shadow: 20px 20px 30px rgba(0, 0, 0, 0.2);
+}
+
+.tilt-card:hover .tilt-layer--fg,
+.tilt-card:focus-within .tilt-layer--fg {
+  /* Push it even further on hover */
+  transform: translateZ(80px);
+}
+
+.tilt-layer--fg h3 { margin: 0 0 8px 0; font-size: 1.5rem; font-weight: 700; }
+.tilt-layer--fg p { margin: 0; font-size: 1rem; opacity: 0.9; }
+
+/* Respect User Preferences for accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .flip-card-inner, .tilt-card, .tilt-layer {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15911 by providing utilities and examples for native CSS 3D transforms (`perspective` and `preserve-3d`).

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-perspective-3d/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It adds standard utilities for creating 3D rendering contexts (`.ease-perspective-container` and `.ease-preserve-3d`) alongside demos showcasing interactive depth and card flipping.

**How does a developer use it?**

```html
<div class="ease-perspective-container">
  <div class="ease-preserve-3d">
     <!-- 3D Transform elements go here! -->
  </div>
</div>
