### PR TITLE
fix: expand CI path filters for JS, tests, and manifests (issue #20378)

### DIFF
--- a/submissions/core_changes-issue-20378/README.md
+++ b/submissions/core_changes-issue-20378/README.md
@@ -1,0 +1,75 @@
+# Core Changes Proposal: Issue #20378
+
+## Problem Description
+
+Issue [#20378](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/20378) reports that the `CI` workflow path filters in `.github/workflows/ci.yml` miss JavaScript helpers, tests, and package manifest changes.
+
+**Current path filters** (push and pull_request):
+
+```yaml
+paths:
+  - '**/*.css'
+  - '**/*.html'
+  - 'scripts/**'
+  - '.github/workflows/ci.yml'
+  - 'stylelint.config.json'
+  - 'htmlhint.config.json'
+```
+
+**Missing paths that can affect runtime behavior or validation:**
+
+- `**/*.js` — JavaScript helpers (`core/modal.js`, `core/tabs.js`, `core/reveal.js`, etc.)
+- `tests/**` — Smoke tests and test utilities
+- `package.json` — Dependency changes affect install and test behavior
+- `package-lock.json` — Lockfile reflects actual dependency resolutions
+- `vitest.config.js` — Test runner configuration
+
+Without these, a PR changing only `core/modal.js` or `tests/smoke.test.js` receives no automated validation at all.
+
+## Proposed Fix
+
+Add the missing paths to both `push` and `pull_request` triggers in `.github/workflows/ci.yml`:
+
+```yaml
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.css'
+      - '**/*.html'
+      - '**/*.js'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vitest.config.js'
+      - '.github/workflows/ci.yml'
+      - 'stylelint.config.json'
+      - 'htmlhint.config.json'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/*.css'
+      - '**/*.html'
+      - '**/*.js'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vitest.config.js'
+      - '.github/workflows/ci.yml'
+      - 'stylelint.config.json'
+      - 'htmlhint.config.json'
+```
+
+## Why this is submitted here
+
+Per the `CONTRIBUTING.md` policy and Core Framework Protection, this fix is proposed as a formal submission in the `submissions/` directory rather than modifying `.github/workflows/ci.yml` directly.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci.yml` | Add `**/*.js`, `tests/**`, `package.json`, `package-lock.json`, `vitest.config.js` to path filters |
+
+Fixes #20378

--- a/submissions/core_changes-issue-20378/demo.html
+++ b/submissions/core_changes-issue-20378/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Issue #20378 — CI path filters miss JS, tests, manifests</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <h1>Core Fix Proposal for Issue #20378</h1>
+        <p>
+            The <code>CI</code> workflow path filters in <code>.github/workflows/ci.yml</code>
+            miss JavaScript helpers, tests, package manifests, and test config &mdash;
+            changes to these files get zero automated validation.
+        </p>
+
+        <div class="comparison">
+            <div class="side bad">
+                <h2>Before (Missing paths)</h2>
+                <div class="code-block">
+                    <span class="line">paths:</span>
+                    <span class="line">  - '**/*.css'</span>
+                    <span class="line">  - '**/*.html'</span>
+                    <span class="line">  - 'scripts/**'</span>
+                    <span class="line diff-miss">  # MISSING: **/*.js</span>
+                    <span class="line diff-miss">  # MISSING: tests/**</span>
+                    <span class="line diff-miss">  # MISSING: package.json</span>
+                    <span class="line diff-miss">  # MISSING: package-lock.json</span>
+                    <span class="line diff-miss">  # MISSING: vitest.config.js</span>
+                </div>
+                <div class="files">
+                    <div class="file untracked">core/modal.js</div>
+                    <div class="file untracked">tests/smoke.test.js</div>
+                    <div class="file untracked">package.json</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step fail">PR gets NO automated checks</div>
+                </div>
+                <p class="result fail">Changes bypass CI entirely</p>
+            </div>
+
+            <div class="side good">
+                <h2>After (All paths covered)</h2>
+                <div class="code-block">
+                    <span class="line">paths:</span>
+                    <span class="line">  - '**/*.css'</span>
+                    <span class="line">  - '**/*.html'</span>
+                    <span class="line diff-add">+  - '**/*.js'</span>
+                    <span class="line">  - 'scripts/**'</span>
+                    <span class="line diff-add">+  - 'tests/**'</span>
+                    <span class="line diff-add">+  - 'package.json'</span>
+                    <span class="line diff-add">+  - 'package-lock.json'</span>
+                    <span class="line diff-add">+  - 'vitest.config.js'</span>
+                </div>
+                <div class="files">
+                    <div class="file tracked">core/modal.js</div>
+                    <div class="file tracked">tests/smoke.test.js</div>
+                    <div class="file tracked">package.json</div>
+                    <div class="arrow">&darr;</div>
+                    <div class="step pass">CI triggers &amp; runs lint</div>
+                </div>
+                <p class="result pass">All relevant changes trigger CI</p>
+            </div>
+        </div>
+
+        <p class="note">See <code>README.md</code> for the full proposed changes to <code>.github/workflows/ci.yml</code>.</p>
+    </main>
+</body>
+</html>

--- a/submissions/core_changes-issue-20378/style.css
+++ b/submissions/core_changes-issue-20378/style.css
@@ -1,0 +1,183 @@
+/* Issue #20378 — CI path filters ignore JavaScript helpers, tests, and package manifest changes
+   Proposed fix: add missing paths to .github/workflows/ci.yml */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0b1121;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main {
+  max-width: 800px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #f8fafc;
+}
+
+h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+p {
+  color: #94a3b8;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+code {
+  background: #1e293b;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.875em;
+  color: #e2e8f0;
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.side {
+  background: #1e293b;
+  border-radius: 8px;
+  padding: 1.25rem;
+  border: 1px solid #334155;
+}
+
+.side.bad { border-color: #ef4444; }
+.side.good { border-color: #22c55e; }
+
+.code-block {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.line {
+  display: block;
+  white-space: pre;
+}
+
+.line.diff-miss {
+  color: #fca5a5;
+  font-style: italic;
+}
+
+.line.diff-add {
+  color: #86efac;
+  background: rgba(34, 197, 94, 0.1);
+}
+
+mark {
+  background: transparent;
+  color: #facc15;
+  font-weight: 600;
+}
+
+.files {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  text-align: center;
+}
+
+.file {
+  display: inline-block;
+  padding: 0.35rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  margin: 0.2rem;
+}
+
+.file.untracked {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid #ef4444;
+  color: #fca5a5;
+}
+
+.file.tracked {
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid #22c55e;
+  color: #86efac;
+}
+
+.files .arrow {
+  display: block;
+  font-size: 1.2rem;
+  color: #475569;
+  padding: 0.25rem 0;
+}
+
+.files .step {
+  display: inline-block;
+  background: #1e293b;
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.step.fail {
+  border: 1px solid #ef4444;
+  color: #fca5a5;
+}
+
+.step.pass {
+  border: 1px solid #22c55e;
+  color: #86efac;
+}
+
+.result {
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.result.fail {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+}
+
+.result.pass {
+  background: rgba(34, 197, 94, 0.15);
+  color: #86efac;
+}
+
+.note {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+/* PROPOSED FIX FOR .github/workflows/ci.yml:
+   Add to both push and pull_request path filters:
+     - '**/*.js'
+     - 'tests/**'
+     - 'package.json'
+     - 'package-lock.json'
+     - 'vitest.config.js'
+*/


### PR DESCRIPTION
## Description

Closes #20378

The `CI` workflow path filters in `.github/workflows/ci.yml` miss `**/*.js`, `tests/**`, `package.json`, `package-lock.json`, and `vitest.config.js`. Changes to JavaScript helpers, test files, or dependency manifests get zero automated validation.

This submission proposes adding the missing paths to both `push` and `pull_request` triggers.

See `submissions/core_changes-issue-20378/README.md` for details.