### PR TITLE
Make manifest repository validation case-insensitive

### DIFF
--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -38,7 +38,11 @@ if (manifest.name !== "easemotion-css") {
   fail('expected package name to be "easemotion-css"');
 }
 
-if (!manifest.repository?.url?.includes("SAPTARSHI-coder/EaseMotion-css")) {
+if (
+  !manifest.repository?.url
+    ?.toLowerCase()
+    .includes("saptarshi-coder/easemotion-css")
+) {
   fail("repository.url must point to SAPTARSHI-coder/EaseMotion-css");
 }
 


### PR DESCRIPTION
## Summary

Normalize the repository URL before validation so the committed lowercase GitHub URL passes the release manifest check.

## Validation

- `node scripts/validate-package.mjs`
- `git diff --check`

Closes #20364