### PR TITLE
fix: propose ease-slide-down to ease-kf-slide-down for announce-bar (issue #20370)

### DIFF
--- a/submissions/core_changes-issue-20370/README.md
+++ b/submissions/core_changes-issue-20370/README.md
@@ -1,0 +1,59 @@
+# Core Changes Proposal: Issue #20370
+
+## Problem Description
+
+Issue [#20370](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20370) reports that `components/announce-bar.css` uses a utility class name as its animation keyframe name.
+
+**The bug** is in `components/announce-bar.css` on line 9:
+
+```css
+.ease-announce-bar {
+  position: relative;
+  padding: 0.75rem 1rem;
+  background: #6c63ff;
+  color: #fff;
+  text-align: center;
+  font-size: 0.875rem;
+  animation: ease-slide-down 0.3s ease;
+  ...
+}
+```
+
+The animation name `ease-slide-down` is a **utility class** (defined in `core/animations.css` line 835), not a `@keyframes` rule. The actual slide-down keyframe is named `ease-kf-slide-down` (defined in `core/animations.css` line 48).
+
+Since `@keyframes ease-slide-down` does not exist anywhere in the framework, the announcement bar appears without its intended entrance motion.
+
+## Proposed Fix
+
+Change `ease-slide-down` to `ease-kf-slide-down` on line 9 of `components/announce-bar.css`, and add `animation-fill-mode: both` so the element starts hidden before the animation runs:
+
+```css
+.ease-announce-bar {
+  ...
+  animation: ease-kf-slide-down 0.3s ease both;
+  ...
+}
+```
+
+Also add a `prefers-reduced-motion` guard at the end of the file so the entrance animation is disabled for users who prefer reduced motion:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-announce-bar {
+    animation: none;
+  }
+}
+```
+
+## Why this is submitted here
+
+Per the `CONTRIBUTING.md` policy and Core Framework Protection, this fix is proposed as a formal submission in the `submissions/` directory rather than modifying `components/announce-bar.css` directly.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `components/announce-bar.css` line 9 | `ease-slide-down` → `ease-kf-slide-down` |
+| `components/announce-bar.css` (end) | Add `@media (prefers-reduced-motion: reduce)` block |
+
+Fixes #20370

--- a/submissions/core_changes-issue-20370/demo.html
+++ b/submissions/core_changes-issue-20370/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Issue #20370 — Announce bar uses class name as keyframe name</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../../easemotion.css">
+</head>
+<body>
+    <main>
+        <h1>Core Fix Proposal for Issue #20370</h1>
+        <p>
+            <code>components/announce-bar.css</code> assigns
+            <code>animation: ease-slide-down 0.3s ease</code> but
+            <code>ease-slide-down</code> is a utility class &mdash;
+            the actual keyframe is <code>ease-kf-slide-down</code>.
+        </p>
+
+        <div class="comparison">
+            <div class="side bad">
+                <h2>Before (Broken)</h2>
+                <div class="code-block">
+                    <span class="line">animation: <mark>ease-slide-down</mark> 0.3s ease;</span>
+                    <span class="line comment">/* No @keyframes ease-slide-down exists */</span>
+                </div>
+                <div class="demo-box">
+                    <div class="announce-broken">
+                        <span>Your session will expire in 5 minutes</span>
+                        <button class="close-btn">&times;</button>
+                    </div>
+                </div>
+                <p class="result fail">Missing keyframe &mdash; no slide-down animation</p>
+            </div>
+
+            <div class="side good">
+                <h2>After (Fixed)</h2>
+                <div class="code-block">
+                    <span class="line">animation: <mark>ease-kf-slide-down</mark> 0.3s ease both;</span>
+                    <span class="line comment">/* Matches @keyframes ease-kf-slide-down */</span>
+                </div>
+                <div class="demo-box">
+                    <div class="announce-fixed">
+                        <span>Your session will expire in 5 minutes</span>
+                        <button class="close-btn">&times;</button>
+                    </div>
+                </div>
+                <p class="result pass">Keyframe exists &mdash; slides down correctly</p>
+            </div>
+        </div>
+
+        <div class="rm-section">
+            <h2>prefers-reduced-motion Support</h2>
+            <p>The fix also adds a <code>@media (prefers-reduced-motion: reduce)</code> guard so the entrance animation is disabled for accessibility.</p>
+            <div class="code-block">
+                <span class="line">@media (prefers-reduced-motion: reduce) {</span>
+                <span class="line indent">.ease-announce-bar { animation: none; }</span>
+                <span class="line">}</span>
+            </div>
+        </div>
+
+        <p class="note">See <code>README.md</code> for the exact proposed changes to <code>components/announce-bar.css</code>.</p>
+    </main>
+</body>
+</html>

--- a/submissions/core_changes-issue-20370/style.css
+++ b/submissions/core_changes-issue-20370/style.css
@@ -1,0 +1,215 @@
+/* Issue #20370 — Announce bar uses ease-slide-down class as keyframe name
+   Proposed fix: change animation name to ease-kf-slide-down + add reduced-motion guard */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0b1121;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main {
+  max-width: 800px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #f8fafc;
+}
+
+h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+p {
+  color: #94a3b8;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+code {
+  background: #1e293b;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.875em;
+  color: #e2e8f0;
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.side {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+}
+
+.side.bad { border-color: #ef4444; }
+.side.good { border-color: #22c55e; }
+
+.code-block {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.line {
+  display: block;
+  white-space: pre;
+}
+
+.line.comment {
+  color: #64748b;
+  font-style: italic;
+}
+
+.line.indent {
+  padding-left: 2ch;
+}
+
+mark {
+  background: transparent;
+  color: #facc15;
+  font-weight: 600;
+}
+
+.demo-box {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  min-height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Broken version — uses wrong keyframe name */
+.announce-broken {
+  position: relative;
+  padding: 0.75rem 1rem;
+  background: #6c63ff;
+  color: #fff;
+  text-align: center;
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  width: 100%;
+  border-radius: 6px;
+  animation: ease-slide-down 0.3s ease;
+}
+
+/* Fixed version — uses ease-kf-slide-down */
+.announce-fixed {
+  position: relative;
+  padding: 0.75rem 1rem;
+  background: #6c63ff;
+  color: #fff;
+  text-align: center;
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  width: 100%;
+  border-radius: 6px;
+  animation: ease-kf-slide-down 0.3s ease both;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.8;
+  padding: 0.25rem;
+  line-height: 1;
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.close-btn:hover {
+  opacity: 1;
+}
+
+.rm-section {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+  margin-bottom: 1.5rem;
+}
+
+.rm-section .code-block {
+  margin-bottom: 0;
+}
+
+.result {
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.result.fail {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+}
+
+.result.pass {
+  background: rgba(34, 197, 94, 0.15);
+  color: #86efac;
+}
+
+.note {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
+/* PROPOSED FIX FOR components/announce-bar.css:
+
+   Change line 9 from:
+     animation: ease-slide-down 0.3s ease;
+   To:
+     animation: ease-kf-slide-down 0.3s ease both;
+
+   Add at end of file (after line 78):
+
+   @media (prefers-reduced-motion: reduce) {
+     .ease-announce-bar {
+       animation: none;
+     }
+   }
+*/


### PR DESCRIPTION
## Description

Closes #20370

`components/announce-bar.css` line 9 uses `animation: ease-slide-down 0.3s ease` but `ease-slide-down` is a utility class, not a keyframe. The actual keyframe is `ease-kf-slide-down`.

This submission proposes changing `ease-slide-down` to `ease-kf-slide-down` and adding a `prefers-reduced-motion` guard.

See `submissions/core_changes-issue-20370/README.md` for details.