### PR TITLE
feat(examples): add Parallax Offset on Hover

### DIFF
--- a/submissions/examples/ease-hover-parallax-offset/README.md
+++ b/submissions/examples/ease-hover-parallax-offset/README.md
@@ -1,0 +1,27 @@
+# Parallax Offset on Hover
+
+## What does it do?
+Layers shift at different speeds when hovering over a card, creating a parallax depth illusion — pure CSS.
+
+## Features
+- Three layers (bg, mid, fg) with different shift speeds
+- Smooth cubic-bezier transitions
+- Depth illusion on hover
+
+## Usage
+```html
+<div class="parallax-card">
+  <div class="parallax-bg"></div>
+  <div class="parallax-mid"></div>
+  <div class="parallax-fg"><!-- content --></div>
+</div>
+```
+
+## Browser Support
+- Chrome 1+, Firefox 3.5+, Safari 3.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-parallax-offset/demo.html
+++ b/submissions/examples/ease-hover-parallax-offset/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Parallax Offset on Hover — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Parallax Offset on Hover</h1>
+  <p class="subtitle">Layers shift at different speeds when hovering — pure CSS.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Hover the card to see the parallax depth effect</p>
+    <div class="parallax-card">
+      <div class="parallax-bg"></div>
+      <div class="parallax-mid"></div>
+      <div class="parallax-fg">
+        <span class="parallax-icon">✦</span>
+        <h3>Deep Space</h3>
+        <p>Move your cursor over this card.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p>Three layers (background, midground, foreground) shift horizontally on hover via <code>transform: translateX()</code> with different animation durations, creating a parallax depth illusion.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-hover-parallax-offset/style.css
+++ b/submissions/examples/ease-hover-parallax-offset/style.css
@@ -1,0 +1,84 @@
+/* ============================================================
+   EaseMotion CSS — Parallax Offset on Hover
+   Layers shift at different speeds on hover
+   ============================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  padding: 4rem 1rem;
+  text-align: center;
+}
+
+h1 { color: #fff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+.subtitle { color: #9ca3af; margin-bottom: 2rem; }
+
+section {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h2 { color: #fff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+.sec-desc { font-size: 0.85rem; color: #9ca3af; margin-bottom: 1rem; }
+
+.parallax-card {
+  position: relative;
+  width: 300px;
+  height: 220px;
+  margin: 0 auto;
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.parallax-bg {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #6366f1, #a78bfa);
+  border-radius: 16px;
+  transition: transform 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.parallax-mid {
+  position: absolute;
+  inset: 10px;
+  background: radial-gradient(circle at 30% 40%, rgba(255,255,255,0.15), transparent 60%);
+  border-radius: 12px;
+  transition: transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.parallax-fg {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.parallax-card:hover .parallax-bg { transform: translateX(-12px); }
+.parallax-card:hover .parallax-mid { transform: translateX(-6px); }
+.parallax-card:hover .parallax-fg { transform: translateX(8px); }
+
+.parallax-icon {
+  font-size: 2.5rem;
+  color: #fff;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+
+.parallax-fg h3 { color: #fff; font-size: 1.2rem; margin-bottom: 0.25rem; }
+.parallax-fg p { color: rgba(255,255,255,0.75); font-size: 0.85rem; margin: 0; }
+
+p { color: #9ca3af; line-height: 1.8; margin-top: 1rem; }
+code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }


### PR DESCRIPTION
## Description

Layers shift at different speeds when hovering over a card, creating a parallax depth illusion — pure CSS.

## Acceptance Criteria
- [x] Three layers with different shift speeds
- [x] Smooth cubic-bezier transitions
- [x] Depth illusion on hover

## Files
- `demo.html` — parallax card demo
- `style.css` — multi-layer hover transitions
- `README.md` — documentation

## Related Issue
Closes #19852