### PR TITLE
CSS Text Box Trim Leading

### DIFF
--- a/submissions/examples/text-box-trim-leading-za/README.md
+++ b/submissions/examples/text-box-trim-leading-za/README.md
@@ -1,0 +1,14 @@
+# CSS Text Box Trim Leading
+
+A CSS demo of text-box-trim removing excess leading space above the first line and below the last line for precise typographic alignment.
+
+## Files
+
+- `demo.html` - Headings and text blocks comparing trimmed vs untrimmed leading
+- `style.css` - text-box-trim, text-box-edge properties
+
+## Usage
+
+Open `demo.html` to see how text-box-trim tightens text alignment.
+
+Closes #19419

--- a/submissions/examples/text-box-trim-leading-za/demo.html
+++ b/submissions/examples/text-box-trim-leading-za/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Box Trim</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="root">
+    <h1>Text Box Trim</h1>
+    <p class="desc">Compare how headings align with adjacent elements before and after applying text-box-trim.</p>
+    <div class="comparison">
+      <div class="side">
+        <h2>Without trim</h2>
+        <div class="row-example">
+          <div class="box untrimmed">
+            <h3 class="no-trim">Heading Text</h3>
+          </div>
+          <div class="box untrimmed">
+            <p class="no-trim">The heading above has excess leading space above the text that pushes it away from the container top edge.</p>
+          </div>
+        </div>
+      </div>
+      <div class="side">
+        <h2>With text-box-trim</h2>
+        <div class="row-example">
+          <div class="box trimmed">
+            <h3 class="do-trim">Heading Text</h3>
+          </div>
+          <div class="box trimmed">
+            <p class="do-trim">The heading above has its leading trimmed so the text aligns flush with the container top edge for precise layouts.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/text-box-trim-leading-za/style.css
+++ b/submissions/examples/text-box-trim-leading-za/style.css
@@ -1,0 +1,75 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: #f5f3ef;
+  color: #1c1917;
+  font-family: "Work Sans", "Segoe UI", Arial, sans-serif;
+  padding: 3rem 2rem;
+}
+.root {
+  max-width: 800px;
+  margin: 0 auto;
+}
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #292524;
+  margin-bottom: 0.5rem;
+}
+.desc {
+  color: #78716c;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+}
+h2 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #a8a29e;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.75rem;
+}
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+.row-example {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.box {
+  background: #fff;
+  border: 1px solid #e7e5e4;
+  border-radius: 10px;
+  padding: 1rem;
+}
+.trimmed {
+  text-box-trim: trim-both;
+}
+h3 {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #292524;
+  line-height: 1.3;
+}
+h3.do-trim {
+  text-box-trim: trim-both;
+  text-box-edge: cap alphabetic;
+}
+h3.no-trim {
+}
+.box p {
+  font-size: 0.85rem;
+  color: #78716c;
+  line-height: 1.5;
+}
+p.do-trim {
+  text-box-trim: trim-both;
+  text-box-edge: cap alphabetic;
+}


### PR DESCRIPTION
A CSS demo of text-box-trim removing excess leading space above and below text for precise typographic alignment.

Closes #19419

## Checklist
- [x] New submission in `submissions/examples/text-box-trim-leading-za/`
- [x] All 3 required files (demo.html, style.css, README.md)
- [x] demo.html has proper DOCTYPE
- [x] style.css contains original CSS
- [x] README.md describes the feature

@gssoc26