### PR TITLE
feat: manual implementation of starting-style utilities #18565

### DIFF
--- a/submissions/examples/starting-style-unique-18565/README.md
+++ b/submissions/examples/starting-style-unique-18565/README.md
@@ -1,0 +1,2 @@
+# Starting-Style Utilities
+Manual implementation for #18565. Provides patterns for animating element entry states using @starting-style.

--- a/submissions/examples/starting-style-unique-18565/demo.html
+++ b/submissions/examples/starting-style-unique-18565/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button id="toggleBtn">Toggle Content</button>
+  <div id="content" class="fade-box">Smoothly appearing content</div>
+
+  <script>
+    document.getElementById('toggleBtn').onclick = () => {
+      document.getElementById('content').classList.toggle('is-open');
+    };
+  </script>
+</body>
+</html>

--- a/submissions/examples/starting-style-unique-18565/style.css
+++ b/submissions/examples/starting-style-unique-18565/style.css
@@ -1,0 +1,17 @@
+/* Starting-style utilities for #18565 */
+
+.fade-box {
+  opacity: 0;
+  transition: opacity 0.4s ease-in-out;
+}
+
+.fade-box.is-open {
+  opacity: 1;
+}
+
+/* Define the starting state for the entry animation */
+@starting-style {
+  .fade-box.is-open {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements `@starting-style` utilities (Issue #18565). These tokens allow developers to define entry transitions for elements that are toggled in the DOM, solving the classic issue where animations fail to trigger during initial rendering or display state changes.

---

## Type of Change
- [x] ✨ New feature/utility submission

## Submission Checklist
- [x] All changes are inside `submissions/examples/starting-style-unique-18565/`
- [x] No modifications to existing `core/` or `components/` files.

## Feature Description
- Adds support for `@starting-style` to enable entry transitions.
- Demonstrates usage with opacity-based entry animations.

Closes #18565