### PR TITLE
fix(submission): add css container query utility classes #16359

### DIFF
--- a/submissions/examples/fix-16359-css-container-query-rs/README.md
+++ b/submissions/examples/fix-16359-css-container-query-rs/README.md
@@ -1,0 +1,18 @@
+# CSS Container Query Utility Classes
+
+This submission implements utilities and patterns utilizing CSS Container Queries (`@container`).
+
+## Bug / Feature Description
+Traditionally, Responsive Web Design relied entirely on Media Queries (`@media (min-width: 768px)`). The problem is that components are often placed in varying contexts (e.g., a card in a wide hero section vs. the exact same card in a narrow sidebar). A component shouldn't care about the *screen size*, it should care about the *space it has available to it*.
+
+Container Queries solve this. By marking a wrapper element as a container, the child elements can query the width of that wrapper to determine their layout.
+
+## Fix / Implementation Details
+- **`.ease-container-inline`**: This class applies `container-type: inline-size` and a `container-name`. You wrap this around your component.
+- **Component Styling (`.ease-cq-card`)**: Built a robust card component that defaults to a mobile-friendly "stacked" column layout.
+- **`@container ease-card-container (min-width: 500px)`**: Added the container query logic. If the wrapper class has at least 500px of breathing room, it automatically changes the card into a horizontal side-by-side layout.
+
+## How to Test
+1. Open `demo.html` in your browser.
+2. Look at the "Resizable Container" on the left. Click and drag the dashed handle to manually shrink the width of the container. Notice how the card snaps to a stacked layout, even though your browser window hasn't changed size!
+3. Look at the "Narrow Column" on the right. It uses the exact same HTML and CSS, but because its parent grid column is narrow, it automatically adopts the stacked layout.

--- a/submissions/examples/fix-16359-css-container-query-rs/demo.html
+++ b/submissions/examples/fix-16359-css-container-query-rs/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Container Query Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        prefix: 'ease-',
+      }
+    </script>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        /* A little CSS resize hack to allow the user to manually drag and resize the container */
+        .resizable-wrapper {
+            resize: horizontal;
+            overflow: hidden;
+            min-width: 300px;
+            max-width: 100%;
+            border-right: 2px dashed #475569;
+            padding-right: 1rem;
+        }
+    </style>
+</head>
+<body class="ease-bg-slate-900 ease-text-white ease-font-sans ease-p-8 ease-min-h-screen">
+
+    <div class="ease-max-w-5xl ease-mx-auto">
+        <div class="ease-text-center ease-mb-16">
+            <h1 class="ease-text-4xl ease-font-bold ease-mb-4">CSS Container Queries</h1>
+            <p class="ease-text-slate-400 ease-text-lg">
+                Instead of styling based on the viewport (`@media`), style components based on the size of their parent container (`@container`).
+            </p>
+        </div>
+
+        <div class="ease-grid ease-grid-cols-1 lg:ease-grid-cols-3 ease-gap-12">
+            
+            <!-- Resizable Container Example -->
+            <div class="lg:ease-col-span-2">
+                <h3 class="ease-text-xl ease-font-bold ease-mb-4">1. Resizable Container</h3>
+                <p class="ease-text-slate-400 ease-mb-6">
+                    Drag the dashed handle on the right side of this card to shrink it. Notice how the card switches from a horizontal layout to a stacked layout automatically when the container gets smaller than 500px, entirely independently of the browser window size!
+                </p>
+
+                <!-- 
+                  The `resizable-wrapper` allows manual dragging. 
+                  The `ease-container-inline` establishes the container query context. 
+                -->
+                <div class="resizable-wrapper">
+                    <div class="ease-container-inline">
+                        
+                        <!-- The component reacting to the @container rules -->
+                        <div class="ease-cq-card">
+                            <img src="https://images.unsplash.com/photo-1550745165-9bc0b252726f?ixlib=rb-4.0.3&auto=format&fit=crop&w=600&q=80" alt="Retro Tech" class="ease-cq-image">
+                            <div class="ease-cq-content">
+                                <h4 class="ease-cq-title">Retro Console Revival</h4>
+                                <p class="ease-cq-desc">Discover the history behind the 8-bit era. This component is completely modular and can be dropped into any sidebar, grid, or hero section and will adapt its own layout.</p>
+                                <button class="ease-cq-btn">Read Article</button>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+
+            <!-- Narrow Container Example -->
+            <div>
+                <h3 class="ease-text-xl ease-font-bold ease-mb-4">2. Same Component, Narrow Column</h3>
+                <p class="ease-text-slate-400 ease-mb-6">
+                    This is the exact same component HTML and CSS as the one on the left. But because it is placed inside a narrow sidebar grid column, it queries its container, realizes it has less than 500px, and adopts the stacked mobile layout.
+                </p>
+
+                <!-- 
+                  We apply the exact same container context class. 
+                  Because this grid column is narrow, the @container rule (min-width: 500px) fails, 
+                  so it uses the default stacked layout.
+                -->
+                <div class="ease-container-inline">
+                    <div class="ease-cq-card">
+                        <img src="https://images.unsplash.com/photo-1550745165-9bc0b252726f?ixlib=rb-4.0.3&auto=format&fit=crop&w=600&q=80" alt="Retro Tech" class="ease-cq-image">
+                        <div class="ease-cq-content">
+                            <h4 class="ease-cq-title">Retro Console Revival</h4>
+                            <p class="ease-cq-desc">Discover the history behind the 8-bit era. This component is completely modular.</p>
+                            <button class="ease-cq-btn">Read Article</button>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/fix-16359-css-container-query-rs/style.css
+++ b/submissions/examples/fix-16359-css-container-query-rs/style.css
@@ -1,0 +1,89 @@
+/* CSS Container Query Utilities */
+
+/* 
+  1. Define the Container Wrapper
+  This establishes the element as a query container. Any elements inside it 
+  will be able to query its size, rather than the viewport size.
+*/
+.ease-container-inline {
+    container-type: inline-size;
+    container-name: ease-card-container;
+    /* Required for inline-size containers to function properly in some edge layouts */
+    width: 100%; 
+}
+
+/* 
+  2. The Component that adapts to the container
+  This is the default mobile/narrow layout.
+*/
+.ease-cq-card {
+    display: flex;
+    flex-direction: column;
+    background-color: #1e293b; /* slate-800 */
+    border: 1px solid #334155; /* slate-700 */
+    border-radius: 1rem;
+    overflow: hidden;
+}
+
+.ease-cq-image {
+    width: 100%;
+    height: 12rem;
+    object-fit: cover;
+}
+
+.ease-cq-content {
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.ease-cq-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: white;
+}
+
+.ease-cq-desc {
+    color: #94a3b8; /* slate-400 */
+    font-size: 0.875rem;
+}
+
+.ease-cq-btn {
+    align-self: flex-start;
+    padding: 0.5rem 1rem;
+    background-color: #3b82f6; /* blue-500 */
+    color: white;
+    border-radius: 0.5rem;
+    font-weight: 500;
+}
+
+/* 
+  3. Container Query Rules
+  If the specific container wrapper is larger than 500px, adapt the layout!
+*/
+@container ease-card-container (min-width: 500px) {
+    .ease-cq-card {
+        flex-direction: row;
+        align-items: stretch;
+    }
+    
+    .ease-cq-image {
+        width: 40%;
+        height: auto;
+    }
+    
+    .ease-cq-content {
+        width: 60%;
+        justify-content: center;
+        padding: 2rem;
+    }
+
+    .ease-cq-title {
+        font-size: 1.5rem;
+    }
+
+    .ease-cq-desc {
+        font-size: 1rem;
+    }
+}


### PR DESCRIPTION
**fix(submission): add css container query utility classes #16359**

## Related Issue  
Closes #16359

---
## Type of Change
- [x] Bug Fix  
- [ ] New Feature  
- [ ] Documentation Update  
- [ ] Refactor  
- [ ] Chore

---
## Description
This PR implements patterns utilizing CSS Container Queries (`@container`), solving the biggest limitation of Media Queries (`@media`). Components can now style themselves based on the width of their specific parent container rather than the global browser viewport.

---
## Changes Made
- `submissions/examples/fix-16359-css-container-query-rs/demo.html` — A side-by-side comparison showing the exact same component reacting differently based on its container context (one resizable, one forced into a narrow column).
- `submissions/examples/fix-16359-css-container-query-rs/style.css` — Adds `.ease-container-inline` to establish `container-type: inline-size`. Includes an `@container` block that automatically shifts a card from a stacked mobile layout to a side-by-side row layout when the wrapper hits `500px`.
- `submissions/examples/fix-16359-css-container-query-rs/README.md` — Explanation of the container query paradigm shift.

---
## How to Verify Locally
1. Navigate to the `submissions/examples/fix-16359-css-container-query-rs/` folder.
2. Open `demo.html` in your browser.
3. On the left side, drag the dashed handle to manually shrink the resizable container. Notice how the card snaps to a stacked layout, even though the overall browser window hasn't changed size.
4. On the right side, observe that the identical component HTML/CSS naturally adopts the stacked layout because it is trapped in a narrow parent column.

---
## Checklist
- [x] My code follows the project's coding style  
- [x] I have tested my changes locally  
- [x] I have updated the documentation if required  
- [x] No existing functionality has been broken  
- [x] All checks and linting pass successfully

---
## GSSoC'26 Contributor Declaration
- [x] I confirm that I am a participant of GSSoC'26  
- [x] I have followed the contribution guidelines of this project  
- [x] This PR is ready for review

---
**Labels:** `type:bug` · `component` · `good first issue` · `GSSoC-26` · `level:intermediate`
