### PR TITLE
fix: propose @keyframes ease-icon-pop for compare-table (issue #20369)

### DIFF
--- a/submissions/core_changes-issue-20369/README.md
+++ b/submissions/core_changes-issue-20369/README.md
@@ -1,0 +1,48 @@
+# Core Changes Proposal: Issue #20369
+
+## Problem Description
+
+Issue [#20369](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20369) reports that `components/compare-table.css` references undefined `ease-icon-pop` keyframes.
+
+**The bug** is in `components/compare-table.css` on line 80:
+
+```css
+.ease-icon-check, .ease-icon-cross {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  animation: ease-icon-pop 0.3s ease both;
+}
+```
+
+The animation name `ease-icon-pop` does not exist anywhere in the framework. The file only defines `@keyframes ease-icon-draw` (used by the pseudo-elements for the drawing stroke effect), but the parent icon container references `ease-icon-pop` which has no matching keyframe rule. This means the icons appear without their intended pop-in scale animation.
+
+## Proposed Fix
+
+Add the missing `@keyframes ease-icon-pop` definition to `components/compare-table.css`. The keyframe should provide a scale pop-in effect that complements the drawing stroke animation on the pseudo-elements:
+
+```css
+@keyframes ease-icon-pop {
+  from {
+    transform: scale(0);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.15);
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+```
+
+This creates a pop-in effect: the icon scales up from 0, overshoots slightly to 1.15, then settles at 1 — all while fading in. It pairs naturally with `ease-icon-draw` which fades in the stroke pseudo-elements.
+
+## Why this is submitted here
+
+Per the `CONTRIBUTING.md` policy and Core Framework Protection, this fix is proposed as a formal submission in the `submissions/` directory rather than modifying `components/compare-table.css` directly.
+
+Fixes #20369

--- a/submissions/core_changes-issue-20369/demo.html
+++ b/submissions/core_changes-issue-20369/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Issue #20369 — Missing ease-icon-pop Keyframes Fix</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../../easemotion.css">
+</head>
+<body>
+    <main>
+        <h1>Core Fix Proposal for Issue #20369</h1>
+        <p>
+            <code>components/compare-table.css</code> assigns
+            <code>animation: ease-icon-pop 0.3s ease both</code> to icon containers
+            but only defines <code>@keyframes ease-icon-draw</code> — the
+            <code>ease-icon-pop</code> keyframe is missing.
+        </p>
+
+        <div class="comparison">
+            <div class="side bad">
+                <h2>Before (Broken)</h2>
+                <div class="code-block">
+                    <span class="line">animation: <mark>ease-icon-pop</mark> 0.3s ease both;</span>
+                    <span class="line comment">/* No @keyframes ease-icon-pop defined */</span>
+                </div>
+                <div class="demo-box">
+                    <div class="ease-icon-check icon-demo" style="animation: none;">
+                        <span class="icon-inner"></span>
+                    </div>
+                    <div class="ease-icon-cross icon-demo" style="animation: none;">
+                        <span class="icon-inner"></span>
+                    </div>
+                </div>
+                <p class="result fail">Missing keyframe — no pop-in animation</p>
+            </div>
+
+            <div class="side good">
+                <h2>After (Fixed)</h2>
+                <div class="code-block">
+                    <span class="line">animation: <mark>ease-icon-pop</mark> 0.3s ease both;</span>
+                    <span class="line comment">/* @keyframes ease-icon-pop { ... } now defined */</span>
+                </div>
+                <div class="demo-box">
+                    <div class="ease-icon-check icon-demo pop-in">
+                        <span class="icon-inner"></span>
+                    </div>
+                    <div class="ease-icon-cross icon-demo pop-in">
+                        <span class="icon-inner"></span>
+                    </div>
+                </div>
+                <p class="result pass">Keyframe exists — icons pop in correctly</p>
+            </div>
+        </div>
+
+        <p class="note">See <code>README.md</code> for the proposed <code>@keyframes ease-icon-pop { ... }</code> addition to <code>components/compare-table.css</code>.</p>
+    </main>
+</body>
+</html>

--- a/submissions/core_changes-issue-20369/style.css
+++ b/submissions/core_changes-issue-20369/style.css
@@ -1,0 +1,224 @@
+/* Issue #20369 — compare-table icons reference undefined ease-icon-pop keyframes
+   Proposed addition of @keyframes ease-icon-pop to components/compare-table.css */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0b1121;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main {
+  max-width: 800px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #f8fafc;
+}
+
+h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+p {
+  color: #94a3b8;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+code {
+  background: #1e293b;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.875em;
+  color: #e2e8f0;
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.side {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+}
+
+.side.bad { border-color: #ef4444; }
+.side.good { border-color: #22c55e; }
+
+.code-block {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.line {
+  display: block;
+  white-space: pre;
+}
+
+.line.comment {
+  color: #64748b;
+  font-style: italic;
+}
+
+mark {
+  background: transparent;
+  color: #facc15;
+  font-weight: 600;
+}
+
+.demo-box {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  min-height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+}
+
+.icon-demo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  position: relative;
+}
+
+.icon-demo.pop-in {
+  animation: ease-icon-pop-demo 0.3s ease both;
+}
+
+.icon-inner {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: #1e293b;
+  border: 2px solid #334155;
+}
+
+.ease-icon-check.pop-in::after {
+  content: '';
+  display: block;
+  width: 0.4rem;
+  height: 0.7rem;
+  border: solid #10b981;
+  border-width: 0 0.15rem 0.15rem 0;
+  transform: rotate(45deg) translateY(-0.05rem);
+  animation: ease-icon-draw-demo 0.3s ease 0.1s both;
+  position: absolute;
+}
+
+.ease-icon-cross.pop-in::before,
+.ease-icon-cross.pop-in::after {
+  content: '';
+  position: absolute;
+  width: 0.15rem;
+  height: 1rem;
+  background: #ef4444;
+  border-radius: 1px;
+  animation: ease-icon-draw-demo 0.3s ease 0.1s both;
+}
+
+.ease-icon-cross.pop-in::before {
+  transform: rotate(45deg);
+}
+
+.ease-icon-cross.pop-in::after {
+  transform: rotate(-45deg);
+}
+
+@keyframes ease-icon-pop-demo {
+  from {
+    transform: scale(0);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.15);
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes ease-icon-draw-demo {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.result {
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.result.fail {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+}
+
+.result.pass {
+  background: rgba(34, 197, 94, 0.15);
+  color: #86efac;
+}
+
+.note {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
+/* PROPOSED FIX FOR components/compare-table.css:
+   Add the following @keyframes block after line 112 (after ease-icon-draw):
+
+   @keyframes ease-icon-pop {
+     from {
+       transform: scale(0);
+       opacity: 0;
+     }
+     50% {
+       transform: scale(1.15);
+     }
+     to {
+       transform: scale(1);
+       opacity: 1;
+     }
+   }
+*/


### PR DESCRIPTION
## Description

Closes #20369

`components/compare-table.css` line 80 references `ease-icon-pop` keyframes that are never defined. This submission proposes adding the missing `@keyframes ease-icon-pop` block.

See `submissions/core_changes-issue-20369/README.md` for details.