### PR TITLE
Transition Behavior Allow Discrete

### DIFF
--- a/submissions/examples/transition-behavior-za/README.md
+++ b/submissions/examples/transition-behavior-za/README.md
@@ -1,0 +1,14 @@
+# Transition Behavior Allow Discrete
+
+A CSS demo of transition-behavior: allow-discrete enabling smooth transitions for discrete properties like display. Combined with @starting-style for entry animations.
+
+## Files
+
+- `demo.html` - Toggle box with display transition
+- `style.css` - transition-behavior: allow-discrete, @starting-style, opacity transition
+
+## Usage
+
+Open `demo.html` and click the button to see the discrete transition effect.
+
+Closes #19390

--- a/submissions/examples/transition-behavior-za/demo.html
+++ b/submissions/examples/transition-behavior-za/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Transition Behavior</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="center">
+    <h1>Transition Behavior</h1>
+    <p class="sub">Click the button to see allow-discrete transition on display.</p>
+    <button class="toggle-btn" id="toggleBtn">Toggle Box</button>
+    <div class="box-wrap">
+      <div class="demo-box" id="demoBox">
+        <p>This box uses transition-behavior: allow-discrete to animate from display: none to display: block.</p>
+      </div>
+    </div>
+  </div>
+  <script>
+    const btn = document.getElementById("toggleBtn");
+    const box = document.getElementById("demoBox");
+    btn.addEventListener("click", () => {
+      box.classList.toggle("visible");
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/transition-behavior-za/style.css
+++ b/submissions/examples/transition-behavior-za/style.css
@@ -1,0 +1,74 @@
+html,
+body,
+h1,
+p,
+div,
+button {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: #312e41;
+  color: #e6e0f0;
+  font-family: "Bricolage Grotesque", "Segoe UI", system-ui, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 4rem 2rem;
+}
+.center {
+  text-align: center;
+  max-width: 500px;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #c8bfe8;
+}
+.sub {
+  color: #8f86a8;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+}
+.toggle-btn {
+  padding: 0.75rem 2rem;
+  border: none;
+  border-radius: 10px;
+  background: #7c6ff0;
+  color: #fff;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.toggle-btn:hover {
+  background: #6c5ce7;
+}
+.box-wrap {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: center;
+}
+.demo-box {
+  display: none;
+  padding: 1.5rem;
+  background: #4a4266;
+  border-radius: 14px;
+  max-width: 400px;
+  line-height: 1.6;
+  font-size: 0.95rem;
+  color: #d8d0ec;
+  transition: opacity 0.4s, display 0.4s allow-discrete;
+  opacity: 0;
+}
+.demo-box.visible {
+  display: block;
+  opacity: 1;
+}
+@starting-style {
+  .demo-box.visible {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
A CSS demo of transition-behavior: allow-discrete enabling smooth transitions for discrete CSS properties like display and overlay.

Closes #19390

## Checklist
- [x] New submission in `submissions/examples/transition-behavior-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26