### PR TITLE
feat: add RTL slide direction fix submission

### DIFF
--- a/submissions/examples/rtl-slide-direction-naresh/README.md
+++ b/submissions/examples/rtl-slide-direction-naresh/README.md
@@ -1,0 +1,61 @@
+# RTL-Aware Slide Animations Workaround
+
+## The Bug
+When a document's text direction is set to Right-To-Left (`dir="rtl"`) on the `html` or `body` element, layout direction and horizontal flow are mirrored to suit languages like Arabic, Hebrew, and Urdu. However, standard CSS keyframe animations with hardcoded coordinate values:
+- `transform: translateX(-100%)` (starts on the left)
+- `transform: translateX(100%)` (starts on the right)
+
+Do not dynamically mirror themselves because translate coordinates are always screen-absolute (negative X is always left, positive X is always right). As a result, `.ease-slide-in-left` slides in from the wrong side (the end instead of the start) and `.ease-slide-in-right` does the opposite.
+
+## Suggested Fix: CSS Variable Overrides in Keyframes
+To achieve writing-direction-aware animations without duplicating animation keyframes, we back keyframe translation offsets with CSS custom properties.
+
+### 1. Keyframe Refactoring
+Define keyframes using CSS variables with LTR-default fallbacks:
+```css
+@keyframes ease-kf-slide-in-from-left {
+  from {
+    opacity: 0;
+    transform: translateX(var(--ease-slide-from-left, -100%));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes ease-kf-slide-in-from-right {
+  from {
+    opacity: 0;
+    transform: translateX(var(--ease-slide-from-right, 100%));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+```
+
+### 2. RTL Override Rules
+Create logical selectors targeting elements nested inside elements with `dir="rtl"` to flip/mirror the offsets:
+```css
+/* Standard LTR configuration default is active */
+.ease-slide-in-from-left {
+  animation: ease-kf-slide-in-from-left 0.5s ease-out both;
+}
+
+.ease-slide-in-from-right {
+  animation: ease-kf-slide-in-from-right 0.5s ease-out both;
+}
+
+/* RTL overrides to invert the direction */
+[dir="rtl"] .ease-slide-in-from-left {
+  --ease-slide-from-left: 100%;
+}
+
+[dir="rtl"] .ease-slide-in-from-right {
+  --ease-slide-from-right: -100%;
+}
+```
+
+This ensures slide animations remain logical: sliding "from the start of inline layout" in both LTR (starts on left) and RTL (starts on right).

--- a/submissions/examples/rtl-slide-direction-naresh/demo.html
+++ b/submissions/examples/rtl-slide-direction-naresh/demo.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS — RTL-Aware Slide Animations Fix</title>
+  <meta name="description" content="Interactive demonstration showcasing logical, writing-direction-aware slide animations using CSS variables under RTL layout conditions.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header class="header">
+      <h1>RTL Slide Animation Fix</h1>
+      <p>Ensuring horizontal animations adapt dynamically to Right-To-Left layout systems</p>
+    </header>
+
+    <!-- Global Controls -->
+    <div class="controls-bar">
+      <button id="btn-toggle-direction" class="btn" onclick="toggleWritingDirection()">Toggle Writing Direction (Current: LTR)</button>
+      <button id="btn-replay-all" class="btn btn-secondary" onclick="replayAnimations()">Replay Animations</button>
+    </div>
+
+    <!-- Active State indicator -->
+    <div style="text-align: center; margin-bottom: 2rem;">
+      <span id="current-state-banner" class="status-indicator">Active Mode: LTR (Left-To-Right)</span>
+    </div>
+
+    <!-- Demo Wrapper with dynamic dir attribute -->
+    <main id="demo-root" dir="ltr">
+      <div class="showcase-grid">
+        
+        <!-- Left Column: Legacy Absolute Animations -->
+        <section class="panel-card">
+          <h2>1. Legacy Hardcoded Absolute Slides</h2>
+          <p style="color: #94a3b8; font-size: 0.9rem; line-height: 1.5; margin: 0;">
+            These elements use absolute coordinate keyframes (<code>translateX(-100%)</code> / <code>translateX(100%)</code>). Under RTL, they slide in from the wrong/opposite direction.
+          </p>
+
+          <div>
+            <span style="font-size: 0.85rem; color: #a78bfa; font-weight: 600; display: block; margin-bottom: 0.5rem;">.ease-absolute-left (Slide Left)</span>
+            <div class="demo-box">
+              <div id="anim-absolute-left" class="box-inner ease-absolute-left">Absolute Left</div>
+            </div>
+          </div>
+
+          <div>
+            <span style="font-size: 0.85rem; color: #a78bfa; font-weight: 600; display: block; margin-bottom: 0.5rem;">.ease-absolute-right (Slide Right)</span>
+            <div class="demo-box">
+              <div id="anim-absolute-right" class="box-inner ease-absolute-right">Absolute Right</div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Right Column: Refactored Logical (RTL-aware) Animations -->
+        <section class="panel-card">
+          <h2>2. Refactored Logical RTL-Aware Slides</h2>
+          <p style="color: #94a3b8; font-size: 0.9rem; line-height: 1.5; margin: 0;">
+            These elements use keyframes backed by CSS variables. When <code>dir="rtl"</code> is set on the container, the start/end offsets automatically swap.
+          </p>
+
+          <div>
+            <span style="font-size: 0.85rem; color: #f472b6; font-weight: 600; display: block; margin-bottom: 0.5rem;">.ease-logical-left (Slide Left -> Logical Start)</span>
+            <div class="demo-box">
+              <div id="anim-logical-left" class="box-inner ease-logical-left">Logical Left</div>
+            </div>
+          </div>
+
+          <div>
+            <span style="font-size: 0.85rem; color: #f472b6; font-weight: 600; display: block; margin-bottom: 0.5rem;">.ease-logical-right (Slide Right -> Logical End)</span>
+            <div class="demo-box">
+              <div id="anim-logical-right" class="box-inner ease-logical-right">Logical Right</div>
+            </div>
+          </div>
+        </section>
+
+      </div>
+    </main>
+  </div>
+
+  <script>
+    function toggleWritingDirection() {
+      const demoRoot = document.getElementById('demo-root');
+      const toggleBtn = document.getElementById('btn-toggle-direction');
+      const banner = document.getElementById('current-state-banner');
+      
+      if (demoRoot.getAttribute('dir') === 'ltr') {
+        demoRoot.setAttribute('dir', 'rtl');
+        document.documentElement.setAttribute('dir', 'rtl');
+        toggleBtn.innerText = 'Toggle Writing Direction (Current: RTL)';
+        toggleBtn.classList.add('btn-active');
+        banner.innerText = 'Active Mode: RTL (Right-To-Left)';
+        banner.style.color = '#f472b6';
+        banner.style.borderColor = 'rgba(244, 114, 182, 0.25)';
+        banner.style.backgroundColor = 'rgba(244, 114, 182, 0.1)';
+      } else {
+        demoRoot.setAttribute('dir', 'ltr');
+        document.documentElement.setAttribute('dir', 'ltr');
+        toggleBtn.innerText = 'Toggle Writing Direction (Current: LTR)';
+        toggleBtn.classList.remove('btn-active');
+        banner.innerText = 'Active Mode: LTR (Left-To-Right)';
+        banner.style.color = '#60a5fa';
+        banner.style.borderColor = 'rgba(96, 165, 250, 0.25)';
+        banner.style.backgroundColor = 'rgba(96, 165, 250, 0.1)';
+      }
+
+      // Re-trigger animations immediately to show layout-aware start direction changes
+      replayAnimations();
+    }
+
+    function replayAnimations() {
+      const elements = [
+        { id: 'anim-absolute-left', className: 'ease-absolute-left' },
+        { id: 'anim-absolute-right', className: 'ease-absolute-right' },
+        { id: 'anim-logical-left', className: 'ease-logical-left' },
+        { id: 'anim-logical-right', className: 'ease-logical-right' }
+      ];
+
+      elements.forEach(item => {
+        const el = document.getElementById(item.id);
+        if (el) {
+          el.classList.remove(item.className);
+          void el.offsetWidth; // Force layout recalculation/reflow to reset keyframe state
+          el.classList.add(item.className);
+        }
+      });
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/rtl-slide-direction-naresh/style.css
+++ b/submissions/examples/rtl-slide-direction-naresh/style.css
@@ -1,0 +1,224 @@
+/* RTL-Aware Slide Animations Demo Styles */
+
+/* ── Base Theme Design ── */
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #0b1121;
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 2rem;
+}
+
+.container {
+  max-width: 900px;
+  width: 100%;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.header h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #fff 40%, #818cf8 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.header p {
+  color: #94a3b8;
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.controls-bar {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.btn {
+  background-color: #3b82f6;
+  border: none;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.2);
+}
+
+.btn:hover {
+  background-color: #2563eb;
+  transform: translateY(-1px);
+}
+
+.btn-secondary {
+  background-color: #475569;
+  box-shadow: 0 4px 12px rgba(71, 85, 105, 0.2);
+}
+
+.btn-secondary:hover {
+  background-color: #334155;
+}
+
+.btn-active {
+  background-color: #818cf8;
+  box-shadow: 0 4px 12px rgba(129, 140, 248, 0.4);
+}
+
+.btn-active:hover {
+  background-color: #6366f1;
+}
+
+/* ── Comparison Showcase Columns ── */
+.showcase-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
+@media (max-width: 768px) {
+  .showcase-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.panel-card {
+  background: #141e33;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel-card h2 {
+  font-size: 1.25rem;
+  margin: 0;
+  color: #a78bfa;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 0.75rem;
+}
+
+.demo-box {
+  background: #1e293b;
+  border-radius: 12px;
+  padding: 1.5rem;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+}
+
+.box-inner {
+  background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  color: white;
+  box-shadow: 0 4px 15px rgba(99, 102, 241, 0.3);
+  display: inline-block;
+}
+
+/* Status Banner */
+.status-indicator {
+  text-align: center;
+  font-size: 0.95rem;
+  font-weight: bold;
+  color: #60a5fa;
+  background-color: rgba(96, 165, 250, 0.1);
+  padding: 0.5rem 1rem;
+  border-radius: 30px;
+  border: 1px solid rgba(96, 165, 250, 0.25);
+  display: inline-block;
+  align-self: center;
+}
+
+/* ── Slide Animations Definitions ── */
+
+/* 1. Legacy Hardcoded Absolute Keyframes */
+@keyframes ease-kf-absolute-left {
+  from { opacity: 0; transform: translateX(-100%); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ease-kf-absolute-right {
+  from { opacity: 0; transform: translateX(100%); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.ease-absolute-left {
+  animation: ease-kf-absolute-left 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.ease-absolute-right {
+  animation: ease-kf-absolute-right 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* 2. Refactored Logical (Writing-Direction Aware) Keyframes */
+@keyframes ease-kf-logical-left {
+  from {
+    opacity: 0;
+    transform: translateX(var(--ease-slide-from-left, -100%));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes ease-kf-logical-right {
+  from {
+    opacity: 0;
+    transform: translateX(var(--ease-slide-from-right, 100%));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.ease-logical-left {
+  animation: ease-kf-logical-left 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.ease-logical-right {
+  animation: ease-kf-logical-right 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* ── RTL Custom Property Overrides ── */
+[dir="rtl"] .ease-logical-left {
+  --ease-slide-from-left: 100%;
+}
+
+[dir="rtl"] .ease-logical-right {
+  --ease-slide-from-right: -100%;
+}
+
+/* Helper rules to toggle layout mirroring for RTL demo containers */
+[dir="rtl"] {
+  text-align: right;
+}
+
+[dir="rtl"] .btn {
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.2);
+}


### PR DESCRIPTION
## Pull Request Description
This PR adds an interactive submission documenting and demonstrating logical, direction-aware slide animations. In RTL (Right-to-Left) environments, absolute horizontal slide animations (e.g. `transform: translateX(-100%)`) slide in from the wrong side (the end instead of the start direction). The workaround introduces CSS variable values inside keyframes (`var(--ease-slide-dir, ...)`), allowing dynamically swapped values on `[dir="rtl"]` selectors without duplicating code.
---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)
---
## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/examples/rtl-slide-direction-naresh/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
---
## Feature Description
**What does this add?**
It adds support for writing-direction-aware horizontal slide animations under `dir="rtl"` layout conditions without code duplication, using a custom-property backed `@keyframes` pattern.
**How does a developer use it?**
1. Define keyframes with CSS variables and sensible fallbacks:
```css
@keyframes ease-kf-logical-left {
  from {
    opacity: 0;
    transform: translateX(var(--ease-slide-from-left, -100%));
  }
  to {
    opacity: 1;
    transform: translateX(0);
  }
}
Add logical overrides for RTL documents:
css
.ease-logical-left {
  animation: ease-kf-logical-left 0.6s ease-out both;
}
[dir="rtl"] .ease-logical-left {
  --ease-slide-from-left: 100%;
}