### PR TITLE
feat: add text clip reveal animation (#19200)

### DIFF
--- a/submissions/examples/text-clip-reveal-ar/README.md
+++ b/submissions/examples/text-clip-reveal-ar/README.md
@@ -1,0 +1,23 @@
+﻿# Text Clip Reveal Animation
+
+A CSS-only text reveal effect that uses clip-path to progressively unmask text from left to right. Ideal for hero headings, section titles, or call-to-action text.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-py-16, ease-inline-block
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-2xl, ease-font-semibold, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-6, ease-mt-8
+- **Components:** ease-btn, ease-btn-primary
+- **Hover Effects:** ease-hover-scale-105
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500, ease-transition
+
+## How it works
+- The text is initially hidden using clip-path: inset(0 100% 0 0), which clips everything to the right of the left edge.
+- When the eveal class is added, the clip-path transitions to inset(0 0 0 0), revealing the full text.
+- JavaScript toggles the class on page load and via the Replay button.
+- The effect respects prefers-reduced-motion by showing the text instantly without animation.
+
+## How to use
+1. Add the class clip-reveal-text to any text element you want to animate.
+2. Toggle the eveal class to trigger the effect.
+3. Copy style.css into your project and ensure the path to easemotion.css is correct.

--- a/submissions/examples/text-clip-reveal-ar/demo.html
+++ b/submissions/examples/text-clip-reveal-ar/demo.html
@@ -1,0 +1,48 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>text-clip-reveal – Clip-path Text Reveal</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">Text Clip Reveal</h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Text is revealed from left to right using <code>clip-path</code>.
+    </p>
+
+    <!-- Text element with clip-path reveal -->
+    <div id="reveal-text" class="clip-reveal-text ease-text-2xl ease-font-semibold ease-inline-block">
+      Amazing Headline
+    </div>
+
+    <button id="replay-btn" class="ease-btn ease-btn-primary ease-hover-scale-105 ease-transition ease-mt-8">
+      Replay
+    </button>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-6 ease-fade-in ease-delay-500">
+      Pure CSS animation; <code>prefers-reduced-motion</code> disables the effect.
+    </p>
+  </div>
+
+  <script>
+    const textEl = document.getElementById('reveal-text');
+    const replayBtn = document.getElementById('replay-btn');
+
+    function play() {
+      textEl.classList.remove('reveal');
+      void textEl.offsetWidth;          // force reflow to restart animation
+      textEl.classList.add('reveal');
+    }
+
+    // Auto-play on load
+    window.addEventListener('load', () => setTimeout(play, 300));
+    replayBtn.addEventListener('click', play);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/text-clip-reveal-ar/style.css
+++ b/submissions/examples/text-clip-reveal-ar/style.css
@@ -1,0 +1,24 @@
+﻿/* ============================================================
+   text-clip-reveal – Clip-path reveal animation
+   ============================================================ */
+
+.clip-reveal-text {
+  clip-path: inset(0 100% 0 0);      /* hidden: right side clipped fully */
+  transition: clip-path 0.6s ease-out;
+  display: inline-block;
+}
+
+.clip-reveal-text.reveal {
+  clip-path: inset(0 0 0 0);         /* fully visible */
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .clip-reveal-text {
+    transition: none;
+    clip-path: none;                 /* show text immediately */
+  }
+  .clip-reveal-text.reveal {
+    clip-path: none;
+  }
+}


### PR DESCRIPTION
Closes #19200

Text Clip Reveal Animation
Text is revealed from left to right using clip-path transition.

Files added
- submissions/examples/text-clip-reveal-ar/demo.html
- submissions/examples/text-clip-reveal-ar/style.css
- submissions/examples/text-clip-reveal-ar/README.md

How it works
- clip-path: inset(0 100% 0 0) hides text; transitions to inset(0 0 0 0) on reveal.
- JavaScript toggles class for auto-play and replay.
- Respects prefers-reduced-motion.