### PR TITLE
fix: reveal scroll fallback for browsers without IntersectionObserver

### DIFF
--- a/submissions/fix-reveal-scroll-fallback/README.md
+++ b/submissions/fix-reveal-scroll-fallback/README.md
@@ -1,0 +1,11 @@
+# Fix: Reveal Scroll Fallback
+
+Replaces the instant-reveal fallback in `core/reveal.js` (used when IntersectionObserver is unavailable) with a throttled scroll and resize event listener, so older browsers still get a scroll-triggered reveal effect.
+
+## Usage
+
+Open `demo.html` and scroll. Cards fade in as they enter the viewport using a `requestAnimationFrame`-throttled scroll listener. Click the button to switch between the current fallback (all revealed at once) and the proposed scroll-based fallback.
+
+## Why
+
+The current fallback reveals every element immediately on page load, removing any scroll-reveal experience for users on older browsers. A throttled scroll listener is a lightweight, well-supported progressive enhancement that gracefully degrades the reveal effect instead of disabling it entirely.

--- a/submissions/fix-reveal-scroll-fallback/demo.html
+++ b/submissions/fix-reveal-scroll-fallback/demo.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Reveal Scroll Fallback</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      font-family: var(--ease-font-sans);
+      background: var(--ease-color-bg);
+      color: var(--ease-color-text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .hero {
+      height: 80vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 2rem;
+    }
+    .badge {
+      display: inline-block;
+      padding: 0.35rem 0.85rem;
+      border-radius: var(--ease-radius-full);
+      font-size: 0.8rem;
+      font-weight: 600;
+      margin: 0.5rem 0;
+    }
+    .badge.old {
+      background: var(--ease-color-warning-100);
+      color: var(--ease-color-warning-700);
+    }
+    .badge.new {
+      background: var(--ease-color-primary-100);
+      color: var(--ease-color-primary);
+    }
+    button {
+      padding: 0.5rem 1.25rem;
+      border: 2px solid var(--ease-color-primary);
+      background: transparent;
+      color: var(--ease-color-primary);
+      border-radius: var(--ease-radius-full);
+      font-size: 0.85rem;
+      cursor: pointer;
+    }
+    button:hover {
+      background: var(--ease-color-primary);
+      color: var(--ease-color-text-on-primary);
+    }
+    .reveal-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      width: min(90%, 480px);
+    }
+    .card {
+      background: var(--ease-color-surface);
+      padding: 2rem;
+      border-radius: var(--ease-radius-lg);
+      border: 1px solid var(--ease-color-neutral-200);
+      box-shadow: var(--ease-shadow-sm);
+    }
+    .card h3 {
+      margin: 0 0 0.25rem;
+      font-size: 1.05rem;
+    }
+    .card p {
+      margin: 0;
+      font-size: 0.9rem;
+      color: var(--ease-color-muted);
+    }
+    .footer {
+      height: 40vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--ease-color-muted);
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="hero">
+    <h1>Reveal: scroll fallback</h1>
+    <p style="color:var(--ease-color-muted)">
+      When IntersectionObserver is unavailable, the current fallback reveals everything at once.
+      This demo shows the proposed throttled scroll/resize listener instead.
+    </p>
+    <div>
+      <span id="modeLabel" class="badge new">Scroll fallback (proposed)</span>
+    </div>
+    <button id="modeBtn" style="margin-top:1rem">Switch to: Instant reveal (current)</button>
+  </div>
+
+  <div class="reveal-grid" id="revealGrid">
+    <div class="card demo-reveal-card"><h3>Scroll down</h3><p>Each card fades in as you scroll — even without IntersectionObserver.</p></div>
+    <div class="card demo-reveal-card"><h3>Throttled scroll</h3><p>A requestAnimationFrame throttle keeps it performant.</p></div>
+    <div class="card demo-reveal-card"><h3>Resize too</h3><p>The listener also fires on window resize for layout shifts.</p></div>
+    <div class="card demo-reveal-card"><h3>Graceful</h3><p>Old browsers get a basic scroll-reveal instead of a static page.</p></div>
+    <div class="card demo-reveal-card"><h3>Fifth card</h3><p>Each card only reveals once — unobserve is simulated via class check.</p></div>
+    <div class="card demo-reveal-card"><h3>Last card</h3><p>Toggle the button above to compare both behaviours.</p></div>
+  </div>
+
+  <div class="footer">&#8593; Scroll back up to see revealed cards &#8593;</div>
+
+  <script>
+    (function () {
+      var revealClass = 'demo-reveal-card';
+      var activeClass = 'active';
+      var mode = 'scroll'; // 'scroll' | 'instant'
+      var ticking = false;
+      var modeLabel = document.getElementById('modeLabel');
+      var modeBtn = document.getElementById('modeBtn');
+
+      function isCentered(el) {
+        var rect = el.getBoundingClientRect();
+        return rect.top < window.innerHeight * 0.85 && rect.bottom > 0;
+      }
+
+      function revealVisible() {
+        var els = document.querySelectorAll('.' + revealClass + ':not(.' + activeClass + ')');
+        for (var i = 0; i < els.length; i++) {
+          if (isCentered(els[i])) {
+            els[i].classList.add(activeClass);
+          }
+        }
+      }
+
+      function revealAll() {
+        var els = document.querySelectorAll('.' + revealClass);
+        for (var i = 0; i < els.length; i++) {
+          els[i].classList.add(activeClass);
+        }
+      }
+
+      function resetAll() {
+        var els = document.querySelectorAll('.' + revealClass);
+        for (var i = 0; i < els.length; i++) {
+          els[i].classList.remove(activeClass);
+        }
+      }
+
+      function onScroll() {
+        if (!ticking) {
+          requestAnimationFrame(function () {
+            revealVisible();
+            ticking = false;
+          });
+          ticking = true;
+        }
+      }
+
+      var scrollHandler = null;
+      var resizeHandler = null;
+
+      function applyMode() {
+        resetAll();
+
+        if (scrollHandler) { window.removeEventListener('scroll', scrollHandler); }
+        if (resizeHandler) { window.removeEventListener('resize', resizeHandler); }
+
+        if (mode === 'instant') {
+          revealAll();
+          modeLabel.className = 'badge old';
+          modeLabel.textContent = 'Instant reveal (current fallback)';
+          modeBtn.textContent = 'Switch to: Scroll fallback (proposed)';
+        } else {
+          scrollHandler = function () { onScroll(); };
+          resizeHandler = function () { onScroll(); };
+          window.addEventListener('scroll', scrollHandler);
+          window.addEventListener('resize', resizeHandler);
+          revealVisible();
+          modeLabel.className = 'badge new';
+          modeLabel.textContent = 'Scroll fallback (proposed)';
+          modeBtn.textContent = 'Switch to: Instant reveal (current)';
+        }
+      }
+
+      modeBtn.addEventListener('click', function () {
+        mode = mode === 'scroll' ? 'instant' : 'scroll';
+        applyMode();
+      });
+
+      applyMode();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/fix-reveal-scroll-fallback/style.css
+++ b/submissions/fix-reveal-scroll-fallback/style.css
@@ -1,0 +1,19 @@
+/* =============================================================
+   Fix: Scroll Fallback for Browsers without IntersectionObserver
+   
+   core/reveal.js falls back to revealing every element at once
+   when IntersectionObserver is unavailable. This fix replaces
+   that with a throttled scroll + resize listener so older
+   browsers still get a scroll-triggered reveal.
+   ============================================================= */
+
+.demo-reveal-card {
+  opacity: 0;
+  transform: translateY(24px);
+}
+
+.demo-reveal-card.active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}


### PR DESCRIPTION
When IntersectionObserver is unavailable, core/reveal.js currently reveals every element at once. This replaces that with a throttled scroll + resize listener so older browsers still get a scroll-triggered reveal instead of everything appearing instantly.

Submissions/fix-reveal-scroll-fallback/ -- does NOT edit core/ or components/.

Open demo.html and scroll. Click the button to compare the current fallback (instant reveal) vs the proposed scroll-based fallback.

Fixes #18793