### PR TITLE
feat: add css grid magazine layout

### DIFF
--- a/submissions/examples/css-grid-magazine-tm/README.md
+++ b/submissions/examples/css-grid-magazine-tm/README.md
@@ -1,0 +1,18 @@
+# CSS Grid Magazine
+
+## What does this do?
+Provides a magazine-style CSS Grid layout system — hero sections with mixed-size cards, editor's pick grids with wide/tall/featured spans, and responsive article columns — using EaseMotion CSS tokens for colours, spacing, and typography.
+
+## How is it used?
+Add `.mag-grid` with a layout class (`.mag-hero`, `.mag-mixed`, `.mag-articles`, `.mag-compact`) then place `.mag-card` elements inside. Use `.mag-card-wide`, `.mag-card-tall`, `.mag-card-featured`, `.mag-card-compact` for size/emphasis variants.
+
+```html
+<div class="mag-grid mag-hero">
+  <div class="mag-card mag-card-featured">...</div>
+  <div class="mag-card">...</div>
+  <div class="mag-card">...</div>
+</div>
+```
+
+## Why is it useful?
+Magazine-style grids are a common pattern for content-heavy sites (news, blogs, portfolios). These classes provide a consistent, responsive system that adapts at 768px and 1024px breakpoints, supports mixed-size articles, and integrates with EaseMotion's design tokens for theming and accessibility.

--- a/submissions/examples/css-grid-magazine-tm/demo.html
+++ b/submissions/examples/css-grid-magazine-tm/demo.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Grid Magazine</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 2rem 1.5rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f1f5f9; }
+    }
+    .page-title {
+      text-align: center;
+      margin-bottom: 0.25rem;
+      font-size: clamp(1.5rem, 4vw, 2.2rem);
+    }
+    .page-sub {
+      text-align: center;
+      font-size: 0.9rem;
+      color: #64748b;
+      max-width: 500px;
+      margin: 0 auto 2.5rem;
+    }
+    @media (prefers-color-scheme: dark) { .page-sub { color: #94a3b8; } }
+    section {
+      max-width: 1200px;
+      margin: 0 auto 3rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1 class="page-title">Magazine Grid</h1>
+  <p class="page-sub">CSS Grid magazine-style layouts — hero sections, mixed-size grids, and article columns. Resize the browser to see breakpoints.</p>
+
+  <!-- 1. Hero layout -->
+  <section>
+    <div class="mag-section-header">
+      <h2>Featured story</h2>
+      <a href="#">View all &rarr;</a>
+    </div>
+    <div class="mag-grid mag-hero">
+      <div class="mag-card mag-card-featured">
+        <div style="display:flex;flex-direction:column;height:100%;">
+          <img class="mag-card-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='320'%3E%3Crect width='600' height='320' fill='%236c63ff' opacity='0.12'/%3E%3Ctext x='300' y='170' text-anchor='middle' fill='%236c63ff' font-size='20' font-family='system-ui'%3E Hero image %3C/text%3E%3C/svg%3E" alt="" />
+          <div class="mag-card-body">
+            <span class="mag-card-tag">Featured</span>
+            <h3>How CSS Grid Is Changing Editorial Layout Design</h3>
+            <p>Grid empowers designers to create complex, responsive layouts with clean markup — no more nested flex containers or float hacks.</p>
+            <span class="mag-card-meta">By A. Designer &middot; 8 min read</span>
+          </div>
+        </div>
+      </div>
+      <div class="mag-card">
+        <img class="mag-card-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='180'%3E%3Crect width='300' height='180' fill='%23ff6b9d' opacity='0.1'/%3E%3Ctext x='150' y='100' text-anchor='middle' fill='%23ff6b9d' font-size='12' font-family='system-ui'%3E Trending %3C/text%3E%3C/svg%3E" alt="" />
+        <div class="mag-card-body">
+          <span class="mag-card-tag">Trending</span>
+          <h3>Subgrid Changes Everything</h3>
+          <p>Aligning nested grid items is finally straightforward.</p>
+          <span class="mag-card-meta">4 min read</span>
+        </div>
+      </div>
+      <div class="mag-card">
+        <img class="mag-card-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='180'%3E%3Crect width='300' height='180' fill='%2322c55e' opacity='0.1'/%3E%3Ctext x='150' y='100' text-anchor='middle' fill='%2322c55e' font-size='12' font-family='system-ui'%3E New %3C/text%3E%3C/svg%3E" alt="" />
+        <div class="mag-card-body">
+          <span class="mag-card-tag">New</span>
+          <h3>Container Queries and Grid</h3>
+          <p>Combining two powerful CSS features for true component responsiveness.</p>
+          <span class="mag-card-meta">6 min read</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 2. Mixed-size grid -->
+  <section>
+    <div class="mag-section-header">
+      <h2>Editor's picks</h2>
+      <a href="#">More &rarr;</a>
+    </div>
+    <div class="mag-grid mag-mixed">
+      <div class="mag-card mag-card-wide">
+        <div class="mag-card-body">
+          <span class="mag-card-tag">Deep dive</span>
+          <h3>The Complete Guide to CSS Grid Template Areas</h3>
+          <p>Named grid areas make layouts readable and maintainable at a glance.</p>
+        </div>
+      </div>
+      <div class="mag-card mag-card-tall" style="justify-content:center;">
+        <blockquote class="mag-pullquote" style="border:none;background:none;padding:1rem;">
+          "Grid is the layout tool CSS always deserved."
+          <cite>— Jen Simmons</cite>
+        </blockquote>
+      </div>
+      <div class="mag-card">
+        <div class="mag-card-body">
+          <span class="mag-card-tag">Tutorial</span>
+          <h3>Auto-fill vs Auto-fit</h3>
+          <p>Understanding the difference matters for responsive grids.</p>
+        </div>
+      </div>
+      <div class="mag-card mag-card-featured mag-card-wide">
+        <div class="mag-card-body">
+          <span class="mag-card-tag">Featured</span>
+          <h3>Grid + Flex: When to Use Which</h3>
+          <p>A practical decision guide for modern CSS layouts.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 3. Article grid -->
+  <section>
+    <div class="mag-section-header">
+      <h2>Latest articles</h2>
+      <a href="#">Browse all &rarr;</a>
+    </div>
+    <div class="mag-grid mag-articles">
+      <div class="mag-card mag-card-compact">
+        <div class="mag-card-body">
+          <span class="mag-card-tag">CSS</span>
+          <h3>Grid Gap Gotchas</h3>
+          <p>Common pitfalls when spacing grid items.</p>
+        </div>
+      </div>
+      <div class="mag-card mag-card-compact">
+        <div class="mag-card-body">
+          <span class="mag-card-tag">CSS</span>
+          <h3>Overlapping Grid Items</h3>
+          <p>Intentional overlap for creative layouts.</p>
+        </div>
+      </div>
+      <div class="mag-card mag-card-compact">
+        <div class="mag-card-body">
+          <span class="mag-card-tag">CSS</span>
+          <h3>Grid and Accessibility</h3>
+          <p>How source order affects screen readers.</p>
+        </div>
+      </div>
+      <div class="mag-card mag-card-compact">
+        <div class="mag-card-body">
+          <span class="mag-card-tag">CSS</span>
+          <h3>Explicit vs Implicit Grids</h3>
+          <p>Controlling auto-generated rows and columns.</p>
+        </div>
+      </div>
+      <div class="mag-card mag-card-compact">
+        <div class="mag-card-body">
+          <span class="mag-card-tag">CSS</span>
+          <h3>Masonry Layouts with Grid</h3>
+          <p>Upcoming masonry support and current workarounds.</p>
+        </div>
+      </div>
+      <div class="mag-card mag-card-compact">
+        <div class="mag-card-body">
+          <span class="mag-card-tag">CSS</span>
+          <h3>Grid DevTools Tips</h3>
+          <p>Browser tools that make grid debugging easy.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/css-grid-magazine-tm/style.css
+++ b/submissions/examples/css-grid-magazine-tm/style.css
@@ -1,0 +1,259 @@
+/* ============================================================
+   css-grid-magazine-tm
+   Magazine-style CSS Grid layout system with featured articles,
+   mixed-size grids, and responsive auto-fill patterns. Uses
+   EaseMotion CSS tokens for colours, spacing, and typography.
+   ============================================================ */
+
+/* ── Magazine grid layouts ───────────────────────────────── */
+
+.mag-grid {
+  display: grid;
+  gap: var(--ease-space-6, 1.5rem);
+}
+
+/* Featured hero layout: large leading item + smaller grid */
+.mag-hero {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .mag-hero {
+    grid-template-columns: 2fr 1fr;
+  }
+
+  .mag-hero .mag-card:first-child {
+    grid-row: span 2;
+  }
+}
+
+@media (min-width: 1024px) {
+  .mag-hero {
+    grid-template-columns: 3fr 1fr 1fr;
+    grid-auto-rows: minmax(200px, auto);
+  }
+}
+
+/* Mixed-size masonry-style grid */
+.mag-mixed {
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-auto-rows: minmax(180px, auto);
+}
+
+.mag-mixed .mag-card-wide {
+  grid-column: span 2;
+}
+
+.mag-mixed .mag-card-tall {
+  grid-row: span 2;
+}
+
+.mag-mixed .mag-card-featured {
+  grid-column: span 2;
+  grid-row: span 2;
+}
+
+/* Three-column article grid */
+.mag-articles {
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+}
+
+@media (min-width: 900px) {
+  .mag-articles {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* Four-column compact grid */
+.mag-compact {
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+/* ── Magazine card ───────────────────────────────────────── */
+
+.mag-card {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 12px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.mag-card:hover {
+  box-shadow: var(--ease-shadow-lg, 0 8px 24px rgba(0,0,0,0.1));
+  transform: translateY(-2px);
+}
+
+.mag-card-img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.mag-hero .mag-card:first-child .mag-card-img {
+  height: 240px;
+}
+
+@media (min-width: 768px) {
+  .mag-hero .mag-card:first-child .mag-card-img {
+    height: 100%;
+    min-height: 320px;
+  }
+}
+
+.mag-card-body {
+  padding: var(--ease-space-5, 1.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-2, 0.5rem);
+  flex: 1;
+}
+
+.mag-card-tag {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+.mag-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--ease-color-text, #1e293b);
+}
+
+.mag-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--ease-color-muted, #64748b);
+}
+
+.mag-card-meta {
+  font-size: 0.75rem;
+  color: var(--ease-color-neutral-400, #94a3b8);
+  margin-top: auto;
+  padding-top: var(--ease-space-2, 0.5rem);
+}
+
+/* Featured card variant */
+.mag-card-featured {
+  border: 2px solid var(--ease-color-primary, #6c63ff);
+}
+
+.mag-card-featured .mag-card-tag {
+  color: var(--ease-color-primary, #6c63ff);
+}
+
+.mag-card-featured h3 {
+  font-size: 1.2rem;
+}
+
+/* Compact card variant */
+.mag-card-compact .mag-card-body {
+  padding: var(--ease-space-3, 0.75rem);
+}
+
+.mag-card-compact h3 {
+  font-size: 0.9rem;
+}
+
+.mag-card-compact p {
+  font-size: 0.78rem;
+}
+
+/* Card without image — more padding on body */
+.mag-card:not(:has(img)) .mag-card-body {
+  padding: var(--ease-space-6, 1.5rem);
+}
+
+/* ── Section headers ─────────────────────────────────────── */
+
+.mag-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.mag-section-header h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ease-color-text, #1e293b);
+}
+
+.mag-section-header a {
+  font-size: 0.85rem;
+  color: var(--ease-color-primary, #6c63ff);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.mag-section-header a:hover {
+  text-decoration: underline;
+}
+
+/* ── Sidebar / pull quote ────────────────────────────────── */
+
+.mag-pullquote {
+  background: var(--ease-color-primary-100, #e0e7ff);
+  border-left: 4px solid var(--ease-color-primary, #6c63ff);
+  padding: var(--ease-space-5, 1.25rem);
+  border-radius: 0 var(--ease-radius-md, 8px) var(--ease-radius-md, 8px) 0;
+  font-style: italic;
+  font-size: 1.05rem;
+  line-height: 1.5;
+  color: var(--ease-color-text, #1e293b);
+}
+
+.mag-pullquote cite {
+  display: block;
+  margin-top: var(--ease-space-2, 0.5rem);
+  font-size: 0.85rem;
+  font-style: normal;
+  color: var(--ease-color-muted, #64748b);
+}
+
+/* ── Dark mode ───────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .mag-card {
+    background: var(--ease-color-surface-dark, #1e293b);
+    border-color: var(--ease-color-neutral-700, #334155);
+  }
+
+  .mag-card h3 {
+    color: var(--ease-color-text-dark, #f1f5f9);
+  }
+
+  .mag-card p {
+    color: var(--ease-color-muted-dark, #94a3b8);
+  }
+
+  .mag-pullquote {
+    background: rgba(108, 99, 255, 0.1);
+  }
+
+  .mag-section-header h2 {
+    color: var(--ease-color-text-dark, #f1f5f9);
+  }
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .mag-card {
+    transition: none;
+  }
+
+  .mag-card:hover {
+    transform: none;
+    box-shadow: var(--ease-shadow-sm, 0 1px 3px rgba(0,0,0,0.06));
+  }
+}


### PR DESCRIPTION
## ✦ Description

Adds a magazine-style CSS Grid layout system — hero sections with mixed-size cards, editor's pick grids with wide/tall/featured spans, and responsive article columns — using EaseMotion CSS tokens for colours, spacing, and typography.

Fixes #18827

---

## ⟡ Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (non-breaking change to docs)
- [ ] Code styling/formatting (prettier, eslint, spacing)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [ ] I have verified that my changes work correctly on both desktop and mobile viewports.
- [ ] (If applicable) I have run npm run lint and npm run format locally before pushing.

---

## Description

### Files

`submissions/examples/css-grid-magazine-tm/`
- `style.css` — `.mag-hero`, `.mag-mixed`, `.mag-articles`, `.mag-compact` grid layouts with `.mag-card`, `.mag-card-wide`, `.mag-card-tall`, `.mag-card-featured`, `.mag-card-compact` variants, pullquote styling, dark mode, reduced motion
- `demo.html` — 3 sections: hero layout (2fr/1fr/1fr), editor's picks mixed grid, compact article grid
- `README.md` — documentation

### Grid layouts

| Class | Columns | Use |
|-------|---------|-----|
| `.mag-hero` | 2fr 1fr 1fr @1024px | Featured story + side cards |
| `.mag-mixed` | auto-fill minmax(280px, 1fr) | Masonry-style mixed sizes |
| `.mag-articles` | 3 cols @900px | Article listing |
| `.mag-compact` | auto-fill minmax(220px, 1fr) | Dense grid |

### Card variants

`.mag-card-featured` (prominent border, larger heading), `.mag-card-compact` (smaller padding, smaller text), `.mag-card-wide` (span 2 columns), `.mag-card-tall` (span 2 rows).

### Dark mode + reduced motion

Full `prefers-color-scheme: dark` support. Card hover transitions disabled under `prefers-reduced-motion: reduce`.

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

---

## Additional Notes
- Pure CSS, no JavaScript
- Responsive at 768px and 1024px breakpoints
- Branch pushed: Pcmhacker-piro/EaseMotion-css:css-grid-magazine-tm