### PR TITLE
fix(layout): apply flex-wrap to navigation links to prevent mobile horizontal overflow (#20367)

### DIFF
--- a/submissions/examples/Unresponsive-Navigation-Menu-Layout/README.md
+++ b/submissions/examples/Unresponsive-Navigation-Menu-Layout/README.md
@@ -1,0 +1,9 @@
+# Bug Fix: Navigation Menu Wrapping
+
+## Issue
+On screens smaller than 500px, the rigid `display: flex` container on the navigation menu lacked a wrap rule. This forced navigation items to shrink beyond readability or pushed them out of the viewport, causing a horizontal scrollbar.
+
+## Solution
+1. Added `flex-wrap: wrap` to `.demo-nav-links`.
+2. Created a sub-600px breakpoint to switch the main header container (`.demo-nav-inner`) to a column layout.
+3. Dynamically reduced flex gaps and increased individual link padding on mobile to prioritize touch-target accessibility while preventing overflow.

--- a/submissions/examples/Unresponsive-Navigation-Menu-Layout/demo.html
+++ b/submissions/examples/Unresponsive-Navigation-Menu-Layout/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bug 3 Patch - Nav Wrap</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="demo-nav">
+    <div class="ease-container demo-nav-inner">
+      <a href="index.html" class="demo-logo">EaseMotion CSS</a>
+      <ul class="demo-nav-links">
+        <li><a href="#buttons">Buttons</a></li>
+        <li><a href="#cards">Cards</a></li>
+        <li><a href="#animations">Animations</a></li>
+        <li><a href="#layout">Layout</a></li>
+        <li><a href="./">Docs</a></li>
+      </ul>
+    </div>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/Unresponsive-Navigation-Menu-Layout/style.css
+++ b/submissions/examples/Unresponsive-Navigation-Menu-Layout/style.css
@@ -1,0 +1,38 @@
+/* Boilerplate CSS */
+:root {
+  --ease-space-6: 1.5rem;
+  --ease-radius-md: 6px;
+}
+
+/* COMPLEX CSS: Allowing flex children to wrap and re-aligning on mobile */
+.demo-nav-links {
+  display: flex;
+  flex-wrap: wrap; /* Crucial fix for overflow */
+  gap: var(--ease-space-6);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Responsive adjustment for extra narrow viewports */
+@media (max-width: 600px) {
+  .demo-nav-inner {
+    flex-direction: column;
+    gap: 1.25rem;
+    padding: 15px 0;
+    text-align: center;
+  }
+  
+  .demo-nav-links {
+    gap: 0.85rem;
+    width: 100%;
+    justify-content: center;
+  }
+  
+  .demo-nav-links a {
+    padding: 8px 14px; /* Increase touch target size on mobile */
+    background: rgba(255,255,255,0.03); /* Subtle separation for wrapped items */
+  }
+}


### PR DESCRIPTION
PR Description:
This PR addresses horizontal overflow and overlapping elements in the header on mobile viewports.
Added flex-wrap: wrap to the .demo-nav-links container.
Introduced a max-width: 600px media query to stack the main logo and the navigation links block gracefully on narrow screens.
Adjusted the flex gaps dynamically based on the viewport to ensure touch targets remain adequately spaced without breaking the DOM boundary.
<img width="276" height="556" alt="Screenshot 2026-06-25 at 9 10 09 AM" src="https://github.com/user-attachments/assets/89bd769e-0486-44bc-8baa-85cb54ceb112" />
fixes #20367 