### PR TITLE
fix: add push/PR triggers to test workflow (issue #20377)

### DIFF
--- a/submissions/core_changes-issue-20377/README.md
+++ b/submissions/core_changes-issue-20377/README.md
@@ -1,0 +1,63 @@
+# Core Changes Proposal: Issue #20377
+
+## Problem Description
+
+Issue [#20377](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20377) reports that `.github/workflows/test.yml` defines a full lint and validation job but its only trigger is `workflow_dispatch`, so it never runs automatically on pushes or pull requests.
+
+**The bug** is in `.github/workflows/test.yml` on lines 3–4:
+
+```yaml
+on:
+  workflow_dispatch:
+```
+
+The separate `ci.yml` workflow only checks changed HTML/CSS files and does not run the full suite (`npm run lint`, `npm run lint:duplicates`, `npm test`). This means changes can be merged without running the complete validation pipeline.
+
+## Proposed Fix
+
+Add `pull_request` and `push` triggers to `.github/workflows/test.yml`, scoped to the paths that affect the validation results (core CSS, components, scripts, tests, configs, and package manifests):
+
+```yaml
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'core/**'
+      - 'components/**'
+      - 'easemotion/**'
+      - 'scss/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'stylelint.config.json'
+      - '.github/workflows/test.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'core/**'
+      - 'components/**'
+      - 'easemotion/**'
+      - 'scss/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'stylelint.config.json'
+      - '.github/workflows/test.yml'
+  workflow_dispatch:
+```
+
+This ensures the full validation suite (Stylelint + duplicate linter + tests) runs automatically when relevant files change, while retaining manual dispatch.
+
+## Why this is submitted here
+
+Per the `CONTRIBUTING.md` policy and Core Framework Protection, this fix is proposed as a formal submission in the `submissions/` directory rather than modifying `.github/workflows/test.yml` directly.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/test.yml` | Add `push` and `pull_request` triggers with path filters |
+
+Fixes #20377

--- a/submissions/core_changes-issue-20377/demo.html
+++ b/submissions/core_changes-issue-20377/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Issue #20377 — Test workflow only runs manually</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <h1>Core Fix Proposal for Issue #20377</h1>
+        <p>
+            <code>.github/workflows/test.yml</code> defines the full validation suite
+            but only triggers on <code>workflow_dispatch</code> &mdash; it never runs
+            automatically on push or pull request.
+        </p>
+
+        <div class="comparison">
+            <div class="side bad">
+                <h2>Before (Manual Only)</h2>
+                <div class="code-block">
+                    <span class="line">on:</span>
+                    <span class="line indent"><mark>workflow_dispatch:</mark></span>
+                </div>
+                <div class="flow">
+                    <div class="step">👤 Developer pushes code</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step">ci.yml runs (partial lint)</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step fail">❌ test.yml skipped &mdash; manual only</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step">Merge without full validation</div>
+                </div>
+                <p class="result fail">Full test suite never runs automatically</p>
+            </div>
+
+            <div class="side good">
+                <h2>After (Auto + Manual)</h2>
+                <div class="code-block">
+                    <span class="line">on:</span>
+                    <span class="line indent">push:</span>
+                    <span class="line indent">pull_request:</span>
+                    <span class="line indent"><mark>workflow_dispatch:</mark></span>
+                </div>
+                <div class="flow">
+                    <div class="step">👤 Developer pushes code</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step">ci.yml runs (partial lint)</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step pass">✅ test.yml runs automatically</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step">Block merge if validation fails</div>
+                </div>
+                <p class="result pass">Full suite runs on every relevant change</p>
+            </div>
+        </div>
+
+        <div class="diff-section">
+            <h2>Proposed Diff for <code>.github/workflows/test.yml</code></h2>
+            <div class="code-block">
+                <span class="line">on:</span>
+                <span class="line diff-add">+  push:</span>
+                <span class="line diff-add">+    branches: [ main ]</span>
+                <span class="line diff-add">+    paths:</span>
+                <span class="line diff-add">+      - 'core/**'</span>
+                <span class="line diff-add">+      - 'components/**'</span>
+                <span class="line diff-add">+      - 'easemotion/**'</span>
+                <span class="line diff-add">+      - 'scss/**'</span>
+                <span class="line diff-add">+      - 'scripts/**'</span>
+                <span class="line diff-add">+      - 'tests/**'</span>
+                <span class="line diff-add">+      - 'package.json'</span>
+                <span class="line diff-add">+      - 'package-lock.json'</span>
+                <span class="line diff-add">+      - 'stylelint.config.json'</span>
+                <span class="line diff-add">+      - '.github/workflows/test.yml'</span>
+                <span class="line diff-add">+  pull_request:</span>
+                <span class="line diff-add">+    branches: [ main ]</span>
+                <span class="line diff-add">+    paths:</span>
+                <span class="line diff-add">+      - 'core/**'</span>
+                <span class="line diff-add">+      - 'components/**'</span>
+                <span class="line diff-add">+      - 'easemotion/**'</span>
+                <span class="line diff-add">+      - 'scss/**'</span>
+                <span class="line diff-add">+      - 'scripts/**'</span>
+                <span class="line diff-add">+      - 'tests/**'</span>
+                <span class="line diff-add">+      - 'package.json'</span>
+                <span class="line diff-add">+      - 'package-lock.json'</span>
+                <span class="line diff-add">+      - 'stylelint.config.json'</span>
+                <span class="line diff-add">+      - '.github/workflows/test.yml'</span>
+                <span class="line">   workflow_dispatch:</span>
+            </div>
+        </div>
+
+        <p class="note">See <code>README.md</code> for the full proposed changes to <code>.github/workflows/test.yml</code>.</p>
+    </main>
+</body>
+</html>

--- a/submissions/core_changes-issue-20377/style.css
+++ b/submissions/core_changes-issue-20377/style.css
@@ -1,0 +1,208 @@
+/* Issue #20377 — Test and validation workflow runs only when manually dispatched
+   Proposed fix: add push and pull_request triggers to .github/workflows/test.yml */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0b1121;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main {
+  max-width: 800px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #f8fafc;
+}
+
+h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+p {
+  color: #94a3b8;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+code {
+  background: #1e293b;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.875em;
+  color: #e2e8f0;
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.side {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+}
+
+.side.bad { border-color: #ef4444; }
+.side.good { border-color: #22c55e; }
+
+.code-block {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.line {
+  display: block;
+  white-space: pre;
+}
+
+.line.comment {
+  color: #64748b;
+  font-style: italic;
+}
+
+.line.indent {
+  padding-left: 2ch;
+}
+
+.line.diff-del {
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.line.diff-add {
+  color: #86efac;
+  background: rgba(34, 197, 94, 0.1);
+}
+
+mark {
+  background: transparent;
+  color: #facc15;
+  font-weight: 600;
+}
+
+.flow {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  text-align: center;
+}
+
+.step {
+  background: #1e293b;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  display: inline-block;
+}
+
+.step.fail {
+  border: 1px solid #ef4444;
+}
+
+.step.pass {
+  border: 1px solid #22c55e;
+}
+
+.arrow {
+  font-size: 1.2rem;
+  color: #475569;
+  padding: 0.25rem 0;
+}
+
+.diff-section {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+  margin-bottom: 1.5rem;
+}
+
+.diff-section .code-block {
+  margin-bottom: 0;
+}
+
+.result {
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.result.fail {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+}
+
+.result.pass {
+  background: rgba(34, 197, 94, 0.15);
+  color: #86efac;
+}
+
+.note {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+/* PROPOSED FIX FOR .github/workflows/test.yml:
+
+   Change:
+     on:
+       workflow_dispatch:
+
+   To:
+     on:
+       push:
+         branches: [ main ]
+         paths:
+           - 'core/**'
+           - 'components/**'
+           - 'easemotion/**'
+           - 'scss/**'
+           - 'scripts/**'
+           - 'tests/**'
+           - 'package.json'
+           - 'package-lock.json'
+           - 'stylelint.config.json'
+           - '.github/workflows/test.yml'
+       pull_request:
+         branches: [ main ]
+         paths:
+           - 'core/**'
+           - 'components/**'
+           - 'easemotion/**'
+           - 'scss/**'
+           - 'scripts/**'
+           - 'tests/**'
+           - 'package.json'
+           - 'package-lock.json'
+           - 'stylelint.config.json'
+           - '.github/workflows/test.yml'
+       workflow_dispatch:
+*/


### PR DESCRIPTION
## Description

Closes #20377

`.github/workflows/test.yml` defines the full validation suite (Stylelint, duplicate linter, tests) but only runs on `workflow_dispatch`, so it never runs automatically. The separate `ci.yml` only lints changed HTML/CSS files.

This submission proposes adding `push` and `pull_request` triggers with path filters for core, components, scripts, tests, and package manifests.

See `submissions/core_changes-issue-20377/README.md` for details.