### PR TITLE
fix(submission): add morphing svg shape animation classes #16342

### DIFF
--- a/submissions/examples/fix-16342-morphing-svg-shape-animation-rs/README.md
+++ b/submissions/examples/fix-16342-morphing-svg-shape-animation-rs/README.md
@@ -1,0 +1,19 @@
+# Morphing SVG Shape Animation Classes
+
+This submission adds CSS utility classes to effortlessly create organic, morphing blob animations using SVG paths. 
+
+## Bug / Feature Description
+Blob and organic shape morphing are widely used in modern web design for backgrounds, avatars, and hero image enclosures. Instead of bringing in a heavy JS library (like anime.js or GSAP), modern browsers support animating the SVG `d` attribute directly via CSS.
+
+## Fix / Implementation Details
+- Added `.ease-animate-morph`, `.ease-animate-morph-fast`, and `.ease-animate-morph-slow` utility classes.
+- Created a generic `@keyframes ease-morph-blob` containing three distinct organic blob paths that smoothly transition.
+- Added an `.ease-hover-morph` utility that uses CSS `transition` on the `d` attribute to change shapes specifically when hovered.
+- Demonstrated these classes with varying speeds and interactive triggers in the demo file.
+
+> **Note:** For `d` path morphing to work natively in CSS, the path data in all keyframes must have the exact same number and sequence of drawing commands.
+
+## How to Test
+1. Open `demo.html` in a modern browser (Chrome, Edge, Firefox).
+2. Observe the continuous morphing of the "Continuous Blob" and "Fast Morph" SVG shapes.
+3. Hover your mouse over the third shape to see it smoothly transition to a completely different organic path structure via pure CSS hover.

--- a/submissions/examples/fix-16342-morphing-svg-shape-animation-rs/demo.html
+++ b/submissions/examples/fix-16342-morphing-svg-shape-animation-rs/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Morphing SVG Shapes Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        prefix: 'ease-',
+      }
+    </script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-slate-900 ease-text-white ease-font-sans ease-min-h-screen ease-flex ease-flex-col ease-items-center ease-justify-center ease-p-8">
+
+    <div class="ease-text-center ease-mb-16">
+        <h1 class="ease-text-4xl ease-font-bold ease-mb-4 ease-bg-clip-text ease-text-transparent ease-bg-gradient-to-r ease-from-pink-400 ease-to-indigo-500">
+            Morphing SVG Shape Utilities
+        </h1>
+        <p class="ease-text-lg ease-text-slate-400 ease-max-w-xl ease-mx-auto">
+            Smooth, organic shape morphing animations using pure CSS `d: path()` transitions. Perfect for backgrounds, avatars, and hero sections.
+        </p>
+    </div>
+
+    <div class="ease-grid ease-grid-cols-1 md:ease-grid-cols-3 ease-gap-12 ease-w-full ease-max-w-5xl">
+        
+        <!-- Continuous Morph -->
+        <div class="ease-flex ease-flex-col ease-items-center">
+            <h3 class="ease-text-xl ease-font-semibold ease-mb-8">Continuous Blob</h3>
+            <div class="ease-relative ease-w-64 ease-h-64 ease-flex ease-items-center ease-justify-center">
+                <svg viewBox="-100 -100 200 200" class="ease-absolute ease-inset-0 ease-w-full ease-h-full ease-animate-morph ease-text-indigo-500/80">
+                    <path fill="currentColor" d="M41.8,-53C53,-41.4,60,-27.1,63.1,-11.8C66.2,3.5,65.4,19.8,58.3,34C51.2,48.2,37.8,60.3,21.9,66.6C6,72.9,-12.4,73.4,-27.6,66.5C-42.8,59.6,-54.8,45.3,-62.7,29.1C-70.6,12.9,-74.4,-5.2,-69,-20.5C-63.6,-35.8,-49,-48.3,-34.5,-58.5C-20,-68.7,-5.5,-76.6,6.3,-84.4C18.1,-92.2,28.6,-66.2,41.8,-53Z"></path>
+                </svg>
+                <div class="ease-relative ease-z-10 ease-font-bold ease-text-xl">Organic</div>
+            </div>
+        </div>
+
+        <!-- Fast Morph -->
+        <div class="ease-flex ease-flex-col ease-items-center">
+            <h3 class="ease-text-xl ease-font-semibold ease-mb-8">Fast Morph</h3>
+            <div class="ease-relative ease-w-64 ease-h-64 ease-flex ease-items-center ease-justify-center">
+                <svg viewBox="-100 -100 200 200" class="ease-absolute ease-inset-0 ease-w-full ease-h-full ease-animate-morph-fast ease-text-pink-500/80">
+                    <path fill="currentColor" d="M41.8,-53C53,-41.4,60,-27.1,63.1,-11.8C66.2,3.5,65.4,19.8,58.3,34C51.2,48.2,37.8,60.3,21.9,66.6C6,72.9,-12.4,73.4,-27.6,66.5C-42.8,59.6,-54.8,45.3,-62.7,29.1C-70.6,12.9,-74.4,-5.2,-69,-20.5C-63.6,-35.8,-49,-48.3,-34.5,-58.5C-20,-68.7,-5.5,-76.6,6.3,-84.4C18.1,-92.2,28.6,-66.2,41.8,-53Z"></path>
+                </svg>
+                <div class="ease-relative ease-z-10 ease-font-bold ease-text-xl">Fast</div>
+            </div>
+        </div>
+
+        <!-- Hover Morph (using custom path) -->
+        <div class="ease-flex ease-flex-col ease-items-center">
+            <h3 class="ease-text-xl ease-font-semibold ease-mb-8">Hover to Morph</h3>
+            <div class="ease-relative ease-w-64 ease-h-64 ease-flex ease-items-center ease-justify-center">
+                <svg viewBox="-100 -100 200 200" class="ease-absolute ease-inset-0 ease-w-full ease-h-full ease-hover-morph ease-text-teal-500/80 hover:ease-text-teal-400 ease-transition-colors ease-duration-500">
+                    <path fill="currentColor" d="M30.6,-36.8C40.6,-31.6,50.3,-24.1,55.8,-13.7C61.3,-3.3,62.6,10,58.1,21.5C53.6,33,43.3,42.7,31.7,48.4C20.1,54.1,7.2,55.8,-5.3,54.7C-17.8,53.6,-29.9,49.7,-38.5,41.9C-47.1,34.1,-52.2,22.4,-56.3,10.2C-60.4,-2,-63.5,-14.7,-58.8,-24.4C-54.1,-34.1,-41.6,-40.8,-30.3,-45.5C-19,-50.2,-8.9,-52.9,0.7,-53.8C10.3,-54.7,20.6,-42,30.6,-36.8Z"></path>
+                </svg>
+                <div class="ease-relative ease-z-10 ease-font-bold ease-text-xl ease-pointer-events-none">Hover Me</div>
+            </div>
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/fix-16342-morphing-svg-shape-animation-rs/style.css
+++ b/submissions/examples/fix-16342-morphing-svg-shape-animation-rs/style.css
@@ -1,0 +1,44 @@
+/* Morphing SVG Shape Animation Utilities */
+
+/* 
+   Note: Morphing SVG paths via CSS requires the paths to have the exact same number 
+   and types of commands in the `d` attribute. 
+*/
+
+.ease-animate-morph path {
+    animation: ease-morph-blob 5s ease-in-out infinite alternate;
+}
+
+.ease-animate-morph-fast path {
+    animation: ease-morph-blob 2.5s ease-in-out infinite alternate;
+}
+
+.ease-animate-morph-slow path {
+    animation: ease-morph-blob 10s ease-in-out infinite alternate;
+}
+
+/* Hover-based morphing */
+.ease-hover-morph path {
+    transition: d 0.5s ease-in-out;
+}
+
+/* We provide CSS variables so users can override paths inline if they want custom morphs */
+.ease-hover-morph:hover path {
+    d: var(--ease-morph-target, path("M22.8,-35.1C31.5,-28.9,41.9,-23.7,48.5,-15.1C55.1,-6.5,57.9,5.5,54.8,16.1C51.7,26.7,42.7,35.9,32.3,42.4C21.9,48.9,10.9,52.7,0.4,52C-10.1,51.3,-20.2,46.1,-29.6,39.3C-39,32.5,-47.7,24,-52.3,13.4C-56.9,2.8,-57.4,-9.9,-52.2,-20.5C-47,-31.1,-36.1,-39.6,-25.3,-44.6C-14.5,-49.6,-3.8,-51.1,5.1,-48C14,-44.9,28,-37.2,22.8,-35.1Z"));
+}
+
+/* A standard blob morph keyframe using generic paths */
+@keyframes ease-morph-blob {
+    0% {
+        /* Blob 1 */
+        d: path("M41.8,-53C53,-41.4,60,-27.1,63.1,-11.8C66.2,3.5,65.4,19.8,58.3,34C51.2,48.2,37.8,60.3,21.9,66.6C6,72.9,-12.4,73.4,-27.6,66.5C-42.8,59.6,-54.8,45.3,-62.7,29.1C-70.6,12.9,-74.4,-5.2,-69,-20.5C-63.6,-35.8,-49,-48.3,-34.5,-58.5C-20,-68.7,-5.5,-76.6,6.3,-84.4C18.1,-92.2,28.6,-66.2,41.8,-53Z");
+    }
+    50% {
+        /* Blob 2 */
+        d: path("M36.7,-58.9C49.1,-52.2,61.7,-43.6,68.9,-31.1C76.1,-18.6,77.9,-2.2,74.5,12.9C71.1,28,62.5,41.8,50.4,51.4C38.3,61,22.7,66.4,7.1,65.5C-8.5,64.6,-24,-57.4,-36.4,-48C-48.8,-38.6,-58.1,-27,-63.9,-13.4C-69.7,0.2,-72,15.8,-66.6,28.5C-61.2,41.2,-48.1,51,-34.6,58C-21.1,65,-7.2,69.2,5.2,69C17.6,68.8,28.5,-61.7,36.7,-58.9Z");
+    }
+    100% {
+        /* Blob 3 */
+        d: path("M51.8,-63.3C66.1,-51.7,75.9,-34.4,78.2,-16.1C80.5,2.2,75.3,21.5,63.9,35.9C52.5,50.3,34.9,59.8,16.5,64.9C-1.9,70,-20.1,70.7,-37.2,64.5C-54.3,58.3,-70.3,45.2,-79,28C-87.7,10.8,-89.1,-10.5,-80.7,-26.6C-72.3,-42.7,-54.1,-53.6,-37.8,-63.5C-21.5,-73.4,-7.1,-82.3,6.8,-90.4C20.7,-98.5,37.5,-74.9,51.8,-63.3Z");
+    }
+}


### PR DESCRIPTION
**fix(submission): add morphing svg shape animation classes #16342**

## Related Issue  
Closes #16342

---
## Type of Change
- [x] Bug Fix  
- [ ] New Feature  
- [ ] Documentation Update  
- [ ] Refactor  
- [ ] Chore

---
## Description
This PR introduces pure CSS SVG morphing utilities. Organic shapes and blobs are extremely common in modern design for backgrounds or avatars. Instead of utilizing external JavaScript libraries (like anime.js or GSAP) to interpolate paths, these utilities use native CSS `d: path()` interpolation, which handles shape transitions natively and efficiently.

---
## Changes Made
- `submissions/examples/fix-16342-morphing-svg-shape-animation-rs/demo.html` — A self-contained demo page demonstrating continuous shape morphing at different speeds, alongside an interactive hover-to-morph example.
- `submissions/examples/fix-16342-morphing-svg-shape-animation-rs/style.css` — Includes the `.ease-animate-morph` utilities, a generic `@keyframes` defining standard organic blob transitions, and a `.ease-hover-morph` utility.
- `submissions/examples/fix-16342-morphing-svg-shape-animation-rs/README.md` — Detailed explanation of the utilities, requirements for native CSS path transitions, and how to verify it locally.

---
## How to Verify Locally
1. Navigate to the `submissions/examples/fix-16342-morphing-svg-shape-animation-rs/` folder.
2. Open `demo.html` in a modern browser like Chrome, Edge, or Firefox.
3. Observe the continuous fluid animations on the first two SVG shapes.
4. Hover over the third SVG shape to trigger the secondary path morph transition.

---
## Checklist
- [x] My code follows the project's coding style  
- [x] I have tested my changes locally  
- [x] I have updated the documentation if required  
- [x] No existing functionality has been broken  
- [x] All checks and linting pass successfully

---
## GSSoC'26 Contributor Declaration
- [x] I confirm that I am a participant of GSSoC'26  
- [x] I have followed the contribution guidelines of this project  
- [x] This PR is ready for review

---
**Labels:** `type:bug` · `component` · `good first issue` · `GSSoC-26` · `level:intermediate`
