### PR TITLE
feat: add outline-offset-utilities CSS demo (#15904)

### DIFF
--- a/submissions/examples/ease-outline-offset-utilities/README.md
+++ b/submissions/examples/ease-outline-offset-utilities/README.md
@@ -1,0 +1,20 @@
+# Outline Offset Utilities (`ease-outline-offset-utilities`)
+
+A demonstration of how to leverage CSS `outline-offset` alongside `outline` to create interactive hover frames and accessible focus rings that never trigger layout shifts.
+
+## 🚀 Features & EaseMotion Showcase
+
+- **Layout Safe**: Unlike `border` which adds physical width to the box-model, `outline` and `outline-offset` draw *outside* the box bounds, preventing adjacent elements from shuddering or shifting on hover.
+- **Negative Insets**: Proves that `outline-offset` accepts negative values, enabling inner-border styling without complex pseudo-elements.
+- **Spring Physics Simulation**: Shows how applying a `cubic-bezier` transition to `outline-offset` can create delightful spring/bouncy feedback loops native to CSS.
+- **Accessibility Friendly**: Provides the definitive pattern for the `:focus-visible` offset ring that all interactive EaseMotion components should follow.
+
+## 🛠️ Usage
+
+This demo is self-contained. Open `demo.html` in your browser. All required CSS is inside `style.css`.
+
+To create an animated floating frame:
+```html
+<div class="ease-outline-frame">
+  <img src="photo.jpg" alt="Gallery item">
+</div>

--- a/submissions/examples/ease-outline-offset-utilities/demo.html
+++ b/submissions/examples/ease-outline-offset-utilities/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Outline Offset Utilities | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>Outline Offset Utilities</h2>
+      <p>Create layout-safe hover framing and accessible focus rings using <code>outline-offset</code>. Unlike borders, outlines don't affect element dimensions!</p>
+    </div>
+
+    <!-- Example 1: The Accessibility Focus Ring -->
+    <div class="demo-section">
+      <h3>1. The Accessible Focus Ring</h3>
+      <p class="description">Standard practice for accessible interactive elements. Tab to focus the button.</p>
+      
+      <button class="ease-outline-focus">Click or Tab to Focus</button>
+    </div>
+
+    <!-- Example 2: The Double Frame Hover -->
+    <div class="demo-section">
+      <h3>2. The Double Frame Hover</h3>
+      <p class="description">Animates the outline offset outward to create a floating frame effect.</p>
+      
+      <div class="ease-outline-frame" tabindex="0">
+        <img src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?q=80&w=400&auto=format&fit=crop" alt="Abstract rendering" class="image-placeholder">
+      </div>
+    </div>
+
+    <!-- Example 3: Inset Outline Hover -->
+    <div class="demo-section">
+      <h3>3. The Inset Outline Hover</h3>
+      <p class="description">Uses a negative outline offset to pull the outline *inside* the element on hover.</p>
+      
+      <div class="ease-outline-inset" tabindex="0">
+        <span class="inset-text">Hover to Inset</span>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-outline-offset-utilities/style.css
+++ b/submissions/examples/ease-outline-offset-utilities/style.css
@@ -1,0 +1,146 @@
+/* ========================================================================
+   Component: ease-outline-offset-utilities
+   ======================================================================== */
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+/* Demo UI Styles */
+.demo-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 600px;
+  padding: 50px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-header h2 { margin-top: 0; color: #0f172a; font-size: 1.75rem; margin-bottom: 12px;}
+.demo-header p { color: #64748b; margin: 0; font-size: 1rem; line-height: 1.6; }
+
+.demo-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 32px;
+  background: #f1f5f9;
+  border-radius: 12px;
+}
+
+.demo-section h3 { margin: 0 0 8px 0; color: #334155; font-size: 1.1rem; }
+.description { margin: 0 0 20px 0; font-size: 0.9rem; color: #64748b; }
+
+/* ------------------------------------------------------------------------
+   Outline Utility 1: Focus Ring
+   ------------------------------------------------------------------------ */
+
+.ease-outline-focus {
+  padding: 12px 24px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: white;
+  background-color: #2563eb;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  /* Reset outline to prepare for focus */
+  outline: 2px solid transparent;
+  outline-offset: 0px;
+  transition: outline-color 0.2s, outline-offset 0.2s, background-color 0.2s;
+}
+
+.ease-outline-focus:hover {
+  background-color: #1d4ed8;
+}
+
+.ease-outline-focus:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 4px;
+}
+
+/* ------------------------------------------------------------------------
+   Outline Utility 2: Double Frame Hover
+   ------------------------------------------------------------------------ */
+
+.ease-outline-frame {
+  width: 200px;
+  height: 150px;
+  border-radius: 8px;
+  /* Image must have hidden overflow if rounded corners are used */
+  overflow: hidden;
+  /* Setup base outline invisible and close to element */
+  outline: 2px solid transparent;
+  outline-offset: 0px;
+  cursor: pointer;
+  transition: outline-color 0.3s ease, outline-offset 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.image-placeholder {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.ease-outline-frame:hover,
+.ease-outline-frame:focus-visible {
+  /* Animate offset outward and make visible */
+  outline: 2px solid #8b5cf6;
+  outline-offset: 8px;
+}
+
+/* ------------------------------------------------------------------------
+   Outline Utility 3: Inset Outline
+   ------------------------------------------------------------------------ */
+
+.ease-outline-inset {
+  width: 100%;
+  max-width: 250px;
+  padding: 20px;
+  background-color: #e2e8f0;
+  border-radius: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  color: #334155;
+  cursor: pointer;
+  
+  /* Outline sits directly on the border edge */
+  outline: 2px solid transparent;
+  outline-offset: 0px;
+  transition: outline-color 0.3s ease, outline-offset 0.3s ease, background-color 0.3s;
+}
+
+.ease-outline-inset:hover,
+.ease-outline-inset:focus-visible {
+  background-color: #cbd5e1;
+  outline: 2px solid #0f172a;
+  /* Negative offset pulls it INSIDE the element! */
+  outline-offset: -8px;
+}
+
+/* Accessibility Fallbacks */
+@media (prefers-reduced-motion: reduce) {
+  .ease-outline-focus, .ease-outline-frame, .ease-outline-inset {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15904 by demonstrating layout-safe outline offset utilities for hover framing and accessible focus rings.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-outline-offset-utilities/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It provides examples for `.ease-outline-focus`, `.ease-outline-frame`, and `.ease-outline-inset` demonstrating how to animate outline distances natively.

**How does a developer use it?**

```html
<div class="ease-outline-frame">
  <!-- Inner content -->
</div>

