### PR TITLE
feat: add usage examples showcase (entrance, hover, loop, delayed combo)

### DIFF
--- a/submissions/examples/usage-examples-showcase-ms07/README.md
+++ b/submissions/examples/usage-examples-showcase-ms07/README.md
@@ -1,0 +1,26 @@
+# Usage Examples Showcase
+
+1. **What does this do?**
+   A single-page showcase of four common usage patterns from the framework's HTML snippet — an entrance animation, a hover effect, a continuous loop, and combined effects with a delay — shown side by side with the class names that produce each one, plus a small reference table mapping this demo's class names to their `ease-*` equivalents.
+
+2. **How is it used?**
+   Each example pairs an `examples-*` animation class with `examples-duration-*` / `examples-delay-*` / `examples-infinite` modifier classes:
+
+   ```html
+   <div class="examples-fade examples-duration-300">Welcome</div>
+   <button class="examples-pulse-hover examples-duration-500">Hover Me</button>
+   <div class="examples-bounce examples-duration-1000 examples-infinite">Bouncing Box</div>
+   <div class="examples-slide-left examples-duration-400 examples-delay-200">Delayed Slide</div>
+   ```
+
+3. **Why is this useful?**
+   New users adopting an animation library often learn fastest from side-by-side runnable examples rather than a flat class list — seeing entrance, hover, loop, and delay patterns together (with their class names visible) makes the "compose small classes together" philosophy of EaseMotion CSS concrete rather than abstract.
+
+### Important scope note for the maintainer
+The original issue requested a full **"Comprehensive Documentation and Usage Examples Hub"** — including a complete utility class reference, a CDN integration guide, and a CodePen collection. That's genuinely **not buildable as a `submissions/examples/` folder**, for two reasons:
+- A real documentation hub has to live in `docs/`, which contributors are explicitly blocked from editing under the current contribution rules.
+- It needs to reference the actual `ease-*` classes that exist in `core/`, which this demo can't see or guarantee accuracy against.
+
+This submission is a deliberately scoped-down slice of that request: a single self-contained example page demonstrating the four patterns from the issue's own HTML snippet, runnable standalone. It does **not** include the CDN setup guide, the full utility class table, or CodePen embeds — those would need to be built directly by the maintainer (or in a real `docs/` PR) rather than as a contributor submission. Happy to expand this into more side-by-side examples if that's useful, but the "hub" itself is out of scope for this folder.
+
+- Tested in Chrome, Firefox, and Edge.

--- a/submissions/examples/usage-examples-showcase-ms07/demo.html
+++ b/submissions/examples/usage-examples-showcase-ms07/demo.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Usage Examples Showcase — Demo</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <main class="examples-wrapper">
+
+    <header class="examples-header">
+      <h1>Usage Examples</h1>
+      <p>Four common patterns — entrance, hover, loop, and delayed combinations — shown together with the class names that produce them.</p>
+    </header>
+
+    <!-- Entrance Animation Example -->
+    <section class="examples-card">
+      <div class="examples-stage">
+        <div class="examples-box examples-fade" data-replay>Welcome</div>
+      </div>
+      <div class="examples-meta">
+        <span class="examples-label">Entrance Animation</span>
+        <code class="examples-code">examples-fade examples-duration-300</code>
+        <p class="examples-desc">Fades and lifts in once on load. Click the box to replay it.</p>
+      </div>
+    </section>
+
+    <!-- Hover Effect Example -->
+    <section class="examples-card">
+      <div class="examples-stage">
+        <button class="examples-box examples-pulse-hover examples-duration-500" type="button">Hover Me</button>
+      </div>
+      <div class="examples-meta">
+        <span class="examples-label">Hover Effect</span>
+        <code class="examples-code">examples-pulse-hover examples-duration-500</code>
+        <p class="examples-desc">Pulses outward while the pointer is over the element.</p>
+      </div>
+    </section>
+
+    <!-- Loop Animation Example -->
+    <section class="examples-card">
+      <div class="examples-stage">
+        <div class="examples-box examples-bounce examples-duration-1000 examples-infinite">Bouncing Box</div>
+      </div>
+      <div class="examples-meta">
+        <span class="examples-label">Loop Animation</span>
+        <code class="examples-code">examples-bounce examples-duration-1000 examples-infinite</code>
+        <p class="examples-desc">Repeats continuously rather than running once.</p>
+      </div>
+    </section>
+
+    <!-- Combined Effects with Delay -->
+    <section class="examples-card">
+      <div class="examples-stage">
+        <div class="examples-box examples-slide-left examples-duration-400 examples-delay-200" data-replay>Delayed Slide</div>
+      </div>
+      <div class="examples-meta">
+        <span class="examples-label">Combined Effects with Delay</span>
+        <code class="examples-code">examples-slide-left examples-duration-400 examples-delay-200</code>
+        <p class="examples-desc">Slides in from the left, starting 200ms after the others. Click the box to replay it.</p>
+      </div>
+    </section>
+
+    <!-- Reference table -->
+    <section class="examples-reference">
+      <h2>Class Reference</h2>
+      <p class="examples-reference-note">
+        This demo uses the <code>examples-*</code> prefix so it can run standalone.
+        In the framework itself, the equivalent classes follow the <code>ease-*</code> convention shown below.
+      </p>
+      <table class="examples-table">
+        <thead>
+          <tr>
+            <th>Demo class (this file)</th>
+            <th>Framework class</th>
+            <th>What it does</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>examples-fade</code></td>
+            <td><code>ease-fade</code></td>
+            <td>Fade + lift in on load</td>
+          </tr>
+          <tr>
+            <td><code>examples-pulse-hover</code></td>
+            <td><code>ease-pulse-hover</code></td>
+            <td>Outward pulse on hover</td>
+          </tr>
+          <tr>
+            <td><code>examples-bounce</code></td>
+            <td><code>ease-bounce</code></td>
+            <td>Vertical bounce motion</td>
+          </tr>
+          <tr>
+            <td><code>examples-slide-left</code></td>
+            <td><code>ease-slide-left</code></td>
+            <td>Slide in from the left</td>
+          </tr>
+          <tr>
+            <td><code>examples-duration-*</code></td>
+            <td><code>duration-*</code></td>
+            <td>Sets animation length (300/400/500/1000ms shown here)</td>
+          </tr>
+          <tr>
+            <td><code>examples-delay-*</code></td>
+            <td><code>delay-*</code></td>
+            <td>Sets animation start delay (200ms shown here)</td>
+          </tr>
+          <tr>
+            <td><code>examples-infinite</code></td>
+            <td><code>ease-infinite</code></td>
+            <td>Repeats the animation indefinitely</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+  </main>
+
+  <script>
+    (function () {
+      document.querySelectorAll('[data-replay]').forEach((el) => {
+        el.addEventListener('click', () => {
+          el.classList.add('examples-replay-reset');
+          void el.offsetWidth; 
+          el.classList.remove('examples-replay-reset');
+        });
+      });
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/usage-examples-showcase-ms07/style.css
+++ b/submissions/examples/usage-examples-showcase-ms07/style.css
@@ -1,0 +1,279 @@
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0b0f19;
+  color: #e7e9ee;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.examples-wrapper {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+}
+
+.examples-header h1 {
+  margin: 0 0 8px;
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.examples-header p {
+  margin: 0 0 36px;
+  color: #aeb4c4;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  max-width: 560px;
+}
+
+/* ---------------------------------------------------------------
+   Example cards
+   --------------------------------------------------------------- */
+
+.examples-card {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 24px;
+  align-items: center;
+  padding: 22px;
+  border: 1px solid #ffffff14;
+  border-radius: 14px;
+  background: #11162280;
+  margin-bottom: 18px;
+}
+
+.examples-stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 90px;
+}
+
+.examples-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.examples-label {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #93c5fd;
+}
+
+.examples-code {
+  font-family: "SF Mono", Consolas, "Courier New", monospace;
+  font-size: 0.8rem;
+  color: #c7d2ff;
+  background: #00000040;
+  padding: 3px 8px;
+  border-radius: 6px;
+  display: inline-block;
+  width: fit-content;
+}
+
+.examples-desc {
+  margin: 2px 0 0;
+  font-size: 0.85rem;
+  color: #aeb4c4;
+}
+
+/* ---------------------------------------------------------------
+   The demo box / button shared across examples
+   --------------------------------------------------------------- */
+
+.examples-box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 140px;
+  padding: 14px 18px;
+  border-radius: 10px;
+  background: #6c63ff;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  border: 0;
+  cursor: pointer;
+}
+
+/* Used by the JS replay helper to momentarily strip the animation so
+   it can be retriggered from scratch on click. */
+.examples-replay-reset {
+  animation: none !important;
+  opacity: 1 !important;
+  transform: none !important;
+}
+
+/* ---------------------------------------------------------------
+   Entrance Animation Example — fade + lift in once on load
+   --------------------------------------------------------------- */
+
+.examples-fade {
+  animation: examples-fade-in 0.5s ease both;
+}
+
+@keyframes examples-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ---------------------------------------------------------------
+   Hover Effect Example — outward pulse while hovered
+   --------------------------------------------------------------- */
+
+.examples-pulse-hover {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.examples-pulse-hover:hover {
+  animation: examples-pulse 0.6s ease-in-out infinite;
+}
+
+@keyframes examples-pulse {
+  0%, 100% { transform: scale(1); box-shadow: 0 0 0 0 #6c63ff66; }
+  50%      { transform: scale(1.06); box-shadow: 0 0 0 8px #6c63ff22; }
+}
+
+/* ---------------------------------------------------------------
+   Loop Animation Example — continuous vertical bounce
+   --------------------------------------------------------------- */
+
+.examples-bounce {
+  animation-name: examples-bounce-move;
+  animation-duration: 1000ms;
+  animation-timing-function: ease-in-out;
+}
+
+@keyframes examples-bounce-move {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-14px); }
+}
+
+/* ---------------------------------------------------------------
+   Combined Effects with Delay — slide in from the left
+   --------------------------------------------------------------- */
+
+.examples-slide-left {
+  animation-name: examples-slide-left-in;
+  animation-duration: 400ms;
+  animation-timing-function: ease;
+  animation-fill-mode: both;
+}
+
+@keyframes examples-slide-left-in {
+  from { opacity: 0; transform: translateX(-24px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* ---------------------------------------------------------------
+   Utility modifiers — duration / delay / infinite
+   Applied alongside an animation-name class above; these only set
+   the timing, so the same duration/delay classes work across every
+   animation in this file.
+   --------------------------------------------------------------- */
+
+.examples-duration-300  { animation-duration: 300ms; }
+.examples-duration-400  { animation-duration: 400ms; }
+.examples-duration-500  { animation-duration: 500ms; }
+.examples-duration-1000 { animation-duration: 1000ms; }
+
+.examples-delay-200 { animation-delay: 200ms; }
+
+.examples-infinite { animation-iteration-count: infinite; }
+
+/* ---------------------------------------------------------------
+   Reference table
+   --------------------------------------------------------------- */
+
+.examples-reference {
+  margin-top: 44px;
+  padding-top: 28px;
+  border-top: 1px solid #ffffff14;
+}
+
+.examples-reference h2 {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
+}
+
+.examples-reference-note {
+  margin: 0 0 18px;
+  font-size: 0.85rem;
+  color: #aeb4c4;
+  line-height: 1.5;
+}
+
+.examples-reference-note code {
+  font-family: "SF Mono", Consolas, "Courier New", monospace;
+  background: #00000040;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.examples-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.examples-table th {
+  text-align: left;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8b93a7;
+  padding: 8px 10px;
+  border-bottom: 1px solid #ffffff1a;
+}
+
+.examples-table td {
+  padding: 10px 10px;
+  border-bottom: 1px solid #ffffff0d;
+  color: #d6dae5;
+}
+
+.examples-table code {
+  font-family: "SF Mono", Consolas, "Courier New", monospace;
+  background: #00000040;
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: #c7d2ff;
+}
+
+/* ===================================================================
+   Responsive behavior
+   =================================================================== */
+
+@media (max-width: 600px) {
+  .examples-card {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .examples-meta {
+    align-items: center;
+  }
+
+  .examples-table {
+    font-size: 0.78rem;
+  }
+}
+
+/* Respect users who prefer reduced motion across every example */
+@media (prefers-reduced-motion: reduce) {
+  .examples-fade,
+  .examples-bounce,
+  .examples-slide-left,
+  .examples-pulse-hover:hover {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a single self-contained showcase page demonstrating four common
usage patterns — entrance animation, hover effect, continuous loop,
and combined effects with a delay — side by side with their class
names, plus a reference table mapping this demo's names to their
`ease-*` equivalents.

This is a deliberately scoped-down slice of the original
"Comprehensive Documentation Hub" request — see Notes for Maintainer
below for why the rest of that issue isn't included here.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/usage-examples-showcase-ms07/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A runnable example page pairing four animation patterns (fade-in
entrance, hover pulse, infinite bounce loop, delayed slide-in) with
visible class names and a small class-name reference table.

**How does a developer use it?**

```html
<div class="examples-fade examples-duration-300">Welcome</div>
<button class="examples-pulse-hover examples-duration-500">Hover Me</button>
<div class="examples-bounce examples-duration-1000 examples-infinite">Bouncing Box</div>
<div class="examples-slide-left examples-duration-400 examples-delay-200">Delayed Slide</div>
```

**Why does it fit EaseMotion CSS?**

New users learn animation libraries faster from runnable side-by-side
examples than from a flat class list. Seeing entrance, hover, loop,
and delay patterns together makes the "compose small classes
together" philosophy concrete.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The original issue requested a full "Comprehensive Documentation and
Usage Examples Hub" including a complete utility class reference, a
CDN integration guide, and a CodePen collection. That's not buildable
as a `submissions/examples/` folder: a real docs hub has to live in
`docs/`, which contributors can't edit under the current rules, and
it would need to reference the actual `ease-*` classes in `core/`,
which this demo can't see or verify against. This submission covers
only the runnable-examples slice of that request — the CDN guide,
full class table, and CodePen embeds are intentionally left out and
would need to be handled directly by you or in a real `docs/` PR.
Happy to add more side-by-side examples if useful.

Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/18949