### PR TITLE
Mix Blend Mode with Isolation

### DIFF
--- a/submissions/examples/mix-blend-isolate-za/README.md
+++ b/submissions/examples/mix-blend-isolate-za/README.md
@@ -1,0 +1,14 @@
+# Mix Blend Mode with Isolation
+
+A CSS demo comparing mix-blend-mode behavior with and without the isolation property. Shows how isolation: isolate creates a new stacking context that prevents blend mode propagation.
+
+## Files
+
+- `demo.html` - Two blend stage comparisons
+- `style.css` - Isolation property, mix-blend-mode difference, gradient backgrounds
+
+## Usage
+
+Open `demo.html` to see how isolation contains the blend mode effect.
+
+Closes #19355

--- a/submissions/examples/mix-blend-isolate-za/demo.html
+++ b/submissions/examples/mix-blend-isolate-za/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Isolation Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Isolation &amp; Blend Modes</h1>
+  <div class="demo-row">
+    <div class="demo-col">
+      <h2>Without isolation</h2>
+      <div class="blend-stage">
+        <div class="blend-layer difference">A</div>
+      </div>
+      <span class="blend-label">difference bleeds through</span>
+    </div>
+    <div class="demo-col">
+      <h2>With isolation</h2>
+      <div class="blend-stage isolated">
+        <div class="blend-layer difference">A</div>
+      </div>
+      <span class="blend-label">difference is contained</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/mix-blend-isolate-za/style.css
+++ b/submissions/examples/mix-blend-isolate-za/style.css
@@ -1,0 +1,68 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+body {
+  background: #2d2d2d;
+  color: #e0e0e0;
+  font-family: "Century Gothic", "Segoe UI", Arial, sans-serif;
+  padding: 3rem;
+  text-align: center;
+}
+h1 {
+  font-weight: 300;
+  letter-spacing: 0.04em;
+  margin-bottom: 3rem;
+  color: #ccc;
+}
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+.demo-col {
+  text-align: center;
+}
+.demo-col h2 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+  color: #999;
+}
+.blend-stage {
+  position: relative;
+  width: 260px;
+  height: 200px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #ff6b6b, #feca57, #48dbfb);
+}
+.blend-layer {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 3rem;
+  font-weight: 800;
+  color: #fff;
+  background: rgba(0,0,0,0.3);
+}
+.blend-layer.difference {
+  mix-blend-mode: difference;
+}
+.isolated {
+  isolation: isolate;
+}
+.blend-label {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: #888;
+  background: #3a3a3a;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+}


### PR DESCRIPTION
A CSS demo showing how the isolation property affects mix-blend-mode behavior, preventing blend mode propagation through the stacking context.

Closes #19355

## Checklist
- [x] New submission in `submissions/examples/mix-blend-isolate-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26