### PR TITLE
fix: make repository URL validation case-insensitive in release check (#20364)

### DIFF
--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -38,7 +38,9 @@ if (manifest.name !== "easemotion-css") {
   fail('expected package name to be "easemotion-css"');
 }
 
-if (!manifest.repository?.url?.includes("SAPTARSHI-coder/EaseMotion-css")) {
+const repoUrl = (manifest.repository?.url ?? "").toLowerCase();
+const requiredRepo = "saptarshi-coder/easemotion-css";
+if (!repoUrl.includes(requiredRepo)) {
   fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
 }
 

--- a/tests/validate-package.test.js
+++ b/tests/validate-package.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+
+describe('validate-package.mjs', () => {
+  it('should pass validation against the committed package.json', () => {
+    const result = execSync(
+      'node scripts/validate-package.mjs',
+      { encoding: 'utf8', cwd: new URL('..', import.meta.url).pathname },
+    );
+    expect(result).toContain('package.json is valid');
+  });
+});


### PR DESCRIPTION
## Description

The `validate-package.mjs` script used a case-sensitive `.includes()` check for the repository URL:

```js
manifest.repository?.url?.includes("SAPTARSHI-coder/EaseMotion-css")
```

GitHub repository paths are case-insensitive, so the URL in `package.json` uses lowercase (`saptarshi-coder/easemotion-css`) while the validator required the exact mixed-case string. This caused `npm run release:check` to fail on the current `main` branch.

**Fix:** Normalize both sides to lowercase before comparing.

**Regression test:** Added `tests/validate-package.test.js` that runs `validate:manifest` against the committed `package.json` and asserts it passes. Included in the `npm test` suite.

Fixes #20364

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] Bug verified against source code
- [x] Fix tested
- [x] No regressions

## Testing

Run:
```
npm run validate:manifest
npm test
```
Both should pass.