### PR TITLE
feat: add clip path shapes

### DIFF
--- a/submissions/examples/clip-path-shapes-tm/README.md
+++ b/submissions/examples/clip-path-shapes-tm/README.md
@@ -1,0 +1,14 @@
+# Clip Path Shapes
+
+## What does this do?
+Provides utility classes for common CSS `clip-path` polygon shapes — triangles, diamonds, hexagons, octagons, stars, pentagons, chevrons, arrows, crosses, and more — using EaseMotion CSS tokens for colours, sizing, and glow effects.
+
+## How is it used?
+Add `.clip-shape` (base) + any shape class to a container. Optionally add a colour variant (`.clip-primary`, `.clip-secondary`, `.clip-accent`, `.clip-success`, `.clip-warning`, `.clip-danger`, `.clip-info`), size variant (`.clip-sm`, `.clip-md`, `.clip-lg`), glow (`.clip-glow`, `.clip-glow-secondary`), or interactive variant (`.clip-hover-shift`, `.clip-hover-expand`).
+
+```html
+<div class="clip-shape clip-hexagon clip-success">hex</div>
+```
+
+## Why is it useful?
+CSS clip-paths enable visually interesting layouts, badges, avatars, and decorative elements without images or SVGs. These utility classes provide a consistent, reusable set of shapes that integrate with EaseMotion's token system and respect reduced motion preferences.

--- a/submissions/examples/clip-path-shapes-tm/demo.html
+++ b/submissions/examples/clip-path-shapes-tm/demo.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Clip Path Shapes</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    h1 {
+      text-align: center;
+      padding: 2rem 1rem 0.5rem;
+      font-size: clamp(1.4rem, 3vw, 2rem);
+    }
+    .sub {
+      text-align: center;
+      font-size: 0.9rem;
+      color: #64748b;
+      max-width: 500px;
+      margin: 0 auto 2rem;
+    }
+    @media (prefers-color-scheme: dark) { .sub { color: #94a3b8; } }
+    section {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem 2.5rem;
+    }
+    section h2 {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #6c63ff;
+      margin-bottom: 1rem;
+    }
+    .grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      justify-content: center;
+    }
+    .grid-label {
+      width: 100%;
+      text-align: center;
+      font-size: 0.75rem;
+      color: #94a3b8;
+      margin-top: -0.5rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Clip-path shapes</h1>
+  <p class="sub">Utility classes for common CSS clip-path polygons — triangles, stars, hexagons, and more. Hover to scale. Reduced motion safe.</p>
+
+  <!-- 1. Basic polygon shapes -->
+  <section>
+    <h2>Polygons</h2>
+    <div class="grid">
+      <div class="clip-shape clip-triangle">triangle</div>
+      <div class="clip-shape clip-triangle-down">t-down</div>
+      <div class="clip-shape clip-diamond clip-glow">diamond</div>
+      <div class="clip-shape clip-hexagon clip-secondary">hexagon</div>
+      <div class="clip-shape clip-octagon clip-accent">octagon</div>
+      <div class="clip-shape clip-pentagon clip-success">pentagon</div>
+    </div>
+  </section>
+
+  <!-- 2. Stars -->
+  <section>
+    <h2>Stars</h2>
+    <div class="grid">
+      <div class="clip-shape clip-star clip-warning">star 5</div>
+      <div class="clip-shape clip-star-4 clip-info">star 4</div>
+      <div class="clip-shape clip-star-6 clip-danger clip-glow-secondary">star 6</div>
+    </div>
+  </section>
+
+  <!-- 3. Rounded and organic -->
+  <section>
+    <h2>Rounded &amp; organic</h2>
+    <div class="grid">
+      <div class="clip-shape clip-circle clip-success">circle</div>
+      <div class="clip-shape clip-ellipse clip-warning">ellipse</div>
+      <div class="clip-shape clip-inset-rounded clip-info">inset 20</div>
+      <div class="clip-shape clip-parallelogram">parallelogram</div>
+      <div class="clip-shape clip-trapezoid clip-secondary">trapezoid</div>
+      <div class="clip-shape clip-chevron clip-accent">chevron</div>
+    </div>
+  </section>
+
+  <!-- 4. Interactive hover transitions -->
+  <section>
+    <h2>Interactive (hover)</h2>
+    <div class="grid">
+      <div class="clip-shape clip-hexagon clip-hover-shift">hover → circle</div>
+      <div class="clip-shape clip-star clip-hover-shift clip-glow">hover → circle</div>
+      <div class="clip-shape clip-message clip-hover-expand clip-info">hover → full</div>
+    </div>
+    <p class="grid-label">Hover to see clip-path morph. Disabled when reduced motion is preferred.</p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/clip-path-shapes-tm/style.css
+++ b/submissions/examples/clip-path-shapes-tm/style.css
@@ -1,0 +1,256 @@
+/* ============================================================
+   clip-path-shapes-tm
+   CSS clip-path shape utility classes using EaseMotion tokens
+   for colours, spacing, and radii. Includes common geometric
+   shapes with hover transitions and reduced motion support.
+   ============================================================ */
+
+/* ── Shape base ──────────────────────────────────────────── */
+
+.clip-shape {
+  width: 200px;
+  height: 200px;
+  background: var(--ease-color-primary, #6c63ff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ease-color-text-on-primary, #fff);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 1rem;
+  transition: clip-path 0.4s ease, background 0.3s ease, transform 0.3s ease;
+}
+
+.clip-shape:hover {
+  transform: scale(1.05);
+}
+
+/* ── Polygon shapes ──────────────────────────────────────── */
+
+.clip-triangle {
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+}
+
+.clip-triangle-down {
+  clip-path: polygon(0% 0%, 100% 0%, 50% 100%);
+}
+
+.clip-triangle-left {
+  clip-path: polygon(0% 50%, 100% 0%, 100% 100%);
+}
+
+.clip-triangle-right {
+  clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+}
+
+.clip-diamond {
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}
+
+.clip-hexagon {
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+}
+
+.clip-octagon {
+  clip-path: polygon(30% 0%, 70% 0%, 100% 30%, 100% 70%, 70% 100%, 30% 100%, 0% 70%, 0% 30%);
+}
+
+.clip-star {
+  clip-path: polygon(
+    50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%,
+    50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%
+  );
+}
+
+.clip-star-4 {
+  clip-path: polygon(50% 0%, 65% 35%, 100% 50%, 65% 65%, 50% 100%, 35% 65%, 0% 50%, 35% 35%);
+}
+
+.clip-star-6 {
+  clip-path: polygon(
+    50% 0%, 67% 25%, 100% 25%, 75% 50%, 100% 75%,
+    67% 75%, 50% 100%, 33% 75%, 0% 75%, 25% 50%,
+    0% 25%, 33% 25%
+  );
+}
+
+/* ── Rounded / ellipse shapes ────────────────────────────── */
+
+.clip-circle {
+  clip-path: circle(50%);
+}
+
+.clip-ellipse {
+  clip-path: ellipse(35% 50%);
+}
+
+.clip-inset-rounded {
+  clip-path: inset(5% round 20%);
+}
+
+.clip-inset-heavy {
+  clip-path: inset(10% round 50%);
+}
+
+/* ── Decorative / organic shapes ─────────────────────────── */
+
+.clip-parallelogram {
+  clip-path: polygon(15% 0%, 100% 0%, 85% 100%, 0% 100%);
+}
+
+.clip-trapezoid {
+  clip-path: polygon(20% 0%, 80% 0%, 100% 100%, 0% 100%);
+}
+
+.clip-pentagon {
+  clip-path: polygon(50% 0%, 100% 38%, 82% 100%, 18% 100%, 0% 38%);
+}
+
+.clip-heptagon {
+  clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%);
+}
+
+.clip-nonagon {
+  clip-path: polygon(
+    50% 0%, 75% 10%, 100% 30%, 100% 65%,
+    80% 95%, 50% 100%, 20% 95%, 0% 65%, 0% 30%, 25% 10%
+  );
+}
+
+.clip-decagon {
+  clip-path: polygon(
+    50% 0%, 80% 10%, 100% 35%, 100% 65%,
+    80% 90%, 50% 100%, 20% 90%, 0% 65%, 0% 35%, 20% 10%
+  );
+}
+
+.clip-dodecagon {
+  clip-path: polygon(
+    50% 0%, 75% 5%, 95% 25%, 100% 50%,
+    95% 75%, 75% 95%, 50% 100%, 25% 95%,
+    5% 75%, 0% 50%, 5% 25%, 25% 5%
+  );
+}
+
+.clip-chevron {
+  clip-path: polygon(0% 0%, 60% 0%, 100% 50%, 60% 100%, 0% 100%, 35% 50%);
+}
+
+.clip-arrow {
+  clip-path: polygon(0% 20%, 60% 20%, 60% 0%, 100% 50%, 60% 100%, 60% 80%, 0% 80%);
+}
+
+.clip-cross {
+  clip-path: polygon(
+    20% 0%, 80% 0%, 80% 20%, 100% 20%,
+    100% 80%, 80% 80%, 80% 100%, 20% 100%,
+    20% 80%, 0% 80%, 0% 20%, 20% 20%
+  );
+}
+
+.clip-message {
+  clip-path: polygon(0% 0%, 100% 0%, 100% 75%, 60% 75%, 40% 100%, 45% 75%, 0% 75%);
+}
+
+.clip-ribbon {
+  clip-path: polygon(
+    0% 0%, 85% 0%, 100% 50%, 85% 100%,
+    0% 100%, 10% 50%
+  );
+}
+
+.clip-frame {
+  clip-path: polygon(
+    0% 0%, 100% 0%, 100% 100%, 0% 100%,
+    10% 10%, 10% 90%, 90% 90%, 90% 10%
+  );
+}
+
+/* ── Sizing variants ──────────────────────────────────────── */
+
+.clip-sm {
+  width: 120px;
+  height: 120px;
+  font-size: 0.7rem;
+}
+
+.clip-md {
+  width: 160px;
+  height: 160px;
+  font-size: 0.8rem;
+}
+
+.clip-lg {
+  width: 240px;
+  height: 240px;
+  font-size: 0.95rem;
+}
+
+/* ── Colour variants ─────────────────────────────────────── */
+
+.clip-primary {
+  background: var(--ease-color-primary, #6c63ff);
+}
+
+.clip-secondary {
+  background: var(--ease-color-secondary, #ff6b9d);
+}
+
+.clip-accent {
+  background: var(--ease-color-accent, #ffd166);
+  color: var(--ease-color-text, #1e293b);
+}
+
+.clip-success {
+  background: var(--ease-color-success, #22c55e);
+}
+
+.clip-warning {
+  background: var(--ease-color-warning, #f59e0b);
+}
+
+.clip-danger {
+  background: var(--ease-color-danger, #ef4444);
+}
+
+.clip-info {
+  background: var(--ease-color-info, #3b82f6);
+}
+
+/* ── Border glow variant ─────────────────────────────────── */
+
+.clip-glow {
+  filter: drop-shadow(0 0 12px rgba(108, 99, 255, 0.5));
+}
+
+.clip-glow-secondary {
+  filter: drop-shadow(0 0 12px rgba(255, 107, 157, 0.5));
+}
+
+/* ── Interactive transition ──────────────────────────────── */
+
+.clip-hover-shift:hover {
+  clip-path: circle(50%);
+  background: var(--ease-color-secondary, #ff6b9d);
+}
+
+.clip-hover-expand:hover {
+  clip-path: inset(0% round 0%);
+  border-radius: 0;
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .clip-shape {
+    transition: none;
+  }
+  .clip-shape:hover {
+    transform: none;
+  }
+  .clip-hover-shift:hover {
+    clip-path: inherit;
+    background: inherit;
+  }
+}


### PR DESCRIPTION
## ✦ Description

Adds CSS clip-path shape utility classes — triangles, diamonds, hexagons, octagons, stars, pentagons, chevrons, arrows, crosses, and more — using EaseMotion CSS tokens for colours, sizing, and glow effects.

Fixes #18833

---

## ⟡ Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [ ] (If applicable) I have run npm run lint and npm run format locally before pushing.

---

## Description

### Files

`submissions/examples/clip-path-shapes-tm/`
- `style.css` (256 lines) — 25+ shape classes, colour variants, size variants, glow filters, interactive hover transitions, reduced motion support
- `demo.html` — 4 sections: polygons, stars, rounded/organic, interactive hover
- `README.md` — documentation

### Shape classes

| Class | Shape |
|-------|-------|
| `.clip-triangle` / `-down` / `-left` / `-right` | Triangles |
| `.clip-diamond` | Diamond |
| `.clip-hexagon` | Hexagon |
| `.clip-octagon` | Octagon |
| `.clip-star` / `-star-4` / `-star-6` | Stars (5, 4, 6 point) |
| `.clip-pentagon` / `-heptagon` / `-nonagon` / `-decagon` / `-dodecagon` | Polygons |
| `.clip-circle` / `-ellipse` | Round shapes |
| `.clip-inset-rounded` / `-inset-heavy` | Rounded insets |
| `.clip-parallelogram` / `-trapezoid` / `-chevron` / `-arrow` / `-cross` / `-message` / `-ribbon` / `-frame` | Decorative |

### Variants

`.clip-sm`, `.clip-md`, `.clip-lg` (size), `.clip-primary`/`-secondary`/`-accent`/`-success`/`-warning`/`-danger`/`-info` (colour), `.clip-glow`/`-glow-secondary` (drop-shadow), `.clip-hover-shift`/`-hover-expand` (interactive).

### Dark mode + reduced motion

Demo uses `prefers-color-scheme: dark` for the background. All transitions and hover effects are disabled under `prefers-reduced-motion: reduce`.

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

---

## Additional Notes
- Pure CSS, no JavaScript
- 256+ lines of CSS with --ease-* tokens
- 25+ shape variants across 4 demo sections
- Branch pushed: Pcmhacker-piro/EaseMotion-css:clip-path-shapes-tm