### PR TITLE
feat: Added prefers-reduced-motion pattern

### DIFF
--- a/submissions/ease-reduced-motion-demo-aryanm9026/README.md
+++ b/submissions/ease-reduced-motion-demo-aryanm9026/README.md
@@ -1,0 +1,53 @@
+# ease-reduced-motion-demo
+
+## 1. What does this do?
+
+A set of entrance and interaction animation components that correctly implement `prefers-reduced-motion` support — substituting motion with opacity transitions rather than disabling animations globally.
+
+## 2. How is it used?
+
+Add the class to any element. Animations trigger on page load. Use stagger helpers for sequential reveals.
+
+```html
+<div class="ease-slide-up">Slides up and fades in</div>
+<div class="ease-slide-left">Slides from left and fades in</div>
+<div class="ease-zoom-in">Scales up and fades in</div>
+<div class="ease-flip-in">Flips in on X axis and fades in</div>
+
+<div class="ease-slide-up ease-delay-1">First</div>
+<div class="ease-slide-up ease-delay-2">Second</div>
+<div class="ease-slide-up ease-delay-3">Third</div>
+
+<button class="ease-pulse-hover">Pulses on hover</button>
+
+<div class="ease-shimmer" style="height: 12px; border-radius: 6px;"></div>
+```
+
+When the OS `prefers-reduced-motion: reduce` setting is active, all motion is automatically replaced with a short opacity fade. No class changes needed.
+
+## 3. Why is it useful?
+
+EaseMotion CSS is an animation-first framework, but animations are an accessibility concern. Vestibular disorders, epilepsy, and motion sensitivity affect over 70 million users globally — for them, large translate/scale/rotate animations can cause dizziness, nausea, or seizures.
+
+The standard fix is `@media (prefers-reduced-motion: reduce) { * { animation: none !important; } }` — but this is the wrong approach. It silently breaks JavaScript that listens for `animationend` events, and it removes visual feedback entirely, making state changes invisible.
+
+**The correct pattern (used here):** replace motion with a short opacity fade. State changes remain perceivable. `animationend` still fires. The user gets a calmer experience without losing functionality.
+
+This submission is also intended as a **reference pattern** for how reduced-motion support should be applied across EaseMotion CSS. Every animation class in the framework can adopt this same two-layer structure:
+
+```css
+.ease-slide-up {
+  opacity: 0;
+  transform: translateY(32px);
+  animation: em-slideUp 0.5s ease forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-slide-up {
+    transform: none;
+    animation-name: em-fadeIn;
+  }
+}
+```
+
+This approach is compliant with **WCAG 2.1 Success Criterion 2.2.2 (Pause, Stop, Hide)**.

--- a/submissions/ease-reduced-motion-demo-aryanm9026/demo.html
+++ b/submissions/ease-reduced-motion-demo-aryanm9026/demo.html
@@ -1,0 +1,366 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — Reduced Motion Pattern Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      background: #0f172a;
+      color: #f1f5f9;
+      min-height: 100vh;
+      padding: 2rem 1rem 4rem;
+    }
+
+    .page-header {
+      text-align: center;
+      margin-bottom: 3rem;
+    }
+
+    .page-header h1 {
+      font-size: clamp(1.4rem, 4vw, 2rem);
+      font-weight: 700;
+      color: #f8fafc;
+      margin-bottom: 0.5rem;
+    }
+
+    .page-header p {
+      font-size: 0.9rem;
+      color: #94a3b8;
+      max-width: 520px;
+      margin: 0 auto 1.25rem;
+      line-height: 1.6;
+    }
+
+    .motion-banner {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 0.8rem;
+      font-weight: 600;
+      padding: 6px 14px;
+      border-radius: 99px;
+      border: 1px solid;
+    }
+
+    .motion-banner.full  { background: #0f3460; border-color: #3b82f6; color: #93c5fd; }
+    .motion-banner.reduced { background: #1a1a2e; border-color: #8b5cf6; color: #c4b5fd; }
+
+    .dot {
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      display: inline-block;
+    }
+
+    .dot-blue   { background: #3b82f6; }
+    .dot-purple { background: #8b5cf6; }
+
+    .section-label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: #475569;
+      margin-bottom: 1rem;
+    }
+
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      max-width: 900px;
+      margin: 0 auto 3rem;
+    }
+
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 14px;
+      padding: 1.25rem;
+    }
+
+    .card-icon {
+      width: 40px; height: 40px;
+      border-radius: 10px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 1.2rem;
+      margin-bottom: 0.85rem;
+    }
+
+    .card h3 { font-size: 0.95rem; font-weight: 600; margin-bottom: 0.35rem; color: #f1f5f9; }
+    .card p  { font-size: 0.8rem; color: #94a3b8; line-height: 1.5; }
+
+    .card-badge {
+      display: inline-block;
+      margin-top: 0.75rem;
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 3px 9px;
+      border-radius: 99px;
+      background: #0f3460;
+      color: #93c5fd;
+      border: 1px solid #1d4ed8;
+    }
+
+    .notif-list {
+      max-width: 420px;
+      margin: 0 auto 3rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .notif {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1rem;
+    }
+
+    .notif-dot {
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      margin-top: 4px;
+      flex-shrink: 0;
+    }
+
+    .notif-dot.green  { background: #22c55e; box-shadow: 0 0 6px #22c55e88; }
+    .notif-dot.blue   { background: #3b82f6; box-shadow: 0 0 6px #3b82f688; }
+    .notif-dot.amber  { background: #f59e0b; box-shadow: 0 0 6px #f59e0b88; }
+
+    .notif-title { font-size: 0.875rem; font-weight: 600; color: #f1f5f9; margin-bottom: 2px; }
+    .notif-body  { font-size: 0.78rem; color: #94a3b8; }
+
+    .shimmer-list {
+      max-width: 420px;
+      margin: 0 auto 3rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .shimmer-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .shimmer-avatar {
+      width: 44px; height: 44px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .shimmer-lines { flex: 1; display: flex; flex-direction: column; gap: 8px; }
+
+    .shimmer-line {
+      height: 12px;
+      border-radius: 6px;
+    }
+
+    .shimmer-line.short { width: 55%; }
+
+    .hover-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      justify-content: center;
+      max-width: 900px;
+      margin: 0 auto 3rem;
+    }
+
+    .hover-btn {
+      background: linear-gradient(135deg, #1d4ed8, #7c3aed);
+      border: none;
+      color: #fff;
+      font-size: 0.875rem;
+      font-weight: 600;
+      padding: 0.65rem 1.5rem;
+      border-radius: 10px;
+      cursor: pointer;
+    }
+
+    .replay-wrap {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+
+    .replay-btn {
+      background: transparent;
+      border: 1px solid #334155;
+      color: #94a3b8;
+      font-size: 0.8rem;
+      padding: 8px 20px;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: border-color 0.2s, color 0.2s;
+    }
+
+    .replay-btn:hover { border-color: #3b82f6; color: #93c5fd; }
+
+    .footer-note {
+      text-align: center;
+      font-size: 0.75rem;
+      color: #475569;
+      max-width: 480px;
+      margin: 0 auto;
+      line-height: 1.6;
+      border-top: 1px solid #1e293b;
+      padding-top: 2rem;
+    }
+
+    .hidden { display: none; }
+  </style>
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>EaseMotion CSS — Reduced Motion Pattern</h1>
+    <p>All animations below substitute motion with opacity when <code>prefers-reduced-motion: reduce</code> is active. No animation is hard-disabled — state changes stay visible.</p>
+    <div id="banner" class="motion-banner full">
+      <span class="dot dot-blue"></span>
+      <span id="banner-text">Full motion active</span>
+    </div>
+  </header>
+
+  <p class="section-label" style="text-align:center;">Entrance animations — slide, zoom, flip</p>
+  <div class="demo-grid" id="card-grid">
+
+    <div class="card ease-slide-up ease-delay-1">
+      <div class="card-icon" style="background:#0f3460;">🚀</div>
+      <h3>Slide up</h3>
+      <p>Enters by translating up 32px while fading in. Reduced: fade only.</p>
+      <span class="card-badge">.ease-slide-up</span>
+    </div>
+
+    <div class="card ease-slide-left ease-delay-2">
+      <div class="card-icon" style="background:#1a1a2e;">⚡</div>
+      <h3>Slide left</h3>
+      <p>Enters from the left while fading in. Reduced: fade only.</p>
+      <span class="card-badge">.ease-slide-left</span>
+    </div>
+
+    <div class="card ease-zoom-in ease-delay-3">
+      <div class="card-icon" style="background:#0d2137;">🎯</div>
+      <h3>Zoom in</h3>
+      <p>Scales from 88% to 100% while fading in. Reduced: fade only.</p>
+      <span class="card-badge">.ease-zoom-in</span>
+    </div>
+
+    <div class="card ease-flip-in ease-delay-4">
+      <div class="card-icon" style="background:#12102b;">✨</div>
+      <h3>Flip in</h3>
+      <p>Rotates in on X axis while fading. Reduced: fade only.</p>
+      <span class="card-badge">.ease-flip-in</span>
+    </div>
+
+  </div>
+
+  <p class="section-label" style="text-align:center;">Staggered entrance — notification list</p>
+  <div class="notif-list" id="notif-list">
+
+    <div class="notif ease-slide-up ease-delay-1">
+      <span class="notif-dot green"></span>
+      <div>
+        <p class="notif-title">Deployment successful</p>
+        <p class="notif-body">v2.4.1 is live on production.</p>
+      </div>
+    </div>
+
+    <div class="notif ease-slide-up ease-delay-2">
+      <span class="notif-dot blue"></span>
+      <div>
+        <p class="notif-title">New pull request</p>
+        <p class="notif-body">feat: add scroll-driven animations</p>
+      </div>
+    </div>
+
+    <div class="notif ease-slide-up ease-delay-3">
+      <span class="notif-dot amber"></span>
+      <div>
+        <p class="notif-title">Review requested</p>
+        <p class="notif-body">3 files changed — waiting for your approval.</p>
+      </div>
+    </div>
+
+  </div>
+
+  <p class="section-label" style="text-align:center;">Shimmer skeleton loader — sweep vs static tint</p>
+  <div class="shimmer-list">
+
+    <div class="shimmer-row">
+      <div class="shimmer-avatar ease-shimmer"></div>
+      <div class="shimmer-lines">
+        <div class="shimmer-line ease-shimmer"></div>
+        <div class="shimmer-line short ease-shimmer"></div>
+      </div>
+    </div>
+
+    <div class="shimmer-row">
+      <div class="shimmer-avatar ease-shimmer"></div>
+      <div class="shimmer-lines">
+        <div class="shimmer-line ease-shimmer"></div>
+        <div class="shimmer-line short ease-shimmer"></div>
+      </div>
+    </div>
+
+  </div>
+
+  <p class="section-label" style="text-align:center;">Hover animation — pulse scale (hover me)</p>
+  <div class="hover-row">
+    <button class="hover-btn ease-pulse-hover">Hover to pulse</button>
+    <button class="hover-btn ease-pulse-hover">Try this one too</button>
+    <button class="hover-btn ease-pulse-hover">And this one</button>
+  </div>
+
+  <div class="replay-wrap">
+    <button class="replay-btn" onclick="replayEntrances()">↺ Replay entrance animations</button>
+  </div>
+
+  <footer class="footer-note">
+    All animation classes use <code>@media (prefers-reduced-motion: reduce)</code> to substitute motion with a short opacity fade — never <code>animation: none</code>. This keeps <code>animationend</code> events firing and state changes visible. WCAG 2.1 SC 2.2.2 compliant.
+  </footer>
+
+  <script>
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const banner = document.getElementById('banner');
+    const bannerText = document.getElementById('banner-text');
+
+    function updateBanner(reduced) {
+      if (reduced) {
+        banner.className = 'motion-banner reduced';
+        banner.querySelector('.dot').className = 'dot dot-purple';
+        bannerText.textContent = 'Reduced motion active — opacity substitution in effect';
+      } else {
+        banner.className = 'motion-banner full';
+        banner.querySelector('.dot').className = 'dot dot-blue';
+        bannerText.textContent = 'Full motion active';
+      }
+    }
+
+    updateBanner(mq.matches);
+    mq.addEventListener('change', e => updateBanner(e.matches));
+
+    function replayEntrances() {
+      const zones = [
+        document.getElementById('card-grid'),
+        document.getElementById('notif-list')
+      ];
+      zones.forEach(zone => {
+        const items = zone.querySelectorAll('[class*="ease-slide"], [class*="ease-zoom"], [class*="ease-flip"]');
+        items.forEach(el => {
+          el.style.animation = 'none';
+          el.offsetHeight;
+          el.style.animation = '';
+        });
+      });
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/ease-reduced-motion-demo-aryanm9026/style.css
+++ b/submissions/ease-reduced-motion-demo-aryanm9026/style.css
@@ -1,0 +1,130 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --ease-dur-fast:   0.25s;
+  --ease-dur-normal: 0.5s;
+  --ease-dur-slow:   0.8s;
+  --ease-timing:     cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-fade-dur:   0.18s;       
+}
+
+.ease-slide-up {
+  opacity: 0;
+  transform: translateY(32px);
+  animation: em-slideUp var(--ease-dur-normal) var(--ease-timing) forwards;
+}
+
+@keyframes em-slideUp {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.ease-slide-left {
+  opacity: 0;
+  transform: translateX(-40px);
+  animation: em-slideLeft var(--ease-dur-normal) var(--ease-timing) forwards;
+}
+
+@keyframes em-slideLeft {
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.ease-zoom-in {
+  opacity: 0;
+  transform: scale(0.88);
+  animation: em-zoomIn var(--ease-dur-normal) var(--ease-timing) forwards;
+}
+
+@keyframes em-zoomIn {
+  to { opacity: 1; transform: scale(1); }
+}
+
+.ease-flip-in {
+  opacity: 0;
+  transform: rotateX(45deg) translateY(16px);
+  transform-origin: top center;
+  animation: em-flipIn var(--ease-dur-slow) var(--ease-timing) forwards;
+}
+
+@keyframes em-flipIn {
+  to { opacity: 1; transform: rotateX(0deg) translateY(0); }
+}
+
+.ease-delay-1 { animation-delay: 0.08s; }
+.ease-delay-2 { animation-delay: 0.16s; }
+.ease-delay-3 { animation-delay: 0.24s; }
+.ease-delay-4 { animation-delay: 0.32s; }
+.ease-delay-5 { animation-delay: 0.40s; }
+
+.ease-pulse-hover:hover {
+  animation: em-pulse 0.6s var(--ease-timing) both;
+}
+
+@keyframes em-pulse {
+  0%   { transform: scale(1); }
+  45%  { transform: scale(1.06); }
+  100% { transform: scale(1); }
+}
+
+.ease-shimmer {
+  position: relative;
+  overflow: hidden;
+  background: #e2e8f0;
+}
+
+.ease-shimmer::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.6) 50%, transparent 100%);
+  animation: em-shimmer 1.4s ease infinite;
+}
+
+@keyframes em-shimmer {
+  to { transform: translateX(100%); }
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+
+  :root {
+    --ease-dur-fast:   var(--ease-fade-dur);
+    --ease-dur-normal: var(--ease-fade-dur);
+    --ease-dur-slow:   var(--ease-fade-dur);
+  }
+
+  .ease-slide-up {
+    transform: none;
+    animation-name: em-fadeIn;
+  }
+
+  .ease-slide-left {
+    transform: none;
+    animation-name: em-fadeIn;
+  }
+
+  .ease-zoom-in {
+    transform: none;
+    animation-name: em-fadeIn;
+  }
+
+  .ease-flip-in {
+    transform: none;
+    animation-name: em-fadeIn;
+  }
+
+  .ease-pulse-hover:hover {
+    animation: none;
+    transform: none;
+  }
+
+  .ease-shimmer::after {
+    animation: none;
+    transform: none;
+    background: rgba(255,255,255,0.3);
+  }
+
+  @keyframes em-fadeIn {
+    to { opacity: 1; }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a set of entrance and interaction animation components that correctly implement `prefers-reduced-motion` support across 4 animation types (slide-up, slide-left, zoom-in, flip-in), a shimmer skeleton loader, and a hover pulse. All motion is substituted with a short opacity fade when the OS reduce-motion setting is active — never hard-disabled — keeping `animationend` events intact and state changes visible. This submission also serves as a reference pattern for how reduced-motion support should be applied consistently across the EaseMotion CSS framework (WCAG 2.1 SC 2.2.2).

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

Closes #19064 

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/examples/ease-reduced-motion-demo-[your-initials]/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `prefers-reduced-motion`-aware animation component set that substitutes motion with opacity transitions rather than disabling animations globally — preserving `animationend` events and visual feedback for all users.

**How does a developer use it?**

```html
<!-- Entrance animations -->
<div class="ease-slide-up">Slides up and fades in</div>
<div class="ease-slide-left">Slides from left and fades in</div>
<div class="ease-zoom-in">Scales up and fades in</div>
<div class="ease-flip-in">Flips in on X axis and fades in</div>

<!-- Stagger delays — combine with any entrance class -->
<div class="ease-slide-up ease-delay-1">First</div>
<div class="ease-slide-up ease-delay-2">Second</div>
<div class="ease-slide-up ease-delay-3">Third</div>

<!-- Hover pulse -->
<button class="ease-pulse-hover">Pulses on hover</button>

<!-- Shimmer skeleton loader -->
<div class="ease-shimmer" style="height: 12px; border-radius: 6px;"></div>
```

When `prefers-reduced-motion: reduce` is active, all of the above automatically switch to a short opacity fade — no extra classes, no JavaScript needed.

**Why does it fit EaseMotion CSS?**

EaseMotion CSS is animation-first and zero-dependency — but shipping animations without motion accessibility support is a liability, not a feature. This component demonstrates the correct two-layer CSS pattern the entire framework should adopt: full motion by default, opacity substitution under reduced-motion. The approach is WCAG 2.1 SC 2.2.2 compliant, works with zero JavaScript, and is consistent with the framework's philosophy of clean, human-readable utility classes.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

The demo includes a live banner that reads the OS `prefers-reduced-motion` setting and updates in real time, a replay button to re-trigger entrance animations without refreshing, and all four animation types shown across staggered cards and a notification list. Can also be tested instantly in Chrome DevTools via `Ctrl+Shift+P` → "Emulate CSS prefers-reduced-motion: reduce".

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The key design decision here is the substitution pattern inside `@media (prefers-reduced-motion: reduce)` — instead of `animation: none`, each class swaps its `animation-name` to a shared `em-fadeIn` keyframe and resets `transform: none`. This means:

1. `animationend` still fires — nothing breaks if JS listens for it
2. Elements don't snap in invisibly — the fade keeps state changes perceivable
3. The shared keyframe (`em-fadeIn`) is defined once and reused by all classes, keeping the reduced-motion block DRY

I'd suggest this two-layer structure (full motion + `@media` substitute block) as the standard pattern for future animation submissions across the framework. Happy for you to adjust timings, naming, or anything else during integration.

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [[Discord Server](https://discord.gg/hWSdGrccBU)](https://discord.gg/hWSdGrccBU)!## Pull Request Description

Adds a set of entrance and interaction animation components that correctly implement `prefers-reduced-motion` support across 4 animation types (slide-up, slide-left, zoom-in, flip-in), a shimmer skeleton loader, and a hover pulse. All motion is substituted with a short opacity fade when the OS reduce-motion setting is active — never hard-disabled — keeping `animationend` events intact and state changes visible. This submission also serves as a reference pattern for how reduced-motion support should be applied consistently across the EaseMotion CSS framework (WCAG 2.1 SC 2.2.2).

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/examples/ease-reduced-motion-demo-[your-initials]/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `prefers-reduced-motion`-aware animation component set that substitutes motion with opacity transitions rather than disabling animations globally — preserving `animationend` events and visual feedback for all users.

**How does a developer use it?**

```html
<!-- Entrance animations -->
<div class="ease-slide-up">Slides up and fades in</div>
<div class="ease-slide-left">Slides from left and fades in</div>
<div class="ease-zoom-in">Scales up and fades in</div>
<div class="ease-flip-in">Flips in on X axis and fades in</div>

<!-- Stagger delays — combine with any entrance class -->
<div class="ease-slide-up ease-delay-1">First</div>
<div class="ease-slide-up ease-delay-2">Second</div>
<div class="ease-slide-up ease-delay-3">Third</div>

<!-- Hover pulse -->
<button class="ease-pulse-hover">Pulses on hover</button>

<!-- Shimmer skeleton loader -->
<div class="ease-shimmer" style="height: 12px; border-radius: 6px;"></div>
```

When `prefers-reduced-motion: reduce` is active, all of the above automatically switch to a short opacity fade — no extra classes, no JavaScript needed.

**Why does it fit EaseMotion CSS?**

EaseMotion CSS is animation-first and zero-dependency — but shipping animations without motion accessibility support is a liability, not a feature. This component demonstrates the correct two-layer CSS pattern the entire framework should adopt: full motion by default, opacity substitution under reduced-motion. The approach is WCAG 2.1 SC 2.2.2 compliant, works with zero JavaScript, and is consistent with the framework's philosophy of clean, human-readable utility classes.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

The demo includes a live banner that reads the OS `prefers-reduced-motion` setting and updates in real time, a replay button to re-trigger entrance animations without refreshing, and all four animation types shown across staggered cards and a notification list. Can also be tested instantly in Chrome DevTools via `Ctrl+Shift+P` → "Emulate CSS prefers-reduced-motion: reduce".

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The key design decision here is the substitution pattern inside `@media (prefers-reduced-motion: reduce)` — instead of `animation: none`, each class swaps its `animation-name` to a shared `em-fadeIn` keyframe and resets `transform: none`. This means:

1. `animationend` still fires — nothing breaks if JS listens for it
2. Elements don't snap in invisibly — the fade keeps state changes perceivable
3. The shared keyframe (`em-fadeIn`) is defined once and reused by all classes, keeping the reduced-motion block DRY

I'd suggest this two-layer structure (full motion + `@media` substitute block) as the standard pattern for future animation submissions across the framework. Happy for you to adjust timings, naming, or anything else during integration.

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **2 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [[Discord Server](https://discord.gg/hWSdGrccBU)](https://discord.gg/hWSdGrccBU)!