### PR TITLE
CSS Timeline Scope Shared Scroll Timeline

### DIFF
--- a/submissions/examples/timeline-scope-za/README.md
+++ b/submissions/examples/timeline-scope-za/README.md
@@ -1,0 +1,14 @@
+# CSS Timeline Scope Shared Scroll Timeline
+
+A CSS demo of timeline-scope property enabling named scroll timelines to be shared between ancestor and descendant elements for coordinated scroll-driven animations.
+
+## Files
+
+- `demo.html` - Scrollable content with shared timeline progress bar
+- `style.css` - timeline-scope, scroll-timeline-name, animation-timeline
+
+## Usage
+
+Open `demo.html` and scroll the content area to see the progress bar animate.
+
+Closes #19401

--- a/submissions/examples/timeline-scope-za/demo.html
+++ b/submissions/examples/timeline-scope-za/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Timeline Scope</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Timeline Scope</h1>
+  <p class="subtitle">The progress bar below shares a scroll timeline declared on the main container via timeline-scope.</p>
+  <div class="scroll-area" id="scrollArea">
+    <div class="progress-rail">
+      <div class="progress-fill"></div>
+    </div>
+    <div class="content">
+      <section><h2>Section 1</h2><p>Scroll down to see the shared timeline-scope progress bar animate across the top.</p></section>
+      <section><h2>Section 2</h2><p>The progress bar uses animation-timeline: --page-scroll linked via timeline-scope.</p></section>
+      <section><h2>Section 3</h2><p>Timeline scope allows descendant elements to reference ancestor scroll-timelines by name.</p></section>
+      <section><h2>Section 4</h2><p>Without timeline-scope, the timeline name would not be visible outside the declaring element.</p></section>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/timeline-scope-za/style.css
+++ b/submissions/examples/timeline-scope-za/style.css
@@ -1,0 +1,75 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: inherit;
+}
+html {
+  box-sizing: border-box;
+}
+body {
+  background: #0d1117;
+  color: #c9d1d9;
+  font-family: "DM Sans", Helvetica, Arial, sans-serif;
+  padding: 2rem;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  color: #58a6ff;
+  margin-bottom: 0.25rem;
+}
+.subtitle {
+  color: #8b949e;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+  max-width: 600px;
+}
+.scroll-area {
+  height: 400px;
+  overflow-y: auto;
+  scroll-timeline-name: --page-scroll;
+  scroll-timeline-axis: block;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  position: relative;
+}
+.progress-rail {
+  position: sticky;
+  top: 0;
+  height: 6px;
+  background: #21262d;
+  z-index: 10;
+}
+.progress-fill {
+  height: 100%;
+  width: 100%;
+  background: linear-gradient(90deg, #58a6ff, #bc8cff);
+  transform-origin: 0 50%;
+  animation: scaleProgress 1s linear;
+  animation-timeline: --page-scroll;
+  timeline-scope: --page-scroll;
+}
+@keyframes scaleProgress {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
+}
+.content section {
+  padding: 3rem 2rem;
+  border-bottom: 1px solid #21262d;
+}
+.content section:last-child {
+  border-bottom: none;
+}
+.content h2 {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: #f0f6fc;
+  margin-bottom: 0.75rem;
+}
+.content p {
+  color: #8b949e;
+  line-height: 1.7;
+  max-width: 500px;
+}


### PR DESCRIPTION
A CSS demo of timeline-scope property enabling named scroll timelines declared on ancestors to be shared with descendant elements for scroll-driven animations.

Closes #19401

## Checklist
- [x] New submission in `submissions/examples/timeline-scope-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26