### PR TITLE
feat: add outline-none utility (#15112)

### DIFF
--- a/submissions/examples/ease-outline-none/README.md
+++ b/submissions/examples/ease-outline-none/README.md
@@ -1,0 +1,28 @@
+# Outline None Utility Proposal (`ease-outline-none`)
+
+A proposal for `core/utilities.css` adding a standard `.outline-none` utility class.
+
+## 🚀 Features
+
+- **`.outline-none`**: Visually removes the default browser focus outline ring from an element.
+- **Accessible Implementation**: Uses `outline: 2px solid transparent !important;` instead of `outline: none;`. This visually hides the outline for standard users but preserves it for Windows High Contrast Mode users, ensuring accessibility isn't compromised.
+
+## 🛠️ Usage
+
+Open `demo.html` in your browser. All code is contained within `style.css`. Click or Tab through the buttons to see the default browser outline vs the removed outline.
+
+You apply this class to any interactive element (buttons, inputs, links) where you wish to hide the default browser focus ring:
+
+```html
+<button class="outline-none custom-focus-style">
+  Submit
+</button>
+```
+
+**⚠️ Important Accessibility Note:**
+You should *never* remove a focus outline without providing a custom alternative (like a `box-shadow` or background color change on `:focus-visible`). This utility is intended to clear the browser defaults so that designers can apply custom, animated, on-brand focus states!
+
+*Note: This is submitted via the `submissions/examples/` directory to adhere to the strict CI/CD guidelines preventing external modification of `core/` files. The maintainer can easily merge these rules into `core/utilities.css`.*
+
+## 🔗 Related Issue
+Resolves Issue #15112

--- a/submissions/examples/ease-outline-none/demo.html
+++ b/submissions/examples/ease-outline-none/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Outline None Utility | EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  
+  <div class="showcase-wrapper">
+    <header class="showcase-header">
+      <h1>Outline None Utility</h1>
+      <p>A pure CSS proposal for <code>core/utilities.css</code> to add <code>.outline-none</code>.</p>
+    </header>
+
+    <div class="demo-section">
+      <h3>Focus Outline Comparison</h3>
+      <p>Tab through or click the buttons to see the default browser focus ring vs the removed outline.</p>
+      
+      <div class="btn-group">
+        <!-- Default browser outline -->
+        <button class="btn btn-default">Default Focus Outline</button>
+        
+        <!-- Proposed outline-none -->
+        <button class="btn outline-none">No Outline (.outline-none)</button>
+        
+        <!-- Accessible Custom Outline (Example of why we need outline-none as a base) -->
+        <button class="btn outline-none btn-custom-focus">Custom Accessible Focus</button>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-outline-none/style.css
+++ b/submissions/examples/ease-outline-none/style.css
@@ -1,0 +1,107 @@
+/* Showcase Styles */
+:root {
+  --bg-color: #f8fafc;
+  --text-color: #0f172a;
+  --border-color: #e2e8f0;
+  --demo-bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    --border-color: #334155;
+    --demo-bg: #1e293b;
+  }
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.showcase-wrapper {
+  text-align: center;
+  padding: 2rem;
+  width: 100%;
+  max-width: 900px;
+}
+
+.showcase-header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 2.2rem;
+  letter-spacing: -0.02em;
+}
+
+.showcase-header p {
+  margin: 0 0 2rem 0;
+  opacity: 0.8;
+}
+
+.demo-section {
+  background-color: var(--demo-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  padding: 2.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.demo-section h3 {
+  margin: 0 0 0.5rem 0;
+}
+
+.demo-section p {
+  margin: 0 0 1.5rem 0;
+  opacity: 0.8;
+}
+
+/* Demo Specific Button Styles */
+.btn-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  margin-top: 2rem;
+}
+
+.btn {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: white;
+  background-color: #3b82f6;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.2s, box-shadow 0.2s;
+  width: 100%;
+  max-width: 300px;
+}
+
+.btn:hover {
+  background-color: #2563eb;
+}
+
+/* Custom focus example showing why outline-none is useful */
+.btn-custom-focus:focus-visible {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.5); /* Blue ring */
+}
+
+/* ------------------------------------------------------------------------
+   PROPOSAL: Outline None Utility
+   Intended for core/utilities.css
+   ------------------------------------------------------------------------ */
+
+.outline-none {
+  outline: 2px solid transparent !important;
+  outline-offset: 2px !important;
+}
+
+/* Note: Setting outline to 'transparent' rather than 'none' is best practice 
+   for Windows High Contrast mode accessibility while still visually removing the outline. */


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #15112 by proposing a utility class to remove the default browser focus outline securely.

---

## Type of Change

- [x] ✨ New animation / hover effect (Base Utility)
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/ease-outline-none/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
It adds a `.outline-none` utility class that correctly and accessibly hides the default browser focus outline.

**How does a developer use it?**

```html
<!-- Apply to interactive elements that have custom focus styles -->
<button class="outline-none custom-focus-style">
  Submit
</button>
