### PR TITLE
fix: dynamically respond to prefers-reduced-motion changes

### DIFF
--- a/core/reveal.js
+++ b/core/reveal.js
@@ -3,6 +3,7 @@
 
   var revealClass = 'ease-reveal';
   var activeClass = 'ease-reveal-active';
+  var observer = null;
 
   function isCentered(el) {
     var rect = el.getBoundingClientRect();
@@ -10,67 +11,74 @@
     return rect.top < vh * 0.85 && rect.bottom > 0;
   }
 
-  // Check if user prefers reduced motion
-  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (prefersReducedMotion) {
-    var readyReduced = function () {
-      var els = document.querySelectorAll('.' + revealClass);
-      Array.prototype.forEach.call(els, function (el) {
-        el.classList.add(activeClass);
-      });
-    };
+  var motionMedia = window.matchMedia('(prefers-reduced-motion: reduce)');
 
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', readyReduced);
-    } else {
-      readyReduced();
+  function revealAll() {
+    var els = document.querySelectorAll('.' + revealClass);
+    Array.prototype.forEach.call(els, function (el) {
+      el.classList.add(activeClass);
+    });
+    if (observer) {
+      observer.disconnect();
+      observer = null;
     }
-    return;
   }
 
-  var supportsObserver = 'IntersectionObserver' in window;
+  function initReveal() {
+    if (motionMedia.matches) {
+      revealAll();
+      return;
+    }
 
-  if (supportsObserver) {
-    var observer = new IntersectionObserver(
-      function (entries) {
-        entries.forEach(function (entry) {
-          if (entry.isIntersecting) {
-            entry.target.classList.add(activeClass);
-            observer.unobserve(entry.target);
+    if ('IntersectionObserver' in window) {
+      observer = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add(activeClass);
+              observer.unobserve(entry.target);
+            }
+          });
+        },
+        { threshold: 0.15 }
+      );
+
+      function ready() {
+        var els = document.querySelectorAll('.' + revealClass);
+        Array.prototype.forEach.call(els, function (el) {
+          if (isCentered(el)) {
+            el.classList.add(activeClass);
+          } else {
+            observer.observe(el);
           }
         });
-      },
-      { threshold: 0.15 }
-    );
+      }
 
-    var ready = function () {
-      var els = document.querySelectorAll('.' + revealClass);
-      Array.prototype.forEach.call(els, function (el) {
-        if (isCentered(el)) {
-          el.classList.add(activeClass);
-        } else {
-          observer.observe(el);
-        }
-      });
-    };
-
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', ready);
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', ready);
+      } else {
+        ready();
+      }
     } else {
-      ready();
-    }
-  } else {
-    var readyFallback = function () {
-      var els = document.querySelectorAll('.' + revealClass);
-      Array.prototype.forEach.call(els, function (el) {
-        el.classList.add(activeClass);
-      });
-    };
-
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', readyFallback);
-    } else {
-      readyFallback();
+      revealAll();
     }
   }
+
+  motionMedia.addEventListener('change', function () {
+    if (motionMedia.matches) {
+      revealAll();
+    } else {
+      var els = document.querySelectorAll('.' + revealClass);
+      Array.prototype.forEach.call(els, function (el) {
+        el.classList.remove(activeClass);
+      });
+      if (observer) {
+        observer.disconnect();
+        observer = null;
+      }
+      initReveal();
+    }
+  });
+
+  initReveal();
 })();


### PR DESCRIPTION
## ✦ Description

The `prefers-reduced-motion` check in `core/reveal.js` was only evaluated once during script initialization. If a user changes their OS motion accessibility preference while the page is open, the reveal behavior would not update until a full page reload.

---

## ⟡ Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.

---

## ⟡ Root Cause

The previous code did:

```js
var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
```

This only ran once at load time. If the OS accessibility setting changed while the page was open, the reveal script had no way to respond.

## Changes Made
- Added a `change` event listener on the media query using `matchMedia(...).addEventListener`
- Extracted shared logic into `revealAll()` and `initReveal()` helper functions
- When reduced motion is enabled: all elements are revealed immediately and the IntersectionObserver is disconnected
- When reduced motion is disabled: all reveal classes are reset, the old observer is disconnected, and a fresh IntersectionObserver is initialized

Closes #18791

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

---

## Additional Notes
- No frontend or UI changes were introduced.
- Branch pushed: Pcmhacker-piro/EaseMotion-css:fix/reduced-motion-dynamic