### PR TITLE
feat: manual implementation of interpolate-size utilities #18556

### DIFF
--- a/submissions/examples/interpolate-size-unique-18556/README.md
+++ b/submissions/examples/interpolate-size-unique-18556/README.md
@@ -1,0 +1,2 @@
+# Interpolate-Size Utilities
+Manual implementation for #18556. Provides utility examples for leveraging interpolate-size: allow-keywords.

--- a/submissions/examples/interpolate-size-unique-18556/demo.html
+++ b/submissions/examples/interpolate-size-unique-18556/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button onclick="document.querySelector('.expandable').classList.toggle('is-open')">Toggle Expand</button>
+  <div class="expandable">
+    <p>This content box will smoothly animate from 50px to its auto-calculated height.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/interpolate-size-unique-18556/style.css
+++ b/submissions/examples/interpolate-size-unique-18556/style.css
@@ -1,0 +1,17 @@
+/* Interpolate-size utilities for #18556 */
+
+:root {
+  /* Enable interpolation for keywords like 'auto' */
+  interpolate-size: allow-keywords;
+}
+
+.expandable {
+  height: 50px;
+  overflow: hidden;
+  background: #f1f5f9;
+  transition: height 0.5s ease-in-out;
+}
+
+.expandable.is-open {
+  height: auto;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `interpolate-size` utilities (Issue #18556). These tokens allow developers to transition elements to `height: auto` or `width: auto` smoothly, resolving a classic pain point in responsive web development.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/interpolate-size-unique-18556/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Enables `interpolate-size: allow-keywords` in the root scope.
- Provides patterns for auto-height transition components.

Closes #18556