### PR TITLE
feat: add animated notification toast stack component (#19286)

### DIFF
--- a/submissions/core_changes-issue-19286/README.md
+++ b/submissions/core_changes-issue-19286/README.md
@@ -1,0 +1,52 @@
+# Animated Notification Toast Stack
+
+Pure CSS animated toast notification stack with slide-in entrance, dismiss-on-click, and four severity variants. Zero JavaScript.
+
+## Features
+
+- **4 toast variants**: success (green), error (red), warning (amber), info (blue)
+- **Slide-in from right** via `@keyframes toastIn` with `cubic-bezier` easing
+- **Staggered entrance** — each toast appears with increasing `animation-delay`
+- **Dismiss on click** — checkbox hack slides the toast out via `@keyframes toastOut`
+- **Icon per type** with colored circular background
+- **Stacked layout** with vertical gap between toasts
+- **Responsive** — max 420px on desktop, full-width on mobile
+- **Pure CSS, zero JavaScript**
+- **`prefers-reduced-motion`** support — disables all animations
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `demo.html` | 4 stacked toasts with hidden checkbox controls |
+| `style.css` | All styles, animations, dismiss logic, responsive, reduced-motion |
+| `README.md` | This documentation |
+
+## How It Works
+
+Each toast has a hidden checkbox sibling. The close button is a `<label>` that toggles the checkbox. When checked, CSS sibling selectors (`#dismiss-N:checked ~ .toast-stack .toast[data-toast="N"]`) trigger the `toastOut` animation, which slides the toast right and collapses its height.
+
+## Usage
+
+```html
+<input type="checkbox" id="dismiss-1" hidden>
+<div class="toast-stack">
+  <div class="toast toast-success" data-toast="1">
+    <span class="toast-icon">✓</span>
+    <div class="toast-body">
+      <strong>Success</strong>
+      <p>Your changes have been saved.</p>
+    </div>
+    <label class="toast-close" for="dismiss-1">×</label>
+  </div>
+</div>
+```
+
+## Keyframes
+
+| Keyframe | Purpose |
+|----------|---------|
+| `toastIn` | Slides toast in from right with opacity fade |
+| `toastOut` | Slides toast out to right, collapses height to zero |
+
+Fixes #19286

--- a/submissions/core_changes-issue-19286/demo.html
+++ b/submissions/core_changes-issue-19286/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animated Notification Toast Stack — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrapper">
+    <h1 class="title">Animated Notification Toast Stack</h1>
+    <p class="subtitle">Pure CSS toast notifications — click the × to dismiss each toast</p>
+
+    <input type="checkbox" id="dismiss-1" hidden>
+    <input type="checkbox" id="dismiss-2" hidden>
+    <input type="checkbox" id="dismiss-3" hidden>
+    <input type="checkbox" id="dismiss-4" hidden>
+
+    <div class="toast-stack">
+      <div class="toast toast-success" data-toast="1">
+        <span class="toast-icon">✓</span>
+        <div class="toast-body">
+          <strong>Success</strong>
+          <p>Your changes have been saved.</p>
+        </div>
+        <label class="toast-close" for="dismiss-1">×</label>
+      </div>
+
+      <div class="toast toast-error" data-toast="2">
+        <span class="toast-icon">✕</span>
+        <div class="toast-body">
+          <strong>Error</strong>
+          <p>Something went wrong. Please try again.</p>
+        </div>
+        <label class="toast-close" for="dismiss-2">×</label>
+      </div>
+
+      <div class="toast toast-warning" data-toast="3">
+        <span class="toast-icon">⚠</span>
+        <div class="toast-body">
+          <strong>Warning</strong>
+          <p>Your session will expire in 5 minutes.</p>
+        </div>
+        <label class="toast-close" for="dismiss-3">×</label>
+      </div>
+
+      <div class="toast toast-info" data-toast="4">
+        <span class="toast-icon">ℹ</span>
+        <div class="toast-body">
+          <strong>Info</strong>
+          <p>A new update is available.</p>
+        </div>
+        <label class="toast-close" for="dismiss-4">×</label>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/core_changes-issue-19286/style.css
+++ b/submissions/core_changes-issue-19286/style.css
@@ -1,0 +1,172 @@
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+
+body{
+  font-family:'Segoe UI',system-ui,-apple-system,sans-serif;
+  background:#0f172a;
+  color:#e2e8f0;
+  min-height:100vh;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:40px 20px
+}
+
+.wrapper{
+  width:100%;
+  max-width:640px;
+  text-align:center
+}
+
+.title{
+  font-size:clamp(1.4rem,4vw,1.9rem);
+  font-weight:700;
+  margin-bottom:6px;
+  background:linear-gradient(135deg,#38bdf8,#0ea5e9);
+  -webkit-background-clip:text;
+  -webkit-text-fill-color:transparent;
+  background-clip:text
+}
+
+.subtitle{
+  font-size:0.95rem;
+  color:#64748b;
+  margin-bottom:44px
+}
+
+input[type="checkbox"]{display:none}
+
+.toast-stack{
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+  max-width:420px;
+  margin:0 auto
+}
+
+.toast{
+  display:flex;
+  align-items:flex-start;
+  gap:14px;
+  padding:16px 18px;
+  border-radius:12px;
+  backdrop-filter:blur(12px);
+  border:1px solid rgba(255,255,255,0.08);
+  text-align:left;
+  position:relative;
+  transform:translateX(120%);
+  opacity:0;
+  animation:toastIn 0.5s cubic-bezier(0.22,1,0.36,1) forwards
+}
+
+.toast[data-toast="1"]{animation-delay:0.1s}
+.toast[data-toast="2"]{animation-delay:0.4s}
+.toast[data-toast="3"]{animation-delay:0.7s}
+.toast[data-toast="4"]{animation-delay:1.0s}
+
+@keyframes toastIn{
+  from{transform:translateX(120%);opacity:0}
+  to{transform:translateX(0);opacity:1}
+}
+
+@keyframes toastOut{
+  from{transform:translateX(0);opacity:1;max-height:80px;margin-bottom:0;padding:16px 18px}
+  to{transform:translateX(120%);opacity:0;max-height:0;margin-bottom:-14px;padding:0 18px}
+}
+
+.toast-success{
+  background:rgba(34,197,94,0.12);
+  border-color:rgba(34,197,94,0.25)
+}
+
+.toast-error{
+  background:rgba(239,68,68,0.12);
+  border-color:rgba(239,68,68,0.25)
+}
+
+.toast-warning{
+  background:rgba(245,158,11,0.12);
+  border-color:rgba(245,158,11,0.25)
+}
+
+.toast-info{
+  background:rgba(56,189,248,0.12);
+  border-color:rgba(56,189,248,0.25)
+}
+
+.toast-icon{
+  font-size:1.2rem;
+  line-height:1.4;
+  flex-shrink:0;
+  width:28px;
+  height:28px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  border-radius:50%
+}
+
+.toast-success .toast-icon{background:rgba(34,197,94,0.2);color:#22c55e}
+.toast-error .toast-icon{background:rgba(239,68,68,0.2);color:#ef4444}
+.toast-warning .toast-icon{background:rgba(245,158,11,0.2);color:#f59e0b}
+.toast-info .toast-icon{background:rgba(56,189,248,0.2);color:#38bdf8}
+
+.toast-body{flex:1;min-width:0}
+
+.toast-body strong{
+  display:block;
+  font-size:0.9rem;
+  font-weight:600;
+  margin-bottom:2px
+}
+
+.toast-success .toast-body strong{color:#22c55e}
+.toast-error .toast-body strong{color:#ef4444}
+.toast-warning .toast-body strong{color:#f59e0b}
+.toast-info .toast-body strong{color:#38bdf8}
+
+.toast-body p{
+  font-size:0.82rem;
+  color:#94a3b8;
+  line-height:1.4
+}
+
+.toast-close{
+  font-size:1.2rem;
+  line-height:1;
+  color:#64748b;
+  cursor:pointer;
+  padding:2px 6px;
+  border-radius:6px;
+  transition:background 0.2s,color 0.2s;
+  flex-shrink:0
+}
+
+.toast-close:hover{
+  background:rgba(255,255,255,0.08);
+  color:#f1f5f9
+}
+
+#dismiss-1:checked ~ .toast-stack .toast[data-toast="1"],
+#dismiss-2:checked ~ .toast-stack .toast[data-toast="2"],
+#dismiss-3:checked ~ .toast-stack .toast[data-toast="3"],
+#dismiss-4:checked ~ .toast-stack .toast[data-toast="4"]{
+  animation:toastOut 0.35s ease-in forwards;
+  pointer-events:none
+}
+
+@media(max-width:480px){
+  .toast-stack{max-width:100%}
+  .toast{padding:14px 16px}
+  .toast-body p{font-size:0.8rem}
+}
+
+@media(prefers-reduced-motion:reduce){
+  .toast{animation:none;transform:none;opacity:1}
+  #dismiss-1:checked ~ .toast-stack .toast[data-toast="1"],
+  #dismiss-2:checked ~ .toast-stack .toast[data-toast="2"],
+  #dismiss-3:checked ~ .toast-stack .toast[data-toast="3"],
+  #dismiss-4:checked ~ .toast-stack .toast[data-toast="4"]{
+    animation:none;
+    opacity:0.3
+  }
+}


### PR DESCRIPTION
## ✦ Description

Pure CSS animated toast notification stack with 4 severity variants, slide-in entrance, staggered animation, and dismiss-on-click via checkbox hack. Zero JavaScript.

**Variants:**
- **Success** (green) — ✓ icon
- **Error** (red) — ✕ icon  
- **Warning** (amber) — ⚠ icon
- **Info** (blue) — ℹ icon

**Technical details:**
- `@keyframes toastIn` slides toast from right with cubic-bezier easing
- Staggered entrance via increasing `animation-delay` (0.1s, 0.4s, 0.7s, 1.0s)
- `@keyframes toastOut` for dismiss — slides right and collapses height to zero
- Checkbox hack: hidden `<input type="checkbox">` with `<label>` as close button
- CSS sibling selector `#dismiss-N:checked ~ .toast-stack .toast[data-toast="N"]` triggers dismiss
- Responsive: max 420px on desktop, full-width on mobile
- prefers-reduced-motion support
- Pure CSS, zero JavaScript

Fixes #19286

## ⟡ Type of Change

- [x] New feature (non-breaking change which adds functionality)

## ✦ Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or console errors.

## Description

### Files Changed
- `submissions/core_changes-issue-19286/demo.html` — 4 stacked toasts with hidden checkboxes
- `submissions/core_changes-issue-19286/style.css` — All styles, animations, dismiss logic, responsive, reduced-motion
- `submissions/core_changes-issue-19286/README.md` — Documentation

### Testing
Open `submissions/core_changes-issue-19286/demo.html` and click × on any toast to dismiss.