### PR TITLE
feat: add animated tooltip showcase example (closes #19100)

### DIFF
--- a/submissions/examples/animated-tooltip/README.md
+++ b/submissions/examples/animated-tooltip/README.md
@@ -1,0 +1,19 @@
+# Animated Tooltip Showcase
+
+This is a pure HTML and CSS implementation of animated tooltips for the EaseMotion CSS repository. It demonstrates lightweight, framework-free hover interactions that can be easily integrated into any web layout.
+
+## What it Demonstrates
+
+The showcase demonstrates three distinct tooltip hover/focus animation patterns created using only CSS transitions. It is designed to be highly readable, semantic, and beginner-friendly.
+
+## Included Variants
+
+1. **Fade-in Tooltip** (`.tooltip-fade`): A smooth transition focusing strictly on opacity and visibility.
+2. **Slide-up Tooltip** (`.tooltip-slide`): A dynamic, organic entrance animating opacity, visibility, and vertical translation.
+3. **Tooltip with Arrow Indicator** (`.tooltip-arrow`): Adds a custom CSS arrow at the bottom pointing to the trigger element, utilizing custom border triangle styling combined with a subtle fade-and-slide motion.
+
+## How to Preview
+
+To view the live demo:
+1. Open the file `demo.html` directly in any web browser of your choice.
+2. Hover or focus on any of the buttons to trigger the corresponding animated tooltip.

--- a/submissions/examples/animated-tooltip/demo.html
+++ b/submissions/examples/animated-tooltip/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Tooltip Showcase - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="showcase-container">
+    <h1>Animated Tooltip Showcase</h1>
+    <p class="subtitle">A collection of lightweight, pure HTML + CSS animated tooltips</p>
+
+    <div class="tooltip-grid">
+      <!-- 1. Fade-in Tooltip -->
+      <button class="tooltip-trigger">
+        Fade-in Tooltip
+        <span class="tooltip-box tooltip-fade">Smooth Fade-in Effect</span>
+      </button>
+
+      <!-- 2. Slide-up Tooltip -->
+      <button class="tooltip-trigger">
+        Slide-up Tooltip
+        <span class="tooltip-box tooltip-slide">Slide-up & Fade-in Effect</span>
+      </button>
+
+      <!-- 3. Tooltip with Arrow Indicator -->
+      <button class="tooltip-trigger">
+        Tooltip with Arrow
+        <span class="tooltip-box tooltip-arrow">Arrow Indicator Effect</span>
+      </button>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/animated-tooltip/style.css
+++ b/submissions/examples/animated-tooltip/style.css
@@ -1,0 +1,170 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* ==========================================================================
+   EaseMotion CSS - Animated Tooltip Showcase
+   ========================================================================== */
+
+/* Basic Reset & Page Layout */
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: #0f172a; /* Slate 900 */
+  color: #f8fafc; /* Slate 50 */
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.showcase-container {
+  text-align: center;
+  max-width: 800px;
+  width: 100%;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 2.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #a5b4fc, #6366f1);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+  color: #94a3b8; /* Slate 400 */
+  font-size: 1rem;
+  margin-bottom: 3rem;
+}
+
+/* Flex layout for the demo elements */
+.tooltip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2.5rem;
+  margin-top: 2rem;
+}
+
+/* Tooltip Trigger Button */
+.tooltip-trigger {
+  position: relative;
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #4f46e5; /* Indigo 600 */
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  outline: none;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.tooltip-trigger:hover,
+.tooltip-trigger:focus-visible {
+  background-color: #4338ca; /* Indigo 700 */
+  transform: translateY(-2px);
+}
+
+.tooltip-trigger:active {
+  transform: translateY(0);
+}
+
+/* ==========================================================================
+   TOOLTIP CORE
+   ========================================================================== */
+
+.tooltip-box {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 12px;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #f8fafc;
+  background-color: #1e293b; /* Slate 800 */
+  border: 1px solid #334155; /* Slate 700 */
+  border-radius: 0.375rem;
+  white-space: nowrap;
+  pointer-events: none;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  
+  /* Initial State for Animations */
+  opacity: 0;
+  visibility: hidden;
+}
+
+/* Trigger Tooltip on Hover/Focus */
+.tooltip-trigger:hover .tooltip-box,
+.tooltip-trigger:focus-within .tooltip-box {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ==========================================================================
+   TOOLTIP VARIANTS
+   ========================================================================== */
+
+/* 1. Fade-in Tooltip */
+.tooltip-fade {
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+/* 2. Slide-up Tooltip */
+.tooltip-slide {
+  transform: translateX(-50%) translateY(8px);
+  transition: opacity 0.25s cubic-bezier(0.16, 1, 0.3, 1), 
+              transform 0.25s cubic-bezier(0.16, 1, 0.3, 1), 
+              visibility 0.25s ease;
+}
+
+.tooltip-trigger:hover .tooltip-slide,
+.tooltip-trigger:focus-within .tooltip-slide {
+  transform: translateX(-50%) translateY(0);
+}
+
+/* 3. Tooltip with Arrow Indicator */
+.tooltip-arrow {
+  /* Combine with a subtle fade/slide animation */
+  transform: translateX(-50%) translateY(4px);
+  transition: opacity 0.2s ease, 
+              transform 0.2s ease, 
+              visibility 0.2s ease;
+}
+
+.tooltip-trigger:hover .tooltip-arrow,
+.tooltip-trigger:focus-within .tooltip-arrow {
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Draw CSS border triangle pointing down */
+.tooltip-arrow::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: #1e293b transparent transparent transparent; /* Matches Slate 800 background */
+}
+
+/* Border Arrow Outline (draws the border matching the box border) */
+.tooltip-arrow::before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 7px;
+  border-style: solid;
+  border-color: #334155 transparent transparent transparent; /* Matches Slate 700 border */
+  z-index: -1;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new self-contained Animated Tooltip Showcase under `submissions/examples/animated-tooltip/`.

This submission demonstrates three tooltip variants implemented using only HTML and CSS:

* Fade-in Tooltip
* Slide-up Tooltip
* Tooltip with Arrow Indicator

The showcase is isolated to the contributor area and does not modify any framework files.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/animated-tooltip/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A lightweight tooltip showcase demonstrating three common tooltip animation styles using pure HTML and CSS.

**How does a developer use it?**

```html
<button class="tooltip-trigger">
  Hover me
  <span class="tooltip">Tooltip content</span>
</button>
```

**Why does it fit EaseMotion CSS?**

This submission aligns with EaseMotion CSS's animation-first philosophy by showcasing simple, reusable motion effects through human-readable and easy-to-understand UI interactions. It is self-contained, beginner-friendly, and demonstrates a commonly used interface pattern.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(not tested)*

---

## Notes for Maintainer

This submission is intentionally kept minimal and focused on tooltip behavior only. No framework files were modified, and all code is contained within the contributor submission directory.

Closes #19100.
