### PR TITLE
Text Combine Upright Digits

### DIFF
--- a/submissions/examples/text-combine-upright-za/README.md
+++ b/submissions/examples/text-combine-upright-za/README.md
@@ -1,0 +1,14 @@
+# Text Combine Upright Digits
+
+A CSS demo of text-combine-upright property (tate-chu-yoko) that compresses digits into a single character space within vertical writing mode.
+
+## Files
+
+- `demo.html` - Two vertical text blocks comparing with and without text-combine-upright
+- `style.css` - text-combine-upright: all, writing-mode: vertical-rl
+
+## Usage
+
+Open `demo.html` to see how '2026' compresses in the vertical text.
+
+Closes #19386

--- a/submissions/examples/text-combine-upright-za/demo.html
+++ b/submissions/examples/text-combine-upright-za/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Combine Upright</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Text Combine Upright</h1>
+  <div class="combo-row">
+    <div class="combo-col">
+      <h2>Without text-combine-upright</h2>
+      <div class="vtext normal">Published in 2026 on CSS</div>
+    </div>
+    <div class="combo-col">
+      <h2>With text-combine-upright</h2>
+      <div class="vtext combined">Published in 2026 on CSS</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/text-combine-upright-za/style.css
+++ b/submissions/examples/text-combine-upright-za/style.css
@@ -1,0 +1,50 @@
+body,
+h1,
+h2,
+div {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: #f0eade;
+  color: #2c2416;
+  font-family: "Noto Serif", "Georgia", "Times New Roman", serif;
+  padding: 3rem 2rem;
+  min-height: 100vh;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 3rem;
+  color: #44403c;
+}
+.combo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3rem;
+}
+.combo-col {
+  text-align: center;
+}
+.combo-col h2 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #78716c;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 1rem;
+}
+.vtext {
+  writing-mode: vertical-rl;
+  font-size: 1.8rem;
+  height: 280px;
+  padding: 1.5rem 0.75rem;
+  background: #fff;
+  border: 1px solid #e7e5e4;
+  border-radius: 12px;
+  font-family: "Noto Serif", serif;
+  line-height: 1.8;
+}
+.combined {
+  text-combine-upright: all;
+}


### PR DESCRIPTION
A CSS demo of text-combine-upright property that compresses digits into a single character space in vertical writing mode.

Closes #19386

## Checklist
- [x] New submission in `submissions/examples/text-combine-upright-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26