### PR TITLE
Text Clip Reveal Animation

### DIFF
--- a/submissions/examples/text-clip-reveal-za/README.md
+++ b/submissions/examples/text-clip-reveal-za/README.md
@@ -1,0 +1,12 @@
+# Text Clip Reveal Animation
+
+Lines of text reveal from left to right using CSS clip-path animations with staggered delays.
+
+## Files
+
+- `demo.html` - Three lines of text with staggered reveals
+- `style.css` - Clip-path keyframes, gradient text, delay utilities
+
+## Usage
+
+Open `demo.html` to see each line of text sweep in from left to right.

--- a/submissions/examples/text-clip-reveal-za/README.md
+++ b/submissions/examples/text-clip-reveal-za/README.md
@@ -10,3 +10,5 @@ Lines of text reveal from left to right using CSS clip-path animations with stag
 ## Usage
 
 Open `demo.html` to see each line of text sweep in from left to right.
+
+Closes #19193

--- a/submissions/examples/text-clip-reveal-za/demo.html
+++ b/submissions/examples/text-clip-reveal-za/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Clip Reveal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1 class="reveal-line">
+      <span class="reveal-text">EaseMotion CSS</span>
+    </h1>
+    <p class="reveal-line delay-1">
+      <span class="reveal-text">Smooth text reveal animations</span>
+    </p>
+    <p class="reveal-line delay-2">
+      <span class="reveal-text">Powered by clip-path transitions</span>
+    </p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/text-clip-reveal-za/style.css
+++ b/submissions/examples/text-clip-reveal-za/style.css
@@ -1,0 +1,68 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0f172a;
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+}
+
+main {
+  max-width: 600px;
+}
+
+.reveal-line {
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.reveal-text {
+  display: inline-block;
+  animation: clip-reveal 1.2s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  transform-origin: left;
+  clip-path: inset(0 100% 0 0);
+  color: #f1f5f9;
+}
+
+h1 .reveal-text {
+  font-size: clamp(2.2rem, 6vw, 3.5rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+p .reveal-text {
+  font-size: 1.2rem;
+  color: #94a3b8;
+  -webkit-text-fill-color: #94a3b8;
+}
+
+@keyframes clip-reveal {
+  0% {
+    clip-path: inset(0 100% 0 0);
+    opacity: 0;
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    clip-path: inset(0 0% 0 0);
+    opacity: 1;
+  }
+}
+
+.delay-1 .reveal-text {
+  animation-delay: 0.25s;
+}
+
+.delay-2 .reveal-text {
+  animation-delay: 0.5s;
+}


### PR DESCRIPTION
CSS text revealed through a sliding clip-path animation that sweeps from left to right, creating a typewriter-like reveal.

Closes #19193

## Checklist
- [x] New submission in `submissions/examples/text-clip-reveal-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26