### PR TITLE
feat: add CSS-only glitch image reveal (#17647)

### DIFF
--- a/submissions/examples/ease-glitch-image-reveal/README.md
+++ b/submissions/examples/ease-glitch-image-reveal/README.md
@@ -1,0 +1,23 @@
+# CSS-Only Glitch Image Reveal (`ease-glitch-image-reveal`)
+
+A hyper-stylized, cyberpunk glitch hover effect built entirely with CSS `clip-path` animations. 
+
+## 🚀 Features
+
+- **Zero-JS Glitch**: Uses duplicate image layers and rapid CSS `clip-path: inset()` keyframes to horizontally slice and offset the image in real-time.
+- **RGB Splitting**: Utilizes `background-blend-mode: multiply` and `mix-blend-mode: screen` to isolate and offset red and cyan color channels, creating a chromatic aberration effect.
+- **Reveal Mechanic**: The image rests in a dark, desaturated state and explodes into full color and glitching noise instantly on hover.
+- **Accessible**: Features strict `prefers-reduced-motion` fallbacks to kill the rapid glitch keyframes for users with motion sensitivity.
+
+## 🛠️ Usage
+
+Open `demo.html` in your browser. All code is contained within `style.css`. 
+
+Simply apply the inline custom property `--img-url` to the container to pass the image into the layers!
+
+```html
+<div class="ease-glitch-image-reveal" style="--img-url: url('path-to-image.jpg');">
+  <div class="glitch-layer base-layer"></div>
+  <div class="glitch-layer glitch-layer-1"></div>
+  <div class="glitch-layer glitch-layer-2"></div>
+</div>

--- a/submissions/examples/ease-glitch-image-reveal/demo.html
+++ b/submissions/examples/ease-glitch-image-reveal/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Glitch Image Reveal | EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
+</head>
+<body>
+  
+  <div class="glitch-showcase-wrapper">
+    <header class="showcase-header">
+      <h1>Glitch Image Reveal</h1>
+      <p>A cyberpunk-inspired hover effect using CSS <code>clip-path</code> keyframes.</p>
+    </header>
+
+    <div class="demo-area">
+      <!-- Glitch Reveal Component -->
+      <!-- We use a wrapper and multiple layers of the same image to achieve the split channels -->
+      <div class="ease-glitch-image-reveal" style="--img-url: url('https://images.unsplash.com/photo-1515630278258-407f66498911?q=80&w=800&auto=format&fit=crop');">
+        
+        <!-- Base hidden layer -->
+        <div class="glitch-layer base-layer"></div>
+        
+        <!-- Glitch layers (Red/Cyan splits) -->
+        <div class="glitch-layer glitch-layer-1"></div>
+        <div class="glitch-layer glitch-layer-2"></div>
+        
+        <!-- Text Overlay -->
+        <div class="glitch-text">ACCESS GRANTED</div>
+      </div>
+    </div>
+    
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-glitch-image-reveal/style.css
+++ b/submissions/examples/ease-glitch-image-reveal/style.css
@@ -1,0 +1,183 @@
+/* Custom Showcase Styles */
+
+:root {
+  --bg-color: #050505;
+  --text-color: #f8fafc;
+  --border-color: #1f2937;
+  --demo-bg: #0a0a0a;
+  
+  --glitch-width: 400px;
+  --glitch-height: 250px;
+}
+
+body {
+  margin: 0;
+  font-family: 'Share Tech Mono', monospace;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.glitch-showcase-wrapper {
+  text-align: center;
+  padding: 2rem;
+  width: 100%;
+  max-width: 600px;
+}
+
+.showcase-header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 2.5rem;
+  letter-spacing: -0.04em;
+  color: #00ffcc;
+  text-shadow: 0 0 10px rgba(0, 255, 204, 0.5);
+}
+
+.showcase-header p {
+  margin: 0 0 3rem 0;
+  opacity: 0.8;
+}
+
+.demo-area {
+  display: flex;
+  justify-content: center;
+  padding: 4rem;
+  background-color: var(--demo-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8);
+}
+
+/* ------------------------------------------------------------------------
+   Component: CSS-Only Glitch Image Reveal
+   ------------------------------------------------------------------------ */
+
+.ease-glitch-image-reveal {
+  position: relative;
+  width: var(--glitch-width);
+  height: var(--glitch-height);
+  background-color: #111;
+  border: 2px solid #333;
+  overflow: hidden;
+  cursor: crosshair;
+}
+
+.glitch-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: var(--img-url);
+  background-size: cover;
+  background-position: center;
+}
+
+/* Base image is hidden as noise initially */
+.base-layer {
+  filter: grayscale(100%) contrast(1.5) brightness(0.2);
+  transition: filter 0.3s ease;
+}
+
+/* Glitch layers are hidden completely until hover */
+.glitch-layer-1, 
+.glitch-layer-2 {
+  opacity: 0;
+  mix-blend-mode: screen;
+}
+
+/* The color channel splits */
+.glitch-layer-1 {
+  background-color: rgba(255, 0, 102, 0.3);
+  background-blend-mode: multiply;
+}
+
+.glitch-layer-2 {
+  background-color: rgba(0, 255, 204, 0.3);
+  background-blend-mode: multiply;
+}
+
+.glitch-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.5rem;
+  font-weight: bold;
+  letter-spacing: 0.2em;
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 10;
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.8);
+}
+
+/* Hover States */
+
+.ease-glitch-image-reveal:hover .base-layer {
+  filter: grayscale(0%) contrast(1) brightness(1);
+}
+
+.ease-glitch-image-reveal:hover .glitch-text {
+  opacity: 1;
+  animation: glitch-text-anim 0.4s infinite;
+}
+
+.ease-glitch-image-reveal:hover .glitch-layer-1 {
+  opacity: 1;
+  animation: glitch-anim-1 2s infinite linear alternate-reverse;
+}
+
+.ease-glitch-image-reveal:hover .glitch-layer-2 {
+  opacity: 1;
+  animation: glitch-anim-2 3s infinite linear alternate-reverse;
+}
+
+/* Glitch Keyframes using clip-path slices */
+@keyframes glitch-anim-1 {
+  0% { clip-path: inset(20% 0 80% 0); transform: translate(-2px, 1px); }
+  10% { clip-path: inset(40% 0 60% 0); transform: translate(2px, -1px); }
+  20% { clip-path: inset(80% 0 5% 0); transform: translate(-2px, 2px); }
+  30% { clip-path: inset(10% 0 40% 0); transform: translate(2px, -2px); }
+  40% { clip-path: inset(50% 0 30% 0); transform: translate(-2px, 1px); }
+  50% { clip-path: inset(5% 0 80% 0); transform: translate(2px, -1px); }
+  60% { clip-path: inset(70% 0 10% 0); transform: translate(-2px, 2px); }
+  70% { clip-path: inset(30% 0 50% 0); transform: translate(2px, -2px); }
+  80% { clip-path: inset(15% 0 70% 0); transform: translate(-2px, 1px); }
+  90% { clip-path: inset(60% 0 20% 0); transform: translate(2px, -1px); }
+  100% { clip-path: inset(0% 0 100% 0); transform: translate(0, 0); }
+}
+
+@keyframes glitch-anim-2 {
+  0% { clip-path: inset(10% 0 60% 0); transform: translate(2px, -1px); }
+  10% { clip-path: inset(80% 0 5% 0); transform: translate(-2px, 1px); }
+  20% { clip-path: inset(30% 0 50% 0); transform: translate(2px, 2px); }
+  30% { clip-path: inset(70% 0 15% 0); transform: translate(-2px, -2px); }
+  40% { clip-path: inset(20% 0 70% 0); transform: translate(2px, 1px); }
+  50% { clip-path: inset(90% 0 2% 0); transform: translate(-2px, -1px); }
+  60% { clip-path: inset(40% 0 40% 0); transform: translate(2px, 2px); }
+  70% { clip-path: inset(5% 0 80% 0); transform: translate(-2px, -2px); }
+  80% { clip-path: inset(50% 0 30% 0); transform: translate(2px, 1px); }
+  90% { clip-path: inset(25% 0 60% 0); transform: translate(-2px, -1px); }
+  100% { clip-path: inset(0% 0 100% 0); transform: translate(0, 0); }
+}
+
+@keyframes glitch-text-anim {
+  0%, 100% { transform: translate(-50%, -50%) skew(0deg); opacity: 1; }
+  20% { transform: translate(-52%, -50%) skew(-10deg); opacity: 0.8; }
+  40% { transform: translate(-48%, -52%) skew(10deg); opacity: 0.9; }
+  60% { transform: translate(-50%, -48%) skew(0deg); opacity: 1; }
+  80% { transform: translate(-50%, -50%) skew(5deg); opacity: 0.5; }
+}
+
+/* Reduced Motion Override */
+@media (prefers-reduced-motion: reduce) {
+  .ease-glitch-image-reveal:hover .glitch-layer-1,
+  .ease-glitch-image-reveal:hover .glitch-layer-2,
+  .ease-glitch-image-reveal:hover .glitch-text {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #17647 by implementing a highly requested cyberpunk "glitch" image reveal effect entirely in native CSS!

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-glitch-image-reveal/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It provides an edgy, attention-grabbing hover effect that slices and color-shifts an image using `clip-path` keyframes.

**How does a developer use it?**

```html
<div class="ease-glitch-image-reveal" style="--img-url: url('image.jpg');">
  <div class="glitch-layer base-layer"></div>
  <div class="glitch-layer glitch-layer-1"></div>
  <div class="glitch-layer glitch-layer-2"></div>
</div>
