### PR TITLE
feat: add incident communication channel roster (#19155)

### DIFF
--- a/submissions/examples/incident-communication-channel-roster-ts/README.md
+++ b/submissions/examples/incident-communication-channel-roster-ts/README.md
@@ -1,0 +1,75 @@
+# Incident Communication Channel Roster
+
+## Overview
+
+An incident communication channel roster for operations teams listing primary, backup, degraded, and unavailable communication channels with owner and response details — pure CSS, zero JavaScript.
+
+## Features
+
+* Four channel states: primary, backup, degraded, unavailable
+* Color-coded left accent bar and status badges (green, blue, yellow, red)
+* Text labels on all status badges so meaning is clear without color alone
+* Channel icon, name, and owner information
+* Response time details for each channel
+* Hover slide effect for interactive feel
+* Staggered slide-in entrance animation
+* Dark theme with glassmorphism cards
+* Fully responsive layout
+* Reduced-motion accessibility support
+
+## Channel States
+
+| State | Color | Badge Text | Description |
+|-------|-------|------------|-------------|
+| Primary | Green (#22c55e) | Primary | Fully operational, first-line channel |
+| Backup | Blue (#3b82f6) | Backup | Operational but secondary priority |
+| Degraded | Yellow (#eab308) | Degraded | Functioning with reduced capacity |
+| Unavailable | Red (#ef4444) | Unavailable | Currently not operational |
+
+## Realistic Entries
+
+- **Status Page** (primary) — hosted status dashboard with 1min response
+- **Slack Incident Channel** (primary) — real-time chat with 30s response
+- **Conference Bridge** (backup) — dial-in for voice coordination with 2min response
+- **Email Updates** (backup) — mass notification distribution with 5min response
+- **SMS Alert Gateway** (degraded) — text message relay with 10min response
+- **PagerDuty Integration** (unavailable) — automated paging currently down
+
+## Example Usage
+
+```html
+<div class="channel-card primary">
+  <div class="channel-icon">📡</div>
+  <div class="channel-info">
+    <div class="channel-name">Status Page</div>
+    <div class="channel-owner">Infrastructure Team</div>
+  </div>
+  <div class="channel-meta">
+    <span class="channel-status primary">Primary</span>
+    <div class="channel-response">ETA: <strong>1 min</strong></div>
+  </div>
+</div>
+```
+
+## Accessibility
+
+Status is conveyed through both color and text label. The component respects `prefers-reduced-motion` to disable all animations.
+
+## Browser Compatibility
+
+Compatible with modern browsers supporting:
+
+* CSS Animations
+* CSS Transforms
+* CSS Keyframes
+* CSS Backdrop Filter
+* Media Queries
+
+## Acceptance Criteria
+
+* Uses CSS keyframes.
+* Smooth and reusable animation.
+* Lightweight implementation.
+* Accessible design.
+* Easy integration into existing projects.
+* Consistent with EaseMotion CSS principles.

--- a/submissions/examples/incident-communication-channel-roster-ts/demo.html
+++ b/submissions/examples/incident-communication-channel-roster-ts/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Incident Communication Channel Roster</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="header">
+    <h1>Incident Communication Channels</h1>
+    <p>Active roster for incident response coordination</p>
+  </div>
+
+  <div class="roster">
+    <div class="channel-card primary">
+      <div class="channel-icon" style="background:rgba(34,197,94,0.12);color:#22c55e">&#x1F4E1;</div>
+      <div class="channel-info">
+        <div class="channel-name">Status Page</div>
+        <div class="channel-owner">Infrastructure Team</div>
+      </div>
+      <div class="channel-meta">
+        <span class="channel-status primary">Primary</span>
+        <div class="channel-response">ETA: <strong>1 min</strong></div>
+      </div>
+    </div>
+
+    <div class="channel-card primary">
+      <div class="channel-icon" style="background:rgba(34,197,94,0.12);color:#22c55e">&#x1F4AC;</div>
+      <div class="channel-info">
+        <div class="channel-name">Slack Incident Channel</div>
+        <div class="channel-owner">On-Call Engineering</div>
+      </div>
+      <div class="channel-meta">
+        <span class="channel-status primary">Primary</span>
+        <div class="channel-response">ETA: <strong>30 sec</strong></div>
+      </div>
+    </div>
+
+    <div class="channel-card backup">
+      <div class="channel-icon" style="background:rgba(59,130,246,0.12);color:#60a5fa">&#x260E;</div>
+      <div class="channel-info">
+        <div class="channel-name">Conference Bridge</div>
+        <div class="channel-owner">INC Commander</div>
+      </div>
+      <div class="channel-meta">
+        <span class="channel-status backup">Backup</span>
+        <div class="channel-response">ETA: <strong>2 min</strong></div>
+      </div>
+    </div>
+
+    <div class="channel-card backup">
+      <div class="channel-icon" style="background:rgba(59,130,246,0.12);color:#60a5fa">&#x2709;</div>
+      <div class="channel-info">
+        <div class="channel-name">Email Updates</div>
+        <div class="channel-owner">Communications Lead</div>
+      </div>
+      <div class="channel-meta">
+        <span class="channel-status backup">Backup</span>
+        <div class="channel-response">ETA: <strong>5 min</strong></div>
+      </div>
+    </div>
+
+    <div class="channel-card degraded">
+      <div class="channel-icon" style="background:rgba(234,179,8,0.12);color:#eab308">&#x1F4F1;</div>
+      <div class="channel-info">
+        <div class="channel-name">SMS Alert Gateway</div>
+        <div class="channel-owner">SRE Team</div>
+      </div>
+      <div class="channel-meta">
+        <span class="channel-status degraded">Degraded</span>
+        <div class="channel-response">ETA: <strong>10 min</strong></div>
+      </div>
+    </div>
+
+    <div class="channel-card unavailable">
+      <div class="channel-icon" style="background:rgba(239,68,68,0.12);color:#ef4444">&#x1F6A8;</div>
+      <div class="channel-info">
+        <div class="channel-name">PagerDuty Integration</div>
+        <div class="channel-owner">Platform Team</div>
+      </div>
+      <div class="channel-meta">
+        <span class="channel-status unavailable">Unavailable</span>
+        <div class="channel-response">ETA: <strong>Investigating</strong></div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/incident-communication-channel-roster-ts/style.css
+++ b/submissions/examples/incident-communication-channel-roster-ts/style.css
@@ -1,0 +1,204 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  background: #0a0e17;
+  color: #f1f5f9;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+  background-image: radial-gradient(circle at 30% 70%, rgba(239, 68, 68, 0.05) 0%, transparent 50%),
+                    radial-gradient(circle at 70% 30%, rgba(59, 130, 246, 0.05) 0%, transparent 50%);
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.header h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #f97316, #ef4444);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.35rem;
+}
+
+.header p {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.roster {
+  max-width: 900px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.channel-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(26, 36, 56, 0.6);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 1.25rem;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.channel-card:hover {
+  transform: translateX(4px);
+}
+
+.channel-card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 4px;
+  height: 100%;
+}
+
+.channel-card.primary::before { background: #22c55e; }
+.channel-card.backup::before { background: #3b82f6; }
+.channel-card.degraded::before { background: #eab308; }
+.channel-card.unavailable::before { background: #ef4444; }
+
+.channel-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.channel-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.channel-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-bottom: 0.15rem;
+}
+
+.channel-owner {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.channel-meta {
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.channel-status {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  margin-bottom: 0.3rem;
+}
+
+.channel-status.primary {
+  background: rgba(34, 197, 94, 0.12);
+  color: #22c55e;
+}
+
+.channel-status.backup {
+  background: rgba(59, 130, 246, 0.12);
+  color: #60a5fa;
+}
+
+.channel-status.degraded {
+  background: rgba(234, 179, 8, 0.12);
+  color: #eab308;
+}
+
+.channel-status.unavailable {
+  background: rgba(239, 68, 68, 0.12);
+  color: #ef4444;
+}
+
+.channel-response {
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.channel-response strong {
+  color: #f1f5f9;
+  font-weight: 600;
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.channel-card {
+  animation: slideIn 0.35s ease forwards;
+  opacity: 0;
+}
+
+.channel-card:nth-child(1) { animation-delay: 0.05s; }
+.channel-card:nth-child(2) { animation-delay: 0.1s; }
+.channel-card:nth-child(3) { animation-delay: 0.15s; }
+.channel-card:nth-child(4) { animation-delay: 0.2s; }
+.channel-card:nth-child(5) { animation-delay: 0.25s; }
+.channel-card:nth-child(6) { animation-delay: 0.3s; }
+
+@media (max-width: 600px) {
+  .channel-card {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .channel-meta {
+    width: 100%;
+    text-align: left;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .channel-response {
+    text-align: left;
+  }
+
+  .header h1 { font-size: 1.3rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Overview

An incident communication channel roster for operations teams listing primary, backup, degraded, and unavailable channels with owner and response details — pure CSS, zero JavaScript.

Fixes #19155

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code styling/formatting

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or console errors
- [x] My changes work correctly on both desktop and mobile viewports

---

## Changes Made

- `submissions/examples/incident-communication-channel-roster-ts/style.css` — channel card styles, 4 state accent bars and badges, staggered slide-in animation, hover effect, responsive layout, reduced-motion support
- `submissions/examples/incident-communication-channel-roster-ts/demo.html` — 6 realistic channel entries (Status Page, Slack, Conference Bridge, Email, SMS Gateway, PagerDuty)
- `submissions/examples/incident-communication-channel-roster-ts/README.md` — documentation following project convention

## Features

- 4 channel states: primary (green), backup (blue), degraded (yellow), unavailable (red)
- 6 realistic entries with owner and ETA details
- Color-coded left accent bar and status badge on each card
- Status clear without relying on color (text badges: Primary, Backup, Degraded, Unavailable)
- Channel icon with colored background
- Hover slide effect (translateX)
- Staggered slide-in entrance animation
- Responsive (stacks meta row on narrow screens)
- Pure CSS, zero JavaScript, no external assets
- Reduced-motion accessibility

---

## Additional Notes

- Placed in submissions/examples/incident-communication-channel-roster-ts per the issue specification
- Four channel states demonstrated across 6 realistic entries
- No core framework files were modified
- No external dependencies or build tools required