### PR TITLE
feat(nav): implement interactive dark/light theme toggle logic (#20357)

### DIFF
--- a/submissions/examples/Missing-Theme-ToggleUI-and-Logic/README.md
+++ b/submissions/examples/Missing-Theme-ToggleUI-and-Logic/README.md
@@ -1,0 +1,7 @@
+## Bug 1: Theme Toggle Implementation
+Added the missing DOM elements and JavaScript logic to support the dark/light mode toggle. The script checks `window.matchMedia` for system defaults and uses `localStorage` for persistence across sessions.
+
+added
+
+hi 
+S

--- a/submissions/examples/Missing-Theme-ToggleUI-and-Logic/demo.html
+++ b/submissions/examples/Missing-Theme-ToggleUI-and-Logic/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bug Fix 1 - Theme Toggle</title>
+</head>
+<body>
+  <nav class="demo-nav">
+    <div class="ease-container demo-nav-inner">
+      <a href="index.html" class="demo-logo">EaseMotion CSS</a>
+      
+      <ul class="demo-nav-links">
+        <li><a href="#buttons">Buttons</a></li>
+        <li><a href="#cards">Cards</a></li>
+        <li><a href="#animations">Animations</a></li>
+        
+        <li>
+          <button class="theme-toggle-btn" id="themeToggle" aria-label="Toggle Theme">
+            <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="5"></circle>
+              <line x1="12" y1="1" x2="12" y2="3"></line>
+              <line x1="12" y1="21" x2="12" y2="23"></line>
+              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+              <line x1="1" y1="12" x2="3" y2="12"></line>
+              <line x1="21" y1="12" x2="23" y2="12"></line>
+              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+            </svg>
+            <svg class="moon-icon" style="display:none;" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </nav>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const themeToggle = document.getElementById('themeToggle');
+      const rootHtml = document.documentElement;
+      
+      // Determine preference based on localStorage or system settings
+      const getThemePreference = () => {
+        const savedTheme = localStorage.getItem('easemotion-theme');
+        if (savedTheme) return savedTheme;
+        return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+      };
+      
+      // Apply theme and update storage
+      const applyTheme = (theme) => {
+        if (theme === 'light') {
+          rootHtml.setAttribute('data-theme', 'light');
+        } else {
+          rootHtml.removeAttribute('data-theme');
+        }
+        localStorage.setItem('easemotion-theme', theme);
+      };
+      
+      // Initialize and attach listener
+      applyTheme(getThemePreference());
+      themeToggle.addEventListener('click', () => {
+        const currentTheme = rootHtml.getAttribute('data-theme');
+        applyTheme(currentTheme === 'light' ? 'dark' : 'light');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/Missing-Theme-ToggleUI-and-Logic/style.css
+++ b/submissions/examples/Missing-Theme-ToggleUI-and-Logic/style.css
@@ -1,0 +1,25 @@
+/* Boilerplate layout variables */
+:root {
+  --docs-header-h: 60px;
+  --page-bg: #0f0e17;
+}
+
+/* FIX: Unified Sidebar Mobile Logic */
+/* Note: Ensure the duplicate .sidebar.active block at the bottom of the original file is DELETED */
+@media (max-width: 768px) {
+  .docs-sidebar {
+    /* Base off-canvas state */
+    transform: translateX(-100%);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    position: fixed;
+    top: var(--docs-header-h);
+    left: 0;
+    width: 280px;
+    height: calc(100vh - var(--docs-header-h));
+    box-shadow: 4px 0 25px rgba(0,0,0,0.25);
+    z-index: 1000;
+    background: var(--page-bg);
+    overflow-y: auto;
+  }
+
+}


### PR DESCRIPTION
Description:Context
: The CSS variables for data-theme="light" were present in docs.css, but the actual HTML button and the JavaScript to trigger the state changes were missing from the demo environment.Changes Proposed:
Added the <button class="theme-toggle-btn"> containing the Sun/Moon SVG icons to .demo-nav-links.

Implemented a JS initialization script that checks localStorage and prefers-color-scheme to set the initial theme state.
Added an event listener to toggle the data-theme attribute on the root HTML element and persist the choice.

fixes #20357 