### PR TITLE
feat(examples): add Icon Nudge Left on Hover

### DIFF
--- a/submissions/examples/ease-hover-icon-left/README.md
+++ b/submissions/examples/ease-hover-icon-left/README.md
@@ -1,0 +1,28 @@
+# Icon Nudge Left on Hover
+
+## What does it do?
+The icon inside a button shifts left when the button is hovered — pure CSS.
+
+## Features
+- Icon nudges left via `translateX(-4px)` on hover
+- Springy cubic-bezier transition
+- Button background + shadow on hover
+
+## Usage
+```css
+.btn-icon {
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.icon-left-btn:hover .btn-icon {
+  transform: translateX(-4px);
+}
+```
+
+## Browser Support
+- Chrome 1+, Firefox 3.5+, Safari 3.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-hover-icon-left/demo.html
+++ b/submissions/examples/ease-hover-icon-left/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Icon Nudge Left on Hover — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Icon Nudge Left on Hover</h1>
+  <p class="subtitle">Icon inside a button shifts left when hovering — pure CSS.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Hover the button — the icon nudges left</p>
+    <button class="icon-left-btn">
+      <span class="btn-icon">←</span>
+      <span class="btn-text">Go Back</span>
+    </button>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p>The icon receives a <code>translateX(-4px)</code> on button hover via the adjacent sibling <code>+</code> selector, creating a subtle nudge effect.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-hover-icon-left/style.css
+++ b/submissions/examples/ease-hover-icon-left/style.css
@@ -1,0 +1,63 @@
+/* ============================================================
+   EaseMotion CSS — Icon Nudge Left on Hover
+   Icon inside a button shifts left on hover
+   ============================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: #0f0f0f;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  padding: 4rem 1rem;
+  text-align: center;
+}
+
+h1 { color: #fff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+.subtitle { color: #9ca3af; margin-bottom: 2rem; }
+
+section {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h2 { color: #fff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+.sec-desc { font-size: 0.85rem; color: #9ca3af; margin-bottom: 1rem; }
+
+.icon-left-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #6366f1;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 0.85rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.icon-left-btn:hover {
+  background: #4f46e5;
+  box-shadow: 0 4px 20px rgba(99, 102, 241, 0.4);
+}
+
+.btn-icon {
+  display: inline-block;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.icon-left-btn:hover .btn-icon {
+  transform: translateX(-4px);
+}
+
+p { color: #9ca3af; line-height: 1.8; margin-top: 1rem; }
+code { background: #2a2a2a; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }


### PR DESCRIPTION
## Description

The icon inside a button shifts left when the button is hovered — pure CSS.

## Acceptance Criteria
- [x] Icon nudges left via translateX(-4px) on hover
- [x] Springy cubic-bezier transition
- [x] Button background + shadow enhancement

## Files
- `demo.html` — icon-left button demo
- `style.css` — icon nudge transition
- `README.md` — documentation

## Related Issue
Closes #19829