### PR TITLE
feat: add css has selector patterns

### DIFF
--- a/submissions/examples/css-has-selector-tm/README.md
+++ b/submissions/examples/css-has-selector-tm/README.md
@@ -1,0 +1,29 @@
+# CSS :has() Selector
+
+## What does this do?
+Demonstrates practical CSS `:has()` selector patterns — cards that adapt their layout based on content (image, tags, checkbox), live form validation without JavaScript, and interactive list styling — using EaseMotion CSS tokens.
+
+## How is it used?
+Add `.has-card` for adaptive cards, `.has-form` + `.has-field` for auto-validating forms, or `.has-list` for interactive lists. The `:has()` selectors are in `style.css` and respond to child elements automatically.
+
+```html
+<!-- Card adapts when it contains an image -->
+<div class="has-card">
+  <img src="..." alt="" />
+  <div class="has-body">
+    <h3>Title</h3>
+    <p>Description</p>
+  </div>
+</div>
+
+<!-- Form validates via :has() — no JS needed -->
+<form class="has-form">
+  <div class="has-field">
+    <input type="email" required />
+    <span class="has-error">Valid email required</span>
+  </div>
+</form>
+```
+
+## Why is it useful?
+The `:has()` selector lets CSS respond to a parent's children — enabling container-aware styling, live validation feedback, and interactive states without JavaScript. These patterns make UI components more self-aware and reduce the need for conditional class toggling.

--- a/submissions/examples/css-has-selector-tm/demo.html
+++ b/submissions/examples/css-has-selector-tm/demo.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS :has() Selector</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    h1 {
+      font-size: clamp(1.3rem, 3vw, 1.8rem);
+      text-align: center;
+      margin-bottom: 0.25rem;
+    }
+    .sub {
+      text-align: center;
+      font-size: 0.9rem;
+      color: #64748b;
+      max-width: 560px;
+      margin: 0 auto 2rem;
+    }
+    @media (prefers-color-scheme: dark) { .sub { color: #94a3b8; } }
+    section {
+      max-width: 1100px;
+      margin: 0 auto 2.5rem;
+    }
+    section h2 {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #6c63ff;
+      margin-bottom: 1rem;
+    }
+    .has-card h3 { margin: 0; font-size: 1rem; }
+    .has-card p { margin: 0; font-size: 0.85rem; color: #64748b; line-height: 1.5; }
+    .has-card .has-body { display: flex; flex-direction: column; gap: 0.5rem; }
+    .has-btn {
+      display: inline-block;
+      padding: 0.4rem 1rem;
+      border-radius: 999px;
+      background: #6c63ff;
+      color: #fff;
+      font-size: 0.8rem;
+      font-weight: 600;
+      text-decoration: none;
+      text-align: center;
+      align-self: flex-start;
+    }
+    @media (prefers-color-scheme: dark) {
+      .has-card p { color: #94a3b8; }
+    }
+  </style>
+</head>
+<body>
+
+  <h1>CSS <code>:has()</code> selector</h1>
+  <p class="sub">Practical patterns using the parent-aware <code>:has()</code> selector — cards that adapt to their content, live form validation, and interactive lists.</p>
+
+  <!-- 1. Cards adapting to content -->
+  <section>
+    <h2>Cards that adapt to their content</h2>
+    <div class="has-row">
+      <div class="has-card">
+        <div class="has-body">
+          <h3>Plain card</h3>
+          <p>No image, no checkbox — standard card layout with default padding.</p>
+        </div>
+      </div>
+      <div class="has-card">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='180'%3E%3Crect width='400' height='180' fill='%236c63ff' opacity='0.15'/%3E%3Ctext x='200' y='100' text-anchor='middle' fill='%236c63ff' font-size='14' font-family='system-ui'%3EImage %2B card%3C/text%3E%3C/svg%3E" alt="Card image" />
+        <div class="has-body">
+          <h3>Card with image</h3>
+          <p><code>:has(img)</code> removes padding, adds overflow hidden, and stacks the image above.</p>
+        </div>
+      </div>
+      <div class="has-card">
+        <div class="has-body">
+          <h3>Card with tags</h3>
+          <p><code>:has(.has-tag)</code> enables the tag flex container.</p>
+          <div class="has-tags">
+            <span class="has-tag">CSS</span>
+            <span class="has-tag">:has()</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 2. Form validation -->
+  <section>
+    <h2>Form validation via :has()</h2>
+    <form class="has-form" style="max-width:500px;">
+      <div class="has-field">
+        <label for="name">Name *</label>
+        <input id="name" type="text" placeholder="Enter your name" required />
+        <span class="has-error">Name is required</span>
+      </div>
+      <div class="has-field">
+        <label for="email">Email *</label>
+        <input id="email" type="email" placeholder="you@example.com" required />
+        <span class="has-error">Valid email required</span>
+      </div>
+      <div class="has-field">
+        <label for="role">Role</label>
+        <select id="role">
+          <option value="">Select...</option>
+          <option>Designer</option>
+          <option>Developer</option>
+          <option>Manager</option>
+        </select>
+      </div>
+      <div style="display:flex;gap:0.75rem;align-items:center;">
+        <input type="checkbox" id="terms" />
+        <label for="terms" style="font-size:0.85rem;">I agree to the terms</label>
+      </div>
+    </form>
+    <p style="font-size:0.8rem;color:#94a3b8;margin-top:0.5rem;">Try it: the form border turns green when valid, red when invalid, and blue on focus. Error messages appear only for invalid touched fields.</p>
+  </section>
+
+  <!-- 3. Interactive list -->
+  <section>
+    <h2>Interactive list with :has()</h2>
+    <div class="has-row">
+      <ul class="has-list" style="flex:1;max-width:320px;" id="demoList">
+        <li class="active">Dashboard</li>
+        <li>Analytics</li>
+        <li>Settings</li>
+        <li>Profile</li>
+        <li>Logout</li>
+      </ul>
+      <div class="has-card" style="flex:1;">
+        <div class="has-body">
+          <h3>List behaviour</h3>
+          <p>Click items above. <code>:has(.active)</code> adds a border to the list, dims non-active items, and highlights the selected one.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    document.getElementById('demoList').addEventListener('click', function (e) {
+      if (e.target.tagName === 'LI') {
+        this.querySelectorAll('li').forEach(function (li) { li.classList.remove('active'); });
+        e.target.classList.add('active');
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/css-has-selector-tm/style.css
+++ b/submissions/examples/css-has-selector-tm/style.css
@@ -1,0 +1,294 @@
+/* ============================================================
+   css-has-selector-tm
+   Practical CSS :has() selector patterns — parent-aware
+   styling, form validation, card variants, and interactive
+   layouts. Uses EaseMotion CSS tokens.
+   ============================================================ */
+
+/* ── 1. Card variants via :has() ─────────────────────────── */
+
+.has-card {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 12px);
+  padding: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm, 0 1px 3px rgba(0,0,0,0.06));
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-3, 0.75rem);
+  transition: box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.has-card:hover {
+  box-shadow: var(--ease-shadow-md, 0 4px 12px rgba(0,0,0,0.08));
+}
+
+/* Card with an image — larger padding, different layout */
+.has-card:has(img) {
+  padding: 0;
+  overflow: hidden;
+}
+
+.has-card:has(img) .has-body {
+  padding: var(--ease-space-5, 1.25rem);
+}
+
+.has-card:has(img) img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+/* Card with a button — add extra bottom spacing */
+.has-card:has(.has-btn) {
+  padding-bottom: var(--ease-space-6, 1.5rem);
+}
+
+/* Card with a checked checkbox — highlight border */
+.has-card:has(input:checked) {
+  border-color: var(--ease-color-primary, #6c63ff);
+  box-shadow: 0 0 0 2px var(--ease-color-primary-100, #e0e7ff);
+}
+
+/* Card with a tag — style the tag container */
+.has-card:has(.has-tag) .has-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.has-tag {
+  padding: 0.2em 0.6em;
+  border-radius: var(--ease-radius-full, 999px);
+  background: var(--ease-color-primary-100, #e0e7ff);
+  color: var(--ease-color-primary, #6c63ff);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+/* ── 2. Form validation via :has() ───────────────────────── */
+
+.has-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-5, 1.25rem);
+  padding: var(--ease-space-6, 1.5rem);
+  background: var(--ease-color-surface, #fff);
+  border: 2px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 12px);
+  transition: border-color 0.3s ease;
+}
+
+.has-form:has(:invalid:not(:placeholder-shown)) {
+  border-color: var(--ease-color-danger, #ef4444);
+}
+
+.has-form:has(:valid:not(:placeholder-shown)) {
+  border-color: var(--ease-color-success, #22c55e);
+}
+
+.has-form:has(:focus) {
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+.has-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-2, 0.5rem);
+}
+
+.has-field label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ease-color-text, #1e293b);
+}
+
+.has-field input,
+.has-field select {
+  padding: 0.6rem 0.85rem;
+  border: 1px solid var(--ease-color-neutral-300, #cbd5e1);
+  border-radius: var(--ease-radius-md, 8px);
+  font-size: 0.9rem;
+  font-family: inherit;
+  background: var(--ease-color-bg, #fff);
+  color: var(--ease-color-text, #1e293b);
+  transition: border-color 0.2s ease;
+}
+
+.has-field input:focus,
+.has-field select:focus {
+  outline: none;
+  border-color: var(--ease-color-primary, #6c63ff);
+  box-shadow: 0 0 0 3px var(--ease-color-primary-100, #e0e7ff);
+}
+
+/* Show error message only when the field is invalid and touched */
+.has-field .has-error {
+  font-size: 0.78rem;
+  color: var(--ease-color-danger, #ef4444);
+  display: none;
+}
+
+.has-field:has(:invalid:not(:placeholder-shown)) .has-error {
+  display: block;
+}
+
+/* Valid field gets a subtle green tint */
+.has-field:has(:valid:not(:placeholder-shown)) input {
+  border-color: var(--ease-color-success, #22c55e);
+  background: rgba(34, 197, 94, 0.03);
+}
+
+/* ── 3. List / sidebar active state ──────────────────────── */
+
+.has-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-1, 0.25rem);
+}
+
+.has-list li {
+  padding: 0.6rem 0.85rem;
+  border-radius: var(--ease-radius-md, 8px);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  color: var(--ease-color-text, #1e293b);
+}
+
+.has-list li:hover {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.has-list li.active {
+  background: var(--ease-color-primary-100, #e0e7ff);
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 600;
+}
+
+/* Style the entire list when one item is active */
+.has-list:has(.active) {
+  border: 1px solid var(--ease-color-primary-200, #c7d2fe);
+  border-radius: var(--ease-radius-lg, 12px);
+  padding: var(--ease-space-2, 0.5rem);
+}
+
+/* Style siblings of the active item */
+.has-list:has(.active) li:not(.active) {
+  opacity: 0.6;
+}
+
+/* ── 4. Container with icon presence ─────────────────────── */
+
+.has-icon-box {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-4, 1rem);
+  padding: var(--ease-space-5, 1.25rem);
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 12px);
+}
+
+.has-icon-box:has(.icon-large) {
+  flex-direction: column;
+  text-align: center;
+  padding: var(--ease-space-8, 2rem);
+}
+
+.has-icon-box .icon-large {
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.has-icon-box:has(.icon-small) {
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.has-icon-box .icon-small {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+
+/* ── 5. Grid that adjusts when a child is featured ───────── */
+
+.has-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--ease-space-5, 1.25rem);
+}
+
+/* When a featured card exists, make it span 2 columns */
+.has-grid:has(.featured) .featured {
+  grid-column: span 2;
+}
+
+.has-grid .featured {
+  border: 2px solid var(--ease-color-primary, #6c63ff);
+  box-shadow: var(--ease-shadow-md, 0 4px 12px rgba(0,0,0,0.08));
+}
+
+/* ── Demo helpers ────────────────────────────────────────── */
+
+.has-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-space-5, 1.25rem);
+}
+
+.has-row > * {
+  flex: 1;
+  min-width: 240px;
+}
+
+/* ── Dark mode ───────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .has-card,
+  .has-form,
+  .has-icon-box {
+    background: var(--ease-color-surface-dark, #1e293b);
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  .has-field input,
+  .has-field select {
+    background: var(--ease-color-bg-dark, #0f172a);
+    border-color: var(--ease-color-neutral-600, #475569);
+    color: var(--ease-color-text-dark, #f1f5f9);
+  }
+
+  .has-list li {
+    color: var(--ease-color-text-dark, #f1f5f9);
+  }
+
+  .has-list li:hover {
+    background: var(--ease-color-neutral-800, #1e293b);
+  }
+
+  .has-list:has(.active) {
+    border-color: var(--ease-color-primary-700, #3730a3);
+  }
+
+  .has-field label {
+    color: var(--ease-color-text-dark, #f1f5f9);
+  }
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .has-card,
+  .has-form,
+  .has-list li {
+    transition: none;
+  }
+
+  .has-card:hover {
+    box-shadow: var(--ease-shadow-sm, 0 1px 3px rgba(0,0,0,0.06));
+  }
+}


### PR DESCRIPTION
## ✦ Description

Demonstrates practical CSS `:has()` selector patterns — cards that adapt layout based on content (image, tags, checkbox), live form validation without JavaScript, and interactive list styling — using EaseMotion CSS tokens.

Fixes #18829

---

## ⟡ Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [ ] (If applicable) I have run npm run lint and npm run format locally before pushing.

---

## Description

### Files

`submissions/examples/css-has-selector-tm/`
- `style.css` — 5 pattern groups using `:has()` with `--ease-*` tokens, dark mode, reduced motion
- `demo.html` — 3 demo sections: adaptive cards, form validation, interactive list
- `README.md` — documentation

### Patterns covered

| Pattern | Selector | Behaviour |
|---------|----------|-----------|
| Card with image | `.has-card:has(img)` | Removes padding, stacks image above |
| Card with button | `.has-card:has(.has-btn)` | Extra bottom spacing |
| Card with checkbox | `.has-card:has(input:checked)` | Highlighted border |
| Card with tags | `.has-card:has(.has-tag)` | Enables flex tag container |
| Form validation | `.has-form:has(:invalid)` | Red border, error message shown |
| Valid form | `.has-form:has(:valid)` | Green border |
| Focused form | `.has-form:has(:focus)` | Blue border |
| Active list item | `.has-list:has(.active)` | Border on list, dimmed siblings |

### Dark mode + reduced motion

Full `prefers-color-scheme: dark` support. All transitions disabled under `prefers-reduced-motion: reduce`.

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

---

## Additional Notes
- Pure CSS — only the list click handler uses JS (for demo interactivity, not required for :has())
- Form validation is entirely CSS-driven via :has(:invalid) and :has(:valid)
- Branch pushed: Pcmhacker-piro/EaseMotion-css:css-has-selector-tm