### PR TITLE
CSS Text Wrap Pretty Paragraphs

### DIFF
--- a/submissions/examples/text-wrap-pretty-para-za/README.md
+++ b/submissions/examples/text-wrap-pretty-para-za/README.md
@@ -1,0 +1,14 @@
+# CSS Text Wrap Pretty Paragraphs
+
+A CSS demo of text-wrap: pretty optimizing the last line of paragraphs to avoid orphaned single words, improving readability in body text.
+
+## Files
+
+- `demo.html` - Two-column comparison of default vs pretty wrapping
+- `style.css` - text-wrap: pretty, serif body typography
+
+## Usage
+
+Open `demo.html` to see how pretty-wrap eliminates orphans on the last line.
+
+Closes #19411

--- a/submissions/examples/text-wrap-pretty-para-za/demo.html
+++ b/submissions/examples/text-wrap-pretty-para-za/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Wrap Pretty</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="page">
+    <h1>Text Wrap Pretty</h1>
+    <p class="lede">Compare how the last line renders with default wrapping versus text-wrap: pretty.</p>
+    <div class="columns">
+      <article class="article">
+        <h2>Default wrap</h2>
+        <p class="default-wrap">The art of typography lies not only in the choice of typeface but also in the careful consideration of spacing, alignment, and the subtle nuances that make text a pleasure to read across various devices and screen sizes.</p>
+        <p class="default-wrap">Notice how the last line of this paragraph has a single orphan word dangling alone, which can disrupt the reading rhythm and create an uneven visual appearance that careful designers strive to avoid in their work.</p>
+      </article>
+      <article class="article">
+        <h2>text-wrap: pretty</h2>
+        <p class="pretty-wrap">The art of typography lies not only in the choice of typeface but also in the careful consideration of spacing, alignment, and the subtle nuances that make text a pleasure to read across various devices and screen sizes.</p>
+        <p class="pretty-wrap">Notice how the last line of this paragraph has a single orphan word dangling alone, which can disrupt the reading rhythm and create an uneven visual appearance that careful designers strive to avoid in their work.</p>
+      </article>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/text-wrap-pretty-para-za/style.css
+++ b/submissions/examples/text-wrap-pretty-para-za/style.css
@@ -1,0 +1,53 @@
+* {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: #fefdfb;
+  color: #292524;
+  font-family: "Source Serif 4", Georgia, "Times New Roman", serif;
+  padding: 3rem 2rem;
+  font-size: 1.1rem;
+  line-height: 1.7;
+}
+.page {
+  max-width: 900px;
+  margin: 0 auto;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1c1917;
+  margin-bottom: 0.5rem;
+  font-family: "Inter", system-ui, sans-serif;
+}
+.lede {
+  color: #78716c;
+  margin-bottom: 2.5rem;
+  font-size: 1rem;
+  font-family: "Inter", system-ui, sans-serif;
+}
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2.5rem;
+}
+.article h2 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #a8a29e;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 1rem;
+  font-family: "Inter", system-ui, sans-serif;
+}
+.article p {
+  margin-bottom: 1rem;
+  text-align: justify;
+}
+.default-wrap {
+  text-wrap: wrap;
+}
+.pretty-wrap {
+  text-wrap: pretty;
+}


### PR DESCRIPTION
A CSS demo of text-wrap: pretty optimizing the last line of paragraphs to avoid orphaned single words.

Closes #19411

## Checklist
- [x] New submission in `submissions/examples/text-wrap-pretty-para-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26