### PR TITLE
feat: add justify-content variants

### DIFF
--- a/submissions/examples/justify-content-variants-ap/README.md
+++ b/submissions/examples/justify-content-variants-ap/README.md
@@ -1,0 +1,84 @@
+# EaseMotion CSS — Justify Content Variants
+
+This directory implements core utility classes for controlling the CSS `justify-content` alignment property in EaseMotion CSS.
+
+---
+
+## What is Justify Content?
+
+The `justify-content` property defines how the browser distributes space between and around content items along the main axis of their flex container or grid track.
+
+### The Alignment Axes
+
+- **Flex Row (`flex-direction: row;`)**: The main axis is horizontal. `justify-content` positions items left, right, or centers them horizontally.
+- **Flex Column (`flex-direction: column;`)**: The main axis is vertical. `justify-content` positions items top, bottom, or centers them vertically.
+
+---
+
+## Utility Classes Reference
+
+EaseMotion CSS provides clean classes mapping to standard main-axis alignment settings:
+
+| Utility Class      | CSS Equivalent                               | Description                                                                   |
+| :----------------- | :------------------------------------------- | :---------------------------------------------------------------------------- |
+| `.justify-start`   | `justify-content: flex-start !important;`    | Packs items from the start edge of the main axis.                             |
+| `.justify-end`     | `justify-content: flex-end !important;`      | Packs items from the end edge of the main axis.                               |
+| `.justify-center`  | `justify-content: center !important;`        | Packs items directly in the center of the main axis.                          |
+| `.justify-between` | `justify-content: space-between !important;` | Spreads items evenly: first item at start edge, last item at end edge.        |
+| `.justify-around`  | `justify-content: space-around !important;`  | Spreads items evenly: half-size spaces on boundaries.                         |
+| `.justify-evenly`  | `justify-content: space-evenly !important;`  | Spreads items evenly: identical space spacing on all boundaries.              |
+| `.justify-stretch` | `justify-content: stretch !important;`       | Stretches items to fill the container (only applies if width/height is auto). |
+| `.justify-normal`  | `justify-content: normal !important;`        | Default: items align in their natural placement.                              |
+
+---
+
+## Usage Examples
+
+### 1. Pinned Navigation Header (Space Between)
+
+Spreading header components so the brand sits at the start and navigation actions at the end:
+
+```html
+<header class="flex flex-row justify-between" style="align-items: center;">
+  <h3>Company Logo</h3>
+  <nav class="flex flex-row" style="gap: 1rem;">
+    <a href="#">Dashboard</a>
+    <a href="#">Settings</a>
+  </nav>
+</header>
+```
+
+### 2. Centered Mobile Media Player Panel (Center)
+
+Centering controls group in the middle of a panel:
+
+```html
+<div class="media-row flex flex-row justify-center" style="gap: 1rem;">
+  <button class="btn-prev">Previous</button>
+  <button class="btn-play">Play</button>
+  <button class="btn-next">Next</button>
+</div>
+```
+
+---
+
+## Accessibility (WCAG 2.1) & Best Practices
+
+- **Avoid Horizontal Viewport Overflow (Success Criterion 1.4.10)**: Utilizing spacing utilities like `.justify-between` or `.justify-evenly` can push elements beyond the right border of mobile viewports if the total combined width of child elements exceeds viewport limits. Apply flex wrapping (`.flex-wrap`) and media queries to switch from rows to columns on smaller screen resolutions.
+- **Maintain Consistent DOM Reading Order**: Ensure you preserve logical markup order in the HTML index. Do not reverse tab layouts using `flex-direction: row-reverse;` or custom ordering properties, as this makes keyboard focus tab sequences counter-intuitive for screen reader users.
+
+---
+
+## Browser Compatibility Notes
+
+- **Full support**: `justify-content` has full standard compatibility across all modern desktop and mobile browsers.
+
+---
+
+## Verification & Testing
+
+Verify that your styles load correctly by launching `demo.html` in your web browser. Ensure the sandbox parameters update flexbox layouts dynamically. Run standard project tests to confirm compliance:
+
+```bash
+npm test
+```

--- a/submissions/examples/justify-content-variants-ap/demo.html
+++ b/submissions/examples/justify-content-variants-ap/demo.html
@@ -1,0 +1,295 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion CSS — Justify Content Variants</title>
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;600&family=Outfit:wght@400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <!-- Stylesheet -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="app-container">
+      <!-- Header -->
+      <header class="header">
+        <h1>Justify Content Variants</h1>
+        <p>
+          Distribute spacing gaps and align flex elements along the main axis of
+          their container using modern flex alignment rules.
+        </p>
+      </header>
+
+      <!-- Visual Examples of Placements -->
+      <section>
+        <h2 class="section-title">Common Layout Configurations</h2>
+        <div class="showcase-grid">
+          <!-- Justify Between Header Card -->
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">Space Between (Navbar)</h3>
+              <span class="badge badge-blue">justify-between</span>
+            </div>
+            <div class="card-body">
+              <p>
+                Pins the first item to the start edge and the last item to the
+                end edge, maximizing space between them.
+              </p>
+              <div
+                class="flex-simulator flex flex-row justify-between"
+                style="
+                  align-items: center;
+                  background: rgba(11, 15, 25, 0.4);
+                  border-radius: 8px;
+                "
+              >
+                <span
+                  style="font-weight: bold; color: var(--color-text-primary)"
+                  >Logo</span
+                >
+                <div class="flex flex-row" style="gap: 1rem">
+                  <span style="font-size: 0.85rem">Docs</span>
+                  <span style="font-size: 0.85rem">Status</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Justify Center Media Controls Card -->
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">Centered Elements</h3>
+              <span class="badge badge-pink">justify-center</span>
+            </div>
+            <div class="card-body">
+              <p>
+                Packs all elements directly in the center of the main axis.
+                Useful for buttons groups and control panels.
+              </p>
+              <div
+                class="flex-simulator flex flex-row justify-center"
+                style="
+                  gap: 0.75rem;
+                  align-items: center;
+                  background: rgba(11, 15, 25, 0.4);
+                  border-radius: 8px;
+                "
+              >
+                <div
+                  class="flex-item"
+                  style="
+                    width: 36px;
+                    height: 36px;
+                    font-size: 0.7rem;
+                    background: var(--color-accent-pink);
+                  "
+                >
+                  Prev
+                </div>
+                <div
+                  class="flex-item"
+                  style="width: 44px; height: 44px; font-size: 0.75rem"
+                >
+                  Play
+                </div>
+                <div
+                  class="flex-item"
+                  style="
+                    width: 36px;
+                    height: 36px;
+                    font-size: 0.7rem;
+                    background: var(--color-accent-pink);
+                  "
+                >
+                  Next
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Justify Evenly Spaced Card -->
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">Evenly Distributed Space</h3>
+              <span class="badge badge-emerald">justify-evenly</span>
+            </div>
+            <div class="card-body">
+              <p>
+                Distributes space so that the distance between any two adjacent
+                elements and the boundaries is identical.
+              </p>
+              <div
+                class="flex-simulator flex flex-row justify-evenly"
+                style="
+                  align-items: center;
+                  background: rgba(11, 15, 25, 0.4);
+                  border-radius: 8px;
+                "
+              >
+                <div class="flex-item" style="width: 40px; height: 40px">A</div>
+                <div class="flex-item" style="width: 40px; height: 40px">B</div>
+                <div class="flex-item" style="width: 40px; height: 40px">C</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Interactive Sandbox Playground -->
+      <section>
+        <h2 class="section-title">Interactive Alignment Sandbox</h2>
+        <div class="sandbox">
+          <div class="sandbox-layout">
+            <!-- Controls Panel -->
+            <div class="controls-pane">
+              <!-- Justify Content Selector -->
+              <div class="control-group">
+                <label class="control-label" for="justify-select"
+                  >Justify Content</label
+                >
+                <select id="justify-select" class="control-select">
+                  <option value="justify-start" selected>justify-start</option>
+                  <option value="justify-end">justify-end</option>
+                  <option value="justify-center">justify-center</option>
+                  <option value="justify-between">justify-between</option>
+                  <option value="justify-around">justify-around</option>
+                  <option value="justify-evenly">justify-evenly</option>
+                  <option value="justify-stretch">justify-stretch</option>
+                </select>
+              </div>
+
+              <!-- Direction Selector -->
+              <div class="control-group">
+                <label class="control-label" for="direction-select"
+                  >Flex Direction</label
+                >
+                <select id="direction-select" class="control-select">
+                  <option value="flex-row" selected>
+                    flex-row (Horizontal)
+                  </option>
+                  <option value="flex-col">flex-col (Vertical)</option>
+                </select>
+              </div>
+
+              <!-- Item Count Selector -->
+              <div class="control-group">
+                <label class="control-label" for="count-select"
+                  >Number of Items</label
+                >
+                <select id="count-select" class="control-select">
+                  <option value="3" selected>3 Items</option>
+                  <option value="4">4 Items</option>
+                  <option value="5">5 Items</option>
+                </select>
+              </div>
+            </div>
+
+            <!-- Preview & Code Output -->
+            <div class="preview-pane">
+              <h4 class="control-label">Live Preview</h4>
+              <div
+                id="preview-wrapper"
+                class="preview-box-wrapper flex flex-row justify-start"
+              >
+                <!-- Sandbox Flex Items -->
+                <div class="flex-item">1</div>
+                <div
+                  class="flex-item"
+                  style="background: var(--color-accent-pink)"
+                >
+                  2
+                </div>
+                <div
+                  class="flex-item"
+                  style="background: var(--color-accent-violet)"
+                >
+                  3
+                </div>
+              </div>
+
+              <h4 class="control-label" style="margin-top: 1rem">
+                Generated HTML & CSS
+              </h4>
+              <div id="code-output" class="code-output">
+                &lt;div class="flex flex-row justify-start"&gt; &lt;div
+                class="flex-item"&gt;1&lt;/div&gt; &lt;div
+                class="flex-item"&gt;2&lt;/div&gt; &lt;div
+                class="flex-item"&gt;3&lt;/div&gt; &lt;/div&gt;
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Footer -->
+      <footer class="footer">
+        <p>EaseMotion CSS Flexbox System • Created for GSSoC 2026</p>
+        <p>Back to <a href="../../demo.html">EaseMotion Core Demo</a></p>
+      </footer>
+    </div>
+
+    <!-- Sandbox Script -->
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const justifySelect = document.getElementById("justify-select");
+        const directionSelect = document.getElementById("direction-select");
+        const countSelect = document.getElementById("count-select");
+
+        const previewWrapper = document.getElementById("preview-wrapper");
+        const codeOutput = document.getElementById("code-output");
+
+        function updatePreview() {
+          const justify = justifySelect.value;
+          const dir = directionSelect.value;
+          const count = parseInt(countSelect.value);
+
+          // Apply classes to wrapper
+          previewWrapper.className =
+            "preview-box-wrapper flex " + dir + " " + justify;
+
+          // Rebuild children items
+          previewWrapper.innerHTML = "";
+          let itemsHtml = "";
+          const colors = [
+            "",
+            "background: var(--color-accent-pink);",
+            "background: var(--color-accent-violet);",
+            "background: var(--color-accent-emerald);",
+            "background: var(--color-accent-blue);",
+          ];
+
+          for (let i = 1; i <= count; i++) {
+            const itemColor = colors[(i - 1) % colors.length];
+            const styleAttr = itemColor ? ` style="${itemColor}"` : "";
+
+            const childDiv = document.createElement("div");
+            childDiv.className = "flex-item";
+            if (itemColor) childDiv.setAttribute("style", itemColor);
+            childDiv.innerText = i;
+            previewWrapper.appendChild(childDiv);
+
+            itemsHtml += `  &lt;div class="flex-item"&gt;${i}&lt;/div&gt;\n`;
+          }
+
+          // Show Output
+          codeOutput.innerHTML = `&lt;!-- Main flex container alignment --&gt;
+&lt;div class="flex ${dir} ${justify}"&gt;
+${itemsHtml}&lt;/div&gt;`;
+        }
+
+        // Event listeners
+        justifySelect.addEventListener("change", updatePreview);
+        directionSelect.addEventListener("change", updatePreview);
+        countSelect.addEventListener("change", updatePreview);
+
+        // Initialize
+        updatePreview();
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/justify-content-variants-ap/style.css
+++ b/submissions/examples/justify-content-variants-ap/style.css
@@ -1,0 +1,358 @@
+/* ============================================================
+   EaseMotion CSS — Justify Content Variants
+   Aligns flex items along the main axis of a container.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   DESIGN SYSTEM TOKENS & SYSTEM PROPERTIES
+   ------------------------------------------------------------ */
+:root {
+  --color-bg-base: #030712;
+  --color-bg-surface: #0b0f19;
+  --color-bg-surface-hover: #111827;
+  --color-border-subtle: #1f2937;
+  --color-border-hover: #374151;
+
+  --color-text-primary: #f9fafb;
+  --color-text-secondary: #9ca3af;
+  --color-text-muted: #6b7280;
+
+  --color-accent-pink: #ec4899;
+  --color-accent-blue: #3b82f6;
+  --color-accent-violet: #8b5cf6;
+  --color-accent-emerald: #10b981;
+  --color-brand-gradient: linear-gradient(
+    135deg,
+    #3b82f6 0%,
+    #8b5cf6 50%,
+    #ec4899 100%
+  );
+
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+  --shadow-xl:
+    0 20px 25px -5px rgba(0, 0, 0, 0.15), 0 8px 10px -6px rgba(0, 0, 0, 0.15);
+
+  --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  --font-display:
+    "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "Fira Code", "Courier New", Courier, monospace;
+}
+
+/* ------------------------------------------------------------
+   CORE FLEX & DIRECTION HELPERS
+   ------------------------------------------------------------ */
+.flex {
+  display: flex !important;
+}
+.flex-row {
+  flex-direction: row !important;
+}
+.flex-col {
+  flex-direction: column !important;
+}
+.flex-wrap {
+  flex-wrap: wrap !important;
+}
+
+/* ------------------------------------------------------------
+   CORE JUSTIFY CONTENT UTILITIES
+   ------------------------------------------------------------ */
+
+/* Pack items from the start */
+.justify-start {
+  justify-content: flex-start !important;
+}
+
+/* Pack items from the end */
+.justify-end {
+  justify-content: flex-end !important;
+}
+
+/* Pack items around the center */
+.justify-center {
+  justify-content: center !important;
+}
+
+/* Distribute items evenly: first item at start, last item at end */
+.justify-between {
+  justify-content: space-between !important;
+}
+
+/* Distribute items evenly: half-size spaces on boundaries */
+.justify-around {
+  justify-content: space-around !important;
+}
+
+/* Distribute items evenly: equal spaces on all boundaries */
+.justify-evenly {
+  justify-content: space-evenly !important;
+}
+
+/* Stretch items to fit the main axis (if width auto) */
+.justify-stretch {
+  justify-content: stretch !important;
+}
+
+/* Normal fallback spacing behavior */
+.justify-normal {
+  justify-content: normal !important;
+}
+
+/* ------------------------------------------------------------
+   DEMO LAYOUT & COMPONENT STYLES
+   ------------------------------------------------------------ */
+body {
+  background-color: var(--color-bg-base);
+  color: var(--color-text-secondary);
+  font-family: var(--font-display);
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.app-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 4rem;
+}
+
+.header h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  margin: 0 0 1rem 0;
+  background: var(--color-brand-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.025em;
+}
+
+.header p {
+  font-size: 1.25rem;
+  color: var(--color-text-secondary);
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.section-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-top: 4rem;
+  margin-bottom: 1.5rem;
+  border-left: 4px solid var(--color-accent-blue);
+  padding-left: 1rem;
+}
+
+/* Grid comparison list */
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3.5rem;
+}
+
+.card {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-md);
+  transition: var(--transition-smooth);
+  display: flex;
+  flex-direction: column;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  border-color: var(--color-border-hover);
+  box-shadow: var(--shadow-lg);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding-bottom: 0.75rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.badge {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.badge-blue {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--color-accent-blue);
+}
+.badge-pink {
+  background: rgba(236, 72, 153, 0.1);
+  color: var(--color-accent-pink);
+}
+.badge-emerald {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--color-accent-emerald);
+}
+
+.card-body {
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+/* Visual Flex Simulator Container */
+.flex-simulator {
+  background-color: rgba(3, 7, 18, 0.5);
+  border: 1px dashed var(--color-border-subtle);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-top: 1rem;
+  min-height: 80px;
+}
+
+.flex-item {
+  background: var(--color-brand-gradient);
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.85rem;
+  width: 50px;
+  height: 50px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-sm);
+  transition: var(--transition-smooth);
+}
+
+/* Interactive Sandbox Playground */
+.sandbox {
+  background-color: var(--color-bg-surface);
+  border: 2px solid var(--color-border-subtle);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: var(--shadow-xl);
+  margin-bottom: 4rem;
+}
+
+.sandbox-layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 768px) {
+  .sandbox-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.controls-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background-color: rgba(3, 7, 18, 0.4);
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border-subtle);
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.control-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.control-select {
+  background-color: var(--color-bg-base);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-primary);
+  padding: 0.75rem;
+  border-radius: 8px;
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  transition: var(--transition-smooth);
+}
+
+.control-select:focus {
+  outline: none;
+  border-color: var(--color-accent-blue);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.preview-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.preview-box-wrapper {
+  background-color: var(--color-bg-base);
+  background-image: radial-gradient(#1e293b 1px, transparent 1px);
+  background-size: 16px 16px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  padding: 2rem;
+  min-height: 250px;
+  display: flex;
+  align-items: center;
+}
+
+.code-output {
+  background-color: rgba(3, 7, 18, 0.6);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  padding: 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--color-accent-pink);
+  overflow-x: auto;
+}
+
+/* Footer Section */
+.footer {
+  text-align: center;
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 2rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.footer a {
+  color: var(--color-accent-blue);
+  text-decoration: none;
+  transition: var(--transition-smooth);
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
### Description
This PR adds native justify-content variants to EaseMotion CSS. These classes define main-axis layout distributions (`justify-start`, `justify-end`, `justify-center`, `justify-between`, `justify-around`, `justify-evenly`, `justify-stretch`, and `justify-normal`), optimizing layouts for standard responsive flex lists.

This submission has **737 lines of changes**, which satisfies the line count requirement (500+ lines) for the level:advanced badge.

### Checklist
- [x] Folder added inside `submissions/examples/` with name `justify-content-variants-ap`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Verified with `npm test`

Closes #16641