### PR TITLE
fix: add dark mode text color to ease-card-glass #2611

### DIFF
--- a/submissions/examples/fix-glass-card/README.md
+++ b/submissions/examples/fix-glass-card/README.md
@@ -1,0 +1,13 @@
+# Glass Card Dark Mode Fix
+
+## Problem
+In Dark Mode, the `.ease-card-glass` component maintained a dark text color against a dark-tinted background, making the content invisible and violating WCAG contrast accessibility guidelines.
+
+## Solution
+Updated the `prefers-color-scheme: dark` media query for `.ease-card-glass` to explicitly include a high-contrast light text color (`#f8fafc`).
+
+## Usage
+Add the following classes to your HTML:
+```html
+<div class="ease-card ease-card-glass">
+    </div>

--- a/submissions/examples/fix-glass-card/demo.html
+++ b/submissions/examples/fix-glass-card/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glass Card Contrast Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <div class="ease-card-glass">
+            <h2>Glass Card Title</h2>
+            <p>This text is now readable in both Light and Dark modes!</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/fix-glass-card/style.css
+++ b/submissions/examples/fix-glass-card/style.css
@@ -1,0 +1,15 @@
+.ease-card-glass {
+    background: rgba(255, 255, 255, 0.5);
+    color: #1e293b; /* Light mode default */
+    padding: 20px;
+    border-radius: 12px;
+    backdrop-filter: blur(10px);
+}
+
+/* Fix: Dark mode text contrast */
+@media (prefers-color-scheme: dark) {
+    .ease-card-glass {
+        background: rgba(30, 41, 59, 0.5);
+        color: #f8fafc; /* Added light text for readability */
+    }
+}


### PR DESCRIPTION
Pull Request Description
This PR resolves issue #2611 by ensuring text readability within the .ease-card-glass component when switching to dark mode. By updating the dark mode media query, we now provide sufficient contrast between the background and text content.

Type of Change
[x] 🐛 Bug fix in an existing submission

Submission Checklist
[x] All changes are inside submissions/examples/fix-glass-card/

[x] Includes demo.html

[x] Includes style.css

[x] Includes README.md

[x] No changes to core/

[x] No changes to components/

[x] One feature per PR

Feature Description
What does this add?
It adds a high-contrast text color override (#f8fafc) specifically for the prefers-color-scheme: dark media query within the glass card component.

How does a developer use it?

HTML
<div class="ease-card ease-card-glass">
  <h3>Glass Card Content</h3>
  <p>Text is now visible in both light and dark modes.</p>
</div>
Why does it fit EaseMotion CSS?
It adheres to the framework's core accessibility-first principles by ensuring that visual aesthetics do not compromise the usability and readability of UI components for all users.

Demo
[x] Demo added (demo.html works by opening directly in a browser)

Browser Testing
[x] Chrome

[x] Firefox

[x] Edge

[x] Safari

Notes for Maintainer
The fix is applied as a scoped media query override. No global styles were altered, ensuring zero impact on other components.