### PR TITLE
Update vulnerable undici dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
 updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "SAPTARSHI-coder"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3356,9 +3356,9 @@
       "optional": true
     },
     "node_modules/undici": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
-      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

Update the lockfile to `undici` 7.28.0 and enable weekly npm Dependabot updates alongside the existing GitHub Actions updates.

## Validation

- `npm audit --package-lock-only --audit-level=high`
- zero vulnerabilities reported
- `git diff --check`

Closes #20376