### PR TITLE
fix(submission): add split text reveal animation #16363

### DIFF
--- a/submissions/examples/fix-16363-split-text-reveal-rs/README.md
+++ b/submissions/examples/fix-16363-split-text-reveal-rs/README.md
@@ -1,0 +1,8 @@
+# Fix: Split Text Reveal
+
+## Description
+This provides a standard class for wrapping text to create a word-level or character-level "reveal from bottom" animation.
+
+## How it works
+- Sets `overflow: hidden` on the wrapper.
+- Animates the inner element's `transform: translateY` from 100% to 0.

--- a/submissions/examples/fix-16363-split-text-reveal-rs/demo.html
+++ b/submissions/examples/fix-16363-split-text-reveal-rs/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Split Text Reveal Animation</title>
+  <link rel="stylesheet" href="../../core/index.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { padding: 2rem; font-family: system-ui; font-size: 2rem; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>Split Text Reveal</h1>
+  <div class="ease-text-reveal">
+    <span style="animation-delay: 0.1s">Hello</span>
+  </div>
+  <div class="ease-text-reveal">
+    <span style="animation-delay: 0.2s">World!</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-16363-split-text-reveal-rs/style.css
+++ b/submissions/examples/fix-16363-split-text-reveal-rs/style.css
@@ -1,0 +1,15 @@
+.ease-text-reveal {
+  display: inline-block;
+  overflow: hidden;
+  vertical-align: bottom;
+}
+
+.ease-text-reveal > span {
+  display: inline-block;
+  transform: translateY(100%);
+  animation: ease-reveal-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes ease-reveal-up {
+  to { transform: translateY(0); }
+}


### PR DESCRIPTION
**fix(submission): add split text reveal animation #16363**

## Related Issue  
Closes #16363

---
## Type of Change
- [x] Bug Fix  
- [x] New Feature  
- [ ] Documentation Update  
- [ ] Refactor  
- [ ] Chore

---
## Description
This PR implements the "Split Text Reveal" animation component. Using a combination of `overflow: hidden` on a wrapper class `.ease-text-reveal` and `transform: translateY` on inner elements, it allows words or characters to smoothly reveal from the bottom.

---
## Changes Made
- `submissions/examples/fix-16363-split-text-reveal-rs/demo.html` — An example of splitting text words into independently animated reveals.
- `submissions/examples/fix-16363-split-text-reveal-rs/style.css` — The CSS animation logic, providing `.ease-text-reveal` structure and `@keyframes ease-reveal-up`.
- `submissions/examples/fix-16363-split-text-reveal-rs/README.md` — Details of the CSS mechanism powering the text reveal.

---
## How to Verify Locally
1. Switch to branch `fix-16363-split-text-reveal-rs`.
2. Open `submissions/examples/fix-16363-split-text-reveal-rs/demo.html` in your browser.
3. Refresh the page to see the text smoothly slide up into visibility from its hidden baseline.

---
## Checklist
- [x] My code follows the project's coding style  
- [x] I have tested my changes locally  
- [x] I have updated the documentation if required  
- [x] No existing functionality has been broken  
- [x] All checks and linting pass successfully

---
## GSSoC'26 Contributor Declaration
- [x] I confirm that I am a participant of GSSoC'26  
- [x] I have followed the contribution guidelines of this project  
- [x] This PR is ready for review

---
**Labels:** `type:bug` · `component` · `good first issue` · `GSSoC-26` · `level:intermediate`
