### PR TITLE
Add Animated Sidebar Navigation with Collapse Effect

### DIFF
--- a/submissions/core_changes-issue-19299/README.md
+++ b/submissions/core_changes-issue-19299/README.md
@@ -1,0 +1,27 @@
+# Animated Sidebar Navigation with Collapse Effect — Issue #19299
+
+## What does this do?
+A pure-CSS animated sidebar navigation that collapses from 240px to 72px using a hidden checkbox toggle, with SVG icons, active-state accent bar, hover effects, responsive mobile overlay, and reduced-motion support.
+
+## How is it used?
+```html
+<input type="checkbox" id="collapse" class="collapse-toggle" />
+<aside class="sidebar">
+  <div class="sidebar-header">
+    <label for="collapse" class="toggle-btn">☰</label>
+    <span class="brand-text">EaseMotion</span>
+  </div>
+  <nav class="nav-list">
+    <a href="#" class="nav-item active">
+      <span class="nav-icon"><!-- SVG --></span>
+      <span class="nav-label">Dashboard</span>
+    </a>
+  </nav>
+</aside>
+<main class="main-content">...</main>
+```
+
+The hidden checkbox controls the sidebar width via CSS sibling selector (`#collapse:checked ~ .sidebar`). No JavaScript required.
+
+## Why is it useful for EaseMotion CSS?
+Sidebar navigation is a foundational UI pattern used in admin dashboards, documentation sites, and web apps. A CSS-only collapsible sidebar with smooth transitions and responsive mobile behavior provides a reusable, accessible pattern that fits EaseMotion CSS's motion-first philosophy.

--- a/submissions/core_changes-issue-19299/demo.html
+++ b/submissions/core_changes-issue-19299/demo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Sidebar Navigation</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <input type="checkbox" id="collapse" class="collapse-toggle" />
+
+  <aside class="sidebar">
+    <div class="sidebar-header">
+      <label for="collapse" class="toggle-btn">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      </label>
+      <span class="brand-text">EaseMotion</span>
+    </div>
+
+    <nav class="nav-list">
+      <a href="#" class="nav-item active">
+        <span class="nav-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <rect x="3" y="3" width="7" height="7" />
+            <rect x="14" y="3" width="7" height="7" />
+            <rect x="3" y="14" width="7" height="7" />
+            <rect x="14" y="14" width="7" height="7" />
+          </svg>
+        </span>
+        <span class="nav-label">Dashboard</span>
+      </a>
+
+      <a href="#" class="nav-item">
+        <span class="nav-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M18 20V10" />
+            <path d="M12 20V4" />
+            <path d="M6 20v-6" />
+          </svg>
+        </span>
+        <span class="nav-label">Analytics</span>
+      </a>
+
+      <a href="#" class="nav-item">
+        <span class="nav-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z" />
+          </svg>
+        </span>
+        <span class="nav-label">Projects</span>
+      </a>
+
+      <a href="#" class="nav-item">
+        <span class="nav-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
+          </svg>
+        </span>
+        <span class="nav-label">Settings</span>
+      </a>
+
+      <a href="#" class="nav-item">
+        <span class="nav-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4" />
+            <polyline points="16 17 21 12 16 7" />
+            <line x1="21" y1="12" x2="9" y2="12" />
+          </svg>
+        </span>
+        <span class="nav-label">Logout</span>
+      </a>
+    </nav>
+  </aside>
+
+  <main class="main-content">
+    <div class="content-header">
+      <label for="collapse" class="mobile-toggle" aria-label="Toggle sidebar">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      </label>
+      <h1>Welcome back</h1>
+    </div>
+    <p>Toggle the sidebar using the hamburger icon in the top-left corner.</p>
+  </main>
+
+</body>
+</html>

--- a/submissions/core_changes-issue-19299/style.css
+++ b/submissions/core_changes-issue-19299/style.css
@@ -1,0 +1,237 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  display: flex;
+  min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #f8fafc;
+}
+
+/* ── Hidden Checkbox (Toggle Control) ── */
+.collapse-toggle {
+  display: none;
+}
+
+/* ── Sidebar ── */
+.sidebar {
+  width: 240px;
+  min-height: 100vh;
+  background: #0f172a;
+  display: flex;
+  flex-direction: column;
+  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+  position: relative;
+  z-index: 10;
+}
+
+/* ── Sidebar Header ── */
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  min-height: 72px;
+}
+
+.toggle-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.toggle-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #e2e8f0;
+}
+
+.brand-text {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  white-space: nowrap;
+  transition: opacity 0.2s ease;
+}
+
+/* ── Navigation ── */
+.nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 8px;
+  flex: 1;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  color: #94a3b8;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
+  border-left: 3px solid transparent;
+  transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
+}
+
+.nav-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #e2e8f0;
+  transform: translateX(4px);
+}
+
+.nav-item.active {
+  background: rgba(99, 102, 241, 0.12);
+  color: #818cf8;
+  border-left-color: #818cf8;
+}
+
+.nav-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+}
+
+.nav-label {
+  transition: opacity 0.2s ease;
+}
+
+/* ── Main Content ── */
+.main-content {
+  flex: 1;
+  padding: 40px;
+  transition: padding 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.content-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.content-header h1 {
+  font-size: 1.75rem;
+  color: #0f172a;
+}
+
+.mobile-toggle {
+  display: none;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  color: #64748b;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.mobile-toggle:hover {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.main-content p {
+  font-size: 1rem;
+  color: #64748b;
+}
+
+/* ── Collapsed State ── */
+#collapse:checked ~ .sidebar {
+  width: 72px;
+}
+
+#collapse:checked ~ .sidebar .brand-text,
+#collapse:checked ~ .sidebar .nav-label {
+  opacity: 0;
+  width: 0;
+  overflow: hidden;
+}
+
+#collapse:checked ~ .sidebar .nav-item {
+  justify-content: center;
+  padding: 10px 0;
+  border-left-color: transparent;
+}
+
+#collapse:checked ~ .sidebar .nav-item.active {
+  border-left-color: transparent;
+}
+
+#collapse:checked ~ .main-content {
+  padding: 40px 40px 40px 24px;
+}
+
+/* ── Responsive (Mobile) ── */
+@media (max-width: 768px) {
+  .mobile-toggle {
+    display: flex;
+  }
+
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    z-index: 100;
+    transform: translateX(0);
+  }
+
+  #collapse:checked ~ .sidebar {
+    transform: translateX(-100%);
+    width: 240px;
+  }
+
+  #collapse:checked ~ .sidebar .brand-text,
+  #collapse:checked ~ .sidebar .nav-label {
+    opacity: 1;
+    width: auto;
+    overflow: visible;
+  }
+
+  #collapse:checked ~ .sidebar .nav-item {
+    justify-content: flex-start;
+    padding: 10px 12px;
+  }
+
+  .main-content {
+    margin-left: 0;
+    padding: 40px 20px;
+  }
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .sidebar,
+  .brand-text,
+  .nav-label,
+  .nav-item,
+  .toggle-btn,
+  .main-content {
+    transition: none !important;
+  }
+
+  .nav-item:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## ✦ Description

Add a pure-CSS animated sidebar navigation with collapse/expand effect using a hidden checkbox toggle. The sidebar transitions from 240px to 72px on collapse, showing only icons in collapsed state.

Fixes #19299

---

## ⟡ Type of Change
- [x] New feature (non-breaking change which adds functionality)

---

## ✦ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.
- [x] I have verified that my changes work correctly on both desktop and mobile viewports.

---

## Additional Notes
- New folder: submissions/core_changes-issue-19299/
- Uses checkbox hack (pure CSS, zero JavaScript)
- 5 nav items with inline SVG icons
- Active state with colored left accent bar
- Hover effect with background + translateX
- Responsive: fixed overlay sidebar on mobile
- prefers-reduced-motion support
- Branch: feat/sidebar-nav-19299-v2