### PR TITLE
feat: add flip stat counter demo

### DIFF
--- a/submissions/examples/flip-stat-counter/README.md
+++ b/submissions/examples/flip-stat-counter/README.md
@@ -1,0 +1,17 @@
+# Flip Stat Counter
+
+## What does this do?
+A dashboard stat card set that flips into view and adds a subtle hover tilt for active metric panels.
+
+## How is it used?
+```html
+<div class="stats-grid">
+  <article class="stat-tile">
+    <span class="stat-label">Views</span>
+    <strong>48K</strong>
+  </article>
+</div>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS an analytics-friendly component for emphasizing key numbers with restrained, readable motion.

--- a/submissions/examples/flip-stat-counter/demo.html
+++ b/submissions/examples/flip-stat-counter/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flip Stat Counter Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="dashboard" aria-labelledby="stats-title">
+    <section class="stats-card">
+      <p class="section-label">Analytics motion</p>
+      <h1 id="stats-title">Flip Stat Counter</h1>
+      <div class="stats-grid">
+        <article class="stat-tile">
+          <span class="stat-label">Views</span>
+          <strong>48K</strong>
+          <small>+18 percent</small>
+        </article>
+        <article class="stat-tile">
+          <span class="stat-label">Clicks</span>
+          <strong>9.6K</strong>
+          <small>+11 percent</small>
+        </article>
+        <article class="stat-tile">
+          <span class="stat-label">Saves</span>
+          <strong>724</strong>
+          <small>+32 percent</small>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/flip-stat-counter/style.css
+++ b/submissions/examples/flip-stat-counter/style.css
@@ -1,0 +1,130 @@
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(140deg, #082f49, #155e75 45%, #fef08a);
+  color: #0f172a;
+  font-family: "Trebuchet MS", Arial, sans-serif;
+}
+
+.dashboard {
+  width: min(94vw, 840px);
+  padding: 26px;
+}
+
+.stats-card {
+  border-radius: 28px;
+  padding: clamp(24px, 5vw, 46px);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 30px 86px rgba(8, 47, 73, 0.35);
+}
+
+.section-label {
+  margin: 0 0 10px;
+  color: #0891b2;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 30px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.94;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  perspective: 1000px;
+}
+
+.stat-tile {
+  position: relative;
+  overflow: hidden;
+  min-height: 170px;
+  border-radius: 22px;
+  padding: 22px;
+  background: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+  transform-origin: center top;
+  animation: flip-in 760ms cubic-bezier(.2, .8, .2, 1) both;
+}
+
+.stat-tile:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+.stat-tile:nth-child(3) {
+  animation-delay: 240ms;
+}
+
+.stat-tile::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  background: rgba(15, 23, 42, 0.12);
+}
+
+.stat-label {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 7px 12px;
+  background: #cffafe;
+  color: #155e75;
+  font-size: 0.76rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.stat-tile strong {
+  display: block;
+  margin: 26px 0 8px;
+  font-size: clamp(2.2rem, 6vw, 4rem);
+  letter-spacing: 0.02em;
+}
+
+.stat-tile small {
+  color: #15803d;
+  font-weight: 800;
+}
+
+.stat-tile:hover,
+.stat-tile:focus-within {
+  animation: tilt-card 700ms ease both;
+}
+
+@keyframes flip-in {
+  0% {
+    opacity: 0;
+    transform: rotateX(-76deg) translateY(18px);
+  }
+  70% {
+    opacity: 1;
+    transform: rotateX(8deg) translateY(0);
+  }
+  100% {
+    opacity: 1;
+    transform: rotateX(0deg);
+  }
+}
+
+@keyframes tilt-card {
+  0%, 100% {
+    transform: rotateX(0deg) rotateY(0deg);
+  }
+  45% {
+    transform: rotateX(5deg) rotateY(-5deg) translateY(-6px);
+  }
+}
+
+@media (max-width: 760px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a flip stat counter submission for dashboard metric cards with staggered flip-in animation and hover tilt feedback.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/flip-stat-counter/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A dashboard stat card set that flips into view and adds a subtle hover tilt for active metric panels.

**How does a developer use it?**

```html
<div class="stats-grid">
  <article class="stat-tile">
    <span class="stat-label">Views</span>
    <strong>48K</strong>
  </article>
</div>
```

**Why does it fit EaseMotion CSS?**

It provides an analytics-friendly motion component that highlights numbers without adding JavaScript.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Local verification: `npm test` passed with 1 test file and 13 tests.
