### PR TITLE
CSS Text Wrap Balance Headlines

### DIFF
--- a/submissions/examples/text-wrap-balance-headline-za/README.md
+++ b/submissions/examples/text-wrap-balance-headline-za/README.md
@@ -1,0 +1,14 @@
+# CSS Text Wrap Balance Headlines
+
+A CSS demo of text-wrap: balance creating visually balanced multi-line headlines by evening out line lengths and preventing orphaned words.
+
+## Files
+
+- `demo.html` - Headlines comparing default vs balanced wrapping
+- `style.css` - text-wrap: balance property, serif typography
+
+## Usage
+
+Open `demo.html` to see how balanced wrapping improves headline appearance.
+
+Closes #19409

--- a/submissions/examples/text-wrap-balance-headline-za/demo.html
+++ b/submissions/examples/text-wrap-balance-headline-za/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Wrap Balance</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Text Wrap Balance</h1>
+    <div class="split">
+      <div class="col">
+        <h2>wrap: unbalanced (default)</h2>
+        <div class="headline unbalanced">The quick brown fox jumps over the lazy dog near the riverbank.</div>
+        <p class="note">Default wrapping leaves uneven lines with orphaned words.</p>
+      </div>
+      <div class="col">
+        <h2>wrap: balance</h2>
+        <div class="headline balanced">The quick brown fox jumps over the lazy dog near the riverbank.</div>
+        <p class="note">Balanced wrapping evens out line lengths for a cleaner look.</p>
+      </div>
+    </div>
+    <div class="more">
+      <h2>More examples</h2>
+      <div class="headline unbalanced">This is a significantly longer headline that demonstrates the wrapping difference even more dramatically across multiple lines of text content.</div>
+      <div class="headline balanced">This is a significantly longer headline that demonstrates the wrapping difference even more dramatically across multiple lines of text content.</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/text-wrap-balance-headline-za/style.css
+++ b/submissions/examples/text-wrap-balance-headline-za/style.css
@@ -1,0 +1,63 @@
+body,
+h1,
+h2,
+p,
+div {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: #faf9f6;
+  color: #1c1917;
+  font-family: "Playfair Display", Georgia, "Times New Roman", serif;
+  padding: 3rem 2rem;
+}
+.container {
+  max-width: 780px;
+  margin: 0 auto;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 2.5rem;
+  color: #292524;
+}
+h2 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #a8a29e;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 1rem;
+}
+.split {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  margin-bottom: 3rem;
+}
+.col {
+  flex: 1 1 300px;
+}
+.headline {
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: #292524;
+  max-width: 100%;
+  margin-bottom: 0.75rem;
+}
+.balanced {
+  text-wrap: balance;
+}
+.note {
+  font-size: 0.85rem;
+  color: #78716c;
+  font-family: "Inter", system-ui, sans-serif;
+}
+.more .headline {
+  margin-bottom: 1.5rem;
+}
+.more .headline:last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
A CSS demo of text-wrap: balance creating visually balanced multi-line headlines by evening out line lengths.

Closes #19409

## Checklist
- [x] New submission in `submissions/examples/text-wrap-balance-headline-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26