### PR TITLE
Overscroll Behavior Contain Demo

### DIFF
--- a/submissions/examples/overscroll-behavior-contain-za/README.md
+++ b/submissions/examples/overscroll-behavior-contain-za/README.md
@@ -1,0 +1,14 @@
+# Overscroll Behavior Contain Demo
+
+A CSS demo of the overscroll-behavior property. Shows how overscroll-behavior: contain prevents nested scrollable areas from triggering the parent page scroll when they reach their boundary.
+
+## Files
+
+- `demo.html` - Two nested scroll areas side by side
+- `style.css` - overscroll-behavior property, comparison layout
+
+## Usage
+
+Open `demo.html` and scroll past the bottom of each panel to see the difference in behavior.
+
+Closes #19362

--- a/submissions/examples/overscroll-behavior-contain-za/demo.html
+++ b/submissions/examples/overscroll-behavior-contain-za/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Overscroll Behavior</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Overscroll Behavior</h1>
+  <div class="compare">
+    <div class="area">
+      <h2>auto (default) &mdash; scroll chains</h2>
+      <div class="scroll-panel auto-scroll">
+        <p>Scroll past the bottom &mdash; the page background will also scroll.</p>
+        <p>Item 1</p><p>Item 2</p><p>Item 3</p><p>Item 4</p><p>Item 5</p><p>Item 6</p><p>Item 7</p><p>Item 8</p>
+      </div>
+    </div>
+    <div class="area">
+      <h2>contain &mdash; no scroll chain</h2>
+      <div class="scroll-panel contain-scroll">
+        <p>Scroll past the bottom &mdash; only this panel scrolls, the page stays put.</p>
+        <p>Item 1</p><p>Item 2</p><p>Item 3</p><p>Item 4</p><p>Item 5</p><p>Item 6</p><p>Item 7</p><p>Item 8</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/overscroll-behavior-contain-za/style.css
+++ b/submissions/examples/overscroll-behavior-contain-za/style.css
@@ -1,0 +1,62 @@
+body,
+div,
+h1,
+h2,
+p {
+  margin: 0;
+  padding: 0;
+}
+html {
+  scroll-behavior: smooth;
+}
+body {
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 50%, #0f172a 100%);
+  color: #e2e8f0;
+  font-family: "DM Sans", "Segoe UI", Helvetica, Arial, sans-serif;
+  min-height: 200vh;
+  padding: 3rem 2rem;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 500;
+  margin-bottom: 2.5rem;
+  color: #94a3b8;
+}
+.compare {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+.area {
+  flex: 1 1 340px;
+}
+.area h2 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+}
+.scroll-panel {
+  height: 260px;
+  overflow-y: auto;
+  padding: 1rem;
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid #334155;
+  border-radius: 12px;
+  line-height: 1.6;
+  font-size: 0.9rem;
+}
+.scroll-panel p {
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(51, 65, 85, 0.3);
+  border-radius: 6px;
+}
+.auto-scroll {
+  overscroll-behavior: auto;
+}
+.contain-scroll {
+  overscroll-behavior: contain;
+}


### PR DESCRIPTION
A CSS demo of overscroll-behavior showing how to prevent scroll chaining in nested scrollable areas.

Closes #19362

## Checklist
- [x] New submission in `submissions/examples/overscroll-behavior-contain-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26