### PR TITLE
resolve #18876: Responsive Sticky Footer Layout Grid

### DIFF
--- a/submissions/examples/new-sticky-footer-layout-sn100/README.md
+++ b/submissions/examples/new-sticky-footer-layout-sn100/README.md
@@ -1,0 +1,7 @@
+﻿# Responsive Sticky Footer Layout Grid
+
+Clean page layout grid structure pinning the footer to page bottom.
+
+## How to use
+1. Link the component stylesheet `style.css` in your HTML header.
+2. Embed the structure code into your body sections.

--- a/submissions/examples/new-sticky-footer-layout-sn100/demo.html
+++ b/submissions/examples/new-sticky-footer-layout-sn100/demo.html
@@ -1,0 +1,27 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS: Responsive Sticky Footer Layout Grid</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #0b0c10;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<div class="ease-sticky-layout">
+  <header class="header">Header Section</header>
+  <main class="content">Main Content Section (Height adaptable)</main>
+  <footer class="footer">Footer Section (Pinned)</footer>
+</div>
+</body>
+</html>

--- a/submissions/examples/new-sticky-footer-layout-sn100/style.css
+++ b/submissions/examples/new-sticky-footer-layout-sn100/style.css
@@ -1,0 +1,27 @@
+﻿/* ==========================================================================
+   EaseMotion CSS: Responsive Sticky Footer Layout Grid
+   ========================================================================== */
+
+@layer components {
+.ease-sticky-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 300px;
+  width: 400px;
+  border: 1px solid #333;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #0b0c10;
+}
+.header, .footer {
+  background: #111;
+  padding: 1rem;
+  color: #fff;
+  text-align: center;
+}
+.content {
+  flex-grow: 1;
+  padding: 2rem;
+  color: #ccc;
+}
+}


### PR DESCRIPTION
﻿Closes #18876

## What this does
Clean page layout grid structure pinning the footer to page bottom.

## Files
- `submissions/examples/new-sticky-footer-layout-sn100/style.css`
- `submissions/examples/new-sticky-footer-layout-sn100/demo.html`
- `submissions/examples/new-sticky-footer-layout-sn100/README.md`
