### PR TITLE
Expand CI path coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,23 +2,33 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - '**/*.css'
-      - '**/*.html'
-      - 'scripts/**'
-      - '.github/workflows/ci.yml'
-      - 'stylelint.config.json'
-      - 'htmlhint.config.json'
+      - "**/*.css"
+      - "**/*.html"
+      - "**/*.js"
+      - "tests/**"
+      - "scripts/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vitest.config.js"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/stylelint.config.json"
+      - ".github/workflows/htmlhint.config.json"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - '**/*.css'
-      - '**/*.html'
-      - 'scripts/**'
-      - '.github/workflows/ci.yml'
-      - 'stylelint.config.json'
-      - 'htmlhint.config.json'
+      - "**/*.css"
+      - "**/*.html"
+      - "**/*.js"
+      - "tests/**"
+      - "scripts/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vitest.config.js"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/stylelint.config.json"
+      - ".github/workflows/htmlhint.config.json"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Expand automatic CI triggers to cover JavaScript helpers, tests, package manifests, Vitest configuration, and the actual HTMLHint and Stylelint configuration paths.

## Validation

- workflow syntax reviewed
- `git diff --check`

Closes #20378