### PR TITLE
Slide Reveal Image Effect

### DIFF
--- a/submissions/examples/slide-reveal-image-za/README.md
+++ b/submissions/examples/slide-reveal-image-za/README.md
@@ -1,0 +1,14 @@
+# Slide Reveal Image Effect
+
+An image reveal effect where a dark overlay slides away on hover to unveil the content beneath.
+
+## Files
+
+- `demo.html` - Reveal container with gradient background
+- `style.css` - Sliding overlay with cubic-bezier easing
+
+## Usage
+
+Open `demo.html` and hover over the image area to reveal it.
+
+Closes #19234

--- a/submissions/examples/slide-reveal-image-za/demo.html
+++ b/submissions/examples/slide-reveal-image-za/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Slide Reveal Image</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="reveal-page">
+    <h1>Slide Reveal</h1>
+    <div class="reveal-container">
+      <div class="reveal-image-bg"></div>
+      <div class="reveal-overlay"></div>
+    </div>
+    <p>Hover over the image to reveal it with a sliding overlay.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/slide-reveal-image-za/style.css
+++ b/submissions/examples/slide-reveal-image-za/style.css
@@ -1,0 +1,63 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0f172a;
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+}
+
+.reveal-page {
+  text-align: center;
+}
+
+h1 {
+  color: #f1f5f9;
+  margin-bottom: 1rem;
+  font-size: 2.2rem;
+}
+
+p {
+  color: #64748b;
+  margin-top: 1rem;
+  font-size: 0.95rem;
+}
+
+.reveal-container {
+  position: relative;
+  width: 400px;
+  max-width: 90vw;
+  height: 300px;
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.reveal-image-bg {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #6366f1 0%, #a855f7 40%, #ec4899 100%);
+  border-radius: 16px;
+}
+
+.reveal-overlay {
+  position: absolute;
+  inset: 0;
+  background: #0f172a;
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.reveal-overlay {
+  transform-origin: left;
+  transform: scaleX(1);
+}
+
+.reveal-container:hover .reveal-overlay {
+  transform: scaleX(0);
+}


### PR DESCRIPTION
An image revealed by a sliding overlay that moves to unveil the full image, creating a dramatic before/after or entrance effect.

Closes #19234

## Checklist
- [x] New submission in `submissions/examples/slide-reveal-image-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26