### PR TITLE
feat: manual implementation of starting-style utilities #18560

### DIFF
--- a/submissions/examples/starting-style-unique-18560/README.md
+++ b/submissions/examples/starting-style-unique-18560/README.md
@@ -1,0 +1,2 @@
+# Starting-Style Utilities
+Manual implementation for #18560. Provides utility patterns for using @starting-style to animate element entry states.

--- a/submissions/examples/starting-style-unique-18560/demo.html
+++ b/submissions/examples/starting-style-unique-18560/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="content" class="reveal-box">Animated Content</div>
+  <button onclick="document.getElementById('content').classList.add('is-active')">
+    Trigger Entrance
+  </button>
+</body>
+</html>

--- a/submissions/examples/starting-style-unique-18560/style.css
+++ b/submissions/examples/starting-style-unique-18560/style.css
@@ -1,0 +1,20 @@
+/* Starting-style utilities for #18560 */
+
+.reveal-box {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s, transform 0.6s;
+}
+
+.reveal-box.is-active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Use @starting-style to animate the element when it first appears */
+@starting-style {
+  .reveal-box.is-active {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `@starting-style` utilities (Issue #18560). These tokens allow developers to define entry animations for elements appearing in the DOM, solving the long-standing limitation of animating transitions for newly rendered or toggled elements.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/starting-style-unique-18560/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Adds support for `@starting-style` to enable entry transitions.
- Demonstrates usage with opacity and transform-based entry animations.

Closes #18560