### PR TITLE
fix: add will-change to .ease-hover-morph-card for animation optimization (#3916)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1112,17 +1112,10 @@
    Standardized to: .ease-hover-morph-card */
 .ease-hover-morph-card {
   border-radius: var(--ease-radius-md);
+  will-change: border-radius, transform;
   transition:
     border-radius var(--ease-speed-medium) var(--ease-ease),
     transform var(--ease-speed-medium) var(--ease-ease);
-}
-
-/* Promote to GPU layer only on hover — avoids permanent compositing
-   overhead on all .ease-hover-morph-card elements in the page */
-@media (hover: hover) and (pointer: fine) {
-  .ease-hover-morph-card:hover {
-    will-change: border-radius, transform;
-  }
 }
 
 .ease-hover-morph-card:hover {


### PR DESCRIPTION
## Description

The `.ease-hover-morph-card` class in `core/animations.css` animates `border-radius` on hover but placed `will-change` inside a `@media (hover: hover) and (pointer: fine)` wrapper on the `:hover` state only. This meant the browser hint arrived too late, after the animation already started, causing potential jank on lower-end devices.

**Fix:**
- Moved `will-change: border-radius, transform` into the base `.ease-hover-morph-card` declaration
- Removed the media-query-wrapped hover block (which was redundant)

This aligns with the existing pattern used by `.ease-reveal` and `.ease-typewriter` in the same file, and matches the `easemotion/hover.css` definition.

Fixes #3916

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance optimization

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] Bug verified against source code
- [x] No regressions