### PR TITLE
[Phase 287] Meta-Verse Commerce Analytics (#18691)

### DIFF
--- a/submissions/examples/meta-verse-commerce-analytics-bv/README.md
+++ b/submissions/examples/meta-verse-commerce-analytics-bv/README.md
@@ -1,0 +1,15 @@
+# Meta-Verse Commerce Analytics
+
+A metaverse commerce analytics dashboard built with EaseMotion CSS tokens. Tracks virtual economy metrics, top worlds by revenue, user demographics, top traded assets, recent activity, and commerce KPIs in a futuristic purple-dark theme.
+
+## Features
+
+- **Stat cards** — total revenue, active users, transactions, assets traded
+- **Top virtual worlds** — 5 worlds ranked by revenue with user counts
+- **User demographics** — age group distribution with color-coded progress bars and gender split
+- **Top traded assets** — 5 ranked assets with volume and price in ETH
+- **Recent activity** — timestamped feed of marketplace events
+- **Commerce metrics** — avg transaction value, conversion rate, session time, etc.
+- **Economy snapshot** — market cap, total users, transactions, assets, worlds, creators
+- Responsive 12-column grid with dark mode (default) and light mode support
+- Reduced-motion compliant

--- a/submissions/examples/meta-verse-commerce-analytics-bv/demo.html
+++ b/submissions/examples/meta-verse-commerce-analytics-bv/demo.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Meta-Verse Commerce Analytics</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="meta-dash">
+    <!-- Header -->
+    <div class="meta-header">
+      <h1>&#127760; Meta-Verse Commerce Analytics</h1>
+      <span class="meta-header-status">&#9679; Live</span>
+    </div>
+
+    <!-- Stat cards -->
+    <div class="meta-card meta-col-3">
+      <div class="meta-stat-value">$4.2M</div>
+      <div class="meta-stat-label">Total Revenue (24h)</div>
+      <div class="meta-stat-trend up">&#9650; +12.4%</div>
+    </div>
+    <div class="meta-card meta-col-3">
+      <div class="meta-stat-value">847K</div>
+      <div class="meta-stat-label">Active Users</div>
+      <div class="meta-stat-trend up">&#9650; +8.7%</div>
+    </div>
+    <div class="meta-card meta-col-3">
+      <div class="meta-stat-value">312K</div>
+      <div class="meta-stat-label">Transactions</div>
+      <div class="meta-stat-trend up">&#9650; +5.2%</div>
+    </div>
+    <div class="meta-card meta-col-3">
+      <div class="meta-stat-value">28.4K</div>
+      <div class="meta-stat-label">Assets Traded</div>
+      <div class="meta-stat-trend down">&#9660; -1.3%</div>
+    </div>
+
+    <!-- Virtual worlds -->
+    <div class="meta-card meta-col-6">
+      <div class="meta-card-title">Top Virtual Worlds by Revenue</div>
+      <div class="meta-world">
+        <span class="meta-world-icon">&#127987;</span>
+        <div class="meta-world-info">
+          <div class="meta-world-name">Decentraland</div>
+          <div class="meta-world-users">142K active users</div>
+        </div>
+        <span class="meta-world-revenue">$1.24M</span>
+      </div>
+      <div class="meta-world">
+        <span class="meta-world-icon">&#127775;</span>
+        <div class="meta-world-info">
+          <div class="meta-world-name">The Sandbox</div>
+          <div class="meta-world-users">98K active users</div>
+        </div>
+        <span class="meta-world-revenue">$987K</span>
+      </div>
+      <div class="meta-world">
+        <span class="meta-world-icon">&#127918;</span>
+        <div class="meta-world-info">
+          <div class="meta-world-name">Somnium Space</div>
+          <div class="meta-world-users">67K active users</div>
+        </div>
+        <span class="meta-world-revenue">$654K</span>
+      </div>
+      <div class="meta-world">
+        <span class="meta-world-icon">&#127749;</span>
+        <div class="meta-world-info">
+          <div class="meta-world-name">Voxel Worlds</div>
+          <div class="meta-world-users">41K active users</div>
+        </div>
+        <span class="meta-world-revenue">$412K</span>
+      </div>
+      <div class="meta-world">
+        <span class="meta-world-icon">&#127756;</span>
+        <div class="meta-world-info">
+          <div class="meta-world-name">NeoCities</div>
+          <div class="meta-world-users">29K active users</div>
+        </div>
+        <span class="meta-world-revenue">$298K</span>
+      </div>
+    </div>
+
+    <!-- User demographics -->
+    <div class="meta-card meta-col-6">
+      <div class="meta-card-title">User Demographics</div>
+      <div class="meta-progress">
+        <div class="meta-progress-row">
+          <span class="meta-progress-label">18-24</span>
+          <div class="meta-progress-track"><div class="meta-progress-fill pink" style="width:35%"></div></div>
+          <span class="meta-progress-pct">35%</span>
+        </div>
+        <div class="meta-progress-row">
+          <span class="meta-progress-label">25-34</span>
+          <div class="meta-progress-track"><div class="meta-progress-fill" style="width:41%"></div></div>
+          <span class="meta-progress-pct">41%</span>
+        </div>
+        <div class="meta-progress-row">
+          <span class="meta-progress-label">35-44</span>
+          <div class="meta-progress-track"><div class="meta-progress-fill cyan" style="width:15%"></div></div>
+          <span class="meta-progress-pct">15%</span>
+        </div>
+        <div class="meta-progress-row">
+          <span class="meta-progress-label">45+</span>
+          <div class="meta-progress-track"><div class="meta-progress-fill green" style="width:9%"></div></div>
+          <span class="meta-progress-pct">9%</span>
+        </div>
+      </div>
+      <!-- Gender split -->
+      <div style="margin-top:1rem;border-top:1px solid rgba(139,92,246,0.06);padding-top:1rem">
+        <div class="meta-metric">
+          <span class="meta-metric-label">Male</span>
+          <span class="meta-metric-value">58%</span>
+        </div>
+        <div class="meta-metric">
+          <span class="meta-metric-label">Female</span>
+          <span class="meta-metric-value">36%</span>
+        </div>
+        <div class="meta-metric">
+          <span class="meta-metric-label">Non-binary / Other</span>
+          <span class="meta-metric-value">6%</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Top assets -->
+    <div class="meta-card meta-col-4">
+      <div class="meta-card-title">Top Traded Assets</div>
+      <div class="meta-asset">
+        <span class="meta-asset-rank">#1</span>
+        <span class="meta-asset-name">Cyber Ape #4421</span>
+        <span class="meta-asset-vol">1.2K vol</span>
+        <span class="meta-asset-price">12.4 ETH</span>
+      </div>
+      <div class="meta-asset">
+        <span class="meta-asset-rank">#2</span>
+        <span class="meta-asset-name">Meta LAND Parcel</span>
+        <span class="meta-asset-vol">890 vol</span>
+        <span class="meta-asset-price">8.7 ETH</span>
+      </div>
+      <div class="meta-asset">
+        <span class="meta-asset-rank">#3</span>
+        <span class="meta-asset-name">Neon Sneaker X</span>
+        <span class="meta-asset-vol">654 vol</span>
+        <span class="meta-asset-price">3.2 ETH</span>
+      </div>
+      <div class="meta-asset">
+        <span class="meta-asset-rank">#4</span>
+        <span class="meta-asset-name">Phantom Skin Epic</span>
+        <span class="meta-asset-vol">512 vol</span>
+        <span class="meta-asset-price">1.8 ETH</span>
+      </div>
+      <div class="meta-asset">
+        <span class="meta-asset-rank">#5</span>
+        <span class="meta-asset-name">Digital Art Frame</span>
+        <span class="meta-asset-vol">423 vol</span>
+        <span class="meta-asset-price">0.9 ETH</span>
+      </div>
+    </div>
+
+    <!-- Activity feed -->
+    <div class="meta-card meta-col-4">
+      <div class="meta-card-title">Recent Activity</div>
+      <div class="meta-activity">
+        <span class="meta-activity-icon">&#128176;</span>
+        <div class="meta-activity-content">
+          <div class="meta-activity-text">Cyber Ape #4421 sold for 12.4 ETH</div>
+          <div class="meta-activity-time">2 min ago</div>
+        </div>
+      </div>
+      <div class="meta-activity">
+        <span class="meta-activity-icon">&#127760;</span>
+        <div class="meta-activity-content">
+          <div class="meta-activity-text">New LAND parcel minted in Decentraland</div>
+          <div class="meta-activity-time">8 min ago</div>
+        </div>
+      </div>
+      <div class="meta-activity">
+        <span class="meta-activity-icon">&#128101;</span>
+        <div class="meta-activity-content">
+          <div class="meta-activity-text">User count crossed 800K milestone</div>
+          <div class="meta-activity-time">23 min ago</div>
+        </div>
+      </div>
+      <div class="meta-activity">
+        <span class="meta-activity-icon">&#128200;</span>
+        <div class="meta-activity-content">
+          <div class="meta-activity-text">Daily revenue hit 24h high of $4.2M</div>
+          <div class="meta-activity-time">41 min ago</div>
+        </div>
+      </div>
+      <div class="meta-activity">
+        <span class="meta-activity-icon">&#127775;</span>
+        <div class="meta-activity-content">
+          <div class="meta-activity-text">The Sandbox launched limited edition skins</div>
+          <div class="meta-activity-time">1h ago</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Key metrics -->
+    <div class="meta-card meta-col-4">
+      <div class="meta-card-title">Commerce Metrics</div>
+      <div class="meta-metric">
+        <span class="meta-metric-label">Avg. Transaction Value</span>
+        <span class="meta-metric-value">$13.42</span>
+      </div>
+      <div class="meta-metric">
+        <span class="meta-metric-label">Conversion Rate</span>
+        <span class="meta-metric-value">4.8%</span>
+      </div>
+      <div class="meta-metric">
+        <span class="meta-metric-label">Avg. Session Time</span>
+        <span class="meta-metric-value">24.6 min</span>
+      </div>
+      <div class="meta-metric">
+        <span class="meta-metric-label">Items per Transaction</span>
+        <span class="meta-metric-value">2.3</span>
+      </div>
+      <div class="meta-metric">
+        <span class="meta-metric-label">Returning Users</span>
+        <span class="meta-metric-value">67%</span>
+      </div>
+      <div class="meta-metric">
+        <span class="meta-metric-label">New Users (24h)</span>
+        <span class="meta-metric-value">12.4K</span>
+      </div>
+    </div>
+
+    <!-- Data summary -->
+    <div class="meta-card meta-col-12">
+      <div class="meta-card-title">Economy Snapshot</div>
+      <div class="meta-data-grid">
+        <div class="meta-data-cell">
+          <div class="value">$18.7M</div>
+          <div class="label">Market cap</div>
+        </div>
+        <div class="meta-data-cell">
+          <div class="value">2.4M</div>
+          <div class="label">Total users</div>
+        </div>
+        <div class="meta-data-cell">
+          <div class="value">1.8M</div>
+          <div class="label">Total transactions</div>
+        </div>
+        <div class="meta-data-cell">
+          <div class="value">94.2K</div>
+          <div class="label">Unique assets</div>
+        </div>
+        <div class="meta-data-cell">
+          <div class="value">156</div>
+          <div class="label">Active worlds</div>
+        </div>
+        <div class="meta-data-cell">
+          <div class="value">42K</div>
+          <div class="label">Creators</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/meta-verse-commerce-analytics-bv/style.css
+++ b/submissions/examples/meta-verse-commerce-analytics-bv/style.css
@@ -1,0 +1,388 @@
+/* ============================================================
+   meta-verse-commerce-analytics-bv
+   Metaverse commerce analytics dashboard with virtual economy
+   metrics, trading activity, top assets, user demographics,
+   and revenue tracking. Uses EaseMotion CSS tokens.
+   ============================================================ */
+
+/* ── Dashboard layout ────────────────────────────────────── */
+
+.meta-dash {
+  display: grid;
+  gap: var(--ease-space-4, 1rem);
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: var(--ease-space-5, 1.25rem);
+  background: linear-gradient(135deg, #0b0e1a, #111827);
+  min-height: 100vh;
+}
+
+@media (min-width: 768px) {
+  .meta-dash {
+    grid-template-columns: repeat(12, 1fr);
+  }
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.meta-header {
+  grid-column: span 12;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ease-space-3, 0.75rem);
+  padding-bottom: var(--ease-space-3, 0.75rem);
+  border-bottom: 1px solid rgba(139, 92, 246, 0.15);
+}
+
+.meta-header h1 {
+  font-size: clamp(1.1rem, 2.5vw, 1.5rem);
+  font-weight: 700;
+  color: #e0e0ff;
+  letter-spacing: 0.01em;
+}
+
+.meta-header-status {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--ease-radius-full, 999px);
+  background: rgba(139, 92, 246, 0.1);
+  color: #a78bfa;
+  border: 1px solid rgba(139, 92, 246, 0.15);
+}
+
+/* ── Card ────────────────────────────────────────────────── */
+
+.meta-card {
+  background: rgba(17, 24, 39, 0.85);
+  border: 1px solid rgba(139, 92, 246, 0.1);
+  border-radius: var(--ease-radius-lg, 12px);
+  padding: var(--ease-space-5, 1.25rem);
+  backdrop-filter: blur(6px);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.meta-card:hover {
+  border-color: rgba(139, 92, 246, 0.2);
+  box-shadow: 0 0 24px rgba(139, 92, 246, 0.05);
+}
+
+.meta-card-title {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(167, 139, 250, 0.5);
+  margin-bottom: var(--ease-space-3, 0.75rem);
+}
+
+/* Column spans */
+.meta-col-3 { grid-column: span 12; }
+.meta-col-4 { grid-column: span 12; }
+.meta-col-6 { grid-column: span 12; }
+.meta-col-12 { grid-column: span 12; }
+@media (min-width: 768px) {
+  .meta-col-3 { grid-column: span 3; }
+  .meta-col-4 { grid-column: span 4; }
+  .meta-col-6 { grid-column: span 6; }
+  .meta-col-12 { grid-column: span 12; }
+}
+
+/* ── Stat cards ──────────────────────────────────────────── */
+
+.meta-stat-value {
+  font-size: clamp(1.3rem, 2.5vw, 1.7rem);
+  font-weight: 700;
+  color: #e0e0ff;
+  line-height: 1.1;
+  margin-bottom: var(--ease-space-1, 0.25rem);
+}
+
+.meta-stat-label {
+  font-size: 0.78rem;
+  color: rgba(167, 139, 250, 0.45);
+}
+
+.meta-stat-trend {
+  font-size: 0.75rem;
+  font-weight: 500;
+  margin-top: var(--ease-space-1, 0.25rem);
+}
+
+.meta-stat-trend.up { color: #22c55e; }
+.meta-stat-trend.down { color: #ef4444; }
+
+/* ── Virtual world list ──────────────────────────────────── */
+
+.meta-world {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-2, 0.5rem) 0;
+  border-bottom: 1px solid rgba(139, 92, 246, 0.06);
+}
+
+.meta-world:last-child {
+  border-bottom: none;
+}
+
+.meta-world-icon {
+  font-size: 1.3rem;
+  line-height: 1;
+  width: 32px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.meta-world-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.meta-world-name {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.meta-world-users {
+  font-size: 0.72rem;
+  color: rgba(167, 139, 250, 0.45);
+}
+
+.meta-world-revenue {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #a78bfa;
+  text-align: right;
+}
+
+/* ── Progress bar ────────────────────────────────────────── */
+
+.meta-progress {
+  margin: var(--ease-space-2, 0.5rem) 0;
+}
+
+.meta-progress-row {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  margin-bottom: var(--ease-space-2, 0.5rem);
+}
+
+.meta-progress-label {
+  width: 110px;
+  font-size: 0.82rem;
+  color: rgba(167, 139, 250, 0.55);
+  flex-shrink: 0;
+}
+
+.meta-progress-track {
+  flex: 1;
+  height: 6px;
+  border-radius: var(--ease-radius-full, 999px);
+  background: rgba(139, 92, 246, 0.06);
+  overflow: hidden;
+}
+
+.meta-progress-fill {
+  height: 100%;
+  border-radius: var(--ease-radius-full, 999px);
+  background: linear-gradient(90deg, #8b5cf6, #a78bfa);
+  transition: width 0.8s ease;
+}
+
+.meta-progress-fill.pink { background: linear-gradient(90deg, #ec4899, #f472b6); }
+.meta-progress-fill.cyan { background: linear-gradient(90deg, #06b6d4, #22d3ee); }
+.meta-progress-fill.green { background: linear-gradient(90deg, #22c55e, #4ade80); }
+
+.meta-progress-pct {
+  width: 40px;
+  text-align: right;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgba(167, 139, 250, 0.55);
+}
+
+/* ── Asset row ───────────────────────────────────────────── */
+
+.meta-asset {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-2, 0.5rem) 0;
+  border-bottom: 1px solid rgba(139, 92, 246, 0.06);
+}
+
+.meta-asset:last-child {
+  border-bottom: none;
+}
+
+.meta-asset-rank {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgba(167, 139, 250, 0.35);
+  width: 20px;
+  flex-shrink: 0;
+}
+
+.meta-asset-name {
+  flex: 1;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.meta-asset-vol {
+  font-size: 0.78rem;
+  color: rgba(167, 139, 250, 0.5);
+}
+
+.meta-asset-price {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #a78bfa;
+  text-align: right;
+  width: 70px;
+}
+
+/* ── Metric row ──────────────────────────────────────────── */
+
+.meta-metric {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--ease-space-2, 0.5rem) 0;
+  border-bottom: 1px solid rgba(139, 92, 246, 0.06);
+}
+
+.meta-metric:last-child {
+  border-bottom: none;
+}
+
+.meta-metric-label {
+  font-size: 0.82rem;
+  color: rgba(167, 139, 250, 0.5);
+}
+
+.meta-metric-value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+/* ── Activity feed ───────────────────────────────────────── */
+
+.meta-activity {
+  display: flex;
+  gap: var(--ease-space-3, 0.75rem);
+  padding: var(--ease-space-2, 0.5rem) 0;
+  border-bottom: 1px solid rgba(139, 92, 246, 0.06);
+}
+
+.meta-activity:last-child {
+  border-bottom: none;
+}
+
+.meta-activity-icon {
+  font-size: 1.1rem;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
+.meta-activity-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.meta-activity-text {
+  font-size: 0.82rem;
+  color: rgba(226, 232, 240, 0.65);
+  line-height: 1.4;
+}
+
+.meta-activity-time {
+  font-size: 0.7rem;
+  color: rgba(167, 139, 250, 0.3);
+  margin-top: 0.15rem;
+}
+
+/* ── Data grid ───────────────────────────────────────────── */
+
+.meta-data-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.meta-data-cell {
+  text-align: center;
+  padding: var(--ease-space-2, 0.5rem);
+}
+
+.meta-data-cell .value {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #e0e0ff;
+}
+
+.meta-data-cell .label {
+  font-size: 0.68rem;
+  color: rgba(167, 139, 250, 0.4);
+  margin-top: 0.15rem;
+}
+
+/* ── Light theme ─────────────────────────────────────────── */
+
+@media (prefers-color-scheme: light) {
+  .meta-dash {
+    background: linear-gradient(135deg, #f5f3ff, #eef2ff);
+  }
+
+  .meta-card {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(139, 92, 246, 0.1);
+  }
+
+  .meta-header h1 { color: #1e1b4b; }
+  .meta-header-status { background: rgba(139, 92, 246, 0.08); color: #7c3aed; }
+
+  .meta-stat-value { color: #1e1b4b; }
+  .meta-stat-label { color: rgba(30, 27, 75, 0.45); }
+
+  .meta-world-name { color: rgba(30, 27, 75, 0.85); }
+  .meta-world-revenue { color: #7c3aed; }
+
+  .meta-progress-label { color: rgba(30, 27, 75, 0.55); }
+  .meta-progress-pct { color: rgba(30, 27, 75, 0.55); }
+
+  .meta-metric-value { color: rgba(30, 27, 75, 0.85); }
+  .meta-metric-label { color: rgba(30, 27, 75, 0.5); }
+
+  .meta-activity-text { color: rgba(30, 27, 75, 0.65); }
+
+  .meta-data-cell .value { color: #1e1b4b; }
+  .meta-data-cell .label { color: rgba(30, 27, 75, 0.4); }
+
+  .meta-asset-name { color: rgba(30, 27, 75, 0.8); }
+  .meta-asset-price { color: #7c3aed; }
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .meta-card {
+    transition: none;
+  }
+
+  .meta-card:hover {
+    box-shadow: none;
+  }
+
+  .meta-progress-fill {
+    transition: none;
+  }
+}


### PR DESCRIPTION
✦ Description
Implements Meta-Verse Commerce Analytics dashboard as part of Phase 287. Provides virtual economy metrics, top worlds by revenue, user demographics, top traded assets, recent activity feed, commerce KPIs, and an economy snapshot in a futuristic purple-dark theme.

⟡ Type of Change
- [x] New feature (submission)

✦ Checklist
- [x] Submission follows EaseMotion CSS structure
- [x] README includes feature description
- [x] Files under submissions/examples/meta-verse-commerce-analytics-bv/
- [x] CSS uses EaseMotion tokens where possible
- [x] Responsive design with 12-column grid
- [x] Dark mode and reduced motion support