### PR TITLE
fix: propose will-change GPU memory optimization for ease-reveal (#17…

### DIFF
--- a/submissions/examples/ease-reveal-memory-fix-proposal/README.md
+++ b/submissions/examples/ease-reveal-memory-fix-proposal/README.md
@@ -1,0 +1,24 @@
+# Architectural Proposal: `.ease-reveal` GPU Memory Fix (`ease-reveal-memory-fix-proposal`)
+
+This submission provides a concrete architectural fix for the GPU memory bloat issue caused by permanent `will-change` declarations.
+
+## 🚀 The Problem & Solution
+
+- **The Problem**: Currently, `core/animations.css` applies `will-change: transform, opacity` directly to `.ease-reveal`. Because `will-change` forces the browser to pre-allocate a GPU compositor layer, a page with hundreds of reveal elements will consume massive amounts of VRAM immediately on load, causing crashes on lower-end mobile devices (Safari on iOS is notoriously strict about this).
+- **The Fix**: We must remove `will-change` from the base `.ease-reveal` class. Instead, we introduce a `.ease-reveal-pending` utility class. The intersection observer script should attach this class slightly before the element enters the viewport, and remove it once the transition completes.
+
+## 🛠️ Proposed Core Changes
+
+If approved, the maintainer should manually apply the following diff to `core/animations.css`:
+
+```diff
+ .ease-reveal {
+   opacity: 0;
+   transform: translateY(30px);
+-  will-change: transform, opacity;
+   transition: opacity 0.6s cubic-bezier(0.4, 0, 0.2, 1), transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+ }
+ 
++.ease-reveal-pending {
++  will-change: transform, opacity;
++}

--- a/submissions/examples/ease-reveal-memory-fix-proposal/demo.html
+++ b/submissions/examples/ease-reveal-memory-fix-proposal/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GPU Memory Bloat Fix Proposal | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>Architectural Proposal: GPU Memory Fix</h2>
+      <p>Resolves issue <strong>#17467</strong>. This demonstrates how we should refactor <code>.ease-reveal</code> to prevent massive GPU compositor layer bloat on pages with many elements.</p>
+    </div>
+
+    <div class="demo-section">
+      <div class="card bad-architecture">
+        <h4>❌ Current Architecture</h4>
+        <p>Currently, <code>.ease-reveal</code> applies <code>will-change: transform, opacity</code> permanently upon page load. If you have 500 cards on a page, the browser pre-allocates 500 GPU layers instantly, crashing low-end devices.</p>
+        <div class="mock-element ease-reveal-legacy">Legacy Element</div>
+      </div>
+
+      <div class="card good-architecture">
+        <h4>✅ Proposed Architecture</h4>
+        <p>We remove <code>will-change</code> from the base class. Instead, JavaScript (like reveal.js) adds a <code>.ease-reveal-pending</code> class just before the element enters the viewport to trigger the GPU promotion exactly when needed.</p>
+        <div class="mock-element ease-reveal-new ease-reveal-pending">New Element</div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-reveal-memory-fix-proposal/style.css
+++ b/submissions/examples/ease-reveal-memory-fix-proposal/style.css
@@ -1,0 +1,96 @@
+/* ========================================================================
+   Component: ease-reveal-memory-fix-proposal
+   ======================================================================== */
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+/* Demo UI Styles */
+.demo-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 800px;
+  padding: 50px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.demo-header {
+  text-align: center;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 20px;
+}
+
+.demo-header h2 { margin-top: 0; color: #0f172a; font-size: 1.75rem; margin-bottom: 12px;}
+.demo-header p { color: #64748b; margin: 0; font-size: 1.05rem; line-height: 1.6;}
+
+.demo-section {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+}
+
+.card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background-color: #f1f5f9;
+}
+
+.bad-architecture h4 { color: #dc2626; margin: 0; font-size: 1.1rem; }
+.good-architecture h4 { color: #16a34a; margin: 0; font-size: 1.1rem; }
+
+.card p { margin: 0; font-size: 0.9rem; color: #475569; line-height: 1.5; }
+
+.mock-element {
+  padding: 20px;
+  background-color: #ffffff;
+  border: 2px dashed #cbd5e1;
+  text-align: center;
+  font-weight: 600;
+  color: #334155;
+  border-radius: 8px;
+  margin-top: auto;
+}
+
+
+/* ------------------------------------------------------------------------
+   The Proposed Fix Implementation (For Review)
+   ------------------------------------------------------------------------ */
+
+/* ❌ OLD WAY (What is currently in core/animations.css) */
+.ease-reveal-legacy {
+  /* This causes memory bloat when applied to hundreds of elements! */
+  will-change: transform, opacity; 
+  transition: all 0.5s ease;
+}
+
+/* ✅ NEW WAY (Proposed implementation) */
+.ease-reveal-new {
+  /* Base class NO LONGER has will-change */
+  transition: all 0.5s ease;
+}
+
+/* JS adds this class 100px before the element enters viewport */
+.ease-reveal-pending {
+  /* GPU layer is promoted ONLY when the animation is imminent */
+  will-change: transform, opacity;
+}
+
+/* Once animation completes, JS removes .ease-reveal-pending to free RAM */


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #17467 by proposing a critical GPU memory architecture fix for `.ease-reveal`. *(Note: Because PRs are banned from modifying `core/` files, I have submitted this fix as an architectural proposal inside `submissions/examples/ease-reveal-memory-fix-proposal` for your review so the bot doesn't reject it).*

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-reveal-memory-fix-proposal/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It provides the exact CSS diff needed to stop `.ease-reveal` from permanently consuming GPU compositor layers upon page load.

**How does a developer use it?**

```css
/* Maintainers should move will-change to this pending class: */
.ease-reveal-pending {
  will-change: transform, opacity;
}
