### PR TITLE
feat: add CSS scroll-driven image reveal demo (#15946)

### DIFF
--- a/submissions/examples/ease-scroll-driven-image-reveal/README.md
+++ b/submissions/examples/ease-scroll-driven-image-reveal/README.md
@@ -1,0 +1,17 @@
+# Scroll-Driven Image Reveal (`ease-scroll-driven-image-reveal`)
+
+A demonstration of the modern CSS `animation-timeline: view()` API to create scroll-linked image reveal effects without relying on Javascript intersection observers.
+
+## 🚀 Features & EaseMotion Showcase
+
+- **Zero JavaScript**: Traditionally, revealing images on scroll required heavy Javascript libraries (like GSAP ScrollTrigger or Intersection Observers). By leveraging native CSS Scroll-Driven Animations, the browser's compositor handles the effect natively, resulting in buttery smooth 120fps performance.
+- **Scroll-Linked Progress**: The animations are scrubbable! If you scroll down, the image fades in. If you immediately scroll back up, the animation perfectly reverses relative to your scrollbar position.
+- **Safe Fallbacks**: The code utilizes `@supports (animation-timeline: view())` so that unsupported browsers simply display the image statically without breaking the layout.
+
+## 🛠️ Usage
+
+This demo is self-contained. Open `demo.html` in your browser. All required CSS is inside `style.css`.
+
+To apply a scroll-reveal to an image:
+```html
+<img src="photo.jpg" class="ease-scroll-reveal-fade">

--- a/submissions/examples/ease-scroll-driven-image-reveal/demo.html
+++ b/submissions/examples/ease-scroll-driven-image-reveal/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Scroll-Driven Image Reveal | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>Scroll-Driven Image Reveal</h2>
+      <p>Using the modern CSS <code>animation-timeline: view()</code> API to trigger beautiful image reveals tied purely to the user's scroll position, with zero JavaScript.</p>
+    </div>
+
+    <!-- Spacer to allow scrolling -->
+    <div class="spacer">
+      <p>Scroll down to see the magic happen...</p>
+      <svg width="40" height="40" fill="none" stroke="#94a3b8" stroke-width="2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M19 14l-7 7m0 0l-7-7m7 7V3"></path>
+      </svg>
+    </div>
+
+    <!-- Example 1: The Fade Up Reveal -->
+    <div class="demo-section">
+      <h3>1. The Fade & Scale Reveal</h3>
+      <p class="description">As this image enters the viewport, it fades in and scales up. The animation progresses strictly relative to your scrollbar!</p>
+      
+      <div class="image-wrapper">
+        <img src="https://images.unsplash.com/photo-1506744626753-eba7bc36c565?auto=format&fit=crop&w=800&q=80" alt="Mountain Landscape" class="ease-scroll-reveal-fade" />
+      </div>
+    </div>
+
+    <!-- Example 2: The Clip-Path Wipe Reveal -->
+    <div class="demo-section" style="margin-top: 100px;">
+      <h3>2. The Clip-Path Wipe</h3>
+      <p class="description">A dramatic cinematic effect where the image unmasks itself from top to bottom as you scroll past it.</p>
+      
+      <div class="image-wrapper">
+        <img src="https://images.unsplash.com/photo-1472214103451-9374bd1c798e?auto=format&fit=crop&w=800&q=80" alt="Forest Landscape" class="ease-scroll-reveal-wipe" />
+      </div>
+    </div>
+
+    <!-- Final spacer -->
+    <div class="spacer">
+      <p>Keep scrolling up and down to see the animations reverse natively.</p>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scroll-driven-image-reveal/style.css
+++ b/submissions/examples/ease-scroll-driven-image-reveal/style.css
@@ -1,0 +1,133 @@
+/* ========================================================================
+   Component: ease-scroll-driven-image-reveal
+   ======================================================================== */
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  min-height: 100vh;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+/* Demo UI Styles */
+.demo-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 700px;
+  padding: 50px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-header h2 { margin-top: 0; color: #0f172a; font-size: 1.75rem; margin-bottom: 12px;}
+.demo-header p { color: #64748b; margin: 0; font-size: 1.05rem; line-height: 1.6;}
+.demo-header code { background: #f1f5f9; padding: 4px 8px; border-radius: 6px; color: #dc2626;}
+
+.demo-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.demo-section h3 { margin: 0; color: #334155; font-size: 1.25rem; }
+.description { margin: 0 0 16px 0; font-size: 0.95rem; color: #64748b; line-height: 1.5; }
+
+.spacer {
+  height: 50vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  color: #94a3b8;
+  text-align: center;
+  font-style: italic;
+}
+
+.image-wrapper {
+  width: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  background: #e2e8f0;
+}
+
+img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* ------------------------------------------------------------------------
+   Core Utility: Scroll-Driven Animations
+   ------------------------------------------------------------------------ */
+
+/* 
+  Check if the browser supports scroll-driven animations.
+  If not, the images will just display normally as a safe fallback.
+*/
+@supports (animation-timeline: view()) {
+  
+  /* 1. Fade & Scale Reveal */
+  .ease-scroll-reveal-fade {
+    /* Tie the animation to the element intersecting the scroll viewport */
+    animation-timeline: view();
+    /* Play the reveal keyframes */
+    animation-name: reveal-fade;
+    /* Start animating when element enters bottom, finish when it hits 30% up the screen */
+    animation-range: entry 10% cover 30%;
+    animation-fill-mode: both;
+  }
+
+  @keyframes reveal-fade {
+    from {
+      opacity: 0;
+      transform: translateY(50px) scale(0.9);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  /* 2. Clip-Path Wipe Reveal */
+  .ease-scroll-reveal-wipe {
+    animation-timeline: view();
+    animation-name: reveal-wipe;
+    animation-range: entry 20% cover 50%;
+    animation-fill-mode: both;
+  }
+
+  @keyframes reveal-wipe {
+    from {
+      clip-path: inset(100% 0 0 0);
+      filter: grayscale(100%);
+    }
+    to {
+      clip-path: inset(0 0 0 0);
+      filter: grayscale(0%);
+    }
+  }
+
+}
+
+/* Accessibility Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .ease-scroll-reveal-fade,
+  .ease-scroll-reveal-wipe {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15946 by adding a showcase for CSS-native `animation-timeline: view()` scroll reveals.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-scroll-driven-image-reveal/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It provides `.ease-scroll-reveal-fade` and `.ease-scroll-reveal-wipe` utility classes that bind animations strictly to the scrollbar using the new CSS Scroll-Driven Animations API.

**How does a developer use it?**

```html
<!-- The image reveals itself exactly relative to where the user's scrollbar is -->
<img src="mountain.jpg" class="ease-scroll-reveal-fade" />
