### PR TITLE
feat: add CSS text box trim demo (#19419)

### DIFF
--- a/submissions/examples/text-box-trim-ar/README.md
+++ b/submissions/examples/text-box-trim-ar/README.md
@@ -1,0 +1,22 @@
+﻿# CSS Text Box Trim Leading
+
+A demo of the experimental 	ext-box-trim property, which eliminates excess leading space at the top of the first line and bottom of the last line, enabling precise typographic alignment.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-grid, ease-gap, ease-flex-wrap, ease-py-16, ease-mx-auto
+- **Background:** ease-bg-gray-50, ease-bg-white
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-2xl, ease-font-semibold, ease-text-sm, ease-text-gray-400, ease-text-xs, ease-text-gray-500
+- **Spacing:** ease-mb-2, ease-mb-4, ease-mb-6, ease-mb-10, ease-mb-12, ease-mt-12, ease-p-6
+- **Components:** ease-card, ease-btn, ease-btn-primary
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How it works
+- The 	ext-box-trim property is applied to headings and buttons to trim the top and bottom leading space.
+- Side-by-side comparisons show the difference in vertical alignment.
+- The property is experimental and supported in Chromium 130+.
+- Graceful fallback: browsers that don't support it will simply ignore the property, and the standard text rendering will be used.
+
+## How to use
+1. Open demo.html in a modern Chromium browser (Chrome 130+ or Edge 130+) to see the effect.
+2. Add 	ext-box-trim: trim-both to headings, buttons, or any text element for tighter alignment.
+3. Ensure the path to easemotion.css is correct.

--- a/submissions/examples/text-box-trim-ar/demo.html
+++ b/submissions/examples/text-box-trim-ar/demo.html
@@ -1,0 +1,63 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>text-box-trim – CSS Text Box Trim Demo</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-max-w-2xl ease-py-16">
+
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in ease-text-center">
+      Text Box Trim
+    </h1>
+    <p class="ease-text-gray-500 ease-mb-10 ease-fade-in ease-delay-200 ease-text-center">
+      Precise typographic alignment by removing excess leading above and below text.
+    </p>
+
+    <!-- Comparison: heading with and without text-box-trim -->
+    <section class="ease-mb-12">
+      <h2 class="ease-text-2xl ease-font-semibold ease-mb-6">Heading Alignment</h2>
+      <div class="ease-grid ease-grid-cols-2 ease-gap-8">
+        <div class="ease-card ease-p-6 ease-bg-white">
+          <p class="ease-text-sm ease-text-gray-400 ease-mb-2">Without text-box-trim</p>
+          <div class="demo-box">
+            <h3 class="no-trim">Design System</h3>
+            <p class="ease-text-xs ease-text-gray-500">Excess space above</p>
+          </div>
+        </div>
+        <div class="ease-card ease-p-6 ease-bg-white">
+          <p class="ease-text-sm ease-text-gray-400 ease-mb-2">With text-box-trim</p>
+          <div class="demo-box">
+            <h3 class="trim">Design System</h3>
+            <p class="ease-text-xs ease-text-gray-500">Tight alignment</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Button alignment comparison -->
+    <section class="ease-mb-12">
+      <h2 class="ease-text-2xl ease-font-semibold ease-mb-6">Button Text Centering</h2>
+      <div class="ease-flex ease-gap-8 ease-flex-wrap">
+        <div class="ease-card ease-p-6 ease-bg-white">
+          <p class="ease-text-sm ease-text-gray-400 ease-mb-2">Without text-box-trim</p>
+          <button class="ease-btn ease-btn-primary no-trim-btn">Get Started</button>
+        </div>
+        <div class="ease-card ease-p-6 ease-bg-white">
+          <p class="ease-text-sm ease-text-gray-400 ease-mb-2">With text-box-trim</p>
+          <button class="ease-btn ease-btn-primary trim-btn">Get Started</button>
+        </div>
+      </div>
+    </section>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-12 ease-text-center ease-fade-in ease-delay-500">
+      Uses the experimental <code>text-box-trim</code> property (Chromium 130+). Falls back gracefully.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/text-box-trim-ar/style.css
+++ b/submissions/examples/text-box-trim-ar/style.css
@@ -1,0 +1,46 @@
+﻿/* ============================================================
+   CSS Text Box Trim Demo
+   ============================================================ */
+
+/* Demo boxes show spacing clearly */
+.demo-box {
+  background: #f8fafc;
+  border: 1px dashed #cbd5e1;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+}
+
+/* Heading without text-box-trim */
+.no-trim {
+  font-size: 2rem;
+  line-height: 1.2;
+  margin: 0;
+  border-bottom: 1px solid #e2e8f0;   /* visual reference */
+}
+
+/* Heading with text-box-trim */
+.trim {
+  font-size: 2rem;
+  line-height: 1.2;
+  margin: 0;
+  border-bottom: 1px solid #e2e8f0;
+  text-box-trim: trim-both;            /* removes leading at top and bottom */
+}
+
+/* Button without text-box-trim */
+.no-trim-btn {
+  /* default */
+}
+
+/* Button with text-box-trim */
+.trim-btn {
+  text-box-trim: trim-both;
+}
+
+/* Accessibility: respect reduced motion (no animations here) */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #19419

CSS Text Box Trim Leading
Demo of the experimental text-box-trim property for precise typographic alignment.

Files added
- submissions/examples/text-box-trim-ar/demo.html
- submissions/examples/text-box-trim-ar/style.css
- submissions/examples/text-box-trim-ar/README.md

How it works
- Compares headings and buttons with and without text-box-trim.
- Tighter vertical alignment with trim-both.
- Graceful fallback for unsupported browsers.
- Respects prefers-reduced-motion.