### PR TITLE
feat(examples): add Cyberpunk Glitch Text Effect with CSS animation

### DIFF
--- a/submissions/examples/ease-text-glitch/README.md
+++ b/submissions/examples/ease-text-glitch/README.md
@@ -1,0 +1,24 @@
+# Cyberpunk Glitch Text
+
+## What does it do?
+A pure CSS cyberpunk-style glitch text effect using pseudo-elements, clip-path slicing, and text-shadow offset animation.
+
+## Features
+- Cyan and magenta offset pseudo-elements
+- Clip-path slices create horizontal glitch bands
+- Rapid keyframe animation on hover
+- Pure CSS, no JavaScript
+
+## Usage
+```html
+<h2 class="glitch-text" data-text="SYSTEM FAILURE">SYSTEM FAILURE</h2>
+```
+
+## Browser Support
+- Chrome 1+, Firefox 3.5+, Safari 3.1+
+
+## Tech Stack
+- HTML + CSS only, no JavaScript
+
+## Preview
+Open `demo.html` directly in browser.

--- a/submissions/examples/ease-text-glitch/demo.html
+++ b/submissions/examples/ease-text-glitch/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Glitch Text — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Cyberpunk Glitch Text</h1>
+  <p class="subtitle">A pure CSS glitch text effect with offset pseudo-elements and scan-line distortion.</p>
+
+  <section>
+    <h2>Demo</h2>
+    <p class="sec-desc">Hover the text to trigger the glitch effect</p>
+    <div class="glitch-wrapper">
+      <h2 class="glitch-text" data-text="SYSTEM FAILURE">SYSTEM FAILURE</h2>
+    </div>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p>The text uses <code>::before</code> and <code>::after</code> pseudo-elements with offset <code>clip-path</code> rectangles and <code>text-shadow</code> in cyan and magenta. On hover, a rapid keyframe animation creates the glitch distortion.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/ease-text-glitch/style.css
+++ b/submissions/examples/ease-text-glitch/style.css
@@ -1,0 +1,85 @@
+/* ============================================================
+   EaseMotion CSS — Cyberpunk Glitch Text
+   Pure CSS glitch effect with pseudo-element distortion
+   ============================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: #0a0a0a;
+  color: #d1d5db;
+  font-family: system-ui, sans-serif;
+  padding: 4rem 1rem;
+  text-align: center;
+}
+
+h1 { color: #fff; font-size: 1.75rem; margin-bottom: 0.25rem; }
+.subtitle { color: #9ca3af; margin-bottom: 2rem; }
+
+section {
+  background: #111;
+  border: 1px solid #222;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h2 { color: #fff; font-size: 1.1rem; margin-bottom: 0.75rem; }
+.sec-desc { font-size: 0.85rem; color: #9ca3af; margin-bottom: 1rem; }
+
+.glitch-wrapper {
+  padding: 2rem 0;
+}
+
+.glitch-text {
+  position: relative;
+  display: inline-block;
+  font-size: 2.8rem;
+  font-weight: 800;
+  color: #fff;
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.glitch-text::before,
+.glitch-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+}
+
+.glitch-text:hover::before {
+  opacity: 1;
+  color: #00f5ff;
+  z-index: -1;
+  clip-path: inset(10% 0 60% 0);
+  animation: glitch-shift 0.3s ease-in-out 4;
+}
+
+.glitch-text:hover::after {
+  opacity: 1;
+  color: #ff00e4;
+  z-index: -2;
+  clip-path: inset(60% 0 10% 0);
+  animation: glitch-shift 0.3s ease-in-out 4 reverse;
+}
+
+@keyframes glitch-shift {
+  0%   { transform: translate(0); }
+  20%  { transform: translate(-4px, 2px); }
+  40%  { transform: translate(4px, -2px); }
+  60%  { transform: translate(-2px, 1px); }
+  80%  { transform: translate(3px, -1px); }
+  100% { transform: translate(-3px, 2px); }
+}
+
+p { color: #9ca3af; line-height: 1.8; margin-top: 1rem; }
+code { background: #222; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; }


### PR DESCRIPTION
## Description

A pure CSS cyberpunk-style glitch text effect using pseudo-elements, clip-path slicing, and text-shadow offset animation. Hover to trigger the glitch.

## Acceptance Criteria
- [x] Cyan and magenta offset pseudo-elements
- [x] Clip-path slices creating horizontal glitch bands
- [x] Rapid keyframe animation on hover

## Files
- `demo.html` — glitch text demo
- `style.css` — glitch-shift keyframes
- `README.md` — documentation

## Related Issue
Closes #19988