### PR TITLE
Forced Color Adjust Demo

### DIFF
--- a/submissions/examples/forced-color-adjust-za/README.md
+++ b/submissions/examples/forced-color-adjust-za/README.md
@@ -1,0 +1,14 @@
+# Forced Color Adjust Demo
+
+A CSS demo of the forced-color-adjust property showing how forced-color-adjust: none preserves custom colors in forced color modes like Windows High Contrast Mode.
+
+## Files
+
+- `demo.html` - Two cards comparing auto vs none behavior
+- `style.css` - forced-color-adjust property, card layout
+
+## Usage
+
+Open `demo.html` and enable Windows High Contrast Mode to see the difference.
+
+Closes #19366

--- a/submissions/examples/forced-color-adjust-za/demo.html
+++ b/submissions/examples/forced-color-adjust-za/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Forced Color Adjust</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Forced Color Adjust</h1>
+  <p class="intro">In Windows High Contrast Mode, the right card preserves its custom colors.</p>
+  <div class="card-row">
+    <div class="demo-card auto-adjust">
+      <div class="card-icon">A</div>
+      <h2>auto (default)</h2>
+      <p>Colors are replaced by system colors in forced modes.</p>
+      <span class="card-badge">default</span>
+    </div>
+    <div class="demo-card no-adjust">
+      <div class="card-icon preserve">P</div>
+      <h2>forced-color-adjust: none</h2>
+      <p>Custom colors are preserved in forced color modes.</p>
+      <span class="card-badge preserve">preserved</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/forced-color-adjust-za/style.css
+++ b/submissions/examples/forced-color-adjust-za/style.css
@@ -1,0 +1,84 @@
+body,
+h1,
+h2,
+p,
+div,
+span {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+body {
+  background: #f0ebe3;
+  color: #2d2a24;
+  font-family: "Barlow", "Segoe UI", Tahoma, Geneva, sans-serif;
+  padding: 3rem 2rem;
+  min-height: 100vh;
+}
+h1 {
+  font-size: 2.2rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  color: #1c1917;
+}
+.intro {
+  color: #78716c;
+  margin-bottom: 2.5rem;
+  font-size: 1rem;
+}
+.card-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+.demo-card {
+  flex: 1 1 280px;
+  background: #fff;
+  border: 1px solid #e7e5e4;
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 1px 6px rgba(0,0,0,0.04);
+}
+.demo-card h2 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #292524;
+}
+.demo-card p {
+  font-size: 0.9rem;
+  color: #78716c;
+  line-height: 1.5;
+  margin-bottom: 1.25rem;
+}
+.card-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: #7c3aed;
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+}
+.card-icon.preserve {
+  background: #059669;
+}
+.card-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  background: #f5f5f4;
+  color: #44403c;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 999px;
+}
+.card-badge.preserve {
+  background: #d1fae5;
+  color: #065f46;
+}
+.no-adjust {
+  forced-color-adjust: none;
+}


### PR DESCRIPTION
A CSS demo of forced-color-adjust property showing how to control color preservation in Windows High Contrast Mode and forced color schemes.

Closes #19366

## Checklist
- [x] New submission in `submissions/examples/forced-color-adjust-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26