### PR TITLE
fix: propose @keyframes ease-kf-hover-pulse-glow for missing keyframe (issue #20372)

### DIFF
--- a/submissions/core_changes-issue-20372/README.md
+++ b/submissions/core_changes-issue-20372/README.md
@@ -1,0 +1,66 @@
+# Core Changes Proposal: Issue #20372
+
+## Problem Description
+
+Issue [#20372](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20372) reports that the `.ease-hover-pulse-glow` utility references undefined `@keyframes ease-kf-hover-pulse-glow`.
+
+**The bug** is in `core/animations.css` at line 1379:
+
+```css
+.ease-hover-pulse-glow {
+  z-index: 1;
+  position: relative;
+  transform-origin: center;
+  transition: transform var(--ease-speed-medium) var(--ease-ease-bounce),
+              filter var(--ease-speed-medium) var(--ease-ease-bounce);
+}
+
+.ease-hover-pulse-glow:hover {
+  animation: ease-kf-hover-pulse-glow var(--ease-speed-medium) var(--ease-ease-bounce) forwards;
+}
+```
+
+The animation name `ease-kf-hover-pulse-glow` does not exist — no `@keyframes` rule defines it anywhere in `core/`, `components/`, or modular stylesheets. On hover, no pulse or glow effect occurs.
+
+## Proposed Fix
+
+Add the missing `@keyframes ease-kf-hover-pulse-glow` definition to `core/animations.css`. The keyframe should combine a scale pulse with a glow via `filter: brightness()` and a subtle `box-shadow`:
+
+```css
+@keyframes ease-kf-hover-pulse-glow {
+  0% {
+    transform: scale(1);
+    filter: brightness(1);
+    box-shadow: 0 0 0 0 rgba(108, 99, 255, 0);
+  }
+  50% {
+    transform: scale(1.08);
+    filter: brightness(1.2);
+    box-shadow: 0 0 20px 4px rgba(108, 99, 255, 0.35);
+  }
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+    box-shadow: 0 0 10px 2px rgba(108, 99, 255, 0.15);
+  }
+}
+```
+
+This creates a combined pulse+glow effect:
+- **Pulse**: scale up to 1.08 at midpoint, then settle back
+- **Glow**: `brightness(1.2)` boosts perceived glow, `box-shadow` expands outward in sync
+
+Also add a `prefers-reduced-motion` guard so the animation is suppressed for accessibility.
+
+## Why this is submitted here
+
+Per the `CONTRIBUTING.md` policy and Core Framework Protection, this fix is proposed as a formal submission in the `submissions/` directory rather than modifying `core/animations.css` directly.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `core/animations.css` (after line 1380) | Add `@keyframes ease-kf-hover-pulse-glow` block |
+| `core/animations.css` (end of file) | Add `@media (prefers-reduced-motion: reduce)` rule |
+
+Fixes #20372

--- a/submissions/core_changes-issue-20372/demo.html
+++ b/submissions/core_changes-issue-20372/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Issue #20372 — Missing ease-kf-hover-pulse-glow Keyframes</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../../easemotion.css">
+</head>
+<body>
+    <main>
+        <h1>Core Fix Proposal for Issue #20372</h1>
+        <p>
+            <code>.ease-hover-pulse-glow</code> in <code>core/animations.css</code> applies
+            <code>animation: ease-kf-hover-pulse-glow ...</code> but that
+            <code>@keyframes</code> rule is never defined &mdash; no pulse or glow occurs on hover.
+        </p>
+
+        <div class="comparison">
+            <div class="side bad">
+                <h2>Before (Broken)</h2>
+                <div class="code-block">
+                    <span class="line">.ease-hover-pulse-glow:hover {</span>
+                    <span class="line indent">animation: <mark>ease-kf-hover-pulse-glow</mark> ... forwards;</span>
+                    <span class="line">}</span>
+                    <span class="line comment">/* No @keyframes ease-kf-hover-pulse-glow defined */</span>
+                </div>
+                <div class="demo-box">
+                    <div class="card broken-pulse">Hover me</div>
+                </div>
+                <p class="result fail">Missing keyframe &mdash; nothing happens on hover</p>
+            </div>
+
+            <div class="side good">
+                <h2>After (Fixed)</h2>
+                <div class="code-block">
+                    <span class="line">@keyframes <mark>ease-kf-hover-pulse-glow</mark> {</span>
+                    <span class="line indent">0% { transform: scale(1); filter: brightness(1); box-shadow: 0 0 0 0 transparent; }</span>
+                    <span class="line indent">50% { transform: scale(1.08); filter: brightness(1.2); box-shadow: 0 0 20px 4px rgba(108,99,255,0.35); }</span>
+                    <span class="line indent">100% { transform: scale(1); filter: brightness(1); box-shadow: 0 0 10px 2px rgba(108,99,255,0.15); }</span>
+                    <span class="line">}</span>
+                </div>
+                <div class="demo-box">
+                    <div class="card fixed-pulse">Hover me</div>
+                </div>
+                <p class="result pass">Keyframe defined &mdash; pulses &amp; glows on hover</p>
+            </div>
+        </div>
+
+        <p class="note">See <code>README.md</code> for the exact proposed <code>@keyframes</code> block to add to <code>core/animations.css</code>.</p>
+    </main>
+</body>
+</html>

--- a/submissions/core_changes-issue-20372/style.css
+++ b/submissions/core_changes-issue-20372/style.css
@@ -1,0 +1,221 @@
+/* Issue #20372 — .ease-hover-pulse-glow references missing keyframes
+   Proposed fix: add @keyframes ease-kf-hover-pulse-glow to core/animations.css */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0b1121;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main {
+  max-width: 800px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #f8fafc;
+}
+
+h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+p {
+  color: #94a3b8;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+code {
+  background: #1e293b;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.875em;
+  color: #e2e8f0;
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.side {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+}
+
+.side.bad { border-color: #ef4444; }
+.side.good { border-color: #22c55e; }
+
+.code-block {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.line {
+  display: block;
+  white-space: pre;
+}
+
+.line.comment {
+  color: #64748b;
+  font-style: italic;
+}
+
+.line.indent {
+  padding-left: 2ch;
+}
+
+mark {
+  background: transparent;
+  color: #facc15;
+  font-weight: 600;
+}
+
+.demo-box {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 1.5rem;
+  margin-bottom: 0.75rem;
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card {
+  padding: 1rem 2rem;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  color: #fff;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  text-align: center;
+  width: 160px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Broken version — references undefined keyframe */
+.card.broken-pulse {
+  z-index: 1;
+  position: relative;
+  transform-origin: center;
+}
+
+.card.broken-pulse:hover {
+  animation: ease-kf-hover-pulse-glow 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/* Fixed version — with actual keyframe defined */
+.card.fixed-pulse {
+  z-index: 1;
+  position: relative;
+  transform-origin: center;
+}
+
+.card.fixed-pulse:hover {
+  animation: ease-kf-hover-pulse-glow-fixed 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/* The proposed keyframe definition */
+@keyframes ease-kf-hover-pulse-glow-fixed {
+  0% {
+    transform: scale(1);
+    filter: brightness(1);
+    box-shadow: 0 0 0 0 rgba(108, 99, 255, 0);
+  }
+  50% {
+    transform: scale(1.08);
+    filter: brightness(1.2);
+    box-shadow: 0 0 20px 4px rgba(108, 99, 255, 0.35);
+  }
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+    box-shadow: 0 0 10px 2px rgba(108, 99, 255, 0.15);
+  }
+}
+
+.result {
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.result.fail {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+}
+
+.result.pass {
+  background: rgba(34, 197, 94, 0.15);
+  color: #86efac;
+}
+
+.note {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
+/* PROPOSED FIX FOR core/animations.css:
+   Add the following @keyframes block after line 1380:
+
+   @keyframes ease-kf-hover-pulse-glow {
+     0% {
+       transform: scale(1);
+       filter: brightness(1);
+       box-shadow: 0 0 0 0 rgba(108, 99, 255, 0);
+     }
+     50% {
+       transform: scale(1.08);
+       filter: brightness(1.2);
+       box-shadow: 0 0 20px 4px rgba(108, 99, 255, 0.35);
+     }
+     100% {
+       transform: scale(1);
+       filter: brightness(1);
+       box-shadow: 0 0 10px 2px rgba(108, 99, 255, 0.15);
+     }
+   }
+
+   Also add at end of file (after the closing brace of @layer):
+   @media (prefers-reduced-motion: reduce) {
+     .ease-hover-pulse-glow,
+     .ease-hover-pulse-glow:hover {
+       animation: none !important;
+     }
+   }
+*/


### PR DESCRIPTION
## Description

Closes #20372

`.ease-hover-pulse-glow:hover` in `core/animations.css` line 1379 references `ease-kf-hover-pulse-glow` but no `@keyframes` rule with that name exists.

This submission proposes adding the missing `@keyframes ease-kf-hover-pulse-glow` with a combined scale pulse and glow effect, plus a `prefers-reduced-motion` guard.

See `submissions/core_changes-issue-20372/README.md` for details.