### PR TITLE
feat: add kinetic filter toolbar demo

### DIFF
--- a/submissions/examples/kinetic-filter-toolbar/README.md
+++ b/submissions/examples/kinetic-filter-toolbar/README.md
@@ -1,0 +1,21 @@
+# Kinetic Filter Toolbar
+
+## What does this do?
+A responsive search and filter toolbar with animated focus states, selected chips, and staggered result previews.
+
+## How is it used?
+```html
+<form class="filter-toolbar">
+  <label class="search-field">
+    <span>Search</span>
+    <input type="search" value="motion">
+  </label>
+  <label class="chip">
+    <input type="radio" name="category" checked>
+    <span>All</span>
+  </label>
+</form>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS a practical filter pattern that combines form accessibility with clear, lightweight motion feedback.

--- a/submissions/examples/kinetic-filter-toolbar/demo.html
+++ b/submissions/examples/kinetic-filter-toolbar/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kinetic Filter Toolbar Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-shell" aria-labelledby="toolbar-title">
+    <section class="filter-panel">
+      <p class="eyebrow">Motion filter set</p>
+      <h1 id="toolbar-title">Kinetic Filter Toolbar</h1>
+      <p class="intro">A compact search and filter surface with animated active states, focus rings, and staggered result previews.</p>
+
+      <form class="filter-toolbar" aria-label="Project filters">
+        <label class="search-field">
+          <span>Search</span>
+          <input type="search" value="motion" aria-label="Search motion examples">
+        </label>
+
+        <fieldset class="chip-group">
+          <legend>Category</legend>
+          <label class="chip">
+            <input type="radio" name="category" checked>
+            <span>All</span>
+          </label>
+          <label class="chip">
+            <input type="radio" name="category">
+            <span>Hover</span>
+          </label>
+          <label class="chip">
+            <input type="radio" name="category">
+            <span>Cards</span>
+          </label>
+          <label class="chip">
+            <input type="radio" name="category">
+            <span>Forms</span>
+          </label>
+        </fieldset>
+      </form>
+
+      <div class="result-strip" aria-label="Filtered preview results">
+        <article>
+          <span class="status"></span>
+          <strong>Magnetic CTA</strong>
+          <small>Hover motion</small>
+        </article>
+        <article>
+          <span class="status"></span>
+          <strong>Panel Reveal</strong>
+          <small>Layout motion</small>
+        </article>
+        <article>
+          <span class="status"></span>
+          <strong>Focus Pulse</strong>
+          <small>Form feedback</small>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/kinetic-filter-toolbar/style.css
+++ b/submissions/examples/kinetic-filter-toolbar/style.css
@@ -1,0 +1,188 @@
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #16213e 0%, #0f5132 55%, #f2cc8f 100%);
+  color: #17202a;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.demo-shell {
+  width: min(92vw, 760px);
+  padding: 24px;
+}
+
+.filter-panel {
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.48);
+  border-radius: 24px;
+  padding: clamp(24px, 5vw, 42px);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.28);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #0f766e;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4.1rem);
+  line-height: 0.95;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 16px 0 28px;
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+.filter-toolbar {
+  display: grid;
+  gap: 18px;
+}
+
+.search-field {
+  display: grid;
+  gap: 8px;
+  font-weight: 700;
+}
+
+.search-field input {
+  border: 2px solid #d1d5db;
+  border-radius: 18px;
+  padding: 16px 18px;
+  color: #111827;
+  font: inherit;
+  outline: none;
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.search-field input:focus {
+  border-color: #0f766e;
+  box-shadow: 0 0 0 5px rgba(15, 118, 110, 0.16);
+  transform: translateY(-2px);
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.chip-group legend {
+  width: 100%;
+  margin-bottom: 2px;
+  font-weight: 700;
+}
+
+.chip input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.chip span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 42px;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  padding: 0 18px;
+  background: #ffffff;
+  cursor: pointer;
+  transition: background 180ms ease, color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+
+.chip input:checked + span {
+  background: #111827;
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(17, 24, 39, 0.25);
+  transform: translateY(-3px);
+}
+
+.chip input:focus-visible + span {
+  outline: 3px solid #f59e0b;
+  outline-offset: 3px;
+}
+
+.result-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.result-strip article {
+  position: relative;
+  min-height: 96px;
+  border-radius: 18px;
+  padding: 18px;
+  background: #f8fafc;
+  animation: lift-in 620ms both;
+}
+
+.result-strip article:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.result-strip article:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.status {
+  display: block;
+  width: 26px;
+  height: 5px;
+  margin-bottom: 20px;
+  border-radius: 999px;
+  background: #0f766e;
+  animation: status-scan 1.8s ease-in-out infinite;
+}
+
+.result-strip strong,
+.result-strip small {
+  display: block;
+}
+
+.result-strip small {
+  margin-top: 6px;
+  color: #64748b;
+}
+
+@keyframes lift-in {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes status-scan {
+  0%, 100% {
+    width: 26px;
+  }
+  50% {
+    width: 52px;
+  }
+}
+
+@media (max-width: 680px) {
+  .result-strip {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a focused kinetic filter toolbar submission with accessible search input, animated radio chips, and staggered result preview cards.

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/kinetic-filter-toolbar/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A responsive search and filter toolbar with animated focus states, selected chips, and staggered result previews.

**How does a developer use it?**

```html
<form class="filter-toolbar">
  <label class="search-field">
    <span>Search</span>
    <input type="search" value="motion">
  </label>
  <label class="chip">
    <input type="radio" name="category" checked>
    <span>All</span>
  </label>
</form>
```

**Why does it fit EaseMotion CSS?**

It turns a common filtering workflow into a readable, animation-first component without external dependencies.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Local verification: `npm test` passed with 1 test file and 13 tests.
