### PR TITLE
Outline Offset Focus Ring

### DIFF
--- a/submissions/examples/outline-offset-ring-za/README.md
+++ b/submissions/examples/outline-offset-ring-za/README.md
@@ -1,0 +1,14 @@
+# Outline Offset Focus Ring
+
+A focus ring demonstration using CSS outline and outline-offset properties to create accessible, styled focus indicators for interactive elements.
+
+## Files
+
+- `demo.html` - Four focus ring variants on buttons
+- `style.css` - outline-offset property, :focus-visible styling, dark theme
+
+## Usage
+
+Open `demo.html` and tab through the buttons to see different focus ring styles.
+
+Closes #19353

--- a/submissions/examples/outline-offset-ring-za/demo.html
+++ b/submissions/examples/outline-offset-ring-za/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Outline Offset Rings</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Focus Ring Showcase</h1>
+  <div class="demo-grid">
+    <div class="demo-card">
+      <h2>Thin Ring</h2>
+      <button class="btn ring-thin">Focus me</button>
+      <span class="note">outline: 2px solid<br>outline-offset: 3px</span>
+    </div>
+    <div class="demo-card">
+      <h2>Thick Ring</h2>
+      <button class="btn ring-thick">Focus me</button>
+      <span class="note">outline: 3px solid<br>outline-offset: 4px</span>
+    </div>
+    <div class="demo-card">
+      <h2>Dashed Ring</h2>
+      <button class="btn ring-dashed">Focus me</button>
+      <span class="note">outline: 2px dashed<br>outline-offset: 2px</span>
+    </div>
+    <div class="demo-card">
+      <h2>Double Ring</h2>
+      <button class="btn ring-double">Focus me</button>
+      <span class="note">outline: 2px double<br>outline-offset: 5px</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/outline-offset-ring-za/style.css
+++ b/submissions/examples/outline-offset-ring-za/style.css
@@ -1,0 +1,79 @@
+:focus {
+  outline: none;
+}
+body {
+  background: #1e1b2e;
+  color: #e2dff0;
+  min-height: 100svh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem;
+  font-family: "Nunito Sans", "Segoe UI", Tahoma, sans-serif;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 300;
+  color: #c7c0e0;
+  margin: 0;
+}
+.demo-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.demo-card {
+  background: #2d2848;
+  padding: 2rem;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+.demo-card h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #a79fc9;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+.btn {
+  padding: 0.6rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  background: #6c5ce7;
+  color: #fff;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.95rem;
+  transition: background 0.2s;
+}
+.btn:hover {
+  background: #7c6ff0;
+}
+.btn:focus-visible {
+  outline: 2px solid #6c5ce7;
+  outline-offset: 3px;
+}
+.btn.ring-thick:focus-visible {
+  outline: 3px solid #fd79a8;
+  outline-offset: 4px;
+  border-radius: 8px;
+}
+.btn.ring-dashed:focus-visible {
+  outline: 2px dashed #fdcb6e;
+  outline-offset: 2px;
+}
+.btn.ring-double:focus-visible {
+  outline: 2px double #00cec9;
+  outline-offset: 5px;
+  border-radius: 8px;
+}
+.note {
+  font-size: 0.7rem;
+  color: #8880a8;
+  font-family: "Consolas", "Courier New", monospace;
+  line-height: 1.5;
+}


### PR DESCRIPTION
A focus ring demonstration using CSS outline and outline-offset properties to create accessible, styled focus indicators for interactive elements.

Closes #19353

## Checklist
- [x] New submission in `submissions/examples/outline-offset-ring-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26