### PR TITLE
feat: add token-driven accent-color utilities (#18513)

### DIFF
--- a/submissions/examples/accent-color-tm/README.md
+++ b/submissions/examples/accent-color-tm/README.md
@@ -1,60 +1,27 @@
-# Accent Color
+# Accent Color Utilities (`accent-color-tm`)
 
-A self-contained EaseMotion-css submission that demonstrates the `accent color` pattern using the framework's design tokens.
+A robust, token-driven utility set for leveraging the CSS `accent-color` property. This allows instant theming of native form controls (checkboxes, radio buttons, ranges, and progress bars) without the need for complex custom CSS replacements.
 
-## Features
+## 🚀 Features
 
-- Default `.accent-color` rule backed by `--ease-color-primary-alpha` and `--ease-color-primary-dark`
-- Four size variants (`-sm`, `-md`, `-lg`, `-xl`) using `--ease-space-*` and `--ease-radius-*` tokens
-- Six color variants (`-primary`, `-secondary`, `-success`, `-danger`, `-warning`, `-info`) that map directly to `--ease-color-*` tokens
-- Three shape variants (`-pill`, `-rounded`, `-square`) using `--ease-radius-*` tokens
-- Light variants (`-primary-light`, `-success-light`, `-danger-light`) using `--ease-color-*-alpha` tokens for subtle backgrounds
-- Hover, focus-visible, and active states animated with `--ease-speed-fast` + `--ease-ease-out`
-- Disabled state via `[disabled]` attribute selector
-- Full dark mode support via `prefers-color-scheme: dark`
-- Reduced-motion support via `prefers-reduced-motion: reduce`
-- Inline and block display helpers
+- **Token-Driven Design**: Uses CSS variables (`--ease-color-*`) to seamlessly integrate with EaseMotion's broader design system.
+- **Dark Mode Support**: Colors automatically adapt when `@media (prefers-color-scheme: dark)` is triggered, ensuring legibility and contrast.
+- **Reduced Motion Support**: Included hover effects on the demo cards gracefully degrade for users with motion sensitivity.
+- **Extensible**: Includes a `.ease-accent-custom` class that accepts an inline CSS variable (`--ease-accent-custom`) for on-the-fly component overrides.
 
-## Usage
+## 🛠️ Usage
+
+Open `demo.html` in your browser. All code is contained within `style.css`.
+
+### Available Utilities
 
 ```html
-<div class="accent-color accent-color-md accent-color-primary">
-  Hello world
+<!-- Primary Theme -->
+<div class="ease-accent-primary">
+  <input type="checkbox" checked>
 </div>
-```
 
-## Why is it useful?
-
-EaseMotion-css already provides a comprehensive token system (`--ease-color-*`, `--ease-space-*`, `--ease-radius-*`, `--ease-shadow-*`). This submission turns `accent color` into a composable class set so designers and engineers can mix and match variants without writing new CSS. Each rule references a real design token, so the entire pattern automatically respects the maintainer's design system decisions — including any future token additions.
-
-The submission also demonstrates two important EaseMotion patterns:
-
-1. **Token-first composition** — every visual property (`color`, `background`, `border-radius`, `padding`) comes from a `--ease-*` variable, never a hard-coded value.
-2. **Motion-respectful defaults** — `prefers-reduced-motion` zeros out transitions, and `prefers-color-scheme: dark` swaps the surface tokens for the dark palette.
-
-## Token reference
-
-| Variant | Token(s) used |
-| --- | --- |
-| Default | --ease-color-primary-alpha, --ease-color-primary-dark |
-| Primary | --ease-color-primary |
-| Secondary | --ease-color-secondary |
-| Success | --ease-color-success |
-| Danger | --ease-color-danger |
-| Warning | --ease-color-warning |
-| Info | --ease-color-info |
-| Sizes | --ease-space-*, --ease-radius-{sm,md,lg,xl} |
-| Shapes | --ease-radius-{sm,md,full} |
-| Motion | --ease-speed-fast, --ease-ease-out |
-
-## Accessibility
-
-- `:focus-visible` outline uses `--ease-color-primary` at 2px width for clear keyboard focus.
-- Disabled state halves opacity and disables pointer events.
-- Reduced-motion preference disables all transitions.
-
-## Files
-
-- `style.css` — All rules for `.accent-color` and variants, plus layout, dark mode, and reduced motion.
-- `demo.html` — Six interactive demo cards showing every variant in context.
-- `README.md` — This file.
+<!-- Extensible Custom Variable Override -->
+<div class="ease-accent-custom" style="--ease-accent-custom: #8b5cf6;">
+  <input type="radio" checked>
+</div>

--- a/submissions/examples/accent-color-tm/demo.html
+++ b/submissions/examples/accent-color-tm/demo.html
@@ -3,94 +3,90 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Accent Color Demo</title>
+  <title>Accent Color Tokens | EaseMotion CSS</title>
   <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
 <body>
-  <div class="container">
-    <h1>Accent Color</h1>
-    <p class="subtitle">A real-world demonstration of accent color with EaseMotion-css design tokens.</p>
+  
+  <div class="demo-container">
+    <div class="demo-header">
+      <h2>Accent Color Utilities</h2>
+      <p>A set of token-driven utility classes to effortlessly theme native HTML form controls using the <code>accent-color</code> CSS property. Fully supports dark mode.</p>
+    </div>
 
-    <section class="demo-grid">
-      <div class="demo-card">
-        <h2 class="demo-card-title">Default</h2>
-        <p class="demo-card-body">The base .accent-color uses the framework's primary alpha token.</p>
-        <div class="accent-color">Default Accent Color</div>
-      </div>
-
-      <div class="demo-card">
-        <h2 class="demo-card-title">Sizes</h2>
-        <p class="demo-card-body">Size variants use --ease-space-* and --ease-radius-* tokens.</p>
-        <div class="col">
-          <div class="accent-color accent-color-sm">Small</div>
-          <div class="accent-color accent-color-md">Medium</div>
-          <div class="accent-color accent-color-lg">Large</div>
-          <div class="accent-color accent-color-xl">Extra Large</div>
+    <!-- 6 Interactive Demo Cards -->
+    <div class="card-grid">
+      
+      <!-- Primary -->
+      <div class="card ease-accent-primary">
+        <h4>Primary Accent</h4>
+        <div class="controls">
+          <label><input type="checkbox" checked> Checkbox</label>
+          <label><input type="radio" name="r1" checked> Radio</label>
+          <input type="range" min="0" max="100" value="70">
+          <progress max="100" value="60"></progress>
         </div>
       </div>
 
-      <div class="demo-card">
-        <h2 class="demo-card-title">Color variants</h2>
-        <p class="demo-card-body">All variants consume --ease-color-* tokens.</p>
-        <div class="col">
-          <div class="accent-color accent-color-primary">Primary</div>
-          <div class="accent-color accent-color-secondary">Secondary</div>
-          <div class="accent-color accent-color-success">Success</div>
-          <div class="accent-color accent-color-danger">Danger</div>
-          <div class="accent-color accent-color-warning">Warning</div>
-          <div class="accent-color accent-color-info">Info</div>
+      <!-- Success -->
+      <div class="card ease-accent-success">
+        <h4>Success Accent</h4>
+        <div class="controls">
+          <label><input type="checkbox" checked> Checkbox</label>
+          <label><input type="radio" name="r2" checked> Radio</label>
+          <input type="range" min="0" max="100" value="40">
+          <progress max="100" value="85"></progress>
         </div>
       </div>
 
-      <div class="demo-card">
-        <h2 class="demo-card-title">Shapes</h2>
-        <p class="demo-card-body">Shape variants use --ease-radius-* tokens.</p>
-        <div class="col">
-          <div class="accent-color accent-color-pill">Pill shape</div>
-          <div class="accent-color accent-color-rounded">Rounded</div>
-          <div class="accent-color accent-color-square">Square</div>
+      <!-- Warning -->
+      <div class="card ease-accent-warning">
+        <h4>Warning Accent</h4>
+        <div class="controls">
+          <label><input type="checkbox" checked> Checkbox</label>
+          <label><input type="radio" name="r3" checked> Radio</label>
+          <input type="range" min="0" max="100" value="60">
+          <progress max="100" value="45"></progress>
         </div>
       </div>
 
-      <div class="demo-card">
-        <h2 class="demo-card-title">Light variants</h2>
-        <p class="demo-card-body">Lower contrast via alpha tokens for subtle UI affordances.</p>
-        <div class="col">
-          <div class="accent-color accent-color-primary-light">Primary light</div>
-          <div class="accent-color accent-color-success-light">Success light</div>
-          <div class="accent-color accent-color-danger-light">Danger light</div>
+      <!-- Danger -->
+      <div class="card ease-accent-danger">
+        <h4>Danger Accent</h4>
+        <div class="controls">
+          <label><input type="checkbox" checked> Checkbox</label>
+          <label><input type="radio" name="r4" checked> Radio</label>
+          <input type="range" min="0" max="100" value="90">
+          <progress max="100" value="20"></progress>
         </div>
       </div>
 
-      <div class="demo-card">
-        <h2 class="demo-card-title">Interactive</h2>
-        <p class="demo-card-body">Hover, focus, and active states powered by --ease-ease transitions.</p>
-        <div class="col">
-          <button class="accent-color feature-interactive">Hover me</button>
-          <a href="#0" class="accent-color accent-color-primary feature-interactive">Focus me</a>
-          <button class="accent-color accent-color-success" disabled>Disabled</button>
+      <!-- Info -->
+      <div class="card ease-accent-info">
+        <h4>Info Accent</h4>
+        <div class="controls">
+          <label><input type="checkbox" checked> Checkbox</label>
+          <label><input type="radio" name="r5" checked> Radio</label>
+          <input type="range" min="0" max="100" value="30">
+          <progress max="100" value="75"></progress>
         </div>
       </div>
-    </section>
 
-    <section class="demo-card">
-      <h2 class="demo-card-title">Row layout</h2>
-      <p class="demo-card-body">Inline grouping of variants.</p>
-      <div class="row">
-        <span class="accent-color accent-color-sm">One</span>
-        <span class="accent-color accent-color-md">Two</span>
-        <span class="accent-color accent-color-lg">Three</span>
-        <span class="accent-color accent-color-pill accent-color-primary">Pill</span>
+      <!-- Custom -->
+      <div class="card ease-accent-custom" style="--ease-accent-custom: #8b5cf6;">
+        <h4>Custom Accent</h4>
+        <div class="controls">
+          <label><input type="checkbox" checked> Checkbox</label>
+          <label><input type="radio" name="r6" checked> Radio</label>
+          <input type="range" min="0" max="100" value="50">
+          <progress max="100" value="50"></progress>
+        </div>
+        <small style="color: var(--ease-text-muted); margin-top: auto;">Powered by CSS variable override</small>
       </div>
-    </section>
 
-    <section class="demo-card mt-6">
-      <h2 class="demo-card-title">Usage</h2>
-      <p class="demo-card-body">Drop any .accent-color class on a block-level element.</p>
-      <pre class="code-preview">&lt;div class="accent-color accent-color-md accent-color-primary"&gt;
-  Hello world
-&lt;/div&gt;</pre>
-    </section>
+    </div>
   </div>
+
 </body>
 </html>

--- a/submissions/examples/accent-color-tm/style.css
+++ b/submissions/examples/accent-color-tm/style.css
@@ -1,309 +1,130 @@
-/* ── Accent Color ─────────────────────────────────────── */
+/* ========================================================================
+   Component: accent-color-tm
+   ======================================================================== */
 
-/* Reset */
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
+/* Design Tokens */
 :root {
-  --demo-radius: var(--ease-radius-md);
-  --demo-pad: var(--ease-space-4);
-  --demo-gap: var(--ease-space-3);
-  --demo-border: 1px solid var(--ease-color-neutral-200);
+  --ease-color-primary: #3b82f6;
+  --ease-color-success: #10b981;
+  --ease-color-warning: #f59e0b;
+  --ease-color-danger:  #ef4444;
+  --ease-color-info:    #06b6d4;
+  
+  --ease-bg-body: #f8fafc;
+  --ease-bg-card: #ffffff;
+  --ease-text-main: #0f172a;
+  --ease-text-muted: #64748b;
+  --ease-border: #e2e8f0;
 }
 
-/* Base layout */
-body {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  padding: var(--ease-space-10) var(--ease-space-4);
-  background: var(--ease-color-bg);
-  color: var(--ease-color-text);
-  font-family: var(--ease-font-sans);
-  line-height: var(--ease-leading-normal);
-  transition: background var(--ease-speed-medium) var(--ease-ease);
-}
-
-.container {
-  max-width: var(--ease-container-max, 1100px);
-  width: 100%;
-  margin: 0 auto;
-}
-
-h1 {
-  font-size: var(--ease-text-3xl);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin-bottom: var(--ease-space-2);
-  color: var(--ease-color-text);
-}
-
-.subtitle {
-  font-size: var(--ease-text-lg);
-  color: var(--ease-color-muted);
-  margin-bottom: var(--ease-space-8);
-}
-
-/* Demo grid */
-.demo-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: var(--ease-space-5);
-  margin-bottom: var(--ease-space-8);
-}
-
-.demo-card {
-  padding: var(--ease-space-5);
-  border-radius: var(--ease-radius-lg);
-  background: var(--ease-color-surface);
-  border: var(--demo-border);
-  box-shadow: var(--ease-shadow-sm);
-  transition: transform var(--ease-speed-medium) var(--ease-ease),
-              box-shadow var(--ease-speed-medium) var(--ease-ease);
-}
-
-.demo-card:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--ease-shadow-md);
-}
-
-.demo-card-title {
-  font-size: var(--ease-text-lg);
-  font-weight: 600;
-  margin-bottom: var(--ease-space-2);
-  color: var(--ease-color-text);
-}
-
-.demo-card-body {
-  font-size: var(--ease-text-sm);
-  color: var(--ease-color-muted);
-  line-height: var(--ease-leading-loose);
-}
-
-/* Feature-specific base class */
-.accent-color {
-  display: block;
-  padding: var(--ease-space-3) var(--ease-space-4);
-  border-radius: var(--demo-radius);
-  background: var(--ease-color-primary-alpha);
-  color: var(--ease-color-primary-dark);
-  font-size: var(--ease-text-base);
-  margin: var(--ease-space-2) 0;
-  transition: all var(--ease-speed-fast) var(--ease-ease-out);
-}
-
-.accent-color:hover {
-  background: var(--ease-color-primary);
-  color: var(--ease-selection-color);
-  box-shadow: var(--ease-glow-primary);
-}
-
-.accent-color:focus-visible {
-  outline: 2px solid var(--ease-color-primary);
-  outline-offset: 2px;
-}
-
-.accent-color:active {
-  transform: scale(0.98);
-}
-
-/* Size variants */
-.accent-color-sm {
-  padding: var(--ease-space-2) var(--ease-space-3);
-  font-size: var(--ease-text-sm);
-  border-radius: var(--ease-radius-sm);
-}
-
-.accent-color-md {
-  padding: var(--ease-space-3) var(--ease-space-4);
-  font-size: var(--ease-text-base);
-  border-radius: var(--ease-radius-md);
-}
-
-.accent-color-lg {
-  padding: var(--ease-space-4) var(--ease-space-6);
-  font-size: var(--ease-text-lg);
-  border-radius: var(--ease-radius-lg);
-}
-
-.accent-color-xl {
-  padding: var(--ease-space-5) var(--ease-space-8);
-  font-size: var(--ease-text-xl);
-  border-radius: var(--ease-radius-xl);
-}
-
-/* Color variants */
-.accent-color-primary {
-  background: var(--ease-color-primary);
-  color: var(--ease-selection-color);
-}
-
-.accent-color-secondary {
-  background: var(--ease-color-secondary);
-  color: var(--ease-selection-color);
-}
-
-.accent-color-success {
-  background: var(--ease-color-success);
-  color: var(--ease-selection-color);
-}
-
-.accent-color-danger {
-  background: var(--ease-color-danger);
-  color: var(--ease-selection-color);
-}
-
-.accent-color-warning {
-  background: var(--ease-color-warning);
-  color: var(--ease-selection-color);
-}
-
-.accent-color-info {
-  background: var(--ease-color-info);
-  color: var(--ease-selection-color);
-}
-
-/* Light variants (alpha backgrounds) */
-.accent-color-primary-light {
-  background: var(--ease-color-primary-alpha);
-  color: var(--ease-color-primary-dark);
-  border: 1px solid var(--ease-color-primary-light);
-}
-
-.accent-color-success-light {
-  background: var(--ease-color-success-alpha);
-  color: var(--ease-color-success-dark);
-  border: 1px solid var(--ease-color-success-light);
-}
-
-.accent-color-danger-light {
-  background: var(--ease-color-danger-alpha);
-  color: var(--ease-color-danger-dark);
-  border: 1px solid var(--ease-color-danger-light);
-}
-
-/* Pill / shape variants */
-.accent-color-pill {
-  border-radius: var(--ease-radius-full);
-  padding: var(--ease-space-2) var(--ease-space-5);
-}
-
-.accent-color-square {
-  border-radius: 0;
-}
-
-.accent-color-rounded {
-  border-radius: var(--ease-radius-md);
-}
-
-/* Block / inline display */
-.accent-color-block {
-  display: block;
-  width: 100%;
-}
-
-.accent-color-inline {
-  display: inline-block;
-  margin-right: var(--ease-space-2);
-}
-
-/* Interactive examples */
-.feature-interactive {
-  cursor: pointer;
-  user-select: none;
-}
-
-.feature-interactive:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--ease-shadow-lg);
-}
-
-.feature-interactive:active {
-  transform: translateY(0);
-}
-
-/* Disabled state */
-.accent-color-disabled,
-.accent-color[disabled] {
-  opacity: 0.5;
-  cursor: not-allowed;
-  pointer-events: none;
-}
-
-/* Code/preview block */
-.code-preview {
-  background: var(--ease-color-neutral-900);
-  color: var(--ease-color-neutral-100);
-  font-family: var(--ease-font-mono);
-  font-size: var(--ease-text-sm);
-  padding: var(--ease-space-4);
-  border-radius: var(--ease-radius-md);
-  overflow-x: auto;
-  margin: var(--ease-space-3) 0;
-}
-
-/* Layout helpers */
-.row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--ease-space-3);
-  align-items: center;
-  margin: var(--ease-space-3) 0;
-}
-
-.col {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ease-space-2);
-}
-
-/* Spacing helpers */
-.mt-2 { margin-top: var(--ease-space-2); }
-.mt-4 { margin-top: var(--ease-space-4); }
-.mt-6 { margin-top: var(--ease-space-6); }
-.mb-2 { margin-bottom: var(--ease-space-2); }
-.mb-4 { margin-bottom: var(--ease-space-4); }
-
-/* Dark mode */
+/* Dark Mode Support (Automatically toggles based on OS) */
 @media (prefers-color-scheme: dark) {
   :root {
-    --demo-border: 1px solid var(--ease-color-neutral-700);
-  }
-  body {
-    background: var(--ease-color-neutral-900);
-    color: var(--ease-color-neutral-100);
-  }
-  .demo-card {
-    background: var(--ease-color-neutral-800);
-    border-color: var(--ease-color-neutral-700);
-  }
-  .demo-card-title {
-    color: var(--ease-color-neutral-50);
-  }
-  .demo-card-body {
-    color: var(--ease-color-neutral-300);
-  }
-  .subtitle {
-    color: var(--ease-color-neutral-400);
+    --ease-color-primary: #60a5fa;
+    --ease-color-success: #34d399;
+    --ease-color-warning: #fbbf24;
+    --ease-color-danger:  #f87171;
+    --ease-color-info:    #22d3ee;
+    
+    --ease-bg-body: #0f172a;
+    --ease-bg-card: #1e293b;
+    --ease-text-main: #f8fafc;
+    --ease-text-muted: #94a3b8;
+    --ease-border: #334155;
   }
 }
 
-/* Reduced motion */
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, sans-serif;
+  background-color: var(--ease-bg-body);
+  color: var(--ease-text-main);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 40px 20px;
+  box-sizing: border-box;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Demo Layout */
+.demo-container {
+  width: 100%;
+  max-width: 1000px;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-header h2 { margin-top: 0; font-size: 2rem; margin-bottom: 12px; }
+.demo-header p { color: var(--ease-text-muted); margin: 0; font-size: 1.1rem; line-height: 1.6; }
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  background-color: var(--ease-bg-card);
+  border: 1px solid var(--ease-border);
+  border-radius: 12px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}
+
+.card h4 {
+  margin: 0;
+  font-size: 1.1rem;
+  border-bottom: 1px solid var(--ease-border);
+  padding-bottom: 12px;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.controls label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+/* Reduced Motion */
 @media (prefers-reduced-motion: reduce) {
-  * {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-  .demo-card:hover,
-  .feature-interactive:hover,
-  .accent-color:hover {
-    transform: none;
+  body, .card {
+    transition: none !important;
+    transform: none !important;
   }
 }
+
+/* ------------------------------------------------------------------------
+   Core Component: Accent Color Utilities
+   ------------------------------------------------------------------------ */
+
+.ease-accent-primary { accent-color: var(--ease-color-primary); }
+.ease-accent-success { accent-color: var(--ease-color-success); }
+.ease-accent-warning { accent-color: var(--ease-color-warning); }
+.ease-accent-danger  { accent-color: var(--ease-color-danger); }
+.ease-accent-info    { accent-color: var(--ease-color-info); }
+
+/* Extensible Custom Token */
+.ease-accent-custom  { accent-color: var(--ease-accent-custom, currentColor); }


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #18513 by providing a complete, token-driven utility suite for the `accent-color` property, fully featured with dark mode and reduced motion support!

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/accent-color-tm/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It adds a suite of `.ease-accent-*` utility classes to rapidly style native form controls without writing highly specific, complex, cross-browser `-webkit-` pseudo-element hacks.

**How does a developer use it?**

```html
<!-- Simply wrap the native inputs! -->
<div class="ease-accent-success">
  <input type="checkbox" checked> Checkbox
  <input type="range" value="50">
  <progress value="50" max="100"></progress>
</div>
