### PR TITLE
Object Fit Cover Contain Scale

### DIFF
--- a/submissions/examples/object-fit-cover-za/README.md
+++ b/submissions/examples/object-fit-cover-za/README.md
@@ -1,0 +1,14 @@
+# Object Fit Cover Contain Scale
+
+A CSS demo comparing object-fit property values (cover, contain, fill, scale-down). Shows how each value affects the sizing of replaced elements within their container.
+
+## Files
+
+- `demo.html` - Four object-fit variant cards
+- `style.css` - object-fit property, aspect-ratio containers
+
+## Usage
+
+Open `demo.html` to see the different object-fit values in action.
+
+Closes #19392

--- a/submissions/examples/object-fit-cover-za/demo.html
+++ b/submissions/examples/object-fit-cover-za/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Object Fit Values</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="page">
+    <h1>Object Fit Values</h1>
+    <div class="fit-grid">
+      <div class="fit-card">
+        <h2>cover</h2>
+        <div class="fit-box">
+          <div class="fit-img cover"></div>
+        </div>
+        <span class="fit-tag">Fills area, may crop</span>
+      </div>
+      <div class="fit-card">
+        <h2>contain</h2>
+        <div class="fit-box">
+          <div class="fit-img contain"></div>
+        </div>
+        <span class="fit-tag">Fits inside, may letterbox</span>
+      </div>
+      <div class="fit-card">
+        <h2>fill</h2>
+        <div class="fit-box">
+          <div class="fit-img fill"></div>
+        </div>
+        <span class="fit-tag">Stretches to fill</span>
+      </div>
+      <div class="fit-card">
+        <h2>scale-down</h2>
+        <div class="fit-box">
+          <div class="fit-img scale-down"></div>
+        </div>
+        <span class="fit-tag">Smallest of contain/none</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/object-fit-cover-za/style.css
+++ b/submissions/examples/object-fit-cover-za/style.css
@@ -1,0 +1,75 @@
+body,
+h1,
+h2,
+div,
+span {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: #e5e0d8;
+  color: #1c1917;
+  font-family: "Mona Sans", "Segoe UI", Helvetica, Arial, sans-serif;
+  padding: 3rem 2rem;
+}
+.page {
+  max-width: 900px;
+  margin: 0 auto;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  margin-bottom: 2.5rem;
+  color: #292524;
+}
+.fit-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+.fit-card {
+  text-align: center;
+}
+.fit-card h2 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #57534e;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.75rem;
+}
+.fit-box {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #d6d0c4;
+  border: 2px solid #c4bdb0;
+}
+.fit-img {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #6366f1 0%, #ec4899 50%, #f59e0b 100%);
+  background-size: 200% 200%;
+}
+.fit-img.cover {
+  object-fit: cover;
+}
+.fit-img.contain {
+  object-fit: contain;
+}
+.fit-img.fill {
+  object-fit: fill;
+}
+.fit-img.scale-down {
+  object-fit: scale-down;
+}
+.fit-tag {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: #78716c;
+  background: #d6d0c4;
+  padding: 0.2rem 0.6rem;
+  border-radius: 6px;
+}


### PR DESCRIPTION
A CSS demo comparing object-fit values (cover, contain, fill, scale-down) for controlling how replaced elements fit their container.

Closes #19392

## Checklist
- [x] New submission in `submissions/examples/object-fit-cover-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26