### PR TITLE
feat: add dialog animation replay workaround submission

### DIFF
--- a/submissions/examples/dialog-animation-replay-naresh/README.md
+++ b/submissions/examples/dialog-animation-replay-naresh/README.md
@@ -1,0 +1,41 @@
+# Dialog Animation Replay Workaround
+
+## What does this do?
+Documents workarounds for replaying entrance animations inside a native HTML `<dialog>` element on subsequent opens (since keyframe animations on already rendered DOM nodes do not re-trigger by default when a dialog is closed and reopened).
+
+## How is it used?
+
+### Workaround 1: JavaScript Class Toggling (For Keyframe Animations)
+Trigger the reflow to replay keyframe animations (such as EaseMotion's `.ease-fade-in`):
+```javascript
+function openDialog() {
+  const content = dialog.querySelector('.dialog-content');
+  
+  // Remove and re-add the animation class to force replay
+  content.classList.remove('ease-fade-in');
+  void content.offsetWidth; // Force reflow
+  content.classList.add('ease-fade-in');
+  
+  dialog.showModal();
+}
+```
+
+### Workaround 2: CSS `@starting-style` (For Modern Browsers, Transition-based)
+Define initial transition states directly in CSS to trigger every time the dialog opens:
+```css
+dialog[open] .dialog-content {
+  opacity: 1;
+  transform: scale(1);
+  transition: opacity 0.4s ease-out, transform 0.4s ease-out;
+}
+
+@starting-style {
+  dialog[open] .dialog-content {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+}
+```
+
+## Why is it useful?
+It provides standard, robust approaches for developers to achieve polished entrance animations inside modal dialogs, preventing animations from playing only once on the first modal launch.

--- a/submissions/examples/dialog-animation-replay-naresh/demo.html
+++ b/submissions/examples/dialog-animation-replay-naresh/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS — Dialog Animation Replay Workaround</title>
+  <meta name="description" content="Interactive demo and documentation of workarounds for replaying entrance animations inside native HTML dialog elements.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header style="margin-bottom: 3rem;">
+      <h1 style="font-size: 2.5rem; font-weight: 800; margin-bottom: 0.5rem; background: linear-gradient(135deg, #fff 40%, #818cf8 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">Dialog Replay Workarounds</h1>
+      <p style="color: #94a3b8; font-size: 1.1rem; margin-top: 0;">Replaying animations inside native HTML dialog elements</p>
+    </header>
+
+    <!-- Card 1: JS Workaround -->
+    <div class="card">
+      <h2>1. JS Reflow Toggling (Keyframe animations)</h2>
+      <p style="color: #94a3b8; font-size: 0.95rem; margin-bottom: 1.5rem; line-height: 1.5;">
+        Removes and re-adds the animation class (e.g. <code>.ease-fade-in</code>) before calling <code>.showModal()</code>. This forces the browser to evaluate the keyframe animation from the beginning on every open event.
+      </p>
+      <button id="btn-open-js" class="btn" onclick="openJsDialog()">Open Dialog (JS Toggled)</button>
+    </div>
+
+    <!-- Card 2: starting-style Workaround -->
+    <div class="card">
+      <h2>2. CSS <code>@starting-style</code> (Modern browsers, transition-based)</h2>
+      <p style="color: #94a3b8; font-size: 0.95rem; margin-bottom: 1.5rem; line-height: 1.5;">
+        CSS-only solution using transition properties. Defining initial state within <code>@starting-style</code> triggers the transition naturally every time the modal goes from closed (display: none) to open.
+      </p>
+      <button id="btn-open-css" class="btn" style="background-color: #10b981;" onclick="openCssDialog()">Open Dialog (CSS @starting-style)</button>
+    </div>
+
+    <!-- Dialog 1: JS Keyframe Modal -->
+    <dialog id="jsDialog">
+      <div id="jsDialogContent" class="dialog-content">
+        <h3 class="dialog-header">Keyframe Animation</h3>
+        <p class="dialog-body">
+          This content fades and scales up using a keyframe animation. Thanks to the JS class reset script, this plays every time you open this modal.
+        </p>
+        <div style="text-align: right;">
+          <button id="btn-close-js" class="btn btn-secondary" onclick="closeDialog('jsDialog')">Close</button>
+        </div>
+      </div>
+    </dialog>
+
+    <!-- Dialog 2: CSS Transition Modal -->
+    <dialog id="cssDialog">
+      <div class="dialog-content composed-starting-style">
+        <h3 class="dialog-header">CSS Transition</h3>
+        <p class="dialog-body">
+          This modal animates transitions automatically using <code>@starting-style</code> without any class-toggling scripts.
+        </p>
+        <div style="text-align: right;">
+          <button id="btn-close-css" class="btn btn-secondary" onclick="closeDialog('cssDialog')">Close</button>
+        </div>
+      </div>
+    </dialog>
+  </div>
+
+  <script>
+    function openJsDialog() {
+      const dialog = document.getElementById('jsDialog');
+      const content = document.getElementById('jsDialogContent');
+      
+      // Remove and trigger reflow to reset keyframe animation
+      content.classList.remove('ease-fade-in');
+      void content.offsetWidth; // Force layout recalculation
+      content.classList.add('ease-fade-in');
+      
+      dialog.showModal();
+    }
+
+    function openCssDialog() {
+      const dialog = document.getElementById('cssDialog');
+      dialog.showModal();
+    }
+
+    function closeDialog(id) {
+      document.getElementById(id).close();
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/dialog-animation-replay-naresh/style.css
+++ b/submissions/examples/dialog-animation-replay-naresh/style.css
@@ -1,0 +1,120 @@
+/* Dialog Animation Replay Demo CSS */
+
+/* Base Styles */
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #0b1121;
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 2rem;
+}
+
+.container {
+  max-width: 600px;
+  width: 100%;
+  text-align: center;
+}
+
+.card {
+  background: #141e33;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+h2 {
+  font-size: 1.25rem;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  color: #a78bfa;
+}
+
+.btn {
+  background-color: #3b82f6;
+  border: none;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  margin: 0.5rem;
+  transition: background 0.2s;
+}
+
+.btn:hover {
+  background-color: #2563eb;
+}
+
+.btn-secondary {
+  background-color: #475569;
+}
+
+.btn-secondary:hover {
+  background-color: #334155;
+}
+
+/* Dialog Styles */
+dialog {
+  border: none;
+  border-radius: 16px;
+  background-color: #1e293b;
+  color: #f8fafc;
+  padding: 2rem;
+  max-width: 400px;
+  width: 100%;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+dialog::backdrop {
+  background-color: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(8px);
+}
+
+.dialog-header {
+  margin-top: 0;
+  color: #a78bfa;
+  font-size: 1.5rem;
+}
+
+.dialog-body {
+  color: #94a3b8;
+  margin-bottom: 1.5rem;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+/* ── Animation and Transition Setup ── */
+
+/* Keyframe animations */
+@keyframes demo-fade-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.ease-fade-in {
+  animation: demo-fade-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* Starting-Style Workaround (CSS Transition based) */
+.composed-starting-style {
+  opacity: 1;
+  transform: scale(1);
+  transition: opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+              transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@starting-style {
+  dialog[open] .composed-starting-style {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a self-contained submission documenting and demonstrating workarounds for replaying entrance animations inside a native HTML `<dialog>` element on subsequent opens (since keyframe animations on already rendered DOM nodes do not re-trigger by default when a dialog is closed and reopened).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/dialog-animation-replay-naresh/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It provides clear workarounds using either CSS `@starting-style` transitions or JavaScript class-toggling reflows to ensure entrance animations replay every time a native HTML `<dialog>` is opened.

**How does a developer use it?**

### Workaround 1: JavaScript Reflow
```javascript
function openDialog() {
  const content = dialog.querySelector('.dialog-content');
  content.classList.remove('ease-fade-in');
  void content.offsetWidth; // Force layout reflow
  content.classList.add('ease-fade-in');
  dialog.showModal();
}
dialog[open] .composed-starting-style {
  opacity: 1;
  transform: scale(1);
  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
}

@starting-style {
  dialog[open] .composed-starting-style {
    opacity: 0;
    transform: scale(0.95);
  }
}
