### PR TITLE
feat: add animated breadcrumb navigation (#20328)

### DIFF
--- a/submissions/examples/breadcrumb-trail/README.md
+++ b/submissions/examples/breadcrumb-trail/README.md
@@ -1,0 +1,188 @@
+# Animated Breadcrumb Navigation
+
+A pure-CSS animated breadcrumb trail for showing page hierarchy. Crumbs fade-slide in on mount (staggered), hover underlines slide in from the left, the active crumb pulses softly to anchor "you are here", and separators scale in with each item. Zero JavaScript, zero dependencies.
+
+---
+
+## Preview
+
+| State | Behaviour |
+|-------|-----------|
+| Mount | Crumbs fade + slide in left-to-right with staggered delay |
+| Hover | Underline slides in from left via `scaleX(0 → 1)` |
+| Active | Purple pill with soft repeating `box-shadow` pulse |
+| Separator | Fades in with its crumb item |
+
+---
+
+## Files
+
+```
+submissions/examples/breadcrumb-trail/
+├── demo.html    ← six live variants
+├── style.css    ← all animation classes
+└── README.md
+```
+
+---
+
+## Variants
+
+| Variant | Description |
+|---------|-------------|
+| Basic slash | Default `/` separator |
+| Chevron SVG | Inline SVG arrow separator |
+| Icon + text | Emoji/icon before each crumb label |
+| Truncated | Middle crumbs collapsed to `···` ellipsis |
+| Flat | No card chrome — transparent background |
+| Small | `.ease-breadcrumb-sm` size modifier |
+
+---
+
+## Classes
+
+| Class | Description |
+|-------|-------------|
+| `ease-breadcrumb` | `<ol>` container; card chrome (bg, border, shadow) |
+| `ease-breadcrumb-flat` | Remove card chrome — transparent variant |
+| `ease-breadcrumb-sm` | Small text size (0.75rem) |
+| `ease-breadcrumb-lg` | Large text size (0.9375rem) |
+| `ease-bread-item` | `<li>` crumb item; staggered fade-slide entrance |
+| `ease-bread-link` | `<a>` crumb link; hover underline slide + colour |
+| `ease-bread-icon` | Icon inside a link; colour transitions on hover |
+| `ease-bread-separator` | Separator between crumbs (text or SVG) |
+| `ease-bread-active` | Current page crumb; purple pill + pulse animation |
+| `ease-bread-ellipsis` | Collapsed middle crumbs `···` placeholder |
+
+---
+
+## Usage
+
+### Basic breadcrumb
+
+```html
+<nav aria-label="Breadcrumb">
+  <ol class="ease-breadcrumb">
+
+    <li class="ease-bread-item">
+      <a class="ease-bread-link" href="/">Home</a>
+      <span class="ease-bread-separator" aria-hidden="true">/</span>
+    </li>
+
+    <li class="ease-bread-item">
+      <a class="ease-bread-link" href="/components">Components</a>
+      <span class="ease-bread-separator" aria-hidden="true">/</span>
+    </li>
+
+    <li class="ease-bread-item" aria-current="page">
+      <span class="ease-bread-active">Breadcrumb</span>
+    </li>
+
+  </ol>
+</nav>
+```
+
+### With icons
+
+```html
+<li class="ease-bread-item">
+  <a class="ease-bread-link" href="/">
+    <span class="ease-bread-icon" aria-hidden="true">🏠</span>
+    Home
+  </a>
+  <span class="ease-bread-separator" aria-hidden="true">›</span>
+</li>
+```
+
+### Chevron SVG separator
+
+```html
+<span class="ease-bread-separator" aria-hidden="true">
+  <svg viewBox="0 0 12 12" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="4 2 8 6 4 10"/>
+  </svg>
+</span>
+```
+
+### Truncated path
+
+```html
+<li class="ease-bread-item" aria-label="Hidden path segments">
+  <span class="ease-bread-ellipsis" title="Category > Sub-category > Section">···</span>
+  <span class="ease-bread-separator" aria-hidden="true">›</span>
+</li>
+```
+
+---
+
+## Animation Details
+
+### Crumb entrance — `ease-bread-appear`
+```css
+@keyframes ease-bread-appear {
+  from { opacity: 0; transform: translateX(-4px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+/* Each nth-child gets +60ms delay for the stagger */
+```
+
+### Hover underline — left-to-right slide
+```css
+.ease-bread-link::after {
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform 200ms ease;
+}
+.ease-bread-link:hover::after {
+  transform: scaleX(1);
+}
+```
+
+### Active crumb pulse
+```css
+@keyframes ease-bread-pulse {
+  0%, 100% { box-shadow: 0 0 0 0   var(--ease-bread-active-border); }
+  50%       { box-shadow: 0 0 0 3px transparent; }
+}
+```
+
+---
+
+## Theming
+
+All colours are CSS custom properties on `:root`:
+
+```css
+:root {
+  --ease-bread-text-hover:    #6366f1;
+  --ease-bread-underline:     #6366f1;
+  --ease-bread-active-bg:     #ede9fe;
+  --ease-bread-active-border: #a78bfa;
+  --ease-bread-active-text:   #5b21b6;
+}
+```
+
+---
+
+## Accessibility
+
+- `<nav>` with `aria-label` wraps the `<ol>`
+- `aria-current="page"` on the active item
+- `aria-hidden="true"` on all separators and decorative icons
+- `aria-label` on the ellipsis item describes hidden path segments
+- `focus-visible` ring on all links
+- `prefers-reduced-motion` disables all animations; crumbs are fully visible immediately
+
+---
+
+## Browser Support
+
+Chrome 88+, Firefox 85+, Safari 14+. Uses `transform`, `opacity`, `@keyframes`, and CSS custom properties.
+
+---
+
+## Contributor
+
+**@thakurakanksha288** — GSSoC 2026 participant  
+Issue: [#20328](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20328)

--- a/submissions/examples/breadcrumb-trail/demo.html
+++ b/submissions/examples/breadcrumb-trail/demo.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Breadcrumb Navigation — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-label">EaseMotion CSS — Breadcrumb Navigation Collection</p>
+
+  <!-- ══════════════════════════════════════════════════════
+       VARIANT 1 — Basic breadcrumb with slash separator
+  ══════════════════════════════════════════════════════════ -->
+  <div class="section-wrap">
+    <p class="section-title">✦ Basic — slash separator</p>
+
+    <nav aria-label="Breadcrumb — basic slash">
+      <ol class="ease-breadcrumb">
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">Home</a>
+          <span class="ease-bread-separator" aria-hidden="true">/</span>
+        </li>
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">Components</a>
+          <span class="ease-bread-separator" aria-hidden="true">/</span>
+        </li>
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">Navigation</a>
+          <span class="ease-bread-separator" aria-hidden="true">/</span>
+        </li>
+
+        <li class="ease-bread-item" aria-current="page">
+          <span class="ease-bread-active">Breadcrumb</span>
+        </li>
+
+      </ol>
+    </nav>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════
+       VARIANT 2 — Chevron SVG separator
+  ══════════════════════════════════════════════════════════ -->
+  <div class="section-wrap">
+    <p class="section-title">✦ Chevron SVG separator</p>
+
+    <nav aria-label="Breadcrumb — chevron">
+      <ol class="ease-breadcrumb">
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">Home</a>
+          <span class="ease-bread-separator" aria-hidden="true">
+            <svg viewBox="0 0 12 12" fill="none" stroke="currentColor"
+                 stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="4 2 8 6 4 10"/>
+            </svg>
+          </span>
+        </li>
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">Documentation</a>
+          <span class="ease-bread-separator" aria-hidden="true">
+            <svg viewBox="0 0 12 12" fill="none" stroke="currentColor"
+                 stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="4 2 8 6 4 10"/>
+            </svg>
+          </span>
+        </li>
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">CSS Animations</a>
+          <span class="ease-bread-separator" aria-hidden="true">
+            <svg viewBox="0 0 12 12" fill="none" stroke="currentColor"
+                 stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="4 2 8 6 4 10"/>
+            </svg>
+          </span>
+        </li>
+
+        <li class="ease-bread-item" aria-current="page">
+          <span class="ease-bread-active">Breadcrumb Trail</span>
+        </li>
+
+      </ol>
+    </nav>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════
+       VARIANT 3 — With icons next to text
+  ══════════════════════════════════════════════════════════ -->
+  <div class="section-wrap">
+    <p class="section-title">✦ Icon + text variant</p>
+
+    <nav aria-label="Breadcrumb — with icons">
+      <ol class="ease-breadcrumb">
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">
+            <span class="ease-bread-icon" aria-hidden="true">🏠</span>
+            Home
+          </a>
+          <span class="ease-bread-separator" aria-hidden="true">›</span>
+        </li>
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">
+            <span class="ease-bread-icon" aria-hidden="true">📁</span>
+            Projects
+          </a>
+          <span class="ease-bread-separator" aria-hidden="true">›</span>
+        </li>
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">
+            <span class="ease-bread-icon" aria-hidden="true">⚡</span>
+            EaseMotion
+          </a>
+          <span class="ease-bread-separator" aria-hidden="true">›</span>
+        </li>
+
+        <li class="ease-bread-item" aria-current="page">
+          <span class="ease-bread-active">
+            <span aria-hidden="true">🧭</span>
+            Breadcrumb
+          </span>
+        </li>
+
+      </ol>
+    </nav>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════
+       VARIANT 4 — Truncated / collapsed for long paths
+  ══════════════════════════════════════════════════════════ -->
+  <div class="section-wrap">
+    <p class="section-title">✦ Truncated — long path with ellipsis</p>
+
+    <nav aria-label="Breadcrumb — truncated">
+      <ol class="ease-breadcrumb">
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">
+            <span class="ease-bread-icon" aria-hidden="true">🏠</span>
+            Home
+          </a>
+          <span class="ease-bread-separator" aria-hidden="true">›</span>
+        </li>
+
+        <!-- Collapsed middle crumbs -->
+        <li class="ease-bread-item" aria-label="Hidden path segments">
+          <span class="ease-bread-ellipsis" title="Category > Sub-category > Section">···</span>
+          <span class="ease-bread-separator" aria-hidden="true">›</span>
+        </li>
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">Settings</a>
+          <span class="ease-bread-separator" aria-hidden="true">›</span>
+        </li>
+
+        <li class="ease-bread-item" aria-current="page">
+          <span class="ease-bread-active">Privacy</span>
+        </li>
+
+      </ol>
+    </nav>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════
+       VARIANT 5 — Flat (no card chrome)
+  ══════════════════════════════════════════════════════════ -->
+  <div class="section-wrap">
+    <p class="section-title">✦ Flat variant — no card chrome</p>
+
+    <nav aria-label="Breadcrumb — flat">
+      <ol class="ease-breadcrumb ease-breadcrumb-flat">
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">Home</a>
+          <span class="ease-bread-separator" aria-hidden="true">/</span>
+        </li>
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">Blog</a>
+          <span class="ease-bread-separator" aria-hidden="true">/</span>
+        </li>
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">CSS Tips</a>
+          <span class="ease-bread-separator" aria-hidden="true">/</span>
+        </li>
+
+        <li class="ease-bread-item" aria-current="page">
+          <span class="ease-bread-active">Skeleton Loaders</span>
+        </li>
+
+      </ol>
+    </nav>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════
+       VARIANT 6 — Small size
+  ══════════════════════════════════════════════════════════ -->
+  <div class="section-wrap">
+    <p class="section-title">✦ Small size variant</p>
+
+    <nav aria-label="Breadcrumb — small">
+      <ol class="ease-breadcrumb ease-breadcrumb-sm">
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">Home</a>
+          <span class="ease-bread-separator" aria-hidden="true">›</span>
+        </li>
+
+        <li class="ease-bread-item">
+          <a class="ease-bread-link" href="#">Products</a>
+          <span class="ease-bread-separator" aria-hidden="true">›</span>
+        </li>
+
+        <li class="ease-bread-item" aria-current="page">
+          <span class="ease-bread-active">Keyboard</span>
+        </li>
+
+      </ol>
+    </nav>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/breadcrumb-trail/style.css
+++ b/submissions/examples/breadcrumb-trail/style.css
@@ -1,0 +1,290 @@
+/* ============================================================
+   EaseMotion CSS — Animated Breadcrumb Navigation
+   submissions/examples/breadcrumb-trail/style.css
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --ease-bread-text:          #64748b;
+  --ease-bread-text-hover:    #6366f1;
+  --ease-bread-text-active:   #1e293b;
+  --ease-bread-underline:     #6366f1;
+  --ease-bread-separator:     #cbd5e1;
+  --ease-bread-active-bg:     #ede9fe;
+  --ease-bread-active-border: #a78bfa;
+  --ease-bread-active-text:   #5b21b6;
+  --ease-bread-icon-color:    #94a3b8;
+  --ease-bread-icon-hover:    #6366f1;
+  --ease-bread-ellipsis-bg:   #f1f5f9;
+  --ease-bread-ellipsis-text: #64748b;
+  --ease-bread-bg:            #ffffff;
+  --ease-bread-border:        #e2e8f0;
+  --ease-bread-shadow:        0 2px 10px rgba(0,0,0,0.06);
+
+  --ease-bread-radius:        8px;
+  --ease-bread-duration:      200ms;
+  --ease-bread-easing:        cubic-bezier(0.4, 0, 0.2, 1);
+  --page-bg:                  #f1f5f9;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-bread-text:          #94a3b8;
+    --ease-bread-text-hover:    #818cf8;
+    --ease-bread-text-active:   #f1f5f9;
+    --ease-bread-underline:     #818cf8;
+    --ease-bread-separator:     #334155;
+    --ease-bread-active-bg:     #3b0764;
+    --ease-bread-active-border: #7c3aed;
+    --ease-bread-active-text:   #c4b5fd;
+    --ease-bread-icon-color:    #475569;
+    --ease-bread-icon-hover:    #818cf8;
+    --ease-bread-ellipsis-bg:   #1e293b;
+    --ease-bread-ellipsis-text: #94a3b8;
+    --ease-bread-bg:            #0f172a;
+    --ease-bread-border:        #1e293b;
+    --ease-bread-shadow:        0 2px 10px rgba(0,0,0,0.4);
+    --page-bg:                  #020617;
+  }
+}
+
+/* ── Page shell ──────────────────────────────────────────── */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--page-bg);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2.5rem 1rem 4rem;
+  gap: 2.5rem;
+}
+
+.demo-label {
+  font-size: 0.75rem;
+  color: var(--ease-bread-text);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.section-wrap {
+  width: 100%;
+  max-width: 680px;
+}
+
+.section-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-bread-text);
+  margin-bottom: 0.75rem;
+}
+
+/* ── Breadcrumb container ─────────────────────────────────── */
+.ease-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0;
+  list-style: none;
+  padding: 0.6rem 1rem;
+  background: var(--ease-bread-bg);
+  border: 1px solid var(--ease-bread-border);
+  border-radius: var(--ease-bread-radius);
+  box-shadow: var(--ease-bread-shadow);
+}
+
+/* Flat variant — no card chrome */
+.ease-breadcrumb-flat {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0.5rem 0;
+}
+
+/* ── Crumb item ──────────────────────────────────────────── */
+.ease-bread-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+
+  /* Staggered fade-in on mount */
+  opacity: 0;
+  animation: ease-bread-appear 300ms var(--ease-bread-easing) forwards;
+}
+
+.ease-bread-item:nth-child(1)  { animation-delay: 0ms; }
+.ease-bread-item:nth-child(2)  { animation-delay: 60ms; }
+.ease-bread-item:nth-child(3)  { animation-delay: 120ms; }
+.ease-bread-item:nth-child(4)  { animation-delay: 180ms; }
+.ease-bread-item:nth-child(5)  { animation-delay: 240ms; }
+.ease-bread-item:nth-child(6)  { animation-delay: 300ms; }
+.ease-bread-item:nth-child(7)  { animation-delay: 360ms; }
+
+@keyframes ease-bread-appear {
+  from { opacity: 0; transform: translateX(-4px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* ── Crumb link ──────────────────────────────────────────── */
+.ease-bread-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--ease-bread-text);
+  text-decoration: none;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: color var(--ease-bread-duration) var(--ease-bread-easing);
+  white-space: nowrap;
+}
+
+.ease-bread-link:hover {
+  color: var(--ease-bread-text-hover);
+}
+
+/* Hover underline — slides in from left */
+.ease-bread-link::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 4px;
+  right: 4px;
+  height: 1.5px;
+  background: var(--ease-bread-underline);
+  border-radius: 1px;
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform var(--ease-bread-duration) var(--ease-bread-easing);
+}
+
+.ease-bread-link:hover::after {
+  transform: scaleX(1);
+}
+
+/* Focus-visible ring */
+.ease-bread-link:focus-visible {
+  outline: 2px solid var(--ease-bread-underline);
+  outline-offset: 2px;
+}
+
+/* ── Link icon ───────────────────────────────────────────── */
+.ease-bread-icon {
+  font-size: 0.875rem;
+  color: var(--ease-bread-icon-color);
+  transition: color var(--ease-bread-duration) var(--ease-bread-easing);
+  flex-shrink: 0;
+}
+
+.ease-bread-link:hover .ease-bread-icon {
+  color: var(--ease-bread-icon-hover);
+}
+
+/* ── Separator ───────────────────────────────────────────── */
+.ease-bread-separator {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  color: var(--ease-bread-separator);
+  font-size: 0.75rem;
+  flex-shrink: 0;
+  user-select: none;
+  /* Separator fades in with the item */
+  transition: color var(--ease-bread-duration) var(--ease-bread-easing);
+}
+
+.ease-bread-separator svg {
+  width: 12px;
+  height: 12px;
+  display: block;
+}
+
+/* ── Active / current crumb ──────────────────────────────── */
+.ease-bread-active {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--ease-bread-active-text);
+  background: var(--ease-bread-active-bg);
+  border: 1px solid var(--ease-bread-active-border);
+  border-radius: 5px;
+  padding: 2px 8px;
+  white-space: nowrap;
+
+  /* Subtle pulse to anchor "you are here" */
+  animation:
+    ease-bread-appear   300ms var(--ease-bread-easing) 300ms both,
+    ease-bread-pulse    2.4s  ease-in-out 800ms infinite;
+}
+
+@keyframes ease-bread-pulse {
+  0%, 100% { box-shadow: 0 0 0 0   var(--ease-bread-active-border); }
+  50%       { box-shadow: 0 0 0 3px transparent; }
+}
+
+/* ── Ellipsis / truncated crumb ──────────────────────────── */
+.ease-bread-ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 22px;
+  padding: 0 8px;
+  background: var(--ease-bread-ellipsis-bg);
+  color: var(--ease-bread-ellipsis-text);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  cursor: default;
+  transition: background var(--ease-bread-duration) var(--ease-bread-easing);
+  user-select: none;
+}
+
+/* ── Size variants ───────────────────────────────────────── */
+.ease-breadcrumb-sm .ease-bread-link,
+.ease-breadcrumb-sm .ease-bread-active {
+  font-size: 0.75rem;
+}
+
+.ease-breadcrumb-lg .ease-bread-link,
+.ease-breadcrumb-lg .ease-bread-active {
+  font-size: 0.9375rem;
+}
+
+/* ── Responsive — wrap on small screens ──────────────────── */
+@media (max-width: 480px) {
+  .ease-breadcrumb {
+    padding: 0.5rem 0.75rem;
+  }
+  .ease-bread-link {
+    font-size: 0.75rem;
+  }
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-bread-item,
+  .ease-bread-active,
+  .ease-bread-link,
+  .ease-bread-link::after,
+  .ease-bread-icon {
+    animation: none;
+    transition: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## 🎯 Feature: Animated Breadcrumb Navigation

### Summary

| Item | Detail |
|------|--------|
| Component | Animated Breadcrumb Navigation |
| Folder | `submissions/examples/breadcrumb-trail/` |
| Files | `demo.html`, `style.css`, `README.md` |
| Dependencies | Zero — pure CSS, no JavaScript |
| Issue | Closes #20328 |

### Variants implemented

| Variant | Description |
|---------|-------------|
| Basic slash | Default `/` separator |
| Chevron SVG | Inline SVG arrow separator |
| Icon + text | Icon before each crumb label |
| Truncated | Middle crumbs collapsed to `···` ellipsis |
| Flat | No card chrome |
| Small | `.ease-breadcrumb-sm` size modifier |

### Animations
- **Mount** — crumbs fade + `translateX(-4px → 0)` with staggered 60ms delay per item
- **Hover underline** — `scaleX(0 → 1)` from left via `transform-origin: left center`
- **Active pulse** — repeating `box-shadow` glow on the current page crumb
- **Icons** — colour transitions on link hover

### Variants
- ✅ Light mode
- ✅ Dark mode (`prefers-color-scheme: dark`)
- ✅ `prefers-reduced-motion` — all animations disabled; crumbs fully visible immediately
- ✅ Responsive — wraps on small screens

### Accessibility
- `<nav>` with `aria-label` wrapping `<ol>`
- `aria-current="page"` on active item
- `aria-hidden` on separators and decorative icons
- `focus-visible` ring on all links

### Contributor
**@thakurakanksha288** — GSSoC 2026 participant ✅