### PR TITLE
fix: reveal reduced motion live update (submission)

### DIFF
--- a/submissions/fix-reveal-reduced-motion-dynamic/README.md
+++ b/submissions/fix-reveal-reduced-motion-dynamic/README.md
@@ -1,0 +1,11 @@
+# Fix: Reveal Reduced Motion
+
+Replaces the one-time `matchMedia(...).matches` check in `core/reveal.js` with a `matchMedia(...).addEventListener('change', ...)` listener so reveal elements respond immediately when the OS `prefers-reduced-motion` setting changes, without requiring a page reload.
+
+## Usage
+
+Open `demo.html` in a browser. Scroll to see reveal cards animate. Click the button to simulate reduced motion — all cards appear instantly. The same script listens for real OS-level preference changes via `matchMedia`.
+
+## Why
+
+A static check at load time ignores live accessibility changes. Users who toggle reduced motion after the page loads are stuck with the wrong behaviour until they reload. This fix makes EaseMotion respect accessibility preferences in real time.

--- a/submissions/fix-reveal-reduced-motion-dynamic/demo.html
+++ b/submissions/fix-reveal-reduced-motion-dynamic/demo.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Reduced Motion Live Update</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      font-family: var(--ease-font-sans);
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .hero {
+      height: 80vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 2rem;
+    }
+    .status {
+      padding: 0.5rem 1rem;
+      border-radius: var(--ease-radius-full);
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin: 1rem 0;
+    }
+    .status.reduced {
+      background: var(--ease-color-warning-100);
+      color: var(--ease-color-warning-700);
+    }
+    .status.normal {
+      background: var(--ease-color-info-100);
+      color: var(--ease-color-info-700);
+    }
+    button {
+      padding: 0.5rem 1.25rem;
+      border: 2px solid var(--ease-color-primary);
+      background: transparent;
+      color: var(--ease-color-primary);
+      border-radius: var(--ease-radius-full);
+      font-size: 0.85rem;
+      cursor: pointer;
+      margin-bottom: 3rem;
+    }
+    button:hover {
+      background: var(--ease-color-primary);
+      color: var(--ease-color-text-on-primary);
+    }
+    .reveal-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      width: min(90%, 480px);
+      margin-bottom: 30vh;
+    }
+    .card {
+      background: var(--ease-color-surface);
+      padding: 2rem;
+      border-radius: var(--ease-radius-lg);
+      border: 1px solid var(--ease-color-neutral-200);
+      box-shadow: var(--ease-shadow-sm);
+    }
+    .card h3 {
+      margin: 0 0 0.5rem;
+      font-size: 1.1rem;
+    }
+    .card p {
+      margin: 0;
+      font-size: 0.9rem;
+      color: var(--ease-color-muted);
+    }
+  </style>
+</head>
+<body>
+  <div class="hero">
+    <h1>prefers-reduced-motion: live</h1>
+    <p style="color:var(--ease-color-muted)">
+      The fix uses <code>matchMedia(&quot;(prefers-reduced-motion: reduce)&quot;).addEventListener('change', ...)</code>
+      so reveal elements react immediately when the OS setting changes.
+    </p>
+    <div id="status" class="status">checking...</div>
+    <button id="toggleBtn">Simulate reduced motion</button>
+  </div>
+
+  <div class="reveal-grid">
+    <div class="card demo-reveal-card">
+      <h3>First card</h3>
+      <p>Fades and slides up when scrolled into view — unless motion is reduced.</p>
+    </div>
+    <div class="card demo-reveal-card">
+      <h3>Second card</h3>
+      <p>Toggle reduced motion above and these cards react immediately, no reload needed.</p>
+    </div>
+    <div class="card demo-reveal-card">
+      <h3>Third card</h3>
+      <p>Turning reduced motion on reveals everything at once. Turning it off resets the observer.</p>
+    </div>
+    <div class="card demo-reveal-card">
+      <h3>Fourth card</h3>
+      <p>This is exactly how core/reveal.js should behave.</p>
+    </div>
+  </div>
+
+  <script>
+    var motionMedia = window.matchMedia('(prefers-reduced-motion: reduce)');
+    var overridden = null;
+    var statusEl = document.getElementById('status');
+    var toggleBtn = document.getElementById('toggleBtn');
+    var revealClass = 'demo-reveal-card';
+    var activeClass = 'active';
+    var observer = null;
+
+    function reduced() {
+      return overridden !== null ? overridden : motionMedia.matches;
+    }
+
+    function revealAll() {
+      var els = document.querySelectorAll('.' + revealClass);
+      for (var i = 0; i < els.length; i++) {
+        els[i].classList.add(activeClass);
+      }
+      if (observer) { observer.disconnect(); observer = null; }
+    }
+
+    function initReveal() {
+      if (reduced()) { revealAll(); return; }
+      if ('IntersectionObserver' in window) {
+        observer = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add(activeClass);
+              observer.unobserve(entry.target);
+            }
+          });
+        }, { threshold: 0.15 });
+        var els = document.querySelectorAll('.' + revealClass);
+        for (var i = 0; i < els.length; i++) {
+          var rect = els[i].getBoundingClientRect();
+          if (rect.top < window.innerHeight * 0.85 && rect.bottom > 0) {
+            els[i].classList.add(activeClass);
+          } else {
+            observer.observe(els[i]);
+          }
+        }
+      } else { revealAll(); }
+    }
+
+    function onPreferenceChange() {
+      if (reduced()) {
+        statusEl.className = 'status reduced';
+        statusEl.textContent = 'Reduced motion ON — revealing all';
+        toggleBtn.textContent = 'Restore motion';
+        revealAll();
+      } else {
+        statusEl.className = 'status normal';
+        statusEl.textContent = 'Reduced motion OFF — cards animate on scroll';
+        toggleBtn.textContent = 'Simulate reduced motion';
+        var els = document.querySelectorAll('.' + revealClass);
+        for (var i = 0; i < els.length; i++) {
+          els[i].classList.remove(activeClass);
+        }
+        if (observer) { observer.disconnect(); observer = null; }
+        initReveal();
+      }
+    }
+
+    toggleBtn.addEventListener('click', function () {
+      overridden = overridden === null ? true : (overridden ? false : true);
+      onPreferenceChange();
+    });
+
+    motionMedia.addEventListener('change', function () {
+      if (overridden === null) onPreferenceChange();
+    });
+
+    onPreferenceChange();
+  </script>
+</body>
+</html>

--- a/submissions/fix-reveal-reduced-motion-dynamic/style.css
+++ b/submissions/fix-reveal-reduced-motion-dynamic/style.css
@@ -1,0 +1,21 @@
+/* =============================================================
+   Fix: prefers-reduced-motion Only Checked Once
+   
+   core/reveal.js reads prefers-reduced-motion once at load time.
+   If the user changes their OS setting, reveal ignores it.
+   
+   FIX:
+   Replace matchMedia(...).matches with matchMedia(...).change
+   so reveal reacts dynamically to preference changes.
+   ============================================================= */
+
+.demo-reveal-card {
+  opacity: 0;
+  transform: translateY(24px);
+}
+
+.demo-reveal-card.active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}


### PR DESCRIPTION
Submits a fix for the prefers-reduced-motion check in core/reveal.js. Currently it only runs once at load time. If the user changes their OS setting afterwards, the page ignores it until reload.

The submission folder is submissions/fix-reveal-reduced-motion-dynamic/. It does NOT edit core/ or components/.

Open demo.html in a browser to see the fix in action: scroll down for reveal cards, click the button to toggle reduced motion live, or change your OS setting directly.

Fixes #18791