### PR TITLE
feat: add ease-color-swatch-grid component (#19877)

### DIFF
--- a/submissions/examples/ease-color-swatch-grid-ax/README.md
+++ b/submissions/examples/ease-color-swatch-grid-ax/README.md
@@ -1,0 +1,22 @@
+﻿# ease-color-swatch-grid – Color Selection Grid
+
+A CSS‑only color swatch grid with animated selection feedback. Each swatch is a radio input styled as a colored circle; when selected, a ring scales in and a checkmark appears.
+
+## EaseMotion classes used
+- **Layout:** ease-container, ease-flex, ease-items-center, ease-justify-center, ease-min-h-screen, ease-py-16, ease-gap-4, ease-flex-wrap
+- **Background:** ease-bg-gray-50
+- **Typography:** ease-text-3xl, ease-font-bold, ease-text-gray-500, ease-text-sm, ease-text-gray-400
+- **Spacing:** ease-mb-4, ease-mb-8, ease-mt-8
+- **Animation:** ease-fade-in, ease-delay-200, ease-delay-500
+
+## How it works
+- Hidden radio inputs are paired with a <label> containing a <span> for the colored circle.
+- The :checked pseudo‑class applies a white ring + colored outer ring via ox-shadow, and a checkmark via ::after.
+- The checkmark has a pop‑in animation (check-pop) that overshoots slightly.
+- Hover increases the swatch size and adds a soft blue halo.
+- All animations respect prefers-reduced-motion.
+
+## How to use
+1. Copy the HTML, CSS, and JS from demo.html into your project.
+2. Ensure the path to easemotion.css is correct.
+3. Open demo.html in any modern browser.

--- a/submissions/examples/ease-color-swatch-grid-ax/demo.html
+++ b/submissions/examples/ease-color-swatch-grid-ax/demo.html
@@ -1,0 +1,48 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-color-swatch-grid – Color Selection Grid</title>
+  <link rel="stylesheet" href="../../core/easemotion.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-gray-50 ease-min-h-screen ease-flex ease-items-center ease-justify-center">
+
+  <div class="ease-container ease-text-center ease-py-16">
+    <h1 class="ease-text-3xl ease-font-bold ease-mb-4 ease-fade-in">Color Swatch Grid</h1>
+    <p class="ease-text-gray-500 ease-mb-8 ease-fade-in ease-delay-200">
+      Select a color — the swatch shows a ring and checkmark.
+    </p>
+
+    <!-- Radio-based color grid -->
+    <div class="swatch-grid ease-flex ease-justify-center ease-gap-4 ease-flex-wrap">
+      <label class="swatch-item">
+        <input type="radio" name="color" value="blue" class="sr-only" checked>
+        <span class="swatch" style="background: #3b82f6;"></span>
+      </label>
+      <label class="swatch-item">
+        <input type="radio" name="color" value="green" class="sr-only">
+        <span class="swatch" style="background: #10b981;"></span>
+      </label>
+      <label class="swatch-item">
+        <input type="radio" name="color" value="red" class="sr-only">
+        <span class="swatch" style="background: #ef4444;"></span>
+      </label>
+      <label class="swatch-item">
+        <input type="radio" name="color" value="purple" class="sr-only">
+        <span class="swatch" style="background: #8b5cf6;"></span>
+      </label>
+      <label class="swatch-item">
+        <input type="radio" name="color" value="orange" class="sr-only">
+        <span class="swatch" style="background: #f97316;"></span>
+      </label>
+    </div>
+
+    <p class="ease-text-sm ease-text-gray-400 ease-mt-8 ease-fade-in ease-delay-500">
+      Pure CSS — radio inputs + animated ring and checkmark.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-color-swatch-grid-ax/style.css
+++ b/submissions/examples/ease-color-swatch-grid-ax/style.css
@@ -1,0 +1,74 @@
+﻿/* ============================================================
+   ease-color-swatch-grid – Color selection grid with radio inputs
+   ============================================================ */
+
+/* Hide actual radio inputs */
+.sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0,0,0,0); border: 0;
+}
+
+/* Swatch wrapper label */
+.swatch-item {
+  display: inline-flex;
+  cursor: pointer;
+  position: relative;
+}
+
+/* The colored circle */
+.swatch {
+  display: block;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  position: relative;
+  transition: transform 0.2s ease, box-shadow 0.3s ease;
+  will-change: transform, box-shadow;
+}
+
+/* Hover effect */
+.swatch-item:hover .swatch {
+  transform: scale(1.1);
+  box-shadow: 0 0 0 6px rgba(59, 130, 246, 0.15);
+}
+
+/* Selected state – ring and checkmark */
+.swatch-item input:checked + .swatch {
+  box-shadow: 0 0 0 4px #fff, 0 0 0 8px var(--swatch-color, #3b82f6);
+  transform: scale(1.05);
+}
+
+/* Checkmark via ::after on selected swatch */
+.swatch-item input:checked + .swatch::after {
+  content: '✓';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  color: #fff;
+  font-weight: bold;
+  font-size: 1.2rem;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  animation: check-pop 0.3s ease forwards;
+}
+
+/* Checkmark pop animation */
+@keyframes check-pop {
+  0%   { transform: translate(-50%, -50%) scale(0); }
+  80%  { transform: translate(-50%, -50%) scale(1.3); }
+  100% { transform: translate(-50%, -50%) scale(1); }
+}
+
+/* Accessibility: respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .swatch,
+  .swatch-item input:checked + .swatch {
+    transition: none;
+    transform: none;
+  }
+  .swatch-item input:checked + .swatch::after {
+    animation: none;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}


### PR DESCRIPTION
Closes #19877

ease-color-swatch-grid – Color Selection Grid
A CSS‑only grid of circular color swatches with animated ring and checkmark on selection.

Files added
- submissions/examples/ease-color-swatch-grid-ax/demo.html
- submissions/examples/ease-color-swatch-grid-ax/style.css
- submissions/examples/ease-color-swatch-grid-ax/README.md

How it works
- Hidden radio inputs control the selected state.
- Selected swatch shows a white ring + colored outer ring (box-shadow).
- Checkmark pops in with a scale animation.
- Hover enlarges swatch slightly with a glow.
- Respects prefers-reduced-motion.