### PR TITLE
fix(css): resolve mobile sidebar media query conflicts and unify state classes(#20361)

### DIFF
--- a/submissions/examples/Conflicting-Mobile-Sidebar-Selectors-GitCommands/README.md
+++ b/submissions/examples/Conflicting-Mobile-Sidebar-Selectors-GitCommands/README.md
@@ -1,0 +1,9 @@
+# Bug Fix: Sidebar CSS Conflicts
+
+## Issue
+The stylesheet contained a redundant media query block at the bottom targeting `.sidebar.active`, which conflicted with the main `.docs-sidebar` block higher up in the file. This caused dead code and animation failures when JavaScript attempted to open the mobile menu.
+
+## Solution
+1. Deleted the redundant `.sidebar` media query block entirely.
+2. Centralized all mobile positioning, box-shadows, and `transform: translateX` logic into the primary `.docs-sidebar` media query.
+3. Standardized the active state to strictly use the `.open` class.

--- a/submissions/examples/Conflicting-Mobile-Sidebar-Selectors-GitCommands/demo.html
+++ b/submissions/examples/Conflicting-Mobile-Sidebar-Selectors-GitCommands/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bug 2 Patch - Sidebar Conflict</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="docs-header">
+    <button id="mobileMenuBtn" class="sidebar-toggle">☰</button>
+  </header>
+
+  <aside class="docs-sidebar" id="sidebar">
+    <nav>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Getting Started</div>
+        <ul class="sidebar-nav">
+          <li><a href="#installation">Installation</a></li>
+        </ul>
+      </div>
+    </nav>
+  </aside>
+
+  <script>
+    document.getElementById('mobileMenuBtn').addEventListener('click', () => {
+      const sidebar = document.getElementById('sidebar');
+      // Fix relies on targeting '.open' instead of the broken '.active' class
+      sidebar.classList.toggle('open');
+      
+      // Accessibility update
+      const isOpen = sidebar.classList.contains('open');
+      document.getElementById('mobileMenuBtn').setAttribute('aria-expanded', isOpen);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/Conflicting-Mobile-Sidebar-Selectors-GitCommands/style.css
+++ b/submissions/examples/Conflicting-Mobile-Sidebar-Selectors-GitCommands/style.css
@@ -1,0 +1,32 @@
+/* Boilerplate CSS */
+:root {
+  --docs-header-h: 60px;
+  --page-bg: #0f0e17;
+  --ease-space-6: 1.5rem;
+}
+
+/* COMPLEX CSS: Unified, single-source-of-truth mobile sidebar logic */
+@media (max-width: 768px) {
+  .docs-sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    position: fixed;
+    top: var(--docs-header-h);
+    left: 0;
+    bottom: 0;
+    width: 280px;
+    box-shadow: 4px 0 25px rgba(0,0,0,0.25);
+    z-index: 1000;
+    background: var(--page-bg);
+  }
+
+  /* This single class now handles the slide-in, replacing the broken .sidebar.active */
+  .docs-sidebar.open {
+    transform: translateX(0);
+  }
+  
+  .docs-content {
+    margin-left: 0 !important;
+    padding-top: var(--ease-space-6); 
+  }
+}


### PR DESCRIPTION
PR Description:
This PR fixes a bug in docs.css where two different mobile media queries were fighting for control over the off-canvas sidebar. One query targeted .docs-sidebar while another targeted a non-existent .sidebar class.
Removed the dead code targeting .sidebar.active.
Consolidated the off-canvas translation and z-index logic under .docs-sidebar and its modifier .docs-sidebar.open.
Ensured smooth cubic-bezier transitions for mobile sliding.
<img width="276" height="556" alt="Screenshot 2026-06-25 at 9 10 09 AM" src="https://github.com/user-attachments/assets/008685ef-037c-4a51-85bb-c00df83aeb5a" />
fixes #20361 