### PR TITLE
feat: add pure CSS expanding search bar interaction (#17777)

### DIFF
--- a/submissions/examples/ease-expanding-search-bar/README.md
+++ b/submissions/examples/ease-expanding-search-bar/README.md
@@ -1,0 +1,22 @@
+# CSS-Only Expanding Search Bar (`ease-expanding-search-bar`)
+
+A sleek, minimalistic search input that seamlessly expands from a circular icon into a full text bar using strictly CSS (no JavaScript). 
+
+## 🚀 Features
+
+- **Zero-JS**: Powered entirely by the CSS `:focus-within` and `:hover` pseudo-classes.
+- **Fluid Animation**: Uses `cubic-bezier(0.4, 0, 0.2, 1)` for a premium, non-linear expansion curve.
+- **Accessible**: Includes an `.sr-only` label for screen readers. The `pointer-events: none` on the SVG icon ensures clicking the icon correctly focuses the underlying input.
+- **Dark Mode Support**: Uses `prefers-color-scheme` to automatically adapt the color tokens to dark environments.
+- **Reduced Motion**: Respects OS-level accessibility settings by disabling the width transition for users who prefer reduced motion.
+
+## 🛠️ Usage
+
+Open `demo.html` in your browser. All code is contained within `style.css`. 
+
+### How it works
+
+The core trick relies on setting a fixed closed width on the container, and hiding the input's text using `opacity: 0` and `cursor: pointer`. When the user clicks the container, the input receives focus. We detect this using `.ease-search-container:focus-within`, which triggers the container to expand its width to `280px` and reveals the input's text natively!
+
+## 🔗 Related Issue
+Resolves Issue #17777

--- a/submissions/examples/ease-expanding-search-bar/demo.html
+++ b/submissions/examples/ease-expanding-search-bar/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Expanding Search Bar | EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  
+  <div class="search-showcase-wrapper">
+    <header class="showcase-header">
+      <h1>Expanding Search Bar</h1>
+      <p>A pure CSS expanding search interaction driven by <code>:focus-within</code>.</p>
+    </header>
+
+    <div class="demo-area">
+      <!-- Expanding Search Component -->
+      <div class="ease-search-container">
+        <label for="site-search" class="sr-only">Search</label>
+        
+        <!-- Search Icon SVG -->
+        <svg class="ease-search-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="11" cy="11" r="8"></circle>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+
+        <input type="search" id="site-search" class="ease-search-input" placeholder="Search..." autocomplete="off">
+      </div>
+    </div>
+    
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-expanding-search-bar/style.css
+++ b/submissions/examples/ease-expanding-search-bar/style.css
@@ -1,0 +1,164 @@
+/* Custom Showcase Styles */
+
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #0f172a;
+  --border-color: #e2e8f0;
+  
+  --search-bg: #ffffff;
+  --search-border: #cbd5e1;
+  --search-focus: #3b82f6;
+  --search-text: #334155;
+  --search-icon: #64748b;
+  
+  --search-width-closed: 48px;
+  --search-width-open: 280px;
+  --search-height: 48px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    --border-color: #334155;
+    
+    --search-bg: #1e293b;
+    --search-border: #475569;
+    --search-focus: #60a5fa;
+    --search-text: #f1f5f9;
+    --search-icon: #94a3b8;
+  }
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.search-showcase-wrapper {
+  text-align: center;
+  padding: 2rem;
+  width: 100%;
+  max-width: 600px;
+}
+
+.showcase-header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 2rem;
+  letter-spacing: -0.02em;
+}
+
+.showcase-header p {
+  margin: 0 0 3rem 0;
+  opacity: 0.8;
+}
+
+.demo-area {
+  display: flex;
+  justify-content: center;
+  padding: 4rem;
+  background-color: var(--search-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* ------------------------------------------------------------------------
+   Component: CSS-Only Expanding Search
+   ------------------------------------------------------------------------ */
+
+.ease-search-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: var(--search-width-closed);
+  height: var(--search-height);
+  background-color: var(--search-bg);
+  border: 2px solid var(--search-border);
+  border-radius: calc(var(--search-height) / 2);
+  transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1), 
+              border-color 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+              box-shadow 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+}
+
+.ease-search-icon {
+  position: absolute;
+  left: 12px;
+  color: var(--search-icon);
+  pointer-events: none; /* Let clicks pass through to the input */
+  transition: color 0.4s ease;
+  z-index: 2;
+}
+
+.ease-search-input {
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: transparent;
+  padding: 0 16px 0 44px; /* Room for the icon on the left */
+  font-size: 1rem;
+  color: var(--search-text);
+  outline: none;
+  font-family: inherit;
+  
+  /* Hide text and cursor when closed */
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity 0.3s ease;
+}
+
+/* Remove default webkit search decoration */
+.ease-search-input::-webkit-search-decoration,
+.ease-search-input::-webkit-search-cancel-button {
+  display: none;
+}
+
+/* Expanded State (Triggered when the input gets focus, or container hovered) */
+.ease-search-container:focus-within,
+.ease-search-container:hover {
+  width: var(--search-width-open);
+  border-color: var(--search-focus);
+}
+
+.ease-search-container:focus-within {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.ease-search-container:focus-within .ease-search-icon,
+.ease-search-container:hover .ease-search-icon {
+  color: var(--search-focus);
+}
+
+.ease-search-container:focus-within .ease-search-input,
+.ease-search-container:hover .ease-search-input {
+  opacity: 1;
+  cursor: text;
+}
+
+/* Reduced Motion Override */
+@media (prefers-reduced-motion: reduce) {
+  .ease-search-container,
+  .ease-search-icon,
+  .ease-search-input {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #17777 by adding a beautifully animated, highly polished expanding search bar that runs entirely on CSS `:focus-within`—no JavaScript required!

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-expanding-search-bar/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It provides an elegant pattern for hiding bulky search bars behind a clean icon until the user is ready to type.

**How does a developer use it?**

```html
<div class="ease-search-container">
  <!-- Decorative SVG Icon -->
  <input type="search" class="ease-search-input">
</div>
