### PR TITLE
CSS Filter Drop Shadow vs Box Shadow

### DIFF
--- a/submissions/examples/filter-drop-shadow-za/README.md
+++ b/submissions/examples/filter-drop-shadow-za/README.md
@@ -1,0 +1,14 @@
+# CSS Filter Drop Shadow vs Box Shadow
+
+A CSS demo comparing filter: drop-shadow() with box-shadow. The drop-shadow follows the element's visible contour (clip-path), while box-shadow follows the element box.
+
+## Files
+
+- `demo.html` - Two shapes with different shadow methods
+- `style.css` - filter: drop-shadow, box-shadow, clip-path shapes
+
+## Usage
+
+Open `demo.html` to see how drop-shadow respects clip-path contours.
+
+Closes #19374

--- a/submissions/examples/filter-drop-shadow-za/demo.html
+++ b/submissions/examples/filter-drop-shadow-za/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Drop Shadow vs Box Shadow</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="wrap">
+    <h1>Drop Shadow vs Box Shadow</h1>
+    <div class="row">
+      <div class="col">
+        <h2>box-shadow</h2>
+        <div class="shape box-shadow-demo">
+          <div class="circle-clip"></div>
+        </div>
+        <span class="note">Follows the element box</span>
+      </div>
+      <div class="col">
+        <h2>filter: drop-shadow</h2>
+        <div class="shape drop-shadow-demo">
+          <div class="circle-clip"></div>
+        </div>
+        <span class="note">Follows the visible shape</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/filter-drop-shadow-za/style.css
+++ b/submissions/examples/filter-drop-shadow-za/style.css
@@ -1,0 +1,70 @@
+body,
+h1,
+h2,
+div,
+span {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: #e2e8f0;
+  color: #1e293b;
+  font-family: "Source Sans 3", "Segoe UI", Helvetica, sans-serif;
+  padding: 3rem 2rem;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+.wrap {
+  max-width: 700px;
+  text-align: center;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  margin-bottom: 3rem;
+  color: #0f172a;
+}
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3rem;
+  justify-content: center;
+}
+.col {
+  text-align: center;
+}
+.col h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 1rem;
+}
+.shape {
+  width: 180px;
+  height: 180px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #6366f1;
+  margin: 0 auto 1rem;
+}
+.circle-clip {
+  width: 80px;
+  height: 80px;
+  background: #f59e0b;
+  border-radius: 50%;
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}
+.box-shadow-demo {
+  box-shadow: 0 8px 32px rgba(99,102,241,0.5);
+}
+.drop-shadow-demo {
+  filter: drop-shadow(0 8px 16px rgba(99,102,241,0.6));
+}
+.note {
+  font-size: 0.85rem;
+  color: #64748b;
+}


### PR DESCRIPTION
A CSS demo comparing filter: drop-shadow() with box-shadow, showing how drop-shadow follows element contours including transparent areas.

Closes #19374

## Checklist
- [x] New submission in `submissions/examples/filter-drop-shadow-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26