### PR TITLE
feat: add animated before/after image slider component (#20349)

### DIFF
--- a/submissions/examples/before-after-slider/README.md
+++ b/submissions/examples/before-after-slider/README.md
@@ -1,0 +1,13 @@
+# Animated Before/After Image Slider — EaseMotion CSS
+
+A beautiful, high-performance image-comparison element structure. Uses high-efficiency CSS standard `clip-path` masks linked directly to modern layout variables for perfect, zero-jank coordinate movement tracking.
+
+## 🛠 Features & Class Hooks
+
+| Select Token | Component Anchor | Functional Motion Signature |
+|---|---|---|
+| `.ease-slider-container` | Main Outer Frame | Context wrapper hosting custom tracking values (`--ease-slider-pos`). |
+| `.ease-img-after` | Comparison Layer | Clips horizontal viewing windows using strict rendering layout polygons. |
+| `.ease-slider-range` | Control Input Overlay| Standard range input overlay providing fluid mouse/touch coordinates without bulky libraries. |
+| `.is-snapped` | Edge State Flag | Triggers a momentary outer bright color pulse when elements hit `0%` or `100%`. |
+| `.ease-slider-autosweep` | Entrance Filter | Automatically runs a loop reveal upon initialization to draw user engagement. |

--- a/submissions/examples/before-after-slider/demo.html
+++ b/submissions/examples/before-after-slider/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Before/After Image Slider - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      padding: 40px 20px;
+      max-width: 700px;
+      margin: 0 auto;
+      background: #f8fafc;
+      color: #0f172a;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f8fafc; }
+    }
+    .card {
+      background: #ffffff;
+      padding: 24px;
+      border-radius: 12px;
+      box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+      margin-bottom: 32px;
+    }
+    @media (prefers-color-scheme: dark) {
+      .card { background: #1e293b; box-shadow: none; }
+    }
+    h2 { font-size: 1.1rem; margin-top: 0; margin-bottom: 16px; color: #64748b; }
+  </style>
+</head>
+<body>
+
+  <h1 style="text-align:center; margin-bottom:8px;">↔️ Animated Before/After Slider</h1>
+  <p style="text-align:center; margin-bottom:40px; color:#64748b;">Pure-CSS structural styling mechanics with range track bindings.</p>
+
+  <div class="card">
+    <h2>1. Interactive Slider with Dynamic Labels & Edge Snapping</h2>
+    <div id="interactiveSlider" class="ease-slider-container" style="--ease-slider-pos: 50%;">
+      <span class="ease-slider-label ease-label-before">Original</span>
+      <span class="ease-slider-label ease-label-after">Edited Effect</span>
+
+      <img class="ease-slider-img ease-img-before" src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=80" alt="Before color correction">
+      <img class="ease-slider-img ease-img-after" src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=80&sat=-100" alt="After gray filtering transition">
+
+      <input type="range" class="ease-slider-range" min="0" max="100" value="50" oninput="updateSlider(this, 'interactiveSlider')">
+
+      <div class="ease-slider-divider">
+        <div class="ease-slider-handle">
+          <svg viewBox="0 0 24 24"><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41zm6.82 0L20 12l-4.59-4.59L16.82 6l6 6-6 6-1.41-1.41z" fill="currentColor"/></svg>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>2. Auto-Sweep Preview (Runs on load, then interactive)</h2>
+    <div id="sweepSlider" class="ease-slider-container ease-slider-autosweep" style="--ease-slider-pos: 50%;">
+      <img class="ease-slider-img ease-img-before" src="https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?auto=format&fit=crop&w=800&q=80" alt="Before landscape view">
+      <img class="ease-slider-img ease-img-after" src="https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?auto=format&fit=crop&w=800&q=80&blur=10" alt="After blur preview layout">
+
+      <input type="range" class="ease-slider-range" min="0" max="100" value="50" oninput="updateSlider(this, 'sweepSlider')">
+
+      <div class="ease-slider-divider">
+        <div class="ease-slider-handle">
+          <svg viewBox="0 0 24 24"><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41zm6.82 0L20 12l-4.59-4.59L16.82 6l6 6-6 6-1.41-1.41z" fill="currentColor"/></svg>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function updateSlider(input, containerId) {
+      const container = document.getElementById(containerId);
+      const val = input.value;
+      
+      // Stop the auto-sweep track on user touch
+      if (containerId === 'sweepSlider') container.classList.remove('ease-slider-autosweep');
+
+      // Update structural custom variable property link
+      container.style.setProperty('--ease-slider-pos', `${val}%`);
+
+      // 1. Proportional fade logic triggers
+      if (val < 15) {
+        container.setAttribute('data-pos', 'low');
+      } else if (val > 85) {
+        container.setAttribute('data-pos', 'high');
+      } else {
+        container.removeAttribute('data-pos');
+      }
+
+      // 2. Edge-Snap glow alert handler
+      if (val == 0 || val == 100) {
+        container.classList.add('is-snapped');
+      } else {
+        container.classList.remove('is-snapped');
+      }
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/before-after-slider/style.css
+++ b/submissions/examples/before-after-slider/style.css
@@ -1,0 +1,155 @@
+/* ==========================================================================
+   EaseMotion CSS - Animated Before/After Image Slider
+   ========================================================================== */
+
+:root {
+  --ease-slider-width: 100%;
+  --ease-slider-aspect: 16/9;
+  --ease-divider-color: #ffffff;
+  --ease-handle-size: 40px;
+  --ease-handle-bg: #ffffff;
+  --ease-handle-accent: #3b82f6;
+  --ease-transition-fast: 0.15s ease-out;
+  --ease-slider-pos: 50%; /* Main position updated by input/JS range */
+}
+
+/* --- Container Frame Layout --- */
+.ease-slider-container {
+  position: relative;
+  width: var(--ease-slider-width);
+  aspect-ratio: var(--ease-slider-aspect);
+  border-radius: 12px;
+  overflow: hidden;
+  user-select: none;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}
+
+.ease-slider-img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  pointer-events: none;
+}
+
+/* Layering Order */
+.ease-img-before { z-index: 1; }
+.ease-img-after {
+  z-index: 2;
+  /* Core Reveal Clipping Engine */
+  clip-path: polygon(var(--ease-slider-pos) 0, 100% 0, 100% 100%, var(--ease-slider-pos) 100%);
+}
+
+/* --- Labeled Badges Variant --- */
+.ease-slider-label {
+  position: absolute;
+  top: 16px;
+  padding: 6px 12px;
+  background: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(4px);
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border-radius: 6px;
+  z-index: 3;
+  pointer-events: none;
+  transition: opacity var(--ease-transition-fast);
+}
+.ease-label-before { left: 16px; }
+.ease-label-after { right: 16px; }
+
+/* Dynamic Proportional Fading Overlays */
+.ease-slider-container[data-pos="low"] .ease-label-before { opacity: 0.1; }
+.ease-slider-container[data-pos="high"] .ease-label-after { opacity: 0.1; }
+
+/* --- Draggable Range Input Controller Layer --- */
+.ease-slider-range {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  z-index: 5;
+  cursor: ew-resize;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+/* --- Vertical Divider Line & Grip Handle --- */
+.ease-slider-divider {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--ease-slider-pos);
+  width: 2px;
+  background-color: var(--ease-divider-color);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+  z-index: 4;
+  transform: translateX(-50%);
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ease-slider-handle {
+  width: var(--ease-handle-size);
+  height: var(--ease-handle-size);
+  background: var(--ease-handle-bg);
+  border-radius: 50%;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ease-handle-accent);
+  transition: transform var(--ease-transition-fast), box-shadow var(--ease-transition-fast);
+}
+
+.ease-slider-handle svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+
+/* --- Drag & Limit Animations --- */
+
+/* Handle Grow on Drag (Triggered via Range Focus/Active state context) */
+.ease-slider-range:active ~ .ease-slider-divider .ease-slider-handle {
+  transform: scale(1.18);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.3), 0 6px 14px rgba(0, 0, 0, 0.3);
+}
+
+/* Edge Snap Flash Keyframes */
+@keyframes easeEdgeFlash {
+  0%, 100% { box-shadow: 0 4px 10px rgba(0,0,0,0.25); }
+  50% { box-shadow: 0 0 20px 8px var(--ease-handle-accent); }
+}
+.ease-slider-container.is-snapped .ease-slider-handle {
+  animation: easeEdgeFlash 0.4s ease-out;
+}
+
+/* --- Auto-Sweep Preview Variant --- */
+@keyframes easeAutoSweep {
+  0% { --ease-slider-pos: 20%; }
+  50% { --ease-slider-pos: 80%; }
+  100% { --ease-slider-pos: 50%; }
+}
+.ease-slider-autosweep {
+  animation: easeAutoSweep 3s cubic-bezier(0.4, 0, 0.2, 1) 1;
+}
+
+/* --- Accessibility: prefers-reduced-motion --- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-slider-autosweep {
+    animation: none !important;
+  }
+  .ease-slider-handle {
+    transition: none !important;
+  }
+  .ease-slider-range:active ~ .ease-slider-divider .ease-slider-handle {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## 🎯 Feature: Animated Before/After Image Slider

### Summary
| Item | Detail |
|------|--------|
| Component | Animated Before/After Image Slider |
| Folder | `submissions/examples/before-after-slider/` |
| Files | `demo.html`, `style.css`, `README.md` |
| Dependencies | Zero external files — standard CSS polygon clipping layout |
| Issue | Closes #20349 |

### Variants Implemented
- **Horizontal Draggable Slider Base:** Leverages lightweight `clip-path: polygon()` masks for ultra-smooth rendering.
- **Dynamic Text Labeled Overlays:** Includes "Before" and "After" text modules that fade dynamically based on slide thresholds.
- **Auto-Sweep Initializer Overlay:** Runs a smooth, captivating introductory sweep cycle to guide the user's attention automatically.

### Micro-interaction Details
- **Active Grip Scale Expansion:** Scales up the central pointer grip and scales up soft drop shadow depths under focus.
- **Limit Snap Alerts:** Fires bright background ring highlights the absolute second coordinates collide against layout boundaries.
- **A11y/Reduced Motion Supported:** Disables intro sweeping cycles when device accessibility configs request static presentation layers.

**@thakurakanksha288** — GSSoC 2026 participant ✅