### PR TITLE
Validate the documentation CSS bundle

### DIFF
--- a/scripts/validate-bundle.mjs
+++ b/scripts/validate-bundle.mjs
@@ -7,6 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, "..");
 const bundlePath = path.join(rootDir, "easemotion.min.css");
+const docsBundlePath = path.join(rootDir, "docs", "easemotion.min.css");
 
 // Skip validation in CI if the changed files do not affect the CSS bundle.
 // This prevents unnecessary bundle conflicts for example/sandbox PRs.
@@ -14,29 +15,45 @@ if (process.env.GITHUB_ACTIONS === "true") {
   try {
     const baseBranch = process.env.GITHUB_BASE_REF || "main";
     execSync(`git fetch origin ${baseBranch} --depth=1`, { stdio: "ignore" });
-    
-    const changedFiles = execSync(`git diff --name-only origin/${baseBranch}`, { encoding: "utf8" })
+
+    const changedFiles = execSync(`git diff --name-only origin/${baseBranch}`, {
+      encoding: "utf8",
+    })
       .split("\n")
-      .map(f => f.trim())
+      .map((f) => f.trim())
       .filter(Boolean);
-      
-    const affectsBundle = changedFiles.some(file => 
-      file === "easemotion.css" ||
-      file.startsWith("core/") ||
-      file.startsWith("components/") ||
-      file.startsWith("easemotion/")
+
+    const affectsBundle = changedFiles.some(
+      (file) =>
+        file === "easemotion.css" ||
+        file.startsWith("core/") ||
+        file.startsWith("components/") ||
+        file.startsWith("easemotion/")
     );
 
     if (!affectsBundle) {
-      console.log("No core, component, or entrypoint files modified. Skipping bundle validation.");
+      console.log(
+        "No core, component, or entrypoint files modified. Skipping bundle validation."
+      );
       process.exit(0);
     }
   } catch (err) {
-    console.warn("Could not determine changed files from git diff, running full validation:", err.message);
+    console.warn(
+      "Could not determine changed files from git diff, running full validation:",
+      err.message
+    );
   }
 }
 
-const originalBundle = await readFile(bundlePath, "utf8").catch(() => "");
+const bundlePaths = [bundlePath, docsBundlePath];
+const originalBundles = new Map(
+  await Promise.all(
+    bundlePaths.map(async (filePath) => [
+      filePath,
+      await readFile(filePath, "utf8").catch(() => ""),
+    ])
+  )
+);
 const build = spawnSync(process.execPath, ["scripts/build-minified-css.mjs"], {
   cwd: rootDir,
   encoding: "utf8",
@@ -50,13 +67,27 @@ if (build.error || build.status !== 0) {
   process.exit(build.status ?? 1);
 }
 
-const rebuiltBundle = await readFile(bundlePath, "utf8");
+const staleBundles = [];
+for (const filePath of bundlePaths) {
+  const rebuiltBundle = await readFile(filePath, "utf8");
+  if (originalBundles.get(filePath) !== rebuiltBundle) {
+    staleBundles.push(filePath);
+  }
+}
 
-if (originalBundle !== rebuiltBundle) {
-  await writeFile(bundlePath, originalBundle, "utf8");
+if (staleBundles.length > 0) {
+  await Promise.all(
+    bundlePaths.map((filePath) =>
+      writeFile(filePath, originalBundles.get(filePath), "utf8")
+    )
+  );
   throw new Error(
-    `${path.relative(rootDir, bundlePath)} is stale. Run \`npm run build\` and commit the regenerated bundle.`,
+    `${staleBundles
+      .map((filePath) => path.relative(rootDir, filePath))
+      .join(", ")} ${
+      staleBundles.length === 1 ? "is" : "are"
+    } stale. Run \`npm run build\` and commit the regenerated bundles.`
   );
 }
 
-console.log("easemotion.min.css is up to date.");
+console.log("Generated CSS bundles are up to date.");


### PR DESCRIPTION
## Summary

Extend bundle validation to compare and restore both generated outputs: the root minified bundle and the documentation copy. Stale output errors now identify every affected path.

## Validation

- `node scripts/validate-bundle.mjs`
- `git diff --check`

Closes #20374