### PR TITLE
feat: add backdrop filter glassmorphism

### DIFF
--- a/submissions/examples/backdrop-filter-glassmorphism-tm/README.md
+++ b/submissions/examples/backdrop-filter-glassmorphism-tm/README.md
@@ -1,0 +1,17 @@
+# Backdrop Filter Glassmorphism
+
+## What does this do?
+Provides a set of pure CSS glassmorphism utility classes using `backdrop-filter: blur()` and EaseMotion CSS tokens (`--ease-radius-*`, `--ease-space-*`, `--ease-color-*`, `--ease-shadow-*`) for frosted glass panels, cards, navbars, and hero sections.
+
+## How is it used?
+Add `.glass-panel` to any container. Variants include `.glass-panel-tint` (coloured), `.glass-panel-heavy` (32px blur), `.glass-panel-subtle` (8px blur), `.glass-card` (card with icon), `.glass-nav` (navbar), and `.glass-hero` (hero section).
+
+```html
+<div class="glass-panel">
+  <h3>Frosted card</h3>
+  <p>Content sits on a glass surface with backdrop blur.</p>
+</div>
+```
+
+## Why is it useful?
+Glassmorphism is a modern design trend that adds depth and visual hierarchy without heavy images. These classes use native CSS `backdrop-filter` (no JS, no canvas), integrate with EaseMotion's token system, support dark mode via `[data-theme="dark"]`, and respect `prefers-reduced-motion`.

--- a/submissions/examples/backdrop-filter-glassmorphism-tm/demo.html
+++ b/submissions/examples/backdrop-filter-glassmorphism-tm/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Backdrop Filter Glassmorphism</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    section {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      gap: 2rem;
+    }
+    .demo-bg-blue {
+      background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
+    }
+    .demo-bg-green {
+      background: linear-gradient(135deg, #004d40, #00695c, #004d40);
+    }
+    .demo-bg-warm {
+      background: linear-gradient(135deg, #3e1a0f, #6b2d1a, #3e1a0f);
+    }
+    .section-label {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.4);
+      margin-bottom: -1rem;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- 1. Glass cards grid -->
+  <section class="demo-bg-blue">
+    <p class="section-label">Glass cards</p>
+    <div class="glass-grid">
+      <div class="glass-card glass-panel">
+        <div class="icon">✦</div>
+        <h3>Frosted</h3>
+        <p>Standard glass panel with 16px blur, saturate 1.2, and a subtle white border.</p>
+      </div>
+      <div class="glass-card glass-panel glass-panel-tint">
+        <div class="icon">◇</div>
+        <h3>Tinted</h3>
+        <p>Coloured tint variant with a purple hue — perfect for accent panels.</p>
+      </div>
+      <div class="glass-card glass-panel glass-panel-heavy">
+        <div class="icon">○</div>
+        <h3>Heavy blur</h3>
+        <p>32px blur with stronger saturation for a more pronounced frosted look.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 2. Glass navbar -->
+  <section class="demo-bg-green">
+    <p class="section-label">Glass navbar</p>
+    <div class="glass-nav" style="width:min(90%, 700px);">
+      <span style="font-weight:700;font-size:1.1rem;">Logo</span>
+      <div style="display:flex;gap:0.25rem;">
+        <a href="#">Home</a>
+        <a href="#">Features</a>
+        <a href="#">Pricing</a>
+        <a href="#">About</a>
+      </div>
+    </div>
+    <div class="glass-panel" style="width:min(90%, 700px);text-align:center;color:rgba(255,255,255,0.7);">
+      A glass navigation bar that stays readable over any background.
+    </div>
+  </section>
+
+  <!-- 3. Glass hero -->
+  <section class="demo-bg-warm">
+    <p class="section-label">Glass hero</p>
+    <div class="glass-hero" style="width:min(90%, 600px);">
+      <h1>Glassmorphism</h1>
+      <p>Pure CSS backdrop-filter glass effect using EaseMotion tokens. Fully responsive, dark mode ready, reduced motion safe.</p>
+      <a href="#" class="glass-btn">Get started</a>
+    </div>
+    <div class="glass-grid" style="max-width:700px;">
+      <div class="glass-panel glass-panel-subtle" style="text-align:center;color:rgba(255,255,255,0.6);font-size:0.85rem;padding:1rem;">
+        Subtle variant — 8px blur, minimal opacity
+      </div>
+      <div class="glass-panel" style="text-align:center;color:rgba(255,255,255,0.6);font-size:0.85rem;padding:1rem;">
+        Default variant — 16px blur
+      </div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/backdrop-filter-glassmorphism-tm/style.css
+++ b/submissions/examples/backdrop-filter-glassmorphism-tm/style.css
@@ -1,0 +1,220 @@
+/* ============================================================
+   backdrop-filter-glassmorphism-tm
+   Pure CSS glassmorphism utility with backdrop-filter blur,
+   using EaseMotion CSS tokens for colours, spacing, and radii.
+   ============================================================ */
+
+.glass-panel {
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(16px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--ease-radius-xl, 16px);
+  padding: var(--ease-space-8, 2rem);
+  box-shadow: var(--ease-shadow-lg, 0 8px 32px rgba(0, 0, 0, 0.12));
+  color: var(--ease-color-text, #1e293b);
+  transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+.glass-panel:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Variant: darker glass for dark mode */
+[data-theme="dark"] .glass-panel,
+.glass-panel-dark {
+  background: rgba(0, 0, 0, 0.15);
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+[data-theme="dark"] .glass-panel:hover,
+.glass-panel-dark:hover {
+  background: rgba(0, 0, 0, 0.22);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Variant: coloured tint */
+.glass-panel-tint {
+  background: rgba(108, 99, 255, 0.1);
+  border-color: rgba(108, 99, 255, 0.15);
+}
+
+.glass-panel-tint:hover {
+  background: rgba(108, 99, 255, 0.16);
+}
+
+/* Variant: subtle frosted */
+.glass-panel-subtle {
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+/* Variant: heavy blur */
+.glass-panel-heavy {
+  backdrop-filter: blur(32px) saturate(1.5);
+  -webkit-backdrop-filter: blur(32px) saturate(1.5);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: var(--ease-shadow-xl, 0 16px 48px rgba(0, 0, 0, 0.18));
+}
+
+/* Variant: card with icon header */
+.glass-card {
+  composes: glass-panel;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-4, 1rem);
+}
+
+.glass-card .icon {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.glass-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.glass-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  opacity: 0.8;
+}
+
+/* Variant: navbar */
+.glass-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(20px) saturate(1.3);
+  -webkit-backdrop-filter: blur(20px) saturate(1.3);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--ease-radius-lg, 12px);
+}
+
+.glass-nav a {
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.4rem 0.8rem;
+  border-radius: var(--ease-radius-md, 8px);
+  transition: background 0.2s ease;
+}
+
+.glass-nav a:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* Variant: hero section */
+.glass-hero {
+  text-align: center;
+  padding: 3rem 2rem;
+  background: rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(12px) saturate(1.2);
+  -webkit-backdrop-filter: blur(12px) saturate(1.2);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--ease-radius-2xl, 24px);
+}
+
+.glass-hero h1 {
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  margin: 0 0 0.75rem;
+  font-weight: 700;
+}
+
+.glass-hero p {
+  font-size: 1rem;
+  max-width: 500px;
+  margin: 0 auto 1.5rem;
+  opacity: 0.8;
+  line-height: 1.6;
+}
+
+/* Button */
+.glass-btn {
+  display: inline-block;
+  padding: 0.6rem 1.5rem;
+  border-radius: var(--ease-radius-full, 999px);
+  background: var(--ease-color-primary, #6c63ff);
+  color: var(--ease-color-text-on-primary, #fff);
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.glass-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--ease-shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+}
+
+/* Grid layout */
+.glass-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--ease-space-6, 1.5rem);
+  width: 100%;
+}
+
+/* Background scene */
+.glass-scene {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 2rem;
+  background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
+  overflow: hidden;
+}
+
+/* Decorative blobs behind glass */
+.glass-scene::before,
+.glass-scene::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.glass-scene::before {
+  width: 300px;
+  height: 300px;
+  background: radial-gradient(circle, rgba(108, 99, 255, 0.4), transparent 70%);
+  top: 10%;
+  left: -5%;
+}
+
+.glass-scene::after {
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, rgba(255, 107, 157, 0.3), transparent 70%);
+  bottom: 5%;
+  right: -10%;
+}
+
+/* Ensure glass panels sit above blobs */
+.glass-scene > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .glass-btn:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## ✦ Description

Adds pure CSS glassmorphism utility classes using `backdrop-filter: blur()` and EaseMotion CSS tokens (`--ease-radius-*`, `--ease-space-*`, `--ease-color-*`, `--ease-shadow-*`) for frosted glass panels, cards, navbars, and hero sections.

Fixes #18835

---

## ⟡ Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [ ] (If applicable) I have run npm run lint and npm run format locally before pushing.

---

## Description

### Files

`submissions/examples/backdrop-filter-glassmorphism-tm/`
- `style.css` (220 lines) — `.glass-panel`, `.glass-panel-tint`, `.glass-panel-heavy`, `.glass-panel-subtle`, `.glass-card`, `.glass-nav`, `.glass-hero`, `.glass-btn`, `.glass-grid` with dark mode (`[data-theme="dark"]`) and reduced motion support
- `demo.html` — 3 sections: glass cards grid, glass navbar, glass hero
- `README.md` — documentation

### Variants

| Class | Blur | Use |
|-------|------|-----|
| `.glass-panel` | 16px | Default frosted panel |
| `.glass-panel-tint` | 16px | Purple tinted variant |
| `.glass-panel-heavy` | 32px | Stronger blur |
| `.glass-panel-subtle` | 8px | Minimal frosted |
| `.glass-card` | inherits | Card with icon + text |
| `.glass-nav` | 20px | Navigation bar |
| `.glass-hero` | 12px | Hero section |

### Dark mode

`[data-theme="dark"] .glass-panel` overrides to darker backgrounds and lighter borders.

### Reduced motion

Button hover transforms are disabled via `@media (prefers-reduced-motion: reduce)`.

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

---

## Additional Notes
- Pure CSS, no JavaScript
- 220+ lines of CSS with --ease-* tokens
- 3 interactive demo sections
- Branch pushed: Pcmhacker-piro/EaseMotion-css:backdrop-filter-glassmorphism-tm