### PR TITLE
feat: add orbiting action menu demo

### DIFF
--- a/submissions/examples/orbiting-action-menu/README.md
+++ b/submissions/examples/orbiting-action-menu/README.md
@@ -1,0 +1,15 @@
+# Orbiting Action Menu
+
+## What does this do?
+A floating action menu that expands secondary actions around a central button using circular motion.
+
+## How is it used?
+```html
+<nav class="orbit-menu" aria-label="Quick actions">
+  <button class="main-action" aria-label="Open quick actions">+</button>
+  <a class="orbit-item item-one" href="#">New</a>
+</nav>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS a reusable quick-action interaction with keyboard-friendly focus behavior and no JavaScript.

--- a/submissions/examples/orbiting-action-menu/demo.html
+++ b/submissions/examples/orbiting-action-menu/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Orbiting Action Menu Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="stage" aria-labelledby="menu-title">
+    <section class="menu-card">
+      <div>
+        <p class="label">Floating controls</p>
+        <h1 id="menu-title">Orbiting Action Menu</h1>
+        <p class="copy">Hover or focus the center action to fan supporting actions into a circular motion path.</p>
+      </div>
+
+      <nav class="orbit-menu" aria-label="Quick actions">
+        <button class="main-action" aria-label="Open quick actions">+</button>
+        <a class="orbit-item item-one" href="#" aria-label="Create">New</a>
+        <a class="orbit-item item-two" href="#" aria-label="Share">Send</a>
+        <a class="orbit-item item-three" href="#" aria-label="Archive">Save</a>
+        <a class="orbit-item item-four" href="#" aria-label="Review">View</a>
+      </nav>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/orbiting-action-menu/style.css
+++ b/submissions/examples/orbiting-action-menu/style.css
@@ -1,0 +1,160 @@
+html {
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(circle at 18% 18%, rgba(250, 204, 21, 0.35), transparent 28%),
+    linear-gradient(135deg, #1f2937, #0e7490 55%, #f97316);
+  color: #111827;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.stage {
+  width: min(92vw, 860px);
+  padding: 28px;
+}
+
+.menu-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  align-items: center;
+  gap: 36px;
+  min-height: 420px;
+  border-radius: 26px;
+  padding: clamp(24px, 5vw, 46px);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 28px 90px rgba(15, 23, 42, 0.32);
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #c2410c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  max-width: 9ch;
+  font-size: clamp(2.4rem, 8vw, 5rem);
+  line-height: 0.9;
+}
+
+.copy {
+  max-width: 42ch;
+  color: #4b5563;
+  line-height: 1.65;
+}
+
+.orbit-menu {
+  position: relative;
+  width: 280px;
+  height: 280px;
+  margin: auto;
+  border-radius: 50%;
+  background: conic-gradient(from 90deg, rgba(14, 116, 144, 0.16), rgba(249, 115, 22, 0.22), rgba(14, 116, 144, 0.16));
+}
+
+.main-action,
+.orbit-item {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 800;
+}
+
+.main-action {
+  inset: 50% auto auto 50%;
+  width: 88px;
+  height: 88px;
+  background: #111827;
+  color: #ffffff;
+  font-size: 3rem;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  transition: transform 240ms ease, background 240ms ease;
+  z-index: 2;
+}
+
+.orbit-item {
+  inset: 50% auto auto 50%;
+  width: 68px;
+  height: 68px;
+  background: #ffffff;
+  color: #0f172a;
+  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.24);
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.4);
+  transition: opacity 220ms ease, transform 320ms cubic-bezier(.2, .8, .2, 1);
+}
+
+.orbit-menu:hover .main-action,
+.orbit-menu:focus-within .main-action {
+  background: #0e7490;
+  transform: translate(-50%, -50%) rotate(45deg) scale(0.96);
+}
+
+.orbit-menu:hover .orbit-item,
+.orbit-menu:focus-within .orbit-item {
+  opacity: 1;
+}
+
+.orbit-menu:hover .item-one,
+.orbit-menu:focus-within .item-one {
+  transform: translate(-50%, -160%) scale(1);
+}
+
+.orbit-menu:hover .item-two,
+.orbit-menu:focus-within .item-two {
+  transform: translate(54%, -50%) scale(1);
+}
+
+.orbit-menu:hover .item-three,
+.orbit-menu:focus-within .item-three {
+  transform: translate(-50%, 62%) scale(1);
+}
+
+.orbit-menu:hover .item-four,
+.orbit-menu:focus-within .item-four {
+  transform: translate(-154%, -50%) scale(1);
+}
+
+.orbit-item:hover,
+.orbit-item:focus-visible,
+.main-action:focus-visible {
+  outline: 4px solid #facc15;
+  outline-offset: 4px;
+}
+
+.orbit-item:nth-of-type(2) {
+  transition-delay: 45ms;
+}
+
+.orbit-item:nth-of-type(3) {
+  transition-delay: 90ms;
+}
+
+.orbit-item:nth-of-type(4) {
+  transition-delay: 135ms;
+}
+
+@media (max-width: 720px) {
+  .menu-card {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  h1,
+  .copy {
+    margin-inline: auto;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an orbiting action menu submission with a central action button and four secondary actions that fan out on hover or keyboard focus.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/orbiting-action-menu/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A no-JavaScript floating action menu that expands secondary actions around a central button.

**How does a developer use it?**

```html
<nav class="orbit-menu" aria-label="Quick actions">
  <button class="main-action" aria-label="Open quick actions">+</button>
  <a class="orbit-item item-one" href="#">New</a>
</nav>
```

**Why does it fit EaseMotion CSS?**

It provides a readable motion-first component for compact command surfaces while preserving keyboard focus states.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Local verification: `npm test` passed with 1 test file and 13 tests.
