### PR TITLE
fix: validate both bundle outputs in validate-bundle.mjs (issue #20374)

### DIFF
--- a/submissions/core_changes-issue-20374/README.md
+++ b/submissions/core_changes-issue-20374/README.md
@@ -1,0 +1,74 @@
+# Core Changes Proposal: Issue #20374
+
+## Problem Description
+
+Issue [#20374](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20374) reports that `scripts/validate-bundle.mjs` only validates `easemotion.min.css` but ignores `docs/easemotion.min.css`.
+
+**The bug:** `scripts/build-minified-css.mjs` writes the minified bundle to **two** locations:
+- `easemotion.min.css` (root)
+- `docs/easemotion.min.css` (line 163–164)
+
+But `scripts/validate-bundle.mjs` only captures, compares, and restores the root bundle:
+
+```js
+const bundlePath = path.join(rootDir, "easemotion.min.css");
+const originalBundle = await readFile(bundlePath, "utf8");
+// ... run build ...
+const rebuiltBundle = await readFile(bundlePath, "utf8");
+if (originalBundle !== rebuiltBundle) {
+  await writeFile(bundlePath, originalBundle, "utf8");
+  throw new Error(`${path.relative(rootDir, bundlePath)} is stale. ...`);
+}
+```
+
+This means if `docs/easemotion.min.css` goes stale, validation passes silently and then the build overwrites it, leaving an unreported working-tree change.
+
+## Proposed Fix
+
+Update `scripts/validate-bundle.mjs` to capture, compare, and restore both bundle files:
+
+```js
+const bundlePaths = [
+  path.join(rootDir, "easemotion.min.css"),
+  path.join(rootDir, "docs", "easemotion.min.css"),
+];
+
+const originals = await Promise.all(
+  bundlePaths.map(p => readFile(p, "utf8").catch(() => ""))
+);
+
+// ... run build ...
+
+const stales = [];
+for (let i = 0; i < bundlePaths.length; i++) {
+  const rebuilt = await readFile(bundlePaths[i], "utf8");
+  if (originals[i] !== rebuilt) {
+    stales.push(bundlePaths[i]);
+    await writeFile(bundlePaths[i], originals[i], "utf8");
+  }
+}
+
+if (stales.length > 0) {
+  throw new Error(
+    stales.map(p => `${path.relative(rootDir, p)} is stale.`).join("\n") +
+    `\nRun \`npm run build\` and commit the regenerated bundles.`,
+  );
+}
+
+const names = bundlePaths.map(p => path.relative(rootDir, p)).join(", ");
+console.log(`${names} are up to date.`);
+```
+
+This ensures both bundles are checked, both are restored on failure, and every stale path is listed in the error message.
+
+## Why this is submitted here
+
+Per the `CONTRIBUTING.md` policy and Core Framework Protection, this fix is proposed as a formal submission in the `submissions/` directory rather than modifying `scripts/validate-bundle.mjs` directly.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `scripts/validate-bundle.mjs` | Validate both `easemotion.min.css` and `docs/easemotion.min.css` |
+
+Fixes #20374

--- a/submissions/core_changes-issue-20374/demo.html
+++ b/submissions/core_changes-issue-20374/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Issue #20374 — Bundle validation misses docs/easemotion.min.css</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <h1>Core Fix Proposal for Issue #20374</h1>
+        <p>
+            <code>scripts/validate-bundle.mjs</code> only validates
+            <code>easemotion.min.css</code> but the build script also writes
+            <code>docs/easemotion.min.css</code> &mdash; so the docs bundle can go stale undetected.
+        </p>
+
+        <div class="comparison">
+            <div class="side bad">
+                <h2>Before (Broken)</h2>
+                <div class="code-block">
+                    <span class="line">const bundlePath = path.join(rootDir, <mark>"easemotion.min.css"</mark>);</span>
+                    <span class="line comment">// Only checks root bundle</span>
+                </div>
+                <div class="flow">
+                    <div class="step">Read <code>easemotion.min.css</code></div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step">Run build (rewrites both)</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step">Compare <code>easemotion.min.css</code></div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step fail">❌ <code>docs/easemotion.min.css</code> unchecked</div>
+                </div>
+                <p class="result fail">Docs bundle can go stale silently</p>
+            </div>
+
+            <div class="side good">
+                <h2>After (Fixed)</h2>
+                <div class="code-block">
+                    <span class="line">const bundlePaths = [</span>
+                    <span class="line indent"><mark>"easemotion.min.css"</mark>,</span>
+                    <span class="line indent"><mark>"docs/easemotion.min.css"</mark></span>
+                    <span class="line">];</span>
+                    <span class="line comment">// Both bundles validated</span>
+                </div>
+                <div class="flow">
+                    <div class="step">Read both bundles</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step">Run build (rewrites both)</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step">Compare both bundles</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step pass">✅ Both match &mdash; pass</div>
+                </div>
+                <p class="result pass">All bundles validated &amp; restored on failure</p>
+            </div>
+        </div>
+
+        <div class="diff-section">
+            <h2>Proposed Diff for <code>scripts/validate-bundle.mjs</code></h2>
+            <div class="code-block diff">
+                <span class="line diff-del">-const bundlePath = path.join(rootDir, "easemotion.min.css");</span>
+                <span class="line diff-del">-const originalBundle = await readFile(bundlePath, "utf8").catch(() => "");</span>
+                <span class="line diff-add">+const bundlePaths = [</span>
+                <span class="line diff-add">+  path.join(rootDir, "easemotion.min.css"),</span>
+                <span class="line diff-add">+  path.join(rootDir, "docs", "easemotion.min.css"),</span>
+                <span class="line diff-add">+];</span>
+                <span class="line diff-add">+const originals = await Promise.all(</span>
+                <span class="line diff-add">+  bundlePaths.map(p => readFile(p, "utf8").catch(() => ""))</span>
+                <span class="line diff-add">+);</span>
+            </div>
+        </div>
+
+        <p class="note">See <code>README.md</code> for the full proposed changes to <code>scripts/validate-bundle.mjs</code>.</p>
+    </main>
+</body>
+</html>

--- a/submissions/core_changes-issue-20374/style.css
+++ b/submissions/core_changes-issue-20374/style.css
@@ -1,0 +1,211 @@
+/* Issue #20374 — Bundle validation does not verify docs/easemotion.min.css
+   Proposed fix: validate both bundle files in scripts/validate-bundle.mjs */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0b1121;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main {
+  max-width: 800px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #f8fafc;
+}
+
+h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+p {
+  color: #94a3b8;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+code {
+  background: #1e293b;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.875em;
+  color: #e2e8f0;
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.side {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+}
+
+.side.bad { border-color: #ef4444; }
+.side.good { border-color: #22c55e; }
+
+.code-block {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.line {
+  display: block;
+  white-space: pre;
+}
+
+.line.comment {
+  color: #64748b;
+  font-style: italic;
+}
+
+.line.indent {
+  padding-left: 2ch;
+}
+
+.line.diff-del {
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.line.diff-add {
+  color: #86efac;
+  background: rgba(34, 197, 94, 0.1);
+}
+
+mark {
+  background: transparent;
+  color: #facc15;
+  font-weight: 600;
+}
+
+.flow {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  text-align: center;
+}
+
+.step {
+  background: #1e293b;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  display: inline-block;
+}
+
+.step.fail {
+  border: 1px solid #ef4444;
+}
+
+.step.pass {
+  border: 1px solid #22c55e;
+}
+
+.arrow {
+  font-size: 1.2rem;
+  color: #475569;
+  padding: 0.25rem 0;
+}
+
+.diff-section {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+  margin-bottom: 1.5rem;
+}
+
+.diff-section .code-block {
+  margin-bottom: 0;
+}
+
+.result {
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.result.fail {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+}
+
+.result.pass {
+  background: rgba(34, 197, 94, 0.15);
+  color: #86efac;
+}
+
+.note {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+/* PROPOSED FIX FOR scripts/validate-bundle.mjs:
+
+   Replace:
+     const bundlePath = path.join(rootDir, "easemotion.min.css");
+     const originalBundle = await readFile(bundlePath, "utf8").catch(() => "");
+
+   With:
+     const bundlePaths = [
+       path.join(rootDir, "easemotion.min.css"),
+       path.join(rootDir, "docs", "easemotion.min.css"),
+     ];
+     const originals = await Promise.all(
+       bundlePaths.map(p => readFile(p, "utf8").catch(() => ""))
+     );
+
+   Then replace the comparison/restore block:
+     if (originalBundle !== rebuiltBundle) {
+       await writeFile(bundlePath, originalBundle, "utf8");
+       throw new Error(...);
+     }
+
+   With an iterative comparison that collects all stale paths:
+     const stales = [];
+     for (let i = 0; i < bundlePaths.length; i++) {
+       const rebuilt = await readFile(bundlePaths[i], "utf8");
+       if (originals[i] !== rebuilt) {
+         stales.push(bundlePaths[i]);
+         await writeFile(bundlePaths[i], originals[i], "utf8");
+       }
+     }
+     if (stales.length > 0) {
+       throw new Error(
+         stales.map(p => path.relative(rootDir, p) + " is stale.").join("\n") +
+         "\nRun `npm run build` and commit the regenerated bundles."
+       );
+     }
+
+   And update the success log to mention both files.
+*/


### PR DESCRIPTION
## Description

Closes #20374

`scripts/build-minified-css.mjs` writes to both `easemotion.min.css` and `docs/easemotion.min.css`, but `scripts/validate-bundle.mjs` only validates the root bundle. This means the docs bundle can go stale silently.

This submission proposes updating `validate-bundle.mjs` to save, compare, and restore both bundles, listing every stale path in the error message.

See `submissions/core_changes-issue-20374/README.md` for details.