### PR TITLE
Drop Cap Typography Style

### DIFF
--- a/submissions/examples/drop-cap-typography-za/README.md
+++ b/submissions/examples/drop-cap-typography-za/README.md
@@ -1,0 +1,14 @@
+# Drop Cap Typography Style
+
+A typography demo showing drop caps using CSS ::first-letter pseudo-element with the initial-letter property for magazine-style text layout.
+
+## Files
+
+- `demo.html` - Article with drop cap typography
+- `style.css` - initial-letter property, ::first-line small caps, serif typography
+
+## Usage
+
+Open `demo.html` to see the drop cap effect at the start of the article.
+
+Closes #19350

--- a/submissions/examples/drop-cap-typography-za/demo.html
+++ b/submissions/examples/drop-cap-typography-za/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Drop Cap Typography</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <article>
+    <h1>The Art of the Drop Cap</h1>
+    <p class="byline">A typographic tradition reimagined in CSS</p>
+    <p>Long before digital typesetting, scribes would embellish the first letter of a manuscript with ornate illustrations. Today, CSS lets us revive this tradition with the initial-letter property, giving the opening character a commanding presence that draws the reader into the text.</p>
+    <p>The drop cap spans multiple lines, creating a visual anchor at the start of an article. This technique works best with serif typefaces that carry the weight and elegance of traditional print media.</p>
+    <p>When applied sparingly, a well-crafted drop cap signals quality and care. It tells the reader this is a place where detail matters, where the craft of communication extends beyond mere words.</p>
+    <div class="dropcap-info">
+      <p><code>::first-letter</code> with <code>initial-letter: 3 1</code> creates a three-line drop cap. The first line is rendered in small caps for additional polish.</p>
+    </div>
+  </article>
+</body>
+</html>

--- a/submissions/examples/drop-cap-typography-za/style.css
+++ b/submissions/examples/drop-cap-typography-za/style.css
@@ -1,0 +1,55 @@
+html {
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+body {
+  background: #faf5eb;
+  color: #2c2416;
+  max-width: 42rem;
+  margin: 4rem auto 6rem;
+  padding: 0 2rem;
+  font-family: "Crimson Text", "Palatino", Georgia, serif;
+  font-size: 1.2rem;
+}
+h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.5rem;
+  line-height: 1.2;
+}
+.byline {
+  color: #8b7d6b;
+  font-style: italic;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+}
+p {
+  margin-bottom: 1.2rem;
+}
+p:first-of-type::first-letter {
+  initial-letter: 3 1;
+  font-weight: 700;
+  color: #8b5e3c;
+  margin-right: 0.25em;
+  font-family: "Crimson Text", Georgia, serif;
+  float: left;
+}
+p:first-of-type::first-line {
+  font-variant: small-caps;
+  letter-spacing: 0.06em;
+}
+.dropcap-info {
+  margin-top: 2.5rem;
+  padding: 1.25rem;
+  background: #ede4d4;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  color: #5c4f3a;
+}
+code {
+  background: #e0d6c2;
+  padding: 0.15em 0.4em;
+  border-radius: 3px;
+  font-size: 0.85em;
+}


### PR DESCRIPTION
A typography demo showing drop caps using CSS ::first-letter pseudo-element with initial-letter property for magazine-style text layout.

Closes #19350

## Checklist
- [x] New submission in `submissions/examples/drop-cap-typography-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26