### PR TITLE
feat: add animated node graph connector collection (#18927)

### DIFF
--- a/submissions/examples/node-graph-collection/README.md
+++ b/submissions/examples/node-graph-collection/README.md
@@ -1,0 +1,169 @@
+# Animated Node Graph Connector Collection
+
+A pure CSS/SVG animated node-and-edge graph component for network diagrams, dependency maps, and relationship visualisations. Edges draw in on mount, active edges flow with animated dashes, nodes pop in with a stagger, live nodes pulse, and hovering a node highlights its connected edges while dimming unrelated nodes.
+
+---
+
+## Preview
+
+| State | Behaviour |
+|-------|-----------|
+| Mount | Edges draw in via `stroke-dashoffset`; nodes pop in staggered |
+| Active edge | Traveling dash animates along the path to show data flow |
+| Hover node | Node scales + glows; connected edges highlight amber; others dim |
+| Pulse node | Repeating `drop-shadow` glow marks "live" or "selected" nodes |
+
+---
+
+## Files
+
+```
+submissions/examples/node-graph-collection/
+├── demo.html    ← self-contained SVG demo (microservices graph)
+├── style.css    ← all animation classes
+└── README.md
+```
+
+---
+
+## Classes
+
+| Class | Description |
+|-------|-------------|
+| `ease-graph` | SVG container; fade + scale entrance via `@keyframes ease-graph-mount` |
+| `ease-graph-edge` | SVG path/line; draws in via `stroke-dashoffset` on mount |
+| `ease-graph-edge-active` | Traveling dash overlay; `@keyframes ease-edge-flow` loops indefinitely |
+| `ease-graph-edge-highlight` | Add on node hover to highlight connected edges |
+| `ease-graph-node` | SVG circle; hover scale + glow; pop-in on mount |
+| `ease-graph-node-highlight` | Add on hover to mark the focused node (amber fill) |
+| `ease-graph-node-pulse` | Repeating `drop-shadow` pulse ring for live/selected nodes |
+
+---
+
+## Usage
+
+```html
+<svg class="ease-graph" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- Static edge -->
+  <path class="ease-graph-edge"
+        d="M160,100 L270,60"
+        data-from="gateway" data-to="cache" />
+
+  <!-- Active flow edge -->
+  <path class="ease-graph-edge ease-graph-edge-active"
+        d="M160,100 L270,160"
+        data-from="gateway" data-to="auth" />
+
+  <!-- Regular node -->
+  <circle class="ease-graph-node" cx="295" cy="160" r="26" data-id="auth" />
+
+  <!-- Live / selected node -->
+  <circle class="ease-graph-node ease-graph-node-pulse" cx="150" cy="100" r="26" data-id="gateway" />
+
+</svg>
+```
+
+### Hover highlight wiring (minimal JS)
+
+```js
+nodeGroups.forEach(group => {
+  const circle = group.querySelector('.ease-graph-node');
+  const nodeId = circle.dataset.id;
+
+  group.addEventListener('mouseenter', () => {
+    circle.classList.add('ease-graph-node-highlight');
+    edges.forEach(edge => {
+      if (edge.dataset.from === nodeId || edge.dataset.to === nodeId) {
+        edge.classList.add('ease-graph-edge-highlight');
+      }
+    });
+  });
+
+  group.addEventListener('mouseleave', () => {
+    circle.classList.remove('ease-graph-node-highlight');
+    edges.forEach(edge => edge.classList.remove('ease-graph-edge-highlight'));
+  });
+});
+```
+
+---
+
+## Animation Details
+
+### Edge draw-in — `ease-edge-draw`
+```css
+.ease-graph-edge {
+  stroke-dasharray: 600;
+  stroke-dashoffset: 600;
+  animation: ease-edge-draw 700ms cubic-bezier(0.4,0,0.2,1) forwards;
+}
+@keyframes ease-edge-draw {
+  to { stroke-dashoffset: 0; }
+}
+```
+
+### Active edge flow — `ease-edge-flow`
+```css
+.ease-graph-edge-active {
+  stroke-dasharray: 10 14;
+  animation: ease-edge-flow 1.4s linear infinite;
+}
+@keyframes ease-edge-flow {
+  to { stroke-dashoffset: -48; }
+}
+```
+
+### Node pop-in — `ease-node-popin`
+```css
+@keyframes ease-node-popin {
+  from { transform: scale(0); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+```
+
+### Node pulse — `ease-node-pulse`
+```css
+@keyframes ease-node-pulse {
+  0%, 100% { filter: drop-shadow(0 0 0px var(--ease-graph-pulse-color)); }
+  50%       { filter: drop-shadow(0 0 14px var(--ease-graph-pulse-color)); }
+}
+```
+
+---
+
+## Theming
+
+All colours are CSS custom properties on `:root`:
+
+```css
+:root {
+  --ease-graph-node-fill:            #6366f1;
+  --ease-graph-edge-active:          #6366f1;
+  --ease-graph-node-highlight-fill:  #f59e0b;
+  --ease-graph-pulse-color:          rgba(99,102,241,0.4);
+}
+```
+
+Override to match any brand palette or to use distinct colours per node type.
+
+---
+
+## Accessibility
+
+- `role="img"` + `aria-label` on the SVG container
+- Node `data-id` and edge `data-from`/`data-to` attributes for JS wiring
+- `prefers-reduced-motion` disables all animations and transitions; `stroke-dashoffset` resets to `0` so edges are always visible
+
+---
+
+## Browser Support
+
+Chrome 88+, Firefox 85+, Safari 14+. Uses `stroke-dashoffset` animation, SVG `filter`, `transform-box: fill-box`, and CSS custom properties — all widely supported.
+
+---
+
+## Contributor
+
+**@thakurakanksha288** — GSSoC 2026 participant  
+Issue: [#18927](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/18927)

--- a/submissions/examples/node-graph-collection/demo.html
+++ b/submissions/examples/node-graph-collection/demo.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Node Graph Connector — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-label">EaseMotion CSS — Node Graph Connector Collection</p>
+  <p class="demo-hint">Hover a node to highlight its connections. Active edges pulse with flowing dashes.</p>
+
+  <!-- ── Graph SVG ──────────────────────────────────────── -->
+  <svg
+    class="ease-graph"
+    viewBox="0 0 640 360"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label="Animated node graph showing connected services"
+  >
+    <defs>
+      <!-- Arrowhead marker -->
+      <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+        <path d="M0,0 L0,6 L8,3 z" fill="var(--ease-graph-edge-active)" />
+      </marker>
+      <marker id="arrow-muted" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+        <path d="M0,0 L0,6 L8,3 z" fill="var(--ease-graph-edge-color)" />
+      </marker>
+    </defs>
+
+    <!-- ── Edges (draw behind nodes) ──────────────────── -->
+
+    <!-- Gateway → Auth (active flow) -->
+    <path
+      class="ease-graph-edge ease-graph-edge-active"
+      d="M160,100 L270,160"
+      data-from="gateway" data-to="auth"
+      marker-end="url(#arrow)"
+    />
+
+    <!-- Gateway → Cache -->
+    <path
+      class="ease-graph-edge"
+      d="M160,100 L270,60"
+      data-from="gateway" data-to="cache"
+      marker-end="url(#arrow-muted)"
+    />
+
+    <!-- Auth → DB (active flow) -->
+    <path
+      class="ease-graph-edge ease-graph-edge-active"
+      d="M320,160 L430,200"
+      data-from="auth" data-to="db"
+      marker-end="url(#arrow)"
+    />
+
+    <!-- Auth → Worker -->
+    <path
+      class="ease-graph-edge"
+      d="M320,160 L430,110"
+      data-from="auth" data-to="worker"
+      marker-end="url(#arrow-muted)"
+    />
+
+    <!-- Cache → Worker -->
+    <path
+      class="ease-graph-edge"
+      d="M320,60 L430,110"
+      data-from="cache" data-to="worker"
+      marker-end="url(#arrow-muted)"
+    />
+
+    <!-- Worker → DB -->
+    <path
+      class="ease-graph-edge"
+      d="M480,110 L480,190"
+      data-from="worker" data-to="db"
+      marker-end="url(#arrow-muted)"
+    />
+
+    <!-- DB → Analytics (active) -->
+    <path
+      class="ease-graph-edge ease-graph-edge-active"
+      d="M480,210 L570,270"
+      data-from="db" data-to="analytics"
+      marker-end="url(#arrow)"
+    />
+
+    <!-- Client → Gateway -->
+    <path
+      class="ease-graph-edge ease-graph-edge-active"
+      d="M80,200 L140,110"
+      data-from="client" data-to="gateway"
+      marker-end="url(#arrow)"
+    />
+
+    <!-- ── Nodes ───────────────────────────────────────── -->
+
+    <!-- Client node (pulse — "live") -->
+    <g data-node="client" class="node-group">
+      <circle class="ease-graph-node ease-graph-node-pulse" cx="70" cy="210" r="26"
+              data-id="client" />
+      <text class="ease-graph-label" x="70" y="208">Client</text>
+      <text class="ease-graph-caption" x="70" y="244">Browser</text>
+    </g>
+
+    <!-- Gateway node (pulse — entry point) -->
+    <g data-node="gateway" class="node-group">
+      <circle class="ease-graph-node ease-graph-node-pulse" cx="150" cy="100" r="26"
+              data-id="gateway" />
+      <text class="ease-graph-label" x="150" y="98">GW</text>
+      <text class="ease-graph-caption" x="150" y="134">Gateway</text>
+    </g>
+
+    <!-- Auth node -->
+    <g data-node="auth" class="node-group">
+      <circle class="ease-graph-node" cx="295" cy="160" r="26"
+              data-id="auth" />
+      <text class="ease-graph-label" x="295" y="158">Auth</text>
+      <text class="ease-graph-caption" x="295" y="194">Service</text>
+    </g>
+
+    <!-- Cache node -->
+    <g data-node="cache" class="node-group">
+      <circle class="ease-graph-node" cx="295" cy="58" r="22"
+              data-id="cache" />
+      <text class="ease-graph-label" x="295" y="56">Cache</text>
+      <text class="ease-graph-caption" x="295" y="88">Redis</text>
+    </g>
+
+    <!-- Worker node -->
+    <g data-node="worker" class="node-group">
+      <circle class="ease-graph-node" cx="480" cy="108" r="22"
+              data-id="worker" />
+      <text class="ease-graph-label" x="480" y="106">Worker</text>
+      <text class="ease-graph-caption" x="480" y="138">Queue</text>
+    </g>
+
+    <!-- DB node (pulse — critical) -->
+    <g data-node="db" class="node-group">
+      <circle class="ease-graph-node ease-graph-node-pulse" cx="480" cy="200" r="26"
+              data-id="db" />
+      <text class="ease-graph-label" x="480" y="198">DB</text>
+      <text class="ease-graph-caption" x="480" y="234">Postgres</text>
+    </g>
+
+    <!-- Analytics node -->
+    <g data-node="analytics" class="node-group">
+      <circle class="ease-graph-node" cx="575" cy="272" r="22"
+              data-id="analytics" />
+      <text class="ease-graph-label" x="575" y="270">Stats</text>
+      <text class="ease-graph-caption" x="575" y="302">Analytics</text>
+    </g>
+
+  </svg>
+
+  <!-- Legend -->
+  <div class="graph-legend">
+    <div class="graph-legend-item">
+      <div class="legend-dot" style="background:var(--ease-graph-node-fill)"></div>
+      Node
+    </div>
+    <div class="graph-legend-item">
+      <div class="legend-dot" style="background:var(--ease-graph-node-fill);box-shadow:0 0 0 3px var(--ease-graph-pulse-color)"></div>
+      Live node (pulse)
+    </div>
+    <div class="graph-legend-item">
+      <div class="legend-line" style="background:var(--ease-graph-edge-color)"></div>
+      Static edge
+    </div>
+    <div class="graph-legend-item">
+      <div class="legend-line" style="background:var(--ease-graph-edge-active)"></div>
+      Active flow edge
+    </div>
+    <div class="graph-legend-item">
+      <div class="legend-dot" style="background:var(--ease-graph-node-highlight-fill)"></div>
+      Highlighted (hover)
+    </div>
+  </div>
+
+  <script>
+    // Edge adjacency map: node → edges it is connected to
+    const adjacency = {
+      client:    ['gateway'],
+      gateway:   ['client', 'auth', 'cache'],
+      auth:      ['gateway', 'db', 'worker'],
+      cache:     ['gateway', 'worker'],
+      worker:    ['auth', 'cache', 'db'],
+      db:        ['auth', 'worker', 'analytics'],
+      analytics: ['db'],
+    };
+
+    const edges = document.querySelectorAll('.ease-graph-edge');
+    const nodeGroups = document.querySelectorAll('.node-group');
+
+    nodeGroups.forEach(group => {
+      const circle = group.querySelector('.ease-graph-node');
+      const nodeId = circle.dataset.id;
+
+      group.addEventListener('mouseenter', () => {
+        // Highlight this node
+        circle.classList.add('ease-graph-node-highlight');
+
+        // Highlight connected edges
+        edges.forEach(edge => {
+          const from = edge.dataset.from;
+          const to   = edge.dataset.to;
+          if (from === nodeId || to === nodeId) {
+            edge.classList.add('ease-graph-edge-highlight');
+          }
+        });
+
+        // Dim unconnected nodes
+        const connected = new Set(adjacency[nodeId] || []);
+        nodeGroups.forEach(other => {
+          const otherId = other.querySelector('.ease-graph-node').dataset.id;
+          if (otherId !== nodeId && !connected.has(otherId)) {
+            other.style.opacity = '0.3';
+          }
+        });
+      });
+
+      group.addEventListener('mouseleave', () => {
+        circle.classList.remove('ease-graph-node-highlight');
+        edges.forEach(edge => edge.classList.remove('ease-graph-edge-highlight'));
+        nodeGroups.forEach(other => { other.style.opacity = ''; });
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/node-graph-collection/style.css
+++ b/submissions/examples/node-graph-collection/style.css
@@ -1,0 +1,274 @@
+/* ============================================================
+   EaseMotion CSS — Animated Node Graph Connector Collection
+   submissions/examples/node-graph-collection/style.css
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --ease-graph-bg:              #ffffff;
+  --ease-graph-border:          #e2e8f0;
+  --ease-graph-node-fill:       #6366f1;
+  --ease-graph-node-stroke:     #4f46e5;
+  --ease-graph-node-hover-fill: #818cf8;
+  --ease-graph-node-text:       #ffffff;
+  --ease-graph-node-shadow:     rgba(99,102,241,0.35);
+  --ease-graph-node-highlight-fill:  #f59e0b;
+  --ease-graph-node-highlight-stroke:#d97706;
+  --ease-graph-edge-color:      #cbd5e1;
+  --ease-graph-edge-active:     #6366f1;
+  --ease-graph-edge-highlight:  #f59e0b;
+  --ease-graph-pulse-color:     rgba(99,102,241,0.4);
+  --ease-graph-label-color:     #1e293b;
+  --ease-graph-label-sub:       #64748b;
+  --ease-graph-duration:        300ms;
+  --ease-graph-easing:          cubic-bezier(0.4, 0, 0.2, 1);
+  --page-bg:                    #f1f5f9;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-graph-bg:              #0f172a;
+    --ease-graph-border:          #1e293b;
+    --ease-graph-node-fill:       #818cf8;
+    --ease-graph-node-stroke:     #6366f1;
+    --ease-graph-node-hover-fill: #a5b4fc;
+    --ease-graph-node-text:       #0f172a;
+    --ease-graph-node-shadow:     rgba(129,140,248,0.4);
+    --ease-graph-node-highlight-fill:  #fbbf24;
+    --ease-graph-node-highlight-stroke:#f59e0b;
+    --ease-graph-edge-color:      #334155;
+    --ease-graph-edge-active:     #818cf8;
+    --ease-graph-edge-highlight:  #fbbf24;
+    --ease-graph-pulse-color:     rgba(129,140,248,0.35);
+    --ease-graph-label-color:     #f1f5f9;
+    --ease-graph-label-sub:       #94a3b8;
+    --page-bg:                    #020617;
+  }
+}
+
+/* ── Page shell ──────────────────────────────────────────── */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--page-bg);
+  color: var(--ease-graph-label-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2.5rem 1rem;
+  gap: 0.5rem;
+}
+
+.demo-label {
+  font-size: 0.75rem;
+  color: var(--ease-graph-label-sub);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.demo-hint {
+  font-size: 0.8125rem;
+  color: var(--ease-graph-label-sub);
+  margin-bottom: 1.5rem;
+}
+
+/* ── Graph SVG container ─────────────────────────────────── */
+.ease-graph {
+  width: 100%;
+  max-width: 640px;
+  background: var(--ease-graph-bg);
+  border: 1px solid var(--ease-graph-border);
+  border-radius: 14px;
+  overflow: visible;
+  display: block;
+
+  /* Entrance */
+  animation: ease-graph-mount 400ms var(--ease-graph-easing) forwards;
+}
+
+@keyframes ease-graph-mount {
+  from { opacity: 0; transform: scale(0.96); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+/* ── Edge (SVG path / line) ──────────────────────────────── */
+.ease-graph-edge {
+  stroke: var(--ease-graph-edge-color);
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+
+  /* Draw-in on mount using stroke-dashoffset */
+  stroke-dasharray: 600;
+  stroke-dashoffset: 600;
+  animation: ease-edge-draw 700ms var(--ease-graph-easing) forwards;
+}
+
+@keyframes ease-edge-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+/* Stagger each edge slightly */
+.ease-graph-edge:nth-of-type(1) { animation-delay: 100ms; }
+.ease-graph-edge:nth-of-type(2) { animation-delay: 200ms; }
+.ease-graph-edge:nth-of-type(3) { animation-delay: 300ms; }
+.ease-graph-edge:nth-of-type(4) { animation-delay: 400ms; }
+.ease-graph-edge:nth-of-type(5) { animation-delay: 500ms; }
+
+/* ── Active edge — traveling dash ────────────────────────── */
+.ease-graph-edge-active {
+  stroke: var(--ease-graph-edge-active);
+  stroke-width: 2.5;
+  stroke-dasharray: 10 14;
+  stroke-dashoffset: 0;
+  animation:
+    ease-edge-draw  700ms var(--ease-graph-easing) forwards,
+    ease-edge-flow  1.4s  linear infinite;
+  animation-delay: 0ms, 750ms;
+}
+
+@keyframes ease-edge-flow {
+  to { stroke-dashoffset: -48; }
+}
+
+/* ── Highlighted edge (on node hover) ────────────────────── */
+.ease-graph-edge.ease-graph-edge-highlight {
+  stroke: var(--ease-graph-edge-highlight);
+  stroke-width: 3;
+  transition: stroke var(--ease-graph-duration) var(--ease-graph-easing),
+              stroke-width var(--ease-graph-duration) var(--ease-graph-easing);
+}
+
+/* ── Node (SVG circle) ───────────────────────────────────── */
+.ease-graph-node {
+  fill: var(--ease-graph-node-fill);
+  stroke: var(--ease-graph-node-stroke);
+  stroke-width: 2;
+  cursor: pointer;
+  transform-origin: center;
+  transform-box: fill-box;
+  transition:
+    fill   var(--ease-graph-duration) var(--ease-graph-easing),
+    filter var(--ease-graph-duration) var(--ease-graph-easing),
+    transform var(--ease-graph-duration) var(--ease-graph-easing);
+
+  /* Pop in on mount */
+  animation: ease-node-popin 400ms var(--ease-graph-easing) backwards;
+}
+
+@keyframes ease-node-popin {
+  from { transform: scale(0); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+
+.ease-graph-node:nth-of-type(1) { animation-delay: 600ms; }
+.ease-graph-node:nth-of-type(2) { animation-delay: 700ms; }
+.ease-graph-node:nth-of-type(3) { animation-delay: 800ms; }
+.ease-graph-node:nth-of-type(4) { animation-delay: 900ms; }
+.ease-graph-node:nth-of-type(5) { animation-delay: 1000ms; }
+.ease-graph-node:nth-of-type(6) { animation-delay: 1100ms; }
+
+.ease-graph-node:hover {
+  fill: var(--ease-graph-node-hover-fill);
+  transform: scale(1.18);
+  filter: drop-shadow(0 0 8px var(--ease-graph-node-shadow));
+}
+
+/* ── Highlighted node (on hover — traces its connections) ── */
+.ease-graph-node-highlight {
+  fill: var(--ease-graph-node-highlight-fill) !important;
+  stroke: var(--ease-graph-node-highlight-stroke) !important;
+  transform: scale(1.22) !important;
+  filter: drop-shadow(0 0 10px rgba(245,158,11,0.5)) !important;
+}
+
+/* ── Pulse node — repeating ring ────────────────────────── */
+.ease-graph-node-pulse {
+  animation:
+    ease-node-popin  400ms var(--ease-graph-easing) backwards,
+    ease-node-pulse  2s    ease-in-out infinite;
+  animation-delay: 600ms, 1200ms;
+}
+
+@keyframes ease-node-pulse {
+  0%, 100% {
+    filter: drop-shadow(0 0 0px var(--ease-graph-pulse-color));
+  }
+  50% {
+    filter: drop-shadow(0 0 14px var(--ease-graph-pulse-color));
+  }
+}
+
+/* ── Node label text ─────────────────────────────────────── */
+.ease-graph-label {
+  fill: var(--ease-graph-node-text);
+  font-size: 10px;
+  font-weight: 700;
+  text-anchor: middle;
+  dominant-baseline: central;
+  pointer-events: none;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.ease-graph-caption {
+  fill: var(--ease-graph-label-sub);
+  font-size: 9px;
+  font-weight: 500;
+  text-anchor: middle;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  pointer-events: none;
+}
+
+/* ── Legend strip ────────────────────────────────────────── */
+.graph-legend {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 1rem;
+  font-size: 0.75rem;
+  color: var(--ease-graph-label-sub);
+}
+
+.graph-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legend-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.legend-line {
+  width: 22px;
+  height: 2px;
+  border-radius: 1px;
+  flex-shrink: 0;
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-graph,
+  .ease-graph-edge,
+  .ease-graph-edge-active,
+  .ease-graph-node,
+  .ease-graph-node-pulse {
+    animation: none;
+    stroke-dashoffset: 0;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## 🎯 Feature: Animated Node Graph Connector Collection

### Summary

| Item | Detail |
|------|--------|
| Component | Animated Node Graph Connector Collection |
| Folder | `submissions/examples/node-graph-collection/` |
| Files | `demo.html`, `style.css`, `README.md` |
| Dependencies | Zero — pure CSS/SVG + minimal JS for hover wiring only |
| Issue | Closes #18927 |

### Implemented Classes

| Class | Behaviour |
|-------|-----------|
| `ease-graph-edge` | Draws in via `stroke-dashoffset` animation on mount |
| `ease-graph-edge-active` | Traveling dash via `@keyframes ease-edge-flow` — loops infinitely |
| `ease-graph-edge-highlight` | Amber stroke on connected edges when a node is hovered |
| `ease-graph-node` | Pop-in on mount; scale + glow on hover |
| `ease-graph-node-highlight` | Amber fill marks the focused node on hover |
| `ease-graph-node-pulse` | Repeating `drop-shadow` glow ring for live/selected nodes |

### Animations
- **Edge draw-in** — `stroke-dashoffset: 600 → 0` staggered per edge
- **Active flow** — `stroke-dasharray` traveling dash loops on active edges
- **Node pop-in** — `scale(0) → scale(1)` staggered after edges draw
- **Pulse ring** — `drop-shadow` glow oscillates on live nodes

### Variants
- ✅ Light mode
- ✅ Dark mode (`prefers-color-scheme: dark`)
- ✅ `prefers-reduced-motion` — all animations disabled; edges always visible

### Accessibility
- `role="img"` + `aria-label` on SVG container
- `prefers-reduced-motion` resets `stroke-dashoffset` to `0`

### Contributor
**@thakurakanksha288** — GSSoC 2026 participant ✅