### PR TITLE
feat: add carbon emissions target tracker (#19153)

### DIFF
--- a/submissions/examples/carbon-emissions-target-tracker-ts/README.md
+++ b/submissions/examples/carbon-emissions-target-tracker-ts/README.md
@@ -1,0 +1,73 @@
+# Carbon Emissions Target Tracker
+
+## Overview
+
+A dashboard component for tracking carbon emissions against reduction targets. Displays current emissions, target emissions, and reduction achieved via progress bars, summary cards, and three distinct state cards (on-track, attention-needed, off-track) — all in pure CSS with zero JavaScript.
+
+## Features
+
+* Summary cards for current emissions, target, and reduction achieved
+* Animated progress bars for emissions, target, and reduction metrics
+* Three target state cards with visual and text-based status indicators
+* Color-coded accents (green/yellow/red) plus icon badges for accessibility
+* Status text labels so meaning is clear without relying on color alone
+* Staggered fade-up entrance animations
+* Dark theme with glassmorphism surfaces
+* Fully responsive layout
+* Reduced-motion accessibility support
+
+## Use Cases
+
+* Sustainability dashboards
+* ESG reporting interfaces
+* Corporate carbon footprint trackers
+* Environmental impact monitoring
+
+## Example Usage
+
+```html
+<div class="state-card on-track">
+  <div class="badge">On Track</div>
+  <div class="title">Regional Office</div>
+  <div class="desc">Emissions are 18% below target.</div>
+  <div class="metric">
+    <span class="m-label">Current</span>
+    <span class="m-value">410 tCO₂</span>
+  </div>
+  <div class="metric">
+    <span class="m-label">Target</span>
+    <span class="m-value">500 tCO₂</span>
+  </div>
+</div>
+```
+
+## State Indicators
+
+| State | Color | Badge Text | Icon |
+|-------|-------|------------|------|
+| On Track | Green (#22c55e) | "On Track" | ✓ |
+| Attention Needed | Yellow (#eab308) | "Attention" | ! |
+| Off Track | Red (#ef4444) | "Off Track" | ✗ |
+
+## Accessibility
+
+Status is conveyed through both color and text labels (badge text + icon). The component respects `prefers-reduced-motion` to disable all animations.
+
+## Browser Compatibility
+
+Compatible with modern browsers supporting:
+
+* CSS Animations
+* CSS Transforms
+* CSS Keyframes
+* CSS Backdrop Filter
+* Media Queries
+
+## Acceptance Criteria
+
+* Uses CSS keyframes.
+* Smooth and reusable animation.
+* Lightweight implementation.
+* Accessible design.
+* Easy integration into existing projects.
+* Consistent with EaseMotion CSS principles.

--- a/submissions/examples/carbon-emissions-target-tracker-ts/demo.html
+++ b/submissions/examples/carbon-emissions-target-tracker-ts/demo.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Carbon Emissions Target Tracker</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="header">
+    <h1>Carbon Emissions Tracker</h1>
+    <p>Tracking progress toward 2030 reduction targets</p>
+  </div>
+
+  <div class="dashboard">
+    <div class="summary-row">
+      <div class="summary-card">
+        <div class="label">Current Emissions</div>
+        <div class="value on-track">1,840</div>
+        <div class="unit">tCO&#8322; / year</div>
+      </div>
+      <div class="summary-card">
+        <div class="label">Target Emissions</div>
+        <div class="value attention">2,400</div>
+        <div class="unit">tCO&#8322; / year</div>
+      </div>
+      <div class="summary-card">
+        <div class="label">Reduction Achieved</div>
+        <div class="value off-track">23%</div>
+        <div class="unit">toward 2030 goal</div>
+      </div>
+    </div>
+
+    <div class="progress-group">
+      <h2>Emissions vs Target Progress</h2>
+      <div class="progress-item">
+        <div class="progress-header">
+          <span class="label">Current Emissions</span>
+          <span class="value">1,840 tCO&#8322;</span>
+        </div>
+        <div class="track">
+          <div class="bar current"></div>
+        </div>
+      </div>
+      <div class="progress-item">
+        <div class="progress-header">
+          <span class="label">Target Cap</span>
+          <span class="value">2,400 tCO&#8322;</span>
+        </div>
+        <div class="track">
+          <div class="bar target"></div>
+        </div>
+      </div>
+      <div class="progress-item">
+        <div class="progress-header">
+          <span class="label">Reduction Achieved</span>
+          <span class="value">23%</span>
+        </div>
+        <div class="track">
+          <div class="bar reduction"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="cards-grid">
+      <div class="state-card on-track">
+        <div class="badge">On Track</div>
+        <div class="status-icon">&#10003;</div>
+        <div class="title">Regional Office</div>
+        <div class="desc">Emissions are 18% below target. Efficiency upgrades are ahead of schedule.</div>
+        <div class="metric">
+          <span class="m-label">Current</span>
+          <span class="m-value">410 tCO&#8322;</span>
+        </div>
+        <div class="metric">
+          <span class="m-label">Target</span>
+          <span class="m-value">500 tCO&#8322;</span>
+        </div>
+        <div class="metric">
+          <span class="m-label">Variance</span>
+          <span class="m-value">-90 tCO&#8322;</span>
+        </div>
+      </div>
+
+      <div class="state-card attention">
+        <div class="badge">Attention</div>
+        <div class="status-icon">&#33;</div>
+        <div class="title">Manufacturing Plant</div>
+        <div class="desc">Emissions are at target but rising. Additional mitigation measures recommended.</div>
+        <div class="metric">
+          <span class="m-label">Current</span>
+          <span class="m-value">780 tCO&#8322;</span>
+        </div>
+        <div class="metric">
+          <span class="m-label">Target</span>
+          <span class="m-value">780 tCO&#8322;</span>
+        </div>
+        <div class="metric">
+          <span class="m-label">Variance</span>
+          <span class="m-value">0 tCO&#8322;</span>
+        </div>
+      </div>
+
+      <div class="state-card off-track">
+        <div class="badge">Off Track</div>
+        <div class="status-icon">&#10007;</div>
+        <div class="title">Data Center</div>
+        <div class="desc">Emissions exceed target by 12%. Urgent action required to meet reduction goals.</div>
+        <div class="metric">
+          <span class="m-label">Current</span>
+          <span class="m-value">650 tCO&#8322;</span>
+        </div>
+        <div class="metric">
+          <span class="m-label">Target</span>
+          <span class="m-value">580 tCO&#8322;</span>
+        </div>
+        <div class="metric">
+          <span class="m-label">Variance</span>
+          <span class="m-value">+70 tCO&#8322;</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="legend">
+      <div class="legend-item">
+        <span class="dot green"></span>
+        On Track — within target
+      </div>
+      <div class="legend-item">
+        <span class="dot yellow"></span>
+        Attention — at target boundary
+      </div>
+      <div class="legend-item">
+        <span class="dot red"></span>
+        Off Track — exceeds target
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/carbon-emissions-target-tracker-ts/style.css
+++ b/submissions/examples/carbon-emissions-target-tracker-ts/style.css
@@ -1,0 +1,339 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  background: #0a0e17;
+  color: #f1f5f9;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+  background-image: radial-gradient(circle at 80% 20%, rgba(34, 197, 94, 0.06) 0%, transparent 50%),
+                    radial-gradient(circle at 20% 80%, rgba(59, 130, 246, 0.06) 0%, transparent 50%);
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.header h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #22c55e, #3b82f6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.35rem;
+}
+
+.header p {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.dashboard {
+  max-width: 1000px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.summary-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.summary-card {
+  flex: 1;
+  min-width: 160px;
+  background: rgba(26, 36, 56, 0.6);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 1.25rem;
+  text-align: center;
+}
+
+.summary-card .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+  margin-bottom: 0.4rem;
+}
+
+.summary-card .value {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.summary-card .unit {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin-top: 0.15rem;
+}
+
+.value.on-track { color: #22c55e; }
+.value.attention { color: #eab308; }
+.value.off-track { color: #ef4444; }
+
+.progress-group {
+  background: rgba(26, 36, 56, 0.6);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 1.5rem;
+}
+
+.progress-group h2 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 1.25rem;
+}
+
+.progress-item {
+  margin-bottom: 1rem;
+}
+
+.progress-item:last-child {
+  margin-bottom: 0;
+}
+
+.progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.4rem;
+}
+
+.progress-header .label {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.progress-header .value {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.track {
+  width: 100%;
+  height: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  overflow: hidden;
+  position: relative;
+}
+
+.bar {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.8s cubic-bezier(0.25, 1, 0.5, 1);
+  width: 0;
+}
+
+.bar.current {
+  background: linear-gradient(90deg, #3b82f6, #60a5fa);
+  width: 78%;
+}
+
+.bar.target {
+  background: linear-gradient(90deg, #22c55e, #4ade80);
+  width: 60%;
+}
+
+.bar.reduction {
+  background: linear-gradient(90deg, #a855f7, #c084fc);
+  width: 45%;
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.state-card {
+  background: rgba(26, 36, 56, 0.6);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 1.25rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.state-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+}
+
+.state-card.on-track::before { background: #22c55e; }
+.state-card.attention::before { background: #eab308; }
+.state-card.off-track::before { background: #ef4444; }
+
+.state-card .badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  margin-bottom: 0.75rem;
+}
+
+.state-card.on-track .badge {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+}
+
+.state-card.attention .badge {
+  background: rgba(234, 179, 8, 0.15);
+  color: #eab308;
+}
+
+.state-card.off-track .badge {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.state-card .title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.state-card .desc {
+  font-size: 0.82rem;
+  color: #94a3b8;
+  line-height: 1.5;
+  margin-bottom: 0.75rem;
+}
+
+.state-card .metric {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  padding: 0.35rem 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.state-card .metric .m-label {
+  color: #94a3b8;
+}
+
+.state-card .metric .m-value {
+  font-weight: 600;
+}
+
+.state-card .status-icon {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.state-card.on-track .status-icon { background: #22c55e; }
+.state-card.attention .status-icon { background: #eab308; }
+.state-card.off-track .status-icon { background: #ef4444; }
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1.5rem;
+  padding: 1rem;
+  background: rgba(26, 36, 56, 0.4);
+  border-radius: 10px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.legend-item .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.dot.green { background: #22c55e; }
+.dot.yellow { background: #eab308; }
+.dot.red { background: #ef4444; }
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.summary-card:nth-child(1) { animation: fadeUp 0.4s ease forwards; }
+.summary-card:nth-child(2) { animation: fadeUp 0.4s ease 0.1s forwards; opacity: 0; }
+.summary-card:nth-child(3) { animation: fadeUp 0.4s ease 0.2s forwards; opacity: 0; }
+
+.progress-group { animation: fadeUp 0.4s ease 0.15s forwards; opacity: 0; }
+
+.state-card:nth-child(1) { animation: fadeUp 0.4s ease 0.25s forwards; opacity: 0; }
+.state-card:nth-child(2) { animation: fadeUp 0.4s ease 0.35s forwards; opacity: 0; }
+.state-card:nth-child(3) { animation: fadeUp 0.4s ease 0.45s forwards; opacity: 0; }
+
+@media (max-width: 600px) {
+  .summary-row {
+    flex-direction: column;
+  }
+
+  .summary-card {
+    min-width: auto;
+  }
+
+  .cards-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .header h1 {
+    font-size: 1.35rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Overview

A carbon emissions target tracker dashboard comparing current footprint against reduction targets with on-track, attention-needed, and off-track states using both text and color cues — pure CSS, zero JavaScript.

Fixes #19153

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code styling/formatting

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] My changes work correctly on both desktop and mobile viewports

---

## Changes Made

- `submissions/examples/carbon-emissions-target-tracker-ts/style.css` — animated progress bars, state card styles (green/yellow/red), staggered fade-up animations, responsive layout, reduced-motion support
- `submissions/examples/carbon-emissions-target-tracker-ts/demo.html` — summary cards, progress bars, 3 state cards (Regional Office on-track, Manufacturing Plant attention, Data Center off-track), legend
- `submissions/examples/carbon-emissions-target-tracker-ts/README.md` — documentation following project convention

## Features

- 3 summary cards: current emissions, target, reduction achieved
- 3 animated progress bars with gradient fills
- 3 target state cards with color accent bar, badge text, and status icon
- Status clear without relying on color (badge texts: On Track / Attention / Off Track + icons)
- Staggered fade-up entrance animations
- Responsive layout (stacks on narrow screens)
- Legend explaining all states
- Pure CSS, zero JavaScript, no external assets
- Reduced-motion accessibility

---

## Additional Notes

- Placed in submissions/examples/carbon-emissions-target-tracker-ts per the issue specification
- Three target states demonstrated: on-track (green), attention-needed (yellow), off-track (red)
- No core framework files were modified
- No external dependencies or build tools required