### PR TITLE
CSS Accent Color Themed Form

### DIFF
--- a/submissions/examples/accent-color-theme-za/README.md
+++ b/submissions/examples/accent-color-theme-za/README.md
@@ -1,0 +1,14 @@
+# CSS Accent Color Themed Form
+
+A form demonstrating the CSS accent-color property which themes native form controls (checkboxes, radio buttons, range sliders, progress bars) with a single color value. Includes interactive theme switcher buttons.
+
+## Files
+
+- `demo.html` - Themed form with color picker buttons
+- `style.css` - Accent-color property, progress bar styling, theme switching via CSS custom properties
+
+## Usage
+
+Open `demo.html` and click the color circles to change the form accent color.
+
+Closes #19342

--- a/submissions/examples/accent-color-theme-za/demo.html
+++ b/submissions/examples/accent-color-theme-za/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accent Color Theme</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="form-page">
+    <h1>Accent Color</h1>
+    <p class="form-desc">Native form controls themed with a single CSS property.</p>
+    <div class="theme-options">
+      <button class="theme-btn" data-color="#6366f1" style="background:#6366f1">Indigo</button>
+      <button class="theme-btn" data-color="#ec4899" style="background:#ec4899">Pink</button>
+      <button class="theme-btn" data-color="#22c55e" style="background:#22c55e">Green</button>
+      <button class="theme-btn" data-color="#f59e0b" style="background:#f59e0b">Amber</button>
+    </div>
+    <form class="accent-form">
+      <fieldset>
+        <legend>Preferences</legend>
+        <label class="form-row"><input type="checkbox" checked> Enable notifications</label>
+        <label class="form-row"><input type="checkbox"> Dark mode</label>
+        <label class="form-row"><input type="radio" name="plan" checked> Free plan</label>
+        <label class="form-row"><input type="radio" name="plan"> Pro plan</label>
+        <label class="form-row">Volume <input type="range" min="0" max="100" value="65"></label>
+        <label class="form-row progress-row">Storage <progress max="100" value="42">42%</progress></label>
+      </fieldset>
+    </form>
+  </div>
+  <script>
+    const root = document.documentElement;
+    document.querySelectorAll(".theme-btn").forEach(btn => {
+      btn.addEventListener("click", () => {
+        root.style.setProperty("--accent", btn.dataset.color);
+        document.querySelectorAll(".theme-btn").forEach(b => b.classList.remove("active"));
+        btn.classList.add("active");
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/accent-color-theme-za/style.css
+++ b/submissions/examples/accent-color-theme-za/style.css
@@ -1,0 +1,128 @@
+body,
+h1,
+h2,
+form,
+fieldset,
+label,
+input,
+select,
+textarea,
+p,
+div,
+legend,
+progress,
+button {
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --accent: #6366f1;
+}
+
+body {
+  background: #fafafa;
+  color: #1a1a2e;
+  font-family: "Corbel", "Lucida Grande", "Lucida Sans Unicode", "Segoe UI", sans-serif;
+  padding: 3rem;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+.form-page {
+  max-width: 520px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}
+
+.form-desc {
+  color: #6b7280;
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+.theme-options {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.theme-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 3px solid transparent;
+  cursor: pointer;
+  transition: border-color 0.2s, transform 0.2s;
+}
+
+.theme-btn.active {
+  border-color: #1a1a2e;
+  transform: scale(1.15);
+}
+
+.accent-form {
+  accent-color: var(--accent);
+}
+
+fieldset {
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 1.5rem;
+}
+
+legend {
+  font-weight: 700;
+  font-size: 1.05rem;
+  padding: 0 0.5rem;
+  color: #374151;
+}
+
+.form-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  font-size: 0.95rem;
+  color: #374151;
+  cursor: pointer;
+}
+
+.form-row input[type="range"] {
+  flex: 1;
+  max-width: 200px;
+}
+
+.progress-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+progress {
+  flex: 1;
+  max-width: 200px;
+  height: 8px;
+  border-radius: 4px;
+}
+
+progress::-webkit-progress-bar {
+  background: #e5e7eb;
+  border-radius: 4px;
+}
+
+progress::-webkit-progress-value {
+  background: var(--accent);
+  border-radius: 4px;
+}
+
+progress::-moz-progress-bar {
+  background: var(--accent);
+  border-radius: 4px;
+}


### PR DESCRIPTION
A CSS form demonstrating the accent-color property to theme checkboxes, radio buttons, range sliders, and progress bars with a single color value.

Closes #19342

## Checklist
- [x] New submission in `submissions/examples/accent-color-theme-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26