### PR TITLE
feat: add animation direction showcase example (#19102)

### DIFF
--- a/submissions/examples/animation-directions/README.md
+++ b/submissions/examples/animation-directions/README.md
@@ -1,0 +1,59 @@
+# Animation Direction Showcase
+
+## Overview
+
+A demo page showcasing eight directional CSS animations — fade (left, right, up, down) and slide (left, right, up, down). Each animation has its own demo card with a trigger button to replay the effect, plus a code snippet section for easy reference.
+
+## Features
+
+* 4 fade-in directional animations (left, right, up, down)
+* 4 slide directional animations (left, right, up, down)
+* Individual trigger buttons to replay each animation
+* Modern cubic-bezier easing
+* Lightweight CSS-only implementation
+* Dark theme with glassmorphism cards
+* Accessibility support using `prefers-reduced-motion`
+* Responsive grid layout
+
+## Use Cases
+
+* Learning and understanding CSS animation directions
+* Reference page for choosing the right entrance animation
+* Portfolio and landing page development
+* Educational material for CSS workshops
+
+## Example Usage
+
+```html
+<div class="demo-block anim-fade-in-left">Fade Left</div>
+```
+
+## Animation Behavior
+
+1. Fade animations combine opacity (0 → 1) with directional translate offsets (±40px).
+2. Slide animations use directional translate (±80px) without opacity changes.
+3. All animations use `cubic-bezier(0.25, 1, 0.5, 1)` easing for smooth motion.
+4. Trigger button removes and re-adds the animation class to replay.
+
+## Accessibility
+
+This component respects the user's motion preferences through the `prefers-reduced-motion` media query, which disables all animations.
+
+## Browser Compatibility
+
+Compatible with modern browsers supporting:
+
+* CSS Animations
+* CSS Transforms
+* CSS Keyframes
+* Media Queries
+* CSS Backdrop Filter
+
+## Acceptance Criteria
+
+* Uses CSS keyframes.
+* Smooth and reusable animation.
+* Lightweight implementation.
+* Accessible design.
+* Easy integration into existing projects.
+* Consistent with EaseMotion CSS principles.

--- a/submissions/examples/animation-directions/demo.html
+++ b/submissions/examples/animation-directions/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animation Direction Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="page-header">
+    <h1>Animation Directions</h1>
+    <p>Click any button to replay the animation</p>
+  </header>
+
+  <div class="showcase-grid">
+    <div class="card">
+      <h2>Fade In Left</h2>
+      <div class="demo-box">
+        <div class="demo-block fade-color anim-fade-in-left" id="fade-left">Fade L</div>
+      </div>
+      <button class="trigger-btn" data-target="fade-left" data-anim="anim-fade-in-left">Replay</button>
+    </div>
+
+    <div class="card">
+      <h2>Fade In Right</h2>
+      <div class="demo-box">
+        <div class="demo-block fade-color anim-fade-in-right" id="fade-right">Fade R</div>
+      </div>
+      <button class="trigger-btn" data-target="fade-right" data-anim="anim-fade-in-right">Replay</button>
+    </div>
+
+    <div class="card">
+      <h2>Fade In Up</h2>
+      <div class="demo-box">
+        <div class="demo-block fade-color anim-fade-in-up" id="fade-up">Fade U</div>
+      </div>
+      <button class="trigger-btn" data-target="fade-up" data-anim="anim-fade-in-up">Replay</button>
+    </div>
+
+    <div class="card">
+      <h2>Fade In Down</h2>
+      <div class="demo-box">
+        <div class="demo-block fade-color anim-fade-in-down" id="fade-down">Fade D</div>
+      </div>
+      <button class="trigger-btn" data-target="fade-down" data-anim="anim-fade-in-down">Replay</button>
+    </div>
+
+    <div class="card">
+      <h2>Slide Left</h2>
+      <div class="demo-box">
+        <div class="demo-block slide-color anim-slide-left" id="slide-left">Slide L</div>
+      </div>
+      <button class="trigger-btn" data-target="slide-left" data-anim="anim-slide-left">Replay</button>
+    </div>
+
+    <div class="card">
+      <h2>Slide Right</h2>
+      <div class="demo-box">
+        <div class="demo-block slide-color anim-slide-right" id="slide-right">Slide R</div>
+      </div>
+      <button class="trigger-btn" data-target="slide-right" data-anim="anim-slide-right">Replay</button>
+    </div>
+
+    <div class="card">
+      <h2>Slide Up</h2>
+      <div class="demo-box">
+        <div class="demo-block slide-color anim-slide-up" id="slide-up">Slide U</div>
+      </div>
+      <button class="trigger-btn" data-target="slide-up" data-anim="anim-slide-up">Replay</button>
+    </div>
+
+    <div class="card">
+      <h2>Slide Down</h2>
+      <div class="demo-box">
+        <div class="demo-block slide-color anim-slide-down" id="slide-down">Slide D</div>
+      </div>
+      <button class="trigger-btn" data-target="slide-down" data-anim="anim-slide-down">Replay</button>
+    </div>
+  </div>
+
+  <div class="code-snippet">
+    <h3>Usage</h3>
+    <pre><code>&lt;div class="anim-fade-in-left"&gt;Content&lt;/div&gt;
+&lt;div class="anim-fade-in-right"&gt;Content&lt;/div&gt;
+&lt;div class="anim-fade-in-up"&gt;Content&lt;/div&gt;
+&lt;div class="anim-fade-in-down"&gt;Content&lt;/div&gt;
+&lt;div class="anim-slide-left"&gt;Content&lt;/div&gt;
+&lt;div class="anim-slide-right"&gt;Content&lt;/div&gt;
+&lt;div class="anim-slide-up"&gt;Content&lt;/div&gt;
+&lt;div class="anim-slide-down"&gt;Content&lt;/div&gt;</code></pre>
+  </div>
+
+  <script>
+    document.querySelectorAll('.trigger-btn').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var target = document.getElementById(this.dataset.target);
+        var animClass = this.dataset.anim;
+        target.classList.remove(animClass);
+        void target.offsetWidth;
+        target.classList.add(animClass);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animation-directions/style.css
+++ b/submissions/examples/animation-directions/style.css
@@ -1,0 +1,297 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  background: #0a0e17;
+  color: #f3f4f6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+  background-image: radial-gradient(circle at 50% 0%, rgba(59, 130, 246, 0.08) 0%, transparent 60%);
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #60a5fa, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: #9ca3af;
+  font-size: 0.95rem;
+}
+
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+  max-width: 1100px;
+  width: 100%;
+}
+
+.card {
+  background: rgba(26, 36, 56, 0.6);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.card h2 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 1rem;
+}
+
+.demo-box {
+  width: 100%;
+  height: 120px;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 10px;
+  border: 1px dashed rgba(255, 255, 255, 0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+.demo-block {
+  width: 72px;
+  height: 72px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
+.fade-color {
+  background: linear-gradient(135deg, #3b82f6, #60a5fa);
+}
+
+.slide-color {
+  background: linear-gradient(135deg, #8b5cf6, #a78bfa);
+}
+
+.trigger-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #f3f4f6;
+  padding: 0.5rem 1.25rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 500;
+  font-family: inherit;
+  transition: all 0.2s;
+}
+
+.trigger-btn:hover {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.3);
+  box-shadow: 0 0 12px rgba(59, 130, 246, 0.15);
+}
+
+.trigger-btn:active {
+  transform: scale(0.96);
+}
+
+@keyframes fadeInLeft {
+  from {
+    opacity: 0;
+    transform: translateX(-40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes fadeInRight {
+  from {
+    opacity: 0;
+    transform: translateX(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideLeft {
+  from {
+    transform: translateX(80px);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideRight {
+  from {
+    transform: translateX(-80px);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(80px);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideDown {
+  from {
+    transform: translateY(-80px);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.anim-fade-in-left {
+  animation: fadeInLeft 0.5s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+.anim-fade-in-right {
+  animation: fadeInRight 0.5s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+.anim-fade-in-up {
+  animation: fadeInUp 0.5s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+.anim-fade-in-down {
+  animation: fadeInDown 0.5s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+.anim-slide-left {
+  animation: slideLeft 0.4s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+.anim-slide-right {
+  animation: slideRight 0.4s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+.anim-slide-up {
+  animation: slideUp 0.4s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+.anim-slide-down {
+  animation: slideDown 0.4s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+.code-snippet {
+  margin-top: 2rem;
+  max-width: 1100px;
+  width: 100%;
+  background: rgba(26, 36, 56, 0.6);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+.code-snippet h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 1rem;
+}
+
+pre {
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 10px;
+  padding: 1.25rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: #e2e8f0;
+}
+
+code {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+@media (max-width: 600px) {
+  .showcase-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+  }
+
+  .page-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .demo-box {
+    height: 100px;
+  }
+
+  .demo-block {
+    width: 56px;
+    height: 56px;
+    font-size: 0.65rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Overview

A demo page showcasing eight directional CSS animations — Fade In Left/Right/Up/Down and Slide Left/Right/Up/Down — with individual trigger buttons and usage code snippets.

Fixes #19102

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code styling/formatting

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] My changes work correctly on both desktop and mobile viewports

---

## Changes Made

- `submissions/examples/animation-directions/style.css` — 8 keyframe animations (fade left/right/up/down, slide left/right/up/down), dark theme glassmorphism layout, responsive grid, reduced-motion support
- `submissions/examples/animation-directions/demo.html` — 8 demo cards with labeled animation targets, replay buttons, usage code snippet section
- `submissions/examples/animation-directions/README.md` — documentation following project convention

## Features

- 4 fade-in directional animations with opacity + translate
- 4 slide directional animations with translate only
- Individual replay buttons with JS class toggle
- Modern cubic-bezier easing
- Responsive grid layout
- Reduced-motion accessibility

---

## Additional Notes

- Placed in submissions/examples/animation-directions per the issue specification
- No core framework files were modified
- No external dependencies or build tools required