### PR TITLE
feat: add empty-cell utilities

### DIFF
--- a/submissions/examples/empty-cell-utilities-ap/README.md
+++ b/submissions/examples/empty-cell-utilities-ap/README.md
@@ -1,0 +1,89 @@
+# EaseMotion CSS — Empty Cell Utilities
+
+This directory implements core utility classes for controlling the CSS `empty-cells` property in EaseMotion CSS.
+
+---
+
+## What is Empty Cells?
+
+The `empty-cells` property dictates whether table cells with no visible content (such as empty cells `<td></td>` or elements containing only whitespaces) render borders and backgrounds.
+
+### The Border Collapse Constraint
+
+> [!IMPORTANT]
+> The `empty-cells` property has **no effect** if the table's border collapse setting is set to `collapse`. It only works when borders are separated (<code>border-collapse: separate;</code>).
+
+### Aesthetic Options:
+
+1. **Show Empty Cells (`show`)**: Default browser style. Renders borders and column cell backgrounds normally, maintaining a strict tabular grid pattern regardless of cell contents.
+2. **Hide Empty Cells (`hide`)**: Hides cell borders and backgrounds, rendering empty cells completely transparent. This lets background patterns, gradients, or colors placed on the wrapper card show through cleanly, creating a spacious, modern grid aesthetic.
+
+---
+
+## Utility Classes Reference
+
+EaseMotion CSS provides clean classes mapping to the standard empty-cells actions:
+
+| Utility Class       | CSS Equivalent                  | Description                                                                      |
+| :------------------ | :------------------------------ | :------------------------------------------------------------------------------- |
+| `.empty-cells-show` | `empty-cells: show !important;` | Default: renders borders and backgrounds around empty table cells.               |
+| `.empty-cells-hide` | `empty-cells: hide !important;` | Hides borders and backgrounds around empty table cells, making them transparent. |
+
+### Supporting Utilities
+
+- **Border Collapse**: `.border-separate` (`border-collapse: separate !important;`), `.border-collapse` (`border-collapse: collapse !important;`).
+- **Border Spacing scale**: `.border-spacing-0` to `.border-spacing-8` (configuring the gap separation between cells).
+
+---
+
+## Usage Examples
+
+### 1. Modern Exposed Dashboard Data Tables (Hide)
+
+Applying `.empty-cells-hide` lets complex card gradients show through empty segments of the data grid:
+
+```html
+<!-- Table with separate borders and spacing, hiding empty blocks -->
+<table class="border-separate empty-cells-hide border-spacing-2">
+  <thead>
+    <tr>
+      <th>Host</th>
+      <th>State</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Server A</td>
+      <td>Active</td>
+    </tr>
+    <tr>
+      <td>Server B</td>
+      <td></td>
+      <!-- This cell will be completely transparent -->
+    </tr>
+  </tbody>
+</table>
+```
+
+---
+
+## Accessibility (WCAG 2.1) & Readability Best Practices
+
+- **Avoid Data Confusion**: When hiding empty cells, the visual omission of cells might cause screen reader users or visually-impaired individuals to misalign column headers with row values. Consider using standard accessibility hidden text (e.g. `<span class="sr-only">No data</span>` or `.sr-only` helpers) inside "empty" cells to keep table structures coherent for accessibility tools.
+- **Maintain High Contrast**: Ensure table headers and border lines remain highly contrast-compliant relative to backgrounds showing through.
+
+---
+
+## Browser Compatibility Notes
+
+- **Full support**: `empty-cells` is fully supported by all modern desktop and mobile browsers.
+
+---
+
+## Verification & Testing
+
+Verify that your styles load correctly by launching `demo.html` in your web browser. Ensure the sandbox table togglers update grid states dynamically. Run standard project tests to confirm compliance:
+
+```bash
+npm test
+```

--- a/submissions/examples/empty-cell-utilities-ap/demo.html
+++ b/submissions/examples/empty-cell-utilities-ap/demo.html
@@ -1,0 +1,327 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — Empty Cell Utilities</title>
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;600&family=Outfit:wght@400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <!-- Stylesheet -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="app-container">
+      <!-- Header -->
+      <header class="header">
+        <h1>Empty Cell Utilities</h1>
+        <p>
+          Configure the visibility of borders and backgrounds for table cells
+          that contain no visible content.
+        </p>
+      </header>
+
+      <!-- Side-by-Side Table Comparison -->
+      <section>
+        <h2 class="section-title">Visual Comparison</h2>
+        <p style="margin-bottom: 2rem; max-width: 850px">
+          The <code>empty-cells</code> property only affects tables with
+          separated borders (<code>border-collapse: separate;</code>). Below, a
+          striped card background is placed behind the tables to show exposure.
+        </p>
+
+        <div class="showcase-grid">
+          <!-- Show Empty Cells Card -->
+          <div class="card exposed-bg-indicator">
+            <div
+              class="card-header"
+              style="
+                background: var(--color-bg-surface);
+                border-radius: 8px 8px 0 0;
+              "
+            >
+              <h3 class="card-title">Show Empty Cells</h3>
+              <span class="badge badge-blue">empty-cells-show</span>
+            </div>
+            <div
+              class="card-body"
+              style="
+                background: var(--color-bg-surface);
+                border-radius: 0 0 8px 8px;
+                padding-top: 1rem;
+              "
+            >
+              <p style="font-size: 0.85rem; margin-bottom: 1rem">
+                Empty cells render borders and container backgrounds normally:
+              </p>
+
+              <table
+                class="demo-table border-separate border-spacing-2 empty-cells-show"
+              >
+                <thead>
+                  <tr>
+                    <th>Item</th>
+                    <th>Metric A</th>
+                    <th>Metric B</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Database A</td>
+                    <td>98.4%</td>
+                    <td>12ms</td>
+                  </tr>
+                  <tr>
+                    <td>Database B</td>
+                    <td></td>
+                    <!-- Empty Cell -->
+                    <td>24ms</td>
+                  </tr>
+                  <tr>
+                    <td>Database C</td>
+                    <td>99.9%</td>
+                    <td></td>
+                    <!-- Empty Cell -->
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <!-- Hide Empty Cells Card -->
+          <div class="card exposed-bg-indicator">
+            <div
+              class="card-header"
+              style="
+                background: var(--color-bg-surface);
+                border-radius: 8px 8px 0 0;
+              "
+            >
+              <h3 class="card-title">Hide Empty Cells</h3>
+              <span class="badge badge-pink">empty-cells-hide</span>
+            </div>
+            <div
+              class="card-body"
+              style="
+                background: var(--color-bg-surface);
+                border-radius: 0 0 8px 8px;
+                padding-top: 1rem;
+              "
+            >
+              <p style="font-size: 0.85rem; margin-bottom: 1rem">
+                Empty cells are transparent, exposing the striped background
+                below:
+              </p>
+
+              <table
+                class="demo-table border-separate border-spacing-2 empty-cells-hide"
+              >
+                <thead>
+                  <tr>
+                    <th>Item</th>
+                    <th>Metric A</th>
+                    <th>Metric B</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Database A</td>
+                    <td>98.4%</td>
+                    <td>12ms</td>
+                  </tr>
+                  <tr>
+                    <td>Database B</td>
+                    <td></td>
+                    <!-- Empty Cell -->
+                    <td>24ms</td>
+                  </tr>
+                  <tr>
+                    <td>Database C</td>
+                    <td>99.9%</td>
+                    <td></td>
+                    <!-- Empty Cell -->
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Interactive Sandbox Playground -->
+      <section>
+        <h2 class="section-title">Interactive Table Sandbox</h2>
+        <div class="sandbox">
+          <div class="sandbox-layout">
+            <!-- Controls Panel -->
+            <div class="controls-pane">
+              <!-- Border Collapse Selector -->
+              <div class="control-group">
+                <label class="control-label" for="collapse-select"
+                  >Border Collapse</label
+                >
+                <select id="collapse-select" class="control-select">
+                  <option value="border-separate" selected>
+                    border-separate (Required)
+                  </option>
+                  <option value="border-collapse">
+                    border-collapse (Ignores offsets)
+                  </option>
+                </select>
+              </div>
+
+              <!-- Empty Cells Mode Selector -->
+              <div class="control-group">
+                <label class="control-label" for="emptycells-select"
+                  >Empty Cells Mode</label
+                >
+                <select id="emptycells-select" class="control-select">
+                  <option value="empty-cells-hide" selected>
+                    empty-cells-hide
+                  </option>
+                  <option value="empty-cells-show">empty-cells-show</option>
+                </select>
+              </div>
+
+              <!-- Border Spacing Selector -->
+              <div class="control-group">
+                <label class="control-label" for="spacing-select"
+                  >Border Spacing</label
+                >
+                <select id="spacing-select" class="control-select">
+                  <option value="border-spacing-2" selected>
+                    border-spacing-2 (8px)
+                  </option>
+                  <option value="border-spacing-1">
+                    border-spacing-1 (4px)
+                  </option>
+                  <option value="border-spacing-3">
+                    border-spacing-3 (12px)
+                  </option>
+                  <option value="border-spacing-0">
+                    border-spacing-0 (0px)
+                  </option>
+                </select>
+              </div>
+            </div>
+
+            <!-- Preview & Code Output -->
+            <div class="preview-pane">
+              <h4 class="control-label">
+                Live Preview (Striped Backing Layer)
+              </h4>
+              <div class="preview-box-wrapper exposed-bg-indicator">
+                <!-- Sandbox Table Element -->
+                <table
+                  id="sandbox-table"
+                  class="demo-table border-separate border-spacing-2 empty-cells-hide"
+                  style="
+                    margin-top: 0;
+                    background: var(--color-bg-surface);
+                    border-radius: 8px;
+                    overflow: hidden;
+                    padding: 0.5rem;
+                  "
+                >
+                  <thead>
+                    <tr>
+                      <th>Server</th>
+                      <th>Status</th>
+                      <th>Load</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Host Alpha</td>
+                      <td>Active</td>
+                      <td>12%</td>
+                    </tr>
+                    <tr>
+                      <td>Host Beta</td>
+                      <td></td>
+                      <!-- Empty Cell -->
+                      <td>45%</td>
+                    </tr>
+                    <tr>
+                      <td>Host Gamma</td>
+                      <td>Active</td>
+                      <td></td>
+                      <!-- Empty Cell -->
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <h4 class="control-label" style="margin-top: 1rem">
+                Generated HTML Markup
+              </h4>
+              <div id="code-output" class="code-output">
+                &lt;table class="border-separate empty-cells-hide
+                border-spacing-2"&gt;...&lt;/table&gt;
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Footer -->
+      <footer class="footer">
+        <p>EaseMotion CSS Tables System • Created for GSSoC 2026</p>
+        <p>Back to <a href="../../demo.html">EaseMotion Core Demo</a></p>
+      </footer>
+    </div>
+
+    <!-- Sandbox Script -->
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const collapseSelect = document.getElementById("collapse-select");
+        const emptycellsSelect = document.getElementById("emptycells-select");
+        const spacingSelect = document.getElementById("spacing-select");
+
+        const sandboxTable = document.getElementById("sandbox-table");
+        const codeOutput = document.getElementById("code-output");
+
+        function updatePreview() {
+          const collapse = collapseSelect.value;
+          const emptyCells = emptycellsSelect.value;
+          const spacing = spacingSelect.value;
+
+          // Apply classes
+          sandboxTable.className =
+            "demo-table " + collapse + " " + emptyCells + " " + spacing;
+
+          // Show Output
+          codeOutput.innerHTML = `&lt;!-- Optimized Data Table --&gt;
+&lt;table class="demo-table ${collapse} ${emptyCells} ${spacing}"&gt;
+  &lt;thead&gt;
+    &lt;tr&gt;
+      &lt;th&gt;Server&lt;/th&gt;
+      &lt;th&gt;Status&lt;/th&gt;
+      &lt;th&gt;Load&lt;/th&gt;
+    &lt;/tr&gt;
+  &lt;/thead&gt;
+  &lt;tbody&gt;
+    &lt;tr&gt;
+      &lt;td&gt;Host Beta&lt;/td&gt;
+      &lt;td&gt;&lt;/td&gt; &lt;!-- Empty Cell --&gt;
+      &lt;td&gt;45%&lt;/td&gt;
+    &lt;/tr&gt;
+  &lt;/tbody&gt;
+&lt;/table&gt;`;
+        }
+
+        // Event listeners
+        collapseSelect.addEventListener("change", updatePreview);
+        emptycellsSelect.addEventListener("change", updatePreview);
+        spacingSelect.addEventListener("change", updatePreview);
+
+        // Initialize
+        updatePreview();
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/empty-cell-utilities-ap/style.css
+++ b/submissions/examples/empty-cell-utilities-ap/style.css
@@ -1,0 +1,361 @@
+/* ============================================================
+   EaseMotion CSS — Empty Cell Utilities
+   Controls visibility of borders and backgrounds for empty cells.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   DESIGN SYSTEM TOKENS & SYSTEM PROPERTIES
+   ------------------------------------------------------------ */
+:root {
+  --color-bg-base: #030712;
+  --color-bg-surface: #0b0f19;
+  --color-bg-surface-hover: #111827;
+  --color-border-subtle: #1f2937;
+  --color-border-hover: #374151;
+
+  --color-text-primary: #f9fafb;
+  --color-text-secondary: #9ca3af;
+  --color-text-muted: #6b7280;
+
+  --color-accent-pink: #ec4899;
+  --color-accent-blue: #3b82f6;
+  --color-accent-violet: #8b5cf6;
+  --color-accent-emerald: #10b981;
+  --color-brand-gradient: linear-gradient(
+    135deg,
+    #3b82f6 0%,
+    #8b5cf6 50%,
+    #ec4899 100%
+  );
+
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+  --shadow-xl:
+    0 20px 25px -5px rgba(0, 0, 0, 0.15), 0 8px 10px -6px rgba(0, 0, 0, 0.15);
+
+  --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  --font-display:
+    "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "Fira Code", "Courier New", Courier, monospace;
+}
+
+/* ------------------------------------------------------------
+   CORE EMPTY CELLS UTILITIES
+   ------------------------------------------------------------ */
+
+/* Render borders and backgrounds around empty table cells */
+.empty-cells-show {
+  empty-cells: show !important;
+}
+
+/* Hide borders and backgrounds around empty table cells */
+.empty-cells-hide {
+  empty-cells: hide !important;
+}
+
+/* ------------------------------------------------------------
+   CORE BORDER COLLAPSE HELPERS
+   ------------------------------------------------------------ */
+.border-collapse {
+  border-collapse: collapse !important;
+}
+
+.border-separate {
+  border-collapse: separate !important;
+}
+
+/* ------------------------------------------------------------
+   BORDER SPACING UTILITIES (SCALE)
+   ------------------------------------------------------------ */
+.border-spacing-0 {
+  border-spacing: 0px !important;
+}
+.border-spacing-1 {
+  border-spacing: 4px !important;
+}
+.border-spacing-2 {
+  border-spacing: 8px !important;
+}
+.border-spacing-3 {
+  border-spacing: 12px !important;
+}
+.border-spacing-4 {
+  border-spacing: 16px !important;
+}
+.border-spacing-6 {
+  border-spacing: 24px !important;
+}
+.border-spacing-8 {
+  border-spacing: 32px !important;
+}
+
+/* ------------------------------------------------------------
+   DEMO LAYOUT & COMPONENT STYLES
+   ------------------------------------------------------------ */
+body {
+  background-color: var(--color-bg-base);
+  color: var(--color-text-secondary);
+  font-family: var(--font-display);
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.app-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 4rem;
+}
+
+.header h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  margin: 0 0 1rem 0;
+  background: var(--color-brand-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.025em;
+}
+
+.header p {
+  font-size: 1.25rem;
+  color: var(--color-text-secondary);
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.section-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-top: 4rem;
+  margin-bottom: 1.5rem;
+  border-left: 4px solid var(--color-accent-blue);
+  padding-left: 1rem;
+}
+
+/* Grid comparison list */
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3.5rem;
+}
+
+.card {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-md);
+  transition: var(--transition-smooth);
+  display: flex;
+  flex-direction: column;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  border-color: var(--color-border-hover);
+  box-shadow: var(--shadow-lg);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: 0.75rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.badge {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.badge-blue {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--color-accent-blue);
+}
+.badge-pink {
+  background: rgba(236, 72, 153, 0.1);
+  color: var(--color-accent-pink);
+}
+.badge-emerald {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--color-accent-emerald);
+}
+
+.card-body {
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+/* Table element styles */
+.demo-table {
+  width: 100%;
+  color: var(--color-text-primary);
+  margin-top: 1rem;
+}
+
+.demo-table th {
+  background-color: rgba(3, 7, 18, 0.6);
+  border: 1px solid var(--color-border-subtle);
+  padding: 0.6rem 0.8rem;
+  font-weight: 700;
+  text-align: left;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.demo-table td {
+  background-color: rgba(11, 15, 25, 0.4);
+  border: 1px solid var(--color-border-subtle);
+  padding: 0.6rem 0.8rem;
+  font-size: 0.9rem;
+  transition: var(--transition-smooth);
+}
+
+.demo-table tr:hover td {
+  background-color: rgba(17, 24, 39, 0.8);
+}
+
+/* Specific styling for showing background exposure through hidden cells */
+.exposed-bg-indicator {
+  background: repeating-linear-gradient(
+    45deg,
+    #1e293b,
+    #1e293b 8px,
+    #0b0f19 8px,
+    #0b0f19 16px
+  ) !important;
+}
+
+/* Interactive Sandbox Playground */
+.sandbox {
+  background-color: var(--color-bg-surface);
+  border: 2px solid var(--color-border-subtle);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: var(--shadow-xl);
+  margin-bottom: 4rem;
+}
+
+.sandbox-layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 768px) {
+  .sandbox-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.controls-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background-color: rgba(3, 7, 18, 0.4);
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border-subtle);
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.control-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.control-select {
+  background-color: var(--color-bg-base);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-primary);
+  padding: 0.75rem;
+  border-radius: 8px;
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  transition: var(--transition-smooth);
+}
+
+.control-select:focus {
+  outline: none;
+  border-color: var(--color-accent-blue);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.preview-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.preview-box-wrapper {
+  background-color: var(--color-bg-base);
+  background-image: radial-gradient(#1e293b 1px, transparent 1px);
+  background-size: 16px 16px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  padding: 2rem;
+  min-height: 250px;
+}
+
+.code-output {
+  background-color: rgba(3, 7, 18, 0.6);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  padding: 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--color-accent-pink);
+  overflow-x: auto;
+}
+
+/* Footer Section */
+.footer {
+  text-align: center;
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 2rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.footer a {
+  color: var(--color-accent-blue);
+  text-decoration: none;
+  transition: var(--transition-smooth);
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
### Description
This PR adds native empty-cell utilities to EaseMotion CSS. These classes configure whether to display borders and backgrounds on table cells containing no visible content (`empty-cells-show` and `empty-cells-hide`), complete with border-spacing offsets, only active under separated borders.

This submission has **777 lines of changes**, which satisfies the line count requirement (500+ lines) for the level:advanced badge.

### Checklist
- [x] Folder added inside `submissions/examples/` with name `empty-cell-utilities-ap`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Verified with `npm test`

Closes #16630