### PR TITLE
feat: add caret-color CSS property demo (#15898)

### DIFF
--- a/submissions/examples/ease-caret-color/README.md
+++ b/submissions/examples/ease-caret-color/README.md
@@ -1,0 +1,17 @@
+# Caret Color Utility (`ease-caret-color`)
+
+A demonstration of the `caret-color` CSS property, which allows developers to independently style the color of the blinking text-insertion cursor in `input` and `textarea` elements.
+
+## 🚀 Features & EaseMotion Showcase
+
+- **Micro-Interactions**: Brand consistency lives in the details. The blinking cursor is one of the most interacted-with elements on a page. Coloring it to match your primary brand color (or an error state color) creates a highly premium, custom-built feel.
+- **Independent from Text**: `caret-color` is completely independent of the `color` property. This means you can have standard dark grey text, but a vibrant blue blinking cursor.
+- **The "Ghost Text" Trick**: Because it is independent, you can even set `color: transparent` but keep `caret-color: purple`. This is a fun hack for creating custom visual terminal inputs or hidden password fields where you want a custom cursor but hidden text.
+
+## 🛠️ Usage
+
+This demo is self-contained. Open `demo.html` in your browser. All required CSS is inside `style.css`.
+
+To apply a custom caret color:
+```html
+<input type="text" class="ease-caret-brand">

--- a/submissions/examples/ease-caret-color/demo.html
+++ b/submissions/examples/ease-caret-color/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Caret Color Demo | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>Custom Caret Colors</h2>
+      <p>Using the <code>caret-color</code> property to style the blinking text insertion cursor inside inputs and textareas for ultimate brand consistency.</p>
+    </div>
+
+    <!-- Example 1: The Default Caret -->
+    <div class="demo-section">
+      <h3>1. Default Caret</h3>
+      <p class="description">Normally, the blinking cursor defaults to black (or the default text color). Click inside to see.</p>
+      
+      <input type="text" class="input-default" placeholder="Click me to see the default black cursor..." />
+    </div>
+
+    <!-- Example 2: The Branded Caret -->
+    <div class="demo-section">
+      <h3>2. The Branded Caret</h3>
+      <p class="description">By applying <code>caret-color</code>, we can make the blinking cursor match our brand's primary color (e.g., a vibrant blue).</p>
+      
+      <input type="text" class="ease-caret-brand" placeholder="Click me to see the blue cursor..." />
+    </div>
+
+    <!-- Example 3: The Error Caret -->
+    <div class="demo-section">
+      <h3>3. The Error State Caret</h3>
+      <p class="description">Extremely useful for form validation. When an input is invalid, turning the cursor red immediately signals an error context.</p>
+      
+      <input type="text" class="ease-caret-error" value="invalid_email_format.com" />
+    </div>
+
+    <!-- Example 4: Transparent Text Hack -->
+    <div class="demo-section">
+      <h3>4. The "Ghost Text" Trick</h3>
+      <p class="description">A fun trick: making the text transparent but keeping the cursor visible. Useful for custom search bars or terminal effects.</p>
+      
+      <input type="text" class="ease-caret-ghost" placeholder="Type here... the text is invisible!" />
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-caret-color/style.css
+++ b/submissions/examples/ease-caret-color/style.css
@@ -1,0 +1,120 @@
+/* ========================================================================
+   Component: ease-caret-color
+   ======================================================================== */
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+/* Demo UI Styles */
+.demo-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 650px;
+  padding: 50px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-header h2 { margin-top: 0; color: #0f172a; font-size: 1.75rem; margin-bottom: 12px;}
+.demo-header p { color: #64748b; margin: 0; font-size: 1.05rem; line-height: 1.6;}
+.demo-header code { background: #f1f5f9; padding: 4px 8px; border-radius: 6px; color: #dc2626;}
+
+.demo-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: #f8fafc;
+  padding: 24px;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+}
+
+.demo-section h3 { margin: 0; color: #334155; font-size: 1.15rem; }
+.description { margin: 0 0 10px 0; font-size: 0.95rem; color: #64748b; line-height: 1.5; }
+
+/* ------------------------------------------------------------------------
+   Input Resets
+   ------------------------------------------------------------------------ */
+
+input[type="text"] {
+  width: 100%;
+  padding: 12px 16px;
+  font-size: 1rem;
+  font-family: inherit;
+  border: 2px solid #cbd5e1;
+  border-radius: 8px;
+  background-color: white;
+  color: #0f172a;
+  box-sizing: border-box;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  outline: none;
+}
+
+input[type="text"]:focus {
+  border-color: #94a3b8;
+}
+
+/* ------------------------------------------------------------------------
+   Core Utility: Caret Colors
+   ------------------------------------------------------------------------ */
+
+/* 1. Default (No custom caret color) */
+.input-default:focus {
+  border-color: #3b82f6;
+}
+
+/* 2. Brand Color */
+.ease-caret-brand {
+  /* This changes ONLY the blinking cursor */
+  caret-color: #2563eb; 
+}
+.ease-caret-brand:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+/* 3. Error Color */
+.ease-caret-error {
+  caret-color: #ef4444;
+  color: #ef4444;
+  border-color: #fca5a5;
+  background-color: #fef2f2;
+}
+.ease-caret-error:focus {
+  border-color: #ef4444;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);
+}
+
+/* 4. The Ghost Trick (Transparent text, visible caret) */
+.ease-caret-ghost {
+  /* Make the typed text invisible */
+  color: transparent;
+  /* But keep the cursor brightly visible */
+  caret-color: #8b5cf6;
+  background-color: #1e293b;
+  border-color: #0f172a;
+}
+.ease-caret-ghost::placeholder {
+  color: rgba(255,255,255,0.3);
+}
+.ease-caret-ghost:focus {
+  border-color: #8b5cf6;
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.2);
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15898 by introducing utilities and a showcase for the native CSS `caret-color` property.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-caret-color/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It adds `.ease-caret-brand`, `.ease-caret-error`, and `.ease-caret-ghost` utilities to demonstrate how to independently color the blinking text-insertion cursor in inputs.

**How does a developer use it?**

```html
<input type="text" class="ease-caret-brand" placeholder="Type here..." />
