### PR TITLE
CSS Field Sizing Auto Textarea

### DIFF
--- a/submissions/examples/field-sizing-auto-za/README.md
+++ b/submissions/examples/field-sizing-auto-za/README.md
@@ -1,0 +1,14 @@
+# CSS Field Sizing Auto Textarea
+
+A CSS demo of field-sizing: content making textareas and input fields automatically grow to fit their content without JavaScript.
+
+## Files
+
+- `demo.html` - Form with auto-growing textareas and input
+- `style.css` - field-sizing: content property, form styling
+
+## Usage
+
+Open `demo.html` and type into the fields to see auto-sizing.
+
+Closes #19413

--- a/submissions/examples/field-sizing-auto-za/demo.html
+++ b/submissions/examples/field-sizing-auto-za/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Field Sizing Auto</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="card-form">
+    <h1>Field Sizing Auto</h1>
+    <p class="hint">Type into each field to see field-sizing: auto in action.</p>
+    <div class="field-group">
+      <label for="name">Name (static)</label>
+      <input type="text" id="name" class="field-static" placeholder="Your name" value="John Doe">
+    </div>
+    <div class="field-group">
+      <label for="comment">Comment (auto-grow)</label>
+      <textarea id="comment" class="field-auto" placeholder="Start typing to see auto-grow..." rows="2">This textarea automatically grows as you type more content into it, thanks to field-sizing: auto on the element.</textarea>
+    </div>
+    <div class="field-group">
+      <label for="bio">Bio (auto-grow)</label>
+      <textarea id="bio" class="field-auto" placeholder="Tell us about yourself..." rows="1"></textarea>
+    </div>
+    <div class="field-group">
+      <label for="search">Search (auto-width)</label>
+      <input type="text" id="search" class="field-auto-width" placeholder="Type to expand..." value="field-sizing">
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/field-sizing-auto-za/style.css
+++ b/submissions/examples/field-sizing-auto-za/style.css
@@ -1,0 +1,80 @@
+body,
+h1,
+p,
+label,
+input,
+textarea,
+div {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: #f1f5f9;
+  color: #0f172a;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 3rem 2rem;
+}
+.card-form {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 2rem;
+  max-width: 500px;
+  width: 100%;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+}
+h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+.hint {
+  color: #64748b;
+  font-size: 0.85rem;
+  margin-bottom: 1.5rem;
+}
+.field-group {
+  margin-bottom: 1.25rem;
+}
+label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.4rem;
+}
+.field-static {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  background: #f8fafc;
+}
+.field-auto {
+  field-sizing: content;
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  resize: none;
+  line-height: 1.5;
+  min-height: 3rem;
+}
+.field-auto-width {
+  field-sizing: content;
+  padding: 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  min-width: 200px;
+}


### PR DESCRIPTION
A CSS demo of field-sizing: auto making textareas and input fields automatically grow to fit their content.

Closes #19413

## Checklist
- [x] New submission in `submissions/examples/field-sizing-auto-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26