### PR TITLE
feat: add scroll-snap-align-start utility (#15123)

### DIFF
--- a/submissions/examples/ease-scroll-snap-align-start/README.md
+++ b/submissions/examples/ease-scroll-snap-align-start/README.md
@@ -1,0 +1,28 @@
+# Scroll Snap Align Start Utility Proposal (`ease-scroll-snap-align-start`)
+
+A proposal for `core/utilities.css` adding standard CSS scroll snapping utility for aligning items to the start of a scroll container.
+
+## 🚀 Features
+
+- **`.scroll-snap-align-start`**: Applied to children of a scroll-snapping container. Forces the element to snap to the exact start (top or left) of the scrollport when scrolling stops. Ideal for full-screen feeds, standard image carousels, or sliding menus.
+
+## 🛠️ Usage
+
+Open `demo.html` in your browser. All code is contained within `style.css`. Scroll horizontally in the carousel to see the cards perfectly snap to the left edge!
+
+You apply this class to the *children* of a scrolling container:
+
+```html
+<div class="carousel" style="scroll-snap-type: x mandatory; overflow-x: scroll;">
+  
+  <div class="scroll-snap-align-start">Card 1</div>
+  <div class="scroll-snap-align-start">Card 2</div>
+  <div class="scroll-snap-align-start">Card 3</div>
+
+</div>
+```
+
+*Note: This is submitted via the `submissions/examples/` directory to adhere to the strict CI/CD guidelines preventing external modification of `core/` files. The maintainer can easily merge these rules into `core/utilities.css`.*
+
+## 🔗 Related Issue
+Resolves Issue #15123

--- a/submissions/examples/ease-scroll-snap-align-start/demo.html
+++ b/submissions/examples/ease-scroll-snap-align-start/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll Snap Align Start Utility | EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  
+  <div class="showcase-wrapper">
+    <header class="showcase-header">
+      <h1>Scroll Snap Align Start Utility</h1>
+      <p>A pure CSS proposal for <code>core/utilities.css</code> to add <code>.scroll-snap-align-start</code>.</p>
+    </header>
+
+    <div class="demo-section">
+      <h3>Start Snap Carousel</h3>
+      <p>Scroll horizontally. Items will snap perfectly to the start edge of the container!</p>
+      
+      <!-- The container has snap type X mandatory applied via custom style for the demo to work -->
+      <div class="scroll-container">
+        
+        <!-- Children have the proposed utility class -->
+        <div class="snap-item scroll-snap-align-start bg-blue">Card 1</div>
+        <div class="snap-item scroll-snap-align-start bg-purple">Card 2</div>
+        <div class="snap-item scroll-snap-align-start bg-teal">Card 3</div>
+        <div class="snap-item scroll-snap-align-start bg-rose">Card 4</div>
+        <div class="snap-item scroll-snap-align-start bg-blue">Card 5</div>
+        
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scroll-snap-align-start/style.css
+++ b/submissions/examples/ease-scroll-snap-align-start/style.css
@@ -1,0 +1,104 @@
+/* Showcase Styles */
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #0f172a;
+  --border-color: #e2e8f0;
+  --demo-bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    --border-color: #334155;
+    --demo-bg: #1e293b;
+  }
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.showcase-wrapper {
+  text-align: center;
+  padding: 2rem;
+  width: 100%;
+  max-width: 900px;
+}
+
+.showcase-header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 2.2rem;
+  letter-spacing: -0.02em;
+}
+
+.showcase-header p {
+  margin: 0 0 2rem 0;
+  opacity: 0.8;
+}
+
+.demo-section {
+  background-color: var(--demo-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  padding: 2.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.demo-section h3 {
+  margin: 0 0 0.5rem 0;
+}
+
+.demo-section p {
+  margin: 0 0 1.5rem 0;
+  opacity: 0.8;
+}
+
+/* Demo Specific Container Styles */
+.scroll-container {
+  display: flex;
+  height: 300px;
+  overflow-x: scroll;
+  scroll-snap-type: x mandatory; /* Needed on container for align to work */
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-color);
+  background-color: rgba(0, 0, 0, 0.02);
+  align-items: center;
+  scrollbar-width: none; 
+}
+.scroll-container::-webkit-scrollbar {
+  display: none; 
+}
+
+.snap-item {
+  flex: 0 0 100%; /* Full width cards */
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2rem;
+  font-weight: bold;
+  color: white;
+  box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1);
+}
+
+.bg-blue { background-color: #3b82f6; }
+.bg-purple { background-color: #8b5cf6; }
+.bg-teal { background-color: #14b8a6; }
+.bg-rose { background-color: #f43f5e; }
+
+/* ------------------------------------------------------------------------
+   PROPOSAL: Scroll Snap Align Start Utility
+   Intended for core/utilities.css
+   ------------------------------------------------------------------------ */
+
+.scroll-snap-align-start {
+  scroll-snap-align: start !important;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15123 by proposing a start alignment utility for CSS scroll snapping.

---

## Type of Change

- [x] ✨ New animation / hover effect (Layout Utility)
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-scroll-snap-align-start/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It adds a `.scroll-snap-align-start` utility class that snaps elements exactly to the leading edge (top or left, depending on scroll direction) of their scrolling container.

**How does a developer use it?**

```html
<!-- Apply to the children inside a scroll-snapping container -->
<div class="carousel" style="scroll-snap-type: x mandatory; overflow-x: scroll;">
  
  <div class="card scroll-snap
