### PR TITLE
CSS Interpolate Size Transitions

### DIFF
--- a/submissions/examples/interpolate-size-za/README.md
+++ b/submissions/examples/interpolate-size-za/README.md
@@ -1,0 +1,14 @@
+# CSS Interpolate Size Transitions
+
+A CSS demo of interpolate-size enabling smooth CSS transitions on intrinsic sizing keywords like auto, allowing elements to animate between automatic and fixed sizes.
+
+## Files
+
+- `demo.html` - Expandable panel with height: auto transition
+- `style.css` - interpolate-size: allow-keywords, height transition
+
+## Usage
+
+Open `demo.html` and click the button to see the smooth height transition.
+
+Closes #19415

--- a/submissions/examples/interpolate-size-za/demo.html
+++ b/submissions/examples/interpolate-size-za/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Interpolate Size</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="app">
+    <h1>Interpolate Size</h1>
+    <p class="caption">Smoothly transition between intrinsic and fixed sizes.</p>
+    <div class="demo-box" id="demoBox">
+      <div class="expand-area">
+        <div class="expand-target" id="expandTarget">
+          <p>This panel smoothly transitions its height using interpolate-size. Click the button to toggle between auto and a fixed height.</p>
+          <p>Without interpolate-size, the transition from height: 0 to height: auto would jump instantly.</p>
+        </div>
+      </div>
+      <button class="action-btn" id="toggleBtn">Toggle Expand</button>
+    </div>
+  </div>
+  <script>
+    const target = document.getElementById("expandTarget");
+    const btn = document.getElementById("toggleBtn");
+    btn.addEventListener("click", () => {
+      target.classList.toggle("collapsed");
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/interpolate-size-za/style.css
+++ b/submissions/examples/interpolate-size-za/style.css
@@ -1,0 +1,77 @@
+html,
+body,
+h1,
+p,
+div,
+button {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: #1c1c2e;
+  color: #d8d8f0;
+  font-family: "Space Grotesk", "Segoe UI", system-ui, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 3rem 2rem;
+}
+.app {
+  max-width: 480px;
+  width: 100%;
+  text-align: center;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #a78bfa;
+  margin-bottom: 0.25rem;
+}
+.caption {
+  color: #7878a0;
+  margin-bottom: 2rem;
+  font-size: 0.9rem;
+}
+.demo-box {
+  background: #2a2a44;
+  border-radius: 16px;
+  padding: 1.5rem;
+  text-align: left;
+}
+.expand-target {
+  interpolate-size: allow-keywords;
+  height: auto;
+  overflow: hidden;
+  transition: height 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.expand-target.collapsed {
+  height: 0;
+}
+.expand-target p {
+  color: #a0a0c8;
+  font-size: 0.9rem;
+  line-height: 1.7;
+  margin-bottom: 0.75rem;
+}
+.expand-target p:last-child {
+  margin-bottom: 0;
+}
+.expand-area {
+  margin-bottom: 1rem;
+}
+.action-btn {
+  width: 100%;
+  padding: 0.75rem;
+  border: none;
+  border-radius: 10px;
+  background: #7c3aed;
+  color: #fff;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.action-btn:hover {
+  background: #6d28d9;
+}


### PR DESCRIPTION
A CSS demo of interpolate-size enabling smooth CSS transitions on intrinsic sizing keywords like auto, min-content, and fit-content.

Closes #19415

## Checklist
- [x] New submission in `submissions/examples/interpolate-size-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26