### PR TITLE
Build usable CSS from the SCSS entry point

### DIFF
--- a/scss/_index.scss
+++ b/scss/_index.scss
@@ -2,5 +2,46 @@
 // EaseMotion CSS — SCSS Entry Point
 // ============================================
 
+@use 'sass:meta';
+
 @forward 'variables';
 @forward 'mixins';
+
+// Emit the same framework modules as the primary CSS entry point.
+@include meta.load-css('../core/variables.css');
+@include meta.load-css('../core/base.css');
+@include meta.load-css('../core/animations.css');
+@include meta.load-css('../core/utilities.css');
+@include meta.load-css('../components/ease-marquee.css');
+@include meta.load-css('../components/buttons.css');
+@include meta.load-css('../components/cards.css');
+@include meta.load-css('../components/navbar.css');
+@include meta.load-css('../components/masonry.css');
+@include meta.load-css('../components/chip.css');
+@include meta.load-css('../components/footer.css');
+@include meta.load-css('../components/sidebar.css');
+@include meta.load-css('../components/scroll-progress.css');
+@include meta.load-css('../components/tabs.css');
+@include meta.load-css('../components/badges.css');
+@include meta.load-css('../components/loaders.css');
+@include meta.load-css('../components/tooltips.css');
+@include meta.load-css('../components/modals.css');
+@include meta.load-css('../components/command-palette.css');
+@include meta.load-css('../components/announce-bar.css');
+@include meta.load-css('../components/avatar.css');
+@include meta.load-css('../components/breadcrumb.css');
+@include meta.load-css('../components/btn-magnetic.css');
+@include meta.load-css('../components/compare-table.css');
+@include meta.load-css('../components/connection-status.css');
+@include meta.load-css('../components/fab.css');
+@include meta.load-css('../components/kbd.css');
+@include meta.load-css('../components/pagination.css');
+@include meta.load-css('../components/password-strength.css');
+@include meta.load-css('../components/progress.css');
+@include meta.load-css('../components/read-more.css');
+@include meta.load-css('../components/scroll-gallery.css');
+@include meta.load-css('../components/skeleton.css');
+@include meta.load-css('../components/tag.css');
+@include meta.load-css('../components/toast.css');
+@include meta.load-css('../components/view-transitions.css');
+@include meta.load-css('../components/forms.css');

--- a/tests/integrity.test.js
+++ b/tests/integrity.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("framework integrity", () => {
+  it("builds a usable stylesheet from the SCSS entry point", () => {
+    const build = spawnSync(
+      process.execPath,
+      [
+        join(rootDir, "node_modules", "sass", "sass.js"),
+        "scss/_index.scss",
+        "dist/easemotion.scss.css",
+      ],
+      {
+        cwd: rootDir,
+        encoding: "utf8",
+      },
+    );
+
+    expect(build.status, build.stderr || build.stdout).toBe(0);
+
+    const output = readFileSync(
+      join(rootDir, "dist", "easemotion.scss.css"),
+      "utf8"
+    );
+    expect(output).toContain(".ease-btn");
+    expect(output).toContain(".ease-card");
+    expect(output).toContain(".ease-fade-in");
+  });
+});


### PR DESCRIPTION
## Summary

Make `scss/_index.scss` emit the full framework stylesheet while continuing to forward the Sass variables and mixins. Adds a regression test that verifies representative framework selectors are present in the compiled output.

## Validation

- compiled `scss/_index.scss` successfully
- verified `.ease-btn`, `.ease-card`, and `.ease-fade-in` in output
- `git diff --check`

Closes #20366